### PR TITLE
fix(DAT-370): restore semantic_per_column's source-level detectors

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,36 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-05-27: DAT-370 follow-up — restore the source-level detectors (eval-caught regression)
+
+Eval found that DAT-370 orphaned `semantic_per_column`'s detectors. When detectors
+moved off the per-phase path, only `detect_table` (the table-local phases) was
+wired; `semantic_per_column` runs as the source-level reduce but nothing ran its
+declared detectors — `business_meaning`, `unit_entropy`, `temporal_entropy`,
+`outlier_rate`, `benford` — so they were dead from DAT-370 until now.
+
+Fix: added a source-level `detect_source` activity that runs after the reduce in
+`addSourceWorkflow`, executing the `_SOURCE_LEVEL_PHASES` (= `semantic_per_column`)
+detectors **source-wide** (`run_detector_post_step(table_ids=None)`; single
+sequential step in the parent, no concurrency). Mirrors `detect_table`. A unit
+guard (`test_no_chain_phase_detector_is_orphaned`) now fails if any chain phase
+declares a detector that no detect step runs.
+
+### dataraum-eval
+
+- **Action: re-run the semantic detectors — they now produce scores.**
+  `business_meaning`, `unit_entropy`, `temporal_entropy`, `outlier_rate`, `benford`
+  execute once after the reduce, source-wide (same scope as the pre-DAT-370 coarse
+  run). No detector logic changed — purely the missing execution path restored.
+- Drive a run the same way (`addSourceWorkflow`); the new `detect_source` step is
+  internal to the workflow.
+- `relationship_entropy` / `join_path_determinism` (semantic_per_table) and the
+  other Zone-2/3 detectors remain unwired — their phases aren't in the chain yet.
+
+### dataraum-testdata (hints)
+
+- None.
+
 ## 2026-05-27: DAT-370 — per-table fan-out for add_source (E4b-2)
 
 The table is now the unit of work. `addSourceWorkflow` imports the source,

--- a/packages/engine/src/dataraum/worker/__init__.py
+++ b/packages/engine/src/dataraum/worker/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from dataraum.worker.activity import (
     raw_table_ids,
     run_phase,
+    run_source_detectors,
     run_table_detectors,
     typed_table_id_for_raw,
 )
