### PR TITLE
DAT-321: L2/L3 — All SQLAlchemy → single workspace Postgres

### DIFF
--- a/.claude/dat-321-lane-state.md
+++ b/.claude/dat-321-lane-state.md
@@ -1,0 +1,163 @@
+# DAT-321 Lane State (post-compact handoff)
+
+**Branch:** `feat/dat-321-sqlalchemy-postgres`
+**Worktree:** `/Users/philipp/Code/dataraum/dataraum-context/.worktrees/DAT-321/`
+**Scope (Plan rev 4):** All SQLAlchemy → single workspace Postgres. Workspace tables + per-session tables in one Postgres DB. Per-session tables get `session_id` FK to `investigation_sessions.session_id`. Per-session DuckDB stays per-session (L4 owns DuckLake swap).
+
+## Decisions locked
+- **Hybrid plumbing**: `manager.session_id` set at MCP entry; phases read `ctx.manager.session_id`; deep agents get `session_id` as explicit kwarg. **No ContextVar** (thread-pool unsafe). **No magic SQLAlchemy event listener** (user rejected). **Explicit at every row-construction site.**
+- **FK target**: `investigation_sessions.session_id` (the InvestigationSession PK).
+- **`nullable=False`** — we do NOT relax. User explicitly rejected `nullable=True` partial-ship.
+- **No new tables** (preserves Plan hard rule).
+- **`testcontainers[postgres]>=4.14`** as dev dep. Session-scoped `pg_url` fixture, function-scoped `pg_url_clean` (TRUNCATE CASCADE).
+- **CLI break is acceptable** ("we can remove dev command later, it is unused").
+- **TRUNCATE CASCADE per test**, one Postgres container per pytest invocation.
+
+## Phases committed (Phases 1, 2, 3)
+- `a698bba1` phase 1: port 5 sqlite-dialect JSON imports → portable `sqlalchemy.JSON`
+- `6db4a88b` phase 2: testcontainers dev dep + session-scoped pg fixtures
+- `333c9d3c` phase 3: postgres-only SQLAlchemy + archive flow rewrite
+
+Phase 3 also surfaced + fixed a real production bug (resume_session's cross-DB `delete(Source); add(Source)` workspace-sync), and rewrote `_read_archive_summary` from sqlite3 → SQLAlchemy.
+
+## Phase 4 work in progress (UNCOMMITTED)
+
+### Phase 4a — model files (DONE, 26 columns added across 19 files)
+All per-session SQLAlchemy models have a new column:
+```python
+session_id: Mapped[str] = mapped_column(
+    ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+)
+```
+
+Files touched (all in worktree, uncommitted):
+- `pipeline/db_models.py` (PipelineRun, PhaseLog)
+- `pipeline/fixes/models.py` (DataFix)
+- `documentation/db_models.py` (FixLedgerEntry)
+- `query/db_models.py` (QueryExecutionRecord)
+- `query/snippet_models.py` (SQLSnippetRecord, SnippetUsageRecord)
+- `entropy/db_models.py` (EntropyObjectRecord)
+- `analysis/correlation/db_models.py` (DerivedColumn)
+- `analysis/cycles/db_models.py` (DetectedBusinessCycle)
+- `analysis/eligibility/db_models.py` (ColumnEligibilityRecord)
+- `analysis/relationships/db_models.py` (Relationship)
+- `analysis/semantic/db_models.py` (SemanticAnnotation, TableEntity)
+- `analysis/slicing/db_models.py` (SliceDefinition, ColumnSliceProfile)
+- `analysis/statistics/db_models.py` (StatisticalProfile)
+- `analysis/statistics/quality_db_models.py` (StatisticalQualityMetrics)
+- `analysis/temporal/db_models.py` (TemporalColumnProfile)
+- `analysis/temporal_slicing/db_models.py` (ColumnDriftSummary, TemporalSliceAnalysis — also added `ForeignKey` to imports)
+- `analysis/typing/db_models.py` (TypeCandidate, TypeDecision)
+- `analysis/validation/db_models.py` (ValidationResultRecord — also added `ForeignKey` to imports)
+- `analysis/views/db_models.py` (EnrichedView, SlicingView)
+
+### Phase 4b — plumbing skeleton (DONE)
+- `core/connections.py::ConnectionManager.session_id: str | None` field added.
+- `pipeline/runner.py::RunConfig.session_id: str | None` field added.
+- `pipeline/runner.py::run(config)` passes `session_id=config.session_id` to `setup_pipeline`.
+- `pipeline/setup.py::setup_pipeline(*, ..., session_id: str | None = None)`:
+  - Raises `RuntimeError` if `session_id is None` (fail-loud — CLI/dev path is dead per L5).
+  - `ConnectionManager(conn_config, session_id=session_id)` — wires session_id onto the new manager.
+  - `PipelineRun(run_id=..., session_id=session_id, ...)` — populates the FK.
+- `pipeline/scheduler.py::PipelineScheduler._require_session_id()` helper added (reads `self.manager.session_id`, raises if None).
+- `pipeline/scheduler.py::_write_phase_log` constructs `PhaseLog(session_id=self._require_session_id(), ...)`.
+- `mcp/server.py::_get_session_manager(fingerprint, session_id: str | None = None)`:
+  - Accepts session_id; sets on cached manager (refresh) or new manager.
+  - `None` permitted for bootstrap paths (begin_session, _restore_archived_session) that create InvestigationSession AFTER opening; caller assigns `manager.session_id` once new id is in hand.
+- `mcp/server.py::_run_pipeline(output_dir, session_id, ...)` and `_run_pipeline_background(output_dir, session_id, ...)` accept session_id.
+- `mcp/server.py` call sites updated to pass `active_session_id` to `_get_session_manager`, `_run_pipeline`, `_run_pipeline_background`.
+- `mcp/server.py` `open_session_manager: Callable[..., ConnectionManager]` (was `Callable[[str], ...]`) in the two callee signatures.
+
+### Phase 4b — entropy engine (DONE)
+- `entropy/engine.py::run_detector_post_step(*, session_id: str)` — kwarg-only.
+- `entropy/engine.py::_make_record(*, session_id: str, ...)` — kwarg-only, populates `EntropyObjectRecord(session_id=session_id, ...)`.
+- `pipeline/scheduler.py::_run_post_step_detectors` reads `sid = self._require_session_id()` and threads to both branches of the `if self.session_factory and self.manager` split.
+
+### Phase 4b — test fixture baseline (DONE)
+- `tests/conftest.py::session` fixture now seeds:
+  - `Source(source_id=_TEST_SOURCE_ID, name="test_baseline", source_type="csv")` (flushed first)
+  - `InvestigationSession(session_id=_TEST_SESSION_ID, source_id=_TEST_SOURCE_ID, intent="conftest baseline", status="active", started_at=now())`
+- Helper `test_session_id() -> str` exposed for tests to use at construction sites.
+
+### Phase 4b — STILL TODO
+
+**Production construction sites** (each needs `session_id=...` populated; source of session_id noted):
+- `pipeline/setup.py:170` — PipelineRun ✓ DONE (from setup_pipeline param)
+- `pipeline/scheduler.py:371` — PhaseLog ✓ DONE (via `_require_session_id`)
+- `entropy/engine.py:242` — EntropyObjectRecord ✓ DONE
+- `pipeline/phases/column_eligibility_phase.py:154` — ColumnEligibilityRecord (use `ctx.manager.session_id`)
+- `pipeline/phases/slicing_phase.py:208` — SliceDefinition (use `ctx.manager.session_id`)
+- `pipeline/phases/slicing_view_phase.py:246` — SlicingView (use `ctx.manager.session_id`)
+- `pipeline/phases/enriched_views_phase.py:309` — EnrichedView (use `ctx.manager.session_id`)
+- `pipeline/phases/enriched_views_phase.py:416` — StatisticalProfile (use `ctx.manager.session_id`)
+- `analysis/typing/resolution.py:281` — TypeDecision (thread session_id param from caller)
+- `analysis/typing/resolution.py:423` — TypeDecision (same)
+- `analysis/typing/resolution.py:437` — TypeCandidate (same)
+- `analysis/typing/inference.py:120` — DBTypeCandidate (thread session_id)
+- `analysis/correlation/within_table/derived_columns.py:255` — DBDerivedColumn (thread)
+- `analysis/correlation/within_table/derived_columns.py:433` — DBDerivedColumn (thread)
+- `analysis/cycles/agent.py:326` — DetectedBusinessCycle (thread)
+- `analysis/validation/agent.py:699` — ValidationResultRecord (thread)
+- `analysis/slicing/profiling.py:191` — ColumnSliceProfile (thread)
+- `analysis/temporal/processor.py:286` — TemporalColumnProfile (thread)
+- `analysis/temporal_slicing/analyzer.py:491` — ColumnDriftSummary (thread)
+- `analysis/temporal_slicing/analyzer.py:805` — TemporalSliceAnalysis (thread)
+- `analysis/statistics/quality.py:515` — DBStatisticalQualityMetrics (thread)
+- `query/snippet_library.py:579` — SQLSnippetRecord (MCP-direct; pull from session_mgr.session_id)
+- `query/snippet_library.py:638` — SnippetUsageRecord (same)
+- `query/agent.py:1139` — QueryExecutionRecord (MCP-direct; same)
+- `documentation/ledger.py:57` — FixLedgerEntry (MCP-direct; same)
+- `pipeline/fixes/interpreters.py:315` — Relationship (DB persistence in teach flow; thread)
+
+For "thread session_id" sites: the function signature gets a new `session_id: str` kwarg; caller (usually a Phase) passes `ctx.manager.session_id`.
+
+**Test patches** (each failing test needs `session_id=test_session_id()` at construction):
+Last testmon run showed 47 failures. Files touched:
+- `tests/unit/pipeline/test_cleanup.py` (PhaseLog, StatisticalProfile constructions)
+- `tests/unit/mcp/test_search_snippets.py` (snippet constructions)
+- `tests/unit/analysis/correlation/test_enriched_derived.py` (DerivedColumn)
+- `tests/unit/mcp/test_measure.py` (PhaseLog / EntropyObjectRecord constructions)
+- `tests/unit/mcp/test_look.py` (TableEntity, SemanticAnnotation, Relationship, StatisticalQualityMetrics, TypeCandidate, EntropyObjectRecord, SQLSnippetRecord)
+- `tests/unit/mcp/test_why.py` (FixLedgerEntry)
+- `tests/unit/mcp/test_teach.py` (SemanticAnnotation, Relationship)
+- `tests/unit/mcp/test_run_sql.py` (EntropyObjectRecord)
+- `tests/unit/mcp/test_progress.py` (likely PhaseLog or RunConfig session_id)
+- `tests/unit/analysis/validation/test_resolver.py` (1 ERROR — needs investigation)
+
+After patching each test, re-run `uv run pytest --testmon tests/unit -q` to find next batch.
+
+### Phase 5 — STILL TODO
+Lane smoke `tests/platform/smoke_dat321.py`:
+- Postgres workspace tables present (all ~30 tables)
+- All previously-existing indexes present (named via `inspector.get_indexes`)
+- session_id FK present on each per-session table (verify FK constraint exists)
+- Round-trip insert/read with JSON `connection_config`, `discovered_schema` round-trip
+- Two-sessions-no-leak: create 2 InvestigationSession rows, insert PhaseLog rows for each, query by session_id → no cross-contamination
+- Grep assertion: `rg 'from sqlalchemy.dialects.sqlite' src/` returns zero
+- `os.listdir` assertion: no `.db` file appears on disk at any session run
+
+### Review gate (mandatory)
+After phases land + lane smoke green, launch senior-code-reviewer + spec-compliance-reviewer. Both must approve before PR opens.
+
+### Open PR
+Title: `DAT-321: L2 / Minimum-port — All SQLAlchemy → single workspace Postgres`
+Body must include:
+- 5-bullet "Read first" summary (per ticket gate)
+- Contract reference: Minimum-Port Plan rev 4 (Confluence 20971523)
+- Other lanes in flight (DAT-324 is already merged via PR #111 likely — check `gh pr list --search "DAT-294 in:body"`)
+- Lane smoke result
+- Add row to `.claude/platform-status.md`
+
+## Reviewer-trap quirks (already addressed)
+- `manager.session_id = session_id` on cached manager reopens with refreshed id (resume_session reuses fingerprint with new session_id)
+- `_get_session_manager(fp, None)` allowed for bootstrap; caller assigns id after creation
+- `setup_pipeline` raises if session_id is None — fail-loud per L5
+- `_require_session_id()` on scheduler protects PhaseLog writes
+- testcontainers `pg_url_clean` truncates per test (filter by `inspect(engine).get_table_names()` to skip absent tables in early phases)
+
+## Memory check before continuing
+1. Confirm worktree path still valid: `git worktree list | grep DAT-321`
+2. Confirm tasks #13 + #14 still open in TaskList
+3. Confirm DATABASE_URL fixture works: `uv run pytest tests/unit/core/test_pg_fixture.py -q`
+4. Re-run testmon to confirm the 47 failures are still the right count: `uv run pytest --testmon tests/unit -q`
+5. Resume by patching `pipeline/phases/column_eligibility_phase.py:154` (simplest — phase has `ctx.manager.session_id` directly).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ dev = [
     "pytest-testmon>=2.2.0",
     "zensical>=0.0.24",
     "vulture>=2.15",
+    "testcontainers[postgres]>=4.14",
 ]
 [build-system]
 requires = ["hatchling"]

--- a/src/dataraum/analysis/correlation/db_models.py
+++ b/src/dataraum/analysis/correlation/db_models.py
@@ -37,6 +37,9 @@ class DerivedColumn(Base):
     __tablename__ = "derived_columns"
 
     derived_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     table_id: Mapped[str] = mapped_column(
         ForeignKey("tables.table_id", ondelete="CASCADE"), nullable=False
     )

--- a/src/dataraum/analysis/correlation/processor.py
+++ b/src/dataraum/analysis/correlation/processor.py
@@ -36,6 +36,8 @@ def analyze_correlations(
     table_id: str,
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
+    *,
+    session_id: str,
 ) -> Result[CorrelationAnalysisResult]:
     """Run correlation analysis on a table.
 
@@ -57,7 +59,7 @@ def analyze_correlations(
         if not table:
             return Result.fail(f"Table not found: {table_id}")
 
-        derived_result = detect_derived_columns(table, duckdb_conn, session)
+        derived_result = detect_derived_columns(table, duckdb_conn, session, session_id=session_id)
         derived_columns = derived_result.unwrap() if derived_result.success else []
 
         # Summary stats
@@ -91,6 +93,8 @@ def analyze_enriched_correlations(
     fact_table: Table,
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
+    *,
+    session_id: str,
 ) -> Result[CorrelationAnalysisResult]:
     """Run correlation analysis on an enriched view (fact + dimension columns).
 
@@ -110,7 +114,7 @@ def analyze_enriched_correlations(
 
     try:
         derived_result = detect_enriched_derived_columns(
-            enriched_view, fact_table, duckdb_conn, session
+            enriched_view, fact_table, duckdb_conn, session, session_id=session_id
         )
         derived_columns = derived_result.unwrap() if derived_result.success else []
 

--- a/src/dataraum/analysis/correlation/within_table/derived_columns.py
+++ b/src/dataraum/analysis/correlation/within_table/derived_columns.py
@@ -112,6 +112,8 @@ def detect_derived_columns(
     session: Session,
     min_match_rate: float = 0.80,
     max_workers: int = 8,
+    *,
+    session_id: str,
 ) -> Result[list[DerivedColumn]]:
     """Detect columns that are arithmetic derivations of other columns.
 
@@ -254,6 +256,7 @@ def detect_derived_columns(
         for derived in derived_columns:
             db_derived = DBDerivedColumn(
                 derived_id=derived.derived_id,
+                session_id=session_id,
                 table_id=derived.table_id,
                 derived_column_id=derived.derived_column_id,
                 source_column_ids=derived.source_column_ids,
@@ -280,6 +283,8 @@ def detect_enriched_derived_columns(
     session: Session,
     min_match_rate: float = 0.80,
     max_workers: int = 8,
+    *,
+    session_id: str,
 ) -> Result[list[DerivedColumn]]:
     """Detect derived columns on an enriched view (fact + dimension columns).
 
@@ -432,6 +437,7 @@ def detect_enriched_derived_columns(
         for derived in derived_columns:
             db_derived = DBDerivedColumn(
                 derived_id=derived.derived_id,
+                session_id=session_id,
                 table_id=derived.table_id,
                 derived_column_id=derived.derived_column_id,
                 source_column_ids=derived.source_column_ids,

--- a/src/dataraum/analysis/cycles/agent.py
+++ b/src/dataraum/analysis/cycles/agent.py
@@ -63,6 +63,7 @@ class BusinessCycleAgent(LLMFeature):
         *,
         source_id: str,
         vertical: str,
+        session_id: str,
     ) -> Result[BusinessCycleAnalysis]:
         """Analyze tables for business cycles.
 
@@ -149,7 +150,7 @@ class BusinessCycleAgent(LLMFeature):
             )
 
             # 5. Persist to database
-            self._persist_results(session, analysis, source_id=source_id)
+            self._persist_results(session, analysis, source_id=source_id, session_id=session_id)
 
             return Result.ok(analysis)
 
@@ -314,6 +315,7 @@ class BusinessCycleAgent(LLMFeature):
         analysis: BusinessCycleAnalysis,
         *,
         source_id: str,
+        session_id: str,
     ) -> None:
         """Persist analysis results to database.
 
@@ -325,6 +327,7 @@ class BusinessCycleAgent(LLMFeature):
         for cycle in analysis.cycles:
             db_cycle = DetectedBusinessCycle(
                 cycle_id=cycle.cycle_id,
+                session_id=session_id,
                 source_id=source_id,
                 cycle_name=cycle.cycle_name,
                 cycle_type=cycle.cycle_type,

--- a/src/dataraum/analysis/cycles/db_models.py
+++ b/src/dataraum/analysis/cycles/db_models.py
@@ -36,6 +36,9 @@ class DetectedBusinessCycle(Base):
     __table_args__ = (Index("idx_detected_cycles_source", "source_id"),)
 
     cycle_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     source_id: Mapped[str] = mapped_column(
         ForeignKey("sources.source_id", ondelete="CASCADE"), nullable=False
     )

--- a/src/dataraum/analysis/eligibility/db_models.py
+++ b/src/dataraum/analysis/eligibility/db_models.py
@@ -9,8 +9,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, Text
-from sqlalchemy.dialects.sqlite import JSON
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dataraum.storage import Base

--- a/src/dataraum/analysis/eligibility/db_models.py
+++ b/src/dataraum/analysis/eligibility/db_models.py
@@ -32,6 +32,9 @@ class ColumnEligibilityRecord(Base):
     eligibility_id: Mapped[str] = mapped_column(
         String(36), primary_key=True, default=lambda: str(uuid4())
     )
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     column_id: Mapped[str] = mapped_column(String(36), nullable=False)  # Preserved for audit, no FK
     table_id: Mapped[str] = mapped_column(
         ForeignKey("tables.table_id", ondelete="CASCADE"), nullable=False

--- a/src/dataraum/analysis/relationships/db_models.py
+++ b/src/dataraum/analysis/relationships/db_models.py
@@ -59,6 +59,9 @@ class Relationship(Base):
     relationship_id: Mapped[str] = mapped_column(
         String, primary_key=True, default=lambda: str(uuid4())
     )
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
 
     # Source side
     from_table_id: Mapped[str] = mapped_column(

--- a/src/dataraum/analysis/semantic/db_models.py
+++ b/src/dataraum/analysis/semantic/db_models.py
@@ -40,6 +40,9 @@ class SemanticAnnotation(Base):
     annotation_id: Mapped[str] = mapped_column(
         String, primary_key=True, default=lambda: str(uuid4())
     )
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     column_id: Mapped[str] = mapped_column(
         ForeignKey("columns.column_id", ondelete="CASCADE"), nullable=False
     )
@@ -90,6 +93,9 @@ class TableEntity(Base):
 
     __tablename__ = "table_entities"
     entity_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     table_id: Mapped[str] = mapped_column(
         ForeignKey("tables.table_id", ondelete="CASCADE"), nullable=False
     )

--- a/src/dataraum/analysis/semantic/processor.py
+++ b/src/dataraum/analysis/semantic/processor.py
@@ -144,6 +144,8 @@ def enrich_semantic(
     duckdb_conn: duckdb.DuckDBPyConnection | None = None,
     column_annotations: ColumnAnnotationOutput | None = None,
     required_standard_fields: list[str] | None = None,
+    *,
+    session_id: str,
 ) -> Result[SemanticEnrichmentResult]:
     """Run semantic enrichment on tables.
 
@@ -201,6 +203,7 @@ def enrich_semantic(
 
         # Create or update semantic annotation
         db_annotation = AnnotationModel(
+            session_id=session_id,
             column_id=column_id,
             semantic_role=annotation.semantic_role.value,
             entity_type=annotation.entity_type,
@@ -222,6 +225,7 @@ def enrich_semantic(
             continue
 
         db_entity = EntityModel(
+            session_id=session_id,
             table_id=table_id,
             detected_entity_type=entity.entity_type,
             description=entity.description,
@@ -289,6 +293,7 @@ def enrich_semantic(
 
         db_rel = RelationshipModel(
             relationship_id=rel.relationship_id,
+            session_id=session_id,
             from_table_id=from_table_id,
             from_column_id=from_col_id,
             to_table_id=to_table_id,

--- a/src/dataraum/analysis/slicing/db_models.py
+++ b/src/dataraum/analysis/slicing/db_models.py
@@ -41,6 +41,9 @@ class SliceDefinition(Base):
     )
 
     slice_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     table_id: Mapped[str] = mapped_column(
         ForeignKey("tables.table_id", ondelete="CASCADE"), nullable=False
     )
@@ -92,6 +95,9 @@ class ColumnSliceProfile(Base):
     )
 
     profile_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
 
     # Reference to source column (in the original typed table)
     source_column_id: Mapped[str] = mapped_column(

--- a/src/dataraum/analysis/slicing/profiling.py
+++ b/src/dataraum/analysis/slicing/profiling.py
@@ -25,6 +25,8 @@ logger = get_logger(__name__)
 def build_slice_profiles(
     session: Session,
     source_id: str,
+    *,
+    session_id: str,
 ) -> int:
     """Build ColumnSliceProfile records from per-slice statistical profiles.
 
@@ -189,6 +191,7 @@ def build_slice_profiles(
 
                 session.add(
                     ColumnSliceProfile(
+                        session_id=session_id,
                         source_column_id=eff_col.column_id,
                         slice_column_id=slice_def.column_id,
                         source_table_name=effective_table.table_name,

--- a/src/dataraum/analysis/slicing/slice_runner.py
+++ b/src/dataraum/analysis/slicing/slice_runner.py
@@ -262,6 +262,8 @@ def run_statistics_on_slice(
     slice_info: SliceTableInfo,
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
+    *,
+    session_id: str,
 ) -> Result[Any]:
     """Run statistical profiling on a slice table.
 
@@ -303,6 +305,7 @@ def run_statistics_on_slice(
                 table_id=slice_info.slice_table_id,
                 duckdb_conn=duckdb_conn,
                 session=session,
+                session_id=session_id,
             )
         return result
     finally:
@@ -313,6 +316,8 @@ def run_quality_on_slice(
     slice_info: SliceTableInfo,
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
+    *,
+    session_id: str,
 ) -> Result[Any]:
     """Run statistical quality assessment on a slice table.
 
@@ -328,6 +333,7 @@ def run_quality_on_slice(
         table_id=slice_info.slice_table_id,
         duckdb_conn=duckdb_conn,
         session=session,
+        session_id=session_id,
     )
     return result
 
@@ -338,6 +344,8 @@ def run_analysis_on_slices(
     slice_infos: list[SliceTableInfo],
     run_statistics: bool = True,
     run_quality: bool = True,
+    *,
+    session_id: str,
 ) -> SliceAnalysisResult:
     """Run analysis phases on slice tables.
 
@@ -360,7 +368,9 @@ def run_analysis_on_slices(
     # Run statistics on each slice
     if run_statistics:
         for slice_info in slice_infos:
-            result = run_statistics_on_slice(slice_info, duckdb_conn, session)
+            result = run_statistics_on_slice(
+                slice_info, duckdb_conn, session, session_id=session_id
+            )
             if result.success:
                 stats_count += 1
             else:
@@ -369,7 +379,7 @@ def run_analysis_on_slices(
     # Run quality on each slice
     if run_quality:
         for slice_info in slice_infos:
-            result = run_quality_on_slice(slice_info, duckdb_conn, session)
+            result = run_quality_on_slice(slice_info, duckdb_conn, session, session_id=session_id)
             if result.success:
                 quality_count += 1
             else:

--- a/src/dataraum/analysis/statistics/db_models.py
+++ b/src/dataraum/analysis/statistics/db_models.py
@@ -45,6 +45,9 @@ class StatisticalProfile(Base):
     __tablename__ = "statistical_profiles"
 
     profile_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     column_id: Mapped[str] = mapped_column(
         ForeignKey("columns.column_id", ondelete="CASCADE"), nullable=False
     )

--- a/src/dataraum/analysis/statistics/profiler.py
+++ b/src/dataraum/analysis/statistics/profiler.py
@@ -271,6 +271,8 @@ def profile_statistics(
     session: Session,
     max_workers: int = 8,
     config: dict[str, Any] | None = None,
+    *,
+    session_id: str,
 ) -> Result[StatisticsProfileResult]:
     """Profile typed data to compute all row-based statistics.
 
@@ -393,6 +395,7 @@ def profile_statistics(
 
                     db_profile = DBColumnProfile(
                         profile_id=str(uuid4()),
+                        session_id=session_id,
                         column_id=profile.column_id,
                         profiled_at=profiled_at,
                         layer="typed",

--- a/src/dataraum/analysis/statistics/quality.py
+++ b/src/dataraum/analysis/statistics/quality.py
@@ -392,6 +392,8 @@ def assess_statistical_quality(
     session: Session,
     max_workers: int = 8,
     exclude_outlier_columns: set[str] | None = None,
+    *,
+    session_id: str,
 ) -> Result[list[StatisticalQualityResult]]:
     """Assess statistical quality for all numeric columns in a table.
 
@@ -514,6 +516,7 @@ def assess_statistical_quality(
                     # Persist using hybrid storage (sequential - SQLite writes)
                     db_metric = DBStatisticalQualityMetrics(
                         metric_id=str(uuid4()),
+                        session_id=session_id,
                         column_id=column_id,
                         computed_at=computed_at,
                         benford_compliant=benford_analysis.is_compliant

--- a/src/dataraum/analysis/statistics/quality_db_models.py
+++ b/src/dataraum/analysis/statistics/quality_db_models.py
@@ -46,6 +46,9 @@ class StatisticalQualityMetrics(Base):
     __tablename__ = "statistical_quality_metrics"
 
     metric_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     column_id: Mapped[str] = mapped_column(
         ForeignKey("columns.column_id", ondelete="CASCADE"), nullable=False
     )

--- a/src/dataraum/analysis/temporal/db_models.py
+++ b/src/dataraum/analysis/temporal/db_models.py
@@ -38,6 +38,9 @@ class TemporalColumnProfile(Base):
     __tablename__ = "temporal_column_profiles"
 
     profile_id: Mapped[str] = mapped_column(String, primary_key=True)
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     column_id: Mapped[str] = mapped_column(ForeignKey("columns.column_id"), nullable=False)
     profiled_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
 

--- a/src/dataraum/analysis/temporal/patterns.py
+++ b/src/dataraum/analysis/temporal/patterns.py
@@ -270,11 +270,16 @@ def analyze_trend(
                 )
             )
 
-        # Linear regression
+        # Linear regression. scipy returns NaN on degenerate inputs
+        # (e.g. constant y, zero-variance column). NaN would propagate
+        # into the JSONB ``profile_data`` column on Postgres, which
+        # (correctly) rejects non-standard JSON tokens — so coerce
+        # here to JSON-safe defaults that match the "no detectable
+        # trend" semantics.
         result = stats.linregress(x_clean, y_clean)
-        slope = result.slope
-        rvalue = result.rvalue
-        stderr = result.stderr
+        slope = 0.0 if np.isnan(result.slope) else float(result.slope)
+        rvalue = 0.0 if np.isnan(result.rvalue) else float(result.rvalue)
+        stderr = 0.0 if np.isnan(result.stderr) else float(result.stderr)
 
         # Trend strength is R²
         trend_strength = rvalue**2

--- a/src/dataraum/analysis/temporal/processor.py
+++ b/src/dataraum/analysis/temporal/processor.py
@@ -191,6 +191,7 @@ def profile_temporal(
     session: Session,
     *,
     config: dict[str, Any] | None = None,
+    session_id: str,
 ) -> Result[TemporalProfileResult]:
     """Profile temporal columns in a table.
 
@@ -285,6 +286,7 @@ def profile_temporal(
                     # Create DB object (sequential - SQLite writes)
                     db_profile = TemporalColumnProfile(
                         profile_id=profile.metric_id,
+                        session_id=session_id,
                         column_id=profile.column_id,
                         profiled_at=profiled_at,
                         min_timestamp=profile.min_timestamp,

--- a/src/dataraum/analysis/temporal_slicing/analyzer.py
+++ b/src/dataraum/analysis/temporal_slicing/analyzer.py
@@ -469,6 +469,8 @@ def persist_drift_results(
     slice_table_name: str,
     time_column: str,
     session: Session,
+    *,
+    session_id: str,
 ) -> Result[int]:
     """Persist drift analysis results to database.
 
@@ -489,6 +491,7 @@ def persist_drift_results(
                 evidence_json = result.drift_evidence.model_dump()
 
             record = ColumnDriftSummary(
+                session_id=session_id,
                 slice_table_name=slice_table_name,
                 column_name=result.column_name,
                 time_column=time_column,
@@ -767,6 +770,8 @@ def analyze_period_metrics(
 def persist_period_results(
     result: PeriodAnalysisResult,
     session: Session,
+    *,
+    session_id: str,
 ) -> Result[int]:
     """Persist period analysis results to database.
 
@@ -803,6 +808,7 @@ def persist_period_results(
                 )
 
             record = TemporalSliceAnalysis(
+                session_id=session_id,
                 slice_table_name=result.slice_table_name,
                 time_column=result.time_column,
                 period_label=m.period_label,

--- a/src/dataraum/analysis/temporal_slicing/db_models.py
+++ b/src/dataraum/analysis/temporal_slicing/db_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import UTC, date, datetime
 from uuid import uuid4
 
-from sqlalchemy import JSON, Date, DateTime, Float, Integer, String
+from sqlalchemy import JSON, Date, DateTime, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from dataraum.storage.base import Base
@@ -21,6 +21,9 @@ class ColumnDriftSummary(Base):
     __tablename__ = "column_drift_summaries"
 
     id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
 
     slice_table_name: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     column_name: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
@@ -60,6 +63,9 @@ class TemporalSliceAnalysis(Base):
     __tablename__ = "temporal_slice_analyses"
 
     id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
 
     slice_table_name: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     time_column: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/src/dataraum/analysis/typing/db_models.py
+++ b/src/dataraum/analysis/typing/db_models.py
@@ -53,6 +53,9 @@ class TypeCandidate(Base):
     candidate_id: Mapped[str] = mapped_column(
         String, primary_key=True, default=lambda: str(uuid4())
     )
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     column_id: Mapped[str] = mapped_column(
         ForeignKey("columns.column_id", ondelete="CASCADE"), nullable=False
     )
@@ -98,6 +101,9 @@ class TypeDecision(Base):
     __table_args__ = (UniqueConstraint("column_id", name="uq_column_type_decision"),)
 
     decision_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     column_id: Mapped[str] = mapped_column(
         ForeignKey("columns.column_id", ondelete="CASCADE"), nullable=False
     )

--- a/src/dataraum/analysis/typing/inference.py
+++ b/src/dataraum/analysis/typing/inference.py
@@ -52,6 +52,8 @@ def infer_type_candidates(
     table: Table,
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
+    *,
+    session_id: str,
 ) -> Result[list[TypeCandidateModel]]:
     """Infer type candidates for all VARCHAR columns in a table.
 
@@ -119,6 +121,7 @@ def infer_type_candidates(
             for candidate in candidates:
                 db_candidate = DBTypeCandidate(
                     candidate_id=str(uuid4()),
+                    session_id=session_id,
                     column_id=column.column_id,
                     detected_at=datetime.now(UTC),
                     data_type=candidate.data_type.value,

--- a/src/dataraum/analysis/typing/resolution.py
+++ b/src/dataraum/analysis/typing/resolution.py
@@ -219,6 +219,8 @@ def resolve_types(
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
     min_confidence: float,
+    *,
+    session_id: str,
 ) -> Result[TypeResolutionResult]:
     """Resolve types for a raw table using DuckDB SQL.
 
@@ -280,6 +282,7 @@ def resolve_types(
             raw_col = raw_col_by_id[spec.column_id]
             type_decision = TypeDecision(
                 decision_id=str(uuid4()),
+                session_id=session_id,
                 column=raw_col,
                 decided_type=spec.data_type.value,
                 decision_source=spec.decision_source,
@@ -422,6 +425,7 @@ def resolve_types(
             session.add(
                 TypeDecision(
                     decision_id=str(uuid4()),
+                    session_id=session_id,
                     column_id=target_col_id,
                     decided_type=td.decided_type,
                     decision_source=td.decision_source,
@@ -436,6 +440,7 @@ def resolve_types(
             session.add(
                 TypeCandidate(
                     candidate_id=str(uuid4()),
+                    session_id=session_id,
                     column_id=target_col_id,
                     detected_at=tc.detected_at,
                     data_type=tc.data_type,

--- a/src/dataraum/analysis/validation/agent.py
+++ b/src/dataraum/analysis/validation/agent.py
@@ -71,6 +71,7 @@ class ValidationAgent(LLMFeature):
         persist: bool = True,
         *,
         vertical: str,
+        session_id: str,
     ) -> Result[ValidationRunResult]:
         """Run validation checks across multiple tables.
 
@@ -162,7 +163,7 @@ class ValidationAgent(LLMFeature):
 
         # Persist results to database
         if persist:
-            self._persist_results(session, run_result)
+            self._persist_results(session, run_result, session_id=session_id)
 
         return Result.ok(run_result)
 
@@ -685,6 +686,8 @@ class ValidationAgent(LLMFeature):
         self,
         session: Session,
         run_result: ValidationRunResult,
+        *,
+        session_id: str,
     ) -> None:
         """Persist validation results to the database.
 
@@ -698,6 +701,7 @@ class ValidationAgent(LLMFeature):
             result_data = result.model_dump(mode="json")
             result_record = ValidationResultRecord(
                 result_id=str(uuid4()),
+                session_id=session_id,
                 validation_id=result.validation_id,
                 table_ids=result.table_ids,
                 status=result.status.value,

--- a/src/dataraum/analysis/validation/db_models.py
+++ b/src/dataraum/analysis/validation/db_models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import JSON, DateTime, String, Text
+from sqlalchemy import JSON, DateTime, ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from dataraum.storage import Base
@@ -23,6 +23,9 @@ class ValidationResultRecord(Base):
     __tablename__ = "validation_results"
 
     result_id: Mapped[str] = mapped_column(String, primary_key=True)
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     validation_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
     table_ids: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
 

--- a/src/dataraum/analysis/views/db_models.py
+++ b/src/dataraum/analysis/views/db_models.py
@@ -34,6 +34,9 @@ class EnrichedView(Base):
     __tablename__ = "enriched_views"
 
     view_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
 
     # The fact table this view is based on
     fact_table_id: Mapped[str] = mapped_column(
@@ -80,6 +83,9 @@ class SlicingView(Base):
     __tablename__ = "slicing_views"
 
     view_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
 
     # The fact table this view is based on
     fact_table_id: Mapped[str] = mapped_column(

--- a/src/dataraum/context.py
+++ b/src/dataraum/context.py
@@ -258,6 +258,11 @@ class Context:
             if not source:
                 raise ValueError("No sources found in database")
 
+            sid = self.manager.session_id
+            if not sid:
+                raise ValueError(
+                    "Context.query requires manager.session_id — open via active session."
+                )
             with self.manager.duckdb_cursor() as cursor:
                 result = answer_question(
                     question=question,
@@ -265,6 +270,7 @@ class Context:
                     duckdb_conn=cursor,
                     source_id=source.source_id,
                     contract=contract,
+                    session_id=sid,
                 )
 
             if not result.success or not result.value:

--- a/src/dataraum/core/connections.py
+++ b/src/dataraum/core/connections.py
@@ -1,9 +1,9 @@
-"""Thread-safe connection management for SQLAlchemy + DuckDB.
+"""Connection management for SQLAlchemy + DuckDB.
 
-This module provides concurrent-ready connection management:
-- SQLAlchemy sync sessions (thread-safe with ThreadPoolExecutor)
-- DuckDB cursors for reads and writes
-- WAL mode for SQLite to enable concurrent reads with writes
+Single-engine model post-DAT-321: every SQLAlchemy session bound to one
+workspace Postgres database (workspace tables + per-session tables, the
+latter scoped via ``session_id`` FK). Per-session DuckDB stays per-session;
+L4 swaps that for DuckLake.
 
 Usage:
     from dataraum.core.connections import ConnectionManager, ConnectionConfig
@@ -12,11 +12,9 @@ Usage:
     manager = ConnectionManager(config)
     manager.initialize()
 
-    # Get a session (thread-safe)
     with manager.session_scope() as session:
         # Use session...
 
-    # DuckDB operations (via cursor)
     with manager.duckdb_cursor() as cursor:
         result = cursor.execute("SELECT * FROM table").fetchdf()
 
@@ -25,6 +23,7 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import threading
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -33,7 +32,7 @@ from pathlib import Path
 from typing import Any
 
 import duckdb
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -43,30 +42,45 @@ from dataraum.storage import Base
 logger = get_logger(__name__)
 
 
+_DATABASE_URL_MISSING_MSG = (
+    "DATABASE_URL is not set. The workspace SQLAlchemy engine targets Postgres; "
+    "the container substrate (L1) provides this on the control-plane service "
+    "(see docker-compose.yml). For local dev outside the container, export "
+    "DATABASE_URL=postgresql+psycopg://<user>:<pass>@<host>:<port>/<db>."
+)
+
+
+def _resolve_database_url() -> str:
+    """Read DATABASE_URL or fail loud with an actionable message."""
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        raise RuntimeError(_DATABASE_URL_MISSING_MSG)
+    return url
+
+
 @dataclass
 class ConnectionConfig:
-    """Connection configuration for SQLAlchemy and DuckDB.
+    """Connection configuration for SQLAlchemy (Postgres) + DuckDB.
 
     Attributes:
-        sqlite_path: Path to SQLite database file
-        duckdb_path: Path to DuckDB database file. None for SQLite-only
-            configurations (e.g. the MCP server's workspace registry).
-        pool_size: SQLAlchemy connection pool size
-        max_overflow: Maximum overflow connections beyond pool_size
-        pool_timeout: Seconds to wait for a connection from pool
-        sqlite_timeout: SQLite busy timeout in seconds
-        duckdb_memory_limit: DuckDB memory limit (e.g., "2GB")
-        echo_sql: Whether to echo SQL statements (for debugging)
+        database_url: SQLAlchemy URL for the workspace Postgres engine
+            (``postgresql+psycopg://...``).
+        duckdb_path: Path to per-session DuckDB file. ``None`` for the
+            workspace registry (no per-session data).
+        pool_size: SQLAlchemy connection pool size.
+        max_overflow: Maximum overflow connections beyond pool_size.
+        pool_timeout: Seconds to wait for a connection from pool.
+        duckdb_memory_limit: DuckDB memory limit (e.g., "2GB").
+        echo_sql: Whether to echo SQL statements (for debugging).
     """
 
-    sqlite_path: Path
+    database_url: str
     duckdb_path: Path | None = None
 
     # SQLAlchemy pool settings
     pool_size: int = 5
     max_overflow: int = 10
     pool_timeout: float = 30.0
-    sqlite_timeout: float = 120.0
 
     # DuckDB settings
     duckdb_memory_limit: str = "2GB"
@@ -75,41 +89,45 @@ class ConnectionConfig:
     echo_sql: bool = False
 
     @classmethod
-    def for_directory(cls, output_dir: Path, **kwargs: Any) -> ConnectionConfig:
-        """Create config for a pipeline output directory (SQLite + DuckDB).
+    def for_workspace(cls, **kwargs: Any) -> ConnectionConfig:
+        """Workspace registry config: Postgres-only, no DuckDB.
 
-        Used by CLI, Python SDK, and the MCP server's per-session managers.
-        Both SQLite metadata and DuckDB data files live in `output_dir`.
+        Reads ``DATABASE_URL`` from the environment. Raises if unset.
+        """
+        return cls(database_url=_resolve_database_url(), duckdb_path=None, **kwargs)
+
+    @classmethod
+    def for_directory(cls, output_dir: Path, **kwargs: Any) -> ConnectionConfig:
+        """Per-session config: workspace Postgres + per-session DuckDB.
+
+        SQLAlchemy targets the same workspace Postgres engine as
+        ``for_workspace()``; the per-session DuckDB file lives at
+        ``output_dir/data.duckdb`` (L4 swaps this for DuckLake).
         """
         return cls(
-            sqlite_path=output_dir / "metadata.db",
+            database_url=_resolve_database_url(),
             duckdb_path=output_dir / "data.duckdb",
             **kwargs,
         )
 
-    @classmethod
-    def for_workspace(cls, root: Path, **kwargs: Any) -> ConnectionConfig:
-        """Create config for the MCP server's workspace registry (SQLite only).
-
-        The workspace holds source registrations and the active-session
-        pointer. It has no DuckDB — analytical data lives in per-session
-        directories created on `begin_session`.
-        """
-        return cls(sqlite_path=root / "workspace.db", duckdb_path=None, **kwargs)
-
 
 @dataclass
 class ConnectionManager:
-    """Thread-safe connection management for SQLAlchemy + DuckDB.
+    """Thread-safe connection management for SQLAlchemy (Postgres) + DuckDB.
 
     Provides:
-    - SQLAlchemy sync session factory (thread-safe)
-    - DuckDB access via cursors (concurrent-safe)
+    - SQLAlchemy sync session factory bound to the workspace Postgres engine
+    - DuckDB access via cursors (per-session, optional)
     - Proper cleanup on close
 
+    The ``session_id`` field is populated by callers that open a per-session
+    manager (e.g. ``mcp/server.py::_get_session_manager``). Recorders read
+    it when constructing per-session rows so writes carry the FK scoping
+    required by the post-L2 schema.
+
     Thread Safety:
-    - SQLAlchemy sessions: One session per thread via session_scope()
-    - DuckDB: Use cursor() which is thread-safe
+    - SQLAlchemy sessions: One session per thread via ``session_scope()``
+    - DuckDB: Use ``duckdb_cursor()`` which returns an independent cursor
 
     Usage:
         manager = ConnectionManager(config)
@@ -125,6 +143,7 @@ class ConnectionManager:
     """
 
     config: ConnectionConfig
+    session_id: str | None = None
     _engine: Engine | None = field(default=None, init=False, repr=False)
     _session_factory: sessionmaker[Session] | None = field(default=None, init=False, repr=False)
     _duckdb_conn: duckdb.DuckDBPyConnection | None = field(default=None, init=False, repr=False)
@@ -134,11 +153,11 @@ class ConnectionManager:
     def initialize(self) -> None:
         """Initialize connection pools and databases.
 
-        Creates SQLAlchemy engine with connection pool and DuckDB connection.
-        Safe to call multiple times (idempotent).
+        Creates the SQLAlchemy engine + pool and the optional DuckDB
+        connection. Safe to call multiple times (idempotent).
 
         Raises:
-            RuntimeError: If initialization fails
+            RuntimeError: If initialization fails.
         """
         with self._init_lock:
             if self._initialized:
@@ -153,47 +172,23 @@ class ConnectionManager:
                 raise RuntimeError(f"Failed to initialize connections: {e}") from e
 
     def _init_sqlalchemy(self) -> None:
-        """Initialize SQLAlchemy sync engine with connection pool."""
-        # Handle in-memory vs file-based SQLite
-        if self.config.sqlite_path == Path(":memory:"):
-            db_url = "sqlite:///:memory:"
-        else:
-            self.config.sqlite_path.parent.mkdir(parents=True, exist_ok=True)
-            db_url = f"sqlite:///{self.config.sqlite_path}"
-
+        """Initialize the workspace Postgres SQLAlchemy engine."""
         self._engine = create_engine(
-            db_url,
+            self.config.database_url,
             echo=self.config.echo_sql,
             pool_size=self.config.pool_size,
             max_overflow=self.config.max_overflow,
             pool_timeout=self.config.pool_timeout,
             pool_pre_ping=True,
-            # Explicitly allow cross-thread usage (SQLAlchemy default for file DBs)
-            connect_args={"check_same_thread": False},
         )
 
-        # Configure SQLite pragmas on each connection
-        @event.listens_for(self._engine, "connect")
-        def configure_sqlite(dbapi_conn: Any, connection_record: Any) -> None:
-            cursor = dbapi_conn.cursor()
-            # Enable foreign keys
-            cursor.execute("PRAGMA foreign_keys=ON")
-            # Use WAL mode for better concurrency (readers don't block writers)
-            cursor.execute("PRAGMA journal_mode=WAL")
-            # Set busy timeout (milliseconds)
-            cursor.execute(f"PRAGMA busy_timeout={int(self.config.sqlite_timeout * 1000)}")
-            # Synchronous mode - NORMAL is good balance of safety/speed
-            cursor.execute("PRAGMA synchronous=NORMAL")
-            cursor.close()
-
-        # Import all models to register them with SQLAlchemy
+        # Register all models before create_all so every per-session table
+        # materializes alongside the workspace tables.
         self._import_all_models()
 
-        # Create tables
         Base.metadata.create_all(self._engine)
 
-        # Create session factory
-        # autoflush=False prevents mid-query writes; we flush at commit time with a lock
+        # autoflush=False keeps writes batched; commit happens at scope close.
         self._session_factory = sessionmaker(
             self._engine,
             expire_on_commit=False,
@@ -201,10 +196,11 @@ class ConnectionManager:
         )
 
     def _init_duckdb(self) -> None:
-        """Initialize DuckDB connection for data, if configured.
+        """Initialize the per-session DuckDB connection, if configured.
 
-        SQLite-only configurations (e.g. workspace registry) skip this entirely;
-        `duckdb_cursor()` will raise on attempted use.
+        Workspace-only configurations skip this entirely; ``duckdb_cursor()``
+        will raise on attempted use. L4 swaps the file-backed DuckDB for
+        DuckLake but leaves this hook intact.
         """
         if self.config.duckdb_path is None:
             return
@@ -214,7 +210,6 @@ class ConnectionManager:
             self.config.duckdb_path.parent.mkdir(parents=True, exist_ok=True)
             self._duckdb_conn = duckdb.connect(str(self.config.duckdb_path))
 
-        # Configure DuckDB
         self._duckdb_conn.execute(f"SET memory_limit='{self.config.duckdb_memory_limit}'")
 
     def _import_all_models(self) -> None:
@@ -234,7 +229,6 @@ class ConnectionManager:
         import_all_phase_models()
 
     def _ensure_initialized(self) -> None:
-        """Raise if not initialized."""
         if not self._initialized:
             raise RuntimeError(
                 "ConnectionManager not initialized. Call manager.initialize() first."
@@ -245,17 +239,12 @@ class ConnectionManager:
         """Get a session with automatic cleanup.
 
         Thread-safe: each call creates a new session from the QueuePool.
-        SQLite WAL mode + PRAGMA busy_timeout handle write contention at
-        the C level — no Python-level mutex or retry needed here.
-
-        Session is created with autoflush=False. All writes are batched and
-        committed atomically at the end.
 
         Yields:
-            Session from the connection pool
+            Session from the connection pool.
 
         Raises:
-            RuntimeError: If manager not initialized
+            RuntimeError: If manager not initialized.
 
         Example:
             with manager.session_scope() as session:
@@ -277,14 +266,10 @@ class ConnectionManager:
     def get_session(self) -> Session:
         """Get a new session from the pool.
 
-        The caller is responsible for committing/closing the session.
-        Prefer session_scope() for automatic cleanup.
-
-        Returns:
-            New Session from pool
+        Caller is responsible for committing/closing. Prefer ``session_scope()``.
 
         Raises:
-            RuntimeError: If manager not initialized
+            RuntimeError: If manager not initialized.
         """
         self._ensure_initialized()
         assert self._session_factory is not None
@@ -292,20 +277,14 @@ class ConnectionManager:
 
     @contextmanager
     def duckdb_cursor(self) -> Generator[duckdb.DuckDBPyConnection]:
-        """Get an independent DuckDB cursor on the shared connection.
+        """Get an independent DuckDB cursor on the shared per-session connection.
 
-        Each call returns a fresh cursor via `connection.cursor()`. Cursors
+        Each call returns a fresh cursor via ``connection.cursor()``. Cursors
         have independent statement state and are safe to use from separate
-        threads. Concurrent writes through multiple cursors are serialized
-        by DuckDB internally (DuckDB ≥ 0.10). The underlying connection
-        itself is shared — do not pass the cursor across threads, but each
-        thread holding its own cursor is supported.
-
-        Yields:
-            Independent DuckDB cursor on the shared connection.
+        threads; the underlying connection is shared.
 
         Raises:
-            RuntimeError: If manager not initialized.
+            RuntimeError: If manager not initialized or no DuckDB configured.
 
         Example:
             with manager.duckdb_cursor() as cursor:
@@ -314,9 +293,9 @@ class ConnectionManager:
         self._ensure_initialized()
         if self._duckdb_conn is None:
             raise RuntimeError(
-                "DuckDB cursor requested on a SQLite-only ConnectionManager. "
+                "DuckDB cursor requested on a workspace-only ConnectionManager. "
                 "Workspace managers (ConnectionConfig.for_workspace) have no "
-                "DuckDB; route data operations through a session manager."
+                "DuckDB; route data operations through a per-session manager."
             )
 
         cursor = self._duckdb_conn.cursor()
@@ -329,11 +308,8 @@ class ConnectionManager:
     def engine(self) -> Engine:
         """Get the SQLAlchemy engine.
 
-        Returns:
-            The Engine instance
-
         Raises:
-            RuntimeError: If manager not initialized
+            RuntimeError: If manager not initialized.
         """
         self._ensure_initialized()
         assert self._engine is not None
@@ -362,20 +338,16 @@ class ConnectionManager:
         self._initialized = False
 
     def get_stats(self) -> dict[str, Any]:
-        """Get connection pool statistics.
-
-        Returns:
-            Dict with pool status information
-        """
+        """Get connection pool statistics."""
         self._ensure_initialized()
         assert self._engine is not None
 
         pool: Any = self._engine.pool
         return {
-            "sqlite_pool_size": pool.size() if hasattr(pool, "size") else None,
-            "sqlite_checked_out": pool.checkedout() if hasattr(pool, "checkedout") else None,
-            "sqlite_overflow": pool.overflow() if hasattr(pool, "overflow") else None,
-            "sqlite_checked_in": pool.checkedin() if hasattr(pool, "checkedin") else None,
+            "pool_size": pool.size() if hasattr(pool, "size") else None,
+            "pool_checked_out": pool.checkedout() if hasattr(pool, "checkedout") else None,
+            "pool_overflow": pool.overflow() if hasattr(pool, "overflow") else None,
+            "pool_checked_in": pool.checkedin() if hasattr(pool, "checkedin") else None,
             "duckdb_connected": self._duckdb_conn is not None,
         }
 
@@ -390,15 +362,15 @@ def get_connection_manager(
 ) -> ConnectionManager:
     """Get or create a default ConnectionManager.
 
-    For simple scripts that don't need multiple managers.
-    Creates a singleton manager on first call.
+    For simple scripts that don't need multiple managers. Creates a
+    singleton manager on first call.
 
     Args:
-        output_dir: Output directory (used if config not provided)
-        config: Full configuration (takes precedence over output_dir)
+        output_dir: Output directory for per-session DuckDB (if config not provided).
+        config: Full configuration (takes precedence over output_dir).
 
     Returns:
-        Initialized ConnectionManager
+        Initialized ConnectionManager.
     """
     global _default_manager
 
@@ -424,23 +396,17 @@ def close_default_manager() -> None:
 
 
 def get_manager_for_directory(output_dir: Path) -> ConnectionManager:
-    """Create and initialize a ConnectionManager for a pipeline output directory.
+    """Create and initialize a ConnectionManager for a per-session directory.
 
-    Framework-agnostic: raises FileNotFoundError instead of using CLI-specific
-    error handling (typer.Exit, etc.).
+    Framework-agnostic: raises ``RuntimeError`` if ``DATABASE_URL`` is unset.
 
     Args:
-        output_dir: Directory containing pipeline databases (metadata.db, data.duckdb)
+        output_dir: Directory containing the per-session DuckDB file.
 
     Returns:
         Initialized ConnectionManager. Caller is responsible for closing it.
-
-    Raises:
-        FileNotFoundError: If no metadata database exists at the expected path
     """
     config = ConnectionConfig.for_directory(output_dir)
-    if not config.sqlite_path.exists():
-        raise FileNotFoundError(f"No metadata database at {config.sqlite_path}")
     manager = ConnectionManager(config)
     manager.initialize()
     return manager

--- a/src/dataraum/documentation/db_models.py
+++ b/src/dataraum/documentation/db_models.py
@@ -27,6 +27,9 @@ class FixLedgerEntry(Base):
     __tablename__ = "fix_ledger"
 
     fix_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     source_id: Mapped[str] = mapped_column(ForeignKey("sources.source_id"), nullable=False)
 
     # What action this resolves

--- a/src/dataraum/documentation/ledger.py
+++ b/src/dataraum/documentation/ledger.py
@@ -23,6 +23,8 @@ def log_fix(
     user_input: str,
     interpretation: str,
     status: str = "confirmed",
+    *,
+    session_id: str,
 ) -> FixLedgerEntry:
     """Create a fix entry, superseding any prior fix with the same status for same action+scope.
 
@@ -55,6 +57,7 @@ def log_fix(
 
     # Create new entry
     new_entry = FixLedgerEntry(
+        session_id=session_id,
         source_id=source_id,
         action_name=action_name,
         table_name=table_name,

--- a/src/dataraum/entropy/db_models.py
+++ b/src/dataraum/entropy/db_models.py
@@ -30,6 +30,9 @@ class EntropyObjectRecord(Base):
     __tablename__ = "entropy_objects"
 
     object_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
 
     # Identity - what is being measured
     layer: Mapped[str] = mapped_column(

--- a/src/dataraum/entropy/engine.py
+++ b/src/dataraum/entropy/engine.py
@@ -30,6 +30,8 @@ def run_detector_post_step(
     source_id: str,
     detector_id: str,
     duckdb_conn: Any = None,
+    *,
+    session_id: str,
 ) -> int:
     """Run a single detector as a phase post-step.
 
@@ -96,6 +98,7 @@ def run_detector_post_step(
                     all_records.append(
                         _make_record(
                             source_id=source_id,
+                            session_id=session_id,
                             entropy_obj=obj,
                             table_id=table.table_id,
                             column_id=col.column_id,
@@ -116,6 +119,7 @@ def run_detector_post_step(
                 all_records.append(
                     _make_record(
                         source_id=source_id,
+                        session_id=session_id,
                         entropy_obj=obj,
                         table_id=_resolve_table_id_from_target(
                             obj.target, table_id_by_name, table.table_id
@@ -149,6 +153,7 @@ def run_detector_post_step(
                 all_records.append(
                     _make_record(
                         source_id=source_id,
+                        session_id=session_id,
                         entropy_obj=obj,
                         table_id=ev.fact_table_id,
                         column_id=_extract_column_id(obj),
@@ -237,9 +242,12 @@ def _make_record(
     entropy_obj: EntropyObject,
     table_id: str | None,
     column_id: str | None,
+    *,
+    session_id: str,
 ) -> EntropyObjectRecord:
     """Create an EntropyObjectRecord from an EntropyObject."""
     return EntropyObjectRecord(
+        session_id=session_id,
         source_id=source_id,
         table_id=table_id,
         column_id=column_id,

--- a/src/dataraum/graphs/__init__.py
+++ b/src/dataraum/graphs/__init__.py
@@ -17,7 +17,7 @@ Usage:
         duckdb_conn=conn,
         table_ids=table_ids,
     )
-    result = agent.execute(session, graph, context)
+    result = agent.execute(session, graph, context, session_id=session_id)
 """
 
 from .agent import ExecutionContext, GeneratedCode, GraphAgent

--- a/src/dataraum/graphs/agent.py
+++ b/src/dataraum/graphs/agent.py
@@ -157,6 +157,8 @@ class GraphAgent(LLMFeature):
         parameters: dict[str, Any] | None = None,
         force_regenerate: bool = False,
         inspiration_sql: str | None = None,
+        *,
+        session_id: str,
     ) -> Result[GraphExecution]:
         """Execute a graph by generating and running SQL.
 
@@ -222,6 +224,7 @@ class GraphAgent(LLMFeature):
                         execution_id=generated_code.code_id,
                         cached_snippets=cached_snippets,
                         generated_steps=generated_code.steps,
+                        session_id=session_id,
                     )
             else:
                 # Generate SQL using LLM (with cached snippet hints)
@@ -243,6 +246,7 @@ class GraphAgent(LLMFeature):
                     execution_id=generated_code.code_id,
                     cached_snippets=cached_snippets or {},
                     generated_steps=generated_code.steps,
+                    session_id=session_id,
                 )
 
             if generated_code is None:
@@ -274,6 +278,7 @@ class GraphAgent(LLMFeature):
             generated_code=generated_code,
             schema_mapping_id=schema_mapping_id,
             step_results=execution.step_results,
+            session_id=session_id,
         )
 
         return Result.ok(execution)
@@ -841,12 +846,14 @@ class GraphAgent(LLMFeature):
         execution_id: str,
         cached_snippets: dict[str, dict[str, Any]],
         generated_steps: list[dict[str, str]],
+        *,
+        session_id: str,
     ) -> None:
         """Track how cached snippets were used in graph execution."""
         from dataraum.query.snippet_library import SnippetLibrary
         from dataraum.query.snippet_utils import determine_usage_type
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=session_id)
         used_snippet_ids: set[str] = set()
 
         for gen_step in generated_steps:
@@ -900,6 +907,8 @@ class GraphAgent(LLMFeature):
         generated_code: GeneratedCode,
         schema_mapping_id: str,
         step_results: list[StepResult] | None = None,
+        *,
+        session_id: str,
     ) -> None:
         """Save generated SQL steps as snippets for cross-graph reuse.
 
@@ -917,7 +926,7 @@ class GraphAgent(LLMFeature):
         from dataraum.query.snippet_library import SnippetLibrary
         from dataraum.query.snippet_utils import normalize_expression
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=session_id)
 
         source = f"graph:{graph.graph_id}"
 

--- a/src/dataraum/graphs/agent.py
+++ b/src/dataraum/graphs/agent.py
@@ -265,7 +265,7 @@ class GraphAgent(LLMFeature):
                 failed_ids = [
                     s["snippet_id"] for s in cached_snippets.values() if s.get("snippet_id")
                 ]
-                SnippetLibrary(session).record_failure(failed_ids)
+                SnippetLibrary(session, session_id=session_id).record_failure(failed_ids)
             return Result.fail(exec_result.error or "SQL execution failed")
 
         execution = exec_result.value

--- a/src/dataraum/investigation/db_models.py
+++ b/src/dataraum/investigation/db_models.py
@@ -11,8 +11,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
-from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, String
-from sqlalchemy.dialects.sqlite import JSON
+from sqlalchemy import JSON, DateTime, Float, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dataraum.storage.base import Base

--- a/src/dataraum/mcp/server.py
+++ b/src/dataraum/mcp/server.py
@@ -225,11 +225,24 @@ def create_server(output_dir: Path | None = None) -> Server:
                 return None
             return (pointer.session_id, pointer.fingerprint)
 
-    def _get_session_manager(fingerprint: str) -> ConnectionManager:
-        """Open or reuse the session manager for the given fingerprint."""
+    def _get_session_manager(fingerprint: str, session_id: str | None = None) -> ConnectionManager:
+        """Open or reuse the session manager for the given fingerprint.
+
+        ``session_id`` is the active ``InvestigationSession.session_id`` and
+        is bound onto the manager so per-session writes (PhaseLog,
+        EntropyObjectRecord, snippet rows, ...) carry the FK scoping
+        required post-DAT-321. Pass ``None`` from bootstrap paths that
+        create the InvestigationSession after opening (begin_session,
+        _restore_archived_session) and set ``manager.session_id`` once
+        the new id is in hand. The manager is cached by fingerprint; the
+        session_id is refreshed on every call so a fingerprint reused
+        across sessions (e.g. after resume_session) sees the new id.
+        """
         nonlocal _session_manager, _active_fingerprint
 
         if _session_manager is not None and _active_fingerprint == fingerprint:
+            if session_id is not None:
+                _session_manager.session_id = session_id
             return _session_manager
 
         # Different fingerprint than cached — close stale manager and open new
@@ -242,7 +255,7 @@ def create_server(output_dir: Path | None = None) -> Server:
         session_dir = root_dir / "sessions" / fingerprint
         session_dir.mkdir(parents=True, exist_ok=True)
         config = ConnectionConfig.for_directory(session_dir)
-        _session_manager = CM(config)
+        _session_manager = CM(config, session_id=session_id)
         _session_manager.initialize()
         _active_fingerprint = fingerprint
         return _session_manager
@@ -947,7 +960,7 @@ def create_server(output_dir: Path | None = None) -> Server:
 
         if active is not None:
             active_session_id, active_session_fp = active
-            session_mgr = _get_session_manager(active_session_fp)
+            session_mgr = _get_session_manager(active_session_fp, active_session_id)
             with session_mgr.session_scope() as session:
                 inv = session.execute(
                     select(InvestigationSession)
@@ -1038,10 +1051,12 @@ def create_server(output_dir: Path | None = None) -> Server:
                 session_dir = _session_dir_for(active_session_fp)
                 if measure_experimental and measure_experimental.is_task:
                     loop = asyncio.get_running_loop()
-                    # Capture contract/vertical/fingerprint as locals
+                    # Capture contract/vertical/fingerprint/session_id as locals
                     _contract = active_contract
                     _vertical = active_vertical
                     _fp = active_session_fp
+                    _sid = active_session_id
+                    assert _sid is not None  # guarded by active is not None
 
                     async def _measure_work(task: ServerTaskContext) -> CallToolResult:
                         try:
@@ -1049,12 +1064,13 @@ def create_server(output_dir: Path | None = None) -> Server:
                             await asyncio.to_thread(
                                 _run_pipeline,
                                 session_dir,
+                                _sid,
                                 callback,
                                 _contract,
                                 _vertical,
                                 measure_phase,
                             )
-                            with _get_session_manager(_fp).session_scope() as post_session:
+                            with _get_session_manager(_fp, _sid).session_scope() as post_session:
                                 measure_result = _measure(post_session, target=measure_target)
                             return CallToolResult(
                                 content=[
@@ -1081,9 +1097,14 @@ def create_server(output_dir: Path | None = None) -> Server:
                     )
                 else:
                     # No task API: fire-and-forget
+                    assert active_session_id is not None  # guarded by active is not None
                     bg = asyncio.create_task(
                         _run_pipeline_background(
-                            session_dir, active_contract, active_vertical, measure_phase
+                            session_dir,
+                            active_session_id,
+                            active_contract,
+                            active_vertical,
+                            measure_phase,
                         )
                     )
                     _background_tasks.add(bg)
@@ -1169,6 +1190,7 @@ def create_server(output_dir: Path | None = None) -> Server:
                     arguments["question"],
                     active_contract,
                     display_limit=arguments.get("limit", 10000),
+                    session_id=active_session_id,  # type: ignore[arg-type]  # guarded above
                 )
                 # Export via DuckDB COPY — full data, no Python materialization.
                 # Temp views from execute_sql_steps survive on this cursor.
@@ -1193,6 +1215,7 @@ def create_server(output_dir: Path | None = None) -> Server:
                     sql=arguments.get("sql"),
                     column_mappings=arguments.get("column_mappings"),
                     limit=arguments.get("limit", 100),
+                    session_id=active_session_id,
                 )
                 # Export via DuckDB COPY — full data, no Python materialization
                 export_fmt = arguments.get("export_format")
@@ -1240,6 +1263,7 @@ def create_server(output_dir: Path | None = None) -> Server:
                                 )
                                 teach_params[key] = resolved
 
+                    assert active_session_id is not None  # guarded by flow enforcement
                     result = handle_teach(
                         teach_type=arguments["type"],
                         params=teach_params,
@@ -1248,6 +1272,7 @@ def create_server(output_dir: Path | None = None) -> Server:
                         vertical=active_vertical or "_adhoc",
                         config_root=teach_config_root,
                         target=teach_target,
+                        session_id=active_session_id,
                     )
         elif name == "search_snippets":
             assert session_mgr is not None
@@ -1425,7 +1450,7 @@ def _list_archived_sessions(workspace_mgr: ConnectionManager) -> list[dict[str, 
 
 def _restore_archived_session(
     workspace_mgr: ConnectionManager,
-    open_session_manager: Callable[[str], ConnectionManager],
+    open_session_manager: Callable[..., ConnectionManager],
     close_session_manager: Callable[[], None],
     archive_root: Path,
     sessions_root: Path,
@@ -1728,6 +1753,7 @@ def _get_phase_labels() -> dict[str, str]:
 
 def _run_pipeline(
     output_dir: Path,
+    session_id: str,
     event_callback: EventCallback | None = None,
     contract: str | None = None,
     vertical: str | None = None,
@@ -1740,6 +1766,8 @@ def _run_pipeline(
 
     Args:
         output_dir: Pipeline output directory (the session_dir).
+        session_id: Active InvestigationSession id (FK target for every
+            per-session row written by the pipeline).
         event_callback: Optional callback for pipeline events.
         contract: Active contract name from the session.
         vertical: Domain vertical (e.g. 'finance'). None → '_adhoc'.
@@ -1758,6 +1786,7 @@ def _run_pipeline(
         vertical=vertical,
         target_phase=target_phase,
         force_phase=target_phase is not None,
+        session_id=session_id,
     )
 
     result = run(config)
@@ -1797,6 +1826,7 @@ def _run_pipeline(
 
 async def _run_pipeline_background(
     output_dir: Path,
+    session_id: str,
     contract: str | None = None,
     vertical: str | None = None,
     target_phase: str | None = None,
@@ -1807,7 +1837,9 @@ async def _run_pipeline_background(
     This function restores it in its finally block — even on failure.
     """
     try:
-        await asyncio.to_thread(_run_pipeline, output_dir, None, contract, vertical, target_phase)
+        await asyncio.to_thread(
+            _run_pipeline, output_dir, session_id, None, contract, vertical, target_phase
+        )
     except Exception:
         _log.exception("Background pipeline failed for %s", output_dir)
     finally:
@@ -1820,6 +1852,8 @@ def _query(
     question: str,
     contract_name: str | None = None,
     display_limit: int = 10_000,
+    *,
+    session_id: str,
 ) -> tuple[dict[str, Any], Any]:
     """Execute a natural language query.
 
@@ -1848,6 +1882,7 @@ def _query(
         source_id=source.source_id,
         contract=contract_name,
         display_limit=display_limit,
+        session_id=session_id,
     )
 
     if not result.success or not result.value:
@@ -2256,6 +2291,8 @@ def _run_sql(
     sql: str | None = None,
     column_mappings: dict[str, str] | None = None,
     limit: int = 100,
+    *,
+    session_id: str | None = None,
 ) -> dict[str, Any]:
     """Execute SQL directly against analyzed data.
 
@@ -2300,6 +2337,7 @@ def _run_sql(
         column_mappings=column_mappings,
         limit=limit,
         repair_fn=repair_fn,
+        session_id=session_id,
     )
 
 
@@ -2407,7 +2445,7 @@ def _check_prerequisites() -> str | None:
 
 def _begin_new_session(
     workspace_mgr: ConnectionManager,
-    open_session_manager: Callable[[str], ConnectionManager],
+    open_session_manager: Callable[..., ConnectionManager],
     source: str,
     intent: str,
     contract: str | None = None,

--- a/src/dataraum/mcp/server.py
+++ b/src/dataraum/mcp/server.py
@@ -123,64 +123,48 @@ def _resolve_root_dir() -> Path:
     return Path("~/.dataraum").expanduser()
 
 
-def _read_archive_summary(archive_dir: Path, session_id: str, fingerprint: str) -> Any | None:
-    """Read the just-archived session DB and build an ArchivedSession row.
+def _read_archive_summary(workspace_session: Any, session_id: str, fingerprint: str) -> Any | None:
+    """Build an ArchivedSession row from the workspace Postgres state.
 
-    Uses sqlite3 directly so we don't spin up a full ConnectionManager (which
-    would also open DuckDB) for a one-shot read. Returns None if the metadata
-    is unreadable — the caller treats that as a non-fatal indexing miss.
+    Post-DAT-321 every InvestigationSession lives in workspace Postgres, so
+    indexing an archive is a SQLAlchemy SELECT instead of a sqlite3 read
+    against a per-session metadata.db (which no longer exists). Returns
+    None if the session has no matching investigation row or no live source
+    — the caller treats that as a non-fatal indexing miss.
     """
-    import sqlite3
+    from sqlalchemy import select
 
+    from dataraum.investigation.db_models import InvestigationSession
     from dataraum.mcp.db_models import ArchivedSession
+    from dataraum.storage import Source
 
-    metadata_db = archive_dir / "metadata.db"
-    if not metadata_db.exists():
-        return None
-    try:
-        with sqlite3.connect(str(metadata_db)) as conn:
-            inv_row = conn.execute(
-                "SELECT intent, contract, vertical, status, outcome_summary, "
-                "started_at, ended_at, step_count "
-                "FROM investigation_sessions WHERE session_id = ?",
-                (session_id,),
-            ).fetchone()
-            if inv_row is None:
-                return None
-            source_rows = conn.execute(
-                "SELECT name FROM sources WHERE archived_at IS NULL ORDER BY created_at LIMIT 1"
-            ).fetchall()
-    except sqlite3.OperationalError:
-        _log.warning("Could not read archive metadata at %s", metadata_db, exc_info=True)
+    inv = workspace_session.execute(
+        select(InvestigationSession).where(InvestigationSession.session_id == session_id)
+    ).scalar_one_or_none()
+    if inv is None:
+        _log.warning("No InvestigationSession row to index for session_id=%s", session_id)
         return None
 
-    if not source_rows:
-        _log.warning("Archive %s has no source row to index", metadata_db)
+    source = workspace_session.execute(
+        select(Source).where(Source.archived_at.is_(None)).order_by(Source.created_at).limit(1)
+    ).scalar_one_or_none()
+    if source is None:
+        _log.warning("No live Source row to index against for session_id=%s", session_id)
         return None
 
-    intent, contract, vertical, status, outcome_summary, started_at, ended_at, step_count = inv_row
     return ArchivedSession(
         session_id=session_id,
         fingerprint=fingerprint,
-        intent=intent,
-        contract=contract or "exploratory_analysis",
-        vertical=vertical,
-        outcome=status,
-        summary=outcome_summary,
-        source_name=source_rows[0][0],
-        started_at=_parse_sqlite_datetime(started_at),
-        ended_at=_parse_sqlite_datetime(ended_at) or datetime.now(UTC),
-        step_count=step_count or 0,
+        intent=inv.intent,
+        contract=inv.contract or "exploratory_analysis",
+        vertical=inv.vertical,
+        outcome=inv.status,
+        summary=inv.outcome_summary,
+        source_name=source.name,
+        started_at=inv.started_at,
+        ended_at=inv.ended_at or datetime.now(UTC),
+        step_count=inv.step_count or 0,
     )
-
-
-def _parse_sqlite_datetime(value: Any) -> datetime | None:
-    """Convert sqlite3's text/None datetime back to a Python datetime."""
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value
-    return datetime.fromisoformat(str(value))
 
 
 def create_server(output_dir: Path | None = None) -> Server:
@@ -189,9 +173,10 @@ def create_server(output_dir: Path | None = None) -> Server:
     Args:
         output_dir: Explicit base directory (for tests). If not provided,
             resolves via DATARAUM_HOME (default ~/.dataraum/). The workspace
-            registry lives at root/workspace.db, per-session data at
-            root/sessions/{fingerprint}/, archived sessions at
-            root/archive/{session_id}/.
+            registry now lives in Postgres (DATABASE_URL); the host root
+            still anchors per-session DuckDB at root/sessions/{fingerprint}/
+            and archived DuckDB files at root/archive/{session_id}/ until
+            L4 swaps DuckDB for DuckLake.
     """
     if output_dir is None:
         root_dir = _resolve_root_dir()
@@ -200,10 +185,12 @@ def create_server(output_dir: Path | None = None) -> Server:
         root_dir = output_dir
 
     # Two managers, both lazy:
-    # - workspace: SQLite-only registry (sources + ActiveSession pointer).
-    #   Always available; resolves the chicken-and-egg of "which session is active".
-    # - session: opened against sessions/{fingerprint}/ when an active session
-    #   exists. Cached by fingerprint and reopened only on transition.
+    # - workspace: Postgres-backed SQLAlchemy registry (sources +
+    #   ActiveSession pointer + InvestigationSession). Always available;
+    #   resolves the chicken-and-egg of "which session is active".
+    # - session: same workspace Postgres engine for SQLAlchemy + a
+    #   per-fingerprint DuckDB cursor for analytical data. Cached by
+    #   fingerprint and reopened only on transition.
     _workspace_manager: ConnectionManager | None = None
     _session_manager: ConnectionManager | None = None
     _active_fingerprint: str | None = None
@@ -215,8 +202,7 @@ def create_server(output_dir: Path | None = None) -> Server:
             from dataraum.core.connections import ConnectionConfig
             from dataraum.core.connections import ConnectionManager as CM
 
-            config = ConnectionConfig.for_workspace(root_dir)
-            config.sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+            config = ConnectionConfig.for_workspace()
             _workspace_manager = CM(config)
             _workspace_manager.initialize()
         return _workspace_manager
@@ -321,12 +307,12 @@ def create_server(output_dir: Path | None = None) -> Server:
             )
             warning = f"Session ended but archival failed. {session_dir} may need manual cleanup."
 
-        # Index the archived session in workspace.db so resume_session can find
-        # it without scanning every metadata.db. Done before clearing the
-        # pointer so both writes share the workspace transaction lifecycle.
+        # Index the archived session in workspace Postgres so resume_session
+        # can find it cheaply. Done before clearing the pointer so both
+        # writes share the workspace transaction lifecycle.
         with _get_workspace_manager().session_scope() as ws_session:
             if archived_ok:
-                summary = _read_archive_summary(archive_dir, session_id, fingerprint)
+                summary = _read_archive_summary(ws_session, session_id, fingerprint)
                 if summary is not None:
                     ws_session.add(summary)
             ws_session.execute(delete(ActiveSession))
@@ -1593,11 +1579,13 @@ def _restore_archived_session(
                 is not None
             )
 
-        # Sync workspace: replace Sources, set pointer, consume index row.
+        # Sync workspace: set the active pointer and consume the index row.
+        # Sources are no longer copied — workspace and per-session SQLAlchemy
+        # share one Postgres DB post-DAT-321, so the originals are already
+        # the canonical rows and re-inserting them would (a) be redundant and
+        # (b) require destroying the FK-referenced rows on InvestigationSession
+        # we just created.
         with workspace_mgr.session_scope() as ws_session:
-            ws_session.execute(delete(Source))
-            for snapshot in source_snapshots:
-                ws_session.add(Source(**snapshot))
             ws_session.execute(delete(ActiveSession))
             ws_session.add(ActiveSession(id=1, session_id=new_session_id, fingerprint=fingerprint))
             ws_session.execute(
@@ -2521,10 +2509,9 @@ def _begin_new_session(
     session_mgr = open_session_manager(fingerprint)
 
     with session_mgr.session_scope() as session:
-        # Copy the Source record into session DB if not already present
-        existing_ids = set(session.execute(select(Source.source_id)).scalars().all())
-        if source_snapshot["source_id"] not in existing_ids:
-            session.add(Source(**source_snapshot))
+        # Source-copy into the per-session DB is gone post-DAT-321: workspace
+        # and per-session SQLAlchemy share one Postgres database, so the
+        # Source row registered via add_source is already visible here.
 
         # Mark any orphan "active" InvestigationSession rows as abandoned.
         # Handles retries where a prior begin_session wrote to the session DB

--- a/src/dataraum/mcp/server.py
+++ b/src/dataraum/mcp/server.py
@@ -1595,6 +1595,11 @@ def _restore_archived_session(
             )
             new_session_id = inv.session_id
 
+            # Bind session_id to the manager immediately. Any per-session FK
+            # write that fires before the next tool invocation (which would
+            # re-open via _get_session_manager(fp, sid)) needs this set.
+            session_mgr.session_id = new_session_id
+
             has_data = (
                 session.execute(
                     select(EntropyObjectRecord.object_id)
@@ -2583,6 +2588,11 @@ def _begin_new_session(
         )
 
         new_session_id = inv.session_id
+
+    # Bind session_id to the manager immediately. Any per-session FK write
+    # that fires before the next tool invocation (which would re-open via
+    # _get_session_manager(fp, sid)) needs this set.
+    session_mgr.session_id = new_session_id
 
     # --- Set ActiveSession pointer in workspace (last, after session DB is ready) ---
     from sqlalchemy import delete

--- a/src/dataraum/mcp/server.py
+++ b/src/dataraum/mcp/server.py
@@ -1317,6 +1317,22 @@ def create_server(output_dir: Path | None = None) -> Server:
 
         return _json_text_content(result)
 
+    def _close() -> None:
+        """Dispose cached ConnectionManagers (workspace + session).
+
+        Called by tests on teardown and by long-lived runners (HTTP MCP
+        daemon, future). Idempotent. Without this, the cached
+        psycopg pools survive until GC catches them, which Python 3.12+
+        flags as ``ResourceWarning: <psycopg.Connection> was deleted while
+        still open``.
+        """
+        nonlocal _workspace_manager
+        _close_session_manager()
+        if _workspace_manager is not None:
+            _workspace_manager.close()
+            _workspace_manager = None
+
+    server.close = _close  # type: ignore[attr-defined]
     return server
 
 

--- a/src/dataraum/mcp/sql_executor.py
+++ b/src/dataraum/mcp/sql_executor.py
@@ -36,6 +36,7 @@ def run_sql(
     column_mappings: dict[str, str] | None = None,
     limit: int = DEFAULT_ROW_LIMIT,
     repair_fn: RepairFn | None = None,
+    session_id: str | None = None,
 ) -> dict[str, Any]:
     """Execute SQL and return results as a structured dict.
 
@@ -151,6 +152,10 @@ def run_sql(
         else:
             # Save novel steps as snippets
             assert session_source is not None  # set inside the same guard
+            if session_id is None:
+                raise ValueError(
+                    "run_sql with session+source_id requires session_id for snippet saving."
+                )
             snippet_summary = _save_snippets(
                 session,
                 source_id,
@@ -158,6 +163,7 @@ def run_sql(
                 raw_steps or [],
                 snippet_matches,
                 session_source,
+                session_id=session_id,
             )
 
     if is_error:
@@ -277,6 +283,8 @@ def _save_snippets(
     raw_steps: list[dict[str, Any]],
     snippet_matches: dict[str, tuple[str, str]],
     session_source: str,
+    *,
+    session_id: str,
 ) -> dict[str, Any]:
     """Save novel steps as snippets and return summary.
 
@@ -285,7 +293,7 @@ def _save_snippets(
     """
     from dataraum.query.snippet_library import SnippetLibrary
 
-    library = SnippetLibrary(session)
+    library = SnippetLibrary(session, session_id=session_id)
     reused = len(snippet_matches)
     saved = 0
 

--- a/src/dataraum/mcp/teach.py
+++ b/src/dataraum/mcp/teach.py
@@ -516,6 +516,7 @@ def handle_teach(
     vertical: str,
     config_root: Path | None = None,
     target: str | None = None,
+    session_id: str,
 ) -> dict[str, Any]:
     """Dispatch a teach request to the appropriate handler.
 
@@ -566,6 +567,7 @@ def handle_teach(
             [doc],
             session=session,
             config_root=config_root,
+            session_id=session_id,
         )
     except Exception as e:
         logger.error("teach_apply_failed", teach_type=teach_type, error=str(e))

--- a/src/dataraum/pipeline/base.py
+++ b/src/dataraum/pipeline/base.py
@@ -50,6 +50,21 @@ class PhaseContext:
     # Connection manager for vector DB access (optional)
     manager: ConnectionManager | None = None
 
+    # InvestigationSession id for per-session row FK population.
+    # Populated by the scheduler from manager.session_id; tests pass directly.
+    session_id: str | None = None
+
+    def require_session_id(self) -> str:
+        """Return ``session_id`` or raise — phases that persist must call this."""
+        if self.session_id:
+            return self.session_id
+        if self.manager and self.manager.session_id:
+            return self.manager.session_id
+        raise RuntimeError(
+            "PhaseContext.session_id is unset — phases persisting per-session rows "
+            "post-DAT-321 require session_id. Scheduler/test fixture must populate it."
+        )
+
 
 @dataclass
 class PhaseResult:

--- a/src/dataraum/pipeline/db_models.py
+++ b/src/dataraum/pipeline/db_models.py
@@ -24,6 +24,9 @@ class PipelineRun(Base):
     __tablename__ = "pipeline_runs"
 
     run_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     source_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
 
     # Run configuration
@@ -50,6 +53,9 @@ class PhaseLog(Base):
     __tablename__ = "phase_logs"
 
     log_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     run_id: Mapped[str] = mapped_column(
         ForeignKey("pipeline_runs.run_id", ondelete="CASCADE"), nullable=False, index=True
     )

--- a/src/dataraum/pipeline/db_models.py
+++ b/src/dataraum/pipeline/db_models.py
@@ -9,8 +9,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
-from sqlalchemy import DateTime, Float, ForeignKey, String
-from sqlalchemy.dialects.sqlite import JSON
+from sqlalchemy import JSON, DateTime, Float, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from dataraum.storage.base import Base

--- a/src/dataraum/pipeline/fixes/interpreters.py
+++ b/src/dataraum/pipeline/fixes/interpreters.py
@@ -70,7 +70,7 @@ class MetadataInterpreter:
     and applies field_updates via setattr.
     """
 
-    def apply(self, doc: FixDocument, session: Session) -> None:
+    def apply(self, doc: FixDocument, session: Session, *, session_id: str) -> None:
         """Apply a metadata fix to an ORM model.
 
         For markers (no ``model`` in payload), the DataFix record itself
@@ -112,7 +112,9 @@ class MetadataInterpreter:
             # For Relationship, create a new record if none exists
             factory = _MODEL_FACTORIES.get(model_name)
             if factory:
-                instance = factory(session, doc.table_name, doc.column_name, hints)
+                instance = factory(
+                    session, doc.table_name, doc.column_name, hints, session_id=session_id
+                )
                 if instance is None:
                     raise ValueError(
                         f"Cannot create {model_name}: columns not found for "
@@ -277,7 +279,12 @@ _MODEL_RESOLVERS: dict[str, Any] = {
 
 
 def _create_relationship(
-    session: Session, table_name: str, column_name: str | None, hints: dict[str, Any]
+    session: Session,
+    table_name: str,
+    column_name: str | None,
+    hints: dict[str, Any],
+    *,
+    session_id: str,
 ) -> Any:
     """Create a new Relationship when the resolver finds no existing one.
 
@@ -313,6 +320,7 @@ def _create_relationship(
     # relationship_type and cardinality come via field_updates (applied
     # by the setattr loop after creation), not hints.
     return Relationship(
+        session_id=session_id,
         from_table_id=from_table_obj.table_id,
         from_column_id=from_col.column_id,
         to_table_id=to_table_obj.table_id,
@@ -352,6 +360,7 @@ def apply_fix_document(
     *,
     config_root: Path | None = None,
     session: Session | None = None,
+    session_id: str | None = None,
 ) -> None:
     """Apply a fix document using the appropriate interpreter.
 
@@ -373,7 +382,9 @@ def apply_fix_document(
     elif doc.target == "metadata":
         if session is None:
             raise ValueError("session required for metadata fixes")
-        MetadataInterpreter().apply(doc, session)
+        if session_id is None:
+            raise ValueError("session_id required for metadata fixes")
+        MetadataInterpreter().apply(doc, session, session_id=session_id)
 
     else:
         raise ValueError(f"Unknown fix target: {doc.target!r}")
@@ -385,6 +396,7 @@ def apply_and_persist(
     *,
     session: Session,
     config_root: Path | None = None,
+    session_id: str,
 ) -> list[DataFix]:
     """Apply a list of fix documents and persist them to the DB.
 
@@ -404,7 +416,7 @@ def apply_and_persist(
     records: list[DataFix] = []
 
     for doc in sorted_docs:
-        record = DataFix.from_document(source_id, doc)
+        record = DataFix.from_document(source_id, doc, session_id=session_id)
         session.add(record)
 
         try:
@@ -412,6 +424,7 @@ def apply_and_persist(
                 doc,
                 config_root=config_root,
                 session=session,
+                session_id=session_id,
             )
             record.status = "applied"
             record.applied_at = datetime.now(UTC)

--- a/src/dataraum/pipeline/fixes/models.py
+++ b/src/dataraum/pipeline/fixes/models.py
@@ -13,8 +13,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String
-from sqlalchemy.dialects.sqlite import JSON
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from dataraum.storage import Base

--- a/src/dataraum/pipeline/fixes/models.py
+++ b/src/dataraum/pipeline/fixes/models.py
@@ -74,6 +74,9 @@ class DataFix(Base):
     __tablename__ = "data_fixes"
 
     fix_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
     source_id: Mapped[str] = mapped_column(ForeignKey("sources.source_id"), nullable=False)
 
     # What this fix does
@@ -99,10 +102,11 @@ class DataFix(Base):
     applied_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     @classmethod
-    def from_document(cls, source_id: str, doc: FixDocument) -> DataFix:
+    def from_document(cls, source_id: str, doc: FixDocument, *, session_id: str) -> DataFix:
         """Create a DataFix record from an in-memory FixDocument."""
         return cls(
             fix_id=doc.fix_id,
+            session_id=session_id,
             source_id=source_id,
             action=doc.action,
             target=doc.target,

--- a/src/dataraum/pipeline/phases/business_cycles_phase.py
+++ b/src/dataraum/pipeline/phases/business_cycles_phase.py
@@ -168,6 +168,7 @@ class BusinessCyclesPhase(BasePhase):
             table_ids=table_ids,
             source_id=ctx.source_id,
             vertical=vertical,
+            session_id=ctx.require_session_id(),
         )
 
         if not analysis_result.success:

--- a/src/dataraum/pipeline/phases/column_eligibility_phase.py
+++ b/src/dataraum/pipeline/phases/column_eligibility_phase.py
@@ -153,6 +153,7 @@ class ColumnEligibilityPhase(BasePhase):
 
             record = ColumnEligibilityRecord(
                 eligibility_id=str(uuid4()),
+                session_id=ctx.require_session_id(),
                 column_id=column.column_id,
                 table_id=table.table_id,
                 source_id=ctx.source_id,

--- a/src/dataraum/pipeline/phases/correlations_phase.py
+++ b/src/dataraum/pipeline/phases/correlations_phase.py
@@ -133,6 +133,7 @@ class CorrelationsPhase(BasePhase):
                     fact_table=typed_table,
                     duckdb_conn=ctx.duckdb_conn,
                     session=ctx.session,
+                    session_id=ctx.require_session_id(),
                 )
             else:
                 # No enriched view — fallback to typed table only
@@ -140,6 +141,7 @@ class CorrelationsPhase(BasePhase):
                     table_id=typed_table.table_id,
                     duckdb_conn=ctx.duckdb_conn,
                     session=ctx.session,
+                    session_id=ctx.require_session_id(),
                 )
 
             if not corr_result.success:

--- a/src/dataraum/pipeline/phases/data_fixes_phase.py
+++ b/src/dataraum/pipeline/phases/data_fixes_phase.py
@@ -75,6 +75,7 @@ class DataFixesPhase(BasePhase):
                 apply_fix_document(
                     doc,
                     session=ctx.session,
+                    session_id=ctx.require_session_id(),
                 )
                 fix.status = "applied"
                 fix.applied_at = datetime.now(UTC)

--- a/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -307,6 +307,7 @@ class EnrichedViewsPhase(BasePhase):
             else:
                 # Create new view record
                 view_record = EnrichedView(
+                    session_id=ctx.require_session_id(),
                     fact_table_id=fact_table.table_id,
                     view_name=view_name,
                     view_sql=view_sql,
@@ -415,6 +416,7 @@ class EnrichedViewsPhase(BasePhase):
                     is_unique = profile.distinct_count == non_null if non_null > 0 else False
                     db_profile = StatisticalProfile(
                         profile_id=str(uuid4()),
+                        session_id=ctx.require_session_id(),
                         column_id=col.column_id,
                         profiled_at=profiled_at,
                         layer="enriched",

--- a/src/dataraum/pipeline/phases/graph_execution_phase.py
+++ b/src/dataraum/pipeline/phases/graph_execution_phase.py
@@ -204,7 +204,7 @@ class GraphExecutionPhase(BasePhase):
         # Resolve inspiration snippets for promotion path
         from dataraum.query.snippet_library import SnippetLibrary
 
-        snippet_library = SnippetLibrary(ctx.session)
+        snippet_library = SnippetLibrary(ctx.session, session_id=ctx.require_session_id())
 
         # ---- Prep (sequential, cheap reads on main session) ----
         # Build a list of (graph_id, graph, hint_sql, inspiration_id) tuples.
@@ -242,10 +242,13 @@ class GraphExecutionPhase(BasePhase):
             prep.append((graph_id, graph, hint_sql, inspiration_id))
 
         # ---- Execute (parallel when manager wired, serial fallback otherwise) ----
+        sid = ctx.require_session_id()
         if ctx.manager is not None:
-            results = _execute_metrics_parallel(prep, ctx.manager, agent, ctx.source_id, table_ids)
+            results = _execute_metrics_parallel(
+                prep, ctx.manager, agent, ctx.source_id, table_ids, session_id=sid
+            )
         else:
-            results = _execute_metrics_serial(prep, ctx.session, exec_ctx, agent)
+            results = _execute_metrics_serial(prep, ctx.session, exec_ctx, agent, session_id=sid)
 
         # ---- Post (sequential, snippet promotion on main session) ----
         executed = 0
@@ -311,6 +314,8 @@ def _execute_metrics_serial(
     session: Session,
     exec_ctx: _ExecutionContext,
     agent: GraphAgent,
+    *,
+    session_id: str,
 ) -> list[MetricResult]:
     """Fallback path: shared session + cursor, sequential dispatch.
 
@@ -318,7 +323,9 @@ def _execute_metrics_serial(
     """
     out: list[MetricResult] = []
     for graph_id, graph, hint_sql, inspiration_id in prep:
-        result = agent.execute(session, graph, exec_ctx, inspiration_sql=hint_sql)
+        result = agent.execute(
+            session, graph, exec_ctx, inspiration_sql=hint_sql, session_id=session_id
+        )
         out.append((graph_id, result, inspiration_id))
     return out
 
@@ -329,6 +336,8 @@ def _execute_metrics_parallel(
     agent: GraphAgent,
     source_id: str,
     table_ids: list[str],
+    *,
+    session_id: str,
 ) -> list[MetricResult]:
     """Concurrent path: per-call session + cursor, gathered via asyncio.
 
@@ -354,7 +363,14 @@ def _execute_metrics_parallel(
                 # ExecutionContext.with_rich_context raises, etc.).
                 try:
                     result = await asyncio.to_thread(
-                        _execute_isolated, graph, hint_sql, manager, agent, source_id, table_ids
+                        _execute_isolated,
+                        graph,
+                        hint_sql,
+                        manager,
+                        agent,
+                        source_id,
+                        table_ids,
+                        session_id,
                     )
                 except Exception as exc:
                     result = Result.fail(f"Unexpected error executing {graph_id}: {exc}")
@@ -372,6 +388,7 @@ def _execute_isolated(
     agent: GraphAgent,
     source_id: str,
     table_ids: list[str],
+    session_id: str,
 ) -> Result[GraphExecution]:
     """Run one metric with an isolated session + cursor pair.
 
@@ -388,4 +405,6 @@ def _execute_isolated(
             table_ids=table_ids,
             schema_mapping_id=source_id,
         )
-        return agent.execute(session, graph, exec_ctx, inspiration_sql=hint_sql)
+        return agent.execute(
+            session, graph, exec_ctx, inspiration_sql=hint_sql, session_id=session_id
+        )

--- a/src/dataraum/pipeline/phases/semantic_phase.py
+++ b/src/dataraum/pipeline/phases/semantic_phase.py
@@ -296,6 +296,7 @@ class SemanticPhase(BasePhase):
             duckdb_conn=ctx.duckdb_conn,
             column_annotations=column_annotations,
             required_standard_fields=required_standard_fields,
+            session_id=ctx.require_session_id(),
         )
 
         if not enrich_result.success:

--- a/src/dataraum/pipeline/phases/slice_analysis_phase.py
+++ b/src/dataraum/pipeline/phases/slice_analysis_phase.py
@@ -174,6 +174,7 @@ class SliceAnalysisPhase(BasePhase):
             slice_infos=slice_infos,
             run_statistics=True,
             run_quality=True,
+            session_id=ctx.require_session_id(),
         )
 
         errors.extend(analysis_result.errors)

--- a/src/dataraum/pipeline/phases/slicing_phase.py
+++ b/src/dataraum/pipeline/phases/slicing_phase.py
@@ -204,8 +204,10 @@ class SlicingPhase(BasePhase):
         slicing = self._propagate_enriched_dimensions(slicing, context_data, agent)
 
         # Store slice definitions
+        sid = ctx.require_session_id()
         for rec in slicing.recommendations:
             slice_def = SliceDefinition(
+                session_id=sid,
                 table_id=rec.table_id,
                 column_id=rec.column_id,
                 column_name=rec.column_name,

--- a/src/dataraum/pipeline/phases/slicing_view_phase.py
+++ b/src/dataraum/pipeline/phases/slicing_view_phase.py
@@ -244,6 +244,7 @@ class SlicingViewPhase(BasePhase):
 
             # Store SlicingView record
             slicing_view = SlicingView(
+                session_id=ctx.require_session_id(),
                 fact_table_id=fact_table_id,
                 view_name=view_name,
                 view_sql=view_sql,

--- a/src/dataraum/pipeline/phases/statistical_quality_phase.py
+++ b/src/dataraum/pipeline/phases/statistical_quality_phase.py
@@ -160,6 +160,7 @@ class StatisticalQualityPhase(BasePhase):
                 duckdb_conn=ctx.duckdb_conn,
                 session=ctx.session,
                 exclude_outlier_columns=exclude_outlier_columns,
+                session_id=ctx.require_session_id(),
             )
 
             if not quality_result.success:

--- a/src/dataraum/pipeline/phases/statistics_phase.py
+++ b/src/dataraum/pipeline/phases/statistics_phase.py
@@ -141,6 +141,7 @@ class StatisticsPhase(BasePhase):
                 duckdb_conn=ctx.duckdb_conn,
                 session=ctx.session,
                 config=ctx.config,
+                session_id=ctx.require_session_id(),
             )
 
             if not stats_result.success:

--- a/src/dataraum/pipeline/phases/temporal_phase.py
+++ b/src/dataraum/pipeline/phases/temporal_phase.py
@@ -147,6 +147,7 @@ class TemporalPhase(BasePhase):
                 duckdb_conn=ctx.duckdb_conn,
                 session=ctx.session,
                 config=ctx.config if "processing" in ctx.config else None,
+                session_id=ctx.require_session_id(),
             )
 
             if not profile_result.success:

--- a/src/dataraum/pipeline/phases/temporal_slice_analysis_phase.py
+++ b/src/dataraum/pipeline/phases/temporal_slice_analysis_phase.py
@@ -294,6 +294,7 @@ class TemporalSliceAnalysisPhase(BasePhase):
                             slice_table_name=si.slice_table_name,
                             time_column=time_column,
                             session=ctx.session,
+                            session_id=ctx.require_session_id(),
                         )
                         if persist_result.success and persist_result.value is not None:
                             total_drift_summaries += persist_result.value
@@ -311,6 +312,7 @@ class TemporalSliceAnalysisPhase(BasePhase):
                         persist_count = persist_period_results(
                             result=period_result.value,
                             session=ctx.session,
+                            session_id=ctx.require_session_id(),
                         )
                         if persist_count.success and persist_count.value is not None:
                             total_period_analyses += persist_count.value
@@ -325,7 +327,9 @@ class TemporalSliceAnalysisPhase(BasePhase):
         # Build ColumnSliceProfile records for dimensional_entropy detector
         from dataraum.analysis.slicing.profiling import build_slice_profiles
 
-        slice_profiles_count = build_slice_profiles(ctx.session, ctx.source_id)
+        slice_profiles_count = build_slice_profiles(
+            ctx.session, ctx.source_id, session_id=ctx.require_session_id()
+        )
 
         outputs: dict[str, object] = {
             "drift_summaries": total_drift_summaries,

--- a/src/dataraum/pipeline/phases/typing_phase.py
+++ b/src/dataraum/pipeline/phases/typing_phase.py
@@ -268,6 +268,7 @@ class TypingPhase(BasePhase):
                 table=table,
                 duckdb_conn=ctx.duckdb_conn,
                 session=ctx.session,
+                session_id=ctx.require_session_id(),
             )
 
             if not inference_result.success:
@@ -289,6 +290,7 @@ class TypingPhase(BasePhase):
                 duckdb_conn=ctx.duckdb_conn,
                 session=ctx.session,
                 min_confidence=min_confidence,
+                session_id=ctx.require_session_id(),
             )
 
             if not resolution_result.success:

--- a/src/dataraum/pipeline/phases/validation_phase.py
+++ b/src/dataraum/pipeline/phases/validation_phase.py
@@ -167,6 +167,7 @@ class ValidationPhase(BasePhase):
             category=category,
             persist=True,
             vertical=vertical,
+            session_id=ctx.require_session_id(),
         )
 
         if not validation_result.success:

--- a/src/dataraum/pipeline/runner.py
+++ b/src/dataraum/pipeline/runner.py
@@ -59,6 +59,7 @@ class RunConfig:
     event_callback: EventCallback | None = None
     contract: str | None = None  # Target contract name
     vertical: str | None = None  # Domain vertical (e.g. 'finance')
+    session_id: str | None = None  # InvestigationSession.session_id; required for MCP runs
 
 
 @dataclass
@@ -140,6 +141,7 @@ def run(config: RunConfig) -> Result[RunResult]:
             force_phase=config.force_phase,
             contract=config.contract,
             vertical=config.vertical,
+            session_id=config.session_id,
         )
         source_id = setup.source_id
         session = setup.session

--- a/src/dataraum/pipeline/scheduler.py
+++ b/src/dataraum/pipeline/scheduler.py
@@ -65,6 +65,7 @@ class PipelineScheduler:
         runtime_config: dict[str, Any] | None = None,
         session_factory: Callable[[], Any] | None = None,
         manager: Any | None = None,
+        session_id: str | None = None,
     ) -> None:
         # Validate that all declared dependencies reference known phases
         for name, phase in phases.items():
@@ -82,13 +83,36 @@ class PipelineScheduler:
         self._runtime_config = runtime_config or {}
         self.session_factory = session_factory
         self.manager = manager
+        # Explicit override wins; otherwise read from manager.
+        self._session_id_override = session_id
         # Internal state
         self._state: dict[str, PhaseStatus] = dict.fromkeys(phases, PhaseStatus.PENDING)
         self._step = 0
 
         # Validate analysis coverage: warn if detectors require analyses
-        # that no phase produces
+        # that no phase produces.
         self._validate_analysis_coverage()
+
+    def _require_session_id(self) -> str:
+        """Return the active session_id; fail loud if not bound.
+
+        Per-session ORM writes (PhaseLog and downstream rows) carry an FK
+        to investigation_sessions.session_id, populated post-DAT-321.
+
+        Resolution order: explicit ``session_id`` arg → ``manager.session_id``.
+        Tests that exercise the scheduler without a ConnectionManager pass
+        ``session_id`` directly.
+        """
+        sid = self._session_id_override
+        if not sid and self.manager:
+            sid = self.manager.session_id
+        if not sid:
+            raise RuntimeError(
+                "PipelineScheduler session_id is unset — every per-session "
+                "write needs an active InvestigationSession. Pass session_id "
+                "directly or via manager.session_id (set by setup_pipeline)."
+            )
+        return sid
 
     # ------------------------------------------------------------------
     # Public API
@@ -179,6 +203,7 @@ class PipelineScheduler:
                     config=config,
                     session_factory=self.session_factory,
                     manager=self.manager,
+                    session_id=self._session_id_override or self.manager.session_id,
                 )
                 result = phase.run(ctx)
         else:
@@ -323,6 +348,7 @@ class PipelineScheduler:
                     config=config,
                     session_factory=self.session_factory,
                     manager=self.manager,
+                    session_id=self._session_id_override or self.manager.session_id,
                 )
                 return phase.should_skip(ctx)
 
@@ -334,6 +360,8 @@ class PipelineScheduler:
             config=config,
             session_factory=self.session_factory,
             manager=self.manager,
+            session_id=self._session_id_override
+            or (self.manager.session_id if self.manager else None),
         )
         return phase.should_skip(ctx)
 
@@ -350,6 +378,8 @@ class PipelineScheduler:
             config=config,
             session_factory=self.session_factory,
             manager=self.manager,
+            session_id=self._session_id_override
+            or (self.manager.session_id if self.manager else None),
         )
 
     def _write_phase_log(
@@ -370,6 +400,7 @@ class PipelineScheduler:
         now = datetime.now(UTC)
         log = PhaseLog(
             run_id=self.run_id,
+            session_id=self._require_session_id(),
             source_id=self.source_id,
             phase_name=phase_name,
             status=status,
@@ -428,6 +459,7 @@ class PipelineScheduler:
         if not phase.detectors:
             return
 
+        sid = self._require_session_id()
         if self.session_factory and self.manager:
             with (
                 self.session_factory() as detector_session,
@@ -435,8 +467,18 @@ class PipelineScheduler:
             ):
                 for detector_id in phase.detectors:
                     run_detector_post_step(
-                        detector_session, self.source_id, detector_id, detector_cursor
+                        detector_session,
+                        self.source_id,
+                        detector_id,
+                        detector_cursor,
+                        session_id=sid,
                     )
         else:
             for detector_id in phase.detectors:
-                run_detector_post_step(self.session, self.source_id, detector_id, self.duckdb_conn)
+                run_detector_post_step(
+                    self.session,
+                    self.source_id,
+                    detector_id,
+                    self.duckdb_conn,
+                    session_id=sid,
+                )

--- a/src/dataraum/pipeline/setup.py
+++ b/src/dataraum/pipeline/setup.py
@@ -60,6 +60,7 @@ def setup_pipeline(
     force_phase: bool = False,
     contract: str | None = None,
     vertical: str | None = None,
+    session_id: str | None = None,
 ) -> PipelineSetup:
     """Initialize the pipeline for a single source.
 
@@ -94,8 +95,16 @@ def setup_pipeline(
     # 1. Initialize storage
     output_dir.mkdir(parents=True, exist_ok=True)
     conn_config = ConnectionConfig.for_directory(output_dir)
-    manager = ConnectionManager(conn_config)
+    manager = ConnectionManager(conn_config, session_id=session_id)
     manager.initialize()
+
+    if session_id is None:
+        raise RuntimeError(
+            "setup_pipeline requires session_id post-DAT-321; per-session writes "
+            "(PipelineRun, PhaseLog, EntropyObjectRecord, ...) all carry an FK to "
+            "investigation_sessions.session_id. CLI flows must pass an active "
+            "InvestigationSession id (or the CLI itself is going away — see L6)."
+        )
 
     # 2. Per-source config: copy global config to output_dir on first run
     _ensure_source_config(output_dir)
@@ -169,6 +178,7 @@ def setup_pipeline(
     run_id = str(uuid4())
     run_record = PipelineRun(
         run_id=run_id,
+        session_id=session_id,
         source_id=source_id,
         status="running",
         config={
@@ -205,6 +215,7 @@ def setup_pipeline(
         runtime_config=runtime_config,
         session_factory=manager.session_scope,
         manager=manager,
+        session_id=session_id,
     )
 
     return PipelineSetup(

--- a/src/dataraum/query/agent.py
+++ b/src/dataraum/query/agent.py
@@ -96,6 +96,7 @@ class QueryAgent(LLMFeature):
         source_id: str | None = None,
         ephemeral: bool = False,
         display_limit: int = 10_000,
+        session_id: str,
     ) -> Result[QueryResult]:
         """Analyze a natural language question and generate SQL.
 
@@ -298,6 +299,7 @@ class QueryAgent(LLMFeature):
                 execution_id=execution_id,
                 analysis_output=analysis_output,
                 snippet_id_index=snippet_id_index,
+                session_id=session_id,
             )
 
         # Save novel snippets for future reuse (skip if ephemeral or failed)
@@ -307,6 +309,7 @@ class QueryAgent(LLMFeature):
                 execution_id=execution_id,
                 analysis_output=analysis_output,
                 schema_mapping_id=source_id,
+                session_id=session_id,
             )
 
         # Record execution
@@ -322,6 +325,7 @@ class QueryAgent(LLMFeature):
                 error_message=exec_error,
                 confidence_level=confidence_level,
                 contract=contract,
+                session_id=session_id,
             )
 
         # Build risk assessment (combined contract + LLM data)
@@ -540,6 +544,8 @@ class QueryAgent(LLMFeature):
         execution_id: str,
         analysis_output: QueryAnalysisOutput,
         snippet_id_index: dict[str, dict[str, Any]],
+        *,
+        session_id: str,
     ) -> None:
         """Record snippet usage deterministically based on snippet_id.
 
@@ -551,7 +557,7 @@ class QueryAgent(LLMFeature):
         """
         from dataraum.query.snippet_library import SnippetLibrary
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=session_id)
         referenced_snippet_ids: set[str] = set()
 
         for step in analysis_output.steps:
@@ -656,6 +662,8 @@ class QueryAgent(LLMFeature):
         execution_id: str,
         analysis_output: QueryAnalysisOutput,
         schema_mapping_id: str,
+        *,
+        session_id: str,
     ) -> None:
         """Save novel query steps as snippets for future reuse.
 
@@ -671,7 +679,7 @@ class QueryAgent(LLMFeature):
         """
         from dataraum.query.snippet_library import SnippetLibrary
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=session_id)
 
         saved_count = 0
         for step in analysis_output.steps:
@@ -1118,6 +1126,8 @@ class QueryAgent(LLMFeature):
         confidence_level: ConfidenceLevel,
         contract: str | None,
         entropy_action: str | None = None,
+        *,
+        session_id: str,
     ) -> None:
         """Record a query execution for audit trail.
 
@@ -1138,6 +1148,7 @@ class QueryAgent(LLMFeature):
 
         record = QueryExecutionRecord(
             execution_id=execution_id,
+            session_id=session_id,
             source_id=source_id,
             question=question,
             sql_executed=sql,

--- a/src/dataraum/query/core.py
+++ b/src/dataraum/query/core.py
@@ -36,6 +36,7 @@ def answer_question(
     table_ids: list[str] | None = None,
     ephemeral: bool = False,
     display_limit: int = 10_000,
+    session_id: str,
 ) -> Result[QueryResult]:
     """Answer a natural language question about the data.
 
@@ -124,4 +125,5 @@ def answer_question(
         source_id=source_id,
         ephemeral=ephemeral,
         display_limit=display_limit,
+        session_id=session_id,
     )

--- a/src/dataraum/query/db_models.py
+++ b/src/dataraum/query/db_models.py
@@ -27,6 +27,11 @@ class QueryExecutionRecord(Base):
         String, primary_key=True, default=lambda: str(uuid4())
     )
 
+    # Session context (per-session row scoping post-DAT-321)
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
+
     # Source context
     source_id: Mapped[str] = mapped_column(
         ForeignKey("sources.source_id", ondelete="CASCADE"),

--- a/src/dataraum/query/snippet_library.py
+++ b/src/dataraum/query/snippet_library.py
@@ -109,13 +109,28 @@ class SnippetLibrary:
     def __init__(
         self,
         session: Session,
+        *,
+        session_id: str | None = None,
     ):
         """Initialize with database session.
 
         Args:
             session: SQLAlchemy session for snippet metadata
+            session_id: InvestigationSession id for per-row FK population.
+                Required for paths that create new rows (snippet upsert,
+                usage recording). Read-only paths (find_by_*, record_failure)
+                may pass None.
         """
         self.session = session
+        self.session_id = session_id
+
+    def _require_session_id(self) -> str:
+        if not self.session_id:
+            raise RuntimeError(
+                "SnippetLibrary write paths require session_id — "
+                "construct with SnippetLibrary(session, session_id=...)."
+            )
+        return self.session_id
 
     # --- Discovery ---
 
@@ -578,6 +593,7 @@ class SnippetLibrary:
             # Create new snippet
             record = SQLSnippetRecord(
                 snippet_id=str(uuid4()),
+                session_id=self._require_session_id(),
                 snippet_type=snippet_type,
                 standard_field=standard_field,
                 statement=statement,
@@ -637,6 +653,7 @@ class SnippetLibrary:
         """
         record = SnippetUsageRecord(
             usage_id=str(uuid4()),
+            session_id=self._require_session_id(),
             execution_id=execution_id,
             execution_type=execution_type,
             snippet_id=snippet_id,

--- a/src/dataraum/query/snippet_models.py
+++ b/src/dataraum/query/snippet_models.py
@@ -20,8 +20,16 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
-from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint
-from sqlalchemy.dialects.sqlite import JSON
+from sqlalchemy import (
+    JSON,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dataraum.storage import Base

--- a/src/dataraum/query/snippet_models.py
+++ b/src/dataraum/query/snippet_models.py
@@ -59,6 +59,9 @@ class SQLSnippetRecord(Base):
     )
 
     snippet_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
 
     # Discriminator: extract | constant | formula | query
     snippet_type: Mapped[str] = mapped_column(String, nullable=False, index=True)
@@ -120,6 +123,9 @@ class SnippetUsageRecord(Base):
     __tablename__ = "snippet_usage"
 
     usage_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
 
     # --- Execution link ---
     execution_id: Mapped[str] = mapped_column(String, nullable=False, index=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,11 +108,13 @@ def pg_url_clean(pg_url: str) -> str:
     """
     from sqlalchemy import inspect
 
-    from dataraum.core.connections import ConnectionManager as _CM  # noqa: F401
     from dataraum.storage import Base
 
-    # Importing ConnectionManager triggers _import_all_models registration
-    # so Base.metadata has every per-session table by the time we truncate.
+    # Filter by Postgres-side existence: TRUNCATE on a missing table is an
+    # error, so phases before any ConnectionManager.initialize() runs stay
+    # no-ops. Once a test triggers initialize() the side-effect of
+    # _import_all_models registers every model on Base.metadata for the
+    # rest of the pytest invocation.
     engine = create_engine(pg_url, future=True)
     try:
         existing = set(inspect(engine).get_table_names())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,8 @@ def _close_mcp_servers_after_test(monkeypatch: pytest.MonkeyPatch):
     ``Server`` and calls ``server.close()`` on teardown. Tests do not need
     to opt in.
     """
+    import warnings
+
     from dataraum.mcp import server as server_mod
 
     created: list = []
@@ -47,8 +49,8 @@ def _close_mcp_servers_after_test(monkeypatch: pytest.MonkeyPatch):
     for s in created:
         try:
             s.close()  # type: ignore[attr-defined]
-        except Exception:
-            pass
+        except Exception as exc:
+            warnings.warn(f"Failed to close MCP server during test teardown: {s!r} ({exc!r})")
 
 
 @event.listens_for(Session, "before_flush")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,27 @@ from testcontainers.postgres import PostgresContainer
 
 from dataraum.storage import init_database
 
+_TEST_SESSION_ID = "00000000-0000-0000-0000-000000000001"
+_TEST_SOURCE_ID = "00000000-0000-0000-0000-000000000002"
+
+
+@event.listens_for(Session, "before_flush")
+def _autofill_session_id_globally(sess, _flush_ctx, _instances):
+    """Auto-fill per-session FK on any pending row that left it None.
+
+    Pure test convenience — production code always sets ``session_id`` via the
+    hybrid plumbing introduced in DAT-321. This hook keeps test fixtures that
+    construct DB rows directly from having to know about the new FK.
+
+    Excludes ``InvestigationSession`` itself — its ``session_id`` is the PK,
+    not a FK, so autofilling would collide with the baseline row.
+    """
+    for obj in sess.new:
+        if type(obj).__name__ == "InvestigationSession":
+            continue
+        if hasattr(obj, "session_id") and getattr(obj, "session_id", None) is None:
+            obj.session_id = _TEST_SESSION_ID
+
 
 @pytest.fixture(scope="function")
 def engine() -> Engine:
@@ -42,14 +63,44 @@ def engine() -> Engine:
 def session(engine: Engine) -> Session:
     """Create a test database session.
 
-    Creates a session tied to the test's engine.
+    Seeds a baseline ``Source`` + ``InvestigationSession`` row so tests that
+    construct per-session DB models have a valid FK target. The
+    ``session_id`` is auto-populated by the global ``before_flush`` hook
+    above; tests that need the value explicitly call ``baseline_session_id()``.
     """
+    from datetime import UTC, datetime
+
+    from dataraum.investigation.db_models import InvestigationSession
+    from dataraum.storage import Source
+
     factory = sessionmaker(
         bind=engine,
         expire_on_commit=False,
     )
     with factory() as sess:
+        sess.add(Source(source_id=_TEST_SOURCE_ID, name="test_baseline", source_type="csv"))
+        sess.flush()
+        sess.add(
+            InvestigationSession(
+                session_id=_TEST_SESSION_ID,
+                source_id=_TEST_SOURCE_ID,
+                intent="conftest baseline",
+                status="active",
+                started_at=datetime.now(UTC),
+            )
+        )
+        sess.flush()
         yield sess
+
+
+def baseline_session_id() -> str:
+    """Return the baseline InvestigationSession id seeded by the ``session`` fixture.
+
+    Per-session DB models post-DAT-321 carry a NOT NULL FK to
+    ``investigation_sessions.session_id``; tests that ``session.add(...)``
+    one of those rows should set ``session_id=baseline_session_id()``.
+    """
+    return _TEST_SESSION_ID
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
+
 import duckdb
 import pytest
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine, event, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
+from testcontainers.postgres import PostgresContainer
 
 from dataraum.storage import init_database
 
@@ -55,3 +58,70 @@ def duckdb_conn():
     conn = duckdb.connect(":memory:")
     yield conn
     conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Postgres workspace fixtures (DAT-321)
+#
+# The full SQLAlchemy spine runs against Postgres post-L2. A single container
+# is reused for the entire pytest invocation (boot ~3 s, amortized across all
+# tests); per-test isolation is handled by TRUNCATE CASCADE over every table
+# registered on Base.metadata.
+#
+# Fixture overview:
+#   pg_container   — session-scoped, lifecycle of the Postgres 17 container
+#   pg_url         — session-scoped, the psycopg URL ("postgresql+psycopg://…")
+#   pg_url_clean   — function-scoped, same URL but TRUNCATE'd before each test
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def pg_container() -> Generator[PostgresContainer]:
+    """Boot one Postgres 17 container for the whole pytest invocation.
+
+    Pinned to the same image L1's docker-compose runs so any dialect quirk
+    surfaces here too. Cleaned up at session end.
+    """
+    with PostgresContainer("postgres:17") as pg:
+        yield pg
+
+
+@pytest.fixture(scope="session")
+def pg_url(pg_container: PostgresContainer) -> str:
+    """SQLAlchemy URL for the session-scoped Postgres container.
+
+    Forces the psycopg driver to match production (`DATABASE_URL` in the
+    container substrate uses `postgresql+psycopg://`).
+    """
+    return pg_container.get_connection_url(driver="psycopg")
+
+
+@pytest.fixture
+def pg_url_clean(pg_url: str) -> str:
+    """Postgres URL with all Base-registered tables truncated before the test.
+
+    Uses ``TRUNCATE ... RESTART IDENTITY CASCADE`` over ``Base.metadata.tables``
+    so per-test isolation does not depend on FK declaration order. Tables that
+    haven't been created yet (e.g. before ``metadata.create_all``) are simply
+    skipped — TRUNCATE on a missing table is an error, so we filter by what
+    actually exists.
+    """
+    from sqlalchemy import inspect
+
+    from dataraum.core.connections import ConnectionManager as _CM  # noqa: F401
+    from dataraum.storage import Base
+
+    # Importing ConnectionManager triggers _import_all_models registration
+    # so Base.metadata has every per-session table by the time we truncate.
+    engine = create_engine(pg_url, future=True)
+    try:
+        existing = set(inspect(engine).get_table_names())
+        if existing:
+            targets = [t for t in Base.metadata.tables.values() if t.name in existing]
+            if targets:
+                names = ", ".join(f'"{t.name}"' for t in targets)
+                with engine.begin() as conn:
+                    conn.execute(text(f"TRUNCATE {names} RESTART IDENTITY CASCADE"))
+    finally:
+        engine.dispose()
+    return pg_url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,10 @@ def _autofill_session_id_globally(sess, _flush_ctx, _instances):
     Excludes ``InvestigationSession`` itself — its ``session_id`` is the PK,
     not a FK, so autofilling would collide with the baseline row.
     """
+    from dataraum.investigation.db_models import InvestigationSession
+
     for obj in sess.new:
-        if type(obj).__name__ == "InvestigationSession":
+        if isinstance(obj, InvestigationSession):
             continue
         if hasattr(obj, "session_id") and getattr(obj, "session_id", None) is None:
             obj.session_id = _TEST_SESSION_ID

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,46 @@ import pytest
 from sqlalchemy import create_engine, event, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
 from testcontainers.postgres import PostgresContainer
 
 from dataraum.storage import init_database
 
 _TEST_SESSION_ID = "00000000-0000-0000-0000-000000000001"
 _TEST_SOURCE_ID = "00000000-0000-0000-0000-000000000002"
+
+
+@pytest.fixture(autouse=True)
+def _close_mcp_servers_after_test(monkeypatch: pytest.MonkeyPatch):
+    """Auto-close any MCP server created during a test.
+
+    Tests construct servers inline via ``create_server(output_dir=...)``
+    which caches workspace + session ``ConnectionManager`` instances. The
+    cached psycopg pools never get disposed by the test itself, so they
+    leak until GC catches them — Python 3.12+ raises
+    ``ResourceWarning: <psycopg.Connection> was deleted while still open``.
+
+    This fixture monkeypatches ``create_server`` to track every returned
+    ``Server`` and calls ``server.close()`` on teardown. Tests do not need
+    to opt in.
+    """
+    from dataraum.mcp import server as server_mod
+
+    created: list = []
+    original = server_mod.create_server
+
+    def tracked(*args, **kwargs):
+        s = original(*args, **kwargs)
+        created.append(s)
+        return s
+
+    monkeypatch.setattr(server_mod, "create_server", tracked)
+    yield
+    for s in created:
+        try:
+            s.close()  # type: ignore[attr-defined]
+        except Exception:
+            pass
 
 
 @event.listens_for(Session, "before_flush")
@@ -41,12 +75,18 @@ def _autofill_session_id_globally(sess, _flush_ctx, _instances):
 def engine() -> Engine:
     """Create an in-memory SQLite engine for testing.
 
-    Creates a fresh database for each test function.
+    Uses ``StaticPool`` so the engine owns exactly one SQLite connection
+    that ``dispose()`` closes deterministically — Python 3.12+ raises
+    ``ResourceWarning`` if a ``sqlite3.Connection`` is GC'd while still
+    open, and ``QueuePool`` for ``:memory:`` SQLite tends to leave raw
+    connections around for the GC to find.
     """
     test_engine = create_engine(
         "sqlite:///:memory:",
         echo=False,
         future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
     )
 
     # Enable foreign keys for SQLite

--- a/tests/integration/analysis/correlation/test_within_table.py
+++ b/tests/integration/analysis/correlation/test_within_table.py
@@ -14,6 +14,7 @@ from dataraum.analysis.correlation.within_table import (
     detect_derived_columns,
 )
 from dataraum.storage import Column, Source, Table
+from tests.conftest import baseline_session_id
 
 
 @pytest.fixture
@@ -122,7 +123,9 @@ def test_compute_numeric_correlations(session, test_duckdb, table_numeric):
 
 def test_detect_derived_columns(session, test_duckdb, table_numeric):
     """Test derived column detection."""
-    result = detect_derived_columns(table_numeric, test_duckdb, session, min_match_rate=0.95)
+    result = detect_derived_columns(
+        table_numeric, test_duckdb, session, min_match_rate=0.95, session_id=baseline_session_id()
+    )
 
     assert result.success
     derived = result.unwrap()
@@ -230,7 +233,9 @@ def test_zero_target_not_false_positive(session, test_source):
 
     session.commit()
 
-    result = detect_derived_columns(table, conn, session, min_match_rate=0.80)
+    result = detect_derived_columns(
+        table, conn, session, min_match_rate=0.80, session_id=baseline_session_id()
+    )
     assert result.success
     derived = result.unwrap()
 

--- a/tests/integration/analysis/semantic/test_semantic.py
+++ b/tests/integration/analysis/semantic/test_semantic.py
@@ -17,6 +17,7 @@ from dataraum.core.models.base import (
     Result,
     SemanticRole,
 )
+from tests.conftest import baseline_session_id
 
 
 def test_enrich_semantic_stores_annotations(session):
@@ -107,6 +108,7 @@ def test_enrich_semantic_stores_annotations(session):
         agent=agent,
         table_ids=[table.table_id],
         ontology="general",
+        session_id=baseline_session_id(),
     )
 
     # Verify result
@@ -200,6 +202,7 @@ def test_enrich_semantic_handles_missing_columns(session):
         agent=agent,
         table_ids=[table.table_id],
         ontology="general",
+        session_id=baseline_session_id(),
     )
 
     # Should succeed but skip the non-existent column
@@ -286,6 +289,7 @@ def test_enrich_semantic_stores_relationships(session):
         agent=agent,
         table_ids=[customers_table.table_id, orders_table.table_id],
         ontology="general",
+        session_id=baseline_session_id(),
     )
 
     assert result.success

--- a/tests/integration/analysis/statistics/test_quality_parallel.py
+++ b/tests/integration/analysis/statistics/test_quality_parallel.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from dataraum.analysis.statistics import assess_statistical_quality
 from dataraum.storage import Column, Source, Table
+from tests.conftest import baseline_session_id
 
 
 @pytest.fixture
@@ -114,6 +115,7 @@ class TestAssessStatisticalQualityParallel:
             duckdb_conn=test_duckdb,
             session=session,
             max_workers=4,
+            session_id=baseline_session_id(),
         )
 
         assert result.success
@@ -136,6 +138,7 @@ class TestAssessStatisticalQualityParallel:
             duckdb_conn=test_duckdb,
             session=session,
             max_workers=4,
+            session_id=baseline_session_id(),
         )
 
         assert result.success
@@ -164,6 +167,7 @@ class TestAssessStatisticalQualityParallel:
             duckdb_conn=test_duckdb,
             session=session,
             max_workers=4,
+            session_id=baseline_session_id(),
         )
 
         assert result.success
@@ -177,6 +181,7 @@ class TestAssessStatisticalQualityParallel:
             duckdb_conn=test_duckdb,
             session=session,
             max_workers=4,
+            session_id=baseline_session_id(),
         )
 
         assert result.success

--- a/tests/integration/analysis/statistics/test_statistics.py
+++ b/tests/integration/analysis/statistics/test_statistics.py
@@ -14,6 +14,7 @@ from dataraum.analysis.typing import infer_type_candidates, resolve_types
 from dataraum.core.models import SourceConfig
 from dataraum.sources.csv import CSVLoader
 from dataraum.storage import Table
+from tests.conftest import baseline_session_id
 
 
 def _get_typed_table_id(typed_table_name: str, session) -> str | None:
@@ -51,17 +52,27 @@ def profiled_result(simple_csv, duckdb_conn, session):
     raw_table = session.get(Table, staged_table.table_id)
     assert raw_table is not None
 
-    infer_result = infer_type_candidates(raw_table, duckdb_conn, session)
+    infer_result = infer_type_candidates(
+        raw_table, duckdb_conn, session, session_id=baseline_session_id()
+    )
     assert infer_result.success
 
-    resolve_result = resolve_types(staged_table.table_id, duckdb_conn, session, min_confidence=0.85)
+    resolve_result = resolve_types(
+        staged_table.table_id,
+        duckdb_conn,
+        session,
+        min_confidence=0.85,
+        session_id=baseline_session_id(),
+    )
     assert resolve_result.success
     resolution = resolve_result.unwrap()
 
     typed_table_id = _get_typed_table_id(resolution.typed_table_name, session)
     assert typed_table_id is not None
 
-    stats_result = profile_statistics(typed_table_id, duckdb_conn, session)
+    stats_result = profile_statistics(
+        typed_table_id, duckdb_conn, session, session_id=baseline_session_id()
+    )
     assert stats_result.success
     return stats_result.unwrap()
 
@@ -118,7 +129,9 @@ class TestStatisticsProfiler:
 
         raw_table = load_result.unwrap().tables[0]
 
-        stats_result = profile_statistics(raw_table.table_id, duckdb_conn, session)
+        stats_result = profile_statistics(
+            raw_table.table_id, duckdb_conn, session, session_id=baseline_session_id()
+        )
 
         assert not stats_result.success
         assert "typed" in stats_result.error.lower()

--- a/tests/integration/analysis/temporal/test_profiler.py
+++ b/tests/integration/analysis/temporal/test_profiler.py
@@ -12,6 +12,7 @@ from dataraum.analysis.temporal import (
     profile_temporal,
 )
 from dataraum.storage import Column, Source, Table
+from tests.conftest import baseline_session_id
 
 # Use shared fixtures from conftest.py: session, duckdb_conn
 
@@ -67,6 +68,7 @@ def test_profile_temporal_daily_granularity(session: Session, duckdb_conn):
         table_id="table1",
         duckdb_conn=duckdb_conn,
         session=session,
+        session_id=baseline_session_id(),
     )
 
     # Verify result
@@ -131,6 +133,7 @@ def test_profile_temporal_weekly_granularity(session: Session, duckdb_conn):
         table_id="table1",
         duckdb_conn=duckdb_conn,
         session=session,
+        session_id=baseline_session_id(),
     )
 
     # Verify result
@@ -187,6 +190,7 @@ def test_profile_temporal_with_gaps(session: Session, duckdb_conn):
         table_id="table1",
         duckdb_conn=duckdb_conn,
         session=session,
+        session_id=baseline_session_id(),
     )
 
     # Verify result
@@ -248,6 +252,7 @@ def test_profile_temporal_no_temporal_columns(session: Session, duckdb_conn):
         table_id="table1",
         duckdb_conn=duckdb_conn,
         session=session,
+        session_id=baseline_session_id(),
     )
 
     # Should succeed but return no profiles
@@ -321,6 +326,7 @@ def test_profile_temporal_multiple_columns(session: Session, duckdb_conn):
         table_id="table1",
         duckdb_conn=duckdb_conn,
         session=session,
+        session_id=baseline_session_id(),
     )
 
     # Verify result - should create profiles for all 3 temporal columns
@@ -377,6 +383,7 @@ def test_profile_temporal_stores_metrics(session: Session, duckdb_conn):
         table_id="table1",
         duckdb_conn=duckdb_conn,
         session=session,
+        session_id=baseline_session_id(),
     )
 
     assert result.success is True
@@ -442,6 +449,7 @@ def test_profile_temporal_monthly_granularity(session: Session, duckdb_conn):
         table_id="table1",
         duckdb_conn=duckdb_conn,
         session=session,
+        session_id=baseline_session_id(),
     )
 
     # Verify result

--- a/tests/integration/analysis/validation/test_agent.py
+++ b/tests/integration/analysis/validation/test_agent.py
@@ -11,6 +11,7 @@ from dataraum.analysis.validation.models import (
     ValidationStatus,
 )
 from dataraum.core.models.base import Result
+from tests.conftest import baseline_session_id
 
 
 @pytest.fixture
@@ -396,6 +397,7 @@ class TestValidationAgentRunValidations:
             duckdb_conn=duckdb_conn,
             table_ids=["nonexistent-id"],
             vertical="finance",
+            session_id=baseline_session_id(),
         )
 
         assert not result.success
@@ -416,6 +418,7 @@ class TestValidationAgentRunValidations:
                 duckdb_conn=duckdb_conn,
                 table_ids=[table.table_id],
                 vertical="finance",
+                session_id=baseline_session_id(),
             )
 
         assert result.success

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 
 import duckdb
 import pytest
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -29,6 +29,7 @@ from dataraum.pipeline.phases.temporal_phase import TemporalPhase
 from dataraum.pipeline.phases.typing_phase import TypingPhase
 from dataraum.pipeline.pipeline_config import load_phase_declarations
 from dataraum.storage import init_database
+from tests.conftest import baseline_session_id
 
 # Paths to test data
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -100,6 +101,7 @@ class PipelineTestHarness:
                 source_id=self.source_id,
                 table_ids=table_ids or [],
                 config=config or {},
+                session_id=baseline_session_id(),
             )
 
             # Check skip condition
@@ -118,7 +120,11 @@ class PipelineTestHarness:
                 with self.session_factory() as detector_session:
                     for detector_id in detector_ids:
                         run_detector_post_step(
-                            detector_session, self.source_id, detector_id, self.duckdb_conn
+                            detector_session,
+                            self.source_id,
+                            detector_id,
+                            self.duckdb_conn,
+                            session_id=baseline_session_id(),
                         )
                     detector_session.commit()
 
@@ -227,21 +233,48 @@ def _build_phase_dict(*phase_instances: Phase) -> dict[str, Phase]:
 
 
 @pytest.fixture
-def integration_engine() -> Engine:
-    """Create an in-memory SQLite engine for integration tests."""
-    engine = create_engine(
-        "sqlite:///:memory:",
-        echo=False,
-        future=True,
-    )
+def integration_engine(pg_url_clean: str) -> Engine:
+    """Create a Postgres engine on the session-scoped testcontainer.
 
-    @event.listens_for(engine, "connect")
-    def set_sqlite_pragma(dbapi_conn, connection_record):
-        cursor = dbapi_conn.cursor()
-        cursor.execute("PRAGMA foreign_keys=ON")
-        cursor.close()
+    Integration tests target the real Postgres dialect post-DAT-321 so that
+    SQLite-permissive quirks (case insensitivity, JSON-vs-JSONB, looser
+    transaction semantics) can't mask real bugs. Per-test isolation comes
+    from ``pg_url_clean`` (TRUNCATE CASCADE over every Base table).
 
+    Seeds a baseline ``Source`` + ``InvestigationSession`` so the global
+    ``before_flush`` autofill hook in ``tests/conftest.py`` has a valid
+    FK target for any per-session row a test constructs without explicit
+    ``session_id=``. Production code always sets it explicitly.
+    """
+    from datetime import UTC, datetime
+
+    from dataraum.investigation.db_models import InvestigationSession
+    from dataraum.storage import Source
+
+    engine = create_engine(pg_url_clean, echo=False, future=True)
     init_database(engine)
+
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    with factory() as sess:
+        sess.add(
+            Source(
+                source_id="00000000-0000-0000-0000-000000000002",
+                name="test_baseline",
+                source_type="csv",
+            )
+        )
+        sess.flush()
+        sess.add(
+            InvestigationSession(
+                session_id=baseline_session_id(),
+                source_id="00000000-0000-0000-0000-000000000002",
+                intent="integration baseline",
+                status="active",
+                started_at=datetime.now(UTC),
+            )
+        )
+        sess.commit()
+
     yield engine
     engine.dispose()
 

--- a/tests/integration/graphs/test_agent.py
+++ b/tests/integration/graphs/test_agent.py
@@ -32,6 +32,7 @@ from dataraum.graphs.models import (
     StepType,
     TransformationGraph,
 )
+from tests.conftest import baseline_session_id
 
 
 @pytest.fixture
@@ -296,7 +297,7 @@ class TestGraphAgentIntegration:
         context = _make_execution_context(duckdb_with_data)
 
         # Execute
-        result = agent.execute(session, sample_graph, context)
+        result = agent.execute(session, sample_graph, context, session_id=baseline_session_id())
 
         assert result.success
         assert result.value is not None
@@ -352,12 +353,12 @@ class TestGraphAgentIntegration:
         context = _make_execution_context(duckdb_with_data)
 
         # First execution - should call LLM
-        result1 = agent.execute(session, sample_graph, context)
+        result1 = agent.execute(session, sample_graph, context, session_id=baseline_session_id())
         assert result1.success
         assert agent.provider.converse.call_count == 1
 
         # Second execution - should use in-memory cache
-        result2 = agent.execute(session, sample_graph, context)
+        result2 = agent.execute(session, sample_graph, context, session_id=baseline_session_id())
         assert result2.success
         assert agent.provider.converse.call_count == 1  # No additional call
 
@@ -418,7 +419,7 @@ class TestGraphAgentSnippets:
 
         context = _make_execution_context(duckdb_with_data)
 
-        result = agent.execute(session, sample_graph, context)
+        result = agent.execute(session, sample_graph, context, session_id=baseline_session_id())
         assert result.success
 
         # Verify snippet was saved
@@ -452,7 +453,7 @@ class TestGraphAgentSnippets:
         mock_renderer.render_split.return_value = ("System prompt", "Test prompt", 0.0)
 
         # Pre-populate snippet library with a matching snippet
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(amount) AS value FROM test_data",
@@ -474,7 +475,7 @@ class TestGraphAgentSnippets:
         context = _make_execution_context(duckdb_with_data)
 
         # Execute — should assemble from snippets (no LLM call)
-        result = agent.execute(session, sample_graph, context)
+        result = agent.execute(session, sample_graph, context, session_id=baseline_session_id())
         assert result.success
         assert result.value.output_value == 600.0  # 100 + 200 + 300
         assert agent.provider.converse.call_count == 0  # No LLM call needed
@@ -502,7 +503,7 @@ class TestGraphAgentSnippets:
         mock_renderer.render_split.return_value = ("System prompt", "Test prompt", 0.0)
 
         # Pre-populate snippet
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         snippet = library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(amount) AS value FROM test_data",
@@ -523,7 +524,7 @@ class TestGraphAgentSnippets:
 
         context = _make_execution_context(duckdb_with_data)
 
-        result = agent.execute(session, sample_graph, context)
+        result = agent.execute(session, sample_graph, context, session_id=baseline_session_id())
         assert result.success
 
         # Verify usage record was created
@@ -556,7 +557,7 @@ class TestGraphAgentSnippets:
         mock_renderer.render_split.return_value = ("System prompt", "Test prompt", 0.0)
 
         # Pre-populate snippet with column_mappings
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(amount) AS value FROM test_data",
@@ -633,7 +634,7 @@ class TestGraphAgentSnippets:
         context = _make_execution_context(duckdb_with_data)
 
         # Execute — no cached snippets (first time), should still track usage
-        result = agent.execute(session, sample_graph, context)
+        result = agent.execute(session, sample_graph, context, session_id=baseline_session_id())
         assert result.success
 
         # Verify usage records were created

--- a/tests/integration/mcp/test_session_isolation.py
+++ b/tests/integration/mcp/test_session_isolation.py
@@ -1,17 +1,41 @@
-"""Integration tests for DAT-192 session-isolation invariants.
+"""MCP session-lifecycle integration tests (post-DAT-321).
 
-These tests assert the safety properties of the two-manager design at the
-DB level — opening workspace.db and session DBs directly to verify that
-data lands where it should and doesn't bleed across boundaries.
+DAT-192 originally enforced "two SQLite files, no leak" by opening
+``workspace.db`` and per-session ``metadata.db`` files directly via
+``sqlite3.connect()``. DAT-321 unified everything onto a single workspace
+Postgres: there are no separate DB files anymore, only Postgres tables
+scoped by ``session_id``.
+
+The product invariants these tests cover are unchanged:
+
+- ``add_source`` populates ``sources`` but no per-session tables.
+- Same source set → same per-session DuckDB directory (DuckDB stays
+  per-session post-DAT-321 — L4 swaps it for DuckLake).
+- Different source sets → different per-session directories.
+- ``begin_session`` writes both the workspace ``ActiveSession`` pointer
+  and a new ``InvestigationSession`` row in the same Postgres DB.
+- A retried ``begin_session`` marks orphan ``active`` rows as
+  ``abandoned``.
+- ``resume_session`` restores the per-session DuckDB directory in place
+  and the workspace pointer matches.
+
+Assertions go through SQLAlchemy against the testcontainers Postgres,
+not raw ``sqlite3.connect``.
 """
 
 from __future__ import annotations
 
 import json
-import sqlite3
 from pathlib import Path
 
 import pytest
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker
+
+from dataraum.investigation.db_models import InvestigationSession
+from dataraum.mcp.db_models import ActiveSession, ArchivedSession
+from dataraum.storage import Source
 
 
 async def _call(server, name: str, arguments: dict | None = None):
@@ -33,24 +57,14 @@ def _make_csv(tmp_path: Path, name: str, rows: str = "a,b\n1,2\n") -> Path:
     return csv
 
 
-def _query_one(db_path: Path, sql: str) -> tuple | None:
-    """Query a SQLite DB outside SQLAlchemy. Returns first row or None."""
-    with sqlite3.connect(str(db_path)) as conn:
-        return conn.execute(sql).fetchone()
+def _ws_engine(pg_url: str) -> Engine:
+    """A read-side engine bound to the same testcontainer the MCP server uses."""
+    return create_engine(pg_url, future=True)
 
 
-def _query_all(db_path: Path, sql: str) -> list[tuple]:
-    with sqlite3.connect(str(db_path)) as conn:
-        return list(conn.execute(sql).fetchall())
-
-
-def _count(db_path: Path, table: str) -> int:
-    """Count rows in a table; returns 0 if table doesn't exist."""
-    with sqlite3.connect(str(db_path)) as conn:
-        try:
-            return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
-        except sqlite3.OperationalError:
-            return 0
+def _ws_session(pg_url: str):
+    factory = sessionmaker(bind=_ws_engine(pg_url), expire_on_commit=False)
+    return factory()
 
 
 @pytest.fixture
@@ -58,12 +72,19 @@ def api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
 
 
+@pytest.fixture
+def db_url(monkeypatch: pytest.MonkeyPatch, pg_url_clean: str) -> str:
+    """Point the MCP server at the testcontainer Postgres (clean per test)."""
+    monkeypatch.setenv("DATABASE_URL", pg_url_clean)
+    return pg_url_clean
+
+
 class TestAddSourceWritesOnlyToWorkspace:
-    """AC2: add_source writes only to workspace DB. No table/column/entropy data leaks in."""
+    """add_source populates `sources` but no per-session tables."""
 
     @pytest.mark.asyncio
     async def test_add_source_populates_workspace_sources_only(
-        self, tmp_path: Path, api_key: None
+        self, tmp_path: Path, api_key: None, db_url: str
     ) -> None:
         from dataraum.mcp.server import create_server
 
@@ -71,30 +92,28 @@ class TestAddSourceWritesOnlyToWorkspace:
         csv = _make_csv(tmp_path, "data.csv")
         await _call(server, "add_source", {"name": "src1", "path": str(csv)})
 
-        workspace_db = tmp_path / "workspace.db"
-        assert workspace_db.exists()
+        with _ws_session(db_url) as s:
+            sources = list(s.execute(select(Source)).scalars().all())
+            assert len(sources) == 1
+            assert sources[0].name == "src1"
+            assert sources[0].source_type == "csv"
 
-        # Sources is populated
-        assert _count(workspace_db, "sources") == 1
-        row = _query_one(workspace_db, "SELECT name, source_type FROM sources")
-        assert row == ("src1", "csv")
+            # Per-session tables must be empty — pipeline hasn't run yet.
+            for table in ("tables", "columns", "entropy_objects"):
+                count = s.execute(text(f"SELECT COUNT(*) FROM {table}")).scalar()
+                assert count == 0, f"{table} should be empty after add_source"
 
-        # Tables, columns, entropy data must NOT be in the workspace
-        # (these are session-DB concerns; pipeline hasn't run yet anyway,
-        # but the workspace should never see them even after sessions run).
-        assert _count(workspace_db, "tables") == 0
-        assert _count(workspace_db, "columns") == 0
-        assert _count(workspace_db, "entropy_objects") == 0
-
-        # No session dirs created yet — begin_session not called
+        # No per-session DuckDB dirs created yet — begin_session not called.
         assert not (tmp_path / "sessions").exists()
 
 
 class TestSameSourcesReuseSessionDir:
-    """AC3: begin_session with the same source set reuses sessions/{fingerprint}/."""
+    """Same source → same fingerprint → same per-session DuckDB directory."""
 
     @pytest.mark.asyncio
-    async def test_same_sources_same_fingerprint_dir(self, tmp_path: Path, api_key: None) -> None:
+    async def test_same_sources_same_fingerprint_dir(
+        self, tmp_path: Path, api_key: None, db_url: str
+    ) -> None:
         from dataraum.mcp.server import create_server
 
         server = create_server(output_dir=tmp_path)
@@ -106,9 +125,7 @@ class TestSameSourcesReuseSessionDir:
         first_dirs = sorted(p.name for p in sessions_dir.iterdir())
         assert len(first_dirs) == 1
 
-        # End and begin again — same sources → same fingerprint → same dir reused (after archive)
         await _call(server, "end_session", {"outcome": "abandoned"})
-        # After end, the session dir is archived; begin again recreates the same fp dir
         await _call(server, "begin_session", {"source": "src1", "intent": "second"})
 
         second_dirs = sorted(p.name for p in sessions_dir.iterdir())
@@ -116,54 +133,57 @@ class TestSameSourcesReuseSessionDir:
 
 
 class TestDifferentSourcesIsolation:
-    """AC4: different source sets land in different session directories."""
+    """Different source sets land in different per-session directories,
+    and each archived InvestigationSession row carries the matching intent."""
 
     @pytest.mark.asyncio
     async def test_different_sources_different_dirs_no_overwrite(
-        self, tmp_path: Path, api_key: None
+        self, tmp_path: Path, api_key: None, db_url: str
     ) -> None:
         from dataraum.mcp.server import create_server
 
         server = create_server(output_dir=tmp_path)
 
-        # Cycle 1: source A
         csv_a = _make_csv(tmp_path, "a.csv", "x,y\n1,2\n")
         await _call(server, "add_source", {"name": "src_a", "path": str(csv_a)})
         await _call(server, "begin_session", {"source": "src_a", "intent": "session A"})
         await _call(server, "end_session", {"outcome": "abandoned"})
 
-        # Cycle 2: source B (different name + path → different fingerprint)
         csv_b = _make_csv(tmp_path, "b.csv", "x,y\n3,4\n")
         await _call(server, "add_source", {"name": "src_b", "path": str(csv_b)})
         await _call(server, "begin_session", {"source": "src_b", "intent": "session B"})
         await _call(server, "end_session", {"outcome": "abandoned"})
 
-        # Both archived sessions present, in distinct directories
         archive = tmp_path / "archive"
         archived_dirs = sorted(p for p in archive.iterdir())
-        assert len(archived_dirs) == 2
+        assert len(archived_dirs) == 2, "Each source set archives its own DuckDB dir"
 
-        # Each archive contains its own metadata.db with the right session intent
-        intents: list[str] = []
-        for adir in archived_dirs:
-            metadata = adir / "metadata.db"
-            assert metadata.exists()
-            row = _query_one(
-                metadata,
-                "SELECT intent FROM investigation_sessions ORDER BY started_at DESC LIMIT 1",
+        # All InvestigationSession rows live in the unified Postgres now.
+        # Both archived sessions must be present with the right intents.
+        with _ws_session(db_url) as s:
+            rows = list(
+                s.execute(
+                    select(InvestigationSession.intent).where(
+                        InvestigationSession.intent.in_(["session A", "session B"])
+                    )
+                )
+                .scalars()
+                .all()
             )
-            assert row is not None
-            intents.append(row[0])
-        assert set(intents) == {"session A", "session B"}, (
-            "Each archived session must contain only its own InvestigationSession row"
-        )
+            assert set(rows) == {"session A", "session B"}, (
+                "Each InvestigationSession is scoped by its own session_id; "
+                "intents must be present and distinct"
+            )
 
 
 class TestBeginSessionWritesToBothDBs:
-    """begin_session sets ActiveSession pointer in workspace AND InvestigationSession in session DB."""
+    """begin_session sets the workspace ActiveSession pointer AND the
+    InvestigationSession row, with matching session_id."""
 
     @pytest.mark.asyncio
-    async def test_pointer_and_session_row_present(self, tmp_path: Path, api_key: None) -> None:
+    async def test_pointer_and_session_row_present(
+        self, tmp_path: Path, api_key: None, db_url: str
+    ) -> None:
         from dataraum.mcp.server import create_server
 
         server = create_server(output_dir=tmp_path)
@@ -172,88 +192,77 @@ class TestBeginSessionWritesToBothDBs:
 
         await _call(server, "begin_session", {"source": "src1", "intent": "verify_writes"})
 
-        # Workspace has ActiveSession pointer
-        workspace_db = tmp_path / "workspace.db"
-        pointer = _query_one(workspace_db, "SELECT session_id, fingerprint FROM active_session")
-        assert pointer is not None
-        session_id, fingerprint = pointer
-        assert session_id and fingerprint
+        with _ws_session(db_url) as s:
+            pointer = s.execute(select(ActiveSession)).scalar_one()
+            assert pointer.session_id and pointer.fingerprint
 
-        # Session DB has the InvestigationSession with the same id, status=active
+            inv = s.execute(
+                select(InvestigationSession).where(
+                    InvestigationSession.session_id == pointer.session_id
+                )
+            ).scalar_one()
+            assert inv.intent == "verify_writes"
+            assert inv.status == "active"
+
+        # Per-session DuckDB dir name matches the workspace pointer fingerprint.
         sessions_dir = tmp_path / "sessions"
         session_dirs = list(sessions_dir.iterdir())
         assert len(session_dirs) == 1
-        assert session_dirs[0].name == fingerprint  # dir name matches pointer fingerprint
-
-        session_metadata = session_dirs[0] / "metadata.db"
-        row = _query_one(
-            session_metadata,
-            "SELECT session_id, intent, status FROM investigation_sessions",
-        )
-        assert row == (session_id, "verify_writes", "active")
+        assert session_dirs[0].name == pointer.fingerprint
 
 
 class TestGhostSessionCleanup:
-    """Retried begin_session does not leak orphan 'active' InvestigationSession rows.
-
-    Simulates the failure mode where a prior begin_session wrote to the
-    session DB but failed to set the workspace ActiveSession pointer (e.g.,
-    crashed between the two writes). On retry, the orphan must be marked
-    as abandoned.
-    """
+    """A retried begin_session abandons orphan ``active`` InvestigationSession
+    rows (left over from a crashed prior attempt that wrote the row but
+    failed to set the workspace ActiveSession pointer)."""
 
     @pytest.mark.asyncio
-    async def test_retry_marks_orphan_as_abandoned(self, tmp_path: Path, api_key: None) -> None:
+    async def test_retry_marks_orphan_as_abandoned(
+        self, tmp_path: Path, api_key: None, db_url: str
+    ) -> None:
         from dataraum.mcp.server import create_server
 
         server = create_server(output_dir=tmp_path)
         csv = _make_csv(tmp_path, "data.csv")
         await _call(server, "add_source", {"name": "src1", "path": str(csv)})
 
-        # First begin_session creates a session DB with an active InvestigationSession
         await _call(server, "begin_session", {"source": "src1", "intent": "first attempt"})
 
-        # Simulate a crashed begin_session: clear the workspace ActiveSession
-        # pointer but leave the session DB and its 'active' InvestigationSession
-        # in place. From the server's perspective, no session is active —
-        # but the orphan row sits in sessions/{fp}/metadata.db.
-        workspace_db = tmp_path / "workspace.db"
-        with sqlite3.connect(str(workspace_db)) as conn:
-            conn.execute("DELETE FROM active_session")
-            conn.commit()
+        # Simulate a crashed begin_session: clear the workspace pointer
+        # but leave the active InvestigationSession in place.
+        with _ws_session(db_url) as s:
+            s.execute(text("DELETE FROM active_session"))
+            s.commit()
 
-        # Retry begin_session. The orphan from "first attempt" must be marked
-        # as abandoned, and a fresh active session created.
         await _call(server, "begin_session", {"source": "src1", "intent": "fresh attempt"})
 
-        sessions_dir = tmp_path / "sessions"
-        session_dirs = list(sessions_dir.iterdir())
-        assert len(session_dirs) == 1
-        session_metadata = session_dirs[0] / "metadata.db"
-        rows = _query_all(
-            session_metadata,
-            "SELECT intent, status FROM investigation_sessions ORDER BY started_at",
-        )
-        intents = [r[0] for r in rows]
-        statuses = [r[1] for r in rows]
-        assert intents == ["first attempt", "fresh attempt"]
-        assert statuses == ["abandoned", "active"]
+        with _ws_session(db_url) as s:
+            rows = list(
+                s.execute(
+                    select(InvestigationSession.intent, InvestigationSession.status)
+                    .where(InvestigationSession.intent.in_(["first attempt", "fresh attempt"]))
+                    .order_by(InvestigationSession.started_at)
+                ).all()
+            )
+            assert [r.intent for r in rows] == ["first attempt", "fresh attempt"]
+            assert [r.status for r in rows] == ["abandoned", "active"]
 
 
 class TestResumeSessionRestoresArchive:
-    """resume_session restores an archived session in place at the original
-    fingerprint directory. After resume, the workspace pointer matches the
-    restored session and the archive index entry is consumed."""
+    """resume_session restores an archived per-session DuckDB directory in
+    place, consumes the archive index row, and sets the workspace pointer
+    to the restored session."""
 
     @pytest.mark.asyncio
-    async def test_full_archive_restore_cycle(self, tmp_path: Path, api_key: None) -> None:
+    async def test_full_archive_restore_cycle(
+        self, tmp_path: Path, api_key: None, db_url: str
+    ) -> None:
         from dataraum.mcp.server import create_server
 
         server = create_server(output_dir=tmp_path)
         csv = _make_csv(tmp_path, "data.csv")
         await _call(server, "add_source", {"name": "src1", "path": str(csv)})
 
-        # Begin → end. Archive populated; sessions/ empty.
         await _call(server, "begin_session", {"source": "src1", "intent": "first pass"})
         sessions_dir = tmp_path / "sessions"
         original_fp = next(sessions_dir.iterdir()).name
@@ -264,38 +273,43 @@ class TestResumeSessionRestoresArchive:
         assert len(archives_before) == 1
         archive_id = archives_before[0].name
 
-        # Resume by ID.
         result = await _call(server, "resume_session", {"session_id": archive_id})
         assert "error" not in result
         assert result["resumed_from"] == archive_id
 
-        # Filesystem moved back into the original fingerprint dir.
         restored_dirs = list(sessions_dir.iterdir())
         assert len(restored_dirs) == 1
         assert restored_dirs[0].name == original_fp
-        assert (tmp_path / "archive" / archive_id).exists() is False
+        assert not (tmp_path / "archive" / archive_id).exists()
 
-        # Workspace state.
-        workspace_db = tmp_path / "workspace.db"
-        assert _count(workspace_db, "archived_sessions") == 0
-        active = _query_one(workspace_db, "SELECT fingerprint FROM active_session")
-        assert active == (original_fp,)
+        with _ws_session(db_url) as s:
+            # Archive index row consumed.
+            archived = s.execute(
+                select(ArchivedSession).where(ArchivedSession.session_id == archive_id)
+            ).scalar_one_or_none()
+            assert archived is None
 
-        # Session DB has the original InvestigationSession (terminal status)
-        # and a new resumed one (active).
-        rows = _query_all(
-            restored_dirs[0] / "metadata.db",
-            "SELECT intent, status FROM investigation_sessions ORDER BY started_at",
-        )
-        assert [r[0] for r in rows] == ["first pass", "Resumed: first pass"]
-        assert [r[1] for r in rows] == ["delivered", "active"]
+            # Workspace pointer matches the restored fingerprint.
+            pointer = s.execute(select(ActiveSession)).scalar_one()
+            assert pointer.fingerprint == original_fp
+
+            # Original session is terminal; new resumed session is active.
+            rows = list(
+                s.execute(
+                    select(InvestigationSession.intent, InvestigationSession.status)
+                    .where(InvestigationSession.intent.in_(["first pass", "Resumed: first pass"]))
+                    .order_by(InvestigationSession.started_at)
+                ).all()
+            )
+            assert [r.intent for r in rows] == ["first pass", "Resumed: first pass"]
+            assert [r.status for r in rows] == ["delivered", "active"]
 
     @pytest.mark.asyncio
     async def test_resume_then_end_creates_new_archive_entry(
-        self, tmp_path: Path, api_key: None
+        self, tmp_path: Path, api_key: None, db_url: str
     ) -> None:
-        """After resume + end_session, the archive index has the new session_id,
-        not the consumed original."""
+        """After resume + end_session, the archive index has the new
+        session_id (not the consumed original)."""
         from dataraum.mcp.server import create_server
 
         server = create_server(output_dir=tmp_path)

--- a/tests/integration/mcp/test_session_isolation.py
+++ b/tests/integration/mcp/test_session_isolation.py
@@ -26,12 +26,13 @@ not raw ``sqlite3.connect``.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine, select, text
-from sqlalchemy.engine import Engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 from dataraum.investigation.db_models import InvestigationSession
 from dataraum.mcp.db_models import ActiveSession, ArchivedSession
@@ -57,14 +58,21 @@ def _make_csv(tmp_path: Path, name: str, rows: str = "a,b\n1,2\n") -> Path:
     return csv
 
 
-def _ws_engine(pg_url: str) -> Engine:
-    """A read-side engine bound to the same testcontainer the MCP server uses."""
-    return create_engine(pg_url, future=True)
+@contextmanager
+def _ws_session(pg_url: str) -> Iterator[Session]:
+    """Read-side SQLAlchemy session bound to the testcontainer Postgres.
 
-
-def _ws_session(pg_url: str):
-    factory = sessionmaker(bind=_ws_engine(pg_url), expire_on_commit=False)
-    return factory()
+    Owns the engine for the duration of the ``with`` block and disposes it
+    on exit — otherwise the pooled psycopg connections leak (Python 3.12+
+    raises ``ResourceWarning`` when GC catches an open psycopg connection).
+    """
+    engine = create_engine(pg_url, future=True)
+    try:
+        factory = sessionmaker(bind=engine, expire_on_commit=False)
+        with factory() as sess:
+            yield sess
+    finally:
+        engine.dispose()
 
 
 @pytest.fixture

--- a/tests/integration/pipeline/test_temporal_slice_analysis_phase.py
+++ b/tests/integration/pipeline/test_temporal_slice_analysis_phase.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from dataraum.pipeline.base import PhaseContext, PhaseStatus
 from dataraum.pipeline.phases.temporal_slice_analysis_phase import TemporalSliceAnalysisPhase
 from dataraum.storage import Column, Source, Table
+from tests.conftest import baseline_session_id
 
 if TYPE_CHECKING:
     import duckdb
@@ -30,6 +31,7 @@ class TestTemporalSliceAnalysisPhase:
             duckdb_conn=duckdb_conn,
             source_id=source_id,
             config={},
+            session_id=baseline_session_id(),
         )
 
         skip_reason = phase.should_skip(ctx)
@@ -48,6 +50,7 @@ class TestTemporalSliceAnalysisPhase:
             duckdb_conn=duckdb_conn,
             source_id=source_id,
             config={},
+            session_id=baseline_session_id(),
         )
 
         result = phase.run(ctx)
@@ -86,6 +89,7 @@ class TestTemporalSliceAnalysisPhase:
             duckdb_conn=duckdb_conn,
             source_id=source_id,
             config={},
+            session_id=baseline_session_id(),
         )
 
         skip_reason = phase.should_skip(ctx)
@@ -146,6 +150,7 @@ class TestTemporalSliceAnalysisPhase:
             duckdb_conn=duckdb_conn,
             source_id=source_id,
             config={},
+            session_id=baseline_session_id(),
         )
 
         skip_reason = phase.should_skip(ctx)
@@ -233,6 +238,7 @@ class TestTemporalSliceAnalysisPhase:
             duckdb_conn=duckdb_conn,
             source_id=source_id,
             config={},
+            session_id=baseline_session_id(),
         )
 
         skip_reason = phase.should_skip(ctx)
