### PR TITLE
feat(DAT-370): E4b-2 — per-table fan-out for add_source

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,50 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-05-27: DAT-370 — per-table fan-out for add_source (E4b-2)
+
+The table is now the unit of work. `addSourceWorkflow` imports the source,
+**fans out one `processTableWorkflow` child per raw table** (`asyncio.gather`),
+then runs `semantic_per_column` once as the source-level reduce. Each child runs
+the table-local chain scoped to its one table: `typing` (mints a typed id) →
+`statistics` → `column_eligibility` → `statistical_quality` → `temporal` →
+`detect_table`. This replaces DAT-368's coarse single pass over the whole source.
+
+Two structural changes ride along:
+- **Detectors moved off the per-phase path to a stage-level step.** They no
+  longer run as a post-step after each phase; instead one `detect_table` step at
+  the tail of each child runs the table-local detectors (`type_fidelity`,
+  `null_ratio`) **scoped to that child's typed table**. `run_detector_post_step`
+  gained a `table_ids` scope (delete-before-insert + scan restricted to the
+  table) so parallel children never clobber each other's
+  `(source_id, detector_id)` rows.
+- **Message contract redesigned per-boundary.** The uniform
+  `PhaseActivityInput`/`PhaseActivityResult` envelope is gone; activities take
+  typed inputs (a `SourceIdentity` header + their real args) and the workflow
+  returns `AddSourceResult { raw_table_ids, tables:[{raw_table_id, typed_table_id}] }`.
+
+### dataraum-eval
+
+- **Eval action: behavior-preserving — re-verify, don't expect a shift.** Same
+  detectors, same per-table/per-column analysis; only granularity (per-table) and
+  detector *timing* (once per table at stage end vs. once per source-wide phase)
+  changed. The union of per-table detector records equals the old single
+  source-wide run. **This is the per-table execution the eval gate was waiting
+  on** — calibration can now run against the stabilized pattern.
+- **How to drive a run**: start `addSourceWorkflow` (task queue
+  `dataraum-pipeline`) with `AddSourceInput` = `{ identity: { workspace_id,
+  source_id, session_id, vertical? } }`. It fans out per table and stops after
+  `semantic_per_column`; `relationships` + `semantic_per_table` (slice-2) and
+  teach (DAT-343) are still not in the chain.
+- **If recall moves**: suspect the per-table detector scoping (`table_ids` in
+  `run_detector_post_step`) or the per-table `should_skip` rewrites in the four
+  analytics phases — those are the only behavioral touches.
+- **Status**: per-table execution stabilized; eval unblocked to run in parallel.
+
+### dataraum-testdata (hints)
+
+- None. No detector or fixture surface changed; output is preserved.
+
 ## 2026-05-27: DAT-369 — de-monolith (retire the hand-rolled scheduler + monitoring)
 
 Pure-cleanup follow-up to DAT-368. Now that the engine is a Temporal activity

--- a/packages/cockpit/src/temporal/drive-add-source.ts
+++ b/packages/cockpit/src/temporal/drive-add-source.ts
@@ -1,11 +1,11 @@
-// E4a integration driver (DAT-344, P3): prove the TS workflow → Python activity
-// path end-to-end against a running compose stack (temporal + engine-worker +
-// workflow-worker + postgres).
+// Integration driver (DAT-344; per-table fan-out DAT-370): prove the Client →
+// Python workflow path end-to-end against a running compose stack (temporal +
+// engine-worker + postgres).
 //
 // In production the addSourceWorkflow's caller seeds the Source +
-// InvestigationSession (E4b). Here this script does it directly, then starts the
-// workflow and asserts both phases completed and import produced raw tables —
-// which means the cross-language dispatch + the Python substrate both worked.
+// InvestigationSession. Here this script does it directly, then starts the
+// workflow and asserts import discovered raw tables and every table was processed
+// to a typed table — which means the fan-out + the Python substrate both worked.
 //
 // Run against the published compose ports, e.g.:
 //   TEMPORAL_HOST=localhost:7233 TEMPORAL_NAMESPACE=default \
@@ -19,7 +19,7 @@ import { randomUUID } from "node:crypto";
 import { Client, Connection } from "@temporalio/client";
 import postgres from "postgres";
 import { z } from "zod";
