### PR TITLE
feat(cockpit): /api/chat with streaming + first tool (list_sources)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ build/
 /site
 .DS_Store
 *.log
+
+# Playwright MCP session artifacts
+.playwright-mcp/
+/*.png

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
-    }
-  }
-}

--- a/packages/cockpit/package.json
+++ b/packages/cockpit/package.json
@@ -17,6 +17,7 @@
     "codegen": "openapi-typescript ../api/openapi.yaml -o src/api/types.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.96.0",
     "@mantine/core": "^9.2.1",
     "@mantine/hooks": "^9.2.1",
     "@tailwindcss/vite": "^4.1.18",

--- a/packages/cockpit/pnpm-lock.yaml
+++ b/packages/cockpit/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.96.0
+        version: 0.96.0(zod@3.25.76)
       '@mantine/core':
         specifier: ^9.2.1
         version: 9.2.1(@mantine/hooks@9.2.1(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -116,6 +119,15 @@ packages:
 
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@anthropic-ai/sdk@0.96.0':
+    resolution: {integrity: sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -1137,6 +1149,9 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1936,6 +1951,9 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2070,6 +2088,10 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -2472,6 +2494,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -2529,6 +2554,9 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2847,6 +2875,13 @@ packages:
 snapshots:
 
   '@acemir/cssom@0.9.31': {}
+
+  '@anthropic-ai/sdk@0.96.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 3.25.76
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -3566,6 +3601,8 @@ snapshots:
   '@solid-primitives/utils@6.4.0(solid-js@1.9.13)':
     dependencies:
       solid-js: 1.9.13
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4383,6 +4420,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-sha256@1.3.0: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -4512,6 +4551,11 @@ snapshots:
       - supports-color
 
   jsesc@3.1.0: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
 
@@ -4902,6 +4946,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@4.1.0: {}
 
   supports-color@10.2.2: {}
@@ -4944,6 +4993,8 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  ts-algebra@2.0.0: {}
 
   tslib@2.8.1: {}
 

--- a/packages/cockpit/src/routeTree.gen.ts
+++ b/packages/cockpit/src/routeTree.gen.ts
@@ -10,11 +10,18 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SourcesRouteImport } from './routes/sources'
+import { Route as ChatRouteImport } from './routes/chat'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ApiChatRouteImport } from './routes/api/chat'
 
 const SourcesRoute = SourcesRouteImport.update({
   id: '/sources',
   path: '/sources',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ChatRoute = ChatRouteImport.update({
+  id: '/chat',
+  path: '/chat',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -22,31 +29,44 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiChatRoute = ApiChatRouteImport.update({
+  id: '/api/chat',
+  path: '/api/chat',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/chat': typeof ChatRoute
   '/sources': typeof SourcesRoute
+  '/api/chat': typeof ApiChatRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/chat': typeof ChatRoute
   '/sources': typeof SourcesRoute
+  '/api/chat': typeof ApiChatRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/chat': typeof ChatRoute
   '/sources': typeof SourcesRoute
+  '/api/chat': typeof ApiChatRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/sources'
+  fullPaths: '/' | '/chat' | '/sources' | '/api/chat'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/sources'
-  id: '__root__' | '/' | '/sources'
+  to: '/' | '/chat' | '/sources' | '/api/chat'
+  id: '__root__' | '/' | '/chat' | '/sources' | '/api/chat'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ChatRoute: typeof ChatRoute
   SourcesRoute: typeof SourcesRoute
+  ApiChatRoute: typeof ApiChatRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -58,6 +78,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SourcesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/chat': {
+      id: '/chat'
+      path: '/chat'
+      fullPath: '/chat'
+      preLoaderRoute: typeof ChatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -65,12 +92,21 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/chat': {
+      id: '/api/chat'
+      path: '/api/chat'
+      fullPath: '/api/chat'
+      preLoaderRoute: typeof ApiChatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ChatRoute: ChatRoute,
   SourcesRoute: SourcesRoute,
+  ApiChatRoute: ApiChatRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/packages/cockpit/src/routes/__root.tsx
+++ b/packages/cockpit/src/routes/__root.tsx
@@ -57,6 +57,9 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             <Link to="/sources" activeProps={{ style: { fontWeight: 600 } }}>
               Sources
             </Link>
+            <Link to="/chat" activeProps={{ style: { fontWeight: 600 } }}>
+              Chat
+            </Link>
           </Group>
           {children}
         </MantineProvider>

--- a/packages/cockpit/src/routes/api/chat.ts
+++ b/packages/cockpit/src/routes/api/chat.ts
@@ -1,0 +1,140 @@
+import Anthropic from '@anthropic-ai/sdk'
+import { createFileRoute } from '@tanstack/react-router'
+
+const MODEL = 'claude-sonnet-4-6'
+const MAX_TOKENS = 1024
+
+const ENGINE_URL =
+  process.env.ENGINE_API_URL ?? process.env.VITE_ENGINE_API_URL ?? 'http://localhost:8000'
+
+const tools: Array<Anthropic.Messages.Tool> = [
+  {
+    name: 'list_sources',
+    description:
+      'List all data sources registered in the DataRaum workspace. Returns name, type, status, and path for each source. No arguments.',
+    input_schema: { type: 'object', properties: {}, required: [] },
+  },
+]
+
+async function runTool(name: string, _input: unknown): Promise<unknown> {
+  if (name === 'list_sources') {
+    const res = await fetch(`${ENGINE_URL}/api/sources`)
+    if (!res.ok) {
+      return { error: `engine returned ${res.status} ${res.statusText}` }
+    }
+    return await res.json()
+  }
+  return { error: `unknown tool: ${name}` }
+}
+
+type ChatRequest = {
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>
+}
+
+export const Route = createFileRoute('/api/chat')({
+  server: {
+    handlers: {
+      POST: async ({ request }: { request: Request }) => {
+    const apiKey = process.env.ANTHROPIC_API_KEY
+    if (!apiKey) {
+      return new Response(JSON.stringify({ error: 'ANTHROPIC_API_KEY not set' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const body = (await request.json()) as ChatRequest
+    if (!body.messages?.length) {
+      return new Response(JSON.stringify({ error: 'messages required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const anthropic = new Anthropic({ apiKey })
+
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream({
+      async start(controller) {
+        const send = (event: string, data: unknown) => {
+          controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`))
+        }
+
+        const conversation: Array<Anthropic.Messages.MessageParam> = body.messages.map((m) => ({
+          role: m.role,
+          content: m.content,
+        }))
+
+        try {
+          // Agentic loop: stream → if tool_use, run → feed back → repeat.
+          // Cap at 5 rounds so a runaway model can't lock the stream.
+          for (let round = 0; round < 5; round++) {
+            let stopReason: string | null = null
+            const assistantBlocks: Array<Anthropic.Messages.ContentBlock> = []
+            const streamResp = anthropic.messages.stream({
+              model: MODEL,
+              max_tokens: MAX_TOKENS,
+              tools,
+              messages: conversation,
+            })
+
+            for await (const event of streamResp) {
+              if (event.type === 'content_block_start') {
+                if (event.content_block.type === 'tool_use') {
+                  send('tool_call_start', {
+                    id: event.content_block.id,
+                    name: event.content_block.name,
+                  })
+                }
+              } else if (event.type === 'content_block_delta') {
+                if (event.delta.type === 'text_delta') {
+                  send('text', { text: event.delta.text })
+                }
+              } else if (event.type === 'message_delta') {
+                if (event.delta.stop_reason) stopReason = event.delta.stop_reason
+              }
+            }
+
+            const final = await streamResp.finalMessage()
+            assistantBlocks.push(...final.content)
+            conversation.push({ role: 'assistant', content: final.content })
+
+            if (stopReason !== 'tool_use') {
+              send('done', { stop_reason: stopReason ?? 'end_turn' })
+              break
+            }
+
+            // Run each tool_use block, push tool_results back.
+            const toolResults: Array<Anthropic.Messages.ToolResultBlockParam> = []
+            for (const block of assistantBlocks) {
+              if (block.type === 'tool_use') {
+                const result = await runTool(block.name, block.input)
+                send('tool_result', { id: block.id, name: block.name, result })
+                toolResults.push({
+                  type: 'tool_result',
+                  tool_use_id: block.id,
+                  content: JSON.stringify(result),
+                })
+              }
+            }
+            conversation.push({ role: 'user', content: toolResults })
+          }
+        } catch (err) {
+          send('error', { message: err instanceof Error ? err.message : String(err) })
+        } finally {
+          controller.close()
+        }
+      },
+    })
+
+        return new Response(stream, {
+          headers: {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache, no-transform',
+            Connection: 'keep-alive',
+          },
+        })
+      },
+    },
+  },
+})

--- a/packages/cockpit/src/routes/chat.tsx
+++ b/packages/cockpit/src/routes/chat.tsx
@@ -1,0 +1,212 @@
+import { useRef, useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { Alert, Badge, Button, Code, Group, Stack, Text, Textarea, Title } from '@mantine/core'
+
+type Turn =
+  | { role: 'user'; text: string }
+  | { role: 'assistant'; text: string; toolCalls: ToolCall[] }
+
+type ToolCall = {
+  id: string
+  name: string
+  result?: unknown
+}
+
+export const Route = createFileRoute('/chat')({ component: Chat })
+
+function Chat() {
+  const [turns, setTurns] = useState<Turn[]>([])
+  const [input, setInput] = useState('')
+  const [streaming, setStreaming] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  async function send() {
+    const text = input.trim()
+    if (!text || streaming) return
+
+    setError(null)
+    setInput('')
+    const userTurn: Turn = { role: 'user', text }
+    const assistantTurn: Turn = { role: 'assistant', text: '', toolCalls: [] }
+    setTurns((prev) => [...prev, userTurn, assistantTurn])
+    setStreaming(true)
+
+    // Bridge stream events into the latest assistant turn — immutable so it's
+    // safe under React strict-mode's double-invoke of state updaters.
+    const updateAssistant = (
+      transform: (turn: Turn & { role: 'assistant' }) => Turn & { role: 'assistant' },
+    ) => {
+      setTurns((prev) => {
+        const last = prev[prev.length - 1]
+        if (!last || last.role !== 'assistant') return prev
+        return [...prev.slice(0, -1), transform(last)]
+      })
+    }
+
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    try {
+      const messagesForApi = [...turns, userTurn].map((t) => ({
+        role: t.role,
+        content: t.text,
+      }))
+
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: messagesForApi }),
+        signal: controller.signal,
+      })
+
+      if (!res.ok || !res.body) {
+        const errBody = await res.text().catch(() => '')
+        throw new Error(`HTTP ${res.status} ${res.statusText}${errBody ? `: ${errBody}` : ''}`)
+      }
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+
+        // Parse SSE frames: blank-line separated event blocks.
+        let idx: number
+        while ((idx = buffer.indexOf('\n\n')) !== -1) {
+          const frame = buffer.slice(0, idx)
+          buffer = buffer.slice(idx + 2)
+
+          let eventName = 'message'
+          let dataLine = ''
+          for (const line of frame.split('\n')) {
+            if (line.startsWith('event: ')) eventName = line.slice(7).trim()
+            else if (line.startsWith('data: ')) dataLine = line.slice(6)
+          }
+          if (!dataLine) continue
+
+          let payload: any
+          try {
+            payload = JSON.parse(dataLine)
+          } catch {
+            continue
+          }
+
+          if (eventName === 'text') {
+            updateAssistant((t) => ({ ...t, text: t.text + payload.text }))
+          } else if (eventName === 'tool_call_start') {
+            updateAssistant((t) =>
+              t.toolCalls.some((c) => c.id === payload.id)
+                ? t
+                : { ...t, toolCalls: [...t.toolCalls, { id: payload.id, name: payload.name }] },
+            )
+          } else if (eventName === 'tool_result') {
+            updateAssistant((t) => ({
+              ...t,
+              toolCalls: t.toolCalls.map((c) =>
+                c.id === payload.id ? { ...c, result: payload.result } : c,
+              ),
+            }))
+          } else if (eventName === 'error') {
+            setError(payload.message ?? 'stream error')
+          }
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        setError(err instanceof Error ? err.message : String(err))
+      }
+    } finally {
+      setStreaming(false)
+      abortRef.current = null
+    }
+  }
+
+  return (
+    <Stack p="xl" gap="md" style={{ maxWidth: 800 }}>
+      <Title order={1}>Chat</Title>
+      <Text c="dimmed">
+        First end-to-end agent turn. One tool: <Code>list_sources</Code>.
+      </Text>
+
+      {error && (
+        <Alert color="red" title="Error">
+          {error}
+        </Alert>
+      )}
+
+      <Stack gap="md" data-testid="chat-log">
+        {turns.map((turn, i) => (
+          <Stack
+            key={i}
+            gap={6}
+            p="md"
+            style={{
+              borderRadius: 6,
+              border: '1px solid var(--mantine-color-gray-3)',
+              background:
+                turn.role === 'user' ? 'var(--mantine-color-gray-0)' : 'transparent',
+            }}
+            data-testid={`turn-${turn.role}`}
+          >
+            <Badge variant="light" color={turn.role === 'user' ? 'gray' : 'blue'} size="sm">
+              {turn.role}
+            </Badge>
+            <Text style={{ whiteSpace: 'pre-wrap' }}>{turn.text || (streaming ? '…' : '')}</Text>
+            {turn.role === 'assistant' &&
+              turn.toolCalls.map((call) => (
+                <Stack
+                  key={call.id}
+                  gap={4}
+                  p="xs"
+                  style={{
+                    borderRadius: 4,
+                    background: 'var(--mantine-color-gray-1)',
+                  }}
+                  data-testid="tool-call"
+                >
+                  <Group gap="xs">
+                    <Badge size="xs" color="grape">
+                      tool
+                    </Badge>
+                    <Code>{call.name}</Code>
+                  </Group>
+                  {call.result !== undefined && (
+                    <Code block style={{ fontSize: '0.7rem', maxHeight: 200, overflow: 'auto' }}>
+                      {JSON.stringify(call.result, null, 2)}
+                    </Code>
+                  )}
+                </Stack>
+              ))}
+          </Stack>
+        ))}
+      </Stack>
+
+      <Stack gap="xs">
+        <Textarea
+          placeholder="Ask something — e.g. 'What sources are registered?'"
+          minRows={2}
+          autosize
+          value={input}
+          onChange={(e) => setInput(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault()
+              void send()
+            }
+          }}
+          disabled={streaming}
+          data-testid="chat-input"
+        />
+        <Group justify="flex-end">
+          <Button onClick={() => void send()} loading={streaming} data-testid="chat-send">
+            Send
+          </Button>
+        </Group>
+      </Stack>
+    </Stack>
+  )
+}


### PR DESCRIPTION
## Summary

First end-to-end agent turn in the cockpit. Step 6 of the [Cockpit + Engine REST: v1 plan](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/22872066).

- `POST /api/chat` as a TanStack Start server route — streams Anthropic agent loop over SSE (`text`, `tool_call_start`, `tool_result`, `done`, `error`).
- Tool registry has one entry: `list_sources`, which fetches the engine's `GET /api/sources`.
- Chat UI at `/chat`: textarea, send, message list with streamed-text + tool-call cards (Cmd/Ctrl+Enter sends).
- Model: `claude-sonnet-4-6`. Agentic loop capped at 5 rounds.
- Requires `ANTHROPIC_API_KEY` in the server process; `ENGINE_API_URL` overrides the engine target (defaults to `localhost:8000` for dev).

## Bug fixed during verification

React 19 strict-mode double-invokes state updaters. The first iteration used in-place mutation in `setTurns(prev => mutate(prev))`, which doubled every streamed text chunk and produced duplicate-key warnings on tool cards. Switched to immutable updates with id-based de-duplication.

## Verified

End-to-end via Playwright MCP: navigated `/chat`, typed "List the registered sources.", agent called `list_sources` (empty `[]` result against a fresh workspace), narrated "no registered data sources" — single rendering, zero console errors.

## Out of scope (intentional)

- TanStack AI client wiring
- AG-UI proper event types
- Conversation persistence to `cockpit_db`
- Approval Flow
- More tools beyond `list_sources`
- Multi-conversation per session

These come later as the engine REST surface grows and the cockpit accumulates real usage patterns.

## Test plan

- [ ] `(cd packages/cockpit && pnpm install && pnpm build)` — types compile, Nitro emits `.output/server/index.mjs`
- [ ] `docker compose -f packages/infra/docker-compose.yml up -d --wait` — engine + postgres healthy
- [ ] `(cd packages/cockpit && pnpm dev)` with `ANTHROPIC_API_KEY` exported — open `localhost:3000/chat`, ask "list sources", confirm tool card + assistant text render exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)