@@ -419,6 +425,7 @@ class TestTemporalSliceAnalysisPhase:
             duckdb_conn=duckdb_conn,
             source_id=source_id,
             config={},
+            session_id=baseline_session_id(),
         )
 
         result = phase.run(ctx)
@@ -468,6 +475,7 @@ class TestTemporalSliceAnalysisPhase:
             duckdb_conn=duckdb_conn,
             source_id=source_id,
             config={},
+            session_id=baseline_session_id(),
         )
 
         result = phase.run(ctx)

--- a/tests/integration/query/test_agent.py
+++ b/tests/integration/query/test_agent.py
@@ -21,6 +21,7 @@ from dataraum.entropy.contracts import ConfidenceLevel
 from dataraum.graphs.context import ColumnContext, GraphExecutionContext, TableContext
 from dataraum.query.agent import QueryAgent
 from dataraum.query.models import QueryAnalysisOutput
+from tests.conftest import baseline_session_id
 
 
 @pytest.fixture
@@ -504,7 +505,7 @@ class TestQueryAgentSnippets:
         """Test that _discover_snippets returns all snippets in full injection mode."""
         from dataraum.query.snippet_library import SnippetLibrary
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(amount) AS revenue FROM typed_orders",
@@ -548,7 +549,7 @@ class TestQueryAgentSnippets:
         from dataraum.query.snippet_library import SnippetLibrary
         from dataraum.query.snippet_models import SnippetUsageRecord
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         snippet = library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(amount) FROM typed_orders",
@@ -588,6 +589,7 @@ class TestQueryAgentSnippets:
             execution_id="exec-001",
             analysis_output=analysis,
             snippet_id_index=snippet_id_index,
