### PR TITLE
DAT-284 quick wins + session config-root leak fix

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,23 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-05-13: DAT-284 — Quick wins (Sonnet 4.6 + graph prompt enrichment + has_trend)
+
+### dataraum-eval
+- **Changed**: `config/llm/config.yaml` (Sonnet 4.5 → 4.6 on `default_model` + `balanced`), `src/dataraum/graphs/context.py` (`ColumnContext.has_trend` field + populate + emit), `config/llm/prompts/graph_sql_generation.yaml` (new `<temporal_signals>` section).
+- **Affects**: every LLM call routed through the `balanced` or `default` tier (semantic / column / validation / cycle / metric induction, graph SQL generation, enrichment, `why`). Graph SQL generation prompt now includes explicit `temporal_behavior` → aggregation guidance.
+- **Calibrate**: graph-agent metric set smoke. Key scenarios:
+  1. Existing finance metrics (DSO, gross_profit, current_ratio, etc.) still compute against `clean_eval` — no regression from added prompt context.
+  2. Metrics on tables with `temporal_behavior: point_in_time` annotated columns (e.g. balance-sheet items) should pick the `end_of_period` aggregation pattern more reliably.
+  3. Metric YAMLs whose declared `aggregation` conflicts with the column's `temporal_behavior` annotation — the LLM now explicitly trusts the column annotation and notes the override in assumptions.
+- **Notes**:
+  - **Model swap**: `claude-sonnet-4-5` → `claude-sonnet-4-6`. Sonnet 4.6 is the current generation; the short-form ID is canonical (no date suffix, matches existing Haiku pattern). Output format unchanged; structured-output prompts should remain stable but eval should validate.
+  - **`has_trend` surface**: added as `bool | None` on `ColumnContext`, populated from `TemporalColumnProfile.has_trend` (only set for DATE/TIMESTAMP/TIMESTAMPTZ columns by construction). Emitted in the metadata-document's per-column Notes column as `"Trending over time."` when truthy. No DB schema change — `has_trend` was already persisted.
+  - **`<temporal_signals>` prompt section**: bridges existing `temporal_behavior` semantic annotation to existing `<aggregation_types>` block. Includes conflict-resolution rule (trust the column annotation over a misaligned step aggregation). Explicitly notes that the `Trending over time.` note appears on the time-axis column and should be paired with the measure column's `temporal_behavior`.
+  - **`detected_granularity` (AC7 second half)**: already emitted at `src/dataraum/graphs/context.py:1008-1009` for `table.time_column`. No code change in this PR.
+  - **DAT-284 descope**: cold-start baseline + parallelism investigation (originally ACs 1, 3, 4, 5) split to **DAT-299** in v0.2.3. This PR is the quick-wins half (ACs 2, 6, 7, 8).
+- **Status**: pending
+
 ## 2026-05-12: DAT-290 — Single source per session, multi_source pattern retired
 
 ### dataraum-eval

--- a/config/llm/config.yaml
+++ b/config/llm/config.yaml
@@ -9,10 +9,10 @@ version: "1.0.0"
 providers:
   anthropic:
     api_key_env: ANTHROPIC_API_KEY
-    default_model: claude-sonnet-4-5
+    default_model: claude-sonnet-4-6
     models:
       fast: claude-haiku-4-5
-      balanced: claude-sonnet-4-5
+      balanced: claude-sonnet-4-6
 
 # Active provider
 active_provider: anthropic

--- a/config/llm/prompts/graph_sql_generation.yaml
+++ b/config/llm/prompts/graph_sql_generation.yaml
@@ -137,9 +137,12 @@ system_prompt: |
   trust `temporal_behavior` — pick the matching pattern and note the reason
   in the assumptions output.
 
-  When a column's notes column says "Trending over time." it indicates the
-  underlying time series shows directional movement. For period-comparison
-  metrics (growth rates, YoY deltas), this is the relevant time axis.
+  When a column's Notes column says "Trending over time." it indicates the
+  underlying time series shows directional movement. The note appears on
+  the time-axis column (e.g. `order_date`), not on the measure column —
+  pair it with the measure column's `temporal_behavior` to select the
+  correct aggregation. For period-comparison metrics (growth rates, YoY
+  deltas), this is the relevant time axis.
   </temporal_signals>
 
   Use the generate_sql tool to provide your structured response.

