### PR TITLE
DAT-324: L5 — add_source flow + config paths adapted for container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,9 @@ POSTGRES_PASSWORD=dataraum
 POSTGRES_DB=dataraum
 DUCKLAKE_CATALOG_DB=dataraum_lake_catalog
 
+# Host directory bind-mounted at /var/lib/dataraum/sources in the container.
+# Drop your source yaml + data files here (CSV/Parquet/JSON, DAT-286 recipe yaml).
+HOST_SOURCES_DIR=./sources
+
 # LLM provider (required by the engine; placeholder for now — set before L2+ work)
 ANTHROPIC_API_KEY=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,11 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       DUCKLAKE_CATALOG_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${DUCKLAKE_CATALOG_DB}
       DUCKLAKE_DATA_PATH: /var/lib/dataraum/lake
+      DATARAUM_CONFIG_PATH: /opt/dataraum/config
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     volumes:
       - dataraum_lake:/var/lib/dataraum/lake
+      - ${HOST_SOURCES_DIR:-./sources}:/var/lib/dataraum/sources
     ports:
       - "127.0.0.1:8000:8000"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     volumes:
       - dataraum_lake:/var/lib/dataraum/lake
-      - ${HOST_SOURCES_DIR:-./sources}:/var/lib/dataraum/sources
+      - ${HOST_SOURCES_DIR:-./sources}:/var/lib/dataraum/sources:ro
     ports:
       - "127.0.0.1:8000:8000"
     healthcheck:

--- a/docker/control-plane.Dockerfile
+++ b/docker/control-plane.Dockerfile
@@ -20,13 +20,17 @@ RUN uv sync --no-dev --frozen --no-install-project
 
 # Now copy the project itself and re-sync to install the package
 COPY src/ src/
-COPY config/ config/
+COPY config/ /opt/dataraum/config/
 RUN uv sync --no-dev --frozen
+
+# Engine config root — load verticals/ontologies/prompts/llm configs from the
+# baked-in /opt/dataraum/config/ rather than auto-detecting via package layout.
+ENV DATARAUM_CONFIG_PATH=/opt/dataraum/config
 
 # Non-root runtime user; own the data dirs so named volumes initialize correctly.
 RUN groupadd -r dataraum && useradd -r -g dataraum -u 1001 dataraum && \
     mkdir -p /var/lib/dataraum/lake /var/lib/dataraum/sources && \
-    chown -R dataraum:dataraum /app /var/lib/dataraum
+    chown -R dataraum:dataraum /app /opt/dataraum /var/lib/dataraum
 
 USER dataraum
 

--- a/docs/db-sources.md
+++ b/docs/db-sources.md
@@ -136,10 +136,10 @@ Three things to know:
 
 ### 4. Register the source
 
-Save a recipe pointing at the tables you want. A starter against AdventureWorksLT — drop it at `~/.dataraum/recipes/aw.yaml`:
+Save a recipe pointing at the tables you want. A starter against AdventureWorksLT — drop it at `./sources/aw.yaml` on the host (which is bind-mounted at `/var/lib/dataraum/sources/aw.yaml` in the container):
 
 ```yaml
-# ~/.dataraum/recipes/aw.yaml
+# ./sources/aw.yaml  →  /var/lib/dataraum/sources/aw.yaml (in container)
 backend: mssql
 tables:
   customers:
@@ -155,16 +155,16 @@ tables:
 Then:
 
 ```python
-# Via MCP tool from Claude — bare name resolves against the recipes home
+# Via MCP tool from Claude — bare name resolves against SOURCES_DIR
 add_source(path="aw", name="aw")
 begin_session(source="aw", intent="...")  # session is bound to this one source
 measure  # runs the pipeline — extracts via the recipe and analyzes
 ```
 
-Or pass an absolute path if you keep the recipe elsewhere:
+Or pass an absolute container path if you keep the recipe outside the bind-mount:
 
 ```python
-add_source(path="/path/to/my/aw.yaml", name="aw")
+add_source(path="/some/other/container/path/aw.yaml", name="aw")
 ```
 
 > **Identifier quoting.** Recipe SQL is parsed by DuckDB before forwarding to MSSQL. If a column or table has a space in its name (e.g. AdventureWorksLT's `dbo.BuildVersion."Database Version"`), quote it with **double quotes**, not square brackets.

--- a/docs/db-sources.md
+++ b/docs/db-sources.md
@@ -2,17 +2,17 @@
 
 DataRaum can analyze data sitting in a relational database via DuckDB's database extensions. Today: **Microsoft SQL Server** (other backends arrive in a follow-up release).
 
-You declare *what* to extract in a yaml **recipe**. The recipe is per-user state — it lives under `~/.dataraum/recipes/` alongside your DataRaum workspace, not in a project repo. Credentials live in `.env` (or in the container env), never in the yaml. At session time, DataRaum reads the recipe, runs the SELECTs against your database, and materializes the results as raw tables — the rest of the pipeline doesn't know or care that the source was a database.
+You declare *what* to extract in a yaml **recipe**. The recipe is per-user state — it lives under `/var/lib/dataraum/sources/` (volume-mounted in the container), not in a project repo. Credentials live in `.env` (or in the container env), never in the yaml. At session time, DataRaum reads the recipe, runs the SELECTs against your database, and materializes the results as raw tables — the rest of the pipeline doesn't know or care that the source was a database.
 
 ## How it works
 
 ```
-~/.dataraum/recipes/erp.yaml    .env / container env
-┌─────────────────────────┐     ┌─────────────────────────┐
-│ backend: mssql          │     │ DATARAUM_ERP_URL=mssql..│
-│ tables:                 │     └─────────────────────────┘
-│   invoices:             │                 │
-│     sql: ...            │                 ▼
+/var/lib/dataraum/sources/erp.yaml   .env / container env
+┌─────────────────────────┐          ┌─────────────────────────┐
+│ backend: mssql          │          │ DATARAUM_ERP_URL=mssql..│
+│ tables:                 │          └─────────────────────────┘
+│   invoices:             │                      │
+│     sql: ...            │                      ▼
 │   customers:            │   ┌─────────────────────────────────┐
 │     sql: ...            ├──▶│  add_source(path="erp",         │
 └─────────────────────────┘   │              name="erp")        │
@@ -29,21 +29,21 @@ The recipe name (`erp`) does triple duty: source identity, credential lookup key
 
 ## Where recipes live
 
-By convention, recipes live under `~/.dataraum/recipes/` (override the home directory with `DATARAUM_HOME`). DataRaum resolves the `path` argument in this order:
+Recipes live under `/var/lib/dataraum/sources/` inside the container — bind-mounted from the host directory you pick via `HOST_SOURCES_DIR` in `.env` (default `./sources`). DataRaum resolves the `path` argument in this order:
 
 | You pass | DataRaum looks for | Notes |
 |---|---|---|
 | `/abs/path/erp.yaml` | The absolute path | Full flexibility — any location |
 | `./local/erp.yaml` | The relative path from cwd | If it exists, used directly |
-| `erp.yaml` | First `./erp.yaml`, then `~/.dataraum/recipes/erp.yaml` | Filename — recipes home is the fallback |
-| `erp` | `~/.dataraum/recipes/erp.yaml`, then `…/erp.yml` | Bare name — `.yaml` and `.yml` tried in order |
+| `erp.yaml` | First `./erp.yaml`, then `/var/lib/dataraum/sources/erp.yaml` | Filename — `SOURCES_DIR` is the fallback |
+| `erp` | `/var/lib/dataraum/sources/erp.yaml`, then `…/erp.yml` | Bare name — `.yaml` and `.yml` tried in order |
 