-import type { PhaseActivityInput, PhaseActivityResult } from "./types";
+import type { AddSourceInput, AddSourceResult } from "./types";
 
 const env = z
 	.object({
@@ -67,34 +67,40 @@ async function main(): Promise<void> {
 			connection,
 			namespace: env.TEMPORAL_NAMESPACE,
 		});
-		const input: PhaseActivityInput = {
-			workspace_id: env.DATARAUM_WORKSPACE_ID,
-			source_id: sourceId,
-			session_id: sessionId,
+		const input: AddSourceInput = {
+			identity: {
+				workspace_id: env.DATARAUM_WORKSPACE_ID,
+				source_id: sourceId,
+				session_id: sessionId,
+			},
 		};
-		const results = await client.workflow.execute<
-			(input: PhaseActivityInput) => Promise<PhaseActivityResult[]>
+		const result = await client.workflow.execute<
+			(input: AddSourceInput) => Promise<AddSourceResult>
 		>("addSourceWorkflow", {
 			taskQueue: env.TEMPORAL_TASK_QUEUE,
 			workflowId: `addsource-${sourceId}`,
 			args: [input],
 		});
 
-		const [importResult, typingResult] = results;
-		console.log("import:", JSON.stringify(importResult));
-		console.log("typing:", JSON.stringify(typingResult));
+		console.log("result:", JSON.stringify(result));
 
-		const rawTables = (importResult?.outputs?.raw_tables as unknown[]) ?? [];
-		if (importResult?.status !== "completed" || rawTables.length === 0) {
+		if (result.raw_table_ids.length === 0) {
+			throw new Error("import discovered no raw tables");
+		}
+		if (result.tables.length !== result.raw_table_ids.length) {
 			throw new Error(
-				`import did not complete with raw tables: ${importResult?.error}`,
+				`fan-out incomplete: ${result.tables.length} processed vs ` +
+					`${result.raw_table_ids.length} raw tables`,
 			);
 		}
-		if (typingResult?.status !== "completed") {
-			throw new Error(`typing did not complete: ${typingResult?.error}`);
+		for (const table of result.tables) {
+			if (!table.typed_table_id) {
+				throw new Error(`table ${table.raw_table_id} produced no typed table`);
+			}
 		}
 		console.log(
-			"✓ addSourceWorkflow completed: import + typing landed via Temporal",
+			`✓ addSourceWorkflow completed: ${result.tables.length} table(s) ` +
+				"fanned out + typed via Temporal",
 		);
 	} finally {
 		await connection.close();

--- a/packages/cockpit/src/temporal/types.ts
+++ b/packages/cockpit/src/temporal/types.ts
@@ -1,26 +1,33 @@
-// Shared shapes for the addSource workflow ↔ Python phase activities (DAT-344).
+// Shared shapes for the addSourceWorkflow ↔ Python worker (DAT-344, per-table DAT-370).
 //
-// Field names are snake_case to match the engine's Pydantic models
-// (PhaseActivityInput / PhaseActivityResult in dataraum.worker.activity) over
-// Temporal's Pydantic data converter — no key remapping across the boundary.
+// Hand-mirrored from the engine's Pydantic contracts (dataraum.worker.contracts)
+// carried over Temporal's Pydantic data converter — field names are snake_case to
+// match, no key remapping across the boundary. The cockpit is the Client: it starts
+// addSourceWorkflow with AddSourceInput and renders AddSourceResult. The per-table
+// fan-out (ProcessTableWorkflow) and the activity-level messages are engine-internal,
+// so only the parent workflow's input/result are mirrored here.
 
-export interface PhaseActivityInput {
+export interface SourceIdentity {
 	workspace_id: string;
 	source_id: string;
 	// Per-run FK for session-scoped rows; pure data, not a connection scope.
 	session_id: string;
 	vertical?: string | null;
-	// Optional table filter (DAT-342). Empty/omitted = all the source's raw tables.
-	table_ids?: string[];
 }
 
-export interface PhaseActivityResult {
-	phase: string;
-	status: string;
-	summary: string;
-	records_processed: number;
-	records_created: number;
-	outputs: Record<string, unknown>;
-	warnings: string[];
-	error?: string | null;
+export interface AddSourceInput {
+	identity: SourceIdentity;
+}
+
+// One raw→typed mapping, produced by a ProcessTableWorkflow child.
+export interface ProcessTableResult {
+	raw_table_id: string;
+	typed_table_id: string;
+}
+
+export interface AddSourceResult {
+	// The raw tables import discovered (the fan-out source).
+	raw_table_ids: string[];
+	// One entry per processed table; tables.length === raw_table_ids.length on success.
+	tables: ProcessTableResult[];
 }

--- a/packages/engine/src/dataraum/entropy/engine.py
+++ b/packages/engine/src/dataraum/entropy/engine.py
@@ -32,18 +32,26 @@ def run_detector_post_step(
     duckdb_conn: Any = None,
     *,
     session_id: str,
+    table_ids: list[str] | None = None,
 ) -> int:
     """Run a single detector as a phase post-step.
 
     Scoped delete-before-insert: deletes existing records for this
-    (source_id, detector_id) pair, then runs the detector against all
-    typed tables/columns/views and persists new records.
+    (source_id, detector_id) pair, then runs the detector against the typed
+    tables in scope and persists new records.
+
+    When ``table_ids`` is given (the per-table stage step, DAT-370), both the
+    delete and the table scan are restricted to those tables — so parallel
+    child workflows running this detector on different tables never collide on
+    each other's ``(source_id, detector_id)`` rows. ``None`` = source-wide.
 
     Args:
         session: SQLAlchemy session (caller manages commit).
         source_id: Source ID for record provenance.
         detector_id: ID of the detector to run.
         duckdb_conn: DuckDB connection for detectors that query data directly.
+        session_id: Per-run FK for the persisted records.
+        table_ids: Optional typed-table scope; ``None`` runs over all typed tables.
 
     Returns:
         Number of records created.
@@ -58,20 +66,20 @@ def run_detector_post_step(
         logger.warning("post_step_detector_not_found", detector_id=detector_id)
         return 0
 
-    # Scoped delete: remove stale records for this detector only
-    session.execute(
-        delete(EntropyObjectRecord).where(
-            EntropyObjectRecord.source_id == source_id,
-            EntropyObjectRecord.detector_id == detector_id,
-        )
+    # Scoped delete: remove stale records for this detector (and table scope) only
+    delete_stmt = delete(EntropyObjectRecord).where(
+        EntropyObjectRecord.source_id == source_id,
+        EntropyObjectRecord.detector_id == detector_id,
     )
+    if table_ids is not None:
+        delete_stmt = delete_stmt.where(EntropyObjectRecord.table_id.in_(table_ids))
+    session.execute(delete_stmt)
 
-    # Get typed tables
-    typed_tables = list(
-        session.execute(select(Table).where(Table.source_id == source_id, Table.layer == "typed"))
-        .scalars()
-        .all()
-    )
+    # Get typed tables (restricted to the scope when given)
+    typed_stmt = select(Table).where(Table.source_id == source_id, Table.layer == "typed")
+    if table_ids is not None:
+        typed_stmt = typed_stmt.where(Table.table_id.in_(table_ids))
+    typed_tables = list(session.execute(typed_stmt).scalars().all())
     if not typed_tables:
         return 0
 

--- a/packages/engine/src/dataraum/pipeline/phases/base.py
+++ b/packages/engine/src/dataraum/pipeline/phases/base.py
@@ -13,8 +13,11 @@ from abc import ABC, abstractmethod
 from types import ModuleType
 from typing import TYPE_CHECKING
 
+from sqlalchemy import select
+
 from dataraum.core.logging import get_logger
 from dataraum.pipeline.base import PhaseContext, PhaseResult
+from dataraum.storage import Table
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -70,6 +73,19 @@ class BasePhase(ABC):
         Lazy imports inside the property avoid circular imports at decoration time.
         """
         return []
+
+    def _typed_tables(self, ctx: PhaseContext) -> list[Table]:
+        """The typed tables this phase should process, scoped to ``ctx.table_ids``.
+
+        The table-local phases run per-table under the DAT-370 fan-out:
+        ``ctx.table_ids`` carries the single typed table the child workflow is
+        processing, so the phase analyzes exactly that table. An empty
+        ``ctx.table_ids`` means source-wide (direct/test invocation).
+        """
+        stmt = select(Table).where(Table.layer == "typed", Table.source_id == ctx.source_id)
+        if ctx.table_ids:
+            stmt = stmt.where(Table.table_id.in_(ctx.table_ids))
+        return list(ctx.session.execute(stmt).scalars().all())
 
     def run(self, ctx: PhaseContext) -> PhaseResult:
         """Execute the phase.

--- a/packages/engine/src/dataraum/pipeline/phases/column_eligibility_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/column_eligibility_phase.py
@@ -26,7 +26,7 @@ from dataraum.pipeline.base import PhaseContext, PhaseResult
 from dataraum.pipeline.cleanup import exec_delete
 from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.registry import analysis_phase
-from dataraum.storage import Column, Table
+from dataraum.storage import Column
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -56,10 +56,14 @@ class ColumnEligibilityPhase(BasePhase):
         table_ids: list[str],
         column_ids: list[str],
     ) -> int:
-        return exec_delete(
-            session,
-            delete(ColumnEligibilityRecord).where(ColumnEligibilityRecord.source_id == source_id),
+        stmt = delete(ColumnEligibilityRecord).where(
+            ColumnEligibilityRecord.source_id == source_id
         )
+        # Scope to the requested tables when given (per-table replay, DAT-370) so a
+        # single table's re-run does not clobber sibling tables' eligibility rows.
+        if table_ids:
+            stmt = stmt.where(ColumnEligibilityRecord.table_id.in_(table_ids))
+        return exec_delete(session, stmt)
 
     @property
     def db_models(self) -> list[ModuleType]:
@@ -68,9 +72,8 @@ class ColumnEligibilityPhase(BasePhase):
         return [db_models]
 
     def should_skip(self, ctx: PhaseContext) -> str | None:
-        """Skip if all columns already have eligibility records."""
-        stmt = select(Table).where(Table.layer == "typed", Table.source_id == ctx.source_id)
-        typed_tables = ctx.session.execute(stmt).scalars().all()
+        """Skip if the scoped tables' columns all have eligibility records."""
+        typed_tables = self._typed_tables(ctx)
 
         if not typed_tables:
             return "No typed tables found"
@@ -99,9 +102,7 @@ class ColumnEligibilityPhase(BasePhase):
         """Run column eligibility evaluation."""
         config = load_eligibility_config(ctx.config)
 
-        # Get typed tables
-        stmt = select(Table).where(Table.layer == "typed", Table.source_id == ctx.source_id)
-        typed_tables = ctx.session.execute(stmt).scalars().all()
+        typed_tables = self._typed_tables(ctx)
 
         if not typed_tables:
             return PhaseResult.failed("No typed tables found. Run typing phase first.")

--- a/packages/engine/src/dataraum/pipeline/phases/column_eligibility_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/column_eligibility_phase.py
@@ -56,9 +56,7 @@ class ColumnEligibilityPhase(BasePhase):
         table_ids: list[str],
         column_ids: list[str],
     ) -> int:
-        stmt = delete(ColumnEligibilityRecord).where(
-            ColumnEligibilityRecord.source_id == source_id
-        )
+        stmt = delete(ColumnEligibilityRecord).where(ColumnEligibilityRecord.source_id == source_id)
         # Scope to the requested tables when given (per-table replay, DAT-370) so a
         # single table's re-run does not clobber sibling tables' eligibility rows.
         if table_ids:

--- a/packages/engine/src/dataraum/pipeline/phases/statistical_quality_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/statistical_quality_phase.py
@@ -19,7 +19,7 @@ from dataraum.pipeline.base import PhaseContext, PhaseResult
 from dataraum.pipeline.cleanup import exec_delete
 from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.registry import analysis_phase
-from dataraum.storage import Column, Table
+from dataraum.storage import Column
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -62,19 +62,15 @@ class StatisticalQualityPhase(BasePhase):
         return [quality_db_models]
 
     def should_skip(self, ctx: PhaseContext) -> str | None:
-        """Skip if all numeric columns already have quality metrics."""
-
-        # Get typed tables
-        stmt = select(Table).where(Table.layer == "typed", Table.source_id == ctx.source_id)
-        result = ctx.session.execute(stmt)
-        typed_tables = result.scalars().all()
+        """Skip if the scoped tables' numeric columns all have quality metrics."""
+        typed_tables = self._typed_tables(ctx)
 
         if not typed_tables:
             return f"No typed tables found for source {ctx.source_id}"
 
         logger.debug(f"StatQuality: Found {len(typed_tables)} typed tables")
 
-        # Get all columns for typed tables
+        # Get all columns for the scoped typed tables
         typed_table_ids = [t.table_id for t in typed_tables]
         columns_stmt = select(Column).where(Column.table_id.in_(typed_table_ids))
         all_columns = (ctx.session.execute(columns_stmt)).scalars().all()
@@ -95,33 +91,34 @@ class StatisticalQualityPhase(BasePhase):
 
         logger.debug(f"StatQuality: Found {len(numeric_columns)} numeric columns")
 
-        # Check which already have quality metrics
-        assessed_stmt = select(StatisticalQualityMetrics.column_id).distinct()
+        # Check which of THIS scope's numeric columns already have metrics.
+        numeric_ids = {c.column_id for c in numeric_columns}
+        assessed_stmt = select(StatisticalQualityMetrics.column_id).where(
+            StatisticalQualityMetrics.column_id.in_(numeric_ids)
+        )
         assessed_ids = set((ctx.session.execute(assessed_stmt)).scalars().all())
 
-        numeric_ids = {c.column_id for c in numeric_columns}
         if not (numeric_ids - assessed_ids):
             return "All numeric columns already assessed"
 
         return None
 
     def _run(self, ctx: PhaseContext) -> PhaseResult:
-        """Run statistical quality assessment on typed tables."""
-        # Get typed tables for this source
-        stmt = select(Table).where(Table.layer == "typed", Table.source_id == ctx.source_id)
-        result = ctx.session.execute(stmt)
-        typed_tables = result.scalars().all()
+        """Run statistical quality assessment on the scoped typed tables."""
+        typed_tables = self._typed_tables(ctx)
 
         if not typed_tables:
             return PhaseResult.failed("No typed tables found. Run typing phase first.")
 
-        # Get all columns for typed tables
+        # Get all columns for the scoped typed tables
         typed_table_ids = [t.table_id for t in typed_tables]
         columns_stmt = select(Column).where(Column.table_id.in_(typed_table_ids))
         all_columns = (ctx.session.execute(columns_stmt)).scalars().all()
 
-        # Check which already have quality metrics
-        assessed_stmt = select(StatisticalQualityMetrics.column_id).distinct()
+        # Check which of these columns already have quality metrics
+        assessed_stmt = select(StatisticalQualityMetrics.column_id).where(
+            StatisticalQualityMetrics.column_id.in_([c.column_id for c in all_columns])
+        )
         assessed_ids = set((ctx.session.execute(assessed_stmt)).scalars().all())
 
         # Find tables with unassessed numeric columns

--- a/packages/engine/src/dataraum/pipeline/phases/statistics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/statistics_phase.py
@@ -22,7 +22,7 @@ from dataraum.pipeline.base import PhaseContext, PhaseResult
 from dataraum.pipeline.cleanup import exec_delete
 from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.registry import analysis_phase
-from dataraum.storage import Column, Table
+from dataraum.storage import Column
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -60,11 +60,8 @@ class StatisticsPhase(BasePhase):
         return [db_models]
 
     def should_skip(self, ctx: PhaseContext) -> str | None:
-        """Skip if all typed tables already have profiles."""
-        # Get typed tables
-        stmt = select(Table).where(Table.layer == "typed", Table.source_id == ctx.source_id)
-        result = ctx.session.execute(stmt)
-        typed_tables = result.scalars().all()
+        """Skip if the scoped typed tables already have profiles."""
+        typed_tables = self._typed_tables(ctx)
 
         if not typed_tables:
             return "No typed tables found"
@@ -91,11 +88,8 @@ class StatisticsPhase(BasePhase):
         return "All typed tables already profiled"
 
     def _run(self, ctx: PhaseContext) -> PhaseResult:
-        """Run statistical profiling on typed tables."""
-        # Get typed tables for this source
-        stmt = select(Table).where(Table.layer == "typed", Table.source_id == ctx.source_id)
-        result = ctx.session.execute(stmt)
-        typed_tables = result.scalars().all()
+        """Run statistical profiling on the scoped typed tables."""
+        typed_tables = self._typed_tables(ctx)
 
         if not typed_tables:
             return PhaseResult.failed("No typed tables found. Run typing phase first.")

--- a/packages/engine/src/dataraum/pipeline/phases/temporal_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/temporal_phase.py
@@ -22,7 +22,7 @@ from dataraum.pipeline.base import PhaseContext, PhaseResult
 from dataraum.pipeline.cleanup import exec_delete
 from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.registry import analysis_phase
-from dataraum.storage import Column, Table
+from dataraum.storage import Column
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -61,12 +61,8 @@ class TemporalPhase(BasePhase):
         return [db_models]
 
     def should_skip(self, ctx: PhaseContext) -> str | None:
-        """Skip if no temporal columns or all already profiled."""
-
-        # Get typed tables
-        stmt = select(Table).where(Table.layer == "typed", Table.source_id == ctx.source_id)
-        result = ctx.session.execute(stmt)
-        typed_tables = result.scalars().all()
+        """Skip if the scoped tables have no temporal columns or all are profiled."""
+        typed_tables = self._typed_tables(ctx)
 
         if not typed_tables:
             return f"No typed tables found for source {ctx.source_id}"
@@ -86,20 +82,21 @@ class TemporalPhase(BasePhase):
             type_counts[t] = type_counts.get(t, 0) + 1
         logger.debug(f"Temporal: Column types in typed tables: {type_counts}")
 
-        temporal_columns_stmt = select(Column).where(
-            Column.table_id.in_(typed_table_ids),
-            Column.resolved_type.in_(temporal_types),
-        )
-        temporal_columns = (ctx.session.execute(temporal_columns_stmt)).scalars().all()
+        temporal_columns = [c for c in all_columns if c.resolved_type in temporal_types]
 
         if not temporal_columns:
             return f"No temporal columns found (types: {temporal_types}, available: {list(type_counts.keys())})"
 
         logger.debug(f"Temporal: Found {len(temporal_columns)} temporal columns")
 
-        # Check existing profiles
+        # Check existing profiles for THIS scope's temporal columns only.
+        temporal_column_ids = [c.column_id for c in temporal_columns]
         existing_count = (
-            ctx.session.execute(select(func.count(TemporalColumnProfile.profile_id)))
+            ctx.session.execute(
+                select(func.count(TemporalColumnProfile.profile_id)).where(
+                    TemporalColumnProfile.column_id.in_(temporal_column_ids)
+                )
+            )
         ).scalar() or 0
 
         if existing_count >= len(temporal_columns):
@@ -108,11 +105,8 @@ class TemporalPhase(BasePhase):
         return None
 
     def _run(self, ctx: PhaseContext) -> PhaseResult:
-        """Run temporal profiling on typed tables."""
-        # Get typed tables for this source
-        stmt = select(Table).where(Table.layer == "typed", Table.source_id == ctx.source_id)
-        result = ctx.session.execute(stmt)
-        typed_tables = result.scalars().all()
+        """Run temporal profiling on the scoped typed tables."""
+        typed_tables = self._typed_tables(ctx)
 
         if not typed_tables:
             return PhaseResult.failed("No typed tables found. Run typing phase first.")

--- a/packages/engine/src/dataraum/worker/__init__.py
+++ b/packages/engine/src/dataraum/worker/__init__.py
@@ -1,27 +1,53 @@
-"""Temporal activity worker (DAT-344).
+"""Temporal activity worker (DAT-344; per-table fan-out DAT-370).
 
 The engine runs as a pure Python Temporal worker: it bootstraps the substrate
 once (:mod:`dataraum.worker.bootstrap`) and serves both the Python workflows
 (:mod:`dataraum.worker.workflows`) and the pipeline-phase activities
-(:mod:`dataraum.worker.activity`) on one task queue. The cockpit triggers
+(:mod:`dataraum.worker.activities`) on one task queue. The cockpit triggers
 workflows by name via the Temporal Client. No Starlette shell.
 """
 
 from __future__ import annotations
 
-from dataraum.worker.activity import run_phase_activity
+from dataraum.worker.activity import (
+    raw_table_ids,
+    run_phase,
+    run_table_detectors,
+    typed_table_id_for_raw,
+)
 from dataraum.worker.bootstrap import (
     bootstrap_worker_substrate,
     shutdown_worker_substrate,
 )
-from dataraum.worker.contracts import PhaseActivityInput, PhaseActivityResult
-from dataraum.worker.workflows import AddSourceWorkflow
+from dataraum.worker.contracts import (
+    AddSourceInput,
+    AddSourceResult,
+    ImportResult,
+    PhaseOutcome,
+    ProcessTableInput,
+    ProcessTableResult,
+    SourceIdentity,
+    TableScopedInput,
+    TypingResult,
+)
+from dataraum.worker.workflows import AddSourceWorkflow, ProcessTableWorkflow
 
 __all__ = [
+    "AddSourceInput",
+    "AddSourceResult",
     "AddSourceWorkflow",
-    "PhaseActivityInput",
-    "PhaseActivityResult",
+    "ImportResult",
+    "PhaseOutcome",
+    "ProcessTableInput",
+    "ProcessTableResult",
+    "ProcessTableWorkflow",
+    "SourceIdentity",
+    "TableScopedInput",
+    "TypingResult",
     "bootstrap_worker_substrate",
-    "run_phase_activity",
+    "raw_table_ids",
+    "run_phase",
+    "run_table_detectors",
     "shutdown_worker_substrate",
+    "typed_table_id_for_raw",
 ]

--- a/packages/engine/src/dataraum/worker/activities.py
+++ b/packages/engine/src/dataraum/worker/activities.py
@@ -1,22 +1,21 @@
-"""Temporal activity definitions for pipeline phases (DAT-344).
+"""Temporal activity definitions for pipeline phases (DAT-344, per-table DAT-370).
 
-Thin ``@activity.defn`` wrappers over :func:`run_phase_activity`. They hold the
-worker's single :class:`ConnectionManager` (set at bootstrap) and name each
-activity after its pipeline.yaml phase — so the workflow calls them by that
-phase-name string, no shared catalogue.
+Thin ``@activity.defn`` wrappers that translate the per-boundary contracts into
+calls on the Temporal-agnostic helpers in :mod:`dataraum.worker.activity`. They
+hold the worker's single :class:`ConnectionManager` (set at bootstrap) and name
+each activity after its pipeline.yaml phase (plus ``detect_table``) — so the
+workflows call them by that string, no shared catalogue.
 
 Activities are **sync** (``def``): Temporal runs them on the worker's
 ``ThreadPoolExecutor``, the SDK-recommended shape for blocking SQLAlchemy/DuckDB
-work. Each ``run_phase_activity`` call leases a fresh Postgres session + a DuckDB
-**cursor** off the worker's shared DuckLake connection. A DuckDB ``cursor()`` is
-an *independent connection* to the same named in-memory lake DB: it shares the
+work. Each helper call leases a fresh Postgres session + a DuckDB **cursor** off
+the worker's shared DuckLake connection. A DuckDB ``cursor()`` is an
+*independent connection* to the same named in-memory lake DB: it shares the
 catalog (the DuckLake ATTACH, schemas, tables) but carries its own transaction +
-``USE`` state, and is DuckDB's blessed primitive for concurrent access —
-reusing a single connection across threads serializes, but cursors do not (see
-:meth:`ConnectionManager.duckdb_cursor`). So concurrent activities run on
-independent channels; DuckLake reconciles concurrent writers via MVCC +
-optimistic concurrency, and the rare commit conflict raises and is absorbed by
-Temporal's activity retry.
+``USE`` state, and is DuckDB's blessed primitive for concurrent access. So
+concurrent activities (parallel child workflows) run on independent channels;
+DuckLake reconciles concurrent writers via MVCC + optimistic concurrency, and
+the rare commit conflict raises and is absorbed by Temporal's activity retry.
 """
 
 from __future__ import annotations
@@ -28,9 +27,18 @@ from temporalio.exceptions import ApplicationError
 
 from dataraum.pipeline.base import PhaseStatus
 from dataraum.worker.activity import (
-    PhaseActivityInput,
-    PhaseActivityResult,
-    run_phase_activity,
+    raw_table_ids,
+    run_phase,
+    run_table_detectors,
+    typed_table_id_for_raw,
+)
+from dataraum.worker.contracts import (
+    ImportResult,
+    PhaseOutcome,
+    ProcessTableInput,
+    SourceIdentity,
+    TableScopedInput,
+    TypingResult,
 )
 
 if TYPE_CHECKING:
@@ -40,73 +48,103 @@ if TYPE_CHECKING:
 class PhaseActivities:
     """Phase activities bound to the worker's ConnectionManager.
 
-    Registered as bound methods (``worker = Worker(..., activities=[acts.run_import,
-    acts.run_typing])``) so the manager is captured by instance, not a module
-    global — no import-time/runtime ordering coupling.
+    Registered as bound methods (``Worker(..., activities=[acts.run_import, …])``)
+    so the manager is captured by instance, not a module global — no
+    import-time/runtime ordering coupling.
     """
 
     def __init__(self, manager: ConnectionManager) -> None:
         self._manager = manager
 
     @activity.defn(name="import")
-    def run_import(self, payload: PhaseActivityInput) -> PhaseActivityResult:
-        """Import activity — loads the bound source into ``lake.raw.*``."""
-        return _run("import", self._manager, payload)
+    def run_import(self, identity: SourceIdentity) -> ImportResult:
+        """Import activity — loads the source into ``lake.raw.*``, returns raw ids.
+
+        The discovered raw ids are the parent workflow's fan-out source, so they
+        are read authoritatively from the substrate after the phase — correct
+        even when import is skipped because the source was already imported.
+        """
+        self._run_or_raise("import", identity, [])
+        return ImportResult(raw_table_ids=raw_table_ids(self._manager, identity.source_id))
 
     @activity.defn(name="typing")
-    def run_typing(self, payload: PhaseActivityInput) -> PhaseActivityResult:
-        """Typing activity — type-resolves raw tables into ``lake.typed.*``."""
-        return _run("typing", self._manager, payload)
+    def run_typing(self, payload: ProcessTableInput) -> TypingResult:
+        """Typing activity — type-resolves one raw table, returns its typed id."""
+        self._run_or_raise("typing", payload.identity, [payload.raw_table_id])
+        typed_id = typed_table_id_for_raw(
+            self._manager, payload.identity.source_id, payload.raw_table_id
+        )
+        if typed_id is None:
+            raise ApplicationError(
+                f"typing produced no typed table for raw table '{payload.raw_table_id}'",
+                type="PhaseFailed",
+                non_retryable=True,
+            )
+        return TypingResult(typed_table_id=typed_id)
 
     @activity.defn(name="statistics")
-    def run_statistics(self, payload: PhaseActivityInput) -> PhaseActivityResult:
-        """Statistics activity — per-column statistical profiling of typed tables."""
-        return _run("statistics", self._manager, payload)
+    def run_statistics(self, payload: TableScopedInput) -> PhaseOutcome:
+        """Statistics activity — per-column statistical profiling of one typed table."""
+        return self._run_or_raise("statistics", payload.identity, [payload.table_id])
 
     @activity.defn(name="column_eligibility")
-    def run_column_eligibility(self, payload: PhaseActivityInput) -> PhaseActivityResult:
+    def run_column_eligibility(self, payload: TableScopedInput) -> PhaseOutcome:
         """Column-eligibility activity — marks which columns downstream phases analyze."""
-        return _run("column_eligibility", self._manager, payload)
+        return self._run_or_raise("column_eligibility", payload.identity, [payload.table_id])
 
     @activity.defn(name="statistical_quality")
-    def run_statistical_quality(self, payload: PhaseActivityInput) -> PhaseActivityResult:
+    def run_statistical_quality(self, payload: TableScopedInput) -> PhaseOutcome:
         """Statistical-quality activity — Benford + outlier detection on numeric columns."""
-        return _run("statistical_quality", self._manager, payload)
+        return self._run_or_raise("statistical_quality", payload.identity, [payload.table_id])
 
     @activity.defn(name="temporal")
-    def run_temporal(self, payload: PhaseActivityInput) -> PhaseActivityResult:
+    def run_temporal(self, payload: TableScopedInput) -> PhaseOutcome:
         """Temporal activity — pattern/trend profiling of date/time columns."""
-        return _run("temporal", self._manager, payload)
+        return self._run_or_raise("temporal", payload.identity, [payload.table_id])
+
+    @activity.defn(name="detect_table")
+    def run_detect_table(self, payload: TableScopedInput) -> PhaseOutcome:
+        """Run the table-local detectors scoped to one typed table (DAT-370).
+
+        The stage-level detector step: runs once per ``ProcessTableWorkflow`` after
+        its analytics phases, scoped to the child's typed table — never per phase.
+        """
+        count = run_table_detectors(self._manager, payload.identity, payload.table_id)
+        return PhaseOutcome(
+            status=PhaseStatus.COMPLETED.value,
+            summary=f"{count} detector records for table {payload.table_id}",
+        )
 
     @activity.defn(name="semantic_per_column")
-    def run_semantic_per_column(self, payload: PhaseActivityInput) -> PhaseActivityResult:
-        """Semantic-per-column activity — the first LLM phase (roles, concepts, terms).
+    def run_semantic_per_column(self, identity: SourceIdentity) -> PhaseOutcome:
+        """Semantic-per-column activity — the source-level LLM reduce (roles, concepts, terms).
 
-        Needs a working ``ANTHROPIC_API_KEY`` in the worker env + the provider /
-        prompt config resolvable from ``dataraum.core.config``; unlike the four
-        analytics phases above it makes real LLM calls.
+        Runs once over the whole source after the per-table fan-out (its ontology
+        induction is source-global). Needs a working ``ANTHROPIC_API_KEY`` + the
+        provider/prompt config resolvable from ``dataraum.core.config``; unlike the
+        analytics phases it makes real LLM calls.
         """
-        return _run("semantic_per_column", self._manager, payload)
+        return self._run_or_raise("semantic_per_column", identity, [])
 
+    def _run_or_raise(
+        self,
+        phase_name: str,
+        identity: SourceIdentity,
+        table_ids: list[str],
+    ) -> PhaseOutcome:
+        """Run a phase; turn a deterministic phase failure into a non-retryable error.
 
-def _run(
-    phase_name: str,
-    manager: ConnectionManager,
-    payload: PhaseActivityInput,
-) -> PhaseActivityResult:
-    """Run a phase; turn a deterministic phase failure into a non-retryable error.
-
-    A FAILED ``PhaseResult`` means the phase itself decided it cannot proceed
-    (bad path, missing config) — permanent, so we raise a non-retryable
-    ``ApplicationError`` rather than burning Temporal retries. Transient
-    failures (e.g. a DuckLake optimistic-commit conflict) raise out of
-    ``run_phase_activity`` as ordinary exceptions and stay retryable by default.
-    """
-    result = run_phase_activity(manager, phase_name, payload)
-    if result.status == PhaseStatus.FAILED.value:
-        raise ApplicationError(
-            result.error or f"Phase '{phase_name}' failed",
-            type="PhaseFailed",
-            non_retryable=True,
-        )
-    return result
+        A FAILED ``PhaseRun`` means the phase itself decided it cannot proceed
+        (bad path, missing config) — permanent, so we raise a non-retryable
+        ``ApplicationError`` rather than burning Temporal retries. Transient
+        failures (e.g. a DuckLake optimistic-commit conflict) raise out of
+        ``run_phase`` as ordinary exceptions and stay retryable by default.
+        """
+        run = run_phase(self._manager, phase_name, identity, table_ids)
+        if run.status == PhaseStatus.FAILED.value:
+            raise ApplicationError(
+                run.error or f"Phase '{phase_name}' failed",
+                type="PhaseFailed",
+                non_retryable=True,
+            )
+        return PhaseOutcome(status=run.status, summary=run.summary)

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -49,6 +49,11 @@ __all__ = [
 # of the detectors these phases declare in pipeline.yaml (today: type_fidelity
 # from typing, null_ratio from statistics) — scoped to the one typed table, so
 # parallel child workflows never touch each other's detector rows.
+#
+# This is ``typing`` + ``workflows._ANALYTICS_PHASES`` (typing is here for its
+# type_fidelity detector but is scheduled separately as the id-minting step).
+# ``tests/unit/worker/test_phase_constants.py`` pins that relationship so a new
+# table-local phase can't be added to the workflow without its detectors running.
 _TABLE_LOCAL_PHASES = (
     "typing",
     "statistics",

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -1,22 +1,26 @@
-"""Phase-runner for the Temporal activity worker (DAT-344).
+"""Phase-runner for the Temporal activity worker (DAT-344, per-table in DAT-370).
 
-One place wires connections to a phase. :func:`run_phase_activity` leases a
-*scoped* SQLAlchemy session + DuckDB cursor from the worker's single
+One place wires connections to a phase. :func:`run_phase` leases a *scoped*
+SQLAlchemy session + DuckDB cursor from the worker's single
 :class:`~dataraum.core.connections.ConnectionManager`, builds the
 ``PhaseContext`` (source identity from the ``Source`` row + the phase's static
-config), runs the sync phase, then runs its pipeline.yaml-declared detectors as
-post-steps — all without a scheduler, ``PipelineRun``/``PhaseLog`` monitoring
-rows (Temporal's event history is the execution log), or per-activity
-connection wiring.
+config, scoped to ``table_ids``), and runs the sync phase — without a scheduler
+or ``PipelineRun``/``PhaseLog`` monitoring rows (Temporal's event history is the
+execution log).
 
-P2 wraps this in ``@activity.defn`` activities (``run_import`` / ``run_typing``)
-that read the worker-held manager; the runner itself is Temporal-agnostic so it
-can be tested directly against the real substrate.
+Detectors are **not** run here. Per DAT-370 they run once per workflow stage,
+not once per phase: :func:`run_table_detectors` runs the table-local detectors
+scoped to a single typed table at the tail of ``ProcessTableWorkflow``. The
+activity wrappers (:mod:`dataraum.worker.activities`) translate these
+Temporal-agnostic helpers into the per-boundary contracts.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import select
 
 from dataraum.core.config import load_phase_config
 from dataraum.core.logging import get_logger
@@ -25,29 +29,59 @@ from dataraum.pipeline.base import PhaseContext, PhaseStatus
 from dataraum.pipeline.pipeline_config import load_phase_declarations
 from dataraum.pipeline.registry import get_phase_class
 from dataraum.server.workspace import get_active_workspace_id
-from dataraum.storage import Source
-from dataraum.worker.contracts import PhaseActivityInput, PhaseActivityResult
+from dataraum.storage import Source, Table
+from dataraum.worker.contracts import SourceIdentity
 
 if TYPE_CHECKING:
     from dataraum.core.connections import ConnectionManager
 
 logger = get_logger(__name__)
 
-__all__ = ["PhaseActivityInput", "PhaseActivityResult", "run_phase_activity"]
+__all__ = [
+    "PhaseRun",
+    "raw_table_ids",
+    "run_phase",
+    "run_table_detectors",
+    "typed_table_id_for_raw",
+]
+
+# The table-local phases, in dependency order. ``detect_table`` runs the union
+# of the detectors these phases declare in pipeline.yaml (today: type_fidelity
+# from typing, null_ratio from statistics) — scoped to the one typed table, so
+# parallel child workflows never touch each other's detector rows.
+_TABLE_LOCAL_PHASES = (
+    "typing",
+    "statistics",
+    "column_eligibility",
+    "statistical_quality",
+    "temporal",
+)
 
 
-def run_phase_activity(
+@dataclass
+class PhaseRun:
+    """Temporal-agnostic outcome of one phase body (no detector side-effects)."""
+
+    status: str
+    summary: str = ""
+    error: str | None = None
+
+
+def run_phase(
     manager: ConnectionManager,
     phase_name: str,
-    payload: PhaseActivityInput,
-) -> PhaseActivityResult:
-    """Run one pipeline phase + its detectors, leasing connections from ``manager``.
+    identity: SourceIdentity,
+    table_ids: list[str],
+) -> PhaseRun:
+    """Run one pipeline phase scoped to ``table_ids``, leasing connections from ``manager``.
 
     Args:
         manager: the worker's single workspace-level ConnectionManager
             (Postgres + workspace DuckDB already open via ``open_lake``).
         phase_name: a key in pipeline.yaml / the phase registry (e.g. "import").
-        payload: the activity input (IDs + optional table filter).
+        identity: the source-identity header carried by the workflow.
+        table_ids: the phase's table scope. ``[]`` = source-wide (import,
+            semantic_per_column); a single typed id for the analytics phases.
     """
     # Anti-footgun for the deferred multi-workspace isolation (DAT-364): the
     # worker is bound to exactly one workspace, so a payload addressed to a
@@ -56,12 +90,11 @@ def run_phase_activity(
     # non-retryable PhaseFailed in the activity wrapper). Today workspace_id is
     # decorative; this becomes the routing key when isolation lands.
     active_workspace_id = get_active_workspace_id()
-    if payload.workspace_id != active_workspace_id:
-        return PhaseActivityResult(
-            phase=phase_name,
+    if identity.workspace_id != active_workspace_id:
+        return PhaseRun(
             status=PhaseStatus.FAILED.value,
             error=(
-                f"Workspace mismatch: payload targets '{payload.workspace_id}' "
+                f"Workspace mismatch: payload targets '{identity.workspace_id}' "
                 f"but this worker is bound to '{active_workspace_id}'. Refusing "
                 "to run to avoid a cross-workspace miswrite (DAT-364)."
             ),
@@ -69,53 +102,44 @@ def run_phase_activity(
 
     phase_cls = get_phase_class(phase_name)
     if phase_cls is None:
-        return PhaseActivityResult(
-            phase=phase_name,
+        return PhaseRun(
             status=PhaseStatus.FAILED.value,
             error=f"Unknown phase '{phase_name}' — not in the phase registry.",
         )
     phase = phase_cls()
 
     # Lease a scoped session + DuckDB cursor for the phase body. session_scope
-    # commits on clean exit (so the phase's writes are visible to the detector
-    # scope below); duckdb_cursor closes the derived cursor on exit.
+    # commits on clean exit (so the phase's writes are visible to later
+    # activities); duckdb_cursor closes the derived cursor on exit.
     with manager.session_scope() as session, manager.duckdb_cursor() as cursor:
-        source = session.get(Source, payload.source_id)
+        source = session.get(Source, identity.source_id)
         if source is None:
-            return PhaseActivityResult(
-                phase=phase_name,
+            return PhaseRun(
                 status=PhaseStatus.FAILED.value,
                 error=(
-                    f"Source '{payload.source_id}' not found in workspace "
-                    f"'{payload.workspace_id}'. begin_session / the workflow caller "
-                    "must write the Source row before the phase runs."
+                    f"Source '{identity.source_id}' not found in workspace "
+                    f"'{identity.workspace_id}'. The workflow caller must write the "
+                    "Source row before the phase runs."
                 ),
             )
-        config = _build_phase_config(source, phase_name, payload)
+        config = _build_phase_config(source, phase_name, identity)
         ctx = PhaseContext(
             session=session,
             duckdb_conn=cursor,
-            source_id=payload.source_id,
-            table_ids=list(payload.table_ids),
+            source_id=identity.source_id,
+            table_ids=list(table_ids),
             config=config,
             session_factory=manager.session_scope,
             manager=manager,
-            session_id=payload.session_id,
+            session_id=identity.session_id,
         )
 
         skip_reason = phase.should_skip(ctx)
         if skip_reason:
             logger.info("activity.phase_skipped", phase=phase_name, reason=skip_reason)
-            return PhaseActivityResult(
-                phase=phase_name,
-                status=PhaseStatus.SKIPPED.value,
-                summary=skip_reason,
-            )
+            return PhaseRun(status=PhaseStatus.SKIPPED.value, summary=skip_reason)
 
         result = phase.run(ctx)
-
-    if result.status == PhaseStatus.COMPLETED:
-        _run_detectors(manager, phase_name, payload)
 
     logger.info(
         "activity.phase_done",
@@ -123,29 +147,102 @@ def run_phase_activity(
         status=result.status.value,
         duration=result.duration_seconds,
     )
-    return PhaseActivityResult(
-        phase=phase_name,
+    return PhaseRun(
         status=result.status.value,
         summary=result.summary,
-        records_processed=result.records_processed,
-        records_created=result.records_created,
-        outputs=result.outputs or {},
-        warnings=result.warnings,
         error=result.error,
     )
+
+
+def raw_table_ids(manager: ConnectionManager, source_id: str) -> list[str]:
+    """The source's raw table ids — the fan-out source the parent needs.
+
+    Read after the ``import`` activity (run or skipped), so the parent always
+    has the authoritative set regardless of whether import did fresh work.
+    """
+    with manager.session_scope() as session:
+        rows = session.execute(
+            select(Table.table_id).where(Table.source_id == source_id, Table.layer == "raw")
+        )
+        return [row[0] for row in rows]
+
+
+def typed_table_id_for_raw(
+    manager: ConnectionManager,
+    source_id: str,
+    raw_table_id: str,
+) -> str | None:
+    """Resolve the typed table id ``typing`` produced for one raw table.
+
+    Typing creates the typed table under the same ``table_name`` as its raw
+    input, so the mapping is by name. Returns the persisted id whether typing
+    just minted it or it already existed (skip path) — ``None`` if neither the
+    raw row nor its typed table is present.
+    """
+    with manager.session_scope() as session:
+        raw = session.get(Table, raw_table_id)
+        if raw is None:
+            return None
+        return session.execute(
+            select(Table.table_id).where(
+                Table.source_id == source_id,
+                Table.table_name == raw.table_name,
+                Table.layer == "typed",
+            )
+        ).scalar_one_or_none()
+
+
+def run_table_detectors(
+    manager: ConnectionManager,
+    identity: SourceIdentity,
+    table_id: str,
+) -> int:
+    """Run the table-local detectors scoped to one typed table.
+
+    The stage-level replacement for the per-phase detector post-steps (DAT-370):
+    runs the union of the detectors the table-local phases declare in
+    pipeline.yaml, each scoped to ``table_id`` via ``run_detector_post_step``'s
+    ``table_ids`` filter. Scoping the delete-before-insert to the single table is
+    what lets parallel child workflows run their detectors without colliding on
+    the shared ``(source_id, detector_id)`` rows.
+    """
+    declarations = load_phase_declarations()
+    detector_ids: list[str] = []
+    for phase_name in _TABLE_LOCAL_PHASES:
+        decl = declarations.get(phase_name)
+        if not decl:
+            continue
+        for detector_id in decl.detectors:
+            if detector_id not in detector_ids:
+                detector_ids.append(detector_id)
+
+    if not detector_ids:
+        return 0
+
+    total = 0
+    with manager.session_scope() as session, manager.duckdb_cursor() as cursor:
+        for detector_id in detector_ids:
+            total += run_detector_post_step(
+                session,
+                identity.source_id,
+                detector_id,
+                cursor,
+                session_id=identity.session_id,
+                table_ids=[table_id],
+            )
+    return total
 
 
 def _build_phase_config(
     source: Source,
     phase_name: str,
-    payload: PhaseActivityInput,
+    identity: SourceIdentity,
 ) -> dict[str, Any]:
     """Reconstruct ``ctx.config`` = phase static config + source-identity runtime config.
 
-    Mirrors the ``phase_config | runtime_config`` merge ``setup_pipeline`` does,
+    Mirrors the ``phase_config | runtime_config`` merge ``setup_pipeline`` did,
     minus the PipelineRun-only fields (fingerprint, source_path) the worker path
-    doesn't carry. The caller (:func:`run_phase_activity`) guarantees ``source``
-    exists.
+    doesn't carry. The caller (:func:`run_phase`) guarantees ``source`` exists.
     """
     runtime_config: dict[str, Any] = {
         "source_id": source.source_id,
@@ -153,37 +250,10 @@ def _build_phase_config(
         "source_type": source.source_type,
         "source_connection_config": source.connection_config or {},
         "source_backend": source.backend,
-        "vertical": payload.vertical or "_adhoc",
+        "vertical": identity.vertical or "_adhoc",
     }
 
     config: dict[str, Any] = {}
     config.update(load_phase_config(phase_name))
     config.update(runtime_config)
     return config
-
-
-def _run_detectors(
-    manager: ConnectionManager,
-    phase_name: str,
-    payload: PhaseActivityInput,
-) -> None:
-    """Run the phase's pipeline.yaml-declared detectors as post-steps.
-
-    Each detector gets a fresh session + cursor scope, so it observes the
-    committed phase output.
-    """
-    declarations = load_phase_declarations()
-    decl = declarations.get(phase_name)
-    detector_ids = decl.detectors if decl else []
-    if not detector_ids:
-        return
-
-    with manager.session_scope() as session, manager.duckdb_cursor() as cursor:
-        for detector_id in detector_ids:
-            run_detector_post_step(
-                session,
-                payload.source_id,
-                detector_id,
-                cursor,
-                session_id=payload.session_id,
-            )

--- a/packages/engine/src/dataraum/worker/contracts.py
+++ b/packages/engine/src/dataraum/worker/contracts.py
@@ -1,44 +1,118 @@
-"""Worker I/O contracts (DAT-344) — the Pydantic shapes crossing the Temporal boundary.
+"""Worker I/O contracts (DAT-344, redesigned per-boundary in DAT-370).
 
 Deliberately engine-free: imports nothing but Pydantic. Both the activity runner
 (:mod:`dataraum.worker.activity`, which pulls in the whole engine) and the
-workflow (:mod:`dataraum.worker.workflows`, which runs in Temporal's
-determinism sandbox) import these models from here — so the workflow module
-never drags SQLAlchemy/DuckDB/the registry into the sandbox.
+workflows (:mod:`dataraum.worker.workflows`, which run in Temporal's determinism
+sandbox) import these models from here — so the workflow module never drags
+SQLAlchemy/DuckDB/the registry into the sandbox.
+
+The shapes are **typed per boundary**, not one uniform envelope: ``import``
+discovers raw tables, ``typing`` mints a typed id, the analytics phases are
+scoped to a single typed table, and the workflows thread an identity header. The
+scheduler-era ``PhaseActivityInput``/``PhaseActivityResult`` god-envelope (one
+shape for all phases, with a ``table_ids`` field downstream phases ignored) is
+gone — the fan-out (DAT-370) made the per-boundary inputs concrete.
 """
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
-class PhaseActivityInput(BaseModel):
-    """Pydantic input for a phase activity — IDs only, serialized over Temporal.
+class SourceIdentity(BaseModel):
+    """The identity header the workflows carry into every activity.
 
-    The runner reconstructs everything else (source identity, phase config) from
-    these IDs + the workspace substrate, mirroring what ``setup_pipeline``
-    assembles in-process today.
+    Pure data — IDs the runner uses to reconstruct source identity + phase
+    config from the workspace substrate. ``session_id`` is the per-run FK for
+    session-scoped rows (the workflow execution processing the source), NOT a
+    connection scope. ``workspace_id`` is the (future, DAT-364) routing key the
+    runner checks against the worker's bound workspace.
     """
 
     workspace_id: str
     source_id: str
-    # Per-run FK for session-scoped rows (e.g. the type_fidelity detector's
-    # EntropyObjectRecord). Pure data — NOT a connection scope. In the platform
-    # model this is the workflow execution processing the source.
     session_id: str
     vertical: str | None = None
-    # Optional table filter (DAT-342). Empty = all of the source's raw tables.
-    table_ids: list[str] = Field(default_factory=list)
 
 
-class PhaseActivityResult(BaseModel):
-    """Serializable phase outcome returned across the Temporal boundary."""
+class PhaseOutcome(BaseModel):
+    """Lean per-activity result: outcome + human summary.
 
-    phase: str
+    Returned by the activities that don't mint an id (the analytics phases,
+    ``detect_table``, ``semantic_per_column``). A deterministic phase *failure*
+    never travels in here — it is raised as a non-retryable ``ApplicationError``
+    by the activity wrapper — so a returned outcome is always ``completed`` or
+    ``skipped``. Carries no ``table_ids``/``outputs`` god-fields.
+    """
+
     status: str
     summary: str = ""
-    records_processed: int = 0
-    records_created: int = 0
-    outputs: dict[str, object] = Field(default_factory=dict)
-    warnings: list[str] = Field(default_factory=list)
-    error: str | None = None
+
+
+class ImportResult(BaseModel):
+    """``import`` activity result — the discovered raw table ids (the fan-out source).
+
+    Authoritative whether import ran or was skipped (source already imported):
+    the activity reads the source's raw tables from the substrate, so the parent
+    always has the ids it needs to fan out.
+    """
+
+    raw_table_ids: list[str]
+
+
+class ProcessTableInput(BaseModel):
+    """Input to ``ProcessTableWorkflow`` (and its ``typing`` activity).
+
+    One raw table is the unit of work; the child workflow runs the table-local
+    chain over it.
+    """
+
+    identity: SourceIdentity
+    raw_table_id: str
+
+
+class TypingResult(BaseModel):
+    """``typing`` activity result — the freshly minted (or resolved) typed id.
+
+    ``typing`` mints a uuid4 typed id ``!=`` the raw id. It travels in this
+    result, so it is persisted in Temporal history and replayed verbatim — the
+    downstream analytics activities read it from the child workflow, never
+    recompute it.
+    """
+
+    typed_table_id: str
+
+
+class TableScopedInput(BaseModel):
+    """Input to the analytics activities + ``detect_table`` — one typed table.
+
+    ``table_id`` is the *typed* table id from :class:`TypingResult`; the phase
+    scopes its work (and the detect step its measurements) to exactly this table.
+    """
+
+    identity: SourceIdentity
+    table_id: str
+
+
+class ProcessTableResult(BaseModel):
+    """``ProcessTableWorkflow`` result — the raw→typed mapping for one table."""
+
+    raw_table_id: str
+    typed_table_id: str
+
+
+class AddSourceInput(BaseModel):
+    """Input to ``AddSourceWorkflow`` — just the source identity.
+
+    The table set is unknown until ``import`` enumerates it (a source is a dir /
+    DB recipe), so the parent carries identity only and discovers tables at run.
+    """
+
+    identity: SourceIdentity
+
+
+class AddSourceResult(BaseModel):
+    """``AddSourceWorkflow`` result — the discovered raw tables + per-table outcomes."""
+
+    raw_table_ids: list[str]
+    tables: list[ProcessTableResult]

--- a/packages/engine/src/dataraum/worker/main.py
+++ b/packages/engine/src/dataraum/worker/main.py
@@ -30,7 +30,7 @@ from dataraum.worker.bootstrap import (
     bootstrap_worker_substrate,
     shutdown_worker_substrate,
 )
-from dataraum.worker.workflows import AddSourceWorkflow
+from dataraum.worker.workflows import AddSourceWorkflow, ProcessTableWorkflow
 
 logger = get_logger(__name__)
 
@@ -76,7 +76,7 @@ async def run_worker() -> None:
             worker = Worker(
                 client,
                 task_queue=task_queue,
-                workflows=[AddSourceWorkflow],
+                workflows=[AddSourceWorkflow, ProcessTableWorkflow],
                 activities=[
                     phase_activities.run_import,
                     phase_activities.run_typing,
@@ -84,6 +84,7 @@ async def run_worker() -> None:
                     phase_activities.run_column_eligibility,
                     phase_activities.run_statistical_quality,
                     phase_activities.run_temporal,
+                    phase_activities.run_detect_table,
                     phase_activities.run_semantic_per_column,
                 ],
                 activity_executor=executor,
@@ -106,7 +107,7 @@ async def run_worker() -> None:
                 task_queue=task_queue,
                 namespace=namespace,
                 host=host,
-                workflows=["addSourceWorkflow"],
+                workflows=["addSourceWorkflow", "processTableWorkflow"],
                 activities=[
                     "import",
                     "typing",
@@ -114,6 +115,7 @@ async def run_worker() -> None:
                     "column_eligibility",
                     "statistical_quality",
                     "temporal",
+                    "detect_table",
                     "semantic_per_column",
                 ],
             )

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -1,25 +1,49 @@
-"""Temporal workflows (DAT-344) — orchestration, authored in Python.
+"""Temporal workflows (DAT-344; per-table fan-out DAT-370) — orchestration in Python.
 
 Runs in Temporal's determinism sandbox, so this module imports ONLY
-``temporalio`` + the engine-free :mod:`dataraum.worker.contracts` shapes (pulled
-through the sandbox via ``imports_passed_through``). It calls activities by
-their registered string names (``import`` / ``typing``) — it never imports the
-activity implementations, which would drag the engine into the sandbox.
+``temporalio`` + ``asyncio`` + the engine-free :mod:`dataraum.worker.contracts`
+shapes (pulled through the sandbox via ``imports_passed_through``). It calls
+activities by their registered string names — it never imports the activity
+implementations, which would drag the engine into the sandbox.
 
-The activities run on the same worker + task queue (bundled — Temporal's
-recommended default; split onto a dedicated activity task queue later if heavy
-phases need independent scaling).
+Topology (DAT-370): the table is the unit of work.
+
+    AddSourceWorkflow(identity)                              [parent]
+      import()                  -> raw table ids             (source-level enumerator)
+      fan-out via asyncio.gather:
+        ProcessTableWorkflow(raw_id) for each raw id         [child, per table]
+      semantic_per_column()                                  (source-level reduce)
+
+    ProcessTableWorkflow(raw_table_id)                       [child]
+      typing(raw_id) -> typed_id
+      statistics -> column_eligibility -> statistical_quality -> temporal   (typed_id)
+      detect_table(typed_id)                                 (stage-level detectors)
+
+The child gives per-table history isolation + bounded parent history, and
+``typed_id`` is threaded through the child's messages (persisted in history,
+replayed verbatim). Detectors run once at the tail of the stage, scoped to the
+child's typed table — not per phase (DAT-370).
 """
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
 with workflow.unsafe.imports_passed_through():
-    from dataraum.worker.contracts import PhaseActivityInput, PhaseActivityResult
+    from dataraum.worker.contracts import (
+        AddSourceInput,
+        AddSourceResult,
+        ImportResult,
+        PhaseOutcome,
+        ProcessTableInput,
+        ProcessTableResult,
+        TableScopedInput,
+        TypingResult,
+    )
 
 # A deterministic phase failure is raised by the activity as a non-retryable
 # ApplicationError of this type; transient failures (e.g. a DuckLake
@@ -27,43 +51,101 @@ with workflow.unsafe.imports_passed_through():
 _RETRY = RetryPolicy(maximum_attempts=5, non_retryable_error_types=["PhaseFailed"])
 _TIMEOUT = timedelta(minutes=10)
 
-# The slice-1 table-local chain, in dependency order. Each phase runs once over
-# all of the source's tables (per-table fan-out + column batching is E4b-2,
-# DAT-370). ``relationships`` + ``semantic_per_table`` are the cross-table
-# slice-2 cut — deliberately absent. Activities are called by these registered
-# string names; the workflow never imports their implementations.
-_SLICE1_PHASES = (
-    "import",
-    "typing",
+# The table-local analytics phases, in dependency order. ``typing`` precedes
+# them (it mints the typed id); ``detect_table`` follows (stage-level detectors).
+_ANALYTICS_PHASES = (
     "statistics",
     "column_eligibility",
     "statistical_quality",
     "temporal",
-    "semantic_per_column",
 )
+
+
+@workflow.defn(name="processTableWorkflow")
+class ProcessTableWorkflow:
+    """Run the table-local chain for one raw table, then complete.
+
+    ``typing`` mints the typed id; the analytics phases run scoped to it; a
+    single stage-level ``detect_table`` runs the table-local detectors scoped to
+    the same typed table. The typed id travels in the activity results, so it is
+    in history and replayed verbatim — never recomputed.
+    """
+
+    @workflow.run
+    async def run(self, payload: ProcessTableInput) -> ProcessTableResult:
+        typing = await workflow.execute_activity(
+            "typing",
+            payload,
+            result_type=TypingResult,
+            start_to_close_timeout=_TIMEOUT,
+            retry_policy=_RETRY,
+        )
+        scoped = TableScopedInput(identity=payload.identity, table_id=typing.typed_table_id)
+        for phase in _ANALYTICS_PHASES:
+            await workflow.execute_activity(
+                phase,
+                scoped,
+                result_type=PhaseOutcome,
+                start_to_close_timeout=_TIMEOUT,
+                retry_policy=_RETRY,
+            )
+        await workflow.execute_activity(
+            "detect_table",
+            scoped,
+            result_type=PhaseOutcome,
+            start_to_close_timeout=_TIMEOUT,
+            retry_policy=_RETRY,
+        )
+        return ProcessTableResult(
+            raw_table_id=payload.raw_table_id,
+            typed_table_id=typing.typed_table_id,
+        )
 
 
 @workflow.defn(name="addSourceWorkflow")
 class AddSourceWorkflow:
-    """Run the full slice-1 table-local pipeline for one source, then complete.
+    """Import one source, fan out a child workflow per raw table, then reduce.
 
-    Drives :data:`_SLICE1_PHASES` sequentially — the order is a valid
-    topological sort of the pipeline.yaml dependencies (typing reads import's raw
-    tables, statistics reads typed tables, …). Completes after
-    ``semantic_per_column``; there is **no** teach wait (the in-loop
-    signal/wait + typing replay is DAT-343, built on the ``typing`` activity).
+    ``import`` enumerates the source's raw tables (the table set is unknown until
+    it runs); the workflow fans out one :class:`ProcessTableWorkflow` per raw id
+    via ``asyncio.gather`` and waits for all to complete; then
+    ``semantic_per_column`` runs once as the source-level reduce. The data-
+    dependent fan-out is driven off ``import``'s recorded result, so replay is
+    deterministic. There is **no** teach wait (that is DAT-343).
     """
 
     @workflow.run
-    async def run(self, payload: PhaseActivityInput) -> list[PhaseActivityResult]:
-        results: list[PhaseActivityResult] = []
-        for phase in _SLICE1_PHASES:
-            result = await workflow.execute_activity(
-                phase,
-                payload,
-                result_type=PhaseActivityResult,
-                start_to_close_timeout=_TIMEOUT,
-                retry_policy=_RETRY,
+    async def run(self, payload: AddSourceInput) -> AddSourceResult:
+        imported = await workflow.execute_activity(
+            "import",
+            payload.identity,
+            result_type=ImportResult,
+            start_to_close_timeout=_TIMEOUT,
+            retry_policy=_RETRY,
+        )
+
+        # Per-table fan-out. Deterministic, collision-free child ids keep replay
+        # stable; ParentClosePolicy stays the SDK default TERMINATE — the parent
+        # always gathers its children to completion, so there are no orphans.
+        children = [
+            workflow.execute_child_workflow(
+                ProcessTableWorkflow.run,
+                ProcessTableInput(identity=payload.identity, raw_table_id=raw_id),
+                id=f"addsource-{payload.identity.source_id}-table-{raw_id}",
             )
-            results.append(result)
-        return results
+            for raw_id in imported.raw_table_ids
+        ]
+        tables: list[ProcessTableResult] = list(await asyncio.gather(*children))
+
+        # Source-level reduce: ontology induction is source-global, so it runs
+        # once over all tables after the fan-out (moves to the frame workflow
+        # later; not a blocker here).
+        await workflow.execute_activity(
+            "semantic_per_column",
+            payload.identity,
+            result_type=PhaseOutcome,
+            start_to_close_timeout=_TIMEOUT,
+            retry_policy=_RETRY,
+        )
+
+        return AddSourceResult(raw_table_ids=imported.raw_table_ids, tables=tables)

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -53,6 +53,8 @@ _TIMEOUT = timedelta(minutes=10)
 
 # The table-local analytics phases, in dependency order. ``typing`` precedes
 # them (it mints the typed id); ``detect_table`` follows (stage-level detectors).
+# The detect step aggregates detectors over ``activity._TABLE_LOCAL_PHASES`` =
+# ``("typing", *_ANALYTICS_PHASES)``; ``test_phase_constants.py`` pins the link.
 _ANALYTICS_PHASES = (
     "statistics",
     "column_eligibility",
@@ -125,8 +127,13 @@ class AddSourceWorkflow:
         )
 
         # Per-table fan-out. Deterministic, collision-free child ids keep replay
-        # stable; ParentClosePolicy stays the SDK default TERMINATE — the parent
-        # always gathers its children to completion, so there are no orphans.
+        # stable; ParentClosePolicy is TERMINATE (execute_child_workflow's own
+        # default) — the parent always gathers its children to completion, so
+        # there are no orphans in the happy path. On a permanent child failure
+        # gather propagates, the parent ends, and Temporal terminates the
+        # in-flight siblings; a parent retry resumes each child idempotently via
+        # the phases' should_skip (each phase commits atomically in one
+        # session_scope, so there are no partial-write rows to confuse it).
         children = [
             workflow.execute_child_workflow(
                 ProcessTableWorkflow.run,

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -1,40 +1,57 @@
-"""Integration test for the Temporal activity-worker substrate (DAT-344, P1).
+"""Integration test for the Temporal activity-worker substrate (DAT-344; DAT-370).
 
-This is the de-risk slice's core assertion: a single workspace-level
-``ConnectionManager`` (the one a worker holds for its whole life) can run two
-real phases — ``import`` then ``typing`` — as *separate* ``run_phase_activity``
-calls, with the DuckLake ``:memory:`` anchor + the manager's DuckDB connection
-surviving across both, and raw + typed tables landing in the lake. It runs
-against the testcontainer Postgres + a real DuckLake (``lake_anchor``), not
-SQLite or mocks — the substrate reconstitution is exactly what's under test.
+The de-risk slice's core assertion: a single workspace-level ``ConnectionManager``
+(the one a worker holds for its whole life) runs the real phases as separate
+``run_phase`` calls, with the DuckLake ``:memory:`` anchor + the manager's DuckDB
+connection surviving across them and rows landing in the lake. It runs against
+the testcontainer Postgres + a real DuckLake (``lake_anchor``), not SQLite or
+mocks — the substrate reconstitution is exactly what's under test.
+
+DAT-370 makes the table the unit of work: ``import`` enumerates raw tables,
+``typing`` mints one typed id per raw table, the analytics phases run scoped to a
+single typed table, and ``detect_table`` runs the table-local detectors scoped to
+that table. These tests drive that per-table path directly (the production
+workflows fan it out across child workflows).
 """
 
 from __future__ import annotations
 
 import os
+from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 
 from dataraum.core.connections import ConnectionConfig, ConnectionManager
+from dataraum.entropy.db_models import EntropyObjectRecord
 from dataraum.investigation.db_models import InvestigationSession
 from dataraum.storage import Source
-from dataraum.worker import PhaseActivityInput, run_phase_activity
+from dataraum.worker import (
+    SourceIdentity,
+    raw_table_ids,
+    run_phase,
+    run_table_detectors,
+    typed_table_id_for_raw,
+)
 
-# The table-local analytics chain wrapped as activities in E4b (DAT-368), in
-# dependency order. ``semantic_per_column`` (the first LLM phase) is exercised
-# separately, gated behind a real key.
-_SLICE1_ANALYTICS_CHAIN = (
-    "import",
-    "typing",
+# The table-local analytics phases wrapped as activities, in dependency order.
+# ``typing`` precedes them (it mints the typed id); ``detect_table`` follows.
+# ``semantic_per_column`` (the source-level LLM reduce) is exercised separately,
+# gated behind a real key.
+_ANALYTICS_PHASES = (
     "statistics",
     "column_eligibility",
     "statistical_quality",
     "temporal",
 )
+
+# The table-local detectors the stage-level detect step runs (pipeline.yaml:
+# type_fidelity from typing, null_ratio from statistics).
+_TABLE_LOCAL_DETECTORS = {"type_fidelity", "null_ratio"}
 
 _LIVE_LLM_ENV = "DATARAUM_LIVE_LLM_TEST"
 
@@ -52,6 +69,10 @@ def worker_manager(pg_url_clean: str, lake_anchor, lake_clean):  # noqa: ANN001
     manager.open_lake()
     yield manager
     manager.close()
+
+
+def _identity(source_id: str, session_id: str) -> SourceIdentity:
+    return SourceIdentity(workspace_id="test", source_id=source_id, session_id=session_id)
 
 
 def _seed_source_and_session(
@@ -97,10 +118,38 @@ def _lake_tables(manager: ConnectionManager, schema: str) -> list[str]:
     return [r[0] for r in rows]
 
 
+def _process_one_table(
+    manager: ConnectionManager,
+    identity: SourceIdentity,
+    raw_table_id: str,
+) -> str:
+    """Run the table-local chain for one raw table — the ProcessTableWorkflow body.
+
+    typing(raw) -> typed_id -> analytics phases (typed_id) -> detect_table(typed_id).
+    Returns the typed table id. Asserts each step completed.
+    """
+    typing = run_phase(manager, "typing", identity, [raw_table_id])
+    assert typing.status == "completed", f"typing failed: {typing.error}"
+
+    typed_id = typed_table_id_for_raw(manager, identity.source_id, raw_table_id)
+    assert typed_id is not None, f"no typed table for raw {raw_table_id}"
+    assert typed_id != raw_table_id, "typed id must differ from the raw id"
+
+    for phase in _ANALYTICS_PHASES:
+        result = run_phase(manager, phase, identity, [typed_id])
+        # SKIPPED is a valid per-table outcome (e.g. temporal on a table with no
+        # date columns); only FAILED is an error. The activity wrapper likewise
+        # only raises on FAILED.
+        assert result.status in ("completed", "skipped"), f"{phase} failed: {result.error}"
+
+    run_table_detectors(manager, identity, typed_id)
+    return typed_id
+
+
 def test_import_then_typing_share_one_manager(
     worker_manager: ConnectionManager, tmp_path: Path
 ) -> None:
-    """import + typing run as two activities on one manager; anchor survives both."""
+    """import + typing run as two phases on one manager; the anchor survives both."""
     csv = tmp_path / "orders.csv"
     csv.write_text(
         "id,amount,booked_on\n1,10.50,2024-01-01\n2,20.00,2024-01-02\n3,30.25,2024-01-03\n"
@@ -108,155 +157,182 @@ def test_import_then_typing_share_one_manager(
     source_id = str(uuid4())
     session_id = str(uuid4())
     _seed_source_and_session(worker_manager, source_id, session_id, "orders", csv)
+    identity = _identity(source_id, session_id)
 
-    payload = PhaseActivityInput(workspace_id="test", source_id=source_id, session_id=session_id)
-
-    # Activity 1: import (no LLM, no prereq) — raw tables land.
-    import_result = run_phase_activity(worker_manager, "import", payload)
+    # import (no LLM, no prereq) — raw tables land; the source's raw ids are the
+    # fan-out source the parent reads.
+    import_result = run_phase(worker_manager, "import", identity, [])
     assert import_result.status == "completed", import_result.error
-    assert import_result.outputs.get("raw_tables"), "import produced no raw tables"
+    raw_ids = raw_table_ids(worker_manager, source_id)
+    assert raw_ids, "import produced no raw tables"
     assert _lake_tables(worker_manager, "raw"), "no tables in lake.raw after import"
 
-    # The DuckLake connection the worker holds is reused — not reopened — for
-    # the next activity. Capture identity to prove the anchor/connection
-    # survived across the activity boundary.
+    # The DuckLake connection the worker holds is reused — not reopened — for the
+    # next phase. Capture identity to prove the anchor survived the boundary.
     duckdb_conn_after_import = worker_manager._duckdb_conn  # noqa: SLF001
 
-    # Activity 2: typing (DuckDB-heavy; runs the type_fidelity detector, which
-    # writes session-scoped EntropyObjectRecord rows — exercises the session_id
-    # FK + the cursor lifecycle on the SAME long-lived manager).
-    typing_result = run_phase_activity(worker_manager, "typing", payload)
+    # typing scoped to the single raw table (DuckDB-heavy; runs on the SAME
+    # long-lived manager).
+    typing_result = run_phase(worker_manager, "typing", identity, [raw_ids[0]])
     assert typing_result.status == "completed", typing_result.error
     assert _lake_tables(worker_manager, "typed"), "no tables in lake.typed after typing"
+    assert typed_table_id_for_raw(worker_manager, source_id, raw_ids[0]) is not None
 
     assert worker_manager._duckdb_conn is duckdb_conn_after_import, (  # noqa: SLF001
-        "worker DuckDB connection was reopened between activities — the anchor "
-        "lifecycle did not survive the activity boundary"
+        "worker DuckDB connection was reopened between phases — the anchor "
+        "lifecycle did not survive the phase boundary"
     )
 
 
-def test_unknown_phase_returns_failed(worker_manager: ConnectionManager, tmp_path: Path) -> None:
+def test_unknown_phase_returns_failed(worker_manager: ConnectionManager) -> None:
     """A phase name not in the registry fails cleanly rather than raising."""
-    payload = PhaseActivityInput(
-        workspace_id="test", source_id=str(uuid4()), session_id=str(uuid4())
-    )
-    result = run_phase_activity(worker_manager, "does_not_exist", payload)
+    identity = _identity(str(uuid4()), str(uuid4()))
+    result = run_phase(worker_manager, "does_not_exist", identity, [])
     assert result.status == "failed"
     assert "does_not_exist" in (result.error or "")
 
 
-def test_slice1_analytics_chain_runs(
+def test_workspace_mismatch_fails_loud(worker_manager: ConnectionManager) -> None:
+    """A payload addressed to another workspace is refused before any work.
+
+    Anti-footgun for the deferred multi-workspace isolation (DAT-364): the worker
+    is bound to one workspace (``"test"`` under the conftest pointer), so a
+    mismatched ``workspace_id`` must fail rather than silently write into this
+    worker's lake/schema. FAILED here becomes a non-retryable PhaseFailed in the
+    activity wrapper.
+    """
+    identity = SourceIdentity(
+        workspace_id="some-other-workspace",
+        source_id=str(uuid4()),
+        session_id=str(uuid4()),
+    )
+    result = run_phase(worker_manager, "import", identity, [])
+    assert result.status == "failed"
+    assert "Workspace mismatch" in (result.error or "")
+    assert "some-other-workspace" in (result.error or "")
+
+
+def test_per_table_chain_runs(
     worker_manager: ConnectionManager, small_finance_path: Path
 ) -> None:
-    """The six table-local analytics activities run green on a multi-table source.
+    """The full table-local chain runs green per table on a multi-table source.
 
-    Drives each phase through ``run_phase_activity`` — the production worker path,
-    not the retired ``PipelineTestHarness`` — on the one long-lived worker
-    manager. This is the E4b assertion that the slice-1 chain (minus the LLM
-    ``semantic_per_column`` phase, exercised separately) runs end-to-end as
-    activities against a real multi-table DuckLake source.
+    Drives the production worker path (``run_phase`` + ``run_table_detectors``,
+    not the retired ``PipelineTestHarness``) on the one long-lived manager: import
+    once, then the typing→analytics→detect chain scoped per raw table — the
+    sequential shape of the ProcessTableWorkflow fan-out.
     """
     source_id = str(uuid4())
     session_id = str(uuid4())
     _seed_source_and_session(
         worker_manager, source_id, session_id, "small_finance", small_finance_path
     )
-    payload = PhaseActivityInput(workspace_id="test", source_id=source_id, session_id=session_id)
+    identity = _identity(source_id, session_id)
 
-    for phase in _SLICE1_ANALYTICS_CHAIN:
-        result = run_phase_activity(worker_manager, phase, payload)
-        assert result.status == "completed", f"{phase} failed: {result.error}"
+    assert run_phase(worker_manager, "import", identity, []).status == "completed"
+    raw_ids = raw_table_ids(worker_manager, source_id)
+    assert len(raw_ids) > 1, "expected a multi-table source"
 
-    assert _lake_tables(worker_manager, "typed"), "no typed tables after the analytics chain"
+    typed_ids = [_process_one_table(worker_manager, identity, raw_id) for raw_id in raw_ids]
+    assert len(typed_ids) == len(raw_ids)
+    assert _lake_tables(worker_manager, "typed"), "no typed tables after the chain"
+
+
+def test_parallel_tables_do_not_conflict_and_detectors_stay_table_scoped(
+    worker_manager: ConnectionManager, small_finance_path: Path
+) -> None:
+    """Per-table chains run concurrently; the stage detect step stays table-scoped.
+
+    The DAT-370 concurrency + correctness assertion. After ``import``, each raw
+    table's full chain (typing→analytics→detect) runs on its own thread — the
+    fan-out the parent does with child workflows. Each ``run_phase`` /
+    ``run_table_detectors`` call leases its own DuckDB cursor (an independent
+    channel to the shared lake), so DuckLake reconciles the writers via MVCC.
+
+    The detector step is the part the per-phase post-step couldn't do safely:
+    ``run_detector_post_step`` deletes-before-inserts on ``(source_id,
+    detector_id)``. Scoped to one table, parallel children touch only their own
+    rows — so every typed table ends up with its table-local detector records and
+    none clobbers a sibling. We assert exactly that partition.
+    """
+    source_id = str(uuid4())
+    session_id = str(uuid4())
+    _seed_source_and_session(
+        worker_manager, source_id, session_id, "small_finance", small_finance_path
+    )
+    identity = _identity(source_id, session_id)
+
+    assert run_phase(worker_manager, "import", identity, []).status == "completed"
+    raw_ids = raw_table_ids(worker_manager, source_id)
+    assert len(raw_ids) > 1, "expected a multi-table source"
+
+    # Fan the per-table chains out across threads — concurrent typing + analytics
+    # + detect against the shared lake from independent cursors.
+    with ThreadPoolExecutor(max_workers=len(raw_ids)) as executor:
+        futures = [
+            executor.submit(_process_one_table, worker_manager, identity, raw_id)
+            for raw_id in raw_ids
+        ]
+        typed_ids = {future.result() for future in futures}
+
+    assert len(typed_ids) == len(raw_ids), "each raw table maps to a distinct typed table"
+
+    # Every detector record belongs to one of this source's typed tables (no
+    # orphan / cross-table clobber), and each typed table carries the full set of
+    # table-local detectors — proof the scoped delete-before-insert didn't wipe a
+    # sibling's rows under concurrency.
+    with worker_manager.session_scope() as session:
+        rows = session.execute(
+            select(EntropyObjectRecord.table_id, EntropyObjectRecord.detector_id).where(
+                EntropyObjectRecord.source_id == source_id,
+                EntropyObjectRecord.detector_id.in_(_TABLE_LOCAL_DETECTORS),
+            )
+        ).all()
+
+    detectors_by_table: dict[str, set[str]] = defaultdict(set)
+    for table_id, detector_id in rows:
+        assert table_id in typed_ids, f"detector record for unknown table {table_id}"
+        detectors_by_table[table_id].add(detector_id)
+
+    assert set(detectors_by_table) == typed_ids, (
+        "some typed table is missing all its detector records — a concurrent "
+        "scoped delete clobbered a sibling"
+    )
+    for table_id, detectors in detectors_by_table.items():
+        assert detectors == _TABLE_LOCAL_DETECTORS, (
+            f"table {table_id} missing detectors {_TABLE_LOCAL_DETECTORS - detectors}"
+        )
 
 
 @pytest.mark.skipif(
     not os.environ.get(_LIVE_LLM_ENV),
     reason=(
         f"Set {_LIVE_LLM_ENV}=1 (with a real ANTHROPIC_API_KEY) to run the live "
-        "semantic_per_column activity — it makes real Anthropic calls."
+        "semantic_per_column reduce — it makes real Anthropic calls."
     ),
 )
-def test_semantic_per_column_activity_runs_live(
+def test_semantic_per_column_reduce_runs_live(
     worker_manager: ConnectionManager, small_finance_path: Path
 ) -> None:
-    """semantic_per_column runs as an activity end-to-end against a real LLM.
+    """semantic_per_column runs as the source-level reduce end-to-end against a real LLM.
 
     Opt-in only (real Anthropic calls). Validates provider/prompt-config
     resolution + the API key in the worker substrate — the one slice-1 activity
-    E4a could not de-risk offline.
+    E4a could not de-risk offline. It depends on statistics, so the per-table
+    chain runs first, then the source-level reduce.
     """
     source_id = str(uuid4())
     session_id = str(uuid4())
     _seed_source_and_session(
         worker_manager, source_id, session_id, "small_finance", small_finance_path
     )
-    payload = PhaseActivityInput(workspace_id="test", source_id=source_id, session_id=session_id)
+    identity = _identity(source_id, session_id)
 
-    # These are semantic_per_column's exact declared prerequisites per
-    # pipeline.yaml (it depends on statistics, not column_eligibility); run them,
-    # then the LLM phase itself.
-    for phase in ("import", "typing", "statistics", "semantic_per_column"):
-        result = run_phase_activity(worker_manager, phase, payload)
-        assert result.status == "completed", f"{phase} failed: {result.error}"
+    assert run_phase(worker_manager, "import", identity, []).status == "completed"
+    for raw_id in raw_table_ids(worker_manager, source_id):
+        assert run_phase(worker_manager, "typing", identity, [raw_id]).status == "completed"
+        typed_id = typed_table_id_for_raw(worker_manager, source_id, raw_id)
+        assert run_phase(worker_manager, "statistics", identity, [typed_id]).status == "completed"
 
-
-def test_workspace_mismatch_fails_loud(worker_manager: ConnectionManager, tmp_path: Path) -> None:
-    """A payload addressed to another workspace is refused before any work.
-
-    Anti-footgun for the deferred multi-workspace isolation (DAT-364): the
-    worker is bound to one workspace (``"test"`` under the conftest pointer), so
-    a mismatched ``workspace_id`` must fail rather than silently write into this
-    worker's lake/schema. FAILED here becomes a non-retryable PhaseFailed in the
-    activity wrapper.
-    """
-    payload = PhaseActivityInput(
-        workspace_id="some-other-workspace",
-        source_id=str(uuid4()),
-        session_id=str(uuid4()),
-    )
-    result = run_phase_activity(worker_manager, "import", payload)
-    assert result.status == "failed"
-    assert "Workspace mismatch" in (result.error or "")
-    assert "some-other-workspace" in (result.error or "")
-
-
-def test_concurrent_sources_run_on_independent_cursors(
-    worker_manager: ConnectionManager, small_finance_path: Path
-) -> None:
-    """Two sources' activities run concurrently on the one worker manager.
-
-    Each ``run_phase_activity`` leases its own DuckDB cursor — an independent
-    connection/channel to the shared lake — so concurrent activities do not
-    serialize and DuckLake reconciles the writers via MVCC. This exercises the
-    cursor-concurrency model the bundled worker relies on (DAT-368): a single
-    long-lived ``ConnectionManager`` driven by multiple activity threads.
-
-    Note: this drives ``run_phase_activity`` directly (not the ``_run`` activity
-    wrapper), so it proves cursor isolation under concurrency — the FAILED →
-    non-retryable path is covered by ``test_workspace_mismatch_fails_loud``.
-    """
-
-    def _run_chain(name: str) -> list[str]:
-        source_id = str(uuid4())
-        session_id = str(uuid4())
-        _seed_source_and_session(worker_manager, source_id, session_id, name, small_finance_path)
-        payload = PhaseActivityInput(
-            workspace_id="test", source_id=source_id, session_id=session_id
-        )
-        # import (writes lake.raw) + typing (writes lake.typed) — concurrent
-        # writers against the shared lake from two activity threads.
-        return [
-            run_phase_activity(worker_manager, phase, payload).status
-            for phase in ("import", "typing")
-        ]
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        futures = [
-            executor.submit(_run_chain, "concurrent_a"),
-            executor.submit(_run_chain, "concurrent_b"),
-        ]
-        results = [future.result() for future in futures]
-
-    for statuses in results:
-        assert statuses == ["completed", "completed"], statuses
+    result = run_phase(worker_manager, "semantic_per_column", identity, [])
+    assert result.status == "completed", f"semantic_per_column failed: {result.error}"

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -212,9 +212,7 @@ def test_workspace_mismatch_fails_loud(worker_manager: ConnectionManager) -> Non
     assert "some-other-workspace" in (result.error or "")
 
 
-def test_per_table_chain_runs(
-    worker_manager: ConnectionManager, small_finance_path: Path
-) -> None:
+def test_per_table_chain_runs(worker_manager: ConnectionManager, small_finance_path: Path) -> None:
     """The full table-local chain runs green per table on a multi-table source.
 
     Drives the production worker path (``run_phase`` + ``run_table_detectors``,

--- a/packages/engine/tests/unit/pipeline/test_typed_tables_scope.py
+++ b/packages/engine/tests/unit/pipeline/test_typed_tables_scope.py
@@ -1,0 +1,85 @@
+"""Unit tests for ``BasePhase._typed_tables`` per-table scoping (DAT-370).
+
+The four table-local analytics phases (statistics, column_eligibility,
+statistical_quality, temporal) all resolve their working set through this one
+helper. Under the per-table fan-out, ``ctx.table_ids`` carries the single typed
+table a child workflow is processing, so the helper must return exactly that
+table; an empty filter means source-wide (direct/test invocation). These cover
+that resolution directly via a constructed ``PhaseContext`` — no real profiling.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import duckdb
+from sqlalchemy.orm import Session
+
+from dataraum.pipeline.base import PhaseContext
+from dataraum.pipeline.phases.statistics_phase import StatisticsPhase
+from dataraum.storage.models import Source, Table
+
+
+def _source(session: Session) -> Source:
+    source = Source(name=f"src_{uuid4().hex[:8]}", source_type="csv")
+    session.add(source)
+    session.flush()
+    return source
+
+
+def _table(session: Session, source_id: str, name: str, layer: str) -> Table:
+    table = Table(source_id=source_id, table_name=name, layer=layer, row_count=10)
+    session.add(table)
+    session.flush()
+    return table
+
+
+def _ctx(session: Session, duck: duckdb.DuckDBPyConnection, source_id: str, table_ids: list[str]):  # noqa: ANN202
+    return PhaseContext(
+        session=session, duckdb_conn=duck, source_id=source_id, table_ids=table_ids
+    )
+
+
+def test_empty_filter_returns_all_typed_tables(
+    session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+) -> None:
+    src = _source(session)
+    raw = _table(session, src.source_id, "orders", layer="raw")
+    t1 = _table(session, src.source_id, "orders", layer="typed")
+    t2 = _table(session, src.source_id, "items", layer="typed")
+
+    resolved = StatisticsPhase()._typed_tables(_ctx(session, duckdb_conn, src.source_id, []))
+
+    ids = {t.table_id for t in resolved}
+    assert ids == {t1.table_id, t2.table_id}, "empty filter = all typed tables"
+    assert raw.table_id not in ids, "raw tables are never returned"
+
+
+def test_filter_scopes_to_the_single_requested_typed_table(
+    session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+) -> None:
+    src = _source(session)
+    t1 = _table(session, src.source_id, "orders", layer="typed")
+    _table(session, src.source_id, "items", layer="typed")
+
+    resolved = StatisticsPhase()._typed_tables(
+        _ctx(session, duckdb_conn, src.source_id, [t1.table_id])
+    )
+
+    assert [t.table_id for t in resolved] == [t1.table_id], (
+        "a per-table run must see only its own typed table, not its siblings"
+    )
+
+
+def test_filter_does_not_cross_source_boundaries(
+    session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+) -> None:
+    src_a = _source(session)
+    src_b = _source(session)
+    a1 = _table(session, src_a.source_id, "orders", layer="typed")
+    _table(session, src_b.source_id, "orders", layer="typed")
+
+    # Scoped to src_a but with no filter: only src_a's typed tables.
+    resolved = StatisticsPhase()._typed_tables(_ctx(session, duckdb_conn, src_a.source_id, []))
+
+    assert [t.table_id for t in resolved] == [a1.table_id]

--- a/packages/engine/tests/unit/pipeline/test_typed_tables_scope.py
+++ b/packages/engine/tests/unit/pipeline/test_typed_tables_scope.py
@@ -35,9 +35,7 @@ def _table(session: Session, source_id: str, name: str, layer: str) -> Table:
 
 
 def _ctx(session: Session, duck: duckdb.DuckDBPyConnection, source_id: str, table_ids: list[str]):  # noqa: ANN202
-    return PhaseContext(
-        session=session, duckdb_conn=duck, source_id=source_id, table_ids=table_ids
-    )
+    return PhaseContext(session=session, duckdb_conn=duck, source_id=source_id, table_ids=table_ids)
 
 
 def test_empty_filter_returns_all_typed_tables(

--- a/packages/engine/tests/unit/worker/fixtures/_generate_histories.py
+++ b/packages/engine/tests/unit/worker/fixtures/_generate_histories.py
@@ -1,0 +1,139 @@
+"""Regenerate the replay fixtures for the per-table workflows (DAT-370).
+
+One-off generator (NOT a test): runs ``AddSourceWorkflow`` under
+``WorkflowEnvironment.start_time_skipping()`` with stub activities, so the import
+stub returns two raw ids and the parent fans out two ``ProcessTableWorkflow``
+children. Captures the parent history (``addsource_history.json``) and one
+child's history (``processtable_history.json``) — the inputs ``test_replay.py``
+feeds through the ``Replayer`` to prove determinism offline.
+
+Run from the engine package root:
+
+    uv run python tests/unit/worker/fixtures/_generate_histories.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from temporalio import activity
+from temporalio.client import WorkflowHistory
+from temporalio.contrib.pydantic import pydantic_data_converter
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+from temporalio.worker.workflow_sandbox import (
+    SandboxedWorkflowRunner,
+    SandboxRestrictions,
+)
+
+from dataraum.worker.contracts import (
+    AddSourceInput,
+    ImportResult,
+    PhaseOutcome,
+    ProcessTableInput,
+    SourceIdentity,
+    TableScopedInput,
+    TypingResult,
+)
+from dataraum.worker.workflows import AddSourceWorkflow, ProcessTableWorkflow
+
+_HERE = Path(__file__).parent
+_SOURCE_ID = "gen-src"
+_RAW_IDS = ["raw-1", "raw-2"]
+_TASK_QUEUE = "history-gen"
+
+
+@activity.defn(name="import")
+async def stub_import(identity: SourceIdentity) -> ImportResult:
+    return ImportResult(raw_table_ids=_RAW_IDS)
+
+
+@activity.defn(name="typing")
+async def stub_typing(payload: ProcessTableInput) -> TypingResult:
+    return TypingResult(typed_table_id=f"typed-{payload.raw_table_id}")
+
+
+@activity.defn(name="statistics")
+async def stub_statistics(payload: TableScopedInput) -> PhaseOutcome:
+    return PhaseOutcome(status="completed")
+
+
+@activity.defn(name="column_eligibility")
+async def stub_column_eligibility(payload: TableScopedInput) -> PhaseOutcome:
+    return PhaseOutcome(status="completed")
+
+
+@activity.defn(name="statistical_quality")
+async def stub_statistical_quality(payload: TableScopedInput) -> PhaseOutcome:
+    return PhaseOutcome(status="completed")
+
+
+@activity.defn(name="temporal")
+async def stub_temporal(payload: TableScopedInput) -> PhaseOutcome:
+    return PhaseOutcome(status="completed")
+
+
+@activity.defn(name="detect_table")
+async def stub_detect_table(payload: TableScopedInput) -> PhaseOutcome:
+    return PhaseOutcome(status="completed")
+
+
+@activity.defn(name="semantic_per_column")
+async def stub_semantic_per_column(identity: SourceIdentity) -> PhaseOutcome:
+    return PhaseOutcome(status="completed")
+
+
+async def main() -> None:
+    async with await WorkflowEnvironment.start_time_skipping(
+        data_converter=pydantic_data_converter
+    ) as env:
+        async with Worker(
+            env.client,
+            task_queue=_TASK_QUEUE,
+            workflows=[AddSourceWorkflow, ProcessTableWorkflow],
+            activities=[
+                stub_import,
+                stub_typing,
+                stub_statistics,
+                stub_column_eligibility,
+                stub_statistical_quality,
+                stub_temporal,
+                stub_detect_table,
+                stub_semantic_per_column,
+            ],
+            workflow_runner=SandboxedWorkflowRunner(
+                restrictions=SandboxRestrictions.default.with_passthrough_modules(
+                    "dataraum", "pydantic", "pydantic_core"
+                )
+            ),
+        ):
+            identity = SourceIdentity(
+                workspace_id="gen-ws", source_id=_SOURCE_ID, session_id="gen-session"
+            )
+            handle = await env.client.start_workflow(
+                AddSourceWorkflow.run,
+                AddSourceInput(identity=identity),
+                id=f"addsource-{_SOURCE_ID}",
+                task_queue=_TASK_QUEUE,
+            )
+            await handle.result()
+
+            parent_history = await handle.fetch_history()
+            child_handle = env.client.get_workflow_handle(
+                f"addsource-{_SOURCE_ID}-table-{_RAW_IDS[0]}"
+            )
+            child_history = await child_handle.fetch_history()
+
+    _write(_HERE / "addsource_history.json", parent_history)
+    _write(_HERE / "processtable_history.json", child_history)
+    print("wrote addsource_history.json + processtable_history.json")
+
+
+def _write(path: Path, history: WorkflowHistory) -> None:
+    path.write_text(json.dumps(history.to_json_dict(), indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/engine/tests/unit/worker/fixtures/addsource_history.json
+++ b/packages/engine/tests/unit/worker/fixtures/addsource_history.json
@@ -2,14 +2,14 @@
   "events": [
     {
       "eventId": "1",
-      "eventTime": "2026-05-27T07:51:47.485Z",
+      "eventTime": "2026-05-27T19:34:20.031Z",
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
       "workflowExecutionStartedEventAttributes": {
         "workflowType": {
           "name": "addSourceWorkflow"
         },
         "taskQueue": {
-          "name": "test-add-source"
+          "name": "history-gen"
         },
         "input": {
           "payloads": [
@@ -17,16 +17,16 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "eyJ3b3Jrc3BhY2VfaWQiOiJ0ZXN0Iiwic291cmNlX2lkIjoiODFlNWU5MWMtNDA5Ny00MzA5LThkZjEtNTQxNWQ2ZTk3YjMxIiwic2Vzc2lvbl9pZCI6ImM1OTgyNDBlLTJiMWEtNDU5MC05NjU5LTJkMzljYjU2M2U3MSIsInZlcnRpY2FsIjpudWxsLCJ0YWJsZV9pZHMiOltdfQ=="
+              "data": "eyJpZGVudGl0eSI6eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9fQ=="
             }
           ]
         },
         "workflowExecutionTimeout": "315360000s",
         "workflowRunTimeout": "315360000s",
         "workflowTaskTimeout": "10s",
-        "originalExecutionRunId": "c7c2c37e-1f5d-49a0-94c8-6dc4f346fffe",
-        "identity": "420106@dataraum-context",
-        "firstExecutionRunId": "c7c2c37e-1f5d-49a0-94c8-6dc4f346fffe",
+        "originalExecutionRunId": "c21ffab9-b567-4114-9c64-8d699ac32c4d",
+        "identity": "380497@dataraum-context",
+        "firstExecutionRunId": "c21ffab9-b567-4114-9c64-8d699ac32c4d",
         "attempt": 1,
         "firstWorkflowTaskBackoff": "0s",
         "priority": {}
@@ -34,11 +34,11 @@
     },
     {
       "eventId": "2",
-      "eventTime": "2026-05-27T07:51:47.485Z",
+      "eventTime": "2026-05-27T19:34:20.031Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "test-add-source"
+          "name": "history-gen"
         },
         "startToCloseTimeout": "10s",
         "attempt": 1
@@ -46,26 +46,26 @@
     },
     {
       "eventId": "3",
-      "eventTime": "2026-05-27T07:51:47.485Z",
+      "eventTime": "2026-05-27T19:34:20.031Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "2",
-        "identity": "420106@dataraum-context"
+        "identity": "380497@dataraum-context"
       }
     },
     {
       "eventId": "4",
-      "eventTime": "2026-05-27T07:51:47.493Z",
+      "eventTime": "2026-05-27T19:34:20.036Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "2",
-        "identity": "420106@dataraum-context",
-        "binaryChecksum": "6247a044e0ccd9c7d318354ba04c32ef",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
         "sdkMetadata": {
           "coreUsedFlags": [
+            3,
             2,
-            1,
-            3
+            1
           ],
           "sdkName": "temporal-python",
           "sdkVersion": "1.27.2"
@@ -75,7 +75,7 @@
     },
     {
       "eventId": "5",
-      "eventTime": "2026-05-27T07:51:47.493Z",
+      "eventTime": "2026-05-27T19:34:20.036Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "activityTaskScheduledEventAttributes": {
         "activityId": "1",
@@ -83,7 +83,7 @@
           "name": "import"
         },
         "taskQueue": {
-          "name": "test-add-source",
+          "name": "history-gen",
           "kind": "TASK_QUEUE_KIND_NORMAL"
         },
         "header": {},
@@ -93,7 +93,7 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "eyJ3b3Jrc3BhY2VfaWQiOiJ0ZXN0Iiwic291cmNlX2lkIjoiODFlNWU5MWMtNDA5Ny00MzA5LThkZjEtNTQxNWQ2ZTk3YjMxIiwic2Vzc2lvbl9pZCI6ImM1OTgyNDBlLTJiMWEtNDU5MC05NjU5LTJkMzljYjU2M2U3MSIsInZlcnRpY2FsIjpudWxsLCJ0YWJsZV9pZHMiOltdfQ=="
+              "data": "eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9"
             }
           ]
         },
@@ -116,17 +116,17 @@
     },
     {
       "eventId": "6",
-      "eventTime": "2026-05-27T07:51:47.493Z",
+      "eventTime": "2026-05-27T19:34:20.036Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "5",
-        "identity": "420106@dataraum-context",
+        "identity": "380497@dataraum-context",
         "attempt": 1
       }
     },
     {
       "eventId": "7",
-      "eventTime": "2026-05-27T07:51:47.495Z",
+      "eventTime": "2026-05-27T19:34:20.037Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "activityTaskCompletedEventAttributes": {
         "result": {
@@ -135,22 +135,22 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "eyJwaGFzZSI6ImltcG9ydCIsInN0YXR1cyI6ImNvbXBsZXRlZCIsInN1bW1hcnkiOiJtb2NrIGltcG9ydCIsInJlY29yZHNfcHJvY2Vzc2VkIjowLCJyZWNvcmRzX2NyZWF0ZWQiOjAsIm91dHB1dHMiOnt9LCJ3YXJuaW5ncyI6W10sImVycm9yIjpudWxsfQ=="
+              "data": "eyJyYXdfdGFibGVfaWRzIjpbInJhdy0xIiwicmF3LTIiXX0="
             }
           ]
         },
         "scheduledEventId": "5",
         "startedEventId": "6",
-        "identity": "420106@dataraum-context"
+        "identity": "380497@dataraum-context"
       }
     },
     {
       "eventId": "8",
-      "eventTime": "2026-05-27T07:51:47.495Z",
+      "eventTime": "2026-05-27T19:34:20.037Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "test-add-source"
+          "name": "history-gen"
         },
         "startToCloseTimeout": "10s",
         "attempt": 1
@@ -158,103 +158,118 @@
     },
     {
       "eventId": "9",
-      "eventTime": "2026-05-27T07:51:47.495Z",
+      "eventTime": "2026-05-27T19:34:20.038Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "8",
-        "identity": "420106@dataraum-context"
+        "identity": "380497@dataraum-context"
       }
     },
     {
       "eventId": "10",
-      "eventTime": "2026-05-27T07:51:47.497Z",
+      "eventTime": "2026-05-27T19:34:20.039Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "8",
-        "identity": "420106@dataraum-context",
-        "binaryChecksum": "6247a044e0ccd9c7d318354ba04c32ef",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "11",
-      "eventTime": "2026-05-27T07:51:47.497Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
-      "activityTaskScheduledEventAttributes": {
-        "activityId": "2",
-        "activityType": {
-          "name": "typing"
+      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventType": "EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED",
+      "startChildWorkflowExecutionInitiatedEventAttributes": {
+        "namespace": "default",
+        "workflowId": "addsource-gen-src-table-raw-1",
+        "workflowType": {
+          "name": "processTableWorkflow"
         },
         "taskQueue": {
-          "name": "test-add-source",
+          "name": "history-gen",
           "kind": "TASK_QUEUE_KIND_NORMAL"
         },
-        "header": {},
         "input": {
           "payloads": [
             {
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "eyJ3b3Jrc3BhY2VfaWQiOiJ0ZXN0Iiwic291cmNlX2lkIjoiODFlNWU5MWMtNDA5Ny00MzA5LThkZjEtNTQxNWQ2ZTk3YjMxIiwic2Vzc2lvbl9pZCI6ImM1OTgyNDBlLTJiMWEtNDU5MC05NjU5LTJkMzljYjU2M2U3MSIsInZlcnRpY2FsIjpudWxsLCJ0YWJsZV9pZHMiOltdfQ=="
+              "data": "eyJpZGVudGl0eSI6eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9LCJyYXdfdGFibGVfaWQiOiJyYXctMSJ9"
             }
           ]
         },
-        "scheduleToCloseTimeout": "315360000s",
-        "scheduleToStartTimeout": "315360000s",
-        "startToCloseTimeout": "600s",
-        "heartbeatTimeout": "0s",
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "parentClosePolicy": "PARENT_CLOSE_POLICY_TERMINATE",
         "workflowTaskCompletedEventId": "9",
-        "retryPolicy": {
-          "initialInterval": "1s",
-          "backoffCoefficient": 2.0,
-          "maximumInterval": "100s",
-          "maximumAttempts": 5,
-          "nonRetryableErrorTypes": [
-            "PhaseFailed"
-          ]
-        },
+        "workflowIdReusePolicy": "WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE",
+        "header": {},
+        "memo": {},
         "priority": {}
       }
     },
     {
       "eventId": "12",
-      "eventTime": "2026-05-27T07:51:47.497Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
-      "activityTaskStartedEventAttributes": {
-        "scheduledEventId": "11",
-        "identity": "420106@dataraum-context",
-        "attempt": 1
-      }
-    },
-    {
-      "eventId": "13",
-      "eventTime": "2026-05-27T07:51:47.497Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
-      "activityTaskCompletedEventAttributes": {
-        "result": {
+      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventType": "EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED",
+      "startChildWorkflowExecutionInitiatedEventAttributes": {
+        "namespace": "default",
+        "workflowId": "addsource-gen-src-table-raw-2",
+        "workflowType": {
+          "name": "processTableWorkflow"
+        },
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
           "payloads": [
             {
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "eyJwaGFzZSI6InR5cGluZyIsInN0YXR1cyI6ImNvbXBsZXRlZCIsInN1bW1hcnkiOiJtb2NrIHR5cGluZyIsInJlY29yZHNfcHJvY2Vzc2VkIjowLCJyZWNvcmRzX2NyZWF0ZWQiOjAsIm91dHB1dHMiOnt9LCJ3YXJuaW5ncyI6W10sImVycm9yIjpudWxsfQ=="
+              "data": "eyJpZGVudGl0eSI6eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9LCJyYXdfdGFibGVfaWQiOiJyYXctMiJ9"
             }
           ]
         },
-        "scheduledEventId": "11",
-        "startedEventId": "12",
-        "identity": "420106@dataraum-context"
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "parentClosePolicy": "PARENT_CLOSE_POLICY_TERMINATE",
+        "workflowTaskCompletedEventId": "9",
+        "workflowIdReusePolicy": "WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE",
+        "header": {},
+        "memo": {},
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED",
+      "childWorkflowExecutionStartedEventAttributes": {
+        "namespace": "default",
+        "initiatedEventId": "12",
+        "workflowExecution": {
+          "workflowId": "addsource-gen-src-table-raw-2",
+          "runId": "8ae16fac-cb46-422f-9c83-7f422a768931"
+        },
+        "workflowType": {
+          "name": "processTableWorkflow"
+        }
       }
     },
     {
       "eventId": "14",
-      "eventTime": "2026-05-27T07:51:47.497Z",
+      "eventTime": "2026-05-27T19:34:20.039Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "test-add-source"
+          "name": "history-gen"
         },
         "startToCloseTimeout": "10s",
         "attempt": 1
@@ -262,207 +277,168 @@
     },
     {
       "eventId": "15",
-      "eventTime": "2026-05-27T07:51:47.497Z",
+      "eventTime": "2026-05-27T19:34:20.039Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "14",
-        "identity": "420106@dataraum-context"
+        "identity": "380497@dataraum-context"
       }
     },
     {
       "eventId": "16",
-      "eventTime": "2026-05-27T07:51:47.499Z",
+      "eventTime": "2026-05-27T19:34:20.040Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "14",
-        "identity": "420106@dataraum-context",
-        "binaryChecksum": "6247a044e0ccd9c7d318354ba04c32ef",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "17",
-      "eventTime": "2026-05-27T07:51:47.499Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
-      "activityTaskScheduledEventAttributes": {
-        "activityId": "3",
-        "activityType": {
-          "name": "statistics"
+      "eventTime": "2026-05-27T19:34:20.040Z",
+      "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED",
+      "childWorkflowExecutionStartedEventAttributes": {
+        "namespace": "default",
+        "initiatedEventId": "11",
+        "workflowExecution": {
+          "workflowId": "addsource-gen-src-table-raw-1",
+          "runId": "a39d5eda-26e8-4231-93ac-a79adad2f825"
         },
-        "taskQueue": {
-          "name": "test-add-source",
-          "kind": "TASK_QUEUE_KIND_NORMAL"
-        },
-        "header": {},
-        "input": {
-          "payloads": [
-            {
-              "metadata": {
-                "encoding": "anNvbi9wbGFpbg=="
-              },
-              "data": "eyJ3b3Jrc3BhY2VfaWQiOiJ0ZXN0Iiwic291cmNlX2lkIjoiODFlNWU5MWMtNDA5Ny00MzA5LThkZjEtNTQxNWQ2ZTk3YjMxIiwic2Vzc2lvbl9pZCI6ImM1OTgyNDBlLTJiMWEtNDU5MC05NjU5LTJkMzljYjU2M2U3MSIsInZlcnRpY2FsIjpudWxsLCJ0YWJsZV9pZHMiOltdfQ=="
-            }
-          ]
-        },
-        "scheduleToCloseTimeout": "315360000s",
-        "scheduleToStartTimeout": "315360000s",
-        "startToCloseTimeout": "600s",
-        "heartbeatTimeout": "0s",
-        "workflowTaskCompletedEventId": "15",
-        "retryPolicy": {
-          "initialInterval": "1s",
-          "backoffCoefficient": 2.0,
-          "maximumInterval": "100s",
-          "maximumAttempts": 5,
-          "nonRetryableErrorTypes": [
-            "PhaseFailed"
-          ]
-        },
-        "priority": {}
+        "workflowType": {
+          "name": "processTableWorkflow"
+        }
       }
     },
     {
       "eventId": "18",
-      "eventTime": "2026-05-27T07:51:47.499Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
-      "activityTaskStartedEventAttributes": {
-        "scheduledEventId": "17",
-        "identity": "420106@dataraum-context",
-        "attempt": 1
+      "eventTime": "2026-05-27T19:34:20.040Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "history-gen"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 2
       }
     },
     {
       "eventId": "19",
-      "eventTime": "2026-05-27T07:51:47.499Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
-      "activityTaskCompletedEventAttributes": {
+      "eventTime": "2026-05-27T19:34:20.040Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "18",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": "2026-05-27T19:34:20.042Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "18",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": "2026-05-27T19:34:20.052Z",
+      "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED",
+      "childWorkflowExecutionCompletedEventAttributes": {
         "result": {
           "payloads": [
             {
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "eyJwaGFzZSI6InN0YXRpc3RpY3MiLCJzdGF0dXMiOiJjb21wbGV0ZWQiLCJzdW1tYXJ5IjoibW9jayBzdGF0aXN0aWNzIiwicmVjb3Jkc19wcm9jZXNzZWQiOjAsInJlY29yZHNfY3JlYXRlZCI6MCwib3V0cHV0cyI6e30sIndhcm5pbmdzIjpbXSwiZXJyb3IiOm51bGx9"
+              "data": "eyJyYXdfdGFibGVfaWQiOiJyYXctMiIsInR5cGVkX3RhYmxlX2lkIjoidHlwZWQtcmF3LTIifQ=="
             }
           ]
         },
-        "scheduledEventId": "17",
-        "startedEventId": "18",
-        "identity": "420106@dataraum-context"
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "addsource-gen-src-table-raw-2",
+          "runId": "8ae16fac-cb46-422f-9c83-7f422a768931"
+        },
+        "workflowType": {
+          "name": "processTableWorkflow"
+        },
+        "initiatedEventId": "12",
+        "startedEventId": "13"
       }
     },
     {
-      "eventId": "20",
-      "eventTime": "2026-05-27T07:51:47.499Z",
+      "eventId": "22",
+      "eventTime": "2026-05-27T19:34:20.052Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "test-add-source"
+          "name": "history-gen"
         },
         "startToCloseTimeout": "10s",
         "attempt": 1
       }
     },
     {
-      "eventId": "21",
-      "eventTime": "2026-05-27T07:51:47.499Z",
+      "eventId": "23",
+      "eventTime": "2026-05-27T19:34:20.052Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
-        "scheduledEventId": "20",
-        "identity": "420106@dataraum-context"
+        "scheduledEventId": "22",
+        "identity": "380497@dataraum-context"
       }
     },
     {
-      "eventId": "22",
-      "eventTime": "2026-05-27T07:51:47.501Z",
+      "eventId": "24",
+      "eventTime": "2026-05-27T19:34:20.053Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
-        "scheduledEventId": "20",
-        "identity": "420106@dataraum-context",
-        "binaryChecksum": "6247a044e0ccd9c7d318354ba04c32ef",
+        "scheduledEventId": "22",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
-      "eventId": "23",
-      "eventTime": "2026-05-27T07:51:47.501Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
-      "activityTaskScheduledEventAttributes": {
-        "activityId": "4",
-        "activityType": {
-          "name": "column_eligibility"
-        },
-        "taskQueue": {
-          "name": "test-add-source",
-          "kind": "TASK_QUEUE_KIND_NORMAL"
-        },
-        "header": {},
-        "input": {
-          "payloads": [
-            {
-              "metadata": {
-                "encoding": "anNvbi9wbGFpbg=="
-              },
-              "data": "eyJ3b3Jrc3BhY2VfaWQiOiJ0ZXN0Iiwic291cmNlX2lkIjoiODFlNWU5MWMtNDA5Ny00MzA5LThkZjEtNTQxNWQ2ZTk3YjMxIiwic2Vzc2lvbl9pZCI6ImM1OTgyNDBlLTJiMWEtNDU5MC05NjU5LTJkMzljYjU2M2U3MSIsInZlcnRpY2FsIjpudWxsLCJ0YWJsZV9pZHMiOltdfQ=="
-            }
-          ]
-        },
-        "scheduleToCloseTimeout": "315360000s",
-        "scheduleToStartTimeout": "315360000s",
-        "startToCloseTimeout": "600s",
-        "heartbeatTimeout": "0s",
-        "workflowTaskCompletedEventId": "21",
-        "retryPolicy": {
-          "initialInterval": "1s",
-          "backoffCoefficient": 2.0,
-          "maximumInterval": "100s",
-          "maximumAttempts": 5,
-          "nonRetryableErrorTypes": [
-            "PhaseFailed"
-          ]
-        },
-        "priority": {}
-      }
-    },
-    {
-      "eventId": "24",
-      "eventTime": "2026-05-27T07:51:47.501Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
-      "activityTaskStartedEventAttributes": {
-        "scheduledEventId": "23",
-        "identity": "420106@dataraum-context",
-        "attempt": 1
-      }
-    },
-    {
       "eventId": "25",
-      "eventTime": "2026-05-27T07:51:47.502Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
-      "activityTaskCompletedEventAttributes": {
+      "eventTime": "2026-05-27T19:34:20.053Z",
+      "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED",
+      "childWorkflowExecutionCompletedEventAttributes": {
         "result": {
           "payloads": [
             {
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "eyJwaGFzZSI6ImNvbHVtbl9lbGlnaWJpbGl0eSIsInN0YXR1cyI6ImNvbXBsZXRlZCIsInN1bW1hcnkiOiJtb2NrIGNvbHVtbl9lbGlnaWJpbGl0eSIsInJlY29yZHNfcHJvY2Vzc2VkIjowLCJyZWNvcmRzX2NyZWF0ZWQiOjAsIm91dHB1dHMiOnt9LCJ3YXJuaW5ncyI6W10sImVycm9yIjpudWxsfQ=="
+              "data": "eyJyYXdfdGFibGVfaWQiOiJyYXctMSIsInR5cGVkX3RhYmxlX2lkIjoidHlwZWQtcmF3LTEifQ=="
             }
           ]
         },
-        "scheduledEventId": "23",
-        "startedEventId": "24",
-        "identity": "420106@dataraum-context"
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "addsource-gen-src-table-raw-1",
+          "runId": "a39d5eda-26e8-4231-93ac-a79adad2f825"
+        },
+        "workflowType": {
+          "name": "processTableWorkflow"
+        },
+        "initiatedEventId": "11",
+        "startedEventId": "16"
       }
     },
     {
       "eventId": "26",
-      "eventTime": "2026-05-27T07:51:47.502Z",
+      "eventTime": "2026-05-27T19:34:20.053Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "test-add-source"
+          "name": "history-gen"
         },
         "startToCloseTimeout": "10s",
         "attempt": 1
@@ -470,36 +446,36 @@
     },
     {
       "eventId": "27",
-      "eventTime": "2026-05-27T07:51:47.502Z",
+      "eventTime": "2026-05-27T19:34:20.053Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "26",
-        "identity": "420106@dataraum-context"
+        "identity": "380497@dataraum-context"
       }
     },
     {
       "eventId": "28",
-      "eventTime": "2026-05-27T07:51:47.503Z",
+      "eventTime": "2026-05-27T19:34:20.054Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "26",
-        "identity": "420106@dataraum-context",
-        "binaryChecksum": "6247a044e0ccd9c7d318354ba04c32ef",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "29",
-      "eventTime": "2026-05-27T07:51:47.503Z",
+      "eventTime": "2026-05-27T19:34:20.054Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "activityTaskScheduledEventAttributes": {
-        "activityId": "5",
+        "activityId": "2",
         "activityType": {
-          "name": "statistical_quality"
+          "name": "semantic_per_column"
         },
         "taskQueue": {
-          "name": "test-add-source",
+          "name": "history-gen",
           "kind": "TASK_QUEUE_KIND_NORMAL"
         },
         "header": {},
@@ -509,7 +485,7 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "eyJ3b3Jrc3BhY2VfaWQiOiJ0ZXN0Iiwic291cmNlX2lkIjoiODFlNWU5MWMtNDA5Ny00MzA5LThkZjEtNTQxNWQ2ZTk3YjMxIiwic2Vzc2lvbl9pZCI6ImM1OTgyNDBlLTJiMWEtNDU5MC05NjU5LTJkMzljYjU2M2U3MSIsInZlcnRpY2FsIjpudWxsLCJ0YWJsZV9pZHMiOltdfQ=="
+              "data": "eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9"
             }
           ]
         },
@@ -532,17 +508,17 @@
     },
     {
       "eventId": "30",
-      "eventTime": "2026-05-27T07:51:47.503Z",
+      "eventTime": "2026-05-27T19:34:20.054Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "29",
-        "identity": "420106@dataraum-context",
+        "identity": "380497@dataraum-context",
         "attempt": 1
       }
     },
     {
       "eventId": "31",
-      "eventTime": "2026-05-27T07:51:47.504Z",
+      "eventTime": "2026-05-27T19:34:20.055Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "activityTaskCompletedEventAttributes": {
         "result": {
@@ -551,22 +527,22 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "eyJwaGFzZSI6InN0YXRpc3RpY2FsX3F1YWxpdHkiLCJzdGF0dXMiOiJjb21wbGV0ZWQiLCJzdW1tYXJ5IjoibW9jayBzdGF0aXN0aWNhbF9xdWFsaXR5IiwicmVjb3Jkc19wcm9jZXNzZWQiOjAsInJlY29yZHNfY3JlYXRlZCI6MCwib3V0cHV0cyI6e30sIndhcm5pbmdzIjpbXSwiZXJyb3IiOm51bGx9"
+              "data": "eyJzdGF0dXMiOiJjb21wbGV0ZWQiLCJzdW1tYXJ5IjoiIn0="
             }
           ]
         },
         "scheduledEventId": "29",
         "startedEventId": "30",
-        "identity": "420106@dataraum-context"
+        "identity": "380497@dataraum-context"
       }
     },
     {
       "eventId": "32",
-      "eventTime": "2026-05-27T07:51:47.504Z",
+      "eventTime": "2026-05-27T19:34:20.055Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "test-add-source"
+          "name": "history-gen"
         },
         "startToCloseTimeout": "10s",
         "attempt": 1
@@ -574,236 +550,28 @@
     },
     {
       "eventId": "33",
-      "eventTime": "2026-05-27T07:51:47.504Z",
+      "eventTime": "2026-05-27T19:34:20.055Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "32",
-        "identity": "420106@dataraum-context"
+        "identity": "380497@dataraum-context"
       }
     },
     {
       "eventId": "34",
-      "eventTime": "2026-05-27T07:51:47.505Z",
+      "eventTime": "2026-05-27T19:34:20.055Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "32",
-        "identity": "420106@dataraum-context",
-        "binaryChecksum": "6247a044e0ccd9c7d318354ba04c32ef",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "35",
-      "eventTime": "2026-05-27T07:51:47.505Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
-      "activityTaskScheduledEventAttributes": {
-        "activityId": "6",
-        "activityType": {
-          "name": "temporal"
-        },
-        "taskQueue": {
-          "name": "test-add-source",
-          "kind": "TASK_QUEUE_KIND_NORMAL"
-        },
-        "header": {},
-        "input": {
-          "payloads": [
-            {
-              "metadata": {
-                "encoding": "anNvbi9wbGFpbg=="
-              },
-              "data": "eyJ3b3Jrc3BhY2VfaWQiOiJ0ZXN0Iiwic291cmNlX2lkIjoiODFlNWU5MWMtNDA5Ny00MzA5LThkZjEtNTQxNWQ2ZTk3YjMxIiwic2Vzc2lvbl9pZCI6ImM1OTgyNDBlLTJiMWEtNDU5MC05NjU5LTJkMzljYjU2M2U3MSIsInZlcnRpY2FsIjpudWxsLCJ0YWJsZV9pZHMiOltdfQ=="
-            }
-          ]
-        },
-        "scheduleToCloseTimeout": "315360000s",
-        "scheduleToStartTimeout": "315360000s",
-        "startToCloseTimeout": "600s",
-        "heartbeatTimeout": "0s",
-        "workflowTaskCompletedEventId": "33",
-        "retryPolicy": {
-          "initialInterval": "1s",
-          "backoffCoefficient": 2.0,
-          "maximumInterval": "100s",
-          "maximumAttempts": 5,
-          "nonRetryableErrorTypes": [
-            "PhaseFailed"
-          ]
-        },
-        "priority": {}
-      }
-    },
-    {
-      "eventId": "36",
-      "eventTime": "2026-05-27T07:51:47.505Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
-      "activityTaskStartedEventAttributes": {
-        "scheduledEventId": "35",
-        "identity": "420106@dataraum-context",
-        "attempt": 1
-      }
-    },
-    {
-      "eventId": "37",
-      "eventTime": "2026-05-27T07:51:47.505Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
-      "activityTaskCompletedEventAttributes": {
-        "result": {
-          "payloads": [
-            {
-              "metadata": {
-                "encoding": "anNvbi9wbGFpbg=="
-              },
-              "data": "eyJwaGFzZSI6InRlbXBvcmFsIiwic3RhdHVzIjoiY29tcGxldGVkIiwic3VtbWFyeSI6Im1vY2sgdGVtcG9yYWwiLCJyZWNvcmRzX3Byb2Nlc3NlZCI6MCwicmVjb3Jkc19jcmVhdGVkIjowLCJvdXRwdXRzIjp7fSwid2FybmluZ3MiOltdLCJlcnJvciI6bnVsbH0="
-            }
-          ]
-        },
-        "scheduledEventId": "35",
-        "startedEventId": "36",
-        "identity": "420106@dataraum-context"
-      }
-    },
-    {
-      "eventId": "38",
-      "eventTime": "2026-05-27T07:51:47.505Z",
-      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
-      "workflowTaskScheduledEventAttributes": {
-        "taskQueue": {
-          "name": "test-add-source"
-        },
-        "startToCloseTimeout": "10s",
-        "attempt": 1
-      }
-    },
-    {
-      "eventId": "39",
-      "eventTime": "2026-05-27T07:51:47.505Z",
-      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
-      "workflowTaskStartedEventAttributes": {
-        "scheduledEventId": "38",
-        "identity": "420106@dataraum-context"
-      }
-    },
-    {
-      "eventId": "40",
-      "eventTime": "2026-05-27T07:51:47.507Z",
-      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
-      "workflowTaskCompletedEventAttributes": {
-        "scheduledEventId": "38",
-        "identity": "420106@dataraum-context",
-        "binaryChecksum": "6247a044e0ccd9c7d318354ba04c32ef",
-        "sdkMetadata": {},
-        "meteringMetadata": {}
-      }
-    },
-    {
-      "eventId": "41",
-      "eventTime": "2026-05-27T07:51:47.507Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
-      "activityTaskScheduledEventAttributes": {
-        "activityId": "7",
-        "activityType": {
-          "name": "semantic_per_column"
-        },
-        "taskQueue": {
-          "name": "test-add-source",
-          "kind": "TASK_QUEUE_KIND_NORMAL"
-        },
-        "header": {},
-        "input": {
-          "payloads": [
-            {
-              "metadata": {
-                "encoding": "anNvbi9wbGFpbg=="
-              },
-              "data": "eyJ3b3Jrc3BhY2VfaWQiOiJ0ZXN0Iiwic291cmNlX2lkIjoiODFlNWU5MWMtNDA5Ny00MzA5LThkZjEtNTQxNWQ2ZTk3YjMxIiwic2Vzc2lvbl9pZCI6ImM1OTgyNDBlLTJiMWEtNDU5MC05NjU5LTJkMzljYjU2M2U3MSIsInZlcnRpY2FsIjpudWxsLCJ0YWJsZV9pZHMiOltdfQ=="
-            }
-          ]
-        },
-        "scheduleToCloseTimeout": "315360000s",
-        "scheduleToStartTimeout": "315360000s",
-        "startToCloseTimeout": "600s",
-        "heartbeatTimeout": "0s",
-        "workflowTaskCompletedEventId": "39",
-        "retryPolicy": {
-          "initialInterval": "1s",
-          "backoffCoefficient": 2.0,
-          "maximumInterval": "100s",
-          "maximumAttempts": 5,
-          "nonRetryableErrorTypes": [
-            "PhaseFailed"
-          ]
-        },
-        "priority": {}
-      }
-    },
-    {
-      "eventId": "42",
-      "eventTime": "2026-05-27T07:51:47.507Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
-      "activityTaskStartedEventAttributes": {
-        "scheduledEventId": "41",
-        "identity": "420106@dataraum-context",
-        "attempt": 1
-      }
-    },
-    {
-      "eventId": "43",
-      "eventTime": "2026-05-27T07:51:47.507Z",
-      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
-      "activityTaskCompletedEventAttributes": {
-        "result": {
-          "payloads": [
-            {
-              "metadata": {
-                "encoding": "anNvbi9wbGFpbg=="
-              },
-              "data": "eyJwaGFzZSI6InNlbWFudGljX3Blcl9jb2x1bW4iLCJzdGF0dXMiOiJjb21wbGV0ZWQiLCJzdW1tYXJ5IjoibW9jayBzZW1hbnRpY19wZXJfY29sdW1uIiwicmVjb3Jkc19wcm9jZXNzZWQiOjAsInJlY29yZHNfY3JlYXRlZCI6MCwib3V0cHV0cyI6e30sIndhcm5pbmdzIjpbXSwiZXJyb3IiOm51bGx9"
-            }
-          ]
-        },
-        "scheduledEventId": "41",
-        "startedEventId": "42",
-        "identity": "420106@dataraum-context"
-      }
-    },
-    {
-      "eventId": "44",
-      "eventTime": "2026-05-27T07:51:47.507Z",
-      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
-      "workflowTaskScheduledEventAttributes": {
-        "taskQueue": {
-          "name": "test-add-source"
-        },
-        "startToCloseTimeout": "10s",
-        "attempt": 1
-      }
-    },
-    {
-      "eventId": "45",
-      "eventTime": "2026-05-27T07:51:47.507Z",
-      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
-      "workflowTaskStartedEventAttributes": {
-        "scheduledEventId": "44",
-        "identity": "420106@dataraum-context"
-      }
-    },
-    {
-      "eventId": "46",
-      "eventTime": "2026-05-27T07:51:47.508Z",
-      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
-      "workflowTaskCompletedEventAttributes": {
-        "scheduledEventId": "44",
-        "identity": "420106@dataraum-context",
-        "binaryChecksum": "6247a044e0ccd9c7d318354ba04c32ef",
-        "sdkMetadata": {},
-        "meteringMetadata": {}
-      }
-    },
-    {
-      "eventId": "47",
-      "eventTime": "2026-05-27T07:51:47.508Z",
+      "eventTime": "2026-05-27T19:34:20.055Z",
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
       "workflowExecutionCompletedEventAttributes": {
         "result": {
@@ -812,11 +580,11 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "W3sicGhhc2UiOiJpbXBvcnQiLCJzdGF0dXMiOiJjb21wbGV0ZWQiLCJzdW1tYXJ5IjoibW9jayBpbXBvcnQiLCJyZWNvcmRzX3Byb2Nlc3NlZCI6MCwicmVjb3Jkc19jcmVhdGVkIjowLCJvdXRwdXRzIjp7fSwid2FybmluZ3MiOltdLCJlcnJvciI6bnVsbH0seyJwaGFzZSI6InR5cGluZyIsInN0YXR1cyI6ImNvbXBsZXRlZCIsInN1bW1hcnkiOiJtb2NrIHR5cGluZyIsInJlY29yZHNfcHJvY2Vzc2VkIjowLCJyZWNvcmRzX2NyZWF0ZWQiOjAsIm91dHB1dHMiOnt9LCJ3YXJuaW5ncyI6W10sImVycm9yIjpudWxsfSx7InBoYXNlIjoic3RhdGlzdGljcyIsInN0YXR1cyI6ImNvbXBsZXRlZCIsInN1bW1hcnkiOiJtb2NrIHN0YXRpc3RpY3MiLCJyZWNvcmRzX3Byb2Nlc3NlZCI6MCwicmVjb3Jkc19jcmVhdGVkIjowLCJvdXRwdXRzIjp7fSwid2FybmluZ3MiOltdLCJlcnJvciI6bnVsbH0seyJwaGFzZSI6ImNvbHVtbl9lbGlnaWJpbGl0eSIsInN0YXR1cyI6ImNvbXBsZXRlZCIsInN1bW1hcnkiOiJtb2NrIGNvbHVtbl9lbGlnaWJpbGl0eSIsInJlY29yZHNfcHJvY2Vzc2VkIjowLCJyZWNvcmRzX2NyZWF0ZWQiOjAsIm91dHB1dHMiOnt9LCJ3YXJuaW5ncyI6W10sImVycm9yIjpudWxsfSx7InBoYXNlIjoic3RhdGlzdGljYWxfcXVhbGl0eSIsInN0YXR1cyI6ImNvbXBsZXRlZCIsInN1bW1hcnkiOiJtb2NrIHN0YXRpc3RpY2FsX3F1YWxpdHkiLCJyZWNvcmRzX3Byb2Nlc3NlZCI6MCwicmVjb3Jkc19jcmVhdGVkIjowLCJvdXRwdXRzIjp7fSwid2FybmluZ3MiOltdLCJlcnJvciI6bnVsbH0seyJwaGFzZSI6InRlbXBvcmFsIiwic3RhdHVzIjoiY29tcGxldGVkIiwic3VtbWFyeSI6Im1vY2sgdGVtcG9yYWwiLCJyZWNvcmRzX3Byb2Nlc3NlZCI6MCwicmVjb3Jkc19jcmVhdGVkIjowLCJvdXRwdXRzIjp7fSwid2FybmluZ3MiOltdLCJlcnJvciI6bnVsbH0seyJwaGFzZSI6InNlbWFudGljX3Blcl9jb2x1bW4iLCJzdGF0dXMiOiJjb21wbGV0ZWQiLCJzdW1tYXJ5IjoibW9jayBzZW1hbnRpY19wZXJfY29sdW1uIiwicmVjb3Jkc19wcm9jZXNzZWQiOjAsInJlY29yZHNfY3JlYXRlZCI6MCwib3V0cHV0cyI6e30sIndhcm5pbmdzIjpbXSwiZXJyb3IiOm51bGx9XQ=="
+              "data": "eyJyYXdfdGFibGVfaWRzIjpbInJhdy0xIiwicmF3LTIiXSwidGFibGVzIjpbeyJyYXdfdGFibGVfaWQiOiJyYXctMSIsInR5cGVkX3RhYmxlX2lkIjoidHlwZWQtcmF3LTEifSx7InJhd190YWJsZV9pZCI6InJhdy0yIiwidHlwZWRfdGFibGVfaWQiOiJ0eXBlZC1yYXctMiJ9XX0="
             }
           ]
         },
