### PR TITLE
Doc-drift guards (skill + CI) + pint 0.25.3 fix

### DIFF
--- a/.claude/skills/release-prep/SKILL.md
+++ b/.claude/skills/release-prep/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: release-prep
+description: Pre-release editorial sweep — make sure README, docs, CHANGELOG, and version metadata reflect what actually shipped before tagging.
+allowed-tools:
+  - Read
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Release prep: $ARGUMENTS
+
+A version bump is about to happen. The CI preflight enforces the *mechanical*
+facts — version match across `pyproject.toml` / `server.json`, `server.json`
+schema, and numeric counts of phases / MCP tools / detectors via
+`scripts/check_doc_counts.py`. CI cannot tell you whether the **prose** still
+matches reality. That's this skill's job.
+
+**Run this BEFORE creating the release commit and tag.**
+
+## Input
+
+`$ARGUMENTS` is the target version, e.g. `0.2.2`. If empty, read the version
+from `pyproject.toml` and ask the user whether that's the target.
+
+## Why this exists
+
+Past releases shipped with stale facts (e.g. README claiming "17-phase
+pipeline" after we added phase 18, missing tool rows in the tool table). The
+CI count-check now catches numeric drift, but tool rows, descriptions, examples,
+and links rot quietly. A 5-minute editorial pass before tagging is cheaper than
+a docs-only patch release.
+
+## Procedure
+
+### 1. Establish the baseline
+
+Find the previous release tag and the diff since:
+
+```bash
+PREV=$(git tag --sort=-creatordate | head -1)
+echo "Previous release: $PREV"
+git log --oneline "$PREV"..HEAD
+git diff --stat "$PREV"..HEAD
+```
+
+If `$ARGUMENTS` was empty, also confirm the target version with the user before
+proceeding.
+
+### 2. Run the mechanical check first
+
+```bash
+uv run python scripts/check_doc_counts.py
+```
+
+If it reports drift, fix the doc files it points to before going further. This
+check covers:
+
+- numbered claims like "18 phases", "10 MCP tools", "16 detectors" across the
+  user-facing docs in `DOC_FILES`
+- README tool table completeness vs. tools registered in
+  `src/dataraum/mcp/server.py`
+
+### 3. Editorial sweep
+
+For each file below, skim the **diff since `$PREV`** for behavior changes that
+affect prose, then read the file and update anything that's now wrong.
+
+Files to review (in order):
+
+1. `README.md` — quick start commands, tool table descriptions, workflow
+   example, doc links, badges, install instructions
+2. `CHANGELOG.md` — must have a section for `$ARGUMENTS` summarizing user-facing
+   changes (added / changed / removed / fixed). Don't list internal refactors.
+3. `docs/index.md` — landing page claims and entry points
+4. `docs/pipeline.md` — phase list and per-phase descriptions if phases were
+   added/removed/renamed
+5. `docs/entropy.md` — detector list, scores, thresholds
+6. `docs/mcp-setup.md` — tool descriptions, contract names, session flow
+7. `docs/architecture.md` — module diagram, tool count, data flow
+8. `docs/cli.md` — every documented command must still exist (`dataraum --help`,
+   `dataraum dev --help`)
+9. `docs/configuration.md` — env vars, paths, contracts
+10. `docs/data-model.md` — tables, schema fields
+11. `docs/contributing.md` — module tree, dev commands
+
+For each: ask "what would surprise a new user who reads this against today's
+behavior?" — that's what to fix.
+
+### 4. Verify documented commands actually work
+
+If the docs claim a CLI command exists, run `--help` on it. If they show a
+shell example, sanity-check that it parses (`bash -n` on snippets, or just
+read carefully). Tool descriptions in the README table should match the
+descriptions registered in `src/dataraum/mcp/server.py` at the spirit level
+(don't mechanically copy the multi-paragraph server description into the
+table — keep the README terse).
+
+### 5. Version metadata
+
+Confirm the version bump touches all three places (CI will enforce this on
+tag, but catching it now is cheaper than a failed release):
+
+```bash
+grep '^version = ' pyproject.toml
+python -c 'import json; print(json.load(open("server.json"))["version"])'
+python -c 'import json; print(json.load(open("server.json"))["packages"][0]["version"])'
+```
+
+All three must equal `$ARGUMENTS`.
+
+### 6. Final mechanical check + summary
+
+```bash
+uv run python scripts/check_doc_counts.py
+uv run pytest --testmon tests -q
+```
+
+Report to the user:
+
+- the previous tag and number of commits since
+- which doc files you edited and a one-line summary per file
+- the CHANGELOG entry you wrote (paste it)
+- anything you noticed but didn't change (because it wasn't clearly stale or
+  needed product judgment)
+
+Then stop. **Do NOT create the release commit, tag, or PR yourself** — the user
+does that. The skill ends with "ready for tagging".
+
+## Rules
+
+- This is editorial, not architectural. Don't refactor. Don't rename anything.
+- Don't invent new docs pages. If something is undocumented, say so in the
+  summary so the user can decide whether to defer.
+- Don't update `plans/` (gitignored), Confluence, or Jira from here.
+- Don't push, don't tag, don't run the release workflow.
+- If the diff reveals a behavior change that has no doc anywhere, flag it
+  loudly in the summary — that's the most important thing this skill catches.
+- If `scripts/check_doc_counts.py` exits non-zero after your edits, you are
+  not done.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
                   curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
                   ./mcp-publisher validate server.json
 
