### PR TITLE
fix: seven container + DAT-321 bugs surfaced by eval HTTP MCP smoke

### DIFF
--- a/docker/control-plane.Dockerfile
+++ b/docker/control-plane.Dockerfile
@@ -32,10 +32,16 @@ ENV DATARAUM_CONFIG_PATH=/opt/dataraum/config
 # don't need to provision a writable home — the path is immutable, predictable,
 # and pre-populated at build time. Pattern adapted from web-app/roboduck.
 RUN groupadd -r dataraum && useradd -r -g dataraum -u 1001 dataraum && \
-    mkdir -p /var/lib/dataraum/lake /var/lib/dataraum/sources /opt/dataraum/duckdb-extensions && \
+    mkdir -p /var/lib/dataraum/lake /var/lib/dataraum/sources /var/lib/dataraum/workspace /opt/dataraum/duckdb-extensions && \
     chown -R dataraum:dataraum /app /opt/dataraum /var/lib/dataraum
 
 USER dataraum
+
+# Workspace state (sessions, archives, logs) lives here — outside $HOME so
+# the non-root user doesn't need a writable home directory. Consumers of the
+# image (compose / k8s / `docker run`) inherit this default; mount a volume
+# at /var/lib/dataraum/workspace to persist across container recreations.
+ENV DATARAUM_HOME=/var/lib/dataraum/workspace
 
 # Pre-install the DuckLake extension at image build time. Runtime sets
 # DUCKLAKE_SKIP_INSTALL=1 (read by server/storage.bootstrap_lake) so the cold