@@ -47,6 +48,7 @@ __all__ = [
     "bootstrap_worker_substrate",
     "raw_table_ids",
     "run_phase",
+    "run_source_detectors",
     "run_table_detectors",
     "shutdown_worker_substrate",
     "typed_table_id_for_raw",

--- a/packages/engine/src/dataraum/worker/activities.py
+++ b/packages/engine/src/dataraum/worker/activities.py
@@ -29,6 +29,7 @@ from dataraum.pipeline.base import PhaseStatus
 from dataraum.worker.activity import (
     raw_table_ids,
     run_phase,
+    run_source_detectors,
     run_table_detectors,
     typed_table_id_for_raw,
 )
@@ -125,6 +126,21 @@ class PhaseActivities:
         analytics phases it makes real LLM calls.
         """
         return self._run_or_raise("semantic_per_column", identity, [])
+
+    @activity.defn(name="detect_source")
+    def run_detect_source(self, identity: SourceIdentity) -> PhaseOutcome:
+        """Run the source-level detectors after the reduce (DAT-370 follow-up).
+
+        The source-level analogue of ``detect_table``: runs ``semantic_per_column``'s
+        declared detectors once, source-wide, after the reduce. Without it those
+        detectors are declared in pipeline.yaml but never execute (the gap DAT-370
+        left when detectors moved off the per-phase path).
+        """
+        count = run_source_detectors(self._manager, identity)
+        return PhaseOutcome(
+            status=PhaseStatus.COMPLETED.value,
+            summary=f"{count} source-level detector records",
+        )
 
     def _run_or_raise(
         self,

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -17,6 +17,7 @@ Temporal-agnostic helpers into the per-boundary contracts.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -39,8 +40,10 @@ logger = get_logger(__name__)
 
 __all__ = [
     "PhaseRun",
+    "declared_detector_ids",
     "raw_table_ids",
     "run_phase",
+    "run_source_detectors",
     "run_table_detectors",
     "typed_table_id_for_raw",
 ]
@@ -61,6 +64,15 @@ _TABLE_LOCAL_PHASES = (
     "statistical_quality",
     "temporal",
 )
+
+# The source-level phases whose detectors run once, after the per-table fan-out,
+# in the parent's ``detect_source`` step. ``semantic_per_column`` is a
+# source-global reduce, so its detectors (business_meaning, unit_entropy,
+# temporal_entropy, outlier_rate, benford) read the whole source's typed tables
+# and run once — no concurrency, so the source-wide delete-before-insert is safe.
+# Kept in sync with the workflow + checked against pipeline.yaml by
+# ``tests/unit/worker/test_phase_constants.py`` (no declared chain detector orphaned).
+_SOURCE_LEVEL_PHASES = ("semantic_per_column",)
 
 
 @dataclass
@@ -197,6 +209,20 @@ def typed_table_id_for_raw(
         ).scalar_one_or_none()
 
 
+def declared_detector_ids(phase_names: Iterable[str]) -> list[str]:
+    """The de-duplicated detectors the given phases declare in pipeline.yaml."""
+    declarations = load_phase_declarations()
+    detector_ids: list[str] = []
+    for phase_name in phase_names:
+        decl = declarations.get(phase_name)
+        if not decl:
+            continue
+        for detector_id in decl.detectors:
+            if detector_id not in detector_ids:
+                detector_ids.append(detector_id)
+    return detector_ids
+
+
 def run_table_detectors(
     manager: ConnectionManager,
     identity: SourceIdentity,
@@ -211,16 +237,36 @@ def run_table_detectors(
     what lets parallel child workflows run their detectors without colliding on
     the shared ``(source_id, detector_id)`` rows.
     """
-    declarations = load_phase_declarations()
-    detector_ids: list[str] = []
-    for phase_name in _TABLE_LOCAL_PHASES:
-        decl = declarations.get(phase_name)
-        if not decl:
-            continue
-        for detector_id in decl.detectors:
-            if detector_id not in detector_ids:
-                detector_ids.append(detector_id)
+    return _run_detectors(manager, identity, _TABLE_LOCAL_PHASES, [table_id])
 
+
+def run_source_detectors(manager: ConnectionManager, identity: SourceIdentity) -> int:
+    """Run the source-level detectors once, after the per-table fan-out.
+
+    The parent's ``detect_source`` step: runs the detectors the source-level
+    phases declare (``semantic_per_column``'s business_meaning / unit_entropy /
+    temporal_entropy / outlier_rate / benford), source-wide (``table_ids=None``).
+    Its ontology induction is source-global and it is a single sequential step in
+    the parent — no concurrency — so the source-wide delete-before-insert is safe.
+    Without this step those detectors would be declared but never executed (the
+    gap DAT-370 left when it moved detectors off the per-phase path).
+    """
+    return _run_detectors(manager, identity, _SOURCE_LEVEL_PHASES, None)
+
+
+def _run_detectors(
+    manager: ConnectionManager,
+    identity: SourceIdentity,
+    phase_names: Iterable[str],
+    table_ids: list[str] | None,
+) -> int:
+    """Run the detectors declared by ``phase_names``, scoped to ``table_ids``.
+
+    ``table_ids=None`` runs each detector source-wide; a single-element list
+    scopes it to that typed table. Shared by :func:`run_table_detectors` and
+    :func:`run_source_detectors`.
+    """
+    detector_ids = declared_detector_ids(phase_names)
     if not detector_ids:
         return 0
 
@@ -233,7 +279,7 @@ def run_table_detectors(
                 detector_id,
                 cursor,
                 session_id=identity.session_id,
-                table_ids=[table_id],
+                table_ids=table_ids,
             )
     return total
 

--- a/packages/engine/src/dataraum/worker/main.py
+++ b/packages/engine/src/dataraum/worker/main.py
@@ -86,6 +86,7 @@ async def run_worker() -> None:
                     phase_activities.run_temporal,
                     phase_activities.run_detect_table,
                     phase_activities.run_semantic_per_column,
+                    phase_activities.run_detect_source,
                 ],
                 activity_executor=executor,
                 max_concurrent_activities=_MAX_CONCURRENT_ACTIVITIES,
@@ -117,6 +118,7 @@ async def run_worker() -> None:
                     "temporal",
                     "detect_table",
                     "semantic_per_column",
+                    "detect_source",
                 ],
             )
             async with worker:

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -155,4 +155,16 @@ class AddSourceWorkflow:
             retry_policy=_RETRY,
         )
 
+        # Source-level detect step: run semantic_per_column's declared detectors
+        # once after the reduce (the table-local detectors already ran per child
+        # in detect_table). Without this the source-level detectors are declared
+        # but never execute.
+        await workflow.execute_activity(
+            "detect_source",
+            payload.identity,
+            result_type=PhaseOutcome,
+            start_to_close_timeout=_TIMEOUT,
+            retry_policy=_RETRY,
+        )
+
         return AddSourceResult(raw_table_ids=imported.raw_table_ids, tables=tables)

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -34,6 +34,7 @@ from dataraum.worker import (
     SourceIdentity,
     raw_table_ids,
     run_phase,
+    run_source_detectors,
     run_table_detectors,
     typed_table_id_for_raw,
 )