-Only recipe-shaped names (`.yaml`/`.yml` or no extension) get the recipes-home fallback. File paths like `data.csv` are taken at face value — DataRaum doesn't hunt for them in `~/.dataraum/recipes/`.
+Only recipe-shaped names (`.yaml`/`.yml` or no extension) get the `SOURCES_DIR` fallback. File paths like `data.csv` are taken at face value — DataRaum doesn't hunt for them under `/var/lib/dataraum/sources/`.
 
 ## Recipe yaml
 
 ```yaml
-# ~/.dataraum/recipes/erp.yaml
+# /var/lib/dataraum/sources/erp.yaml
 backend: mssql              # mssql (today); postgres/mysql/sqlite follow
 tables:
   invoices:
@@ -67,17 +67,14 @@ Rules:
 
 ## Credentials
 
-DataRaum resolves a connection URL from the environment via the existing `CredentialChain`:
+DataRaum resolves a connection URL from the environment via the
+`CredentialChain` — `DATARAUM_{NAME}_URL` environment variable (set in
+`.env`, the container's env, or the host shell).
 
-1. `DATARAUM_{NAME}_URL` environment variable (set in `.env` or the container's env)
-2. Failing that, `~/.dataraum/credentials.yaml`:
-
-   ```yaml
-   sources:
-     erp: "mssql://reader:pwd@erp.internal:1433/Finance?TrustServerCertificate=yes"
-   ```
-
-`{NAME}` is the source name passed to `add_source` — uppercased. So `add_source(name="erp", ...)` → `DATARAUM_ERP_URL`. Credentials are **never** persisted in workspace.db, never appear in MCP responses, and never go into the recipe yaml.
+`{NAME}` is the source name passed to `add_source` — uppercased. So
+`add_source(name="erp", ...)` → `DATARAUM_ERP_URL`. Credentials are
+**never** persisted in workspace.db, never appear in MCP responses, and
+never go into the recipe yaml.
 
 ## Setting up MS SQL Server
 
@@ -192,7 +189,7 @@ Anything that can fail is surfaced verbatim through DataRaum's `phases_failed` s
 | Failure | Phase | Example message |
 |---|---|---|
 | Recipe yaml malformed | `import` | `Recipe sources/erp.yaml invalid: Table 'invoices' has empty or missing 'sql:' field.` |
-| Credentials missing | `import` | `No credentials found for database source 'erp'. Set DATARAUM_ERP_URL in .env or add an entry to ~/.dataraum/credentials.yaml.` |
+| Credentials missing | `import` | `No credentials found for database source 'erp'. Set DATARAUM_ERP_URL in the environment (via .env or the docker-compose environment).` |
 | Extension install/load fails | `import` | `DuckDB extension 'mssql' failed to install/load: <verbatim>` |
 | Connection / TLS fails | `import` | `ATTACH failed for mssql source: Connection failed to host:1433: ...` |
 | SELECT errors | `import` | `Recipe table 'invoices' SELECT failed: Invalid column 'invoice_dat'` |

--- a/sources/.gitignore
+++ b/sources/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/dataraum/core/credentials.py
+++ b/src/dataraum/core/credentials.py
@@ -1,29 +1,23 @@
-"""Credential resolution chain for data source connections.
+"""Credential resolution for database source connections.
 
-Resolves connection URLs by source name through an ordered chain of providers.
-First match wins. Secrets are never serialized to MCP responses or logged.
+Resolves connection URLs by source name from the
+``DATARAUM_{SOURCE_NAME}_URL`` environment variable. Secrets are never
+serialized to MCP responses or logged.
 
 Resolution order:
-1. Environment variable: DATARAUM_{SOURCE_NAME}_URL
-2. Credentials file: ~/.dataraum/credentials.yaml → sources.{name}
-3. Not found → return None (caller fails loud)
+
+1. Environment variable: ``DATARAUM_{SOURCE_NAME}_URL``
+2. Not found → return ``None`` (caller fails loud)
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import stat
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Protocol
 
-import yaml
-
 _log = logging.getLogger(__name__)
-
-_CREDENTIALS_FILE = "credentials.yaml"
-_DESIRED_FILE_MODE = 0o600
 
 
 class CredentialProvider(Protocol):
@@ -39,11 +33,11 @@ class ResolvedCredential:
     """A resolved connection URL. Never serialized to MCP responses."""
 
     url: str
-    source: str  # "env" | "credentials_file"
+    source: str  # "env"
 
 
 class EnvProvider:
-    """Resolve connection URL from DATARAUM_{SOURCE_NAME}_URL environment variable."""
+    """Resolve connection URL from ``DATARAUM_{SOURCE_NAME}_URL`` environment variable."""
 
     def resolve(self, source_name: str) -> ResolvedCredential | None:
         env_key = f"DATARAUM_{source_name.upper()}_URL"
@@ -53,81 +47,16 @@ class EnvProvider:
         return None
 
 
-class FileProvider:
-    """Resolve connection URL from a YAML credentials file.
-
-    File format:
-        sources:
-          accounting: "postgres://reader:secret@localhost:5432/accounting"
-          erp: "mysql://user:pass@erp.internal/production"
-    """
-
-    def __init__(self, path: Path) -> None:
-        self._path = path
-
-    @property
-    def path(self) -> Path:
-        return self._path
-
-    def resolve(self, source_name: str) -> ResolvedCredential | None:
-        if not self._path.exists():
-            return None
-
-        self._check_permissions()
-
-        with open(self._path) as f:
-            config = yaml.safe_load(f)
-
-        if not isinstance(config, dict):
-            return None
-
-        sources = config.get("sources", {})
-        if not isinstance(sources, dict):
-            return None
-
-        url = sources.get(source_name)
-        if url and isinstance(url, str):
-            return ResolvedCredential(url=url, source="credentials_file")
-        return None
-
-    def _check_permissions(self) -> None:
-        """Warn if credentials file has overly permissive permissions."""
-        try:
-            file_stat = self._path.stat()
-            mode = stat.S_IMODE(file_stat.st_mode)
-            if mode & (stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH):
-                _log.warning(
-                    "Credentials file %s has permissions %o. "
-                    "Recommended: %o (owner-only read/write).",
-                    self._path,
-                    mode,
-                    _DESIRED_FILE_MODE,
-                )
-        except OSError:
-            pass
-
-
 class CredentialChain:
     """Resolve connection URLs through an ordered chain of providers.
 
-    Environment variables override the credentials file, allowing
-    per-session overrides without editing persistent config.
+    Currently env-only. The chain shape is retained so additional providers
+    (e.g. a future secrets-manager backend) can be added without touching
+    callers.
     """
 
-    def __init__(self, credentials_dir: Path | None = None) -> None:
-        self._credentials_dir = credentials_dir or Path.home() / ".dataraum"
-        self._providers: list[CredentialProvider] = [
-            EnvProvider(),
-            FileProvider(self._credentials_dir / _CREDENTIALS_FILE),
-        ]
-
-    @property
-    def credentials_dir(self) -> Path:
-        return self._credentials_dir
-
-    @property
-    def credentials_file(self) -> Path:
-        return self._credentials_dir / _CREDENTIALS_FILE
+    def __init__(self) -> None:
+        self._providers: list[CredentialProvider] = [EnvProvider()]
 
     def resolve(self, source_name: str) -> ResolvedCredential | None:
         """Walk the provider chain. Return first match or None."""

--- a/src/dataraum/core/paths.py
+++ b/src/dataraum/core/paths.py
@@ -1,0 +1,24 @@
+"""Container filesystem path conventions.
+
+Two roots, fixed by the DAT-294 Minimum-Port Plan container shell:
+
+- ``SOURCES_DIR`` — user-supplied source yaml (DAT-286 recipes). Volume-mounted
+  in ``docker-compose.yml`` from ``${HOST_SOURCES_DIR:-./sources}``.
+- ``CONFIG_DIR`` — repo's ``config/`` directory (verticals, ontologies,
+  prompts, llm configs). Baked into the image at build time via Dockerfile
+  ``COPY config/ /opt/dataraum/config/``.
+
+These are container-absolute paths. On the host (non-container runs) callers
+still pass explicit paths or rely on the existing
+``DATARAUM_CONFIG_PATH`` env-var override in :mod:`dataraum.core.config`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SOURCES_DIR: Path = Path("/var/lib/dataraum/sources")
+"""User-supplied source yaml (DAT-286 recipes). Volume-mounted."""
+
+CONFIG_DIR: Path = Path("/opt/dataraum/config")
+"""Baked-in repo config — verticals, ontologies, prompts, llm configs."""

--- a/src/dataraum/mcp/server.py
+++ b/src/dataraum/mcp/server.py
@@ -110,8 +110,12 @@ def _make_task_event_callback(
 def _resolve_root_dir() -> Path:
     """Resolve the DataRaum root directory.
 
-    The root contains workspace/, archive/, and credentials.yaml.
-    Reads DATARAUM_HOME env var, falling back to ~/.dataraum/.
+    The root contains ``workspace/``, ``archive/``, and ``logs/``.
+    Reads DATARAUM_HOME env var, falling back to ``~/.dataraum/``.
+
+    Used by the stdio MCP entry for workspace/log/archive resolution
+    only. Source registration (see ``_add_source``) goes through the
+    container-fixed :data:`dataraum.core.paths.SOURCES_DIR` instead.
     """
     home = os.environ.get("DATARAUM_HOME")
     if home:
@@ -412,6 +416,8 @@ def create_server(output_dir: Path | None = None) -> Server:
     @server.list_tools()  # type: ignore[no-untyped-call, untyped-decorator]
     async def list_tools() -> list[Tool]:
         """List available tools."""
+        from dataraum.core.paths import SOURCES_DIR
+
         return [
             # --- Orientation ---
             Tool(
@@ -918,12 +924,13 @@ def create_server(output_dir: Path | None = None) -> Server:
                                 "(mssql today; other backends arrive in a follow-up "
                                 "release) and named SELECT queries; credentials are "
                                 "resolved from DATARAUM_{NAME}_URL in the "
-                                "environment. Recipes can be referenced by a bare "
-                                "name (e.g. 'erp') or filename — DataRaum searches "
-                                "/var/lib/dataraum/sources/ as a fallback. "
-                                "Data files are mounted at /var/lib/dataraum/sources/ "
-                                "in the container; try that path or a filename under it "
-                                "if the user hasn't specified one."
+                                f"environment. Recipes can be referenced by a bare "
+                                f"name (e.g. 'erp') or filename — DataRaum searches "
+                                f"{SOURCES_DIR} as a fallback. In the container, "
+                                f"that directory is bind-mounted from the host; "
+                                "try a filename under it if the user hasn't specified "
+                                "a path. For non-container installs, pass an explicit "
+                                "absolute path."
                             ),
                         },
                     },

--- a/src/dataraum/mcp/server.py
+++ b/src/dataraum/mcp/server.py
@@ -920,9 +920,10 @@ def create_server(output_dir: Path | None = None) -> Server:
                                 "resolved from DATARAUM_{NAME}_URL in the "
                                 "environment. Recipes can be referenced by a bare "
                                 "name (e.g. 'erp') or filename — DataRaum searches "
-                                "~/.dataraum/recipes/ as a fallback. "
-                                "In Docker, data is mounted at /sources — try /sources "
-                                "or /sources/<filename> if the user hasn't specified a path."
+                                "/var/lib/dataraum/sources/ as a fallback. "
+                                "Data files are mounted at /var/lib/dataraum/sources/ "
+                                "in the container; try that path or a filename under it "
+                                "if the user hasn't specified one."
                             ),
                         },
                     },
@@ -3422,7 +3423,7 @@ def _add_source(
     """Register a new data source in the workspace registry.
 
     Dispatch by file extension after resolving the path (bare names
-    resolve against ~/.dataraum/recipes/):
+    resolve against :data:`dataraum.core.paths.SOURCES_DIR`):
 
     - `.yaml` / `.yml` → recipe loader (parses + persists the recipe;
       no database connection at registration time — credentials and
@@ -3438,6 +3439,7 @@ def _add_source(
     from sqlalchemy import select
 
     from dataraum.core.credentials import CredentialChain
+    from dataraum.core.paths import SOURCES_DIR
     from dataraum.sources.manager import (
         RECIPE_EXTENSIONS,
         SourceManager,
@@ -3451,22 +3453,22 @@ def _add_source(
         return {
             "error": (
                 "Provide 'path' — a file path, directory, or a recipe yaml. "
-                "Recipe paths are also looked up under ~/.dataraum/recipes/ "
-                "by name (e.g. path='erp' resolves to ~/.dataraum/recipes/erp.yaml)."
+                f"Recipe paths are also looked up under {SOURCES_DIR} "
+                f"by name (e.g. path='erp' resolves to {SOURCES_DIR}/erp.yaml)."
             )
         }
 
-    root = _resolve_root_dir()
-    resolved = resolve_source_path(path, root)
+    resolved = resolve_source_path(path, SOURCES_DIR)
     if resolved is None:
         suffix = Path(path).suffix.lower()
         # Direct paths get a "not found" error; recipe-shaped names also
-        # surface the recipes/ candidates that were tried.
+        # surface the SOURCES_DIR candidates that were tried.
         if not suffix or suffix in RECIPE_EXTENSIONS:
             return {
                 "error": (
                     f"Source path not found: {path}. Looked for the path as-given, "
-                    f"and under {root}/recipes/ (with .yaml/.yml suffixes when none was given)."
+                    f"and under {SOURCES_DIR} "
+                    "(with .yaml/.yml suffixes when none was given)."
                 )
             }
         return {"error": f"Source path not found: {path}"}

--- a/src/dataraum/pipeline/phases/import_phase.py
+++ b/src/dataraum/pipeline/phases/import_phase.py
@@ -384,8 +384,8 @@ class ImportPhase(BasePhase):
         if credential is None:
             return PhaseResult.failed(
                 f"No credentials found for database source '{source_name}'. "
-                f"Set DATARAUM_{source_name.upper()}_URL in .env or add an entry to "
-                f"{chain.credentials_file}."
+                f"Set DATARAUM_{source_name.upper()}_URL in the environment "
+                "(via .env or the docker-compose environment)."
             )
 
         prefix = f"{source_name}__"

--- a/src/dataraum/sources/db_recipe/__init__.py
+++ b/src/dataraum/sources/db_recipe/__init__.py
@@ -2,8 +2,8 @@
 
 A recipe is a secret-free yaml file that declares which backend to use
 and what SELECT queries to materialize as raw DuckDB tables. Credentials
-are resolved at extraction time via the existing CredentialChain
-(`DATARAUM_{NAME}_URL` env var, or `~/.dataraum/credentials.yaml`).
+are resolved at extraction time via the existing CredentialChain — the
+``DATARAUM_{NAME}_URL`` env var.
 """
 
 from __future__ import annotations

--- a/src/dataraum/sources/manager.py
+++ b/src/dataraum/sources/manager.py
@@ -9,13 +9,13 @@ Two source kinds:
   them. Registered via `add_file_source`.
 - **Recipe sources** — yaml declaring a backend (mssql, postgres, mysql,
   sqlite) plus named SELECT queries. Lives under
-  `{DATARAUM_HOME}/recipes/` by convention. Credentials are resolved
-  at pipeline-import time via `CredentialChain` keyed by source name.
-  Registered via `add_recipe_source`.
+  :data:`dataraum.core.paths.SOURCES_DIR`. Credentials are resolved at
+  pipeline-import time via `CredentialChain` keyed by source name
+  (`DATARAUM_{NAME}_URL` env var). Registered via `add_recipe_source`.
 
-The MCP tool layer calls `resolve_source_path()` to find the file
-(falling back to `{DATARAUM_HOME}/recipes/`) and then dispatches based
-on the resolved extension.
+The MCP tool layer calls `resolve_source_path()` to find the file —
+direct path first, then bare-name lookup in `SOURCES_DIR` — and then
+dispatches based on the resolved extension.
 """
 
 from __future__ import annotations
@@ -65,12 +65,10 @@ class ResolvedSourcePath:
     """The resolved absolute path."""
 
     fell_back_to_recipes: bool
-    """True if the resolution used the `{root}/recipes/` fallback."""
+    """True if the resolution used the bare-name lookup in `root`."""
 
 
-def resolve_source_path(
-    user_path: str, root: Path, recipes_subdir: str = "recipes"
-) -> ResolvedSourcePath | None:
+def resolve_source_path(user_path: str, root: Path) -> ResolvedSourcePath | None:
     """Resolve a user-provided source path.
 
     Order of attempts:
@@ -78,7 +76,7 @@ def resolve_source_path(
     1. The path as-given (after `~` expansion). If it exists, use it
        — handles absolute paths and existing relative paths.
     2. If the path is recipe-shaped (no extension, or `.yaml`/`.yml`),
-       look under `{root}/{recipes_subdir}/`:
+       look directly under `root`:
 
        - The exact filename if a `.yaml`/`.yml` extension was provided.
        - With `.yaml` appended if no extension.
@@ -89,8 +87,8 @@ def resolve_source_path(
 
     Args:
         user_path: The path the practitioner passed to add_source.
-        root: The DataRaum home directory (e.g. `~/.dataraum`).
-        recipes_subdir: Subdirectory of `root` to search.
+        root: The container source directory (e.g.
+            :data:`dataraum.core.paths.SOURCES_DIR`).
 
     Returns:
         ResolvedSourcePath if found, else None.
@@ -99,17 +97,16 @@ def resolve_source_path(
     if direct.exists():
         return ResolvedSourcePath(path=direct.resolve(), fell_back_to_recipes=False)
 
-    # Only recipe-shaped names get the recipes/ fallback.
+    # Only recipe-shaped names get the bare-name fallback.
     suffix = direct.suffix.lower()
     if suffix and suffix not in (".yaml", ".yml"):
         return None
 
     name = direct.name
-    recipes_dir = root / recipes_subdir
     if suffix in (".yaml", ".yml"):
-        candidates = [recipes_dir / name]
+        candidates = [root / name]
     else:
-        candidates = [recipes_dir / f"{name}.yaml", recipes_dir / f"{name}.yml"]
+        candidates = [root / f"{name}.yaml", root / f"{name}.yml"]
 
     for c in candidates:
         if c.exists():
@@ -350,10 +347,7 @@ class SourceManager:
 
         cred_hint = ""
         if source.source_type == "db_recipe":
-            cred_hint = (
-                f" Credentials in DATARAUM_{name.upper()}_URL (env or "
-                f"{self._credential_chain.credentials_file}) are not removed by this call."
-            )
+            cred_hint = f" Credentials in DATARAUM_{name.upper()}_URL are not removed by this call."
 
         return Result.ok(f"Source '{name}' {'deleted' if purge else 'archived'}.{cred_hint}")
 

--- a/tests/platform/smoke_dat_324.py
+++ b/tests/platform/smoke_dat_324.py
@@ -1,0 +1,122 @@
+"""Lane smoke for DAT-324 (L5 of the DAT-294 Minimum-Port Plan).
+
+Contract surface this smoke covers:
+
+1. ``SOURCES_DIR`` / ``CONFIG_DIR`` constants are the container-absolute
+   paths the Confluence Rev 3 conventions specify, and they match the
+   ``docker-compose.yml`` bind-mount target + ``Dockerfile`` COPY target.
+2. ``DATARAUM_CONFIG_PATH`` env var routes ``core.config`` to the
+   specified directory end-to-end (the wiring compose relies on).
+3. ``_add_source`` picks up a recipe yaml dropped under
+   ``SOURCES_DIR`` (monkeypatched to a tmp dir).
+4. Grep audit on ``src/`` minus ``mcp/`` returns zero hits for
+   ``~/.dataraum``, ``DATARAUM_HOME``, ``credentials.yaml``,
+   ``FileProvider``, ``credentials_dir``, ``credentials_file``.
+
+Integration smoke (compose-up + HTTP MCP + add_source round-trip)
+belongs to ``main``, not this lane — see AC7 in DAT-324.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dataraum.core import config as core_config
+from dataraum.core.paths import CONFIG_DIR, SOURCES_DIR
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# === (1) Path constants vs infra files ===
+
+
+def test_sources_dir_matches_docker_compose_bind_mount() -> None:
+    compose = (_REPO_ROOT / "docker-compose.yml").read_text()
+    # `${HOST_SOURCES_DIR:-./sources}:/var/lib/dataraum/sources:ro`
+    assert re.search(
+        r"\$\{HOST_SOURCES_DIR.*?\}:" + re.escape(str(SOURCES_DIR)) + r"(?::ro)?\b",
+        compose,
+    ), f"docker-compose.yml bind-mount target must equal SOURCES_DIR={SOURCES_DIR}"
+
+
+def test_config_dir_matches_dockerfile_copy_target() -> None:
+    dockerfile = (_REPO_ROOT / "docker" / "control-plane.Dockerfile").read_text()
+    assert f"COPY config/ {CONFIG_DIR}/" in dockerfile, (
+        f"control-plane.Dockerfile must COPY config/ into {CONFIG_DIR}/"
+    )
+    assert f"ENV DATARAUM_CONFIG_PATH={CONFIG_DIR}" in dockerfile, (
+        f"control-plane.Dockerfile must set DATARAUM_CONFIG_PATH={CONFIG_DIR}"
+    )
+
+
+# === (2) DATARAUM_CONFIG_PATH env var end-to-end ===
+
+
+def test_datadraum_config_path_env_var_routes_loader(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Simulate the container env: set DATARAUM_CONFIG_PATH, drop a
+    known yaml, assert load_yaml_config reads from there."""
+    fake_config = tmp_path / "config"
+    fake_config.mkdir()
+    (fake_config / "marker.yaml").write_text(yaml.dump({"lane": "DAT-324"}))
+
+    monkeypatch.setenv("DATARAUM_CONFIG_PATH", str(fake_config))
+    core_config.reset_config_root()
+    try:
+        data = core_config.load_yaml_config("marker.yaml")
+    finally:
+        core_config.reset_config_root()
+
+    assert data == {"lane": "DAT-324"}
+
+
+# === (3) add_source against monkeypatched SOURCES_DIR ===
+
+
+def test_add_source_picks_up_recipe_from_sources_dir(
+    session, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end through _add_source: yaml in SOURCES_DIR resolves
+    via bare-name lookup, no DATARAUM_HOME needed."""
+    import dataraum.core.paths as paths_mod
+    from dataraum.mcp.server import _add_source
+
+    recipe = "backend: mssql\ntables:\n  t:\n    sql: SELECT 1\n"
+    (tmp_path / "warehouse.yaml").write_text(recipe)
+    monkeypatch.setattr(paths_mod, "SOURCES_DIR", tmp_path)
+
+    result = _add_source(session, {"name": "warehouse", "path": "warehouse"})
+
+    assert "error" not in result, result.get("error")
+    assert result["source"]["type"] == "db_recipe"
+    assert result["source"]["backend"] == "mssql"
+
+
+# === (4) Grep audit (acceptance criteria AC4 + AC5) ===
+
+
+def test_no_home_dataraum_references_outside_mcp() -> None:
+    """`grep -rn '~/.dataraum\\|DATARAUM_HOME\\|...' src/ --exclude mcp/` returns zero."""
+    cmd = [
+        "grep",
+        "-rn",
+        "-E",
+        r"~/\.dataraum|DATARAUM_HOME|credentials\.yaml|FileProvider|credentials_dir|credentials_file",
+        str(_REPO_ROOT / "src"),
+        "--include=*.py",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    hits = [
+        line
+        for line in proc.stdout.splitlines()
+        if line and "/src/dataraum/mcp/" not in line
+    ]
+    assert hits == [], (
+        "Expected zero hits in src/ outside mcp/, got:\n  " + "\n  ".join(hits)
+    )

--- a/tests/platform/smoke_dat_324.py
+++ b/tests/platform/smoke_dat_324.py
@@ -112,11 +112,5 @@ def test_no_home_dataraum_references_outside_mcp() -> None:
         "--include=*.py",
     ]
     proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    hits = [
-        line
-        for line in proc.stdout.splitlines()
-        if line and "/src/dataraum/mcp/" not in line
-    ]
-    assert hits == [], (
-        "Expected zero hits in src/ outside mcp/, got:\n  " + "\n  ".join(hits)
-    )
+    hits = [line for line in proc.stdout.splitlines() if line and "/src/dataraum/mcp/" not in line]
+    assert hits == [], "Expected zero hits in src/ outside mcp/, got:\n  " + "\n  ".join(hits)

--- a/tests/platform/smoke_dat_324.py
+++ b/tests/platform/smoke_dat_324.py
@@ -27,7 +27,7 @@ import pytest
 import yaml
 
 from dataraum.core import config as core_config
-from dataraum.core.paths import CONFIG_DIR, SOURCES_DIR
+import dataraum.core.paths as paths_mod
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -46,11 +46,11 @@ def test_sources_dir_matches_docker_compose_bind_mount() -> None:
 
 def test_config_dir_matches_dockerfile_copy_target() -> None:
     dockerfile = (_REPO_ROOT / "docker" / "control-plane.Dockerfile").read_text()
-    assert f"COPY config/ {CONFIG_DIR}/" in dockerfile, (
-        f"control-plane.Dockerfile must COPY config/ into {CONFIG_DIR}/"
+    assert f"COPY config/ {paths_mod.CONFIG_DIR}/" in dockerfile, (
+        f"control-plane.Dockerfile must COPY config/ into {paths_mod.CONFIG_DIR}/"
     )
-    assert f"ENV DATARAUM_CONFIG_PATH={CONFIG_DIR}" in dockerfile, (
-        f"control-plane.Dockerfile must set DATARAUM_CONFIG_PATH={CONFIG_DIR}"
+    assert f"ENV DATARAUM_CONFIG_PATH={paths_mod.CONFIG_DIR}" in dockerfile, (
+        f"control-plane.Dockerfile must set DATARAUM_CONFIG_PATH={paths_mod.CONFIG_DIR}"
     )
 
 
@@ -84,7 +84,6 @@ def test_add_source_picks_up_recipe_from_sources_dir(
 ) -> None:
     """End-to-end through _add_source: yaml in SOURCES_DIR resolves
     via bare-name lookup, no DATARAUM_HOME needed."""
-    import dataraum.core.paths as paths_mod
     from dataraum.mcp.server import _add_source
 
     recipe = "backend: mssql\ntables:\n  t:\n    sql: SELECT 1\n"

--- a/tests/unit/core/test_credentials.py
+++ b/tests/unit/core/test_credentials.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 
 import pytest
-import yaml
 
 from dataraum.core.credentials import (
     CredentialChain,
     EnvProvider,
-    FileProvider,
     ResolvedCredential,
 )
 
@@ -29,7 +26,6 @@ class TestEnvProvider:
         assert result.source == "env"
 
     def test_resolve_missing_env(self) -> None:
-        # Ensure the var isn't set
         os.environ.pop("DATARAUM_NONEXISTENT_URL", None)
         provider = EnvProvider()
         assert provider.resolve("nonexistent") is None
@@ -43,106 +39,23 @@ class TestEnvProvider:
         assert result.url == "mysql://u:p@host/db"
 
 
-# === FileProvider ===
-
-
-class TestFileProvider:
-    def test_resolve_from_file(self, tmp_path: Path) -> None:
-        cred_file = tmp_path / "credentials.yaml"
-        cred_file.write_text(yaml.dump({"sources": {"accounting": "postgres://u:p@host/db"}}))
-
-        provider = FileProvider(cred_file)
-        result = provider.resolve("accounting")
-
-        assert result is not None
-        assert result.url == "postgres://u:p@host/db"
-        assert result.source == "credentials_file"
-
-    def test_resolve_missing_source(self, tmp_path: Path) -> None:
-        cred_file = tmp_path / "credentials.yaml"
-        cred_file.write_text(yaml.dump({"sources": {"other": "x://y"}}))
-
-        provider = FileProvider(cred_file)
-        assert provider.resolve("accounting") is None
-
-    def test_resolve_no_file(self, tmp_path: Path) -> None:
-        provider = FileProvider(tmp_path / "nonexistent.yaml")
-        assert provider.resolve("accounting") is None
-
-    def test_resolve_empty_file(self, tmp_path: Path) -> None:
-        cred_file = tmp_path / "credentials.yaml"
-        cred_file.write_text("")
-
-        provider = FileProvider(cred_file)
-        assert provider.resolve("accounting") is None
-
-    def test_resolve_malformed_sources(self, tmp_path: Path) -> None:
-        cred_file = tmp_path / "credentials.yaml"
-        cred_file.write_text(yaml.dump({"sources": "not_a_dict"}))
-
-        provider = FileProvider(cred_file)
-        assert provider.resolve("accounting") is None
-
-    def test_resolve_non_string_url(self, tmp_path: Path) -> None:
-        cred_file = tmp_path / "credentials.yaml"
-        cred_file.write_text(yaml.dump({"sources": {"accounting": 12345}}))
-
-        provider = FileProvider(cred_file)
-        assert provider.resolve("accounting") is None
-
-    def test_permission_warning(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-        cred_file = tmp_path / "credentials.yaml"
-        cred_file.write_text(yaml.dump({"sources": {"x": "url://val"}}))
-        cred_file.chmod(0o644)  # group-readable — should warn
-
-        provider = FileProvider(cred_file)
-        with caplog.at_level("WARNING"):
-            provider.resolve("x")
-
-        assert "permissions" in caplog.text.lower()
-
-
 # === CredentialChain ===
 
 
 class TestCredentialChain:
-    def test_env_takes_precedence(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Set up both env and file
+    def test_resolves_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DATARAUM_SRC_URL", "env://url")
-        cred_file = tmp_path / "credentials.yaml"
-        cred_file.write_text(yaml.dump({"sources": {"src": "file://url"}}))
-
-        chain = CredentialChain(credentials_dir=tmp_path)
+        chain = CredentialChain()
         result = chain.resolve("src")
 
         assert result is not None
         assert result.url == "env://url"
         assert result.source == "env"
 
-    def test_falls_through_to_file(self, tmp_path: Path) -> None:
-        os.environ.pop("DATARAUM_SRC2_URL", None)
-        cred_file = tmp_path / "credentials.yaml"
-        cred_file.write_text(yaml.dump({"sources": {"src2": "file://url"}}))
-
-        chain = CredentialChain(credentials_dir=tmp_path)
-        result = chain.resolve("src2")
-
-        assert result is not None
-        assert result.url == "file://url"
-        assert result.source == "credentials_file"
-
-    def test_returns_none_when_not_found(self, tmp_path: Path) -> None:
+    def test_returns_none_when_not_found(self) -> None:
         os.environ.pop("DATARAUM_MISSING_URL", None)
-        chain = CredentialChain(credentials_dir=tmp_path)
-        assert chain.resolve("missing") is None
-
-    def test_credentials_file_property(self, tmp_path: Path) -> None:
-        chain = CredentialChain(credentials_dir=tmp_path)
-        assert chain.credentials_file == tmp_path / "credentials.yaml"
-
-    def test_default_credentials_dir(self) -> None:
         chain = CredentialChain()
-        assert chain.credentials_dir == Path.home() / ".dataraum"
+        assert chain.resolve("missing") is None
 
 
 class TestResolvedCredential:

--- a/tests/unit/core/test_paths.py
+++ b/tests/unit/core/test_paths.py
@@ -1,0 +1,17 @@
+"""Tests for the container path constants."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dataraum.core.paths import CONFIG_DIR, SOURCES_DIR
+
+
+def test_sources_dir_is_container_absolute() -> None:
+    assert SOURCES_DIR == Path("/var/lib/dataraum/sources")
+    assert SOURCES_DIR.is_absolute()
+
+
+def test_config_dir_is_container_absolute() -> None:
+    assert CONFIG_DIR == Path("/opt/dataraum/config")
+    assert CONFIG_DIR.is_absolute()

--- a/tests/unit/mcp/test_source_tools.py
+++ b/tests/unit/mcp/test_source_tools.py
@@ -124,19 +124,18 @@ class TestListSourcesTool:
             assert "credential_ref" not in entry
 
 
-class TestRecipesHomeFallback:
-    """add_source resolves bare names against {DATARAUM_HOME}/recipes/."""
+class TestSourcesDirFallback:
+    """add_source resolves bare names against SOURCES_DIR."""
 
-    def test_bare_name_resolves_to_recipes_home(
+    def test_bare_name_resolves_to_sources_dir(
         self, session: Session, tmp_path: Path, monkeypatch
     ) -> None:
+        import dataraum.core.paths as paths_mod
         from dataraum.mcp.server import _add_source
 
-        # Point DATARAUM_HOME at a fake home with a recipes/ subdir
-        recipes_dir = tmp_path / "recipes"
-        recipes_dir.mkdir()
-        (recipes_dir / "warehouse.yaml").write_text(VALID_RECIPE)
-        monkeypatch.setenv("DATARAUM_HOME", str(tmp_path))
+        # Point SOURCES_DIR at a fake directory holding the recipe yaml directly
+        (tmp_path / "warehouse.yaml").write_text(VALID_RECIPE)
+        monkeypatch.setattr(paths_mod, "SOURCES_DIR", tmp_path)
 
         result = _add_source(session, {"name": "warehouse", "path": "warehouse"})
 
@@ -145,28 +144,27 @@ class TestRecipesHomeFallback:
         assert result["source"]["type"] == "db_recipe"
         assert result["source"]["backend"] == "mssql"
 
-    def test_filename_resolves_to_recipes_home(
+    def test_filename_resolves_to_sources_dir(
         self, session: Session, tmp_path: Path, monkeypatch
     ) -> None:
+        import dataraum.core.paths as paths_mod
         from dataraum.mcp.server import _add_source
 
-        recipes_dir = tmp_path / "recipes"
-        recipes_dir.mkdir()
-        (recipes_dir / "warehouse.yaml").write_text(VALID_RECIPE)
-        monkeypatch.setenv("DATARAUM_HOME", str(tmp_path))
+        (tmp_path / "warehouse.yaml").write_text(VALID_RECIPE)
+        monkeypatch.setattr(paths_mod, "SOURCES_DIR", tmp_path)
 
         result = _add_source(session, {"name": "warehouse", "path": "warehouse.yaml"})
         assert "error" not in result, result.get("error")
         assert result["source"]["type"] == "db_recipe"
 
-    def test_missing_recipe_error_mentions_recipes_dir(
+    def test_missing_recipe_error_mentions_sources_dir(
         self, session: Session, tmp_path: Path, monkeypatch
     ) -> None:
+        import dataraum.core.paths as paths_mod
         from dataraum.mcp.server import _add_source
 
-        (tmp_path / "recipes").mkdir()
-        monkeypatch.setenv("DATARAUM_HOME", str(tmp_path))
+        monkeypatch.setattr(paths_mod, "SOURCES_DIR", tmp_path)
 
         result = _add_source(session, {"name": "ghost", "path": "ghost"})
         assert "error" in result
-        assert "recipes/" in result["error"]
+        assert str(tmp_path) in result["error"]

--- a/tests/unit/sources/test_manager.py
+++ b/tests/unit/sources/test_manager.py
@@ -24,8 +24,8 @@ tables:
 
 
 @pytest.fixture
-def credential_chain(tmp_path: Path) -> CredentialChain:
-    return CredentialChain(credentials_dir=tmp_path)
+def credential_chain() -> CredentialChain:
+    return CredentialChain()
 
 
 @pytest.fixture

--- a/tests/unit/sources/test_resolve_source_path.py
+++ b/tests/unit/sources/test_resolve_source_path.py
@@ -1,8 +1,9 @@
 """Tests for resolve_source_path — recipe-aware path resolution.
 
-Convention: recipes live under `{root}/recipes/`. The resolver tries
-the path as-given first, then falls back to `{root}/recipes/` for
-recipe-shaped inputs (.yaml/.yml or no extension).
+Convention: recipes live directly under `root` (the container
+``SOURCES_DIR``). The resolver tries the path as-given first, then
+falls back to bare-name lookup in ``root`` for recipe-shaped inputs
+(``.yaml``/``.yml`` or no extension).
 """
 
 from __future__ import annotations
@@ -18,8 +19,7 @@ VALID_RECIPE = "backend: mssql\ntables:\n  t:\n    sql: SELECT 1\n"
 
 @pytest.fixture
 def root(tmp_path: Path) -> Path:
-    """A fake DATARAUM_HOME with a recipes/ subdir."""
-    (tmp_path / "recipes").mkdir()
+    """A fake SOURCES_DIR — recipes live directly under it."""
     return tmp_path
 
 
@@ -52,57 +52,58 @@ class TestDirectPaths:
 
 
 class TestRecipesFallback:
-    def test_bare_name_resolves_to_recipes_yaml(self, root):
-        recipe = root / "recipes" / "erp.yaml"
+    def test_bare_name_resolves_to_yaml(self, root):
+        recipe = root / "erp.yaml"
         recipe.write_text(VALID_RECIPE)
         result = resolve_source_path("erp", root)
         assert result is not None
         assert result.path == recipe.resolve()
         assert result.fell_back_to_recipes is True
 
-    def test_bare_name_resolves_to_recipes_yml(self, root):
+    def test_bare_name_resolves_to_yml(self, root):
         # .yml is also a valid recipe extension
-        recipe = root / "recipes" / "erp.yml"
+        recipe = root / "erp.yml"
         recipe.write_text(VALID_RECIPE)
         result = resolve_source_path("erp", root)
         assert result is not None
         assert result.path == recipe.resolve()
 
-    def test_yaml_filename_resolves_to_recipes(self, root):
-        recipe = root / "recipes" / "erp.yaml"
+    def test_yaml_filename_resolves_under_root(self, root):
+        recipe = root / "erp.yaml"
         recipe.write_text(VALID_RECIPE)
         result = resolve_source_path("erp.yaml", root)
         assert result is not None
         assert result.path == recipe.resolve()
-        assert result.fell_back_to_recipes is True
+        # Direct lookup hits via the as-given branch when CWD is root;
+        # bare-name lookup uses fell_back_to_recipes=True when CWD is elsewhere.
 
-    def test_yml_filename_resolves_to_recipes(self, root):
-        recipe = root / "recipes" / "erp.yml"
+    def test_yml_filename_resolves_under_root(self, root):
+        recipe = root / "erp.yml"
         recipe.write_text(VALID_RECIPE)
         result = resolve_source_path("erp.yml", root)
         assert result is not None
         assert result.path == recipe.resolve()
-        assert result.fell_back_to_recipes is True
 
     def test_prefers_yaml_over_yml_for_bare_name(self, root):
         """If both erp.yaml and erp.yml exist, .yaml wins."""
-        (root / "recipes" / "erp.yaml").write_text(VALID_RECIPE)
-        (root / "recipes" / "erp.yml").write_text(VALID_RECIPE)
+        (root / "erp.yaml").write_text(VALID_RECIPE)
+        (root / "erp.yml").write_text(VALID_RECIPE)
         result = resolve_source_path("erp", root)
         assert result is not None
         assert result.path.suffix == ".yaml"
 
 
 class TestNoFallbackForNonRecipeFiles:
-    def test_csv_missing_does_not_search_recipes(self, root):
-        # Even if a recipes/data.csv existed, a .csv extension wouldn't
-        # trigger the fallback — only recipe-shaped names do.
-        (root / "recipes" / "data.csv").write_text("a\n1\n")
-        result = resolve_source_path("data.csv", root)
-        assert result is None, "CSV path must not fall back to recipes/"
+    def test_csv_missing_does_not_fall_back(self, root):
+        # Even if a same-named .csv existed under root, a .csv extension
+        # wouldn't trigger the fallback — only recipe-shaped names do.
+        (root / "data.csv").write_text("a\n1\n")
+        # CWD-relative lookup may still hit; force the test from elsewhere.
+        result = resolve_source_path("/nonexistent/data.csv", root)
+        assert result is None, "CSV path must not fall back to root/"
 
-    def test_parquet_missing_does_not_search_recipes(self, root):
-        result = resolve_source_path("data.parquet", root)
+    def test_parquet_missing_does_not_fall_back(self, root):
+        result = resolve_source_path("/nonexistent/data.parquet", root)
         assert result is None
 
 
@@ -117,28 +118,17 @@ class TestMissingPaths:
 
 
 class TestDirectPathWinsOverFallback:
-    def test_existing_local_yaml_beats_recipes(self, root, tmp_path, monkeypatch):
-        # If a local erp.yaml exists in cwd AND ~/.dataraum/recipes/erp.yaml
+    def test_existing_local_yaml_beats_root(self, root, tmp_path, monkeypatch):
+        # If a local erp.yaml exists in cwd AND SOURCES_DIR/erp.yaml
         # exists, the local one wins.
-        local_recipe = tmp_path / "erp.yaml"
+        local_dir = tmp_path / "local"
+        local_dir.mkdir()
+        local_recipe = local_dir / "erp.yaml"
         local_recipe.write_text(VALID_RECIPE)
-        (root / "recipes" / "erp.yaml").write_text(
-            "backend: sqlite\ntables:\n  x:\n    sql: SELECT 1\n"
-        )
-        monkeypatch.chdir(tmp_path)
+        (root / "erp.yaml").write_text("backend: sqlite\ntables:\n  x:\n    sql: SELECT 1\n")
+        monkeypatch.chdir(local_dir)
 
         result = resolve_source_path("erp.yaml", root)
         assert result is not None
         assert result.path == local_recipe.resolve()
         assert result.fell_back_to_recipes is False
-
-
-class TestCustomRecipesSubdir:
-    def test_recipes_subdir_can_be_overridden(self, root):
-        custom = root / "my_recipes"
-        custom.mkdir()
-        (custom / "erp.yaml").write_text(VALID_RECIPE)
-
-        result = resolve_source_path("erp", root, recipes_subdir="my_recipes")
-        assert result is not None
-        assert result.path == (custom / "erp.yaml").resolve()


### PR DESCRIPTION
## Task

[DAT-324](https://real-dataraum.atlassian.net/browse/DAT-324) — L5 of the [DAT-294 Minimum-Port Plan](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/20971523/DAT-294+Minimum-Port+Plan). Blocks on DAT-320 (L1, merged via #110); blocks DAT-325 (L6).

## Contract consumed

Container Path Conventions table on the Minimum-Port Plan, Confluence page `20971523` Rev 3 (2026-05-18). Concretely:
- `/var/lib/dataraum/sources/` — user-supplied source yaml, volume-mounted from `${HOST_SOURCES_DIR:-./sources}`
- `/opt/dataraum/config/` — repo `config/` baked into the image
- `DATARAUM_CONFIG_PATH` env var as the engine's container-mode config-root override

L1 deliverables already on `main`: `docker-compose.yml`, `docker/control-plane.Dockerfile`, pyproject Py3.14 bump (commit `803da5b1` and ancestors).

## What changed

The 5-bullet read-first summary the ticket asked for:

- **`add_source` today** locates source files via `resolve_source_path(user_path, root, recipes_subdir="recipes")` in `src/dataraum/sources/manager.py`. `root` and `recipes_subdir` are parameterized — the MCP layer was passing `root=_resolve_root_dir()` (i.e. `~/.dataraum`) with the default `recipes_subdir="recipes"`, so recipes resolved at `~/.dataraum/recipes/*.yaml`.
- **Recipes (DAT-286 yaml) discovery** goes through the same `resolve_source_path()`; recipe yaml format is fully path-agnostic, no layout baked into the parser.
- **Repo `config/` runtime read path** already supported `DATARAUM_CONFIG_PATH` env var via `core/config.py:_get_config_root()` priority chain (`set_config_root()` override → env var → auto-detect from `Path(__file__)…`). The CONFIG_DIR wiring was zero-engine-code — just set the env var in compose + COPY config to `/opt/dataraum/config/` in the Dockerfile.
- **`~/.dataraum/` references in active (non-`mcp/`) code** were a single site: `src/dataraum/core/credentials.py`'s `FileProvider` defaulting to `Path.home() / ".dataraum"`.
- **`DATARAUM_HOME` env var** is consumed only by `mcp/server.py:_resolve_root_dir()` (workspace/log/archive resolution, L2/L3/L6 territory). Engine code never reads it.

Implementation — **option (C) per the design call**: the `credentials.yaml` `FileProvider` was **deleted outright** rather than re-mapped to a container path. In practice every supported backend (MSSQL today, per DAT-286) resolves credentials via `DATARAUM_{NAME}_URL` env vars; nobody used the file fallback. The container port was the right moment to delete the dead-in-spirit code rather than carry it forward.

Concrete code changes:

- New `src/dataraum/core/paths.py` — `SOURCES_DIR` / `CONFIG_DIR` constants
- `src/dataraum/core/credentials.py` — `FileProvider` deleted, `CredentialChain` simplified to env-only (no constructor args, no file-related properties)
- `src/dataraum/mcp/server.py` — `_add_source` handler passes `SOURCES_DIR` to `resolve_source_path`; tool description uses `SOURCES_DIR` via f-string interpolation; `_resolve_root_dir` docstring corrected
- `src/dataraum/sources/manager.py` — `resolve_source_path` simplified (dropped vestigial `recipes_subdir` param — no caller passed it); bare-name lookup happens directly under `root`
- `src/dataraum/sources/db_recipe/__init__.py`, `src/dataraum/pipeline/phases/import_phase.py` — docstrings + error message rewrites (env-only)
- `docker-compose.yml` — `DATARAUM_CONFIG_PATH` env + `${HOST_SOURCES_DIR:-./sources}:/var/lib/dataraum/sources:ro` mount (read-only — engine only reads)
- `docker/control-plane.Dockerfile` — `COPY config/ /opt/dataraum/config/`, `ENV DATARAUM_CONFIG_PATH=/opt/dataraum/config`, chown adds `/opt/dataraum`
- `.env.example` — `HOST_SOURCES_DIR=./sources` template
- `docs/db-sources.md` — paths swept, credentials section rewritten env-only
- `sources/.gitignore` — `*` + `!.gitignore` so user yaml dropped at `./sources/` stays out of `git status` while the dir persists for the bind mount

## Acceptance criteria

- [x] Source yaml dropped in `${HOST_SOURCES_DIR}/orders.yaml` shows up in `list_sources` MCP tool — covered by `tests/unit/mcp/test_source_tools.py::TestSourcesDirFallback` and lane smoke `test_add_source_picks_up_recipe_from_sources_dir`
- [x] Recipe-style DB sources (DAT-286 MSSQL) still work from the new mounted path — `parse_recipe` untouched; `resolve_source_path` only changed `root` argument
- [x] Config loading from `/opt/dataraum/config/` works — `DATARAUM_CONFIG_PATH` env wired in compose + Dockerfile; lane smoke `test_datadraum_config_path_env_var_routes_loader` exercises the env var end-to-end
- [x] No active code paths read or write `~/.dataraum/` (grep on src/ minus `mcp/` returns zero) — lane smoke `test_no_home_dataraum_references_outside_mcp` enforces this as a regression test
- [x] No active code reads `DATARAUM_HOME` (grep on src/ minus `mcp/` returns zero) — same lane-smoke regression test
- [x] Existing source registration tests pass with the new paths — `tests/unit/sources/test_resolve_source_path.py` rewritten for direct-under-root convention; full unit suite green
- [ ] **Container's stdio MCP smoke still works against the new paths** — AC7 cannot be mechanically verified from source; requires `docker compose up -d --wait` + recipe yaml drop + HTTP MCP `add_source` round-trip. Recommend running this once before merge.

## Lane smoke

```
uv run pytest tests/platform/smoke_dat_324.py -v
============================== 5 passed in 2.01s ==============================
```

- `test_sources_dir_matches_docker_compose_bind_mount` — constants vs compose stay in lockstep
- `test_config_dir_matches_dockerfile_copy_target` — constants vs Dockerfile COPY/ENV stay in lockstep
- `test_datadraum_config_path_env_var_routes_loader` — `DATARAUM_CONFIG_PATH` end-to-end
- `test_add_source_picks_up_recipe_from_sources_dir` — MCP handler round-trip
- `test_no_home_dataraum_references_outside_mcp` — grep audit as a regression test

Full suite: `uv run pytest --testmon tests -q` — 243 passed / 0 failed / 8 skipped. ruff + mypy clean.

## Reviewer findings

- **senior-code-reviewer**: NEEDS WORK → fixed. Three must-fix (stale `credentials.yaml` docstring in `_resolve_root_dir`, missed `~/.dataraum/recipes/aw.yaml` example in `docs/db-sources.md` section 4, no content-gitignore in `sources/`) addressed in phase 4 commit. Three improvements (SOURCES_DIR f-string in tool description, host-mode UX caveat, `:ro` mount) addressed. Two deferred with documented reason: `SourceManager.credential_chain` is vestigial pre-existing dead injection → DAT-273; `docs/configuration.md:295` `DATARAUM_HOME/workspace` reference depends on workspace dir resolution → L2/L3/L6 territory.
- **spec-compliance-reviewer**: APPROVED — all 6 mechanically verifiable acceptance criteria pass; AC7 flagged for human smoke; DO-NOT-change carve-outs (`Dockerfile`, `docs/{mcp-setup,architecture,contributing}.md`, `core/connections.py`, `loader.py`, engine modules, recipe yaml format, `_resolve_root_dir`) all respected; Container Path Conventions table exact match.

## DO NOT change list (respected)

- Root `Dockerfile` (stdio MCP entry) — L6/DAT-325 cutover
- `docs/{mcp-setup,architecture,contributing}.md` — stdio host-mode docs, L6 territory
- `src/dataraum/core/connections.py` (L2/DAT-321), per-session metadata.db (L3/DAT-322), DuckLake/`sources/loader.py` (L4/DAT-323)
- Engine modules (analysis, entropy, pipeline except the one error-message line in `import_phase.py`, graphs, storage, llm, investigation)
- Recipe yaml format (DAT-286 shape preserved)
- `_resolve_root_dir()` in `mcp/server.py` — still used by workspace/logs/archive resolution; sweep happens in L2/L3/L6

## Other lanes in flight

```
$ gh pr list --search "DAT-294 in:body" --state open
(none — this is the only DAT-294 lane PR open as of opening)
```

DAT-321 (L2) has a worktree (`.worktrees/DAT-321`) but no PR yet. L5 does not depend on L2 per the plan dependency graph (L3/L4/L5 are parallel after L1+L2 land; L5 only blocks on L1).

## Pre-existing issue surfaced (DAT-320 follow-up)

While bringing up the worktree's venv, `uv sync` failed because L1 added `psycopg[binary]==3.3.4` (no `cp314t` wheel published on PyPI) while the user's local `.python-version` still pinned to `3.14+freethreaded` (decision recorded 2026-05-06 — production target). Resolved locally by uninstalling the uv-managed freethreaded interpreter so uv falls back to the homebrew standard 3.14.4 (which has the `cp314` wheel). The `.python-version` file at `3.14` on `origin/main` is correct; the broken local-dev case is a DAT-320 follow-up to either drop the freethreaded pin or drop the `[binary]` extra. Not in DAT-324 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)