-        "workflowTaskCompletedEventId": "45"
+        "workflowTaskCompletedEventId": "33"
       }
     }
   ]

--- a/packages/engine/tests/unit/worker/fixtures/processtable_history.json
+++ b/packages/engine/tests/unit/worker/fixtures/processtable_history.json
@@ -1,0 +1,737 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "processTableWorkflow"
+        },
+        "parentWorkflowNamespace": "default",
+        "parentWorkflowExecution": {
+          "workflowId": "addsource-gen-src",
+          "runId": "c21ffab9-b567-4114-9c64-8d699ac32c4d"
+        },
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJpZGVudGl0eSI6eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9LCJyYXdfdGFibGVfaWQiOiJyYXctMSJ9"
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "315360000s",
+        "workflowRunTimeout": "315360000s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "a39d5eda-26e8-4231-93ac-a79adad2f825",
+        "firstExecutionRunId": "a39d5eda-26e8-4231-93ac-a79adad2f825",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "memo": {},
+        "header": {},
+        "rootWorkflowExecution": {
+          "workflowId": "addsource-gen-src",
+          "runId": "c21ffab9-b567-4114-9c64-8d699ac32c4d"
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-05-27T19:34:20.040Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-05-27T19:34:20.042Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "sdkMetadata": {
+          "coreUsedFlags": [
+            3,
+            1,
+            2
+          ],
+          "sdkName": "temporal-python",
+          "sdkVersion": "1.27.2"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-05-27T19:34:20.042Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "1",
+        "activityType": {
+          "name": "typing"
+        },
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJpZGVudGl0eSI6eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9LCJyYXdfdGFibGVfaWQiOiJyYXctMSJ9"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "315360000s",
+        "startToCloseTimeout": "600s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "3",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2.0,
+          "maximumInterval": "100s",
+          "maximumAttempts": 5,
+          "nonRetryableErrorTypes": [
+            "PhaseFailed"
+          ]
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-05-27T19:34:20.042Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "380497@dataraum-context",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-05-27T19:34:20.043Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJ0eXBlZF90YWJsZV9pZCI6InR5cGVkLXJhdy0xIn0="
+            }
+          ]
+        },
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-05-27T19:34:20.043Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-05-27T19:34:20.043Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-05-27T19:34:20.044Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-05-27T19:34:20.044Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "2",
+        "activityType": {
+          "name": "statistics"
+        },
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJpZGVudGl0eSI6eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9LCJ0YWJsZV9pZCI6InR5cGVkLXJhdy0xIn0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "315360000s",
+        "startToCloseTimeout": "600s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "9",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2.0,
+          "maximumInterval": "100s",
+          "maximumAttempts": 5,
+          "nonRetryableErrorTypes": [
+            "PhaseFailed"
+          ]
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-05-27T19:34:20.045Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "380497@dataraum-context",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-05-27T19:34:20.045Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJzdGF0dXMiOiJjb21wbGV0ZWQiLCJzdW1tYXJ5IjoiIn0="
+            }
+          ]
+        },
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-05-27T19:34:20.045Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-05-27T19:34:20.045Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-05-27T19:34:20.046Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-05-27T19:34:20.046Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "3",
+        "activityType": {
+          "name": "column_eligibility"
+        },
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJpZGVudGl0eSI6eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9LCJ0YWJsZV9pZCI6InR5cGVkLXJhdy0xIn0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "315360000s",
+        "startToCloseTimeout": "600s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "15",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2.0,
+          "maximumInterval": "100s",
+          "maximumAttempts": 5,
+          "nonRetryableErrorTypes": [
+            "PhaseFailed"
+          ]
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": "2026-05-27T19:34:20.046Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "17",
+        "identity": "380497@dataraum-context",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": "2026-05-27T19:34:20.046Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJzdGF0dXMiOiJjb21wbGV0ZWQiLCJzdW1tYXJ5IjoiIn0="
+            }
+          ]
+        },
+        "scheduledEventId": "17",
+        "startedEventId": "18",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": "2026-05-27T19:34:20.046Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": "2026-05-27T19:34:20.046Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "20",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": "2026-05-27T19:34:20.047Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "20",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": "2026-05-27T19:34:20.047Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "4",
+        "activityType": {
+          "name": "statistical_quality"
+        },
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJpZGVudGl0eSI6eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9LCJ0YWJsZV9pZCI6InR5cGVkLXJhdy0xIn0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "315360000s",
+        "startToCloseTimeout": "600s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "21",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2.0,
+          "maximumInterval": "100s",
+          "maximumAttempts": 5,
+          "nonRetryableErrorTypes": [
+            "PhaseFailed"
+          ]
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "24",
+      "eventTime": "2026-05-27T19:34:20.047Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "23",
+        "identity": "380497@dataraum-context",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "25",
+      "eventTime": "2026-05-27T19:34:20.048Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJzdGF0dXMiOiJjb21wbGV0ZWQiLCJzdW1tYXJ5IjoiIn0="
+            }
+          ]
+        },
+        "scheduledEventId": "23",
+        "startedEventId": "24",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "26",
+      "eventTime": "2026-05-27T19:34:20.048Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "27",
+      "eventTime": "2026-05-27T19:34:20.048Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "26",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "28",
+      "eventTime": "2026-05-27T19:34:20.049Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "26",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "29",
+      "eventTime": "2026-05-27T19:34:20.049Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "5",
+        "activityType": {
+          "name": "temporal"
+        },
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJpZGVudGl0eSI6eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9LCJ0YWJsZV9pZCI6InR5cGVkLXJhdy0xIn0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "315360000s",
+        "startToCloseTimeout": "600s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "27",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2.0,
+          "maximumInterval": "100s",
+          "maximumAttempts": 5,
+          "nonRetryableErrorTypes": [
+            "PhaseFailed"
+          ]
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "30",
+      "eventTime": "2026-05-27T19:34:20.049Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "29",
+        "identity": "380497@dataraum-context",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "31",
+      "eventTime": "2026-05-27T19:34:20.050Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJzdGF0dXMiOiJjb21wbGV0ZWQiLCJzdW1tYXJ5IjoiIn0="
+            }
+          ]
+        },
+        "scheduledEventId": "29",
+        "startedEventId": "30",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "32",
+      "eventTime": "2026-05-27T19:34:20.050Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "33",
+      "eventTime": "2026-05-27T19:34:20.050Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "32",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "34",
+      "eventTime": "2026-05-27T19:34:20.051Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "32",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "35",
+      "eventTime": "2026-05-27T19:34:20.051Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "6",
+        "activityType": {
+          "name": "detect_table"
+        },
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJpZGVudGl0eSI6eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9LCJ0YWJsZV9pZCI6InR5cGVkLXJhdy0xIn0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "315360000s",
+        "startToCloseTimeout": "600s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "33",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2.0,
+          "maximumInterval": "100s",
+          "maximumAttempts": 5,
+          "nonRetryableErrorTypes": [
+            "PhaseFailed"
+          ]
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "36",
+      "eventTime": "2026-05-27T19:34:20.051Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "35",
+        "identity": "380497@dataraum-context",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "37",
+      "eventTime": "2026-05-27T19:34:20.052Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJzdGF0dXMiOiJjb21wbGV0ZWQiLCJzdW1tYXJ5IjoiIn0="
+            }
+          ]
+        },
+        "scheduledEventId": "35",
+        "startedEventId": "36",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "38",
+      "eventTime": "2026-05-27T19:34:20.052Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "39",
+      "eventTime": "2026-05-27T19:34:20.052Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "38",
+        "identity": "380497@dataraum-context"
+      }
+    },
+    {
+      "eventId": "40",
+      "eventTime": "2026-05-27T19:34:20.053Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "38",
+        "identity": "380497@dataraum-context",
+        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "41",
+      "eventTime": "2026-05-27T19:34:20.053Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJyYXdfdGFibGVfaWQiOiJyYXctMSIsInR5cGVkX3RhYmxlX2lkIjoidHlwZWQtcmF3LTEifQ=="
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "39"
+      }
+    }
+  ]
+}