@@ -334,3 +335,9 @@ def test_semantic_per_column_reduce_runs_live(
 
     result = run_phase(worker_manager, "semantic_per_column", identity, [])
     assert result.status == "completed", f"semantic_per_column failed: {result.error}"
+
+    # Source-level detect step (detect_source) runs semantic_per_column's declared
+    # detectors after the reduce — the path DAT-370 originally orphaned. With real
+    # annotations present it should persist records.
+    records = run_source_detectors(worker_manager, identity)
+    assert records > 0, "detect_source produced no source-level detector records"

--- a/packages/engine/tests/unit/worker/fixtures/_generate_histories.py
+++ b/packages/engine/tests/unit/worker/fixtures/_generate_histories.py
@@ -85,6 +85,11 @@ async def stub_semantic_per_column(identity: SourceIdentity) -> PhaseOutcome:
     return PhaseOutcome(status="completed")
 
 
+@activity.defn(name="detect_source")
+async def stub_detect_source(identity: SourceIdentity) -> PhaseOutcome:
+    return PhaseOutcome(status="completed")
+
+
 async def main() -> None:
     async with await WorkflowEnvironment.start_time_skipping(
         data_converter=pydantic_data_converter
@@ -102,6 +107,7 @@ async def main() -> None:
                 stub_temporal,
                 stub_detect_table,
                 stub_semantic_per_column,
+                stub_detect_source,
             ],
             workflow_runner=SandboxedWorkflowRunner(
                 restrictions=SandboxRestrictions.default.with_passthrough_modules(

--- a/packages/engine/tests/unit/worker/fixtures/addsource_history.json
+++ b/packages/engine/tests/unit/worker/fixtures/addsource_history.json
@@ -2,7 +2,7 @@
   "events": [
     {
       "eventId": "1",
-      "eventTime": "2026-05-27T19:34:20.031Z",
+      "eventTime": "2026-05-27T21:00:24.952Z",
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
       "workflowExecutionStartedEventAttributes": {
         "workflowType": {
@@ -24,9 +24,9 @@
         "workflowExecutionTimeout": "315360000s",
         "workflowRunTimeout": "315360000s",
         "workflowTaskTimeout": "10s",
-        "originalExecutionRunId": "c21ffab9-b567-4114-9c64-8d699ac32c4d",
-        "identity": "380497@dataraum-context",
-        "firstExecutionRunId": "c21ffab9-b567-4114-9c64-8d699ac32c4d",
+        "originalExecutionRunId": "86ea4bb6-68fb-49f2-b808-7ad51c4384ef",
+        "identity": "623762@dataraum-context",
+        "firstExecutionRunId": "86ea4bb6-68fb-49f2-b808-7ad51c4384ef",
         "attempt": 1,
         "firstWorkflowTaskBackoff": "0s",
         "priority": {}
@@ -34,7 +34,7 @@
     },
     {
       "eventId": "2",
-      "eventTime": "2026-05-27T19:34:20.031Z",
+      "eventTime": "2026-05-27T21:00:24.952Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -46,26 +46,26 @@
     },
     {
       "eventId": "3",
-      "eventTime": "2026-05-27T19:34:20.031Z",
+      "eventTime": "2026-05-27T21:00:24.952Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "2",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "4",
-      "eventTime": "2026-05-27T19:34:20.036Z",
+      "eventTime": "2026-05-27T21:00:24.957Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "2",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {
           "coreUsedFlags": [
-            3,
             2,
-            1
+            1,
+            3
           ],
           "sdkName": "temporal-python",
           "sdkVersion": "1.27.2"
@@ -75,7 +75,7 @@
     },
     {
       "eventId": "5",
-      "eventTime": "2026-05-27T19:34:20.036Z",
+      "eventTime": "2026-05-27T21:00:24.957Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "activityTaskScheduledEventAttributes": {
         "activityId": "1",
@@ -116,17 +116,17 @@
     },
     {
       "eventId": "6",
-      "eventTime": "2026-05-27T19:34:20.036Z",
+      "eventTime": "2026-05-27T21:00:24.957Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "5",
-        "identity": "380497@dataraum-context",
+        "identity": "623762@dataraum-context",
         "attempt": 1
       }
     },
     {
       "eventId": "7",
-      "eventTime": "2026-05-27T19:34:20.037Z",
+      "eventTime": "2026-05-27T21:00:24.959Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "activityTaskCompletedEventAttributes": {
         "result": {
@@ -141,12 +141,12 @@
         },
         "scheduledEventId": "5",
         "startedEventId": "6",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "8",
-      "eventTime": "2026-05-27T19:34:20.037Z",
+      "eventTime": "2026-05-27T21:00:24.959Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -158,28 +158,28 @@
     },
     {
       "eventId": "9",
-      "eventTime": "2026-05-27T19:34:20.038Z",
+      "eventTime": "2026-05-27T21:00:24.959Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "8",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "10",
-      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventTime": "2026-05-27T21:00:24.960Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "8",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "11",
-      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventTime": "2026-05-27T21:00:24.960Z",
       "eventType": "EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED",
       "startChildWorkflowExecutionInitiatedEventAttributes": {
         "namespace": "default",
@@ -214,7 +214,7 @@
     },
     {
       "eventId": "12",
-      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventTime": "2026-05-27T21:00:24.960Z",
       "eventType": "EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED",
       "startChildWorkflowExecutionInitiatedEventAttributes": {
         "namespace": "default",
@@ -249,14 +249,14 @@
     },
     {
       "eventId": "13",
-      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventTime": "2026-05-27T21:00:24.960Z",
       "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED",
       "childWorkflowExecutionStartedEventAttributes": {
         "namespace": "default",
         "initiatedEventId": "12",
         "workflowExecution": {
           "workflowId": "addsource-gen-src-table-raw-2",
-          "runId": "8ae16fac-cb46-422f-9c83-7f422a768931"
+          "runId": "ebe0e360-ed3a-411b-bebd-f231749ce1b9"
         },
         "workflowType": {
           "name": "processTableWorkflow"
@@ -265,7 +265,7 @@
     },
     {
       "eventId": "14",
-      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventTime": "2026-05-27T21:00:24.960Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -277,35 +277,35 @@
     },
     {
       "eventId": "15",
-      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventTime": "2026-05-27T21:00:24.960Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "14",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "16",
-      "eventTime": "2026-05-27T19:34:20.040Z",
+      "eventTime": "2026-05-27T21:00:24.961Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "14",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "17",
-      "eventTime": "2026-05-27T19:34:20.040Z",
+      "eventTime": "2026-05-27T21:00:24.961Z",
       "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED",
       "childWorkflowExecutionStartedEventAttributes": {
         "namespace": "default",
         "initiatedEventId": "11",
         "workflowExecution": {
           "workflowId": "addsource-gen-src-table-raw-1",
-          "runId": "a39d5eda-26e8-4231-93ac-a79adad2f825"
+          "runId": "fb6b0282-dda9-408d-87af-efe3c3609946"
         },
         "workflowType": {
           "name": "processTableWorkflow"
@@ -314,7 +314,7 @@
     },
     {
       "eventId": "18",
-      "eventTime": "2026-05-27T19:34:20.040Z",
+      "eventTime": "2026-05-27T21:00:24.961Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -326,28 +326,28 @@
     },
     {
       "eventId": "19",
-      "eventTime": "2026-05-27T19:34:20.040Z",
+      "eventTime": "2026-05-27T21:00:24.961Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "18",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "20",
-      "eventTime": "2026-05-27T19:34:20.042Z",
+      "eventTime": "2026-05-27T21:00:24.963Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "18",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "21",
-      "eventTime": "2026-05-27T19:34:20.052Z",
+      "eventTime": "2026-05-27T21:00:24.974Z",
       "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED",
       "childWorkflowExecutionCompletedEventAttributes": {
         "result": {
@@ -363,7 +363,7 @@
         "namespace": "default",
         "workflowExecution": {
           "workflowId": "addsource-gen-src-table-raw-2",
-          "runId": "8ae16fac-cb46-422f-9c83-7f422a768931"
+          "runId": "ebe0e360-ed3a-411b-bebd-f231749ce1b9"
         },
         "workflowType": {
           "name": "processTableWorkflow"
@@ -374,7 +374,7 @@
     },
     {
       "eventId": "22",
-      "eventTime": "2026-05-27T19:34:20.052Z",
+      "eventTime": "2026-05-27T21:00:24.974Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -386,28 +386,28 @@
     },
     {
       "eventId": "23",
-      "eventTime": "2026-05-27T19:34:20.052Z",
+      "eventTime": "2026-05-27T21:00:24.974Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "22",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "24",
-      "eventTime": "2026-05-27T19:34:20.053Z",
+      "eventTime": "2026-05-27T21:00:24.975Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "22",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "25",
-      "eventTime": "2026-05-27T19:34:20.053Z",
+      "eventTime": "2026-05-27T21:00:24.976Z",
       "eventType": "EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED",
       "childWorkflowExecutionCompletedEventAttributes": {
         "result": {
@@ -423,7 +423,7 @@
         "namespace": "default",
         "workflowExecution": {
           "workflowId": "addsource-gen-src-table-raw-1",
-          "runId": "a39d5eda-26e8-4231-93ac-a79adad2f825"
+          "runId": "fb6b0282-dda9-408d-87af-efe3c3609946"
         },
         "workflowType": {
           "name": "processTableWorkflow"
@@ -434,7 +434,7 @@
     },
     {
       "eventId": "26",
-      "eventTime": "2026-05-27T19:34:20.053Z",
+      "eventTime": "2026-05-27T21:00:24.976Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -446,28 +446,28 @@
     },
     {
       "eventId": "27",
-      "eventTime": "2026-05-27T19:34:20.053Z",
+      "eventTime": "2026-05-27T21:00:24.976Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "26",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "28",
-      "eventTime": "2026-05-27T19:34:20.054Z",
+      "eventTime": "2026-05-27T21:00:24.977Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "26",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "29",
-      "eventTime": "2026-05-27T19:34:20.054Z",
+      "eventTime": "2026-05-27T21:00:24.977Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "activityTaskScheduledEventAttributes": {
         "activityId": "2",
@@ -508,17 +508,17 @@
     },
     {
       "eventId": "30",
-      "eventTime": "2026-05-27T19:34:20.054Z",
+      "eventTime": "2026-05-27T21:00:24.977Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "29",
-        "identity": "380497@dataraum-context",
+        "identity": "623762@dataraum-context",
         "attempt": 1
       }
     },
     {
       "eventId": "31",
-      "eventTime": "2026-05-27T19:34:20.055Z",
+      "eventTime": "2026-05-27T21:00:24.977Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "activityTaskCompletedEventAttributes": {
         "result": {
@@ -533,12 +533,12 @@
         },
         "scheduledEventId": "29",
         "startedEventId": "30",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "32",
-      "eventTime": "2026-05-27T19:34:20.055Z",
+      "eventTime": "2026-05-27T21:00:24.977Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -550,28 +550,132 @@
     },
     {
       "eventId": "33",
-      "eventTime": "2026-05-27T19:34:20.055Z",
+      "eventTime": "2026-05-27T21:00:24.977Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "32",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "34",
-      "eventTime": "2026-05-27T19:34:20.055Z",
+      "eventTime": "2026-05-27T21:00:24.978Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "32",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "35",
-      "eventTime": "2026-05-27T19:34:20.055Z",
+      "eventTime": "2026-05-27T21:00:24.978Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "3",
+        "activityType": {
+          "name": "detect_source"
+        },
+        "taskQueue": {
+          "name": "history-gen",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJ3b3Jrc3BhY2VfaWQiOiJnZW4td3MiLCJzb3VyY2VfaWQiOiJnZW4tc3JjIiwic2Vzc2lvbl9pZCI6Imdlbi1zZXNzaW9uIiwidmVydGljYWwiOm51bGx9"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "315360000s",
+        "startToCloseTimeout": "600s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "33",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2.0,
+          "maximumInterval": "100s",
+          "maximumAttempts": 5,
+          "nonRetryableErrorTypes": [
+            "PhaseFailed"
+          ]
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "36",
+      "eventTime": "2026-05-27T21:00:24.978Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "35",
+        "identity": "623762@dataraum-context",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "37",
+      "eventTime": "2026-05-27T21:00:24.978Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJzdGF0dXMiOiJjb21wbGV0ZWQiLCJzdW1tYXJ5IjoiIn0="
+            }
+          ]
+        },
+        "scheduledEventId": "35",
+        "startedEventId": "36",
+        "identity": "623762@dataraum-context"
+      }
+    },
+    {
+      "eventId": "38",
+      "eventTime": "2026-05-27T21:00:24.978Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "history-gen"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "39",
+      "eventTime": "2026-05-27T21:00:24.978Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "38",
+        "identity": "623762@dataraum-context"
+      }
+    },
+    {
+      "eventId": "40",
+      "eventTime": "2026-05-27T21:00:24.979Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "38",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "41",
+      "eventTime": "2026-05-27T21:00:24.979Z",
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
       "workflowExecutionCompletedEventAttributes": {
         "result": {
@@ -584,7 +688,7 @@
             }
           ]
         },
-        "workflowTaskCompletedEventId": "33"
+        "workflowTaskCompletedEventId": "39"
       }
     }
   ]

--- a/packages/engine/tests/unit/worker/fixtures/processtable_history.json
+++ b/packages/engine/tests/unit/worker/fixtures/processtable_history.json
@@ -2,7 +2,7 @@
   "events": [
     {
       "eventId": "1",
-      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventTime": "2026-05-27T21:00:24.960Z",
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
       "workflowExecutionStartedEventAttributes": {
         "workflowType": {
@@ -11,7 +11,7 @@
         "parentWorkflowNamespace": "default",
         "parentWorkflowExecution": {
           "workflowId": "addsource-gen-src",
-          "runId": "c21ffab9-b567-4114-9c64-8d699ac32c4d"
+          "runId": "86ea4bb6-68fb-49f2-b808-7ad51c4384ef"
         },
         "taskQueue": {
           "name": "history-gen",
@@ -30,22 +30,22 @@
         "workflowExecutionTimeout": "315360000s",
         "workflowRunTimeout": "315360000s",
         "workflowTaskTimeout": "10s",
-        "originalExecutionRunId": "a39d5eda-26e8-4231-93ac-a79adad2f825",
-        "firstExecutionRunId": "a39d5eda-26e8-4231-93ac-a79adad2f825",
+        "originalExecutionRunId": "fb6b0282-dda9-408d-87af-efe3c3609946",
+        "firstExecutionRunId": "fb6b0282-dda9-408d-87af-efe3c3609946",
         "attempt": 1,
         "firstWorkflowTaskBackoff": "0s",
         "memo": {},
         "header": {},
         "rootWorkflowExecution": {
           "workflowId": "addsource-gen-src",
-          "runId": "c21ffab9-b567-4114-9c64-8d699ac32c4d"
+          "runId": "86ea4bb6-68fb-49f2-b808-7ad51c4384ef"
         },
         "priority": {}
       }
     },
     {
       "eventId": "2",
-      "eventTime": "2026-05-27T19:34:20.039Z",
+      "eventTime": "2026-05-27T21:00:24.960Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -58,26 +58,26 @@
     },
     {
       "eventId": "3",
-      "eventTime": "2026-05-27T19:34:20.040Z",
+      "eventTime": "2026-05-27T21:00:24.961Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "2",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "4",
-      "eventTime": "2026-05-27T19:34:20.042Z",
+      "eventTime": "2026-05-27T21:00:24.963Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "2",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {
           "coreUsedFlags": [
-            3,
             1,
-            2
+            2,
+            3
           ],
           "sdkName": "temporal-python",
           "sdkVersion": "1.27.2"
@@ -87,7 +87,7 @@
     },
     {
       "eventId": "5",
-      "eventTime": "2026-05-27T19:34:20.042Z",
+      "eventTime": "2026-05-27T21:00:24.963Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "activityTaskScheduledEventAttributes": {
         "activityId": "1",
@@ -128,17 +128,17 @@
     },
     {
       "eventId": "6",
-      "eventTime": "2026-05-27T19:34:20.042Z",
+      "eventTime": "2026-05-27T21:00:24.963Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "5",
-        "identity": "380497@dataraum-context",
+        "identity": "623762@dataraum-context",
         "attempt": 1
       }
     },
     {
       "eventId": "7",
-      "eventTime": "2026-05-27T19:34:20.043Z",
+      "eventTime": "2026-05-27T21:00:24.965Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "activityTaskCompletedEventAttributes": {
         "result": {
@@ -153,12 +153,12 @@
         },
         "scheduledEventId": "5",
         "startedEventId": "6",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "8",
-      "eventTime": "2026-05-27T19:34:20.043Z",
+      "eventTime": "2026-05-27T21:00:24.965Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -171,28 +171,28 @@
     },
     {
       "eventId": "9",
-      "eventTime": "2026-05-27T19:34:20.043Z",
+      "eventTime": "2026-05-27T21:00:24.965Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "8",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "10",
-      "eventTime": "2026-05-27T19:34:20.044Z",
+      "eventTime": "2026-05-27T21:00:24.966Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "8",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "11",
-      "eventTime": "2026-05-27T19:34:20.044Z",
+      "eventTime": "2026-05-27T21:00:24.966Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "activityTaskScheduledEventAttributes": {
         "activityId": "2",
@@ -233,17 +233,17 @@
     },
     {
       "eventId": "12",
-      "eventTime": "2026-05-27T19:34:20.045Z",
+      "eventTime": "2026-05-27T21:00:24.966Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "11",
-        "identity": "380497@dataraum-context",
+        "identity": "623762@dataraum-context",
         "attempt": 1
       }
     },
     {
       "eventId": "13",
-      "eventTime": "2026-05-27T19:34:20.045Z",
+      "eventTime": "2026-05-27T21:00:24.967Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "activityTaskCompletedEventAttributes": {
         "result": {
@@ -258,12 +258,12 @@
         },
         "scheduledEventId": "11",
         "startedEventId": "12",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "14",
-      "eventTime": "2026-05-27T19:34:20.045Z",
+      "eventTime": "2026-05-27T21:00:24.967Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -276,28 +276,28 @@
     },
     {
       "eventId": "15",
-      "eventTime": "2026-05-27T19:34:20.045Z",
+      "eventTime": "2026-05-27T21:00:24.967Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "14",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "16",
-      "eventTime": "2026-05-27T19:34:20.046Z",
+      "eventTime": "2026-05-27T21:00:24.968Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "14",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "17",
-      "eventTime": "2026-05-27T19:34:20.046Z",
+      "eventTime": "2026-05-27T21:00:24.968Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "activityTaskScheduledEventAttributes": {
         "activityId": "3",
@@ -338,17 +338,17 @@
     },
     {
       "eventId": "18",
-      "eventTime": "2026-05-27T19:34:20.046Z",
+      "eventTime": "2026-05-27T21:00:24.968Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "17",
-        "identity": "380497@dataraum-context",
+        "identity": "623762@dataraum-context",
         "attempt": 1
       }
     },
     {
       "eventId": "19",
-      "eventTime": "2026-05-27T19:34:20.046Z",
+      "eventTime": "2026-05-27T21:00:24.969Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "activityTaskCompletedEventAttributes": {
         "result": {
@@ -363,12 +363,12 @@
         },
         "scheduledEventId": "17",
         "startedEventId": "18",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "20",
-      "eventTime": "2026-05-27T19:34:20.046Z",
+      "eventTime": "2026-05-27T21:00:24.969Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -381,28 +381,28 @@
     },
     {
       "eventId": "21",
-      "eventTime": "2026-05-27T19:34:20.046Z",
+      "eventTime": "2026-05-27T21:00:24.969Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "20",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "22",
-      "eventTime": "2026-05-27T19:34:20.047Z",
+      "eventTime": "2026-05-27T21:00:24.970Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "20",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "23",
-      "eventTime": "2026-05-27T19:34:20.047Z",
+      "eventTime": "2026-05-27T21:00:24.970Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "activityTaskScheduledEventAttributes": {
         "activityId": "4",
@@ -443,17 +443,17 @@
     },
     {
       "eventId": "24",
-      "eventTime": "2026-05-27T19:34:20.047Z",
+      "eventTime": "2026-05-27T21:00:24.970Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "23",
-        "identity": "380497@dataraum-context",
+        "identity": "623762@dataraum-context",
         "attempt": 1
       }
     },
     {
       "eventId": "25",
-      "eventTime": "2026-05-27T19:34:20.048Z",
+      "eventTime": "2026-05-27T21:00:24.971Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "activityTaskCompletedEventAttributes": {
         "result": {
@@ -468,12 +468,12 @@
         },
         "scheduledEventId": "23",
         "startedEventId": "24",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "26",
-      "eventTime": "2026-05-27T19:34:20.048Z",
+      "eventTime": "2026-05-27T21:00:24.971Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -486,28 +486,28 @@
     },
     {
       "eventId": "27",
-      "eventTime": "2026-05-27T19:34:20.048Z",
+      "eventTime": "2026-05-27T21:00:24.971Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "26",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "28",
-      "eventTime": "2026-05-27T19:34:20.049Z",
+      "eventTime": "2026-05-27T21:00:24.972Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "26",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "29",
-      "eventTime": "2026-05-27T19:34:20.049Z",
+      "eventTime": "2026-05-27T21:00:24.972Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "activityTaskScheduledEventAttributes": {
         "activityId": "5",
@@ -548,17 +548,17 @@
     },
     {
       "eventId": "30",
-      "eventTime": "2026-05-27T19:34:20.049Z",
+      "eventTime": "2026-05-27T21:00:24.972Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "29",
-        "identity": "380497@dataraum-context",
+        "identity": "623762@dataraum-context",
         "attempt": 1
       }
     },
     {
       "eventId": "31",
-      "eventTime": "2026-05-27T19:34:20.050Z",
+      "eventTime": "2026-05-27T21:00:24.972Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "activityTaskCompletedEventAttributes": {
         "result": {
@@ -573,12 +573,12 @@
         },
         "scheduledEventId": "29",
         "startedEventId": "30",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "32",
-      "eventTime": "2026-05-27T19:34:20.050Z",
+      "eventTime": "2026-05-27T21:00:24.972Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -591,28 +591,28 @@
     },
     {
       "eventId": "33",
-      "eventTime": "2026-05-27T19:34:20.050Z",
+      "eventTime": "2026-05-27T21:00:24.973Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "32",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "34",
-      "eventTime": "2026-05-27T19:34:20.051Z",
+      "eventTime": "2026-05-27T21:00:24.974Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "32",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "35",
-      "eventTime": "2026-05-27T19:34:20.051Z",
+      "eventTime": "2026-05-27T21:00:24.974Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "activityTaskScheduledEventAttributes": {
         "activityId": "6",
@@ -653,17 +653,17 @@
     },
     {
       "eventId": "36",
-      "eventTime": "2026-05-27T19:34:20.051Z",
+      "eventTime": "2026-05-27T21:00:24.974Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "35",
-        "identity": "380497@dataraum-context",
+        "identity": "623762@dataraum-context",
         "attempt": 1
       }
     },
     {
       "eventId": "37",
-      "eventTime": "2026-05-27T19:34:20.052Z",
+      "eventTime": "2026-05-27T21:00:24.974Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "activityTaskCompletedEventAttributes": {
         "result": {
@@ -678,12 +678,12 @@
         },
         "scheduledEventId": "35",
         "startedEventId": "36",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "38",
-      "eventTime": "2026-05-27T19:34:20.052Z",
+      "eventTime": "2026-05-27T21:00:24.974Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
@@ -696,28 +696,28 @@
     },
     {
       "eventId": "39",
-      "eventTime": "2026-05-27T19:34:20.052Z",
+      "eventTime": "2026-05-27T21:00:24.974Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "38",
-        "identity": "380497@dataraum-context"
+        "identity": "623762@dataraum-context"
       }
     },
     {
       "eventId": "40",
-      "eventTime": "2026-05-27T19:34:20.053Z",
+      "eventTime": "2026-05-27T21:00:24.976Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "38",
-        "identity": "380497@dataraum-context",
-        "binaryChecksum": "1f3fdf5089105e269bd763a5c4e05da4",
+        "identity": "623762@dataraum-context",
+        "binaryChecksum": "73f160b96fa9d7ecd58a9e7a19a9c37b",
         "sdkMetadata": {},
         "meteringMetadata": {}
       }
     },
     {
       "eventId": "41",
-      "eventTime": "2026-05-27T19:34:20.053Z",
+      "eventTime": "2026-05-27T21:00:24.976Z",
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
       "workflowExecutionCompletedEventAttributes": {
         "result": {

--- a/packages/engine/tests/unit/worker/test_phase_constants.py
+++ b/packages/engine/tests/unit/worker/test_phase_constants.py
@@ -1,20 +1,67 @@
-"""Guard the two table-local phase lists that must stay in sync (DAT-370).
+"""Guard the phase-list constants that the detect steps depend on (DAT-370).
 
 The child workflow schedules the analytics phases from
-``workflows._ANALYTICS_PHASES``; the stage-level detect step aggregates
-detectors from ``activity._TABLE_LOCAL_PHASES``. They describe the same set of
-table-local phases from two angles: ``_TABLE_LOCAL_PHASES`` is ``typing`` (which
-mints the typed id and owns the ``type_fidelity`` detector) plus the analytics
-phases. If a new table-local phase is added to the workflow but not here, its
-pipeline.yaml detectors would silently never run at ``detect_table`` — so pin the
-relationship with a test rather than a comment.
+``workflows._ANALYTICS_PHASES``; the stage-level detect steps run detectors for
+``activity._TABLE_LOCAL_PHASES`` (``detect_table``, per typed table) and
+``activity._SOURCE_LEVEL_PHASES`` (``detect_source``, once after the reduce).
+
+Two invariants are pinned here:
+1. ``_TABLE_LOCAL_PHASES`` is ``("typing", *_ANALYTICS_PHASES)``.
+2. **No detector a chain phase declares in pipeline.yaml is orphaned** — every
+   such detector runs in one of the two detect steps. This is the regression the
+   original DAT-370 cut introduced and eval caught: ``semantic_per_column``
+   declared five detectors but, having moved off the per-phase path, was in no
+   detect step, so they never executed.
 """
 
 from __future__ import annotations
 
-from dataraum.worker.activity import _TABLE_LOCAL_PHASES
+from dataraum.pipeline.pipeline_config import load_phase_declarations
+from dataraum.worker.activity import (
+    _SOURCE_LEVEL_PHASES,
+    _TABLE_LOCAL_PHASES,
+    declared_detector_ids,
+)
 from dataraum.worker.workflows import _ANALYTICS_PHASES
+
+# The analysis phases the workflows actually execute: import + the child's
+# typing/analytics chain + the parent's source-level reduce. Source of truth is
+# workflows.py (parent + child ``run`` bodies); kept here independently so a
+# detector-bearing chain phase that isn't wired into a detect step is caught.
+_CHAIN_PHASES = (
+    "import",
+    "typing",
+    *_ANALYTICS_PHASES,
+    "semantic_per_column",
+)
 
 
 def test_table_local_phases_are_typing_plus_the_analytics_chain() -> None:
     assert _TABLE_LOCAL_PHASES == ("typing", *_ANALYTICS_PHASES)
+
+
+def test_no_chain_phase_detector_is_orphaned() -> None:
+    """Every detector a chain phase declares runs in detect_table or detect_source."""
+    detect_step_phases = set(_TABLE_LOCAL_PHASES) | set(_SOURCE_LEVEL_PHASES)
+    declarations = load_phase_declarations()
+
+    for phase in _CHAIN_PHASES:
+        decl = declarations.get(phase)
+        if not decl or not decl.detectors:
+            continue
+        assert phase in detect_step_phases, (
+            f"phase '{phase}' declares detectors {decl.detectors} but is in no "
+            "detect step (detect_table / detect_source) — they would never run"
+        )
+
+
+def test_source_level_detectors_resolve_to_the_semantic_reduce() -> None:
+    """detect_source picks up semantic_per_column's declared detectors."""
+    assert _SOURCE_LEVEL_PHASES == ("semantic_per_column",)
+    assert set(declared_detector_ids(_SOURCE_LEVEL_PHASES)) == {
+        "business_meaning",
+        "unit_entropy",
+        "temporal_entropy",
+        "outlier_rate",
+        "benford",
+    }


### PR DESCRIPTION
## Eval-caught regression from DAT-370

DAT-370 moved detectors off the per-phase path and wired only `detect_table` (the table-local phases). `semantic_per_column` runs as the source-level reduce, but **nothing ran its declared detectors** — `business_meaning`, `unit_entropy`, `temporal_entropy`, `outlier_rate`, `benford` — so they've been dead since DAT-370 merged. dataraum-eval found this: those detectors produce "no score" because their detect step was never wired.

**Root cause:** during DAT-370 I grepped a stale `/tmp` spike copy of `pipeline.yaml` (old monolithic `semantic` key) instead of the canonical `packages/dataraum-config/pipeline.yaml`, and wrongly concluded `semantic_per_column` declared no detectors — so I never added a source-level detect step.

## Fix
- New `detect_source` activity (`run_detect_source` → `run_source_detectors`) runs the `_SOURCE_LEVEL_PHASES` (= `semantic_per_column`) detectors **source-wide** (`run_detector_post_step(table_ids=None)`) — a single sequential step in the parent after the reduce, so no concurrency, mirroring `detect_table`.
- `AddSourceWorkflow` now runs `… → semantic_per_column → detect_source`.
- Extracted a shared `_run_detectors` helper behind `run_table_detectors` / `run_source_detectors`.
- **Guard test** `test_no_chain_phase_detector_is_orphaned`: fails if any phase the workflow runs declares a detector that no detect step executes — i.e. it would have caught this regression. Plus a test pinning `detect_source` → the five semantic detectors.
- Parent replay fixture regenerated (now includes `detect_source`); live e2e test exercises `run_source_detectors` after the reduce.

## Verification
- testmon affected: 9 passed / 1 skipped; ruff (incl. format) + mypy clean.
- Replay determinism holds for parent (with `detect_source`) + child.

## Eval handoff
`.claude/handoff.md` updated: re-run `business_meaning` / `unit_entropy` / `temporal_entropy` / `outlier_rate` / `benford` — they now produce scores (no detector logic changed, only the missing execution path restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)