### PR TITLE
perf: raise concurrency caps across the analysis layer

### DIFF
--- a/config/phases/temporal.yaml
+++ b/config/phases/temporal.yaml
@@ -115,8 +115,10 @@ quality_issues:
 
 # Sampling and parallelism
 processing:
-  # Maximum parallel workers for column profiling
-  max_workers: 4
+  # Maximum parallel workers for column profiling. CPU-bound — under
+  # PYTHON_GIL=0 (3.14t) threads parallelize; under GIL they serialize
+  # but the cap is harmless.
+  max_workers: 8
   # Time series sampling (Bernoulli)
   sample_percent: 20.0
   min_sample_rows: 1000

--- a/src/dataraum/analysis/correlation/within_table/derived_columns.py
+++ b/src/dataraum/analysis/correlation/within_table/derived_columns.py
@@ -111,7 +111,7 @@ def detect_derived_columns(
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
     min_match_rate: float = 0.80,
-    max_workers: int = 4,
+    max_workers: int = 8,
 ) -> Result[list[DerivedColumn]]:
     """Detect columns that are arithmetic derivations of other columns.
 
@@ -279,7 +279,7 @@ def detect_enriched_derived_columns(
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
     min_match_rate: float = 0.80,
-    max_workers: int = 4,
+    max_workers: int = 8,
 ) -> Result[list[DerivedColumn]]:
     """Detect derived columns on an enriched view (fact + dimension columns).
 

--- a/src/dataraum/analysis/relationships/evaluator.py
+++ b/src/dataraum/analysis/relationships/evaluator.py
@@ -403,7 +403,7 @@ def evaluate_candidates(
     candidates: list[RelationshipCandidate],
     table_paths: dict[str, str],
     duckdb_conn: duckdb.DuckDBPyConnection,
-    max_workers: int = 4,
+    max_workers: int = 8,
 ) -> list[RelationshipCandidate]:
     """Evaluate all relationship candidates with quality metrics.
 

--- a/src/dataraum/analysis/relationships/joins.py
+++ b/src/dataraum/analysis/relationships/joins.py
@@ -616,7 +616,7 @@ def find_join_columns(
     columns2: list[str],
     min_score: float = 0.3,
     min_confidence: float = MIN_CONFIDENCE_THRESHOLD,
-    max_workers: int = 4,
+    max_workers: int = 8,
     column_types1: dict[str, str | None] | None = None,
     column_types2: dict[str, str | None] | None = None,
 ) -> list[dict[str, Any]]:

--- a/src/dataraum/analysis/statistics/profiler.py
+++ b/src/dataraum/analysis/statistics/profiler.py
@@ -269,7 +269,7 @@ def profile_statistics(
     table_id: str,
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
-    max_workers: int = 4,
+    max_workers: int = 8,
     config: dict[str, Any] | None = None,
 ) -> Result[StatisticsProfileResult]:
     """Profile typed data to compute all row-based statistics.

--- a/src/dataraum/analysis/statistics/quality.py
+++ b/src/dataraum/analysis/statistics/quality.py
@@ -390,7 +390,7 @@ def assess_statistical_quality(
     table_id: str,
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
-    max_workers: int = 4,
+    max_workers: int = 8,
     exclude_outlier_columns: set[str] | None = None,
 ) -> Result[list[StatisticalQualityResult]]:
     """Assess statistical quality for all numeric columns in a table.

--- a/src/dataraum/pipeline/phases/graph_execution_phase.py
+++ b/src/dataraum/pipeline/phases/graph_execution_phase.py
@@ -33,9 +33,10 @@ from dataraum.storage import Table
 _log = get_logger(__name__)
 
 # Cap concurrent metric LLM calls. Sonnet 4.6 tier-3+ workspaces handle
-# 4000 RPM comfortably; 5 concurrent leaves headroom for other LLM phases.
-# Bump if profiling shows we're underutilizing capacity.
-_MAX_CONCURRENT_METRICS = 5
+# 4000 RPM (~67 RPS) comfortably; with ~30-60s LLM latencies, 10 concurrent
+# is ~10 RPS at peak — well under the limit. Smoke at cap=5 showed 12
+# metrics fit in 3 waves (~157s); cap=10 should collapse to ~1.2 waves.
+_MAX_CONCURRENT_METRICS = 10
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session


### PR DESCRIPTION
## Summary

Two small tuning changes bundled per the new Light/Heavy rule. Both safe, both unlock real wall-clock wins on cold-start runs.

## Changes (7 files, +14/-11)

**1. `_MAX_CONCURRENT_METRICS` in graph_execution_phase: 5 → 10**

DAT-299 (PR #107, just merged) shipped at cap=5 and the finance smoke showed 12 metrics fit into ~3 waves at ~157s. At cap=10 the wave count collapses to ~1.2, so we'd expect graph_execution to drop from **~157s → ~75-90s** on the same fixture. Sonnet 4.6 tier-3+ workspaces handle 4000 RPM (~67 RPS) and we're at ~10 RPS at peak with 10 concurrent ~30-60s calls — comfortably under the limit.

**2. Analysis ThreadPoolExecutors: default `max_workers` 4 → 8**

Bumped across the seven CPU-bound thread pools:
- `config/phases/temporal.yaml` (processing.max_workers)
- `src/dataraum/analysis/relationships/evaluator.py`
- `src/dataraum/analysis/relationships/joins.py`
- `src/dataraum/analysis/statistics/quality.py`
- `src/dataraum/analysis/statistics/profiler.py`
- `src/dataraum/analysis/correlation/within_table/derived_columns.py` (2 functions)

Helps only under `PYTHON_GIL=0` (the 3.14t production target — `.python-version`, `smithery.yaml`, MCP client configs all set this). Under standard GIL the threads serialize on CPU anyway, so **no regression risk** on GIL'd interpreters (CI, Dockerfile slim image).

No callers in the codebase pass `max_workers` explicitly, so the default-change is the right surface — single point of control.

## Not in this PR

`scheduler.py:260` cross-phase cap (`min(len(phase_names), 4)`) intentionally left alone — compositional with the per-phase caps, raising it could multiply worker counts unpredictably.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (241 files)
- [x] `uv run pytest --testmon tests/unit` — 24 affected tests passed
- [ ] Smoke against finance fixture to confirm the expected `graph_execution` drop (~157s → ~75-90s). Optional pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)