+            - name: Check doc counts (phases / tools / detectors)
+              run: python scripts/check_doc_counts.py
+
     pypi:
         name: Publish to PyPI
         needs: preflight

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ This project uses skills to structure development work. Skills encode the checkp
 | Approved approach after `/refine` | `/implement` | Phased execution with checkpoints and review gate |
 | MCP tool changes completed | Remind: restart session, then `/smoke` | Server runs old code until restarted |
 | Implementation verified and reviewed | Update `.claude/handoff.md` | Bridge to dataraum-eval and dataraum-testdata |
+| "Cut a release", "prep v0.x.y", before tagging | `/release-prep` | Editorial sweep on README/docs/CHANGELOG; CI enforces counts |
 | Quick fix, <3 files, obvious change | Direct implementation | S-size tasks don't need ceremony |
 
 ### Skills (`.claude/skills/`)
@@ -145,6 +146,7 @@ This project uses skills to structure development work. Skills encode the checkp
 - **`/refine <issue>`** — Pre-implementation: explore feasibility, surface spec vs. reality conflicts, align on approach. No code.
 - **`/implement <issue>`** — Phased execution with mandatory self-audit checkpoints. Invokes senior-code-reviewer + spec-compliance-reviewer at the end. Updates `handoff.md`.
 - **`/smoke [tool]`** — Quick MCP UX check: call the tools you just built, feel how they work. Requires session restart if server code changed.
+- **`/release-prep [version]`** — Pre-release editorial sweep across README, `docs/`, `CHANGELOG.md`, and version metadata. Runs `scripts/check_doc_counts.py`. Stops before tagging.
 
 ### Cross-repo handoff
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The server runs an 18-phase analysis pipeline and makes these tools available:
 | `look` | Explore data structure, relationships, and semantic metadata |
 | `measure` | Measure entropy scores, readiness, and data quality |
 | `why` | Explain elevated entropy and propose teach suggestions |
-| `teach` | Extend the world model — sole write tool (concepts, metrics, validations, ...) |
+| `teach` | Extend the operation model — sole write tool (concepts, metrics, validations, ...) |
 | `query` | Natural language query against the data |
 | `run_sql` | Execute SQL directly with export support |
 | `search_snippets` | Discover reusable SQL patterns from prior queries and graph execution |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then in Claude Desktop:
 
 > Add the CSV files in /path/to/my/data and measure data quality
 