--- a/packages/engine/tests/unit/worker/test_phase_constants.py
+++ b/packages/engine/tests/unit/worker/test_phase_constants.py
@@ -1,0 +1,20 @@
+"""Guard the two table-local phase lists that must stay in sync (DAT-370).
+
+The child workflow schedules the analytics phases from
+``workflows._ANALYTICS_PHASES``; the stage-level detect step aggregates
+detectors from ``activity._TABLE_LOCAL_PHASES``. They describe the same set of
+table-local phases from two angles: ``_TABLE_LOCAL_PHASES`` is ``typing`` (which
+mints the typed id and owns the ``type_fidelity`` detector) plus the analytics
+phases. If a new table-local phase is added to the workflow but not here, its
+pipeline.yaml detectors would silently never run at ``detect_table`` — so pin the
+relationship with a test rather than a comment.
+"""
+
+from __future__ import annotations
+
+from dataraum.worker.activity import _TABLE_LOCAL_PHASES
+from dataraum.worker.workflows import _ANALYTICS_PHASES
+
+
+def test_table_local_phases_are_typing_plus_the_analytics_chain() -> None:
+    assert _TABLE_LOCAL_PHASES == ("typing", *_ANALYTICS_PHASES)

--- a/packages/engine/tests/unit/worker/test_replay.py
+++ b/packages/engine/tests/unit/worker/test_replay.py
@@ -1,25 +1,29 @@
-"""Crash-replay determinism for addSourceWorkflow (DAT-344, P4).
+"""Crash-replay determinism for the per-table workflows (DAT-344, P4; DAT-370).
 
 A Temporal worker that dies mid-run is recovered by **replaying** the workflow's