--- a/src/dataraum/analysis/relationships/detector.py
+++ b/src/dataraum/analysis/relationships/detector.py
@@ -33,6 +33,7 @@ def detect_relationships(
     table_ids: list[str],
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
+    session_id: str,
     min_confidence: float = 0.3,
     sample_percent: float = 10.0,
     evaluate: bool = True,
@@ -46,6 +47,8 @@ def detect_relationships(
         table_ids: List of table IDs to analyze
         duckdb_conn: DuckDB connection
         session: SQLAlchemy async session
+        session_id: Active investigation session id — required for the
+            ``relationships.session_id`` NOT NULL constraint (DAT-321).
         min_confidence: Minimum join_confidence threshold (default 0.3)
         sample_percent: Percentage of rows to sample for uniqueness calculation
         evaluate: Whether to evaluate candidates with quality metrics (default True)
@@ -105,7 +108,7 @@ def detect_relationships(
             candidates = evaluate_candidates(candidates, table_paths, duckdb_conn)
 
         # Store candidates in database
-        _store_candidates(session, table_ids, candidates)
+        _store_candidates(session, session_id, table_ids, candidates)
 
         # Count high confidence candidates
         high_conf_count = sum(
@@ -129,6 +132,7 @@ def detect_relationships(
 
 def _store_candidates(
     session: Session,
+    session_id: str,
     table_ids: list[str],
     candidates: list[RelationshipCandidate],
 ) -> None:
@@ -185,6 +189,7 @@ def _store_candidates(
 
             db_rel = RelationshipDB(
                 relationship_id=str(uuid4()),
+                session_id=session_id,
                 from_table_id=table1_id,
                 from_column_id=col1_id,
                 to_table_id=table2_id,

--- a/src/dataraum/analysis/statistics/profiler.py
+++ b/src/dataraum/analysis/statistics/profiler.py
@@ -18,6 +18,7 @@ Note: Correlation analysis is handled separately by analysis/correlation module.
 
 from __future__ import annotations
 
+import math
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
@@ -43,6 +44,21 @@ from dataraum.core.models.base import ColumnRef, Result
 from dataraum.storage import Column, Table
 
 logger = get_logger(__name__)
+
+
+def _finite_or_none(x: Any) -> float | None:
+    """Coerce to float, returning None for NaN, +/-inf, or None.
+
+    DuckDB's SKEWNESS / KURTOSIS aggregates return NaN on zero-variance
+    columns, and Postgres JSON rejects NaN/Infinity tokens. Strip them at
+    the boundary so the JSON-encoded profile payload is always valid.
+    """
+    if x is None:
+        return None
+    f = float(x)
+    if not math.isfinite(f):
+        return None
+    return f
 
 
 def _profile_column_stats_parallel(
@@ -133,29 +149,17 @@ def _profile_column_stats_parallel(
                             max_value=float(numeric_row[1]),
                             mean=mean_val,
                             stddev=stddev_val,
-                            skewness=(
-                                float(numeric_row[4]) if numeric_row[4] is not None else None
-                            ),
-                            kurtosis=(
-                                float(numeric_row[5]) if numeric_row[5] is not None else None
-                            ),
-                            cv=cv_val,
-                            mad=mad_val,
-                            robust_cv=robust_cv_val,
+                            skewness=_finite_or_none(numeric_row[4]),
+                            kurtosis=_finite_or_none(numeric_row[5]),
+                            cv=_finite_or_none(cv_val),
+                            mad=_finite_or_none(mad_val),
+                            robust_cv=_finite_or_none(robust_cv_val),
                             percentiles={
-                                "p01": (
-                                    float(numeric_row[6]) if numeric_row[6] is not None else None
-                                ),
-                                "p25": (
-                                    float(numeric_row[7]) if numeric_row[7] is not None else None
-                                ),
-                                "p50": p50_val,
-                                "p75": (
-                                    float(numeric_row[9]) if numeric_row[9] is not None else None
-                                ),
-                                "p99": (
-                                    float(numeric_row[10]) if numeric_row[10] is not None else None
-                                ),
+                                "p01": _finite_or_none(numeric_row[6]),
+                                "p25": _finite_or_none(numeric_row[7]),
+                                "p50": _finite_or_none(p50_val),
+                                "p75": _finite_or_none(numeric_row[9]),
+                                "p99": _finite_or_none(numeric_row[10]),
                             },
                         )
                 except Exception as e:

--- a/src/dataraum/mcp/server.py
+++ b/src/dataraum/mcp/server.py
@@ -1333,21 +1333,39 @@ def create_server(output_dir: Path | None = None) -> Server:
 
 
 def _get_pipeline_source(session: Any) -> Any | None:
-    """Return the session's bound source.
+    """Return the source bound to the currently-active investigation session.
 
-    Per DAT-290 each session is bound to a single source, copied from the
-    workspace registry by ``begin_session`` into the session DB. This helper
-    is a thin lookup convenience used by tools (look, query, measure,
-    resume_session, ...) that need the Source row attached to ``ctx.source_id``
-    or to the active investigation. Returns None if no non-archived Source
-    exists (unexpected state — surfaces as a tool-level error in callers).
+    Per DAT-290 each InvestigationSession is bound to a single source.
+    Post-DAT-321 all sources live in the shared workspace Postgres (no
+    per-session DB), so this helper must follow the active session pointer
+    instead of guessing the first Source by created_at — that heuristic
+    silently returned the wrong source when multiple were registered.
+
+    Returns None when no session is active, the active pointer references a
+    missing investigation, or the bound source has been archived. Callers
+    surface that as a tool-level "no active source" error.
     """
     from sqlalchemy import select
 
+    from dataraum.investigation.db_models import InvestigationSession
+    from dataraum.mcp.db_models import ActiveSession
     from dataraum.storage import Source
 
+    pointer = session.execute(select(ActiveSession)).scalar_one_or_none()
+    if pointer is None:
+        return None
+
+    inv = session.execute(
+        select(InvestigationSession).where(InvestigationSession.session_id == pointer.session_id)
+    ).scalar_one_or_none()
+    if inv is None:
+        return None
+
     return session.execute(
-        select(Source).where(Source.archived_at.is_(None)).order_by(Source.created_at).limit(1)
+        select(Source).where(
+            Source.source_id == inv.source_id,
+            Source.archived_at.is_(None),
+        )
     ).scalar_one_or_none()
 
 
@@ -3332,14 +3350,46 @@ def _measure(
             "hint": "No entropy data. Pipeline will be triggered.",
         }
 
-    # Build points from column_details + table_details
+    # Build points from column_details + table_details + view_details.
+    # detector_id is the canonical registry id (not always the last dimension
+    # segment — e.g. "value.distribution.benford_compliance" → "benford").
+    detector_id_by_dim: dict[str, str] = {
+        d.dimension_path: d.detector_id for d in registry.get_all_detectors()
+    }
     points: list[dict[str, Any]] = []
     for dim_path, targets in measurement.column_details.items():
+        det_id = detector_id_by_dim.get(dim_path, dim_path.rsplit(".", 1)[-1])
         for tgt, score in targets.items():
-            points.append({"target": tgt, "dimension": dim_path, "score": round(score, 4)})
+            points.append(
+                {
+                    "target": tgt,
+                    "dimension": dim_path,
+                    "detector_id": det_id,
+                    "score": round(score, 4),
+                }
+            )
     for dim_path, targets in measurement.table_details.items():
+        det_id = detector_id_by_dim.get(dim_path, dim_path.rsplit(".", 1)[-1])
         for tgt, score in targets.items():
-            points.append({"target": tgt, "dimension": dim_path, "score": round(score, 4)})
+            points.append(
+                {
+                    "target": tgt,
+                    "dimension": dim_path,
+                    "detector_id": det_id,
+                    "score": round(score, 4),
+                }
+            )
+    for dim_path, targets in measurement.view_details.items():
+        det_id = detector_id_by_dim.get(dim_path, dim_path.rsplit(".", 1)[-1])
+        for tgt, score in targets.items():
+            points.append(
+                {
+                    "target": tgt,
+                    "dimension": dim_path,
+                    "detector_id": det_id,
+                    "score": round(score, 4),
+                }
+            )
 
     scores = _aggregate_layer_scores(measurement.scores)
 

--- a/src/dataraum/pipeline/phases/import_phase.py
+++ b/src/dataraum/pipeline/phases/import_phase.py
@@ -280,14 +280,12 @@ class ImportPhase(BasePhase):
         prefixed_name = f"{source_name}__{staged_table.table_name}"
         duckdb_name = staged_table.raw_table_name
 
-        # Find the Table record from session.new (unflushed pending objects).
-        # We avoid flush() here because SQLite doesn't handle concurrent flushes
-        # well in the free-threaded setup.
-        table_record: Table | None = None
-        for obj in ctx.session.new:
-            if isinstance(obj, Table) and obj.table_id == staged_table.table_id:
-                table_record = obj
-                break
+        # Find the Table record. Loaders add the row to the session but don't
+        # flush. We need a handle for the collision check below; the actual
+        # rename of name + duckdb_path is done via a bulk UPDATE statement
+        # after the rename succeeds (see below) so it works whether the row
+        # is still pending or has been flushed by a prior cycle.
+        table_record: Table | None = ctx.session.get(Table, staged_table.table_id)
 
         # Check for table name collision (e.g., Orders.csv and orders.csv both → same name)
         # Check both flushed records (SELECT) and pending objects (session.new)
@@ -324,10 +322,22 @@ class ImportPhase(BasePhase):
                 "duckdb_rename_failed", table=duckdb_name, target=prefixed_name, error=str(e)
             )
 
-        # Update the Table record in-memory (committed when session scope exits)
-        if table_record:
-            table_record.table_name = prefixed_name
-            table_record.duckdb_path = prefixed_name
+        # Persist the new table_name + duckdb_path. The loader adds the Table
+        # row to the session but does not flush, so a bulk UPDATE here would
+        # match zero rows in the DB. Flush first so the INSERT lands, then
+        # update via the ORM identity map — the attribute writes are picked
+        # up by SQLAlchemy's instrumentation and emitted on the next flush
+        # (or commit at session_scope exit).
+        ctx.session.flush()
+        if table_record is None:
+            table_record = ctx.session.get(Table, staged_table.table_id)
+        if table_record is None:
+            raise RuntimeError(
+                f"Loader did not register Table row for {staged_table.table_id} — "
+                "cannot persist the source-prefixed name."
+            )
+        table_record.table_name = prefixed_name
+        table_record.duckdb_path = prefixed_name
 
         return PhaseResult.success(
             outputs={"raw_tables": [str(staged_table.table_id)]},

--- a/src/dataraum/pipeline/phases/relationships_phase.py
+++ b/src/dataraum/pipeline/phases/relationships_phase.py
@@ -125,6 +125,7 @@ class RelationshipsPhase(BasePhase):
             table_ids=table_ids,
             duckdb_conn=ctx.duckdb_conn,
             session=ctx.session,
+            session_id=ctx.require_session_id(),
             min_confidence=min_confidence,
             sample_percent=sample_percent,
             evaluate=True,

--- a/src/dataraum/pipeline/setup.py
+++ b/src/dataraum/pipeline/setup.py
@@ -114,6 +114,7 @@ def setup_pipeline(
         manager=manager,
         source_path=source_path,
         source_name=source_name,
+        session_id=session_id,
     )
 
     # 4. Per-source fingerprint, captured in the PipelineRun for traceability.
@@ -241,18 +242,21 @@ def _resolve_source_spec(
     manager: ConnectionManager,
     source_path: Path | None,
     source_name: str | None,
+    session_id: str | None = None,
 ) -> _SourceSpec:
     """Resolve the single source for this pipeline run.
 
     - CLI mode (``source_path`` given): derive name from path stem, get-or-create
       a Source row, persist if newly created.
-    - MCP mode (``source_path`` is None): read the (one) Source row that
-      ``begin_session`` wrote into the session DB.
+    - MCP mode (``source_path`` is None): look up the source the active
+      ``InvestigationSession`` is bound to (via its FK). Pre-DAT-321 a session
+      had its own DB so we could trust "the one non-archived Source"; post-321
+      every session shares the workspace Postgres, so we must filter by
+      ``InvestigationSession.source_id``.
 
     Raises:
-        RuntimeError: in MCP mode, if the session DB has zero or multiple
-            non-archived Source rows. Both are configuration bugs upstream —
-            ``begin_session`` is responsible for the one-source invariant.
+        RuntimeError: in MCP mode when the session_id is missing or the bound
+            source can't be found.
     """
     import re
 
@@ -295,21 +299,34 @@ def _resolve_source_spec(
                 backend=new_source.backend,
             )
 
-    # MCP mode — single Source row already populated by begin_session.
+    # MCP mode — follow the InvestigationSession → Source FK.
+    if session_id is None:
+        raise RuntimeError(
+            "_resolve_source_spec: MCP mode requires session_id (post-DAT-321 the "
+            "workspace holds sources for every session, so we cannot guess)."
+        )
+    from dataraum.investigation.db_models import InvestigationSession
+
     with manager.session_scope() as session:
-        active = list(session.execute(select(Source).where(Source.archived_at.is_(None))).scalars())
-        if not active:
+        inv = session.execute(
+            select(InvestigationSession).where(InvestigationSession.session_id == session_id)
+        ).scalar_one_or_none()
+        if inv is None:
             raise RuntimeError(
-                "No source available in the session DB. begin_session was expected "
-                "to copy one Source row from the workspace registry."
+                f"InvestigationSession {session_id} not found — begin_session must "
+                "have written this row before the pipeline runs."
             )
-        if len(active) > 1:
-            names = [s.name for s in active]
+        s = session.execute(
+            select(Source).where(
+                Source.source_id == inv.source_id,
+                Source.archived_at.is_(None),
+            )
+        ).scalar_one_or_none()
+        if s is None:
             raise RuntimeError(
-                f"Session DB has multiple sources ({names}). DAT-290 guarantees one "
-                "source per session — this state is a bug in begin_session."
+                f"Active session {session_id} is bound to source {inv.source_id} but "
+                "that source is missing or archived."
             )
-        s = active[0]
         return _SourceSpec(
             source_id=s.source_id,
             name=s.name,


### PR DESCRIPTION
## Summary

Adapting `dataraum-eval` to drive the containerized control plane over HTTP MCP (L6 cutover, DAT-325) surfaced seven distinct bugs that each prevented an end-to-end pipeline run with multiple registered sources. Each is fixed here.

## What's broken & why

### L0 — container start-up
The non-root `dataraum` user (uid 1001) has no `\$HOME`, so every MCP handler that resolves session/archive/log paths via `~/.dataraum/...` immediately got `EPERM`. Image now pre-creates `/var/lib/dataraum/workspace` (chowned at build) and exports `DATARAUM_HOME` to point at it — every consumer (compose / k8s / `docker run`) gets a working default.

- `docker/control-plane.Dockerfile` — mkdir + chown + `ENV DATARAUM_HOME`

### DAT-321 follow-ups (single-DB workspace assumptions never migrated)

Four sites still assumed the pre-DAT-321 invariant that each session has its own DB holding exactly one Source. Post-DAT-321 every session shares the workspace Postgres, so "give me the source" turns into "the oldest one" and "assert one source per session" fires on the second registration.

- `src/dataraum/mcp/server.py` — `_get_pipeline_source` now follows `ActiveSession → InvestigationSession.source_id`. Heuristic that returned the earliest non-archived Source quietly served the wrong source to every tool (look/measure/query/run_sql/why/...) once a second source was registered.
- `src/dataraum/pipeline/setup.py` — `_resolve_source_spec` takes `session_id` and queries the bound `InvestigationSession.source_id`. The previous "if multiple sources, this is a begin_session bug" RuntimeError fired on every multi-source workspace.
- `src/dataraum/analysis/relationships/detector.py` + `src/dataraum/pipeline/phases/relationships_phase.py` — thread `session_id` from the phase context through `detect_relationships` → `_store_candidates` → `RelationshipDB(...)`. `relationships.session_id` is NOT NULL post-DAT-321 but the detector wasn't migrated; every pipeline halted at the relationships phase with `NotNullViolation`.
- `src/dataraum/pipeline/phases/import_phase.py` — flush the loader's INSERT before updating `Table.table_name` / `duckdb_path` to the source-prefixed form. The pre-existing "scan `session.new`" workaround (cited dead SQLite + free-threaded constraints) silently lost the rename whenever the row had been flushed earlier in the request. DB held `duckdb_path = raw_<bare>` while DuckDB held `<source>__<bare>`, and every typing-phase SQL then errored with `Catalog Error: Table "raw_<bare>" does not exist!` — silently distorting downstream detector scores.

### Postgres JSON safety
- `src/dataraum/analysis/statistics/profiler.py` — coerce NaN / ±Inf to None in `NumericStats` before `model_dump(mode="json")` is fed to a Postgres JSON column. DuckDB's `SKEWNESS` / `KURTOSIS` return NaN on zero-variance columns and Postgres JSON rejects the tokens; halted the `slice_analysis` phase whenever any column was constant.

### MCP `measure` response shape
- `src/dataraum/mcp/server.py` — `points` now also includes `view_details` (loop was missing — view-scoped detector scores were silently dropped) and every point carries `detector_id` alongside `dimension`. The dimension's last segment is not the registry id (`value.distribution.benford_compliance` → `benford`, `structural.relations.relationship_quality` → `relationship_entropy`, etc.), so any client that derived the id from the path joined against the wrong key.

## Validation

\`dataraum-eval\` smoke (full pipeline against the container over HTTP MCP):

\`\`\`
10 PASSED, 2 XFAILED, 2 XPASSED in 13:42
\`\`\`

Matches the pre-cutover detector-recall baseline documented in \`dataraum-eval/CLAUDE.md\` (12/14 effective recall, 2 LLM-nondeterministic).

## Test plan

- [x] Calibration recall passes against detection-v1 + clean baseline via HTTP MCP
- [x] \`ruff check src/\` clean
- [x] \`ruff format --check src/\` clean

## Out of scope / known gaps

- Graph metric LLM failures (\`cash_conversion_cycle\`, \`net_margin\`) — likely vertical config / column-context issue, not infra. Visible as soft warnings; not addressed here.
- Import phase doesn't detect duplicate base names in the source directory (\`x.csv\` + \`x.json\` → same prefixed name → unique-constraint violation late). Real bug, but separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)