-The server runs a 17-phase analysis pipeline and makes these tools available:
+The server runs an 18-phase analysis pipeline and makes these tools available:
 
 | Tool | Description |
 |------|-------------|
@@ -49,8 +49,11 @@ The server runs a 17-phase analysis pipeline and makes these tools available:
 | `add_source` | Register a data source (CSV, Parquet, JSON, or directory) |
 | `look` | Explore data structure, relationships, and semantic metadata |
 | `measure` | Measure entropy scores, readiness, and data quality |
+| `why` | Explain elevated entropy and propose teach suggestions |
+| `teach` | Extend the world model — sole write tool (concepts, metrics, validations, ...) |
 | `query` | Natural language query against the data |
 | `run_sql` | Execute SQL directly with export support |
+| `search_snippets` | Discover reusable SQL patterns from prior queries and graph execution |
 | `end_session` | Archive workspace and end the session |
 
 ### Typical Workflow
@@ -122,7 +125,7 @@ uv run ruff format --check src/
 ## Documentation
 
 - [Architecture](docs/architecture.md) — system design and pipeline overview
-- [Pipeline](docs/pipeline.md) — 17-phase pipeline reference
+- [Pipeline](docs/pipeline.md) — 18-phase pipeline reference
 - [Entropy](docs/entropy.md) — uncertainty quantification system
 - [Data Model](docs/data-model.md) — metadata schema
 - [CLI Reference](docs/cli.md) — command-line interface

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ Traditional semantic layers tell BI tools "what things are called." DataRaum tel
 │                           CONSUMERS                                         │
 │                                                                             │
 │   Claude Code ──── MCP Server (10 tools)                                    │
-│   Claude Desktop ─┘                       Session + World Model             │
+│   Claude Desktop ─┘                       Session + Operation Model         │
 │   Python ──────── Context API                                               │
 │   Terminal ────── CLI (run + dev)                                            │
 └─────────────────────────────────────────────────────────────────────────────┘
@@ -124,9 +124,9 @@ AI doesn't discover metadata at runtime via tools. It receives a pre-assembled c
 
 10 MCP tools organized around investigation sessions: `add_source` → `begin_session` → `look` / `measure` / `why` / `teach` / `query` / `run_sql` / `search_snippets` → `end_session`. Sources are registered first, then the session seals them. The session carries the contract (entropy threshold profile) so the agent doesn't need to pass it on every call.
 
-### The Understanding Layer (World Model)
+### The Understanding Layer (Operation Model)
 
-DataRaum maintains a **world model** for each dataset — a structured, queryable representation of what exists and what it means. Five facets:
+DataRaum maintains an **operation model** for each dataset — a structured, queryable representation of what exists and what it means. Five facets:
 
 | Facet | What | Pipeline phase |
 |-------|------|---------------|
@@ -136,7 +136,7 @@ DataRaum maintains a **world model** for each dataset — a structured, queryabl
 | Validations | What must be true | validation |
 | Filters | What counts, what's excluded | graph_execution |
 
-The world model is built progressively through **teach + rerun** cycles. `teach` extends a vertical YAML overlay (session-scoped at `DATARAUM_HOME/workspace/<session>/vertical/`); `measure(target_phase=...)` reruns the affected phase so downstream metadata reflects the new knowledge. Config teaches (concept, metric, cycle, validation, relationship, type_pattern, null_value) trigger a rerun; metadata teaches (concept_property, explanation) apply immediately.
+The operation model is built progressively through **teach + rerun** cycles. `teach` extends a vertical YAML overlay (session-scoped at `DATARAUM_HOME/workspace/<session>/vertical/`); `measure(target_phase=...)` reruns the affected phase so downstream metadata reflects the new knowledge. Config teaches (concept, metric, cycle, validation, relationship, type_pattern, null_value) trigger a rerun; metadata teaches (concept_property, explanation) apply immediately.
 
 ### Snippet Provenance and Promotion
 