--- a/config/llm/prompts/graph_sql_generation.yaml
+++ b/config/llm/prompts/graph_sql_generation.yaml
@@ -119,6 +119,29 @@ system_prompt: |
   - "constant": Use the parameter value directly (SELECT <value> as value)
   </aggregation_types>
 
+  <temporal_signals>
+  When a column in <dataset_context> carries a `temporal_behavior` annotation,
+  treat it as a strong hint about which aggregation pattern is correct:
+
+  - `temporal_behavior: point_in_time` — stock measure (balance, count, level
+    at a moment). DO NOT SUM across periods. Use the `end_of_period` pattern:
+    filter to the latest period first, then aggregate within it. Examples:
+    accounts_receivable, inventory_value, cash_balance, headcount.
+
+  - `temporal_behavior: additive` — flow measure (activity within a period).
+    SUM across periods is correct. Examples: revenue, expenses, units_sold,
+    transactions_count.
+
+  If the graph step's declared `aggregation` conflicts with the column's
+  `temporal_behavior` (e.g. `aggregation: sum` on a `point_in_time` column),
+  trust `temporal_behavior` — pick the matching pattern and note the reason
+  in the assumptions output.
+
+  When a column's notes column says "Trending over time." it indicates the
+  underlying time series shows directional movement. For period-comparison
+  metrics (growth rates, YoY deltas), this is the relevant time axis.
+  </temporal_signals>
+
   Use the generate_sql tool to provide your structured response.
 
 # User prompt - provides graph and schema context

--- a/src/dataraum/graphs/context.py
+++ b/src/dataraum/graphs/context.py
@@ -57,6 +57,7 @@ class ColumnContext:
     # Temporal metrics
     is_stale: bool | None = None
     detected_granularity: str | None = None
+    has_trend: bool | None = None
 
     # Business metadata (from SemanticAnnotation)
     business_name: str | None = None