-event history against the workflow code when a worker picks it back up. This
-test performs exactly that replay: it feeds a recorded ``addSourceWorkflow``
-history (all seven slice-1 phases completed) through the ``Replayer`` and
-asserts the workflow code replays to the same final state with no
-non-determinism.
+event history against the workflow code when a worker picks it back up. These
+tests perform exactly that replay for both workflows in the per-table topology:
 
-No live server or activities are needed — the Replayer drives only the workflow
-code, using the recorded activity results from the history. The fixture was
-captured from a one-off ``WorkflowEnvironment`` run with mock activities (a
-mock-activity history replays faithfully against the real workflow, since the
-Replayer drives only workflow code). To regenerate after a chain change: run
-``AddSourceWorkflow`` under ``WorkflowEnvironment.start_time_skipping()`` with
-stub activities and write ``handle.fetch_history().to_json_dict()`` here.
+* ``addSourceWorkflow`` — import, fan-out to two ``processTableWorkflow`` children
+  via ``asyncio.gather``, then the ``semantic_per_column`` reduce.
+* ``processTableWorkflow`` — typing, the four analytics phases, then the
+  stage-level ``detect_table``.
+
+No live server or activities are needed — the Replayer drives only workflow code,
+using the recorded activity/child-workflow results from the history. The parent
+replay needs only ``AddSourceWorkflow`` registered: child workflows appear in the
+parent history as start/complete events, not re-executed code.
+
+The fixtures were captured from a one-off ``WorkflowEnvironment`` run with stub
+activities (``fixtures/_generate_histories.py``); regenerate them by running that
+module after a chain change.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from temporalio.client import WorkflowHistory
 from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.worker import Replayer