@@ -256,7 +256,7 @@ Primary interface for AI agents. Tools return markdown formatted for LLM consump
 | `look` | Explore schema, relationships, semantic metadata, readiness |
 | `measure` | Entropy scores + readiness; reruns a target phase on demand |
 | `why` | Evidence synthesis — explains elevated entropy, proposes teaches |
-| `teach` | Extend the world model (9 teach types) |
+| `teach` | Extend the operation model (9 teach types) |
 | `query` | Natural-language data queries with confidence + assumptions |
 | `run_sql` | Execute SQL with auto-repair, export support, snippet caching |
 | `search_snippets` | Discover reusable SQL snippets with provenance |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -175,7 +175,7 @@ src/dataraum/
 ├── llm/               # LLM provider abstraction
 ├── core/              # Config, connections, utilities
 ├── cli/               # Typer CLI (run + dev)
-└── mcp/               # MCP server (7 tools)
+└── mcp/               # MCP server (10 tools)
 ```
 
 See [Architecture](architecture.md) for detailed module descriptions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 # DataRaum Context Engine
 
-**The understanding layer for your data.** A structured, queryable world model that grounds LLMs in a specific company's data — what exists, what it means, how it flows, and what truths can be derived.
+**The understanding layer for your data.** A structured, queryable operation model that grounds LLMs in a specific company's data — what exists, what it means, how it flows, and what truths can be derived.
 
 Traditional semantic layers tell BI tools "what things are called." DataRaum tells AI **what the data means, how it behaves, how it relates, and what you can compute from it.**
 
-The system combines a metadata pipeline (profiles the data), an entropy layer (measures uncertainty), and an interactive MCP surface (explore, explain, teach) so the world model improves progressively through use.
+The system combines a metadata pipeline (profiles the data), an entropy layer (measures uncertainty), and an interactive MCP surface (explore, explain, teach) so the operation model improves progressively through use.
 
 ## Getting Started
 
@@ -15,7 +15,7 @@ The system combines a metadata pipeline (profiles the data), an entropy layer (m
 
 - [Pipeline](pipeline.md) — the 18-phase analysis pipeline and cold-start bootstrap
 - [Entropy](entropy.md) — uncertainty quantification across all metadata dimensions
-- [Architecture](architecture.md) — world model, teach overlay, snippet provenance, key design decisions
+- [Architecture](architecture.md) — operation model, teach overlay, snippet provenance, key design decisions
 
 ## Reference
 

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -213,7 +213,7 @@ add_source(name="accounting", path="/path/to/data")
   → look()                       # Understand the data
   → measure()                    # Check quality scores and readiness
   → why(target="table.col")      # Explain elevated entropy
-  → teach(type="concept", ...)   # Extend the world model
+  → teach(type="concept", ...)   # Extend the operation model
   → measure(target_phase="semantic")  # Re-run affected phase
   → query("total revenue?")      # Ask grounded questions
   → search_snippets(query="dso") # Find reusable SQL
@@ -226,7 +226,7 @@ add_source(name="accounting", path="/path/to/data")
 1. **`add_source`** — registers data. Pipeline runs automatically on first `begin_session`.
 2. **`begin_session`** — creates a workspace, picks a contract. Sources are sealed — no new sources during a session.
 3. **`look` / `measure` / `why`** — understand structure, quality, and root causes.
-4. **`teach`** — extend the world model: concepts, validations, metrics, cycles, type patterns, relationships, explanations. Config teaches trigger a targeted phase re-run.
+4. **`teach`** — extend the operation model: concepts, validations, metrics, cycles, type patterns, relationships, explanations. Config teaches trigger a targeted phase re-run.
 5. **`query` / `run_sql` / `search_snippets`** — answer questions. `query` reasons with context; `run_sql` executes directly; `search_snippets` discovers reusable patterns.
 6. **`end_session`** — archives the workspace.
 

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -1,0 +1,199 @@
+"""Assert that numbered claims in user-facing docs match source-of-truth counts.
+
+Source of truth:
+  - Phases: subclasses of BasePhase under src/dataraum/pipeline/phases/
+  - Detectors: distinct `detector_id = "..."` literals under src/dataraum/entropy/detectors/
+                (excluding the abstract "base" default)
+  - MCP tools: `name="..."` registrations in src/dataraum/mcp/server.py
+
+We scan a fixed set of doc files for numbered claims like
+`18 phases`, `17-phase pipeline`, `10 MCP tools`, `16 detectors`, etc., and
+fail if the number disagrees with the truth.
+
+Run locally:  uv run python scripts/check_doc_counts.py
+Used in CI by .github/workflows/release.yml (preflight job).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+DOC_FILES = [
+    "README.md",
+    "docs/index.md",
+    "docs/architecture.md",
+    "docs/pipeline.md",
+    "docs/entropy.md",
+    "docs/mcp-setup.md",
+    "docs/contributing.md",
+    "docs/cli.md",
+    "docs/configuration.md",
+    "docs/data-model.md",
+]
+
+# Each kind matches noun forms used in prose. Order matters for regex
+# alternation (longest first wins inside a group).
+KINDS: dict[str, tuple[str, ...]] = {
+    "phase": ("phases", "phase"),
+    "tool": ("MCP tools", "mcp tools", "tools", "tool"),
+    "detector": ("entropy detectors", "detectors", "detector"),
+}
+
+
+@dataclass(frozen=True)
+class Truth:
+    phase: int
+    tool: int
+    detector: int
+
+
+def count_phases() -> int:
+    pattern = re.compile(r"class\s+\w+Phase\s*\(\s*BasePhase\s*\)")
+    seen: set[str] = set()
+    for path in (ROOT / "src/dataraum/pipeline/phases").glob("*.py"):
+        for m in pattern.finditer(path.read_text(encoding="utf-8")):
+            seen.add(m.group(0))
+    return len(seen)
+
+
+def count_detectors() -> int:
+    pattern = re.compile(r'^\s*detector_id\s*=\s*"([a-z_]+)"', re.MULTILINE)
+    ids: set[str] = set()
+    for path in (ROOT / "src/dataraum/entropy/detectors").rglob("*.py"):
+        for m in pattern.finditer(path.read_text(encoding="utf-8")):
+            ids.add(m.group(1))
+    ids.discard("base")
+    return len(ids)
+
+
+def tool_names() -> set[str]:
+    server = (ROOT / "src/dataraum/mcp/server.py").read_text(encoding="utf-8")
+    return set(re.findall(r'\bname\s*=\s*"([a-z_]+)"', server))
+
+
+def count_tools() -> int:
+    return len(tool_names())
+
+
+def truth() -> Truth:
+    return Truth(phase=count_phases(), tool=count_tools(), detector=count_detectors())
+
+
+def _kind_alternation() -> str:
+    parts: list[str] = []
+    for forms in KINDS.values():
+        parts.extend(re.escape(f) for f in forms)
+    return "|".join(parts)
+
+
+def _classify(noun: str) -> str:
+    n = noun.lower()
+    for kind, forms in KINDS.items():
+        if any(n == f.lower() for f in forms):
+            return kind
+    raise AssertionError(f"unclassified noun: {noun!r}")
+
+
+@dataclass(frozen=True)
+class Claim:
+    file: str
+    line: int
+    text: str
+    number: int
+    kind: str
+
+
+def find_claims(path: Path) -> list[Claim]:
+    """Find numbered claims about phases/tools/detectors in `path`."""
+    alt = _kind_alternation()
+    # Match either "<n> <noun>" or "<n>-<singular-noun>"  (e.g., "17-phase").
+    pattern = re.compile(
+        rf"\b(?P<num>\d{{1,3}})(?:-|\s+)(?P<noun>{alt})\b",
+        re.IGNORECASE,
+    )
+    claims: list[Claim] = []
+    text = path.read_text(encoding="utf-8")
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for m in pattern.finditer(line):
+            num = int(m.group("num"))
+            kind = _classify(m.group("noun"))
+            claims.append(
+                Claim(
+                    file=str(path.relative_to(ROOT)),
+                    line=lineno,
+                    text=line.strip(),
+                    number=num,
+                    kind=kind,
+                )
+            )
+    return claims
+
+
+def check_readme_tool_table() -> list[str]:
+    """Assert every registered MCP tool appears as a row in the README tool table."""
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    registered = tool_names()
+    documented = set(re.findall(r"^\|\s*`([a-z_]+)`\s*\|", readme, re.MULTILINE))
+    missing = registered - documented
+    extra = documented - registered
+    errors: list[str] = []
+    if missing:
+        errors.append("README.md tool table is missing rows for: " + ", ".join(sorted(missing)))
+    if extra:
+        errors.append(
+            "README.md tool table lists tools not registered in the server: "
+            + ", ".join(sorted(extra))
+        )
+    return errors
+
+
+def check() -> int:
+    t = truth()
+    expected = {"phase": t.phase, "tool": t.tool, "detector": t.detector}
+
+    print(f"source of truth: {t.phase} phases, {t.tool} MCP tools, {t.detector} detectors")
+
+    mismatches: list[tuple[Claim, int]] = []
+    scanned = 0
+    for rel in DOC_FILES:
+        path = ROOT / rel
+        if not path.exists():
+            continue
+        scanned += 1
+        for claim in find_claims(path):
+            want = expected[claim.kind]
+            if claim.number != want:
+                mismatches.append((claim, want))
+
+    print(f"scanned {scanned} doc files")
+
+    table_errors = check_readme_tool_table()
+
+    if not mismatches and not table_errors:
+        print("OK — all numbered claims match and README tool table is complete.")
+        return 0
+
+    if mismatches:
+        print()
+        print(f"{len(mismatches)} stale claim(s):")
+        for claim, want in mismatches:
+            print(
+                f"  {claim.file}:{claim.line}  says {claim.number} {claim.kind}(s), truth is {want}"
+            )
+            print(f"    >> {claim.text}")
+
+    if table_errors:
+        print()
+        for err in table_errors:
+            print(f"  {err}")
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(check())

--- a/src/dataraum/analysis/typing/units.py
+++ b/src/dataraum/analysis/typing/units.py
@@ -151,9 +151,10 @@ def detect_unit(values: list[str], sample_size: int = 100) -> UnitDetectionResul
             # Try to parse as a unit expression
             quantity = ureg.parse_expression(str_value)
 
-            # Check if we got a Quantity (has units) vs just a number
-            if isinstance(quantity, ureg.Quantity):
-                # Extract unit as string
+            # Check if we got a Quantity with actual units. pint >= 0.25.3
+            # returns a dimensionless Quantity for bare numeric strings; treat
+            # those the same as "no unit detected".
+            if isinstance(quantity, ureg.Quantity) and not quantity.dimensionless:
                 unit_str = str(quantity.units)
                 detected_units[unit_str] = detected_units.get(unit_str, 0) + 1
                 successfully_parsed += 1

--- a/src/dataraum/mcp/server.py
+++ b/src/dataraum/mcp/server.py
@@ -188,7 +188,7 @@ def create_server(output_dir: Path | None = None) -> Server:
         "dataraum",
         instructions=(
             "DataRaum is a metadata context engine — it profiles data sources, "
-            "measures data quality (entropy), and builds a queryable world model "
+            "measures data quality (entropy), and builds a queryable operation model "
             "so you can answer analytical questions with grounded confidence.\n"
             "\n"
             "## Session lifecycle\n"
@@ -211,7 +211,7 @@ def create_server(output_dir: Path | None = None) -> Server:
             "**Returning** (begin_session returns has_pipeline_data: true):\n"
             "  begin_session → look (data is already profiled) → query / run_sql\n"
             "\n"
-            "**Teach + re-measure** (improving the world model):\n"
+            "**Teach + re-measure** (improving the operation model):\n"
             "  Bundle multiple teach calls first, then call measure once with "
             "target_phase to re-run the affected pipeline segment. Do not "
             "measure after every teach — batch them.\n"
@@ -226,7 +226,7 @@ def create_server(output_dir: Path | None = None) -> Server:
             "are blocked — call measure again to poll progress.\n"
             "- **why** — explain elevated entropy. Returns executable teach "
             "suggestions. Use after measure shows high scores.\n"
-            "- **teach** — extend the world model. The sole write tool. "
+            "- **teach** — extend the operation model. The sole write tool. "
             "Config teaches need a re-measure; metadata teaches apply immediately.\n"
             "- **query** — answer analytical questions via AI reasoning. "
             "Use when you have a business question. Tracks assumptions and "
@@ -587,7 +587,7 @@ def create_server(output_dir: Path | None = None) -> Server:
             Tool(
                 name="teach",
                 description=(
-                    "Extend the world model with domain knowledge. This is the "
+                    "Extend the operation model with domain knowledge. This is the "
                     "sole write tool — everything the system learns comes "
                     "through teach.\n\n"
                     "Two categories:\n\n"


### PR DESCRIPTION
## Summary

Two unrelated changes bundled into one PR (the docs work is mostly textual).

### 1. Prevent stale docs at release time
- **`scripts/check_doc_counts.py`** derives ground truth from source — phase classes under `pipeline/phases/`, `detector_id` literals under `entropy/detectors/`, MCP tool registrations in `mcp/server.py` — and asserts:
  - numbered claims like "18 phases", "10 MCP tools", "16 detectors" across `README.md` + 9 `docs/*.md` files
  - every registered MCP tool has a row in the README tool table
- **`.github/workflows/release.yml`** runs the check in the `preflight` job, so a tag with stale docs fails before publishing to PyPI / MCP-registry / GHCR.
- **`.claude/skills/release-prep/SKILL.md`** is the editorial counterpart for prose drift the count check can't see (CHANGELOG entry, command examples, links). Stops before tagging — the human still cuts the release.
- **CLAUDE.md** updated to route to `/release-prep`.
- **Drift the new check found and fixed in this PR**:
  - `README.md`: "17-phase pipeline" → "18-phase" (×2)
  - `docs/contributing.md`: "MCP server (7 tools)" → "10 tools"
  - `README.md` tool table: added missing rows for `why`, `teach`, `search_snippets`

### 2. Fix `detect_unit` against pint 0.25.3 (unblocks #73)
pint 0.25.3 changed `parse_expression` to return a dimensionless `Quantity` for bare numeric strings (previously returned `int`/`float`). Without a guard, plain numeric columns like `["123","456","789","1000"]` now get detected as unit `"dimensionless"`, which then surfaces as a DOUBLE candidate with `detected_unit="dimensionless"` in `inference.py`'s pint fallback — the opposite of what "no unit" should mean.

One-line fix at `src/dataraum/analysis/typing/units.py:157`: also require `not quantity.dimensionless` before recording a detected unit. Restores 0.25.2 semantics under both versions.

## Test plan

- [x] `uv run python scripts/check_doc_counts.py` — green
- [x] `uv run pytest tests/unit/analysis/typing/ -q` — 23/23 pass (including `test_returns_none_for_no_units`)
- [x] `ruff format --check` + `ruff check` + `mypy` on edited files — clean
- [ ] CI green on this PR
- [ ] After merge: dependabot rebases #73, CI on #73 goes green automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)