+            session_id=baseline_session_id(),
         )
         session.flush()
 
@@ -623,6 +625,7 @@ class TestQueryAgentSnippets:
             execution_id="exec-002",
             analysis_output=analysis,
             snippet_id_index={},
+            session_id=baseline_session_id(),
         )
         session.flush()
 
@@ -658,6 +661,7 @@ class TestQueryAgentSnippets:
             execution_id="exec-003",
             analysis_output=analysis,
             schema_mapping_id="source_123",
+            session_id=baseline_session_id(),
         )
         session.flush()
 
@@ -701,6 +705,7 @@ class TestQueryAgentSnippets:
             execution_id="exec-004",
             analysis_output=analysis,
             schema_mapping_id="source_123",
+            session_id=baseline_session_id(),
         )
         session.flush()
 
@@ -712,7 +717,7 @@ class TestQueryAgentSnippets:
         """Test that _discover_snippets returns snippets grouped by source graph."""
         from dataraum.query.snippet_library import SnippetLibrary
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(ar) AS value FROM typed_orders",
@@ -768,6 +773,7 @@ class TestQueryAgentSnippets:
             execution_id="exec-first",
             analysis_output=analysis,
             snippet_id_index={},
+            session_id=baseline_session_id(),
         )
         session.flush()
 
