### PR TITLE
DAT-299: concurrent per-metric LLM dispatch in graph_execution

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,22 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-05-14: DAT-299 — Concurrent per-metric LLM dispatch in graph_execution
+
+### dataraum-eval
+- **Changed**: `src/dataraum/pipeline/phases/graph_execution_phase.py` (per-metric loop refactored: prep → execute (parallel/serial) → post), `src/dataraum/graphs/agent.py` (lock around `_code_cache`), `src/dataraum/core/connections.py` (docstring tightening only), `tests/unit/pipeline/test_graph_execution_dispatch.py` (new, 9 tests).
+- **Affects**: `measure` / `_run_pipeline` wall clock during cold-start runs. Per-metric `agent.execute()` calls now dispatch concurrently via `asyncio.to_thread` + `asyncio.gather` with a semaphore cap of 5. **No MCP response shape or schema changes.** Per-metric results (snippets written, snippet promotion via inspiration_snippet_id delete) are functionally unchanged.
+- **Calibrate**: graph-agent metric set wall-clock check on cold-start `clean_eval`. Expected: `graph_execution` phase drops from ~4-5 min sequential to ~60-90s on the same metric count. Snippets produced and metric correctness should be identical to pre-DAT-299 (the LLM is called the same number of times, just concurrently).
+- **Notes**:
+  - **Per-call resource isolation**: each parallel `agent.execute()` opens its own `manager.session_scope()` (auto-commit) and its own `manager.duckdb_cursor()`. The main `ctx.session` is untouched during parallel execution.
+  - **Snippet promotion** (deleting the inspiration snippet after metric success) stays sequential on the main session, post-gather.
+  - **Concurrency cap = 5** (hardcoded `_MAX_CONCURRENT_METRICS`). Sonnet 4.6 tier-3+ workspaces handle this easily; bump in the constant if profiling shows underutilization.
+  - **Free-threading note**: `GraphAgent._code_cache` is now guarded by a `threading.Lock` because the same agent instance is shared across N concurrent workers; under PYTHON_GIL=0 the check-then-set was a race.
+  - **Exception handling**: unexpected exceptions inside the parallel path (e.g. `session_scope` failing) are captured per-worker as `Result.fail(...)` — they no longer abort sibling workers via `asyncio.gather` propagation. The phase's failure semantics (`metrics_executed` / `metrics_failed` in `PhaseResult.outputs`, hard-fail when all failed) are unchanged.
+  - **Serial fallback**: when `ctx.manager is None` (unit tests with no real connection manager), the phase falls back to the previous sequential loop with shared session/cursor. No behavior change for that path.
+  - **Out of scope (deferred)**: cold-start induction parallelism across phases, AsyncAnthropic provider rewrite, configurable concurrency cap.
+- **Status**: pending
+
 ## 2026-05-13: DAT-273 — Post-DAT-266 audit (dead symbols + db column + re-exports)
 
 ### dataraum-eval

--- a/src/dataraum/core/connections.py
+++ b/src/dataraum/core/connections.py
@@ -292,16 +292,20 @@ class ConnectionManager:
 
     @contextmanager
     def duckdb_cursor(self) -> Generator[duckdb.DuckDBPyConnection]:
-        """Get a DuckDB cursor for read operations.
+        """Get an independent DuckDB cursor on the shared connection.
 
-        Cursors from the same connection are thread-safe for reads.
-        Use this for SELECT queries that don't modify data.
+        Each call returns a fresh cursor via `connection.cursor()`. Cursors
+        have independent statement state and are safe to use from separate
+        threads. Concurrent writes through multiple cursors are serialized
+        by DuckDB internally (DuckDB ≥ 0.10). The underlying connection
+        itself is shared — do not pass the cursor across threads, but each
+        thread holding its own cursor is supported.
 
         Yields:
-            DuckDB cursor for read operations
+            Independent DuckDB cursor on the shared connection.
 
         Raises:
-            RuntimeError: If manager not initialized
+            RuntimeError: If manager not initialized.
 
         Example:
             with manager.duckdb_cursor() as cursor:

--- a/src/dataraum/graphs/agent.py
+++ b/src/dataraum/graphs/agent.py
@@ -140,8 +140,14 @@ class GraphAgent(LLMFeature):
         prompt_renderer: PromptRenderer,
     ):
         """Initialize the graph agent."""
+        import threading
+
         super().__init__(config, provider, prompt_renderer)
         self._code_cache: dict[str, GeneratedCode] = {}  # In-memory cache
+        # Cache is read+written from concurrent graph_execution_phase workers
+        # under free-threading (Python 3.14t, PYTHON_GIL=0). The check-then-set
+        # pattern at lines 182/244 is not atomic, so guard with a lock.
+        self._code_cache_lock = threading.Lock()
 
     def execute(
         self,
@@ -178,8 +184,9 @@ class GraphAgent(LLMFeature):
         generated_code: GeneratedCode | None = None
 
         if not force_regenerate:
-            # Check in-memory cache
-            generated_code = self._code_cache.get(cache_key)
+            # Check in-memory cache (lock guards concurrent worker reads)
+            with self._code_cache_lock:
+                generated_code = self._code_cache.get(cache_key)
 
         if generated_code is None:
             # Check snippet library for cached individual steps
@@ -241,7 +248,8 @@ class GraphAgent(LLMFeature):
             if generated_code is None:
                 return Result.fail("Failed to generate or assemble SQL code")
 
-            self._code_cache[cache_key] = generated_code
+            with self._code_cache_lock:
+                self._code_cache[cache_key] = generated_code
 
         # Execute the generated SQL
         exec_result = self._execute_sql(generated_code, context, graph)

--- a/src/dataraum/pipeline/phases/graph_execution_phase.py
+++ b/src/dataraum/pipeline/phases/graph_execution_phase.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import delete, select
 
 from dataraum.core.logging import get_logger
+from dataraum.core.models.base import Result
 from dataraum.pipeline.base import PhaseContext, PhaseResult
 from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.registry import analysis_phase
@@ -40,7 +41,6 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from dataraum.core.connections import ConnectionManager
-    from dataraum.core.models.base import Result
     from dataraum.graphs.agent import ExecutionContext as _ExecutionContext
     from dataraum.graphs.agent import GraphAgent
     from dataraum.graphs.models import GraphExecution, TransformationGraph
@@ -346,9 +346,17 @@ def _execute_metrics_parallel(
             inspiration_id: str | None,
         ) -> MetricResult:
             async with sem:
-                result = await asyncio.to_thread(
-                    _execute_isolated, graph, hint_sql, manager, agent, source_id, table_ids
-                )
+                # Capture unexpected exceptions as Result.fail so one worker
+                # raising doesn't abort siblings via gather propagation.
+                # agent.execute already returns Result for the happy path —
+                # this catches infrastructure failures (session_scope raises,
+                # ExecutionContext.with_rich_context raises, etc.).
+                try:
+                    result = await asyncio.to_thread(
+                        _execute_isolated, graph, hint_sql, manager, agent, source_id, table_ids
+                    )
+                except Exception as exc:
+                    result = Result.fail(f"Unexpected error executing {graph_id}: {exc}")
             return graph_id, result, inspiration_id
 
         return await asyncio.gather(*(_run_one(gid, g, hsql, iid) for gid, g, hsql, iid in prep))

--- a/src/dataraum/pipeline/phases/graph_execution_phase.py
+++ b/src/dataraum/pipeline/phases/graph_execution_phase.py
@@ -7,10 +7,17 @@ agent. Results are stored as SQL snippets for reuse by query/search_snippets.
 Metrics with unresolvable direct field mappings are still attempted — the
 graph agent LLM infers from enriched views and dataset context.
 When no metric YAMLs exist, the phase completes with zero records.
+
+Per-metric LLM calls are independent — dispatched concurrently via
+asyncio.to_thread + gather when the phase context exposes a ConnectionManager
+(so we can give each parallel call its own SQLAlchemy session + DuckDB
+cursor). Falls back to a serial loop in unit tests where the manager isn't
+wired (shared session is fine without concurrency).
 """
 
 from __future__ import annotations
 
+import asyncio
 from types import ModuleType
 from typing import TYPE_CHECKING
 
@@ -24,8 +31,22 @@ from dataraum.storage import Table
 
 _log = get_logger(__name__)
 
+# Cap concurrent metric LLM calls. Sonnet 4.6 tier-3+ workspaces handle
+# 4000 RPM comfortably; 5 concurrent leaves headroom for other LLM phases.
+# Bump if profiling shows we're underutilizing capacity.
+_MAX_CONCURRENT_METRICS = 5
+
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+    from dataraum.core.connections import ConnectionManager
+    from dataraum.core.models.base import Result
+    from dataraum.graphs.agent import ExecutionContext as _ExecutionContext
+    from dataraum.graphs.agent import GraphAgent
+    from dataraum.graphs.models import GraphExecution, TransformationGraph
+
+    MetricPrep = tuple[str, TransformationGraph, str | None, str | None]
+    MetricResult = tuple[str, Result[GraphExecution], str | None]
 
 
 @analysis_phase
@@ -179,25 +200,23 @@ class GraphExecutionPhase(BasePhase):
             prompt_renderer=renderer,
         )
 
-        # Execute metrics sequentially
-        executed = 0
-        failed = 0
-
         # Resolve inspiration snippets for promotion path
         from dataraum.query.snippet_library import SnippetLibrary
 
         snippet_library = SnippetLibrary(ctx.session)
 
+        # ---- Prep (sequential, cheap reads on main session) ----
+        # Build a list of (graph_id, graph, hint_sql, inspiration_id) tuples.
+        # Logs advisory warnings for missing direct mappings and resolves
+        # inspiration snippet SQL up front so the parallel calls don't need
+        # to touch the main session.
+        prep: list[MetricPrep] = []
         for graph_id, graph in metrics.items():
-            # Collect required standard_fields from extract steps
             required_fields = [
                 step.source.standard_field
                 for step in graph.steps.values()
                 if step.source and step.source.standard_field
             ]
-
-            # Advisory check — log missing direct mappings but let the LLM
-            # infer from enriched views and dataset context (as it did pre-DAT-183).
             if required_fields:
                 _, missing = can_execute_metric(field_mappings, required_fields)
                 if missing:
@@ -207,7 +226,6 @@ class GraphExecutionPhase(BasePhase):
                         missing=missing,
                     )
 
-            # Resolve inspiration snippet SQL for promotion path
             hint_sql: str | None = None
             inspiration_id = graph.metadata.inspiration_snippet_id
             if inspiration_id:
@@ -220,8 +238,18 @@ class GraphExecutionPhase(BasePhase):
                         snippet_id=inspiration_id,
                     )
 
-            # Execute — LLM will infer missing field mappings
-            result = agent.execute(ctx.session, graph, exec_ctx, inspiration_sql=hint_sql)
+            prep.append((graph_id, graph, hint_sql, inspiration_id))
+
+        # ---- Execute (parallel when manager wired, serial fallback otherwise) ----
+        if ctx.manager is not None:
+            results = _execute_metrics_parallel(prep, ctx.manager, agent, ctx.source_id, table_ids)
+        else:
+            results = _execute_metrics_serial(prep, ctx.session, exec_ctx, agent)
+
+        # ---- Post (sequential, snippet promotion on main session) ----
+        executed = 0
+        failed = 0
+        for graph_id, result, inspiration_id in results:
             if result.success:
                 executed += 1
                 _log.info("metric_executed", graph_id=graph_id)
@@ -270,3 +298,85 @@ class GraphExecutionPhase(BasePhase):
             records_created=executed,
             summary=summary,
         )
+
+
+# ---------------------------------------------------------------------------
+# Per-metric dispatch
+# ---------------------------------------------------------------------------
+
+
+def _execute_metrics_serial(
+    prep: list[MetricPrep],
+    session: Session,
+    exec_ctx: _ExecutionContext,
+    agent: GraphAgent,
+) -> list[MetricResult]:
+    """Fallback path: shared session + cursor, sequential dispatch.
+
+    Used in unit tests where PhaseContext.manager is None.
+    """
+    out: list[MetricResult] = []
+    for graph_id, graph, hint_sql, inspiration_id in prep:
+        result = agent.execute(session, graph, exec_ctx, inspiration_sql=hint_sql)
+        out.append((graph_id, result, inspiration_id))
+    return out
+
+
+def _execute_metrics_parallel(
+    prep: list[MetricPrep],
+    manager: ConnectionManager,
+    agent: GraphAgent,
+    source_id: str,
+    table_ids: list[str],
+) -> list[MetricResult]:
+    """Concurrent path: per-call session + cursor, gathered via asyncio.
+
+    Each metric runs `agent.execute` on a thread with its own SQLAlchemy
+    session (auto-commit via session_scope) and its own DuckDB cursor.
+    A semaphore caps in-flight LLM calls to _MAX_CONCURRENT_METRICS.
+    """
+
+    async def _run_all() -> list[MetricResult]:
+        sem = asyncio.Semaphore(_MAX_CONCURRENT_METRICS)
+
+        async def _run_one(
+            graph_id: str,
+            graph: TransformationGraph,
+            hint_sql: str | None,
+            inspiration_id: str | None,
+        ) -> MetricResult:
+            async with sem:
+                result = await asyncio.to_thread(
+                    _execute_isolated, graph, hint_sql, manager, agent, source_id, table_ids
+                )
+            return graph_id, result, inspiration_id
+
+        return await asyncio.gather(*(_run_one(gid, g, hsql, iid) for gid, g, hsql, iid in prep))
+
+    return asyncio.run(_run_all())
+
+
+def _execute_isolated(
+    graph: TransformationGraph,
+    hint_sql: str | None,
+    manager: ConnectionManager,
+    agent: GraphAgent,
+    source_id: str,
+    table_ids: list[str],
+) -> Result[GraphExecution]:
+    """Run one metric with an isolated session + cursor pair.
+
+    Wraps the call in manager.session_scope() so writes commit on success
+    and roll back on exception. The DuckDB cursor is independent — the
+    underlying connection is shared with other cursors safely.
+    """
+    from dataraum.graphs.agent import ExecutionContext
+
+    with manager.session_scope() as session, manager.duckdb_cursor() as cursor:
+        exec_ctx = ExecutionContext.with_rich_context(
+            session=session,
+            duckdb_conn=cursor,
+            table_ids=table_ids,
+            schema_mapping_id=source_id,
+        )
+        return agent.execute(session, graph, exec_ctx, inspiration_sql=hint_sql)

--- a/tests/unit/pipeline/test_graph_execution_dispatch.py
+++ b/tests/unit/pipeline/test_graph_execution_dispatch.py
@@ -208,6 +208,54 @@ class TestExecuteMetricsParallel:
         out = gep._execute_metrics_parallel([], _stub_manager(), MagicMock(), "src", [])
         assert out == []
 
+    def test_exception_in_one_worker_does_not_abort_siblings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unexpected exception in one _execute_isolated must be captured as
+        Result.fail for that graph, with the other workers still completing.
+
+        Without the try/except guard around `to_thread`, asyncio.gather would
+        propagate the first exception and discard sibling results.
+        """
+        monkeypatch.setattr(
+            "dataraum.graphs.agent.ExecutionContext.with_rich_context",
+            classmethod(lambda cls, **kw: MagicMock()),
+        )
+
+        # Agent that raises on graph_id="bad", succeeds otherwise
+        class _FlakyAgent:
+            def execute(
+                self,
+                session: Any,
+                graph: _StubGraph,
+                context: Any,
+                inspiration_sql: str | None = None,
+            ) -> Result[str]:
+                if graph.graph_id == "bad":
+                    raise RuntimeError("simulated infra failure")
+                return Result.ok(graph.graph_id)
+
+        manager = _stub_manager()
+        prep = [
+            ("g0", _graph("g0"), None, None),
+            ("bad", _graph("bad"), None, "insp-bad"),
+            ("g2", _graph("g2"), None, None),
+        ]
+
+        out = gep._execute_metrics_parallel(prep, manager, _FlakyAgent(), "src", ["t"])
+
+        by_id = {gid: (r, iid) for gid, r, iid in out}
+        # All three results are present
+        assert set(by_id.keys()) == {"g0", "bad", "g2"}
+        # Siblings succeeded
+        assert by_id["g0"][0].success is True
+        assert by_id["g2"][0].success is True
+        # Failed worker returned a structured Result.fail (not a raised exception)
+        assert by_id["bad"][0].success is False
+        assert "simulated infra failure" in (by_id["bad"][0].error or "")
+        # inspiration_id passthrough preserved even on failure
+        assert by_id["bad"][1] == "insp-bad"
+
 
 # ---------------------------------------------------------------------------
 # Isolated dispatch (per-call session + cursor)
@@ -261,12 +309,15 @@ class TestExecuteIsolated:
 def test_asyncio_run_does_not_deadlock_with_nested_calls(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """`asyncio.run` from inside a synchronous phase must not deadlock.
+    """`asyncio.run` is safe only because callers are synchronous.
 
-    The pipeline scheduler calls phases synchronously (sometimes from
-    a ThreadPoolExecutor in the parallel-phases path). Each call into
-    `_execute_metrics_parallel` creates its own event loop via
-    `asyncio.run` — this test verifies that pattern works.
+    The pipeline scheduler calls phases synchronously — either from the
+    main thread or from a ThreadPoolExecutor worker (the parallel-phases
+    path). Neither has a running event loop, so `asyncio.run` inside the
+    phase creates a fresh loop without conflict. If a future async-native
+    scheduler ever calls this phase from inside an existing loop, this
+    pattern would raise `RuntimeError: This event loop is already
+    running` — that case is out of scope for v0.2.2 and tracked separately.
     """
     # Make sure no event loop is already running in this thread
     with pytest.raises(RuntimeError):

--- a/tests/unit/pipeline/test_graph_execution_dispatch.py
+++ b/tests/unit/pipeline/test_graph_execution_dispatch.py
@@ -1,0 +1,284 @@
+"""Unit tests for graph_execution_phase dispatch helpers (DAT-299).
+
+Focused on the three module-level helpers — `_execute_metrics_serial`,
+`_execute_metrics_parallel`, `_execute_isolated` — and the concurrency
+contract (semaphore cap, per-call resource isolation).
+
+The full phase `_run()` path is exercised by the integration suite and
+the MCP smoke; here we lock the dispatch contract in isolation.
+"""
+
+# Tests pass MagicMock / stub objects where the helpers expect concrete
+# GraphAgent / ConnectionManager / TransformationGraph instances. That's
+# the whole point of mocking — silence the arg-type complaints at module
+# level rather than per-call.
+# mypy: disable-error-code="arg-type, list-item, comparison-overlap"
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dataraum.core.models.base import Result
+from dataraum.pipeline.phases import graph_execution_phase as gep
+
+
+@dataclass
+class _StubGraph:
+    """Minimal graph stand-in. Only metadata.inspiration_snippet_id is read."""
+
+    graph_id: str
+    metadata: Any = None
+
+
+class _StubMetadata:
+    def __init__(self, inspiration_snippet_id: str | None = None) -> None:
+        self.inspiration_snippet_id = inspiration_snippet_id
+
+
+def _graph(gid: str, inspiration: str | None = None) -> _StubGraph:
+    return _StubGraph(graph_id=gid, metadata=_StubMetadata(inspiration))
+
+
+# ---------------------------------------------------------------------------
+# Serial fallback
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteMetricsSerial:
+    def test_dispatches_each_graph_in_order(self) -> None:
+        agent = MagicMock()
+        agent.execute.side_effect = [Result.ok(f"r{i}") for i in range(3)]
+        session = MagicMock()
+        exec_ctx = MagicMock()
+        prep = [
+            ("g0", _graph("g0"), None, None),
+            ("g1", _graph("g1"), "SELECT 1", "insp-1"),
+            ("g2", _graph("g2"), None, None),
+        ]
+
+        out = gep._execute_metrics_serial(prep, session, exec_ctx, agent)
+
+        assert [graph_id for graph_id, _, _ in out] == ["g0", "g1", "g2"]
+        assert [r.value for _, r, _ in out] == ["r0", "r1", "r2"]
+        assert [iid for _, _, iid in out] == [None, "insp-1", None]
+        assert agent.execute.call_count == 3
+        # All calls share the same session + exec_ctx (the fallback contract)
+        for call in agent.execute.call_args_list:
+            assert call.args[0] is session
+            assert call.args[2] is exec_ctx
+
+    def test_propagates_failure_per_graph(self) -> None:
+        agent = MagicMock()
+        agent.execute.side_effect = [
+            Result.ok("ok"),
+            Result.fail("nope"),
+        ]
+        out = gep._execute_metrics_serial(
+            [("g0", _graph("g0"), None, None), ("g1", _graph("g1"), None, None)],
+            MagicMock(),
+            MagicMock(),
+            agent,
+        )
+        assert out[0][1].success is True
+        assert out[1][1].success is False
+        assert out[1][1].error == "nope"
+
+
+# ---------------------------------------------------------------------------
+# Parallel dispatch
+# ---------------------------------------------------------------------------
+
+
+class _ConcurrencyTrackingAgent:
+    """Mock GraphAgent that records the peak in-flight count and per-call sleep."""
+
+    def __init__(self, sleep_seconds: float = 0.05) -> None:
+        self._sleep = sleep_seconds
+        self._lock = threading.Lock()
+        self.in_flight = 0
+        self.peak_in_flight = 0
+        self.calls: list[str] = []
+
+    def execute(
+        self,
+        session: Any,
+        graph: _StubGraph,
+        context: Any,
+        inspiration_sql: str | None = None,
+    ) -> Result[str]:
+        with self._lock:
+            self.in_flight += 1
+            self.peak_in_flight = max(self.peak_in_flight, self.in_flight)
+        # Hold the slot for sleep_seconds so concurrent calls overlap
+        time.sleep(self._sleep)
+        with self._lock:
+            self.in_flight -= 1
+        self.calls.append(graph.graph_id)
+        return Result.ok(graph.graph_id)
+
+
+def _stub_manager() -> MagicMock:
+    """ConnectionManager mock with session_scope + duckdb_cursor context managers."""
+    manager = MagicMock()
+    session = MagicMock()
+    cursor = MagicMock()
+
+    @contextmanager
+    def session_scope() -> Any:
+        yield session
+
+    @contextmanager
+    def duckdb_cursor() -> Any:
+        yield cursor
+
+    manager.session_scope = session_scope
+    manager.duckdb_cursor = duckdb_cursor
+    return manager
+
+
+class TestExecuteMetricsParallel:
+    def test_dispatches_all_graphs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Stub ExecutionContext.with_rich_context so we don't touch DB
+        monkeypatch.setattr(
+            "dataraum.graphs.agent.ExecutionContext.with_rich_context",
+            classmethod(lambda cls, **kw: MagicMock()),
+        )
+        agent = _ConcurrencyTrackingAgent(sleep_seconds=0.01)
+        manager = _stub_manager()
+        prep = [(f"g{i}", _graph(f"g{i}"), None, None) for i in range(7)]
+
+        out = gep._execute_metrics_parallel(prep, manager, agent, "src-1", ["t1"])
+
+        assert sorted(gid for gid, _, _ in out) == [f"g{i}" for i in range(7)]
+        assert all(r.success for _, r, _ in out)
+        assert sorted(agent.calls) == sorted(g.graph_id for _, g, _, _ in prep)
+
+    def test_concurrency_capped_at_max(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "dataraum.graphs.agent.ExecutionContext.with_rich_context",
+            classmethod(lambda cls, **kw: MagicMock()),
+        )
+        # Drop cap to a small number so the test runs fast and the assertion is sharp
+        monkeypatch.setattr(gep, "_MAX_CONCURRENT_METRICS", 2)
+        # Sleep long enough that contention is observable
+        agent = _ConcurrencyTrackingAgent(sleep_seconds=0.05)
+        manager = _stub_manager()
+        prep = [(f"g{i}", _graph(f"g{i}"), None, None) for i in range(8)]
+
+        gep._execute_metrics_parallel(prep, manager, agent, "src", ["t"])
+
+        # With cap=2 and 8 metrics, peak must not exceed 2
+        assert agent.peak_in_flight <= 2, f"Peak in-flight {agent.peak_in_flight} exceeded cap of 2"
+        # But should actually reach the cap (otherwise the test isn't proving anything)
+        assert agent.peak_in_flight == 2
+
+    def test_preserves_inspiration_id_passthrough(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "dataraum.graphs.agent.ExecutionContext.with_rich_context",
+            classmethod(lambda cls, **kw: MagicMock()),
+        )
+        agent = _ConcurrencyTrackingAgent(sleep_seconds=0.0)
+        manager = _stub_manager()
+        prep = [
+            ("g0", _graph("g0"), None, None),
+            ("g1", _graph("g1"), "SELECT 1", "insp-1"),
+            ("g2", _graph("g2"), None, "insp-2"),
+        ]
+
+        out = gep._execute_metrics_parallel(prep, manager, agent, "src", ["t"])
+
+        by_id = {gid: (r, iid) for gid, r, iid in out}
+        assert by_id["g0"][1] is None
+        assert by_id["g1"][1] == "insp-1"
+        assert by_id["g2"][1] == "insp-2"
+
+    def test_empty_prep_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "dataraum.graphs.agent.ExecutionContext.with_rich_context",
+            classmethod(lambda cls, **kw: MagicMock()),
+        )
+        out = gep._execute_metrics_parallel([], _stub_manager(), MagicMock(), "src", [])
+        assert out == []
+
+
+# ---------------------------------------------------------------------------
+# Isolated dispatch (per-call session + cursor)
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteIsolated:
+    def test_opens_fresh_session_and_cursor_per_call(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "dataraum.graphs.agent.ExecutionContext.with_rich_context",
+            classmethod(lambda cls, **kw: MagicMock(_session=kw.get("session"))),
+        )
+
+        manager = MagicMock()
+        opened_sessions: list[MagicMock] = []
+        opened_cursors: list[MagicMock] = []
+
+        @contextmanager
+        def session_scope() -> Any:
+            s = MagicMock(name=f"session-{len(opened_sessions)}")
+            opened_sessions.append(s)
+            yield s
+
+        @contextmanager
+        def duckdb_cursor() -> Any:
+            c = MagicMock(name=f"cursor-{len(opened_cursors)}")
+            opened_cursors.append(c)
+            yield c
+
+        manager.session_scope = session_scope
+        manager.duckdb_cursor = duckdb_cursor
+
+        agent = MagicMock()
+        agent.execute.return_value = Result.ok("done")
+
+        # Each call should open a fresh pair
+        gep._execute_isolated(_graph("g0"), None, manager, agent, "src", ["t"])
+        gep._execute_isolated(_graph("g1"), None, manager, agent, "src", ["t"])
+
+        assert len(opened_sessions) == 2
+        assert len(opened_cursors) == 2
+        assert opened_sessions[0] is not opened_sessions[1]
+        assert opened_cursors[0] is not opened_cursors[1]
+
+
+# ---------------------------------------------------------------------------
+# Async correctness sanity
+# ---------------------------------------------------------------------------
+
+
+def test_asyncio_run_does_not_deadlock_with_nested_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`asyncio.run` from inside a synchronous phase must not deadlock.
+
+    The pipeline scheduler calls phases synchronously (sometimes from
+    a ThreadPoolExecutor in the parallel-phases path). Each call into
+    `_execute_metrics_parallel` creates its own event loop via
+    `asyncio.run` — this test verifies that pattern works.
+    """
+    # Make sure no event loop is already running in this thread
+    with pytest.raises(RuntimeError):
+        asyncio.get_running_loop()
+
+    monkeypatch.setattr(
+        "dataraum.graphs.agent.ExecutionContext.with_rich_context",
+        classmethod(lambda cls, **kw: MagicMock()),
+    )
+    agent = _ConcurrencyTrackingAgent(sleep_seconds=0.0)
+    manager = _stub_manager()
+    prep = [(f"g{i}", _graph(f"g{i}"), None, None) for i in range(3)]
+
+    out = gep._execute_metrics_parallel(prep, manager, agent, "src", ["t"])
+    assert len(out) == 3


### PR DESCRIPTION
## Summary

The per-metric `agent.execute()` loop in `graph_execution_phase` was the dominant LLM-bound phase on cold-start runs (4m43s on the finance fixture with 4 metrics). The calls are independent and isolatable — this PR dispatches them concurrently via `asyncio.to_thread` + `asyncio.gather`, with a semaphore cap of 5 in-flight calls.

Expected wall-clock win on a finance cold-start: **~3 min** (4m43s → ~60-90s). Same LLM call count, same snippet content, same `PhaseResult.outputs` shape.

## Three commits

1. **`feat(pipeline)`** — refactor `_run()` into prep → execute → post. Three new module-level helpers (`_execute_metrics_serial`, `_execute_metrics_parallel`, `_execute_isolated`). Each parallel worker gets its own SQLAlchemy session (via `manager.session_scope()`, auto-commit) and its own DuckDB cursor (via `manager.duckdb_cursor()`). Main `ctx.session` untouched during parallel execution; snippet promotion (delete inspiration snippet) stays sequential on main session post-gather. Serial fallback when `ctx.manager` is `None` (unit tests). 8 unit tests covering both paths + semaphore cap assertion.

2. **`fix(graph-execution)`** — reviewer-driven hardening:
   - **Critical:** `asyncio.gather` without `return_exceptions=True` would propagate any uncaught exception from `_execute_isolated` (e.g. `session_scope` raises) and abort sibling workers. Fix: `try/except` around the `to_thread` call captures unexpected exceptions as `Result.fail(...)` per worker. New regression test `test_exception_in_one_worker_does_not_abort_siblings` with a `FlakyAgent` that raises on one graph_id.
   - **Free-threading race:** `GraphAgent._code_cache` is shared across N concurrent workers via the same agent instance. The check-then-set at `agent.py:182` / `:244` is not atomic under PYTHON_GIL=0 (3.14t, our production target). Added a `threading.Lock` guarding both ops.
   - Nits: DuckDB cursor docstring tightened to describe multi-cursor thread-safety accurately; `asyncio.run` test docstring clarified.

3. **`docs(handoff)`** — calibration entry for the next eval `/accept` session.

## Reviewer verdicts

- **senior-code-reviewer:** NEEDS WORK → both findings (Critical + Improvement) addressed in commit 2.
- **spec-compliance-reviewer:** APPROVE.

## What's NOT in this PR

- Cold-start induction parallelism across phases (semantic / validation / cycle / metric induction in separate phases) — requires scheduler-level changes, not surgical `to_thread`. Deferred.
- `AsyncAnthropic` provider rewrite — deferred to platform pivot when there's a second reason to touch the `LLMProvider` abstraction.
- Configurable concurrency cap — hardcoded at 5 (`_MAX_CONCURRENT_METRICS`).

See DAT-299 description (Jira) for the full narrowed-scope rationale and the list of "looked like batches but aren't" call sites.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (241 files)
- [x] `uv run pytest tests/unit/pipeline/test_graph_execution_dispatch.py` — 9/9 passed
- [x] `uv run pytest tests/integration/graphs tests/integration/pipeline` — 69/69 passed
- [ ] Eval-side wall-clock validation on `clean_eval` cold-start — recorded in `.claude/handoff.md` for the next `/accept` session
- [ ] Live MCP smoke on the finance fixture (optional, recommended before merge to confirm the expected 4m43s → ~60-90s drop in `graph_execution` phase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)