### PR TITLE
DAT-341: drop \btyped_\w+ regex in validation agent (substrate read site)

### DIFF
--- a/packages/engine/src/dataraum/analysis/validation/agent.py
+++ b/packages/engine/src/dataraum/analysis/validation/agent.py
@@ -235,25 +235,28 @@ class ValidationAgent(LLMFeature):
     ) -> list[str]:
         """Derive which tables a validation SQL actually references.
 
-        Parses typed_* table names from the SQL and maps them back to
-        table_ids via the schema. Returns empty list (with warning) if
-        no tables can be resolved — never falls back to all_table_ids.
+        Matches the schema's known ``duckdb_path`` values against the SQL
+        with word-boundary anchors — works for bare (``FROM x__y``) and
+        quoted (``FROM "x__y"``) forms. Returns an empty list (with
+        warning) if no tables can be resolved — never falls back to
+        ``all_table_ids``.
         """
-        # Build duckdb_path → id map from schema (SQL references duckdb paths
-        # like typed_bank_transactions, not logical names like bank_transactions)
+        # Post-DAT-341: duckdb_path is the bare ``<source>__<table>`` form;
+        # tables resolve via the manager's ``USE lake.typed``.
         path_to_id: dict[str, str] = {}
         for t in schema.get("tables", []):
             duckdb_path = t.get("duckdb_path", t["table_name"])
             path_to_id[duckdb_path] = t.get("table_id", "")
 
-        # Find all typed_* table references in SQL
-        referenced_names = set(re.findall(r"\btyped_\w+", sql))
+        referenced_names = {
+            name
+            for name in path_to_id
+            if re.search(rf"(?<!\w){re.escape(name)}(?!\w)", sql)
+        }
 
-        scoped_ids = []
-        for name in referenced_names:
-            tid = path_to_id.get(name)
-            if tid and tid in all_table_ids:
-                scoped_ids.append(tid)
+        scoped_ids = [
+            path_to_id[name] for name in referenced_names if path_to_id[name] in all_table_ids
+        ]
 
         if not scoped_ids and referenced_names:
             logger.warning(

--- a/packages/engine/src/dataraum/analysis/validation/agent.py
+++ b/packages/engine/src/dataraum/analysis/validation/agent.py
@@ -249,9 +249,7 @@ class ValidationAgent(LLMFeature):
             path_to_id[duckdb_path] = t.get("table_id", "")
 
         referenced_names = {
-            name
-            for name in path_to_id
-            if re.search(rf"(?<!\w){re.escape(name)}(?!\w)", sql)
+            name for name in path_to_id if re.search(rf"(?<!\w){re.escape(name)}(?!\w)", sql)
         }
 
         scoped_ids = [


### PR DESCRIPTION
## Summary
- Sibling to commit 3b787061 (DAT-341 phase that fixed 6 hardcoded `typed_*` read sites). This is the seventh: `_scope_table_ids_from_sql` in the validation agent still parsed LLM-generated validation SQL with `re.findall(r"\btyped_\w+", sql)`.
- Post-DAT-341 `Table.duckdb_path` is the bare `<source>__<table>` form (typing_phase.py:154), tables resolve via the manager's `USE lake.typed`, and `resolver.py:75` shows the LLM `FROM "<source>__<table>"` (quoted bare path). So the old regex matched nothing, `ValidationResultRecord` rows got written with `table_ids=[]`, and `cross_table_consistency.load_data` filtered everything out — `can_run()` returned False, `_run_detectors` skipped the detector (snapshot.py:168), and zero records were emitted on every source.
- Surfaced by [dataraum-eval](https://github.com/dataraum/dataraum-eval) calibration: three known injections (invoices.amount, payments.amount, trial_balance.credit_balance) that historically passed produced no score at all.

## Fix
Match the SQL against the known `duckdb_path` values from the schema instead of pattern-matching a prefix. Word-boundary anchors `(?<!\w)` / `(?!\w)` accept both bare (`FROM x__y`) and quoted (`FROM "x__y"`) forms; `re.escape` protects against any path containing regex meta-chars.

## Test plan
- [x] `ruff check` + `mypy` on the changed file — green.
- [x] dataraum-eval calibration: `pytest calibration/test_detector_recall.py --strategy detection-v1 -v` on a fresh PG + DuckLake substrate.
  - Pre-fix: 7 passed / 2 xfail / 2 xpass / **3 failed** (all cross_table_consistency, "produced no score").
  - Post-fix: **10 passed / 2 xfail / 2 xpass** — exact match with the documented baseline.
- [ ] Engine unit suite (no direct tests cover `_scope_table_ids_from_sql`; calibration is the definition of done per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)