@@ -786,7 +792,7 @@ class TestResolveSnippetReferences:
         from dataraum.query.models import QueryAnalysisOutput, SQLStepOutput
         from dataraum.query.snippet_library import SnippetLibrary
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         snippet = library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(amount) AS value FROM typed_orders",
@@ -836,7 +842,7 @@ class TestResolveSnippetReferences:
         from dataraum.query.models import QueryAnalysisOutput, SQLStepOutput
         from dataraum.query.snippet_library import SnippetLibrary
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         snippet = library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(amount) AS value FROM typed_orders",
@@ -942,7 +948,7 @@ class TestResolveSnippetReferences:
         from dataraum.query.models import QueryAnalysisOutput, SQLStepOutput
         from dataraum.query.snippet_library import SnippetLibrary
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         snippet_rev = library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(amount) FROM typed_orders",
@@ -1024,7 +1030,7 @@ class TestResolveSnippetReferences:
 
 
 class TestDeterministicUsageTracking:
-    """Tests for deterministic _track_snippet_usage()."""
+    """Tests for deterministic _track_snippet_usage(session_id=baseline_session_id())."""
 
     def test_adapted_step_tracked(self, mock_agent, session: Session):
         """Step with snippet_id but different SQL tracked as adapted."""
@@ -1034,7 +1040,7 @@ class TestDeterministicUsageTracking:
         from dataraum.query.snippet_library import SnippetLibrary
         from dataraum.query.snippet_models import SnippetUsageRecord
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         snippet = library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(amount) FROM typed_orders",
@@ -1073,6 +1079,7 @@ class TestDeterministicUsageTracking:
             execution_id="exec-adapt",
             analysis_output=analysis,
             snippet_id_index=snippet_id_index,
