### PR TITLE
DAT-329: add permissions block to compose-smoke workflow

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: [main]
 
+permissions:
+    contents: read
+
 jobs:
     compose-smoke:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Task

[DAT-329](https://real-dataraum.atlassian.net/browse/DAT-329) — DAT-320 follow-up. Closes CodeQL [code-scanning alert #5](https://github.com/dataraum/dataraum/security/code-scanning/5) (`actions/missing-workflow-permissions`, CWE-275).

## What changed

Three-line addition to `.github/workflows/compose-smoke.yml`:

```yaml
permissions:
    contents: read
```

Kept at the workflow root rather than per-job — the smoke workflow only checks out code, builds the compose stack, runs smoke checks, and reads logs. `contents: read` is the minimum and sufficient scope. Future workflow additions that need more (e.g. `gh pr comment`) should promote the relevant scope on the specific job, not at the workflow root.

## Acceptance criteria

- [x] `.github/workflows/compose-smoke.yml` has a top-level `permissions: contents: read`
- [ ] CodeQL alert #5 closes automatically after merge (cannot verify pre-merge)
- [ ] Workflow still passes (CI will confirm)

## DO NOT change list (respected)

- Job logic / steps — untouched
- Any other workflow file — each has its own audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)