### PR TITLE
chore: MCP registry publishing prep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,26 @@ jobs:
             - name: Publish to PyPI
               uses: pypa/gh-action-pypi-publish@release/v1
 
+    mcp-registry:
+        name: Publish to MCP Registry
+        needs: pypi
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Install mcp-publisher
+              run: |
+                  curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+
+            - name: Authenticate via OIDC
+              run: ./mcp-publisher login github-oidc
+
+            - name: Publish to MCP Registry
+              run: ./mcp-publisher publish
+
     docker:
         name: Push to GHCR
         runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![License](https://img.shields.io/github/license/dataraum/dataraum)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/dataraum/dataraum/ci.yml?branch=main)](https://github.com/dataraum/dataraum/actions)
 
+<!-- mcp-name: io.github.dataraum/dataraum -->
+
 A rich metadata context engine for AI-driven data analytics.
 
 Traditional semantic layers tell BI tools "what things are called." DataRaum tells AI "what the data means, how it behaves, how it relates, and what you can compute from it."

--- a/server.json
+++ b/server.json
@@ -1,44 +1,36 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.dataraum/dataraum",
-  "display_name": "DataRaum",
-  "description": "Rich metadata context engine for AI-driven data analytics. Pre-computes comprehensive metadata (types, statistics, entropy, relationships, semantic annotations) and serves it as structured context optimized for LLM consumption.",
+  "title": "DataRaum",
+  "description": "Pre-computed metadata context engine for AI-driven data analytics",
   "repository": {
     "url": "https://github.com/dataraum/dataraum",
     "source": "github"
   },
-  "version_detail": {
-    "version": "0.2.0",
-    "release_date": "2026-03-28"
-  },
+  "version": "0.2.0",
   "packages": [
     {
-      "registry_name": "pypi",
-      "name": "dataraum",
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "dataraum",
       "version": "0.2.0",
-      "runtime": "python",
-      "environment_variables": [
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
         {
           "name": "ANTHROPIC_API_KEY",
           "description": "Anthropic API key for LLM-powered semantic analysis",
-          "required": true
+          "isRequired": true,
+          "isSecret": true
         },
         {
           "name": "DATARAUM_HOME",
           "description": "Root directory for workspaces, sessions, and exports",
-          "required": false
+          "isRequired": false
         }
       ]
     }
-  ],
-  "tools": [
-    { "name": "look", "description": "Explore data schema, profiles, and statistics" },
-    { "name": "measure", "description": "Run entropy detectors and get data quality scores" },
-    { "name": "begin_session", "description": "Start an investigation session with intent and contract" },
-    { "name": "end_session", "description": "End session, archive workspace" },
-    { "name": "query", "description": "Natural language question answering over your data" },
-    { "name": "run_sql", "description": "Execute SQL with quality metadata and snippet reuse" },
-    { "name": "add_source", "description": "Register CSV, Parquet, JSON files or database connections" }
-  ],
-  "remotes": []
+  ]
 }


### PR DESCRIPTION
## Summary

- README: hidden `<!-- mcp-name: io.github.dataraum/dataraum -->` for PyPI ownership validation
- server.json: migrated to 2025-12-11 schema (all field names corrected)
- release.yml: auto-publish to MCP Registry after PyPI (OIDC, zero secrets)

Takes effect on next release (v0.2.1). No version bump — just prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)