+            session_id=baseline_session_id(),
         )
         session.flush()
 
@@ -1089,7 +1096,7 @@ class TestDeterministicUsageTracking:
         from dataraum.query.snippet_library import SnippetLibrary
         from dataraum.query.snippet_models import SnippetUsageRecord
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         snippet = library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(amount) FROM typed_orders",
@@ -1128,6 +1135,7 @@ class TestDeterministicUsageTracking:
             execution_id="exec-unused",
             analysis_output=analysis,
             snippet_id_index=snippet_id_index,
+            session_id=baseline_session_id(),
         )
         session.flush()
 
@@ -1149,7 +1157,7 @@ class TestDeterministicUsageTracking:
         from dataraum.query.snippet_library import SnippetLibrary
         from dataraum.query.snippet_models import SnippetUsageRecord
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         s1 = library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(amount) FROM typed_orders",
@@ -1216,6 +1224,7 @@ class TestDeterministicUsageTracking:
             execution_id="exec-mixed",
             analysis_output=analysis,
             snippet_id_index=snippet_id_index,
+            session_id=baseline_session_id(),
         )
         session.flush()
 
@@ -1264,6 +1273,7 @@ class TestSaveNovelSnippetsWithSnippetId:
             execution_id="exec-save",
             analysis_output=analysis,
             schema_mapping_id="source_123",
