### PR TITLE
docs(claude): platform-work conventions — contracts-first, /take runbook

### DIFF
--- a/.claude/platform-status.md
+++ b/.claude/platform-status.md
@@ -5,6 +5,4 @@ Row is added when a lane opens its PR; removed when the PR merges.
 
 | Task | Worktree | Branch | PR | Contract | Status |
 |---|---|---|---|---|---|
-| DAT-325 | ../dataraum-context.worktrees/DAT-325 | feat/DAT-325-cutover-http-mcp-only | [#115](https://github.com/dataraum/dataraum/pull/115) | DAT-291 streamable-HTTP @ main | smoke green (7/7), awaiting review |
-
-_(merged: DAT-320 #110, DAT-324 #111, DAT-321 #113, DAT-323 #114)_
+_(no lanes in flight — DAT-320 #110, DAT-324 #111, DAT-321 #113, DAT-323 #114, DAT-325 #115 merged)_

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -97,7 +97,7 @@ Only proceed to handoff after both reviewers approve (or after discussing unreso
 
 After implementation is complete (honestly complete, reviewers satisfied):
 
-1. Update `.claude/handoff.md` with entries for EACH affected area:
+1. **If this work touched MCP tool surface, detectors, or pipeline phases**, update `.claude/handoff.md` with entries for EACH affected area:
 
    **For dataraum-eval:**
    - What changed (files, modules, behaviors)
@@ -109,6 +109,8 @@ After implementation is complete (honestly complete, reviewers satisfied):
    - Hints for new injection types that would test this feature
    - New ground truth values that should be generated
    - Keep it directional — testdata has its own design concerns
+
+   **Skip the handoff entirely if this is platform-shell work** — control plane, executor wiring, frontend, observability, REST/SSE adapters, contract artifacts. The engine is unchanged, so eval/testdata are unaffected. For platform work, follow the "Parallel platform work" runbook below instead.
 
 2. Summarize to the user:
    - What was done

--- a/.claude/skills/take/SKILL.md
+++ b/.claude/skills/take/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: take
+description: Take a single DAT-294 task end-to-end as one parallel lane — worktree, refine, implement, lane-smoke, PR. Invoke once per task. Launch N concurrently via the Agent tool with isolation:worktree.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - Agent
+  - AskUserQuestion
+  - Skill
+  - EnterWorktree
+  - ExitWorktree
+  - mcp__jira__getJiraIssue
+  - mcp__jira__editJiraIssue
+  - mcp__jira__getConfluencePage
+---
+
+# Take: $ARGUMENTS
+
+You are taking a single DAT-294 task end-to-end as one parallel lane. **One task = one worktree = one branch = one PR = one focused session.**
+
+This skill exists so the user can launch N lanes in parallel via the Agent tool with `isolation: "worktree"` — each agent inherits this skill and runs independently. Without a skill there is no parallelism unit; with it, multiple lanes ship from one orchestrator message.
+
+The full enforcement rules live in `CLAUDE.md → "Parallel platform work runbook"`. This skill executes that runbook. If you find this skill and the runbook diverging, the runbook wins — open a PR to align them.
+
+## Input
+
+$ARGUMENTS is a Jira task identifier (a child of a DAT-294 phase). Refuse to start if the ticket is not under DAT-294 or one of its phase sub-epics.
+
+## Step 1: Pre-check (lane can open)
+
+Before touching any code:
+
+1. **Fetch the task ticket.** Confirm: parent is a DAT-294 phase, status is To Do or In Progress, every `is blocked by` dependency is Done. Surface the blocker list and STOP if any is not Done.
+2. **Check for existing worktree** at `../dataraum-context.worktrees/{task-id}/`. If branch matches `feat/{task-id}-{slug}` → resume it. If branch is something else → STOP and ask. **Note:** worktrees live SIBLING to the main repo (not inside `.worktrees/`) so the orchestrator's `$CLAUDE_PROJECT_DIR` doesn't sweep them and each agent's `$CLAUDE_PROJECT_DIR` is the worktree path itself.
+3. **Check for existing PR** via `gh pr list --search "{task-id} in:title"`. If open → the lane is already in flight. STOP and ask.
+4. **Check the status board** `.claude/platform-status.md`. STOP if another active lane claims this task or a contract this task touches.
+5. **Verify the contract is locked.** The task ticket must reference a contract artifact (path + sha) on the Platform Contracts page. The artifact must be merged on `main`. **If not locked, STOP** — open a contract-lock issue instead. Do not start implementation against an unlocked contract; that is the single biggest cause of parallel-merge chaos.
+
+If anything is wrong, STOP and report. Don't "make it work."
+
+## Step 2: Open the worktree and switch the session into it
+
+```bash
+git fetch origin main
+git worktree add ../dataraum-context.worktrees/{task-id} -b feat/{task-id}-{slug} origin/main
+```
+
+Then call `EnterWorktree` with the absolute path:
+
+```
+EnterWorktree(path="/abs/path/to/../dataraum-context.worktrees/{task-id}")
+```
+
+This switches the session's working directory AND `$CLAUDE_PROJECT_DIR` to the worktree. Every subsequent `Bash` / `Read` / `Edit` / spawned `Agent` call resolves paths relative to the worktree — no `cd` prefix on every command, no per-command permission prompt for paths outside the orchestrator's view.
+
+Worktrees live SIBLING to the main repo (`../dataraum-context.worktrees/{task-id}/`), not inside it. This is load-bearing:
+
+- The orchestrator session's original `$CLAUDE_PROJECT_DIR` = main repo. Its hooks (`ruff format --check .`, etc.) recurse from `.`, which must NOT include the worktrees. Sibling placement gives this for free.
+- After `EnterWorktree`, the session's `$CLAUDE_PROJECT_DIR` = worktree. End-of-turn hooks then scope to this worktree only.
+- No `--exclude` flags, no `.gitignore` hacks. The filesystem layout + `EnterWorktree` do the right thing.
+
+Do NOT use `cd ../dataraum-context.worktrees/...` as a substitute — `Bash` resets cwd between commands and the prefix has to be re-applied every call, which triggers a permission prompt each time.
+
+All subsequent steps run inside the worktree.
+
+## Step 3: Run /refine
+
+Invoke `/refine {task-id}`. Reality-check the spec against the codebase. If `/refine` finds the **contract** is wrong (not the implementation), STOP the lane — re-locking the contract is higher-priority than this task.
+
+## Step 4: Run /implement
+
+After the user approves the refined approach: invoke `/implement {task-id}`.
+
+The DO NOT change scope **must include**:
+
+- Every contract file (consumed, never edited from a lane)
+- Any directory owned by another phase
+- Any cross-cutting infrastructure not owned by this task
+
+`/implement` runs the senior-code-reviewer and spec-compliance-reviewer at the end. Both must approve before this skill proceeds.
+
+## Step 5: Lane smoke
+
+Run smoke scoped to **this task's contract surface only** — backend task: its API/RPC against a minimal stand (Postgres + this process); frontend task: its UI against a contract-mock (Vite dev + mock). Lives at `tests/platform/smoke_{task-id}.py` (or equivalent path the task defines).
+
+Three smoke tiers; only the first is this lane's responsibility:
+
+| Tier | Scope | When | Owner |
+|---|---|---|---|
+| **Lane smoke** | This task's contract surface | Every commit on the lane branch | This skill |
+| **Integration smoke** | Full spine end-to-end on docker-compose | After each PR merges to `main` | CI on `main` |
+| **Journey smoke** | Full Playwright user journey | At first-wave milestones (post-P5, post-P9, post-P11) | `/release-prep` |
+
+If integration smoke on `main` is red because another lane is mid-flight, that is **expected** per DAT-294 ("`main` is allowed to be temporarily user-broken between phases"). Don't block this lane on it.
+
+## Step 6: Open the PR
+
+```bash
+gh pr create --title "{task-id}: {title}" --body "$(cat <<'EOF'
+## Task
+
+{task-id} — {ticket link}
+
+## Contract consumed
+
+{contract path} @ {sha}
+
+## Acceptance criteria
+
+{copied from ticket, checked off}
+
+## Lane smoke
+
+\`\`\`
+{command + result summary}
+\`\`\`
+
+## Other lanes in flight
+
+{output of: gh pr list --search "DAT-294 in:body"}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+The "Other lanes in flight" block is non-negotiable — reviewers need the parallel context to judge merge order.
+
+## Step 7: Update the status board
+
+Edit `.claude/platform-status.md` (create if missing) with one row per active lane:
+
+```markdown
+| Task | Worktree | Branch | PR | Contract | Status |
+|---|---|---|---|---|---|
+| {task-id} | ../dataraum-context.worktrees/{task-id} | feat/{task-id}-{slug} | #NN | {contract}@{sha} | smoke green, awaiting review |
+```
+
+Remove the row when the PR merges. This board is the at-a-glance "all lanes in flight" view for the user.
+
+## Step 8: Exit the worktree and hand back
+
+```
+ExitWorktree(action="keep")
+```
+
+Returns the session to the orchestrator's main-repo cwd so the next lane / status-board update / `gh pr list` poll operates from the right place. `keep` preserves the worktree on disk (PR is still open against it).
+
+Report concisely:
+
+- Lane closed: PR #NN opened, lane smoke green
+- Contract consumed: file + version
+- Lanes unblocked when this merges: list of task tickets that become ready
+- Lanes potentially conflicting at merge: list (cross-reference `platform-status.md`)
+
+**Do NOT merge the PR yourself.** Merge order across parallel lanes is the user's call.
+
+## Parallel launch (orchestrator pattern)
+
+To run multiple lanes concurrently from one orchestrator session: launch each as an Agent tool call with `isolation: "worktree"`, in a single message with multiple tool blocks. Each agent inherits this skill, opens its own worktree, works independently, and closes when its PR is open.
+
+The orchestrator session does NOT touch code — it only:
+- Decomposes the phase into tasks (via `/decompose`)
+- Locks contracts (via dedicated contract-lock PRs, one per contract)
+- Spawns parallel `/take` agents
+- Watches `gh pr list` and `.claude/platform-status.md`
+- Unblocks downstream lanes as PRs merge
+- Triggers journey smoke at milestones
+
+## When NOT to use /take
+
+- Non-platform work (single-stream library work): use `/refine` + `/implement` directly
+- Spikes (DAT-295/296/297/298): throwaway exploration — no worktree isolation needed
+- Contract-lock PRs: separate flow — small, focused, reviewer-heavy, not phased
+- S-size bug fixes inside an already-merged task: normal feature branch on `main`
+
+## Rules
+
+- One task per worktree, one worktree per task
+- Contract locked BEFORE the lane opens — no exceptions
+- Lane smoke is mandatory; integration smoke is informational
+- Do not edit contracts from inside a lane
+- Do not reach into other lanes' code
+- Three-strikes rule applies — stop and report, don't power through
+- The lane closes when the PR opens, not when it merges
+- Update `.claude/platform-status.md` so the user sees all lanes at once

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,52 @@ The line: bundle anything S-size and Light (see above). Keep Heavy items (behavi
 - **MCP tool changes**: always `/smoke` after — UX can't be judged from source code
 - **Detector changes**: always update `handoff.md` — calibration is the definition of done
 
+### Contracts-first for DAT-294 platform work
+
+The DAT-294 platform splits the codebase into parallel work streams (control plane, executors, frontend, observability, chat BFF). Parallel work without locked contracts produces merge mush. The rule:
+
+- **No implementation work starts on a platform phase until its contract is locked** on the [Platform Contracts](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/18972674/Platform+Contracts) page.
+- **Contracts are the sync point.** Frontend codes against types generated from the contract; backend codes against the same contract; they meet at smoke. Don't synchronize on running code — synchronize on the spec.
+- **Spec is source of truth, code generates from spec.** Protos live in `src/dataraum/proto/`, OpenAPI in `src/dataraum/control_plane/openapi.yaml`, etc. Never the reverse.
+- **The seven contracts** are inventoried on the page: Mcp-Session-Id semantics, CP↔executor gRPC service, sessions/principals SQLAlchemy schema, coordination events schema, config storage shape, OpenAPI for `/api/*`, TanStack AI wire format. Each gates a specific phase (P1, P2, P3, P8, P9).
+- **Per the no-backwards-compat rule**, "migration" means porting SQLAlchemy code to Postgres dialect, not Alembic scripts. Schemas drop-and-reinit at cutover.
+
+This rule applies only to DAT-294 phases (P1+). It does NOT apply to v0.2.x maintenance work on `main`.
+
+### Parallel platform work runbook
+
+For DAT-294 phase tasks (decomposed children of P1–P11), multiple tasks within a phase can run as parallel lanes. Each lane = one worktree = one branch = one PR. This runbook replaces the library-style handoff in `/implement` for platform work.
+
+**Invoke `/take {task-id}` to run this end-to-end as one lane.** The skill executes the steps below. To run N lanes concurrently from one orchestrator session, call `/take` via the Agent tool with `isolation: "worktree"` in a single message with multiple tool blocks — that's where the parallelism comes from.
+
+**Per-lane workflow** (what `/take` does):
+
+1. **Verify prerequisites.** The task's contract is locked (see Platform Contracts page). All `is blocked by` dependencies are merged. No other lane already claims this task ID — check `.claude/platform-status.md` and `gh pr list --search "{task-id} in:title"`.
+2. **Open the worktree.**
+   ```bash
+   git fetch origin main
+   git worktree add .worktrees/{task-id} -b feat/{task-id}-{slug} origin/main
+   cd .worktrees/{task-id}
+   ```
+3. **Run `/refine` then `/implement` {task-id}** inside the worktree. The discipline (scope, checkpoints, psych safety, review gate) belongs to `/implement`; its handoff section auto-skips for platform-shell work.
+4. **Lane smoke** scoped to this task's contract surface only (`tests/platform/smoke_{task-id}.py`).
+5. **Open the PR.**
+   ```bash
+   gh pr create --title "{task-id}: {title}" --body "..."
+   ```
+   PR body must reference the contract version (file + sha) consumed and list other open lanes via `gh pr list --search "DAT-294 in:body"` so reviewers see the parallel context.
+6. **Update `.claude/platform-status.md`** with one row per active lane (Task | Worktree | Branch | PR | Contract | Status). Remove the row when the PR merges.
+
+**Parallel etiquette (mandatory):**
+
+- **Never edit a contract from inside a lane.** Contracts change only via dedicated contract-lock PRs. If you find a contract is wrong, STOP the lane and surface it — don't fix it in passing.
+- **Never reach into another lane's code.** Drive-by fixes break parallel discipline. File a follow-up ticket; don't cross lanes.
+- **Rebase once, at the end.** Continuous rebasing during parallel work is merge soup. If `main` moved, rebase before opening the PR — not during.
+- **Lane smoke is yours; integration smoke is `main`'s.** Don't try to keep integration green from inside a lane — `main` is allowed to flicker red between phases per DAT-294.
+- **If a lane needs more than ~2 days, decompose further.** Multi-day lanes usually have hidden coupling.
+
+**Parallel launch (orchestrator pattern):** to run N lanes concurrently from one orchestrator session, launch each as `/take {task-id}` via the Agent tool with `isolation: "worktree"`, in a single message with multiple tool blocks. The orchestrator does NOT touch code — it decomposes the phase into tasks (`/decompose`), spawns the lanes, watches `gh pr list` and `.claude/platform-status.md`, surfaces conflicts, unblocks downstream lanes as PRs merge, and triggers journey smoke at milestones.
+
 ## Work Decomposition Protocol
 
 ### Task Sizing


### PR DESCRIPTION
## Summary

Promotes three CLAUDE-only project-instruction edits that have been used by every DAT-294 lane (DAT-320, DAT-321, DAT-323, DAT-324, DAT-325) but lived as uncommitted working-tree artifacts across multiple sessions until now. No code change.

- **`CLAUDE.md`** — adds "Contracts-first for DAT-294 platform work" (lock the contract on the [Platform Contracts page](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/18972674/Platform+Contracts) before any implementation) and "Parallel platform work runbook" (one task = one worktree = one branch = one PR; `/take` skill executes the per-lane workflow; orchestrator pattern for N concurrent lanes).
- **`.claude/skills/take/SKILL.md`** — the `/take` skill itself: pre-checks, worktree open + EnterWorktree, /refine + /implement, lane smoke, PR open, status-board update, exit.
- **`.claude/skills/implement/SKILL.md`** — gate the engine-handoff section on whether the work touched MCP tools / detectors / pipeline phases; platform-shell work skips it and follows the parallel runbook instead.

## Test plan

- [x] No source code touched — pure project-instruction docs
- [x] These conventions are already what `/take` lanes have been doing; this commit just records them on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)