@@ -28,17 +32,14 @@ from temporalio.worker.workflow_sandbox import (
     SandboxRestrictions,
 )
 
-from dataraum.worker.workflows import AddSourceWorkflow
+from dataraum.worker.workflows import AddSourceWorkflow, ProcessTableWorkflow
 
-_HISTORY = Path(__file__).parent / "fixtures" / "addsource_history.json"
+_FIXTURES = Path(__file__).parent / "fixtures"
 
 
-async def test_addsource_workflow_replays_deterministically() -> None:
-    """Replaying a completed addSourceWorkflow history reaches the same final state."""
-    history = WorkflowHistory.from_json("addsource-replay", _HISTORY.read_text())
-
-    replayer = Replayer(
-        workflows=[AddSourceWorkflow],
+def _replayer(*workflows: type) -> Replayer:
+    return Replayer(
+        workflows=list(workflows),
         data_converter=pydantic_data_converter,
         # Same passthrough as the worker — the workflow module's package import
         # chain loads duckdb's native ext, which can't be reimported in the
@@ -46,8 +47,8 @@ async def test_addsource_workflow_replays_deterministically() -> None:
         #
         # ``coverage`` is test-only: under ``--cov`` on Python 3.14, coverage's
         # default sysmon core lazily imports ``coverage.env`` (which calls
-        # ``platform.python_implementation()``) the first time it traces a
-        # branch in the workflow. That import lands inside the sandbox and trips
+        # ``platform.python_implementation()``) the first time it traces a branch
+        # in the workflow. That import lands inside the sandbox and trips
         # RestrictedWorkflowAccessError. Passing it through keeps coverage's own
         # instrumentation out of the sandbox; coverage is not part of the
         # workflow's determinism contract, so the replay check is unaffected.
@@ -59,6 +60,19 @@ async def test_addsource_workflow_replays_deterministically() -> None:
         ),
     )
 