+            session_id=baseline_session_id(),
         )
         session.flush()
 
@@ -1301,6 +1311,7 @@ class TestSaveNovelSnippetsWithSnippetId:
             execution_id="exec-adapt-save",
             analysis_output=analysis,
             schema_mapping_id="source_123",
+            session_id=baseline_session_id(),
         )
         session.flush()
 

--- a/tests/integration/test_query_agent.py
+++ b/tests/integration/test_query_agent.py
@@ -18,6 +18,7 @@ from dataraum.entropy.contracts import ConfidenceLevel
 from dataraum.graphs.field_mapping import ColumnCandidate, FieldMappings
 from dataraum.query.agent import QueryAgent
 from dataraum.query.models import QueryResult
+from tests.conftest import baseline_session_id
 
 from .conftest import PipelineTestHarness
 
@@ -114,6 +115,7 @@ class TestQueryAgentEndToEnd:
                 question="How many transactions are there?",
                 table_ids=analyzed_table_ids,
                 ephemeral=True,
+                session_id=baseline_session_id(),
             )
 
         assert result.success, f"Query failed: {result.error}"
@@ -146,6 +148,7 @@ class TestQueryAgentEndToEnd:
                 question="What is the total transaction amount?",
                 table_ids=analyzed_table_ids,
                 ephemeral=True,
+                session_id=baseline_session_id(),
             )
 
         assert result.success
@@ -174,6 +177,7 @@ class TestQueryAgentEndToEnd:
                 question="How many customers?",
                 table_ids=analyzed_table_ids,
                 ephemeral=True,
+                session_id=baseline_session_id(),
             )
 
         assert result.success
@@ -205,6 +209,7 @@ class TestContractIntegration:
                 question="How many transactions?",
                 table_ids=analyzed_table_ids,
                 ephemeral=True,
+                session_id=baseline_session_id(),
             )
 
         assert result.success
@@ -233,6 +238,7 @@ class TestContractIntegration:
                 table_ids=analyzed_table_ids,
                 contract="operational_analytics",  # Correct contract name
                 ephemeral=True,
+                session_id=baseline_session_id(),
             )
 
         assert result.success
@@ -257,6 +263,7 @@ class TestContractIntegration:
                 table_ids=analyzed_table_ids,
                 contract="regulatory_reporting",
                 ephemeral=True,
+                session_id=baseline_session_id(),
             )
 
         assert result.success  # Returns Result.ok even for blocked queries
@@ -294,6 +301,7 @@ class TestContractIntegration:
                 table_ids=analyzed_table_ids,
                 auto_contract=True,
                 ephemeral=True,
+                session_id=baseline_session_id(),
             )
 
         assert result.success
@@ -319,6 +327,7 @@ class TestContractIntegration:
                 table_ids=analyzed_table_ids,
                 contract="nonexistent_contract",
                 ephemeral=True,
+                session_id=baseline_session_id(),
             )
 
         assert not result.success
@@ -348,6 +357,7 @@ class TestQueryResultMetadata:
                 question="Test",
                 table_ids=analyzed_table_ids,
                 ephemeral=True,
+                session_id=baseline_session_id(),
             )
 
         assert result.success
@@ -374,6 +384,7 @@ class TestQueryResultMetadata:
                 question="What is the meaning of data?",
                 table_ids=analyzed_table_ids,
                 ephemeral=True,
+                session_id=baseline_session_id(),
             )
 
         assert result.success
@@ -399,6 +410,7 @@ class TestQueryResultMetadata:
                 question="Show transaction stats",
                 table_ids=analyzed_table_ids,
                 ephemeral=True,
+                session_id=baseline_session_id(),
             )
 
         assert result.success

--- a/tests/platform/smoke_dat321.py
+++ b/tests/platform/smoke_dat321.py
@@ -1,0 +1,426 @@
+"""Lane smoke for DAT-321 — All SQLAlchemy → single workspace Postgres.
+
+Scope: verify the L2/L3 unified-Postgres substrate post-port.
+- Every workspace + per-session table is created on a real Postgres 17 dialect.
+- Per-session tables carry a NOT NULL ``session_id`` FK to
+  ``investigation_sessions.session_id`` with the right ON-DELETE behavior
+  guaranteed by Postgres.
+- JSON columns (``connection_config``, ``discovered_schema``,
+  ``PhaseLog.outputs``) round-trip values into ``jsonb`` storage.
+- Two InvestigationSession rows cannot leak across each other.
+- The legacy SQLite dialect import paths are absent from production code.
+- No file-based ``*.db`` artifact appears on disk during a session run.
+
+The Postgres testcontainer is provided by ``tests/conftest.py`` via the
+session-scoped ``pg_container`` / ``pg_url`` fixtures; this smoke connects
+fresh and drops the schema between blocks to keep tier-1 lane semantics.
+
+Run:
+    uv run pytest tests/platform/smoke_dat321.py -v
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import subprocess
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect, select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from dataraum.investigation.db_models import InvestigationSession
+from dataraum.pipeline.db_models import PhaseLog, PipelineRun
+from dataraum.storage import Base, Source, init_database
+
+# ---------------------------------------------------------------------------
+# Per-test isolation: clean schema before each smoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pg_engine(pg_url: str):
+    """Fresh engine against a clean Postgres schema for this smoke."""
+    engine = create_engine(pg_url, future=True)
+    # Drop everything Base knows about (idempotent — TRUNCATE-style guard).
+    Base.metadata.drop_all(engine)
+    init_database(engine)
+    yield engine
+    Base.metadata.drop_all(engine)
+    engine.dispose()
+
+
+@pytest.fixture
+def pg_session(pg_engine):
+    factory = sessionmaker(bind=pg_engine, expire_on_commit=False)
+    with factory() as sess:
+        yield sess
+
+
+# ---------------------------------------------------------------------------
+# 1. Schema present — all workspace + per-session tables on Postgres
+# ---------------------------------------------------------------------------
+
+
+def test_all_tables_present_on_postgres(pg_engine) -> None:
+    """init_database creates every Base-registered table under the pg dialect."""
+    actual = set(inspect(pg_engine).get_table_names())
+    expected = set(Base.metadata.tables.keys())
+    missing = expected - actual
+    assert not missing, f"Missing tables under Postgres: {sorted(missing)}"
+
+
+# ---------------------------------------------------------------------------
+# 2. session_id FK present + NOT NULL on every per-session table
+# ---------------------------------------------------------------------------
+
+
+PER_SESSION_TABLES = {
+    # name -> (FK target column expected)
+    "pipeline_runs": ("investigation_sessions", "session_id"),
+    "phase_logs": ("investigation_sessions", "session_id"),
+    "data_fixes": ("investigation_sessions", "session_id"),
+    "fix_ledger": ("investigation_sessions", "session_id"),
+    "query_executions": ("investigation_sessions", "session_id"),
+    "sql_snippets": ("investigation_sessions", "session_id"),
+    "snippet_usage": ("investigation_sessions", "session_id"),
+    "entropy_objects": ("investigation_sessions", "session_id"),
+    "derived_columns": ("investigation_sessions", "session_id"),
+    "detected_business_cycles": ("investigation_sessions", "session_id"),
+    "column_eligibility": ("investigation_sessions", "session_id"),
+    "relationships": ("investigation_sessions", "session_id"),
+    "semantic_annotations": ("investigation_sessions", "session_id"),
+    "table_entities": ("investigation_sessions", "session_id"),
+    "slice_definitions": ("investigation_sessions", "session_id"),
+    "column_slice_profiles": ("investigation_sessions", "session_id"),
+    "statistical_profiles": ("investigation_sessions", "session_id"),
+    "statistical_quality_metrics": ("investigation_sessions", "session_id"),
+    "temporal_column_profiles": ("investigation_sessions", "session_id"),
+    "column_drift_summaries": ("investigation_sessions", "session_id"),
+    "temporal_slice_analyses": ("investigation_sessions", "session_id"),
+    "type_candidates": ("investigation_sessions", "session_id"),
+    "type_decisions": ("investigation_sessions", "session_id"),
+    "validation_results": ("investigation_sessions", "session_id"),
+    "enriched_views": ("investigation_sessions", "session_id"),
+    "slicing_views": ("investigation_sessions", "session_id"),
+}
+
+
+def test_session_id_fk_and_not_null_on_per_session_tables(pg_engine) -> None:
+    """Every per-session table FKs session_id to investigation_sessions, NOT NULL."""
+    inspector = inspect(pg_engine)
+    existing = set(inspector.get_table_names())
+
+    for table_name, (target_table, target_col) in PER_SESSION_TABLES.items():
+        if table_name not in existing:
+            # If a table isn't on the schema at all the model isn't wired.
+            # Fail loud here — the smoke is the single source of truth.
+            pytest.fail(f"per-session table {table_name!r} missing from Postgres schema")
+
+        columns = {c["name"]: c for c in inspector.get_columns(table_name)}
+        assert "session_id" in columns, f"{table_name}: no session_id column"
+        assert columns["session_id"]["nullable"] is False, (
+            f"{table_name}.session_id must be NOT NULL"
+        )
+
+        fks = inspector.get_foreign_keys(table_name)
+        sid_fks = [
+            fk
+            for fk in fks
+            if "session_id" in fk["constrained_columns"]
+            and fk["referred_table"] == target_table
+            and target_col in fk["referred_columns"]
+        ]
+        assert sid_fks, (
+            f"{table_name}: no FK on session_id → {target_table}.{target_col} (found: {fks})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. JSON columns round-trip through psycopg/jsonb
+# ---------------------------------------------------------------------------
+
+
+def test_json_round_trip_connection_config(pg_session) -> None:
+    """Source.connection_config + discovered_schema survive an insert/select cycle."""
+    src = Source(
+        source_id="src-json-1",
+        name="json-rt",
+        source_type="csv",
+        connection_config={"path": "/data/orders.csv", "header": True, "sep": ","},
+        discovered_schema={
+            "tables": [
+                {"name": "orders", "rows": 42, "tags": ["fact", "transactional"]},
+                {"name": "customers", "rows": None, "tags": []},
+            ],
+            "version": 3,
+        },
+    )
+    pg_session.add(src)
+    pg_session.commit()
+
+    pg_session.expire_all()
+    loaded = pg_session.execute(select(Source).where(Source.source_id == "src-json-1")).scalar_one()
+    assert loaded.connection_config == {"path": "/data/orders.csv", "header": True, "sep": ","}
+    assert loaded.discovered_schema is not None
+    assert loaded.discovered_schema["version"] == 3
+    assert loaded.discovered_schema["tables"][0]["tags"] == ["fact", "transactional"]
+
+
+def test_json_round_trip_phase_log_outputs(pg_session) -> None:
+    """PhaseLog.outputs survives jsonb round-trip with nested arrays + numbers."""
+    pg_session.add(Source(source_id="src-pl", name="pl-rt", source_type="csv"))
+    pg_session.flush()
+    sess = InvestigationSession(
+        session_id="sess-pl-1",
+        source_id="src-pl",
+        intent="json round trip",
+        status="active",
+        started_at=_dt.datetime.now(_dt.UTC),
+    )
+    pg_session.add(sess)
+    pg_session.flush()
+    run = PipelineRun(
+        run_id="run-pl-1",
+        session_id="sess-pl-1",
+        source_id="src-pl",
+        status="running",
+        started_at=_dt.datetime.now(_dt.UTC),
+    )
+    pg_session.add(run)
+    pg_session.flush()
+
+    payload = {
+        "rows_processed": 12345,
+        "tables": ["orders", "invoices"],
+        "scores": {"coverage": 0.97, "freshness": 0.83},
+    }
+    log = PhaseLog(
+        run_id="run-pl-1",
+        session_id="sess-pl-1",
+        source_id="src-pl",
+        phase_name="staging",
+        status="completed",
+        started_at=_dt.datetime.now(_dt.UTC),
+        completed_at=_dt.datetime.now(_dt.UTC),
+        duration_seconds=0.5,
+        outputs=payload,
+    )
+    pg_session.add(log)
+    pg_session.commit()
+
+    pg_session.expire_all()
+    loaded = pg_session.execute(select(PhaseLog).where(PhaseLog.run_id == "run-pl-1")).scalar_one()
+    assert loaded.outputs == payload
+
+
+# ---------------------------------------------------------------------------
+# 4. Two-sessions-no-leak — Postgres enforces what test fixtures fake
+# ---------------------------------------------------------------------------
+
+
+def _seed_session(pg_session, name: str) -> str:
+    src_id = f"src-{name}"
+    sid = f"sess-{name}"
+    pg_session.add(Source(source_id=src_id, name=name, source_type="csv"))
+    pg_session.flush()
+    pg_session.add(
+        InvestigationSession(
+            session_id=sid,
+            source_id=src_id,
+            intent=f"smoke {name}",
+            status="active",
+            started_at=_dt.datetime.now(_dt.UTC),
+        )
+    )
+    pg_session.flush()
+    pg_session.add(
+        PipelineRun(
+            run_id=f"run-{name}",
+            session_id=sid,
+            source_id=src_id,
+            status="running",
+            started_at=_dt.datetime.now(_dt.UTC),
+        )
+    )
+    pg_session.flush()
+    return sid
+
+
+def test_two_sessions_phase_logs_isolated(pg_session) -> None:
+    """Querying PhaseLog by session_id never bleeds across sessions."""
+    sid_a = _seed_session(pg_session, "alpha")
+    sid_b = _seed_session(pg_session, "beta")
+
+    # 3 logs for A
+    for i in range(3):
+        pg_session.add(
+            PhaseLog(
+                run_id="run-alpha",
+                session_id=sid_a,
+                source_id="src-alpha",
+                phase_name=f"phase_a_{i}",
+                status="completed",
+                started_at=_dt.datetime.now(_dt.UTC),
+                completed_at=_dt.datetime.now(_dt.UTC),
+                duration_seconds=0.1,
+            )
+        )
+    # 2 logs for B
+    for i in range(2):
+        pg_session.add(
+            PhaseLog(
+                run_id="run-beta",
+                session_id=sid_b,
+                source_id="src-beta",
+                phase_name=f"phase_b_{i}",
+                status="completed",
+                started_at=_dt.datetime.now(_dt.UTC),
+                completed_at=_dt.datetime.now(_dt.UTC),
+                duration_seconds=0.1,
+            )
+        )
+    pg_session.commit()
+
+    a_rows = (
+        pg_session.execute(select(PhaseLog).where(PhaseLog.session_id == sid_a)).scalars().all()
+    )
+    b_rows = (
+        pg_session.execute(select(PhaseLog).where(PhaseLog.session_id == sid_b)).scalars().all()
+    )
+    assert len(a_rows) == 3
+    assert len(b_rows) == 2
+    assert all(r.session_id == sid_a for r in a_rows)
+    assert all(r.session_id == sid_b for r in b_rows)
+
+
+def test_phase_log_without_session_id_rejected_by_postgres(pg_session) -> None:
+    """Postgres enforces NOT NULL on session_id — no autofill, no silent insert."""
+    pg_session.add(Source(source_id="src-nn", name="nn", source_type="csv"))
+    pg_session.flush()
+    pg_session.add(
+        InvestigationSession(
+            session_id="sess-nn",
+            source_id="src-nn",
+            intent="nn",
+            status="active",
+            started_at=_dt.datetime.now(_dt.UTC),
+        )
+    )
+    pg_session.flush()
+    pg_session.add(
+        PipelineRun(
+            run_id="run-nn",
+            session_id="sess-nn",
+            source_id="src-nn",
+            status="running",
+            started_at=_dt.datetime.now(_dt.UTC),
+        )
+    )
+    pg_session.flush()
+
+    # Bypass ORM defaulting by inserting via raw SQL without session_id.
+    with pytest.raises(IntegrityError):
+        pg_session.execute(
+            text(
+                "INSERT INTO phase_logs (log_id, run_id, source_id, phase_name, status, "
+                "started_at, completed_at, duration_seconds) "
+                "VALUES (:lid, :rid, :sid, 'p', 'completed', NOW(), NOW(), 0.0)"
+            ),
+            {"lid": "log-nn", "rid": "run-nn", "sid": "src-nn"},
+        )
+        pg_session.flush()
+
+
+def test_phase_log_with_bad_session_id_rejected_by_postgres(pg_session) -> None:
+    """Postgres FK rejects a session_id that doesn't exist."""
+    pg_session.add(Source(source_id="src-fk", name="fk", source_type="csv"))
+    pg_session.flush()
+    pg_session.add(
+        InvestigationSession(
+            session_id="sess-fk",
+            source_id="src-fk",
+            intent="fk",
+            status="active",
+            started_at=_dt.datetime.now(_dt.UTC),
+        )
+    )
+    pg_session.flush()
+    pg_session.add(
+        PipelineRun(
+            run_id="run-fk",
+            session_id="sess-fk",
+            source_id="src-fk",
+            status="running",
+            started_at=_dt.datetime.now(_dt.UTC),
+        )
+    )
+    pg_session.flush()
+
+    bad = PhaseLog(
+        run_id="run-fk",
+        session_id="ghost-session-does-not-exist",
+        source_id="src-fk",
+        phase_name="x",
+        status="completed",
+        started_at=_dt.datetime.now(_dt.UTC),
+        completed_at=_dt.datetime.now(_dt.UTC),
+        duration_seconds=0.0,
+    )
+    pg_session.add(bad)
+    with pytest.raises(IntegrityError):
+        pg_session.commit()
+    pg_session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# 5. No SQLite dialect imports remain in production code
+# ---------------------------------------------------------------------------
+
+
+def test_no_sqlite_dialect_imports_in_src() -> None:
+    """grep proof — DAT-321 dropped the sqlite-specific JSON path entirely."""
+    src_root = Path(__file__).resolve().parents[2] / "src"
+    res = subprocess.run(
+        ["grep", "-rn", "from sqlalchemy.dialects.sqlite", str(src_root)],
+        capture_output=True,
+        text=True,
+    )
+    # rg / grep exit 1 == no matches. exit 0 + output == matches.
+    assert res.returncode != 0 or not res.stdout, (
+        f"SQLite dialect import found in src/:\n{res.stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. ConnectionConfig.for_directory accepts DATABASE_URL → Postgres
+# ---------------------------------------------------------------------------
+
+
+def test_connection_config_reads_database_url(monkeypatch, pg_url, tmp_path) -> None:
+    """ConnectionConfig.for_directory must round-trip DATABASE_URL into pg engine."""
+    from dataraum.core.connections import ConnectionConfig, ConnectionManager
+
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    cfg = ConnectionConfig.for_directory(tmp_path)
+    assert cfg.database_url == pg_url
+    assert "postgresql" in cfg.database_url
+
+    manager = ConnectionManager(cfg, session_id="00000000-0000-0000-0000-0000000000aa")
+    try:
+        manager.initialize()
+        with manager.session_scope() as s:
+            result = s.execute(text("SELECT 1 AS x")).scalar()
+            assert result == 1
+    finally:
+        manager.close()
+
+
+def test_connection_config_fails_loud_without_database_url(monkeypatch, tmp_path) -> None:
+    """No DATABASE_URL → fail-loud RuntimeError, not silent SQLite fallback."""
+    from dataraum.core.connections import ConnectionConfig
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(RuntimeError, match="DATABASE_URL"):
+        ConnectionConfig.for_directory(tmp_path)

--- a/tests/platform/smoke_dat321.py
+++ b/tests/platform/smoke_dat321.py
@@ -76,6 +76,10 @@ def test_all_tables_present_on_postgres(pg_engine) -> None:
 # ---------------------------------------------------------------------------
 
 
+# NOTE: `investigation_steps` is intentionally absent — its ``session_id`` FK
+# pre-dates DAT-321 (lives on the InvestigationStep model since DAT-184) and
+# was not introduced by this lane. The 26 tables below are the ones that
+# acquired ``session_id`` as part of this port.
 PER_SESSION_TABLES = {
     # name -> (FK target column expected)
     "pipeline_runs": ("investigation_sessions", "session_id"),
@@ -424,3 +428,55 @@ def test_connection_config_fails_loud_without_database_url(monkeypatch, tmp_path
     monkeypatch.delenv("DATABASE_URL", raising=False)
     with pytest.raises(RuntimeError, match="DATABASE_URL"):
         ConnectionConfig.for_directory(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# 7. Each per-session table has an index on session_id
+# ---------------------------------------------------------------------------
+
+
+def test_session_id_indexed_on_per_session_tables(pg_engine) -> None:
+    """``index=True`` on session_id translates to a real Postgres index.
+
+    Per-session queries (PhaseLog filtered by session_id, snippet lookups,
+    etc.) are the hot path post-DAT-321. The ORM declares ``index=True`` on
+    every session_id column; this verifies it actually lands as a btree.
+    """
+    inspector = inspect(pg_engine)
+    for table_name in PER_SESSION_TABLES:
+        indexes = inspector.get_indexes(table_name)
+        has_sid_index = any("session_id" in idx.get("column_names", []) for idx in indexes)
+        assert has_sid_index, (
+            f"{table_name}: no index covering session_id "
+            f"(found indexes: {[i['name'] for i in indexes]})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. No file-based .db artifact appears on disk during a session lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_no_sqlite_db_files_after_session_initialize(monkeypatch, pg_url, tmp_path) -> None:
+    """Setting up a session manager must not leave .db / .sqlite files behind.
+
+    Pre-DAT-321 the workspace was a file-backed SQLite database; DAT-321
+    moves it into Postgres. If any leftover SQLite path is still wired,
+    initialize() would create a file and this guard would catch it.
+    """
+    from dataraum.core.connections import ConnectionConfig, ConnectionManager
+
+    monkeypatch.setenv("DATABASE_URL", pg_url)
+    cfg = ConnectionConfig.for_directory(tmp_path)
+    manager = ConnectionManager(cfg, session_id="00000000-0000-0000-0000-0000000000bb")
+    try:
+        manager.initialize()
+        with manager.session_scope() as s:
+            s.execute(text("SELECT 1")).scalar()
+    finally:
+        manager.close()
+
+    leftovers = []
+    for ext in (".db", ".sqlite", ".sqlite3"):
+        leftovers.extend(Path(tmp_path).rglob(f"*{ext}"))
+    assert not leftovers, f"SQLite artifact(s) left on disk under {tmp_path}: {leftovers}"

--- a/tests/platform/smoke_dat_324.py
+++ b/tests/platform/smoke_dat_324.py
@@ -26,8 +26,9 @@ from pathlib import Path
 import pytest
 import yaml
 
-from dataraum.core import config as core_config
 import dataraum.core.paths as paths_mod
+from dataraum.core import config as core_config
+from dataraum.core.paths import SOURCES_DIR
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 

--- a/tests/unit/analysis/correlation/test_enriched_derived.py
+++ b/tests/unit/analysis/correlation/test_enriched_derived.py
@@ -15,6 +15,7 @@ from dataraum.analysis.statistics.db_models import StatisticalProfile
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.storage import Column, Table
 from dataraum.storage.models import Source
+from tests.conftest import baseline_session_id
 
 
 @pytest.fixture
@@ -149,7 +150,7 @@ def _create_source(session):
 
 
 class TestDetectsEnrichedDerivedColumns:
-    """Tests for detect_enriched_derived_columns()."""
+    """Tests for detect_enriched_derived_columns( session_id=baseline_session_id())."""
 
     def test_detects_cross_table_derivation(self, enriched_duckdb, session):
         """total = quantity * products__unit_price should be found."""
@@ -172,7 +173,9 @@ class TestDetectsEnrichedDerivedColumns:
             view_table=view_table,
         )
 
-        result = detect_enriched_derived_columns(ev, table, enriched_duckdb, session)
+        result = detect_enriched_derived_columns(
+            ev, table, enriched_duckdb, session, session_id=baseline_session_id()
+        )
         assert result.success
         derived = result.unwrap()
         assert len(derived) >= 1
@@ -209,7 +212,9 @@ class TestDetectsEnrichedDerivedColumns:
 
         ev = _make_enriched_view(session, table, "enriched_test", [])
 
-        result = detect_enriched_derived_columns(ev, table, conn, session)
+        result = detect_enriched_derived_columns(
+            ev, table, conn, session, session_id=baseline_session_id()
+        )
         assert result.success
         derived = result.unwrap()
         assert len(derived) >= 1
@@ -235,7 +240,9 @@ class TestDetectsEnrichedDerivedColumns:
 
         ev = _make_enriched_view(session, table, "enriched_nodim", None)
 
-        result = detect_enriched_derived_columns(ev, table, conn, session)
+        result = detect_enriched_derived_columns(
+            ev, table, conn, session, session_id=baseline_session_id()
+        )
         assert result.success
         assert result.unwrap() == []
         conn.close()
@@ -267,7 +274,9 @@ class TestDetectsEnrichedDerivedColumns:
             view_table=view_table,
         )
 
-        result = detect_enriched_derived_columns(ev, table, conn, session)
+        result = detect_enriched_derived_columns(
+            ev, table, conn, session, session_id=baseline_session_id()
+        )
         assert result.success
         # Only 1 numeric column + 0 numeric dim cols → not enough for triples
         assert result.unwrap() == []
@@ -293,7 +302,9 @@ class TestDetectsEnrichedDerivedColumns:
             view_table=view_table,
         )
 
-        result = detect_enriched_derived_columns(ev, table, enriched_duckdb, session)
+        result = detect_enriched_derived_columns(
+            ev, table, enriched_duckdb, session, session_id=baseline_session_id()
+        )
         assert result.success
         fact_col_ids = {col_qty.column_id, col_total.column_id}
         for dc in result.unwrap():
@@ -319,7 +330,9 @@ class TestDetectsEnrichedDerivedColumns:
             view_table=view_table,
         )
 
-        result = detect_enriched_derived_columns(ev, table, enriched_duckdb, session)
+        result = detect_enriched_derived_columns(
+            ev, table, enriched_duckdb, session, session_id=baseline_session_id()
+        )
         assert result.success
         derived = result.unwrap()
         fact_col_ids = {col_qty.column_id, col_total.column_id}
@@ -352,7 +365,9 @@ class TestDetectsEnrichedDerivedColumns:
 
         ev = _make_enriched_view(session, table, "enriched_dedup", [])
 
-        result = detect_enriched_derived_columns(ev, table, conn, session)
+        result = detect_enriched_derived_columns(
+            ev, table, conn, session, session_id=baseline_session_id()
+        )
         assert result.success
         derived = result.unwrap()
         # Dedup should ensure only one entry per column triple

--- a/tests/unit/analysis/temporal_slicing/test_period_analysis.py
+++ b/tests/unit/analysis/temporal_slicing/test_period_analysis.py
@@ -22,6 +22,7 @@ from dataraum.analysis.temporal_slicing.models import (
     TemporalSliceConfig,
     VolumeAnomalyResult,
 )
+from tests.conftest import baseline_session_id
 
 # ---------------------------------------------------------------------------
 # _compute_period_metrics tests
@@ -595,7 +596,7 @@ class TestPersistPeriodResults:
             ],
         )
 
-        persist_result = persist_period_results(result, session)
+        persist_result = persist_period_results(result, session, session_id=baseline_session_id())
 
         assert persist_result.success
         assert persist_result.value == 2
@@ -647,7 +648,7 @@ class TestPersistPeriodResults:
             ],
         )
 
-        persist_result = persist_period_results(result, session)
+        persist_result = persist_period_results(result, session, session_id=baseline_session_id())
 
         assert persist_result.success
         record = session.add.call_args_list[0][0][0]

--- a/tests/unit/core/test_connections.py
+++ b/tests/unit/core/test_connections.py
@@ -1,4 +1,9 @@
-"""Tests for ConnectionConfig factories and ConnectionManager DuckDB optionality."""
+"""Tests for ConnectionConfig factories and ConnectionManager.
+
+Post-DAT-321: every SQLAlchemy engine binds to the workspace Postgres URL
+read from ``DATABASE_URL``. Tests get a live Postgres via the session-scoped
+``pg_url_clean`` fixture and a monkeypatched ``DATABASE_URL`` env var.
+"""
 
 from __future__ import annotations
 
@@ -9,26 +14,32 @@ import pytest
 from dataraum.core.connections import ConnectionConfig, ConnectionManager
 
 
-class TestForDirectory:
-    """ConnectionConfig.for_directory creates a SQLite + DuckDB config."""
+@pytest.fixture(autouse=True)
+def _database_url(monkeypatch: pytest.MonkeyPatch, pg_url_clean: str) -> None:
+    """Wire DATABASE_URL to the per-test Postgres URL for every test in this module."""
+    monkeypatch.setenv("DATABASE_URL", pg_url_clean)
 
-    def test_paths_set(self, tmp_path: Path) -> None:
+
+class TestForDirectory:
+    """ConnectionConfig.for_directory wires Postgres SQLAlchemy + per-session DuckDB."""
+
+    def test_paths_and_url(self, tmp_path: Path, pg_url_clean: str) -> None:
         config = ConnectionConfig.for_directory(tmp_path)
-        assert config.sqlite_path == tmp_path / "metadata.db"
+        assert config.database_url == pg_url_clean
         assert config.duckdb_path == tmp_path / "data.duckdb"
 
 
 class TestForWorkspace:
-    """ConnectionConfig.for_workspace creates a SQLite-only config (no DuckDB)."""
+    """ConnectionConfig.for_workspace creates a Postgres-only config (no DuckDB)."""
 
-    def test_sqlite_only(self, tmp_path: Path) -> None:
-        config = ConnectionConfig.for_workspace(tmp_path)
-        assert config.sqlite_path == tmp_path / "workspace.db"
+    def test_postgres_only(self, pg_url_clean: str) -> None:
+        config = ConnectionConfig.for_workspace()
+        assert config.database_url == pg_url_clean
         assert config.duckdb_path is None
 
-    def test_workspace_manager_initializes(self, tmp_path: Path) -> None:
-        """A workspace ConnectionManager initializes SQLite without DuckDB."""
-        config = ConnectionConfig.for_workspace(tmp_path)
+    def test_workspace_manager_initializes(self) -> None:
+        """A workspace ConnectionManager initializes Postgres without DuckDB."""
+        config = ConnectionConfig.for_workspace()
         manager = ConnectionManager(config)
         manager.initialize()
         try:
@@ -37,25 +48,55 @@ class TestForWorkspace:
         finally:
             manager.close()
 
-    def test_workspace_manager_rejects_duckdb_cursor(self, tmp_path: Path) -> None:
+    def test_workspace_manager_rejects_duckdb_cursor(self) -> None:
         """duckdb_cursor() on a workspace manager raises with a clear message."""
-        manager = ConnectionManager(ConnectionConfig.for_workspace(tmp_path))
+        manager = ConnectionManager(ConnectionConfig.for_workspace())
         manager.initialize()
         try:
-            with pytest.raises(RuntimeError, match="SQLite-only"):
+            with pytest.raises(RuntimeError, match="workspace-only"):
                 with manager.duckdb_cursor():
                     pass
         finally:
             manager.close()
 
-    def test_active_session_table_created(self, tmp_path: Path) -> None:
+    def test_active_session_table_created(self) -> None:
         """Workspace manager creates the active_session pointer table."""
         from sqlalchemy import inspect
 
-        manager = ConnectionManager(ConnectionConfig.for_workspace(tmp_path))
+        manager = ConnectionManager(ConnectionConfig.for_workspace())
         manager.initialize()
         try:
             inspector = inspect(manager.engine)
             assert "active_session" in inspector.get_table_names()
         finally:
             manager.close()
+
+
+class TestMissingDatabaseUrl:
+    """for_workspace / for_directory fail loud when DATABASE_URL is unset."""
+
+    def test_workspace_fails_without_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        with pytest.raises(RuntimeError, match="DATABASE_URL is not set"):
+            ConnectionConfig.for_workspace()
+
+    def test_directory_fails_without_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        with pytest.raises(RuntimeError, match="DATABASE_URL is not set"):
+            ConnectionConfig.for_directory(tmp_path)
+
+
+class TestSessionId:
+    """ConnectionManager carries an optional session_id for per-session row scoping."""
+
+    def test_session_id_defaults_to_none(self) -> None:
+        manager = ConnectionManager(ConnectionConfig.for_workspace())
+        assert manager.session_id is None
+
+    def test_session_id_is_settable(self) -> None:
+        manager = ConnectionManager(ConnectionConfig.for_workspace(), session_id="sess-abc")
+        assert manager.session_id == "sess-abc"

--- a/tests/unit/core/test_pg_fixture.py
+++ b/tests/unit/core/test_pg_fixture.py
@@ -24,4 +24,4 @@ def test_pg_url_resolves_to_live_postgres(pg_url: str) -> None:
 
 def test_pg_url_clean_runs_without_error(pg_url_clean: str) -> None:
     """pg_url_clean truncates an empty schema as a no-op without error."""
-    assert pg_url_clean == pg_url_clean  # idempotent — just exercises the fixture
+    assert pg_url_clean.startswith("postgresql+psycopg://")

--- a/tests/unit/core/test_pg_fixture.py
+++ b/tests/unit/core/test_pg_fixture.py
@@ -1,0 +1,27 @@
+"""Smoke test for the session-scoped Postgres fixture (DAT-321 phase 2).
+
+The fixture must boot a Postgres 17 container, expose a working psycopg URL,
+and let TRUNCATE-based per-test cleanup run without error. Removed by phase 5
+once the lane smoke covers the same ground.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import create_engine, text
+
+
+def test_pg_url_resolves_to_live_postgres(pg_url: str) -> None:
+    """pg_url is a working psycopg URL against a live Postgres 17 container."""
+    assert pg_url.startswith("postgresql+psycopg://")
+    engine = create_engine(pg_url, future=True)
+    try:
+        with engine.connect() as conn:
+            version = conn.execute(text("SHOW server_version_num")).scalar_one()
+        assert int(version) >= 170000, f"Expected Postgres ≥ 17.0, got {version}"
+    finally:
+        engine.dispose()
+
+
+def test_pg_url_clean_runs_without_error(pg_url_clean: str) -> None:
+    """pg_url_clean truncates an empty schema as a no-op without error."""
+    assert pg_url_clean == pg_url_clean  # idempotent — just exercises the fixture

--- a/tests/unit/documentation/test_ledger.py
+++ b/tests/unit/documentation/test_ledger.py
@@ -7,6 +7,7 @@ from dataraum.documentation.ledger import (
     log_fix,
 )
 from dataraum.storage.models import Source
+from tests.conftest import baseline_session_id
 
 
 def _create_source(session: Session, source_id: str = "src-1") -> str:
@@ -32,6 +33,7 @@ class TestLogFix:
             column_name="amount",
             user_input="The amount is always in EUR",
             interpretation="Column transactions.amount uses EUR as fixed currency unit.",
+            session_id=baseline_session_id(),
         )
 
         assert entry.fix_id is not None
@@ -53,6 +55,7 @@ class TestLogFix:
             column_name="amount",
             user_input="Amount is in USD",
             interpretation="USD currency.",
+            session_id=baseline_session_id(),
         )
         old_id = old.fix_id
 
@@ -64,6 +67,7 @@ class TestLogFix:
             column_name="amount",
             user_input="Actually it's EUR",
             interpretation="EUR currency.",
+            session_id=baseline_session_id(),
         )
 
         session.flush()
@@ -86,6 +90,7 @@ class TestLogFix:
             column_name="amount",
             user_input="EUR",
             interpretation="EUR",
+            session_id=baseline_session_id(),
         )
 
         fix_b = log_fix(
@@ -96,6 +101,7 @@ class TestLogFix:
             column_name="price",
             user_input="USD",
             interpretation="USD",
+            session_id=baseline_session_id(),
         )
 
         session.refresh(fix_a)
@@ -113,6 +119,7 @@ class TestLogFix:
             column_name=None,
             user_input="One row per transaction",
             interpretation="Table grain is one row per transaction.",
+            session_id=baseline_session_id(),
         )
 
         assert entry.column_name is None
@@ -131,6 +138,7 @@ class TestGetActiveFixes:
             column_name="c",
             user_input="old",
             interpretation="old",
+            session_id=baseline_session_id(),
         )
         log_fix(
             session=session,
@@ -140,6 +148,7 @@ class TestGetActiveFixes:
             column_name="c",
             user_input="new",
             interpretation="new",
+            session_id=baseline_session_id(),
         )
 
         active = get_active_fixes(session, source_id)

--- a/tests/unit/graphs/test_context_builder.py
+++ b/tests/unit/graphs/test_context_builder.py
@@ -22,8 +22,19 @@ def _id() -> str:
 
 @pytest.fixture
 def session():
-    """In-memory SQLite session with all tables created."""
-    engine = create_engine("sqlite:///:memory:", echo=False)
+    """In-memory SQLite session with all tables created.
+
+    ``StaticPool`` + explicit dispose keeps Python 3.12+ ``ResourceWarning``
+    quiet by closing the sqlite3 connection deterministically.
+    """
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
 
     @event.listens_for(engine, "connect")
     def set_sqlite_pragma(dbapi_conn, connection_record):
@@ -33,8 +44,11 @@ def session():
 
     init_database(engine)
     factory = sessionmaker(bind=engine)
-    with factory() as s:
-        yield s
+    try:
+        with factory() as s:
+            yield s
+    finally:
+        engine.dispose()
 
 
 def _insert_source_table_column(session: Session) -> tuple[str, str, str]:

--- a/tests/unit/mcp/conftest.py
+++ b/tests/unit/mcp/conftest.py
@@ -11,3 +11,15 @@ def _set_dummy_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     this with monkeypatch.delenv().
     """
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+
+@pytest.fixture(autouse=True)
+def _set_database_url(monkeypatch: pytest.MonkeyPatch, pg_url_clean: str) -> None:
+    """Wire DATABASE_URL to the per-test Postgres URL for every MCP unit test.
+
+    Post-DAT-321, ``ConnectionConfig.for_workspace()`` and ``for_directory()``
+    both read ``DATABASE_URL`` from the environment. The session-scoped
+    Postgres container is reused across tests; ``pg_url_clean`` truncates
+    every Base-registered table before each test for isolation.
+    """
+    monkeypatch.setenv("DATABASE_URL", pg_url_clean)

--- a/tests/unit/mcp/test_end_session.py
+++ b/tests/unit/mcp/test_end_session.py
@@ -146,7 +146,7 @@ class TestEndSessionFullFlow:
     async def test_end_session_archives_and_allows_new(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Full flow: begin → end → session dir archived → workspace.db preserved."""
+        """Full flow: begin → end → session dir archived → workspace ActiveSession cleared."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
 
         from dataraum.mcp.server import create_server
@@ -157,33 +157,36 @@ class TestEndSessionFullFlow:
         csv = tmp_path / "data.csv"
         csv.write_text("a,b\n1,2\n")
 
-        # Setup: add source (writes to workspace.db) and begin session
-        # (creates sessions/{fp}/metadata.db,data.duckdb + sets ActiveSession pointer)
+        # Setup: add source (writes to workspace Postgres) and begin session
+        # (creates sessions/{fp}/data.duckdb + sets ActiveSession pointer)
         await self._call(server, "add_source", {"name": "src", "path": str(csv)})
         r1 = await self._call(server, "begin_session", {"source": "src", "intent": "first"})
         assert "error" not in r1
 
-        # Workspace registry exists; sessions/{fp}/ exists; archive does not
-        assert (tmp_path / "workspace.db").exists()
+        # sessions/{fp}/ exists with the per-session DuckDB; archive does not.
+        # No SQLite .db files should ever appear at the root post-DAT-321.
+        assert not (tmp_path / "workspace.db").exists()
         sessions_dir = tmp_path / "sessions"
         assert sessions_dir.exists()
         session_dirs_before = list(sessions_dir.iterdir())
         assert len(session_dirs_before) == 1  # one fingerprint
-        assert (session_dirs_before[0] / "metadata.db").exists()
+        assert (session_dirs_before[0] / "data.duckdb").exists()
+        assert not (session_dirs_before[0] / "metadata.db").exists()
 
         # End the session
         r2 = await self._call(server, "end_session", {"outcome": "delivered", "summary": "done"})
         assert r2["status"] == "ended"
         assert r2["outcome"] == "delivered"
 
-        # Session dir gone, archive populated, workspace.db preserved
+        # Session dir moved, archive populated with the DuckDB file.
         assert not session_dirs_before[0].exists()
         archive_base = tmp_path / "archive"
         assert archive_base.exists()
         archived = list(archive_base.iterdir())
         assert len(archived) == 1
-        assert (archived[0] / "metadata.db").exists()
-        assert (tmp_path / "workspace.db").exists()  # registry preserved
+        assert (archived[0] / "data.duckdb").exists()
+        assert not (archived[0] / "metadata.db").exists()
+        assert not (tmp_path / "workspace.db").exists()  # never a file
 
     @pytest.mark.asyncio
     async def test_end_session_resets_config_root_override(

--- a/tests/unit/mcp/test_progress.py
+++ b/tests/unit/mcp/test_progress.py
@@ -10,6 +10,7 @@ import pytest
 
 from dataraum.mcp.server import _make_task_event_callback, _run_pipeline
 from dataraum.pipeline.events import EventType, PipelineEvent
+from tests.conftest import baseline_session_id
 
 
 class TestMakeTaskEventCallback:
@@ -139,7 +140,7 @@ class TestRunPipeline:
         mock_result.error = "Setup failed"
 
         with patch("dataraum.pipeline.runner.run", return_value=mock_result):
-            result = _run_pipeline(output_dir=tmp_path)
+            result = _run_pipeline(output_dir=tmp_path, session_id=baseline_session_id())
 
         assert result["pipeline_status"] == "failed"
         assert result["error"] == "Setup failed"
@@ -170,7 +171,7 @@ class TestRunPipeline:
         mock_result.error = None
 
         with patch("dataraum.pipeline.runner.run", return_value=mock_result):
-            result = _run_pipeline(output_dir=tmp_path)
+            result = _run_pipeline(output_dir=tmp_path, session_id=baseline_session_id())
 
         assert result["pipeline_status"] == "failed"
         assert result["phases_completed"] == ["import"]
@@ -197,7 +198,7 @@ class TestRunPipeline:
         mock_result.value = run_result
 
         with patch("dataraum.pipeline.runner.run", return_value=mock_result):
-            result = _run_pipeline(output_dir=tmp_path)
+            result = _run_pipeline(output_dir=tmp_path, session_id=baseline_session_id())
 
         assert result["pipeline_status"] == "failed"
         assert result["phases_failed"] == [
@@ -227,7 +228,7 @@ class TestRunPipeline:
         mock_result.value = run_result
 
         with patch("dataraum.pipeline.runner.run", return_value=mock_result):
-            result = _run_pipeline(output_dir=tmp_path)
+            result = _run_pipeline(output_dir=tmp_path, session_id=baseline_session_id())
 
         assert result["pipeline_status"] == "complete"
         assert result["phases_completed"] == ["import", "typing"]
@@ -245,7 +246,7 @@ class TestRunPipeline:
         )
 
         with patch("dataraum.pipeline.runner.run", return_value=mock_result) as mock_run:
-            _run_pipeline(output_dir=tmp_path)
+            _run_pipeline(output_dir=tmp_path, session_id=baseline_session_id())
 
         run_config = mock_run.call_args[0][0]
         assert run_config.source_path is None
@@ -263,7 +264,7 @@ class TestRunPipeline:
         cb = MagicMock()
 
         with patch("dataraum.pipeline.runner.run", return_value=mock_result) as mock_run:
-            _run_pipeline(output_dir=tmp_path, event_callback=cb)
+            _run_pipeline(output_dir=tmp_path, session_id=baseline_session_id(), event_callback=cb)
 
         run_config = mock_run.call_args[0][0]
         assert run_config.event_callback is cb
@@ -279,7 +280,11 @@ class TestRunPipeline:
         )
 
         with patch("dataraum.pipeline.runner.run", return_value=mock_result) as mock_run:
-            _run_pipeline(output_dir=tmp_path, contract="executive_dashboard")
+            _run_pipeline(
+                output_dir=tmp_path,
+                session_id=baseline_session_id(),
+                contract="executive_dashboard",
+            )
 
         run_config = mock_run.call_args[0][0]
         assert run_config.contract == "executive_dashboard"

--- a/tests/unit/mcp/test_resume_session.py
+++ b/tests/unit/mcp/test_resume_session.py
@@ -3,10 +3,26 @@
 from __future__ import annotations
 
 import json
-import sqlite3
+import os
 from pathlib import Path
 
 import pytest
+from sqlalchemy import create_engine, text
+
+
+def _workspace_query(sql: str, params: tuple | dict | None = None) -> list[tuple]:
+    """Run a raw SQL query against the workspace Postgres and return rows.
+
+    Convenience for tests that previously poked sqlite3 at workspace.db /
+    per-session metadata.db. Post-DAT-321 all SQLAlchemy state lives in
+    workspace Postgres (DATABASE_URL).
+    """
+    engine = create_engine(os.environ["DATABASE_URL"], future=True)
+    try:
+        with engine.connect() as conn:
+            return list(conn.execute(text(sql), params or {}).fetchall())
+    finally:
+        engine.dispose()
 
 
 async def _call(server, name: str, arguments: dict | None = None):
@@ -37,7 +53,7 @@ def server_with_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 
 class TestArchivedSessionWritten:
-    """end_session writes a row to archived_sessions in workspace.db."""
+    """end_session writes a row to archived_sessions in the workspace Postgres."""
 
     @pytest.mark.asyncio
     async def test_end_session_writes_archive_index(self, server_with_key, tmp_path: Path) -> None:
@@ -51,11 +67,10 @@ class TestArchivedSessionWritten:
         assert "error" not in r1
         await _call(server_with_key, "end_session", {"outcome": "delivered", "summary": "done"})
 
-        with sqlite3.connect(str(tmp_path / "workspace.db")) as conn:
-            rows = conn.execute(
-                "SELECT session_id, fingerprint, intent, contract, outcome, "
-                "summary, source_name FROM archived_sessions"
-            ).fetchall()
+        rows = _workspace_query(
+            "SELECT session_id, fingerprint, intent, contract, outcome, "
+            "summary, source_name FROM archived_sessions"
+        )
 
         assert len(rows) == 1
         session_id, fingerprint, intent, contract, outcome, summary, source_name = rows[0]
@@ -189,23 +204,21 @@ class TestResumeSessionRestore:
         assert "_session_id" not in result
         assert "_fingerprint" not in result
 
-        # Filesystem invariants
+        # Filesystem invariants: per-session DuckDB restored, no metadata.db file
         assert not (tmp_path / "archive" / archive_id).exists()
         assert (tmp_path / "sessions" / original_fp).exists()
-        assert (tmp_path / "sessions" / original_fp / "metadata.db").exists()
+        assert (tmp_path / "sessions" / original_fp / "data.duckdb").exists()
+        assert not (tmp_path / "sessions" / original_fp / "metadata.db").exists()
 
-        # Workspace state: ActiveSession set, ArchivedSession row consumed
-        with sqlite3.connect(str(tmp_path / "workspace.db")) as conn:
-            assert (
-                conn.execute(
-                    "SELECT COUNT(*) FROM archived_sessions WHERE session_id = ?",
-                    (archive_id,),
-                ).fetchone()[0]
-                == 0
-            )
-            active = conn.execute("SELECT fingerprint FROM active_session").fetchone()
-            assert active is not None
-            assert active[0] == original_fp
+        # Workspace Postgres state: ActiveSession set, ArchivedSession row consumed
+        archived_rows = _workspace_query(
+            "SELECT COUNT(*) FROM archived_sessions WHERE session_id = :sid",
+            {"sid": archive_id},
+        )
+        assert archived_rows[0][0] == 0
+        active_rows = _workspace_query("SELECT fingerprint FROM active_session")
+        assert len(active_rows) == 1
+        assert active_rows[0][0] == original_fp
 
     @pytest.mark.asyncio
     async def test_restore_preserves_contract_without_re_specification(
@@ -241,16 +254,13 @@ class TestResumeSessionRestore:
         result = await _call(server_with_key, "resume_session", {"session_id": archive_id})
         assert "error" not in result
         # The active InvestigationSession's intent should be prefixed.
-        # We verify via re-listing — the new session is active so listing is empty,
-        # but begin_session response includes the intent for the resumed session
-        # only when called via _orient_to_active_session. Instead: assert by
-        # opening the session DB directly.
+        # The per-session session_dir still exists for the restored DuckDB;
+        # InvestigationSession rows live in workspace Postgres.
         session_dirs = list((tmp_path / "sessions").iterdir())
         assert len(session_dirs) == 1
-        with sqlite3.connect(str(session_dirs[0] / "metadata.db")) as conn:
-            rows = conn.execute(
-                "SELECT intent, status FROM investigation_sessions ORDER BY started_at"
-            ).fetchall()
+        rows = _workspace_query(
+            "SELECT intent, status FROM investigation_sessions ORDER BY started_at"
+        )
         # First row: original (status set by end_session), second row: resumed (active)
         assert len(rows) == 2
         assert rows[0] == ("look at Q1", "abandoned")
@@ -273,11 +283,11 @@ class TestResumeSessionRestore:
         )
 
         session_dirs = list((tmp_path / "sessions").iterdir())
-        with sqlite3.connect(str(session_dirs[0] / "metadata.db")) as conn:
-            row = conn.execute(
-                "SELECT intent FROM investigation_sessions WHERE status = 'active' LIMIT 1"
-            ).fetchone()
-        assert row[0] == "Q2 follow-up"
+        assert len(session_dirs) == 1
+        rows = _workspace_query(
+            "SELECT intent FROM investigation_sessions WHERE status = 'active' LIMIT 1"
+        )
+        assert rows[0][0] == "Q2 follow-up"
 
 
 class TestResumeSessionGuards:

--- a/tests/unit/mcp/test_run_sql.py
+++ b/tests/unit/mcp/test_run_sql.py
@@ -15,6 +15,7 @@ from dataraum.mcp.formatters import format_run_sql_result
 from dataraum.mcp.sql_executor import _build_column_quality, _snippet_key_for_step, run_sql
 from dataraum.query.execution import SQLStep, StepExecutionResult
 from dataraum.storage import init_database
+from tests.conftest import baseline_session_id
 
 
 def _id() -> str:
@@ -413,7 +414,7 @@ def _make_snippet(
     """Helper: insert a snippet record and return its ID."""
     from dataraum.query.snippet_library import SnippetLibrary
 
-    library = SnippetLibrary(session)
+    library = SnippetLibrary(session, session_id=baseline_session_id())
     record = library.save_snippet(
         snippet_type="query",
         sql=sql_text,
@@ -449,6 +450,7 @@ class TestSnippetReuseDetected:
             source_id=source_id,
             table_ids=[table_id],
             sql=sql_text,
+            session_id=baseline_session_id(),
         )
         assert "error" not in result
         step_info = result["steps_executed"][0]
@@ -468,6 +470,7 @@ class TestSnippetReuseDetected:
             source_id=source_id,
             table_ids=[table_id],
             steps=[{"step_id": "my_step", "sql": "SELECT 42 AS x"}],
+            session_id=baseline_session_id(),
         )
         assert "error" not in result
         step_info = result["steps_executed"][0]
@@ -489,6 +492,7 @@ class TestSnippetSavedAfterSuccess:
             source_id=source_id,
             table_ids=[table_id],
             sql=sql_text,
+            session_id=baseline_session_id(),
         )
         assert "error" not in result
         assert result["snippet_summary"]["saved"] == 1
@@ -496,7 +500,7 @@ class TestSnippetSavedAfterSuccess:
 
         # Verify snippet was saved with content-hash key
         expected_key = f"query_{_hashlib.sha256(sql_text.encode()).hexdigest()[:12]}"
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         match = library.find_by_key(
             snippet_type="query",
             schema_mapping_id=source_id,
@@ -521,11 +525,12 @@ class TestSnippetNotSavedOnFailure:
             source_id=source_id,
             table_ids=[table_id],
             sql=bad_sql,
+            session_id=baseline_session_id(),
         )
         assert "error" in result
 
         key = f"query_{_hashlib.sha256(bad_sql.encode()).hexdigest()[:12]}"
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         match = library.find_by_key(
             snippet_type="query",
             schema_mapping_id=source_id,
@@ -552,6 +557,7 @@ class TestSnippetSummaryAccurate:
             source_id=source_id,
             table_ids=[table_id],
             steps=steps,
+            session_id=baseline_session_id(),
         )
         assert "error" not in result
         summary = result["snippet_summary"]
@@ -571,6 +577,7 @@ class TestSnippetIntegrationWithRawSql:
             source_id=source_id,
             table_ids=[table_id],
             sql="SELECT 99 AS val",
+            session_id=baseline_session_id(),
         )
         assert "error" not in result
         assert result["snippet_summary"]["saved"] == 1
@@ -589,6 +596,7 @@ class TestSnippetIntegrationWithRawSql:
             source_id=source_id,
             table_ids=[table_id],
             sql="SELECT 1 AS a",
+            session_id=baseline_session_id(),
         )
         r2 = run_sql(
             cursor,
@@ -596,6 +604,7 @@ class TestSnippetIntegrationWithRawSql:
             source_id=source_id,
             table_ids=[table_id],
             sql="SELECT 2 AS b",
+            session_id=baseline_session_id(),
         )
         assert r1["snippet_summary"]["saved"] == 1
         assert r2["snippet_summary"]["saved"] == 1
@@ -646,11 +655,12 @@ class TestCteDecomposition:
             source_id=source_id,
             table_ids=[table_id],
             sql=sql,
+            session_id=baseline_session_id(),
         )
         assert "error" not in result
         assert result["snippet_summary"]["saved"] == 2
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         rev = library.find_by_key(
             snippet_type="query", schema_mapping_id=source_id, standard_field="revenue"
         )

--- a/tests/unit/mcp/test_run_sql.py
+++ b/tests/unit/mcp/test_run_sql.py
@@ -33,8 +33,20 @@ def cursor() -> duckdb.DuckDBPyConnection:
 
 @pytest.fixture
 def session() -> Generator[Session]:
-    """In-memory SQLite session with all tables created."""
-    engine = create_engine("sqlite:///:memory:", echo=False)
+    """In-memory SQLite session with all tables created.
+
+    Uses ``StaticPool`` + explicit ``engine.dispose()`` so the underlying
+    sqlite3 connection is closed deterministically — Python 3.12+ raises
+    ``ResourceWarning`` if GC catches an open connection.
+    """
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
 
     @event.listens_for(engine, "connect")
     def set_sqlite_pragma(dbapi_conn, connection_record):
@@ -44,8 +56,11 @@ def session() -> Generator[Session]:
 
     init_database(engine)
     factory = sessionmaker(bind=engine)
-    with factory() as s:
-        yield s
+    try:
+        with factory() as s:
+            yield s
+    finally:
+        engine.dispose()
 
 
 def _insert_source_and_table(

--- a/tests/unit/mcp/test_source_tools.py
+++ b/tests/unit/mcp/test_source_tools.py
@@ -94,7 +94,13 @@ class TestListSourcesTool:
     def test_empty_workspace(self, session: Session) -> None:
         from dataraum.mcp.server import _list_sources
 
+        # The conftest `session` fixture seeds a baseline Source as the
+        # InvestigationSession FK target. Filter it out for "empty workspace".
         result = _list_sources(session)
+        result = {
+            "sources": [s for s in result["sources"] if s["name"] != "test_baseline"],
+            "count": result["count"] - 1 if result["count"] else 0,
+        }
         assert result == {"sources": [], "count": 0}
 
     def test_lists_file_and_recipe_sources(self, session: Session, tmp_path: Path) -> None:
@@ -109,6 +115,8 @@ class TestListSourcesTool:
         _add_source(session, {"name": "erp", "path": str(recipe)})
 
         result = _list_sources(session)
+        result["sources"] = [s for s in result["sources"] if s["name"] != "test_baseline"]
+        result["count"] = len(result["sources"])
 
         assert result["count"] == 2
         by_name = {s["name"]: s for s in result["sources"]}

--- a/tests/unit/mcp/test_teach.py
+++ b/tests/unit/mcp/test_teach.py
@@ -20,6 +20,7 @@ from dataraum.analysis.semantic.db_models import SemanticAnnotation
 from dataraum.mcp.teach import handle_teach
 from dataraum.pipeline.fixes.models import DataFix
 from dataraum.storage import Column, Source, Table
+from tests.conftest import baseline_session_id
 
 
 def _id() -> str:
@@ -126,6 +127,7 @@ class TestTeachConcept:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -152,6 +154,7 @@ class TestTeachConcept:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
         # Teach again with updated indicators
         handle_teach(
@@ -161,6 +164,7 @@ class TestTeachConcept:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         ontology = yaml.safe_load(
@@ -186,6 +190,7 @@ class TestTeachConcept:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         ontology = yaml.safe_load(ontology_path.read_text())
@@ -213,6 +218,7 @@ class TestTeachValidation:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -242,6 +248,7 @@ class TestTeachValidation:
                 session=session,
                 vertical="_adhoc",
                 config_root=config_root,
+                session_id=baseline_session_id(),
             )
 
         spec = yaml.safe_load(
@@ -269,6 +276,7 @@ class TestTeachCycle:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -294,6 +302,7 @@ class TestTeachCycle:
                 session=session,
                 vertical="_adhoc",
                 config_root=config_root,
+                session_id=baseline_session_id(),
             )
 
         cycles = yaml.safe_load((config_root / "verticals" / "_adhoc" / "cycles.yaml").read_text())
@@ -318,6 +327,7 @@ class TestTeachTypePattern:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -344,6 +354,7 @@ class TestTeachTypePattern:
                 session=session,
                 vertical="_adhoc",
                 config_root=config_root,
+                session_id=baseline_session_id(),
             )
 
         typing_config = yaml.safe_load((config_root / "phases" / "typing.yaml").read_text())
@@ -363,6 +374,7 @@ class TestTeachNullValue:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -384,6 +396,7 @@ class TestTeachNullValue:
                 session=session,
                 vertical="_adhoc",
                 config_root=config_root,
+                session_id=baseline_session_id(),
             )
 
         null_config = yaml.safe_load((config_root / "null_values.yaml").read_text())
@@ -406,6 +419,7 @@ class TestTeachNullValue:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         null_config = yaml.safe_load((config_root / "null_values.yaml").read_text())
@@ -442,6 +456,7 @@ class TestTeachConceptProperty:
             session=session,
             vertical="_adhoc",
             target="orders.amount",
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -473,6 +488,7 @@ class TestTeachConceptProperty:
             session=session,
             vertical="_adhoc",
             target="orders.amount",
+            session_id=baseline_session_id(),
         )
 
         fixes = session.query(DataFix).filter_by(source_id=source_id).all()
@@ -491,6 +507,7 @@ class TestTeachConceptProperty:
             session=session,
             vertical="_adhoc",
             target="orders.amount",
+            session_id=baseline_session_id(),
         )
 
         assert "error" in result
@@ -533,6 +550,7 @@ class TestTeachRelationship:
             source_id=source_id,
             session=session,
             vertical="_adhoc",
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -560,6 +578,7 @@ class TestTeachRelationship:
             source_id=source_id,
             session=session,
             vertical="_adhoc",
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -585,10 +604,20 @@ class TestTeachRelationship:
             "cardinality": "one-to-many",
         }
         handle_teach(
-            "relationship", params, source_id=source_id, session=session, vertical="_adhoc"
+            "relationship",
+            params,
+            source_id=source_id,
+            session=session,
+            vertical="_adhoc",
+            session_id=baseline_session_id(),
         )
         result = handle_teach(
-            "relationship", params, source_id=source_id, session=session, vertical="_adhoc"
+            "relationship",
+            params,
+            source_id=source_id,
+            session=session,
+            vertical="_adhoc",
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -608,6 +637,7 @@ class TestTeachRelationship:
             source_id=source_id,
             session=session,
             vertical="_adhoc",
+            session_id=baseline_session_id(),
         )
 
         assert "error" in result
@@ -628,6 +658,7 @@ class TestTeachExplanation:
             session=session,
             vertical="_adhoc",
             target="orders.amount",
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -650,6 +681,7 @@ class TestTeachExplanation:
             session=session,
             vertical="_adhoc",
             target="orders",
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -666,7 +698,12 @@ class TestTeachExplanation:
 class TestTeachErrors:
     def test_rejects_unknown_type(self, session: Session) -> None:
         result = handle_teach(
-            "nonexistent", {}, source_id="fake", session=session, vertical="_adhoc"
+            "nonexistent",
+            {},
+            source_id="fake",
+            session=session,
+            vertical="_adhoc",
+            session_id=baseline_session_id(),
         )
         assert "error" in result
         assert "Unknown teach type" in result["error"]
@@ -678,6 +715,7 @@ class TestTeachErrors:
             source_id="fake",
             session=session,
             vertical="_adhoc",
+            session_id=baseline_session_id(),
         )
         assert "error" in result
         assert "Invalid params" in result["error"]
@@ -691,6 +729,7 @@ class TestTeachErrors:
             session=session,
             vertical="_adhoc",
             target=None,
+            session_id=baseline_session_id(),
         )
         assert "error" in result
         assert "requires a target" in result["error"]
@@ -704,6 +743,7 @@ class TestTeachErrors:
             session=session,
             vertical="_adhoc",
             config_root=None,
+            session_id=baseline_session_id(),
         )
         assert "error" in result
 
@@ -725,6 +765,7 @@ class TestConfigTeachDataFix:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         fixes = session.query(DataFix).filter_by(source_id=source_id).all()

--- a/tests/unit/mcp/test_teach_metric.py
+++ b/tests/unit/mcp/test_teach_metric.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from dataraum.mcp.teach import handle_teach
 from dataraum.pipeline.fixes.models import DataFix
 from dataraum.storage import Column, Source, Table
+from tests.conftest import baseline_session_id
 
 
 def _id() -> str:
@@ -99,6 +100,7 @@ class TestTeachMetric:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -144,6 +146,7 @@ class TestTeachMetric:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         params["description"] = "v2"
@@ -154,6 +157,7 @@ class TestTeachMetric:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         metric_path = (
@@ -186,6 +190,7 @@ class TestTeachMetric:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         fixes = session.query(DataFix).filter_by(source_id=source_id).all()
@@ -238,6 +243,7 @@ class TestTeachMetric:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -273,6 +279,7 @@ class TestTeachMetric:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         assert result["status"] == "applied"
@@ -307,6 +314,7 @@ class TestTeachMetric:
             session=session,
             vertical="_adhoc",
             config_root=config_root,
+            session_id=baseline_session_id(),
         )
 
         metric_path = (

--- a/tests/unit/pipeline/test_graph_execution_dispatch.py
+++ b/tests/unit/pipeline/test_graph_execution_dispatch.py
@@ -28,6 +28,7 @@ import pytest
 
 from dataraum.core.models.base import Result
 from dataraum.pipeline.phases import graph_execution_phase as gep
+from tests.conftest import baseline_session_id
 
 
 @dataclass
@@ -64,7 +65,9 @@ class TestExecuteMetricsSerial:
             ("g2", _graph("g2"), None, None),
         ]
 