@@ -727,6 +728,7 @@ def build_execution_context(
                     detected_granularity=temp_profile.detected_granularity
                     if temp_profile
                     else None,
+                    has_trend=temp_profile.has_trend if temp_profile else None,
                     min_timestamp=str(temp_profile.min_timestamp)
                     if temp_profile and temp_profile.min_timestamp
                     else None,
@@ -1177,6 +1179,9 @@ def _build_column_notes(col: ColumnContext) -> str:
 
     if col.is_derived and col.derived_formula:
         notes.append(f"Derived: {col.derived_formula}.")
+
+    if col.has_trend:
+        notes.append("Trending over time.")
 
     # Entropy readiness indicator
     if col.entropy_scores:

--- a/src/dataraum/mcp/server.py
+++ b/src/dataraum/mcp/server.py
@@ -289,10 +289,17 @@ def create_server(output_dir: Path | None = None) -> Server:
 
         from sqlalchemy import delete
 
+        from dataraum.core.config import reset_config_root
         from dataraum.mcp.db_models import ActiveSession
 
         # Close session connections before moving files
         _close_session_manager()
+
+        # Clear the per-session config-root override that pipeline setup
+        # pushed via set_config_root(). Without this, a subsequent
+        # begin_session in the same process tries to read vertical config
+        # from the now-archived session path.
+        reset_config_root()
 
         session_dir = _session_dir_for(fingerprint)
         archive_dir = root_dir / "archive" / session_id

--- a/tests/unit/mcp/test_end_session.py
+++ b/tests/unit/mcp/test_end_session.py
@@ -186,6 +186,44 @@ class TestEndSessionFullFlow:
         assert (tmp_path / "workspace.db").exists()  # registry preserved
 
     @pytest.mark.asyncio
+    async def test_end_session_resets_config_root_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """end_session must clear the per-session config-root override.
+
+        Regression: pipeline setup pushes a session-local config root via
+        set_config_root(). If end_session doesn't reset it, the next
+        begin_session in the same process tries to read vertical config
+        from the now-archived session path and dies with
+        "Config directory not found".
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+        from dataraum.core.config import _get_config_root, set_config_root
+        from dataraum.mcp.server import create_server
+
+        server = create_server(output_dir=tmp_path)
+
+        csv = tmp_path / "data.csv"
+        csv.write_text("a,b\n1,2\n")
+
+        await self._call(server, "add_source", {"name": "src", "path": str(csv)})
+        await self._call(server, "begin_session", {"source": "src", "intent": "test"})
+
+        # Simulate what pipeline setup does — push a per-session config override.
+        # We do this directly instead of running the pipeline (too heavy for unit).
+        stale_session_config = tmp_path / "sessions" / "fakefp" / "config"
+        stale_session_config.mkdir(parents=True, exist_ok=True)
+        set_config_root(stale_session_config)
+        assert _get_config_root() == stale_session_config
+
+        await self._call(server, "end_session", {"outcome": "delivered", "summary": "ok"})
+
+        # After archive, the override is gone — the next begin_session must not
+        # see the archived path.
+        assert _get_config_root() != stale_session_config
+
+    @pytest.mark.asyncio
     async def test_end_session_without_outcome_rejected_by_schema(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

DAT-284 ships the quick-wins half (ACs 2, 6, 7, 8). The investigation half (cold-start baseline + LLM parallelism design) is split to DAT-299 under DAT-272 (v0.2.3). A pre-existing session-lifecycle bug was found during the smoke and fixed alongside.

**Three commits:**

1. **DAT-284 quick wins** — Sonnet 4.5 → 4.6 on `default_model` + `balanced`; `has_trend` field added to `ColumnContext` and emitted in `format_metadata_document` as "Trending over time."; new `<temporal_signals>` section in `graph_sql_generation.yaml` bridges `temporal_behavior` annotation to aggregation choice with explicit conflict-resolution rule.
2. **Senior-reviewer polish** — capitalized "Notes column" to match the markdown header; added clarifying sentence that the trend note appears on the time-axis column and should be paired with the measure column's `temporal_behavior`.
3. **Bonus: config-root leak fix** — `_archive_and_clear_active` now calls `reset_config_root()` symmetric to pipeline setup pushing the override. Without this, the next `begin_session` in the same MCP process dies with "Config directory not found" pointing at the just-archived path. Regression test in `tests/unit/mcp/test_end_session.py`.

## Smoke verified end-to-end

Ran on AdventureWorksLT (~3 min, 10 metrics induced for `_adhoc`) and on the finance fixture (10.4 min, dso/dpo/ebitda_margin/net_income computed). DSO `accounts_receivable` snippet correctly used `period = (SELECT MAX(period))` filter with `aggregation: end_of_period`, and the LLM recorded the reasoning as an explicit assumption:

> *"Accounts receivable is treated as a point-in-time (end_of_period) stock measure — only the latest period's balance is used, not summed across periods"* (confidence: 0.95)

That assumption text is exactly the grounding the new `<temporal_signals>` block was meant to surface.

## What's NOT in this PR

- Cold-start baseline + per-phase profiling + LLM parallelism design — DAT-299 (v0.2.3). The finance smoke confirmed `graph_execution` is the sequential-LLM bottleneck (4m43s on 4 metrics).
- DAT-269 periodic-vs-cumulative trial balance fix — still deferred to v0.2.3.

## Test plan

- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run mypy src/` — no issues in 241 source files
- [x] `uv run pytest tests/unit/mcp/test_end_session.py tests/unit/graphs/` — 116 passed (includes new `test_end_session_resets_config_root_override` regression test)
- [x] MCP smoke on AdventureWorksLT — Sonnet 4.6 + `has_trend` surface verified
- [x] MCP smoke on finance fixture — `<temporal_signals>` prompt section verified via DSO assumption text
- [ ] Eval-side calibration smoke on `clean_eval` — see `.claude/handoff.md` for the next `/accept` session

🤖 Generated with [Claude Code](https://claude.com/claude-code)