+
+@pytest.mark.parametrize(
+    ("workflow", "fixture"),
+    [
+        (AddSourceWorkflow, "addsource_history.json"),
+        (ProcessTableWorkflow, "processtable_history.json"),
+    ],
+)
+async def test_workflow_replays_deterministically(workflow: type, fixture: str) -> None:
+    """Replaying a completed history reaches the same final state, no non-determinism."""
+    history = WorkflowHistory.from_json(
+        "replay", (_FIXTURES / fixture).read_text()
+    )
     # Raises on any non-determinism or replay mismatch; returns cleanly on a
     # faithful replay to the recorded WorkflowExecutionCompleted.
-    await replayer.replay_workflow(history)
+    await _replayer(workflow).replay_workflow(history)

--- a/packages/engine/tests/unit/worker/test_replay.py
+++ b/packages/engine/tests/unit/worker/test_replay.py
@@ -70,9 +70,7 @@ def _replayer(*workflows: type) -> Replayer:
 )
 async def test_workflow_replays_deterministically(workflow: type, fixture: str) -> None:
     """Replaying a completed history reaches the same final state, no non-determinism."""
-    history = WorkflowHistory.from_json(
-        "replay", (_FIXTURES / fixture).read_text()
-    )
+    history = WorkflowHistory.from_json("replay", (_FIXTURES / fixture).read_text())
     # Raises on any non-determinism or replay mismatch; returns cleanly on a
     # faithful replay to the recorded WorkflowExecutionCompleted.
     await _replayer(workflow).replay_workflow(history)