-        out = gep._execute_metrics_serial(prep, session, exec_ctx, agent)
+        out = gep._execute_metrics_serial(
+            prep, session, exec_ctx, agent, session_id=baseline_session_id()
+        )
 
         assert [graph_id for graph_id, _, _ in out] == ["g0", "g1", "g2"]
         assert [r.value for _, r, _ in out] == ["r0", "r1", "r2"]
@@ -86,6 +89,7 @@ class TestExecuteMetricsSerial:
             MagicMock(),
             MagicMock(),
             agent,
+            session_id=baseline_session_id(),
         )
         assert out[0][1].success is True
         assert out[1][1].success is False
@@ -113,6 +117,8 @@ class _ConcurrencyTrackingAgent:
         graph: _StubGraph,
         context: Any,
         inspiration_sql: str | None = None,
+        *,
+        session_id: str = "",
     ) -> Result[str]:
         with self._lock:
             self.in_flight += 1
@@ -155,7 +161,9 @@ class TestExecuteMetricsParallel:
         manager = _stub_manager()
         prep = [(f"g{i}", _graph(f"g{i}"), None, None) for i in range(7)]
 
-        out = gep._execute_metrics_parallel(prep, manager, agent, "src-1", ["t1"])
+        out = gep._execute_metrics_parallel(
+            prep, manager, agent, "src-1", ["t1"], session_id=baseline_session_id()
+        )
 
         assert sorted(gid for gid, _, _ in out) == [f"g{i}" for i in range(7)]
         assert all(r.success for _, r, _ in out)
@@ -173,7 +181,9 @@ class TestExecuteMetricsParallel:
         manager = _stub_manager()
         prep = [(f"g{i}", _graph(f"g{i}"), None, None) for i in range(8)]
 
-        gep._execute_metrics_parallel(prep, manager, agent, "src", ["t"])
+        gep._execute_metrics_parallel(
+            prep, manager, agent, "src", ["t"], session_id=baseline_session_id()
+        )
 
         # With cap=2 and 8 metrics, peak must not exceed 2
         assert agent.peak_in_flight <= 2, f"Peak in-flight {agent.peak_in_flight} exceeded cap of 2"
@@ -193,7 +203,9 @@ class TestExecuteMetricsParallel:
             ("g2", _graph("g2"), None, "insp-2"),
         ]
 
-        out = gep._execute_metrics_parallel(prep, manager, agent, "src", ["t"])
+        out = gep._execute_metrics_parallel(
+            prep, manager, agent, "src", ["t"], session_id=baseline_session_id()
+        )
 
         by_id = {gid: (r, iid) for gid, r, iid in out}
         assert by_id["g0"][1] is None
@@ -205,7 +217,9 @@ class TestExecuteMetricsParallel:
             "dataraum.graphs.agent.ExecutionContext.with_rich_context",
             classmethod(lambda cls, **kw: MagicMock()),
         )
-        out = gep._execute_metrics_parallel([], _stub_manager(), MagicMock(), "src", [])
+        out = gep._execute_metrics_parallel(
+            [], _stub_manager(), MagicMock(), "src", [], session_id=baseline_session_id()
+        )
         assert out == []
 
     def test_exception_in_one_worker_does_not_abort_siblings(
@@ -230,6 +244,8 @@ class TestExecuteMetricsParallel:
                 graph: _StubGraph,
                 context: Any,
                 inspiration_sql: str | None = None,
+                *,
+                session_id: str = "",
             ) -> Result[str]:
                 if graph.graph_id == "bad":
                     raise RuntimeError("simulated infra failure")
@@ -242,7 +258,9 @@ class TestExecuteMetricsParallel:
             ("g2", _graph("g2"), None, None),
         ]
 
-        out = gep._execute_metrics_parallel(prep, manager, _FlakyAgent(), "src", ["t"])
+        out = gep._execute_metrics_parallel(
+            prep, manager, _FlakyAgent(), "src", ["t"], session_id=baseline_session_id()
+        )
 
         by_id = {gid: (r, iid) for gid, r, iid in out}
         # All three results are present
@@ -292,8 +310,12 @@ class TestExecuteIsolated:
         agent.execute.return_value = Result.ok("done")
 
         # Each call should open a fresh pair
-        gep._execute_isolated(_graph("g0"), None, manager, agent, "src", ["t"])
-        gep._execute_isolated(_graph("g1"), None, manager, agent, "src", ["t"])
+        gep._execute_isolated(
+            _graph("g0"), None, manager, agent, "src", ["t"], baseline_session_id()
+        )
+        gep._execute_isolated(
+            _graph("g1"), None, manager, agent, "src", ["t"], baseline_session_id()
+        )
 
         assert len(opened_sessions) == 2
         assert len(opened_cursors) == 2
@@ -331,5 +353,7 @@ def test_asyncio_run_does_not_deadlock_with_nested_calls(
     manager = _stub_manager()
     prep = [(f"g{i}", _graph(f"g{i}"), None, None) for i in range(3)]
 
-    out = gep._execute_metrics_parallel(prep, manager, agent, "src", ["t"])
+    out = gep._execute_metrics_parallel(
+        prep, manager, agent, "src", ["t"], session_id=baseline_session_id()
+    )
     assert len(out) == 3

--- a/tests/unit/pipeline/test_scheduler.py
+++ b/tests/unit/pipeline/test_scheduler.py
@@ -17,6 +17,7 @@ from dataraum.pipeline.db_models import PhaseLog, PipelineRun
 from dataraum.pipeline.events import EventType
 from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.scheduler import PipelineScheduler
+from tests.conftest import baseline_session_id
 
 # ---------------------------------------------------------------------------
 # Test helpers
@@ -80,6 +81,7 @@ def _make_run(session: Session, source_id: str = "src-1") -> str:
     run_id = str(uuid4())
     run = PipelineRun(
         run_id=run_id,
+        session_id=baseline_session_id(),
         source_id=source_id,
         status="running",
         started_at=datetime.now(UTC),
@@ -124,6 +126,7 @@ class TestEmptyPipeline:
             run_id=run_id,
             session=session,
             duckdb_conn=duckdb_conn,
+            session_id=baseline_session_id(),
         )
         events, result = _drive(scheduler.run())
 
@@ -148,6 +151,7 @@ class TestSinglePhase:
             run_id=run_id,
             session=session,
             duckdb_conn=duckdb_conn,
+            session_id=baseline_session_id(),
         )
         events, result = _drive(scheduler.run())
 
@@ -175,6 +179,7 @@ class TestSinglePhase:
             run_id=run_id,
             session=session,
             duckdb_conn=duckdb_conn,
+            session_id=baseline_session_id(),
         )
         events, result = _drive(scheduler.run())
 
@@ -202,6 +207,7 @@ class TestSinglePhase:
             run_id=run_id,
             session=session,
             duckdb_conn=duckdb_conn,
+            session_id=baseline_session_id(),
         )
         events, result = _drive(scheduler.run())
 
@@ -231,6 +237,7 @@ class TestDependencyOrdering:
             run_id=run_id,
             session=session,
             duckdb_conn=duckdb_conn,
+            session_id=baseline_session_id(),
         )
         events, result = _drive(scheduler.run())
 
@@ -253,6 +260,7 @@ class TestDependencyOrdering:
             run_id=run_id,
             session=session,
             duckdb_conn=duckdb_conn,
+            session_id=baseline_session_id(),
         )
         events, result = _drive(scheduler.run())
 
@@ -271,6 +279,7 @@ class TestDependencyOrdering:
             run_id=run_id,
             session=session,
             duckdb_conn=duckdb_conn,
+            session_id=baseline_session_id(),
         )
         events, result = _drive(scheduler.run())
 
@@ -294,6 +303,7 @@ class TestPhaseLog:
             run_id=run_id,
             session=session,
             duckdb_conn=duckdb_conn,
+            session_id=baseline_session_id(),
         )
         _drive(scheduler.run())
 
@@ -360,8 +370,8 @@ class TestPhaseLogWithFactory:
             duckdb_conn=duckdb_conn,
             session_factory=session_scope,
             manager=self._make_manager_stub(duckdb_conn),
+            session_id=baseline_session_id(),
         )
-
         events, result = _drive(scheduler.run())
 
         assert "A" in result.phases_skipped
@@ -387,6 +397,7 @@ class TestPipelineResult:
             run_id=run_id,
             session=session,
             duckdb_conn=duckdb_conn,
+            session_id=baseline_session_id(),
         )
         events, result = _drive(scheduler.run())
 
@@ -410,6 +421,7 @@ class TestDependencyValidation:
                 run_id=run_id,
                 session=session,
                 duckdb_conn=duckdb_conn,
+                session_id=baseline_session_id(),
             )
 
 
@@ -451,6 +463,7 @@ class TestDiamondDependency:
             run_id=run_id,
             session=session,
             duckdb_conn=duckdb_conn,
+            session_id=baseline_session_id(),
         )
         events, result = _drive(scheduler.run())
 
@@ -515,8 +528,8 @@ class TestParallelExecution:
             duckdb_conn=duckdb_conn,
             session_factory=session_scope,
             manager=self._make_manager_stub(duckdb_conn),
+            session_id=baseline_session_id(),
         )
-
         events, result = _drive(scheduler.run())
 
         assert result.success is True
@@ -542,6 +555,7 @@ class TestParallelExecution:
             session=session,
             duckdb_conn=duckdb_conn,
             # No session_factory -> sequential
+            session_id=baseline_session_id(),
         )
 
         events, result = _drive(scheduler.run())
@@ -584,8 +598,8 @@ class TestParallelExecution:
             duckdb_conn=duckdb_conn,
             session_factory=session_scope,
             manager=self._make_manager_stub(duckdb_conn),
+            session_id=baseline_session_id(),
         )
-
         events, result = _drive(scheduler.run())
 
         assert result.success is False
@@ -624,8 +638,8 @@ class TestParallelExecution:
             duckdb_conn=duckdb_conn,
             session_factory=session_scope,
             manager=self._make_manager_stub(duckdb_conn),
+            session_id=baseline_session_id(),
         )
-
         events, result = _drive(scheduler.run())
 
         # Both phases run successfully -- each was the only phase in its wave
@@ -672,6 +686,7 @@ class TestAnalysisCoverageValidation:
                 run_id=run_id,
                 session=session,
                 duckdb_conn=duckdb_conn,
+                session_id=baseline_session_id(),
             )
 
         mock_logger.warning.assert_called_once()
@@ -715,6 +730,7 @@ class TestAnalysisCoverageValidation:
                 run_id=run_id,
                 session=session,
                 duckdb_conn=duckdb_conn,
+                session_id=baseline_session_id(),
             )
 
         mock_logger.warning.assert_not_called()

--- a/tests/unit/query/test_snippet_library.py
+++ b/tests/unit/query/test_snippet_library.py
@@ -4,6 +4,7 @@ import pytest
 
 from dataraum.query.snippet_library import SnippetGraph, SnippetLibrary
 from dataraum.query.snippet_models import SQLSnippetRecord
+from tests.conftest import baseline_session_id
 
 
 class TestSnippetLibraryFindById:
@@ -11,7 +12,7 @@ class TestSnippetLibraryFindById:
 
     def test_find_existing_snippet(self, session):
         """Find a snippet by its primary key."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         record = library.save_snippet(
             snippet_type="extract",
@@ -30,7 +31,7 @@ class TestSnippetLibraryFindById:
 
     def test_find_nonexistent_returns_none(self, session):
         """Unknown snippet_id returns None."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         found = library.find_by_id("nonexistent-id")
         assert found is None
@@ -41,7 +42,7 @@ class TestSnippetLibraryFindByKey:
 
     def test_find_extract_snippet(self, session):
         """Find an extract snippet by exact key."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         # Save a snippet
         library.save_snippet(
@@ -73,7 +74,7 @@ class TestSnippetLibraryFindByKey:
 
     def test_find_no_match(self, session):
         """No snippet for this key."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         match = library.find_by_key(
             snippet_type="extract",
@@ -84,7 +85,7 @@ class TestSnippetLibraryFindByKey:
 
     def test_find_different_schema(self, session):
         """Same field but different schema doesn't match."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -109,7 +110,7 @@ class TestSnippetLibraryFindByKey:
 
     def test_find_constant_snippet(self, session):
         """Find a constant snippet including parameter value."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="constant",
@@ -143,7 +144,7 @@ class TestSnippetLibraryFindByKey:
 
     def test_null_fields_match_correctly(self, session):
         """Null fields in key must match null (not anything)."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         # Snippet with no statement
         library.save_snippet(
@@ -183,7 +184,7 @@ class TestSnippetLibrarySave:
 
     def test_save_new_snippet(self, session):
         """Save creates a new record."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         record = library.save_snippet(
             snippet_type="extract",
@@ -202,7 +203,7 @@ class TestSnippetLibrarySave:
 
     def test_save_keeps_first_writer(self, session):
         """Save with same key keeps original (first writer wins)."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         # First save
         record1 = library.save_snippet(
@@ -237,7 +238,7 @@ class TestSnippetLibrarySave:
 
     def test_save_formula_snippet(self, session):
         """Save a formula snippet with normalized expression."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         record = library.save_snippet(
             snippet_type="formula",
@@ -255,7 +256,7 @@ class TestSnippetLibrarySave:
 
     def test_save_with_column_mappings(self, session):
         """Column mappings are persisted."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         record = library.save_snippet(
             snippet_type="extract",
@@ -279,7 +280,7 @@ class TestSnippetLibraryFindByExpression:
         """Find a formula by normalized expression."""
         from dataraum.query.snippet_utils import normalize_expression
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         # Normalize the expression the same way find_by_expression will
         expr = "(accounts_receivable / revenue) * days_in_period"
@@ -307,7 +308,7 @@ class TestSnippetLibraryFindByExpression:
 
     def test_find_formula_no_match(self, session):
         """No formula for a different expression."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="formula",
@@ -333,7 +334,7 @@ class TestSnippetLibraryRecordUsage:
 
     def test_record_exact_reuse(self, session):
         """Record an exact reuse and update snippet stats."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         snippet = library.save_snippet(
             snippet_type="extract",
@@ -367,7 +368,7 @@ class TestSnippetLibraryRecordUsage:
 
     def test_record_newly_generated(self, session):
         """Record a newly generated step (no snippet)."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         usage = library.record_usage(
             execution_id="exec_002",
@@ -382,7 +383,7 @@ class TestSnippetLibraryRecordUsage:
 
     def test_record_provided_not_used(self, session):
         """Record when snippet was provided but LLM ignored it."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         snippet = library.save_snippet(
             snippet_type="extract",
@@ -414,7 +415,7 @@ class TestSnippetLibraryStats:
 
     def test_empty_stats(self, session):
         """Stats with no data."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         stats = library.get_stats()
 
         assert stats["total_snippets"] == 0
@@ -422,7 +423,7 @@ class TestSnippetLibraryStats:
 
     def test_basic_stats(self, session):
         """Stats with some snippets and usages."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         # Create snippets
         s1 = library.save_snippet(
@@ -481,7 +482,7 @@ class TestSnippetLibraryStats:
 
     def test_stats_filtered_by_schema(self, session):
         """Stats can be filtered by schema_mapping_id."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -513,7 +514,7 @@ class TestSnippetLibraryInvalidation:
 
     def test_invalidate_for_schema(self, session):
         """Invalidating a schema marks all its snippets as unvalidated."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -552,7 +553,7 @@ class TestSnippetLibraryFindAllForSchema:
 
     def test_find_all(self, session):
         """Find all snippets for a schema."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -586,7 +587,7 @@ class TestSnippetLibraryFindAllForSchema:
 
     def test_find_all_with_type_filter(self, session):
         """Filter by snippet type."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -617,7 +618,7 @@ class TestSnippetGraphs:
 
     def test_find_all_graphs(self, session):
         """All snippets grouped by source."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -661,7 +662,7 @@ class TestSnippetGraphs:
 
     def test_find_all_graphs_multiple_sources(self, session):
         """Separate graphs for different sources."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -689,12 +690,12 @@ class TestSnippetGraphs:
 
     def test_find_all_graphs_empty(self, session):
         """No snippets returns empty."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         assert library.find_all_graphs("nonexistent") == []
 
     def test_get_search_vocabulary(self, session):
         """Extract vocabulary from snippet index."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -739,7 +740,7 @@ class TestSnippetGraphs:
 
     def test_find_graphs_by_keys_standard_field(self, session):
         """Search by standard_field returns correct graphs."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -772,7 +773,7 @@ class TestSnippetGraphs:
 
     def test_find_graphs_by_keys_statement(self, session):
         """Search by statement returns correct graphs."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -804,7 +805,7 @@ class TestSnippetGraphs:
 
     def test_find_graphs_by_keys_graph_id(self, session):
         """Search by graph_id returns correct graph."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -843,7 +844,7 @@ class TestSnippetGraphs:
 
     def test_find_graphs_by_keys_multi_category(self, session):
         """Search by concept + statement returns union of matches."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -878,7 +879,7 @@ class TestSnippetGraphs:
 
     def test_find_graphs_by_keys_expands_full_graph(self, session):
         """One matching snippet expands to full graph."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -917,7 +918,7 @@ class TestSnippetGraphs:
 
     def test_find_graphs_by_keys_no_match(self, session):
         """No matching keys returns empty."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         library.save_snippet(
             snippet_type="extract",
@@ -937,7 +938,7 @@ class TestSnippetGraphs:
 
     def test_find_graphs_by_keys_limit(self, session):
         """Respects limit parameter."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         # Create 3 separate graphs
         for name in ["alpha", "beta", "gamma"]:

--- a/tests/unit/query/test_snippet_provenance.py
+++ b/tests/unit/query/test_snippet_provenance.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from dataraum.query.snippet_library import SnippetLibrary
 from dataraum.query.snippet_models import SQLSnippetRecord
+from tests.conftest import baseline_session_id
 
 SOURCE_ID = "test_source"
 
@@ -46,7 +47,7 @@ class TestSnippetProvenance:
 
     def test_save_snippet_with_provenance(self, session: Session) -> None:
         """Provenance dict roundtrips through save_snippet."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         provenance = {
             "field_resolution": "inferred",
             "was_repaired": False,
@@ -73,7 +74,7 @@ class TestSnippetProvenance:
 
     def test_save_snippet_without_provenance(self, session: Session) -> None:
         """Provenance is None when not provided."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         record = library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(amount) FROM t",
@@ -90,7 +91,7 @@ class TestSnippetProvenance:
         provenance = {"field_resolution": "direct", "was_repaired": False}
         _add_snippet(session, SOURCE_ID, provenance=provenance)
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         match = library.find_by_key(
             snippet_type="extract",
             schema_mapping_id=SOURCE_ID,
@@ -108,7 +109,7 @@ class TestSnippetProvenance:
         record.failure_count = 1
         session.flush()
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         new_provenance = {"field_resolution": "direct", "was_repaired": True}
         updated = library.save_snippet(
             snippet_type="extract",
@@ -150,7 +151,7 @@ class TestVocabularyHarmonization:
         session.add(record)
         session.flush()
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         vocab = library.get_search_vocabulary(schema_mapping_id=SOURCE_ID)
 
         assert "revenue" in vocab["standard_fields"]
@@ -185,7 +186,7 @@ class TestVocabularyHarmonization:
         session.add(record)
         session.flush()
 
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         vocab = library.get_search_vocabulary(schema_mapping_id=SOURCE_ID)
 
         # One-off step_id from query agent should not pollute vocabulary

--- a/tests/unit/query/test_snippet_search.py
+++ b/tests/unit/query/test_snippet_search.py
@@ -5,6 +5,7 @@ without LLM calls.
 """
 
 from dataraum.query.snippet_library import SnippetLibrary
+from tests.conftest import baseline_session_id
 
 
 def _create_dso_graph(library: SnippetLibrary, schema: str = "s1") -> None:
@@ -64,7 +65,7 @@ class TestSnippetSearchByConcept:
 
     def test_single_concept_returns_graph(self, session):
         """Searching by 'accounts_receivable' returns DSO graph."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         _create_dso_graph(library)
         session.flush()
 
@@ -79,7 +80,7 @@ class TestSnippetSearchByConcept:
 
     def test_shared_concept_returns_multiple_graphs(self, session):
         """Same standard_field in different key combos returns multiple graphs."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         # Two graphs with 'revenue' but different key combos (no upsert collision)
         library.save_snippet(
@@ -119,7 +120,7 @@ class TestSnippetSearchByGraphId:
 
     def test_direct_graph_id_lookup(self, session):
         """Searching by graph_id 'dso' returns the full DSO graph."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         _create_dso_graph(library)
         session.flush()
 
@@ -134,7 +135,7 @@ class TestSnippetSearchByGraphId:
 
     def test_multiple_graph_ids(self, session):
         """Searching multiple graph_ids returns all matching graphs."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         # Two independent graphs with non-overlapping keys
         library.save_snippet(
@@ -172,7 +173,7 @@ class TestSnippetSearchCombined:
 
     def test_concept_plus_graph_id_union(self, session):
         """Concept + graph_id returns union of matches."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
 
         # Two independent graphs
         library.save_snippet(
@@ -214,7 +215,7 @@ class TestSnippetSearchEdgeCases:
 
     def test_empty_search_returns_empty(self, session):
         """No keys provided returns empty list."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         _create_dso_graph(library)
         session.flush()
 
@@ -223,7 +224,7 @@ class TestSnippetSearchEdgeCases:
 
     def test_invalid_keys_return_empty(self, session):
         """Non-existent keys return empty list."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         _create_dso_graph(library)
         session.flush()
 
@@ -236,7 +237,7 @@ class TestSnippetSearchEdgeCases:
 
     def test_wrong_schema_returns_empty(self, session):
         """Correct keys but wrong schema returns empty."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         _create_dso_graph(library, schema="s1")
         session.flush()
 
@@ -248,7 +249,7 @@ class TestSnippetSearchEdgeCases:
 
     def test_nonexistent_graph_id_returns_empty(self, session):
         """Graph ID that doesn't exist in DB returns empty."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         _create_dso_graph(library)
         session.flush()
 
@@ -264,7 +265,7 @@ class TestSearchResultFormat:
 
     def test_graph_structure(self, session):
         """Each returned graph has source, graph_id, source_type, and snippets."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         _create_dso_graph(library)
         session.flush()
 
@@ -285,7 +286,7 @@ class TestSearchResultFormat:
 
     def test_snippet_fields_present(self, session):
         """Each snippet in a graph has required fields."""
-        library = SnippetLibrary(session)
+        library = SnippetLibrary(session, session_id=baseline_session_id())
         _create_dso_graph(library)
         session.flush()
 

--- a/tests/unit/sources/parquet/test_parquet_loader.py
+++ b/tests/unit/sources/parquet/test_parquet_loader.py
@@ -18,8 +18,20 @@ from dataraum.storage import init_database
 
 @pytest.fixture
 def test_session():
-    """Create an in-memory SQLite session for testing."""
-    engine = create_engine("sqlite:///:memory:", echo=False)
+    """Create an in-memory SQLite session for testing.
+
+    ``StaticPool`` keeps a single connection that ``dispose()`` closes
+    deterministically — silences Python 3.12+ ``ResourceWarning`` on
+    GC'd sqlite3 connections.
+    """
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
 
     @event.listens_for(engine, "connect")
     def set_sqlite_pragma(dbapi_conn, connection_record):
@@ -31,10 +43,11 @@ def test_session():
 
     factory = sessionmaker(bind=engine, expire_on_commit=False)
 
-    with factory() as session:
-        yield session
-
-    engine.dispose()
+    try:
+        with factory() as session:
+            yield session
+    finally:
+        engine.dispose()
 
 
 @pytest.fixture

--- a/tests/unit/sources/test_manager.py
+++ b/tests/unit/sources/test_manager.py
@@ -265,7 +265,10 @@ class TestAddRecipeSource:
 
 class TestListSources:
     def test_list_empty(self, manager: SourceManager) -> None:
-        assert manager.list_sources() == []
+        # Conftest seeds a baseline Source as the InvestigationSession FK
+        # target; filter it out to assert the workspace-as-registered view.
+        sources = [s for s in manager.list_sources() if s.name != "test_baseline"]
+        assert sources == []
 
     def test_list_registered(self, manager: SourceManager, tmp_path: Path) -> None:
         csv = tmp_path / "data.csv"
@@ -273,7 +276,7 @@ class TestListSources:
         manager.add_file_source("src_la", str(csv))
         manager.add_file_source("src_lb", str(csv))
 
-        sources = manager.list_sources()
+        sources = [s for s in manager.list_sources() if s.name != "test_baseline"]
         assert len(sources) == 2
         names = [s.name for s in sources]
         assert "src_la" in names
@@ -307,7 +310,7 @@ class TestListSources:
         manager.add_file_source("to_remove", str(csv))
         manager.remove_source("to_remove")
 
-        sources = manager.list_sources()
+        sources = [s for s in manager.list_sources() if s.name != "test_baseline"]
         assert len(sources) == 1
         assert sources[0].name == "active"
 

--- a/uv.lock
+++ b/uv.lock
@@ -160,6 +160,47 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -312,6 +353,7 @@ dev = [
     { name = "pytest-testmon" },
     { name = "ruff" },
     { name = "scipy-stubs" },
+    { name = "testcontainers" },
     { name = "types-pyyaml" },
     { name = "vulture" },
     { name = "zensical" },
@@ -354,6 +396,7 @@ dev = [
     { name = "pytest-testmon", specifier = ">=2.2.0" },
     { name = "ruff", specifier = ">=0.2.0" },
     { name = "scipy-stubs", specifier = ">=1.16.3.2" },
+    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.14" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
     { name = "vulture", specifier = ">=2.15" },
     { name = "zensical", specifier = ">=0.0.24" },
@@ -384,6 +427,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -1413,6 +1470,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1707,6 +1779,22 @@ wheels = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1806,6 +1894,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -1948,6 +2045,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Task

[DAT-321](https://real-dataraum.atlassian.net/browse/DAT-321) — L2/L3 of the DAT-294 Minimum-Port Plan. Originally split (L2 workspace port + L3 per-session model port); merged during refinement to avoid dual-dialect transitional cruft. DAT-322 closed as superseded.

## Read first (5 bullets)

- **Substrate change, no behavior change.** Every SQLAlchemy persistence path moves from per-session SQLite to a single workspace Postgres database. Per-session DuckDB stays per-session (L4 swaps it for DuckLake).
- **Per-session tables gain a NOT NULL `session_id` FK** to `investigation_sessions.session_id`. 26 model classes across 19 files.
- **Hybrid plumbing** — `manager.session_id` set at the MCP boundary, `PhaseContext.session_id` threaded through pipeline phases, deep agents take `session_id` as an explicit kwarg. **No ContextVar** (thread-pool unsafe under the scheduler's `ThreadPoolExecutor` and `graph_execution_phase`'s `asyncio.to_thread`). **No SQLAlchemy event listener in production** (rejected as too magic).
- **No backwards-compat.** `DATABASE_URL` is required; `ConnectionConfig.for_directory()` raises if it isn't set. The dev CLI (`dataraum run`) breaks accordingly — acceptable per the platform pivot.
- **`testcontainers[postgres]>=4.14`** is the new test substrate. Session-scoped Postgres 17 container (boots once, ~3s), per-test isolation via `TRUNCATE … RESTART IDENTITY CASCADE`.

## Contract consumed

Minimum-Port Plan rev 4 — [Confluence DD/20971523](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/20971523). Frozen before this lane opened; not modified from inside the lane (per parallel-platform-work etiquette).

## Acceptance criteria

- [x] All SQLAlchemy → single workspace Postgres (no SQLite fallback in `src/`)
- [x] 26 per-session models carry NOT NULL `session_id` FK to `investigation_sessions`
- [x] All construction sites populate `session_id` (verified by lane smoke + spec review)
- [x] Hybrid plumbing only — no ContextVar, no SQLAlchemy event listener in `src/`
- [x] `DATABASE_URL` required, fail-loud RuntimeError when unset
- [x] `testcontainers[postgres]` + Postgres 17 fixtures (session-scoped + TRUNCATE-isolated)
- [x] Lane smoke green
- [x] Senior code reviewer + spec compliance reviewer both approve

## Plumbing summary

| Layer | What changed |
|---|---|
| Models | 26 per-session models gain `session_id: Mapped[str] = mapped_column(ForeignKey("investigation_sessions.session_id"), nullable=False, index=True)` |
| Connection | `ConnectionConfig.database_url` replaces `sqlite_path`; `ConnectionManager.session_id` field for per-session row scoping |
| Pipeline | `PhaseContext.session_id` + `require_session_id()` helper; `PipelineScheduler` accepts `session_id` override for tests |
| Phases | 14 phase files pass `ctx.require_session_id()` to their analysis helpers |
| Analysis | Function signatures gain `session_id: str` kwarg, threaded to row constructors |
| Agents | `BusinessCycleAgent`, `ValidationAgent`, `QueryAgent`, `GraphAgent`, semantic enrichment all accept + thread `session_id` |
| MCP | `_get_session_manager(fp, session_id=None)`, `_run_pipeline(session_id)`, `_query(session_id)`, `_run_sql(session_id=None)`, `handle_teach(session_id)` |
| Snippets | `SnippetLibrary(session, session_id=None)` — optional kwarg for read-only paths, `_require_session_id()` guards write paths |

## Lane smoke (12 checks)

`tests/platform/smoke_dat321.py`:

\`\`\`
$ uv run pytest tests/platform/smoke_dat321.py -v
============================= 12 passed in 5.89s ==============================
\`\`\`

- All Base-registered tables present under Postgres dialect
- `session_id` FK + NOT NULL on every per-session table (26 tables)
- `session_id` indexed on every per-session table (the hot path post-DAT-321)
- JSON columns round-trip through psycopg/jsonb (`Source.connection_config`, `Source.discovered_schema`, `PhaseLog.outputs`)
- Two-sessions-no-leak (PhaseLog filtered by session_id returns only the matching session's rows)
- Postgres enforces NOT NULL (raw SQL insert without session_id raises IntegrityError)
- Postgres enforces FK (PhaseLog with a non-existent session_id raises IntegrityError)
- grep proof — no `from sqlalchemy.dialects.sqlite` imports in `src/`
- No `.db`/`.sqlite` artifact on disk after `ConnectionManager.initialize()`
- `ConnectionConfig.for_directory` honors DATABASE_URL and fails loud when unset

## Tests

- **1587 unit tests green** (full suite, `pytest tests/unit`)
- **12 lane smoke green** (`pytest tests/platform/smoke_dat321.py` against Postgres 17 testcontainer)
- mypy: clean
- ruff (check + format): clean

## Review gate

| Reviewer | Verdict | Action |
|---|---|---|
| senior-code-reviewer | APPROVED (with 3 improvements) | Addressed: SnippetLibrary construction at `graphs/agent.py:268` made consistent; `_restore_archived_session` + `_begin_new_session` now bind `manager.session_id` immediately after the InvestigationSession row is created (closes one-commit-away silent-corruption window); test conftest `before_flush` exclusion uses `isinstance(InvestigationSession)` instead of `__name__` string match |
| spec-compliance-reviewer | NEEDS WORK → fixed | **Critical missed site**: `analysis/semantic/processor.py::enrich_semantic()` was persisting `SemanticAnnotation`, `TableEntity`, `Relationship` rows without `session_id`. The test conftest autofill hook was masking it. Production Postgres would have raised `IntegrityError` on the next semantic pipeline run. Fixed by threading `session_id` through `enrich_semantic()` from the phase. Also added the two smoke checks the original Phase 5 silently dropped (index check + no-`.db`-on-disk check). |

## Out of scope / follow-ups

- **Integration smoke for the parallel metric execution path** (`graph_execution_phase._execute_metrics_parallel` against testcontainers). Lane smoke covers schema + FK + JSON round-trips; the parallel-dispatch session_id pass-through is unit-tested but not exercised end-to-end against Postgres. Worth a dedicated integration test post-merge.
- **DuckDB → DuckLake swap** is L4 (next lane). Per-session DuckDB stays per-session in this PR.
- **`.claude/platform-status.md`** updated in the main repo working tree (untracked file, lane status maintained per the runbook).

## Other lanes in flight

\`\`\`
$ gh pr list --search "DAT-294 in:body"
(no open lanes — DAT-320 merged via #110, DAT-324 merged via #111)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)