### PR DESCRIPTION
## DAT-370 — per-table fan-out for `add_source`

The table is now the unit of work. `addSourceWorkflow` imports the source, **fans out one `processTableWorkflow` child per raw table** (`asyncio.gather`), then runs `semantic_per_column` once as the source-level reduce. Each child runs the table-local chain scoped to its one table: `typing` (mints the typed id, threaded through history) → `statistics` → `column_eligibility` → `statistical_quality` → `temporal` → `detect_table`. Replaces DAT-368's coarse single pass over the whole source.

### What changed
- **Contract redesigned per-boundary** (`worker/contracts.py`): the uniform `PhaseActivityInput`/`PhaseActivityResult` envelope is gone — replaced by a `SourceIdentity` header + typed per-activity inputs; the workflow returns `AddSourceResult { raw_table_ids, tables:[{raw_table_id, typed_table_id}] }`.
- **Detectors moved off the per-phase path to a stage-level step.** Previously each phase ran its pipeline.yaml detectors as a *source-scoped delete-before-insert* post-step — which races + clobbers under per-table fan-out. Now one `detect_table` step at the tail of each child runs the table-local detectors (`type_fidelity`, `null_ratio`) **scoped to that child's typed table**. `run_detector_post_step` gained a `table_ids` scope (delete + scan restricted to the table). Per-table union is identical to the old source-wide run.
- **The 4 analytics phases** (`statistics`/`column_eligibility`/`statistical_quality`/`temporal`) scope `_run`/`should_skip` to `ctx.table_ids` (single typed table) via a shared `BasePhase._typed_tables` helper; the "re-derive all typed tables of the source" logic is deleted. `column_eligibility.cleanup` scoped to `table_ids`.
- **Cockpit** (`temporal/types.ts`, `temporal/drive-add-source.ts`): mirror the new shapes; the driver reads `AddSourceResult` by name, no positional result destructuring.

### Verification
- testmon: **217 passed / 9 skipped**; ruff + mypy + vulture + biome + tsc clean.
- Replay determinism holds for **both** parent and child workflows (regenerated fixtures + committed generator).
- A real-substrate concurrent multi-table test proves the table-scoped detector partition holds under parallelism (each table gets its full detector set, no sibling clobber).
- New unit tests: `_typed_tables` scoping + a guard pinning the two table-local phase-list constants in sync.

### Reviewers
senior-code-reviewer: **APPROVE** · spec-compliance-reviewer: **COMPLIANT** (all 9 acceptance criteria).

### Eval handoff
`.claude/handoff.md` updated: **behavior-preserving** (re-verify, don't expect a recall shift). Per-table execution — the pattern the eval gate was waiting on — is now stable, so calibration can run in parallel.

### Not in this PR
- Full compose e2e (the workflow ends in `semantic_per_column`, which makes real LLM calls) — covered offline by replay + real-Postgres/DuckLake integration.
- `semantic_per_column` per-table + column batching — split-out follow-up (eval-sensitive, output-preserving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)