### PR TITLE
feat(dat-371): induce _adhoc ontology as concept overlay rows, not YAML writes

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,47 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-05-28: DAT-371 — `_adhoc` ontology induction moves to `concept` overlay rows
+
+Follow-up to DAT-343 that unblocks DAT-339 user testing. The baked-in
+config root is bind-mounted `:ro`, so `semantic_per_column`'s cold-start
+`_adhoc` path (which used to `OntologyLoader.save()` back to
+`verticals/_adhoc/ontology.yaml`) crashed with `OSError: Read-only file
+system`. Induced concepts now persist as `config_overlay` rows.
+
+### dataraum-eval
+
+- **Eval action: no recalibration needed.** No detector logic changed;
+  concept-content is still produced by the same LLM induction agent
+  with the same prompt and tool schema. What changed is *where* the
+  induced concepts live (Postgres overlay rows, not a YAML file) and
+  the layered-read path that materializes them.
+- **New `concept` overlay applier** in `dataraum.core.overlay`:
+  ``verticals/<v>/ontology.yaml`` reads now merge concept rows
+  (upsert-replace by `name`) **before** `concept_property` patches. If
+  any eval fixture inserts both for the same vertical, the order matters
+  — a `concept` row replaces a concept wholesale; subsequent
+  `concept_property` rows for that concept patch on top.
+- **`OntologyLoader.load` now routes through `load_yaml_config`** so the
+  overlay applies. The in-loader cache is removed (live reads must
+  reflect freshly-inserted rows). Eval fixtures that pass
+  `verticals_dir=...` still bypass the overlay and are deterministic.
+- **`OntologyLoader.save` is deleted.** Any eval helper that wrote a
+  vertical YAML via the loader must switch to inserting `ConfigOverlay`
+  rows (one per concept; `type='concept'`; payload includes `vertical`).
+- **New `_adhoc` baseline ships at
+  `packages/dataraum-config/verticals/_adhoc/ontology.yaml`** with
+  `concepts: []`. The induction-on-cold-start path inserts overlay rows
+  on top of this empty baseline.
+- **Cockpit `concept` payload is now typed** (`ConceptPayload` in
+  `teach.validation.ts`) mirroring `OntologyConcept` — required:
+  `vertical` + `name`; everything else optional with passthrough.
+
+### dataraum-testdata
+
+- No testdata change required. Adhoc induction still happens on the
+  same data shape; the only difference is the persistence substrate.
+
 ## 2026-05-28: DAT-343 — teach via Postgres `config_overlay` + remove-and-replay (E3)
 
 DAT-343 retires the DAT-358 filesystem teach overlay and replaces it with a

--- a/packages/cockpit/src/temporal/drive-add-source.ts
+++ b/packages/cockpit/src/temporal/drive-add-source.ts
@@ -93,13 +93,12 @@ async function runInitial(
 			workspace_id: env.DATARAUM_WORKSPACE_ID,
 			source_id: sourceId,
 			session_id: sessionId,
-			// Use a baked-in vertical so semantic_per_column's _adhoc
-			// induction path (which writes verticals/_adhoc/ontology.yaml
-			// to the now-read-only mounted config) is bypassed. Tracked as
-			// a follow-up to move induction off filesystem writes — see
-			// .claude/dat339-pivot-status.md (DAT-343 follow-up: _adhoc to
-			// concept overlay rows).
-			vertical: "finance",
+			// `_adhoc` is the empty / start-here vertical (DAT-371): cold-start
+			// induction generates concepts from the data and stores them as
+			// `concept` overlay rows, not as YAML writes. This smoke is the
+			// real DAT-371 acceptance test — a clean run proves induction
+			// works against the read-only mounted config.
+			vertical: "_adhoc",
 		},
 	};
 	const result = await client.workflow.execute<

--- a/packages/cockpit/src/tools/teach.test.ts
+++ b/packages/cockpit/src/tools/teach.test.ts
@@ -109,6 +109,85 @@ describe("validateTeach", () => {
 		});
 	});
 
+	describe("concept", () => {
+		it("accepts vertical+name (minimal)", () => {
+			const out = validateTeach({
+				type: "concept",
+				payload: { vertical: "_adhoc", name: "revenue" },
+			});
+			expect(out.vertical).toBe("_adhoc");
+			expect(out.name).toBe("revenue");
+		});
+
+		it("accepts the full OntologyConcept shape", () => {
+			const out = validateTeach({
+				type: "concept",
+				payload: {
+					vertical: "_adhoc",
+					name: "revenue",
+					description: "Total income",
+					indicators: ["revenue", "sales", "income"],
+					exclude_patterns: ["cost", "expense"],
+					temporal_behavior: "additive",
+					typical_role: "measure",
+					typical_values: ["10000", "20000"],
+					unit_from_concept: "currency",
+					is_unit_dimension: false,
+				},
+			});
+			expect(out.indicators).toEqual(["revenue", "sales", "income"]);
+			expect(out.typical_role).toBe("measure");
+			expect(out.is_unit_dimension).toBe(false);
+		});
+
+		it("rejects missing vertical", () => {
+			expect(() =>
+				validateTeach({
+					type: "concept",
+					payload: { name: "revenue" },
+				}),
+			).toThrow(TeachValidationError);
+		});
+
+		it("rejects missing name", () => {
+			expect(() =>
+				validateTeach({
+					type: "concept",
+					payload: { vertical: "_adhoc" },
+				}),
+			).toThrow(TeachValidationError);
+		});
+
+		it("rejects empty vertical", () => {
+			expect(() =>
+				validateTeach({
+					type: "concept",
+					payload: { vertical: "", name: "revenue" },
+				}),
+			).toThrow(TeachValidationError);
+		});
+
+		it("rejects a non-object payload (must be a dict)", () => {
+			expect(() =>
+				validateTeach({ type: "concept", payload: "just a string" }),
+			).toThrow(TeachValidationError);
+		});
+
+		it("passes through extra optional fields", () => {
+			// Mirrors passthrough() — the applier can accept new fields without
+			// a code change in the cockpit.
+			const out = validateTeach({
+				type: "concept",
+				payload: {
+					vertical: "_adhoc",
+					name: "revenue",
+					some_future_field: "ok",
+				},
+			});
+			expect(out.some_future_field).toBe("ok");
+		});
+	});
+
 	describe("concept_property", () => {
 		it("accepts vertical+concept+property+value", () => {
 			const out = validateTeach({
@@ -181,7 +260,6 @@ describe("validateTeach", () => {
 
 	describe("deferred types (generic passthrough)", () => {
 		it.each([
-			"concept",
 			"validation",
 			"cycle",
 			"metric",
@@ -192,12 +270,6 @@ describe("validateTeach", () => {
 				payload: { anything: "goes", here: { nested: true } },
 			});
 			expect(out).toEqual({ anything: "goes", here: { nested: true } });
-		});
-
-		it("concept rejects a non-object payload (must be a dict)", () => {
-			expect(() =>
-				validateTeach({ type: "concept", payload: "just a string" }),
-			).toThrow();
 		});
 	});
 

--- a/packages/cockpit/src/tools/teach.validation.ts
+++ b/packages/cockpit/src/tools/teach.validation.ts
@@ -50,10 +50,31 @@ const ConceptPropertyPayload = z
 	})
 	.passthrough();
 
-// Six deferred types — slice 1 proves the write path only; consumers either
-// land in slice 2+ or already read ConfigOverlay directly (relationship's
-// join_path_determinism detector). Generic object passthrough until each
-// type's consumer is wired, then we tighten here.
+// Mirrors OntologyConcept (packages/engine/.../analysis/semantic/ontology.py).
+// Used both by user teach AND by the engine's cold-start _adhoc induction
+// (DAT-371), which inserts one `concept` row per induced concept instead of
+// writing YAML. Required: vertical + name; the rest mirrors the OntologyConcept
+// fields and is optional. passthrough() lets the applier accept new optional
+// fields without lock-step cockpit edits.
+const ConceptPayload = z
+	.object({
+		vertical: z.string().min(1),
+		name: z.string().min(1),
+		description: z.string().optional(),
+		indicators: z.array(z.string()).optional(),
+		exclude_patterns: z.array(z.string()).optional(),
+		temporal_behavior: z.string().optional(),
+		typical_role: z.string().optional(),
+		typical_values: z.array(z.string()).optional(),
+		unit_from_concept: z.string().optional(),
+		is_unit_dimension: z.boolean().optional(),
+	})
+	.passthrough();
+
+// Five still-deferred types — slice 1 proves the write path only; consumers
+// either land in slice 2+ or already read ConfigOverlay directly
+// (relationship's join_path_determinism detector). Generic object passthrough
+// until each type's consumer is wired, then we tighten here.
 const GenericPayload = z.record(z.string(), z.unknown());
 
 // `relationship` is consumed today by join_path_determinism via
@@ -72,9 +93,9 @@ const RelationshipPayload = z
 const TYPE_SCHEMAS = {
 	type_pattern: TypePatternPayload,
 	null_value: NullValuePayload,
+	concept: ConceptPayload,
 	concept_property: ConceptPropertyPayload,
 	relationship: RelationshipPayload,
-	concept: GenericPayload,
 	validation: GenericPayload,
 	cycle: GenericPayload,
 	metric: GenericPayload,

--- a/packages/dataraum-config/verticals/_adhoc/ontology.yaml
+++ b/packages/dataraum-config/verticals/_adhoc/ontology.yaml
@@ -1,0 +1,22 @@
+# _adhoc — the empty / start-here vertical (DAT-371)
+#
+# Used when no domain vertical has been selected. Cold-start runs of the
+# semantic_per_column phase trigger an LLM induction agent that proposes
+# business concepts from the data's schemas + samples; those concepts are
+# written as `concept`-type rows in the workspace's `config_overlay`
+# table, NOT back into this file. This baseline stays empty — the
+# overlay materializes the induced concepts on every layered read.
+#
+# Selecting `_adhoc` is therefore the "let the engine figure it out"
+# mode; selecting a stock vertical (e.g. `finance`) skips induction and
+# uses the curated concept set under that vertical's directory.
+
+name: _adhoc
+version: "1.0.0"
+description: |
+  Empty baseline used when no domain vertical is selected. The engine
+  induces concepts from the data on cold start and stores them as
+  config_overlay rows; the layered loader materializes them as if they
+  were in this file.
+
+concepts: []

--- a/packages/engine/src/dataraum/analysis/semantic/ontology.py
+++ b/packages/engine/src/dataraum/analysis/semantic/ontology.py
@@ -1,7 +1,11 @@
 """Ontology loading from configuration files.
 
 Loads ontology definitions from config/verticals/<vertical>/ontology.yaml.
-Follows the same pattern as PromptRenderer for YAML config loading.
+Reads go through :func:`dataraum.core.config.load_yaml_config` so the
+workspace's active overlay rows (DAT-343; ``concept`` and
+``concept_property`` types per DAT-371) are merged onto the baked-in
+YAML. Custom ``verticals_dir`` (test fixtures) bypasses the overlay —
+they're deterministic.
 """
 
 from pathlib import Path
@@ -9,7 +13,7 @@ from pathlib import Path
 import yaml
 from pydantic import BaseModel, Field
 
-from dataraum.core.config import get_config_dir
+from dataraum.core.config import get_config_dir, load_yaml_config
 
 
 class OntologyConcept(BaseModel):
@@ -45,26 +49,40 @@ class OntologyLoader:
         """Initialize ontology loader.
 
         Args:
-            verticals_dir: Root verticals directory.
-                          If None, uses config/verticals/
+            verticals_dir: Root verticals directory. ``None`` (production)
+                routes loads through :func:`load_yaml_config` so workspace
+                overlay rows are merged. A custom path (tests / fixtures)
+                reads YAML directly and bypasses the overlay —
+                deterministic for unit tests.
         """
-        if verticals_dir is None:
-            verticals_dir = get_config_dir("verticals")
-
         self.verticals_dir = verticals_dir
-        self._cache: dict[str, OntologyDefinition] = {}
+        # No cache: the overlay-aware production path must reflect newly
+        # inserted overlay rows on the next call (e.g. _adhoc induction
+        # inserts rows then re-reads in the same phase). Per-load latency
+        # is one filesystem read + dict copies; not a hotspot.
 
     def load(self, vertical: str) -> OntologyDefinition | None:
-        """Load and cache an ontology definition for a vertical.
+        """Load an ontology definition for a vertical.
+
+        Production path (``verticals_dir`` is ``None``) goes through
+        :func:`load_yaml_config` so any active overlay rows for
+        ``verticals/<vertical>/ontology.yaml`` are merged in. The test
+        path (explicit ``verticals_dir``) reads YAML directly and
+        bypasses the overlay.
 
         Args:
-            vertical: Vertical name (e.g. 'finance')
+            vertical: Vertical name (e.g. ``'finance'`` or ``'_adhoc'``).
 
         Returns:
-            Loaded ontology definition, or None if not found
+            Loaded (and overlay-merged) ontology definition, or ``None``
+            if the baked-in YAML doesn't exist.
         """
-        if vertical in self._cache:
-            return self._cache[vertical]
+        if self.verticals_dir is None:
+            try:
+                data = load_yaml_config(f"verticals/{vertical}/ontology.yaml")
+            except FileNotFoundError:
+                return None
+            return OntologyDefinition(**data)
 
         ontology_path = self.verticals_dir / vertical / "ontology.yaml"
         if not ontology_path.exists():
@@ -73,38 +91,19 @@ class OntologyLoader:
         with open(ontology_path) as f:
             data = yaml.safe_load(f)
 
-        ontology = OntologyDefinition(**data)
-        self._cache[vertical] = ontology
-        return ontology
-
-    def save(self, vertical: str, definition: OntologyDefinition) -> Path:
-        """Write an OntologyDefinition to YAML.
-
-        Args:
-            vertical: Vertical name (e.g. '_adhoc')
-            definition: The ontology to persist
-
-        Returns:
-            Path to the written YAML file
-        """
-        ontology_path = self.verticals_dir / vertical / "ontology.yaml"
-        ontology_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(ontology_path, "w") as f:
-            yaml.dump(
-                definition.model_dump(exclude_none=True),
-                f,
-                default_flow_style=False,
-                sort_keys=False,
-            )
-        self._cache.pop(vertical, None)
-        return ontology_path
+        return OntologyDefinition(**data)
 
     def list_verticals(self) -> list[str]:
-        """List available verticals with ontology definitions."""
-        if not self.verticals_dir.exists():
-            return []
+        """List available verticals with ontology definitions on disk.
 
-        return [p.parent.name for p in self.verticals_dir.glob("*/ontology.yaml")]
+        Lists only baked-in verticals — overlay rows can't add a wholly
+        new vertical (they augment a vertical whose YAML exists). Returns
+        ``[]`` if the verticals root doesn't exist.
+        """
+        root = self.verticals_dir if self.verticals_dir is not None else get_config_dir("verticals")
+        if not root.exists():
+            return []
+        return [p.parent.name for p in root.glob("*/ontology.yaml")]
 
     def format_concepts_for_prompt(self, ontology: OntologyDefinition | None) -> str:
         """Format ontology concepts for inclusion in LLM prompts.

--- a/packages/engine/src/dataraum/core/overlay.py
+++ b/packages/engine/src/dataraum/core/overlay.py
@@ -24,11 +24,18 @@ Registered teach types
 ----------------------
 * ``type_pattern`` — ``phases/typing.yaml`` ``overrides.patterns.<name>``
 * ``null_value`` — ``null_values.yaml`` under its declared category list
+* ``concept`` — ``verticals/<vertical>/ontology.yaml``, upsert-replace
+  by ``name`` into ``concepts:``; routed via :func:`apply_overlay`'s
+  vertical-path detection. Used both by user teach and by the engine's
+  cold-start ``_adhoc`` induction (DAT-371) which writes one row per
+  induced concept instead of a YAML file.
 * ``concept_property`` — ``verticals/<vertical>/ontology.yaml``,
   patching a field on a named concept entry; routed via
-  :func:`apply_overlay`'s vertical-path detection.
+  :func:`apply_overlay`'s vertical-path detection. Concept rows are
+  applied first (define / replace), then concept_property rows patch on
+  top.
 
-The 6 deferred types (``concept``, ``validation``, ``cycle``, ``metric``,
+The 5 still-deferred types (``validation``, ``cycle``, ``metric``,
 ``relationship``, ``explanation``) have no applier in slice 1 — the
 cockpit may still write their rows, but the layered read is a no-op
 until slice 2+ wires their consumers.
@@ -143,6 +150,39 @@ def _apply_null_value(base: dict[str, Any], rows: list[OverlayRow]) -> dict[str,
     return out
 
 
+def _apply_concept(base: dict[str, Any], rows: list[OverlayRow]) -> dict[str, Any]:
+    """Upsert-replace concept rows into a vertical ontology's ``concepts:`` list.
+
+    Payload shape mirrors :class:`OntologyConcept`:
+    ``{vertical, name, description?, indicators?, exclude_patterns?,
+    temporal_behavior?, typical_role?, typical_values?, unit_from_concept?,
+    is_unit_dimension?}``. ``vertical`` is matched by the caller (this
+    applier only sees rows already filtered to the loading vertical).
+
+    Merge semantics: one row = one concept. Same ``name`` replaces — the
+    last row for a given concept name wins (rows are pre-sorted ASC by
+    ``created_at``). Used by user teach AND by ``_adhoc`` cold-start
+    induction (DAT-371) — induction writes N concept rows instead of a
+    YAML file, and the layered read materializes them as if they were in
+    the base file.
+    """
+    out = dict(base)
+    concepts = [dict(c) for c in (out.get("concepts") or [])]
+    by_name = {c.get("name"): i for i, c in enumerate(concepts) if c.get("name")}
+    for row in rows:
+        payload = {k: v for k, v in row.payload.items() if k != "vertical"}
+        name = payload.get("name")
+        if not name:
+            continue
+        if name in by_name:
+            concepts[by_name[name]] = payload
+        else:
+            by_name[name] = len(concepts)
+            concepts.append(payload)
+    out["concepts"] = concepts
+    return out
+
+
 def _apply_concept_property(base: dict[str, Any], rows: list[OverlayRow]) -> dict[str, Any]:
     """Patch a property on a named concept in a vertical ontology.
 
@@ -208,8 +248,12 @@ def apply_overlay(relative_path: str, base: dict[str, Any]) -> dict[str, Any]:
     registered or no row targets this path.
 
     Dispatch:
-        * ``verticals/<v>/ontology.yaml`` — apply ``concept_property``
-          rows whose payload ``vertical`` matches ``<v>``.
+        * ``verticals/<v>/ontology.yaml`` — apply ``concept`` rows whose
+          payload ``vertical`` matches ``<v>`` (upsert-replace the list),
+          then ``concept_property`` rows for the same vertical patch on
+          top. The order matters: concept defines / replaces a whole
+          concept entry; concept_property patches one field on the
+          (possibly just-replaced) concept.
         * everything else — look up ``relative_path`` in the registry;
           apply each matching teach type's rows.
     """
@@ -228,12 +272,20 @@ def apply_overlay(relative_path: str, base: dict[str, Any]) -> dict[str, Any]:
         _VERTICAL_ONTOLOGY_SUFFIX
     ):
         vertical = relative_path[len(_VERTICAL_ONTOLOGY_PREFIX) : -len(_VERTICAL_ONTOLOGY_SUFFIX)]
-        matching = [
+        concept_rows = [
+            r for r in rows if r.type == "concept" and r.payload.get("vertical") == vertical
+        ]
+        property_rows = [
             r
             for r in rows
             if r.type == "concept_property" and r.payload.get("vertical") == vertical
         ]
-        return _apply_concept_property(base, matching) if matching else base
+        merged = base
+        if concept_rows:
+            merged = _apply_concept(merged, concept_rows)
+        if property_rows:
+            merged = _apply_concept_property(merged, property_rows)
+        return merged
 
     merged = base
     for teach_type, spec in _REGISTRY.items():

--- a/packages/engine/src/dataraum/pipeline/phases/semantic_per_column_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/semantic_per_column_phase.py
@@ -215,12 +215,28 @@ class SemanticPerColumnPhase(BasePhase):
         renderer: PromptRendererType,
         table_ids: list[str],
     ) -> str | None:
-        """Induce an ``_adhoc`` ontology from schemas when none exists. Returns error or None."""
+        """Induce an ``_adhoc`` ontology and persist it as ``concept`` overlay rows.
+
+        DAT-371: the baked-in config root is bind-mounted read-only, so the
+        old "write YAML back to ``verticals/_adhoc/ontology.yaml``" path
+        crashes on cold start. Induced concepts now land as one
+        ``config_overlay`` row per concept (``type="concept"``,
+        ``payload={"vertical": "_adhoc", **concept.model_dump()}``,
+        workspace-scoped — ``session_id=None``); the layered loader
+        materializes them on every subsequent ontology read via
+        :func:`dataraum.core.overlay._apply_concept`.
+
+        Returns the error string on induction failure, ``None`` on
+        success (including the short-circuit when concepts already exist).
+        """
         from dataraum.analysis.semantic.induction import OntologyInductionAgent
         from dataraum.analysis.semantic.ontology import OntologyLoader
+        from dataraum.storage import ConfigOverlay
 
-        loader = OntologyLoader()
-        existing = loader.load("_adhoc")
+        # Short-circuit: re-read through the layered loader so already-
+        # induced concept rows count as "the ontology exists". This is
+        # what makes a re-run after a successful induction idempotent.
+        existing = OntologyLoader().load("_adhoc")
         if existing is not None and existing.concepts:
             return None
 
@@ -231,5 +247,21 @@ class SemanticPerColumnPhase(BasePhase):
             return f"Ontology induction failed: {induction.error}"
         if not induction.value or not induction.value.concepts:
             return "Ontology induction returned no concepts."
-        loader.save("_adhoc", induction.value)
+
+        for concept in induction.value.concepts:
+            ctx.session.add(
+                ConfigOverlay(
+                    session_id=None,  # workspace-scoped: induction is not per-session
+                    type="concept",
+                    payload={"vertical": "_adhoc", **concept.model_dump(exclude_none=True)},
+                )
+            )
+        # Commit so the resolver (which leases its own session via
+        # session_scope) can see the newly inserted rows on the next
+        # load. Postgres READ COMMITTED means a flush alone wouldn't make
+        # the rows visible across sessions. Committing here is also a
+        # crash-safety win: induction is expensive (LLM call); if a later
+        # phase fails, the next run short-circuits this branch via the
+        # ``existing.concepts`` check above.
+        ctx.session.commit()
         return None

--- a/packages/engine/tests/unit/analysis/semantic/test_ontology_loader.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_ontology_loader.py
@@ -2,10 +2,7 @@
 
 from pathlib import Path
 
-import yaml
-
 from dataraum.analysis.semantic import OntologyLoader
-from dataraum.analysis.semantic.ontology import OntologyConcept, OntologyDefinition
 
 
 class TestOntologyLoader:
@@ -36,20 +33,21 @@ class TestOntologyLoader:
 
         assert "No specific ontology concepts defined" in formatted
 
-    def test_ontology_caching(self):
-        """Test that ontologies are cached after first load."""
+    def test_load_adhoc_baseline_is_empty(self) -> None:
+        """The baked-in _adhoc vertical exists but ships with no concepts.
+
+        Cold-start runs of semantic_per_column populate it via overlay
+        rows (DAT-371); the file itself stays at ``concepts: []``.
+        """
         loader = OntologyLoader()
+        ontology = loader.load("_adhoc")
 
-        # First load
-        ontology1 = loader.load("finance")
-        # Second load (should hit cache)
-        ontology2 = loader.load("finance")
-
-        # Should be the same object (cached)
-        assert ontology1 is ontology2
+        assert ontology is not None
+        assert ontology.name == "_adhoc"
+        assert ontology.concepts == []
 
     def test_custom_verticals_dir(self, tmp_path: Path) -> None:
-        """Test using a custom verticals directory."""
+        """Test using a custom verticals directory (bypasses overlay)."""
         # Create a test vertical with ontology file
         vertical_dir = tmp_path / "test_vertical"
         vertical_dir.mkdir()
@@ -73,58 +71,3 @@ concepts:
         assert ontology.name == "test_ontology"
         assert len(ontology.concepts) == 1
         assert ontology.concepts[0].name == "test_concept"
-
-    def test_save_writes_yaml(self, tmp_path: Path) -> None:
-        """Test save() writes a valid ontology YAML file."""
-        loader = OntologyLoader(verticals_dir=tmp_path)
-        (tmp_path / "test_save").mkdir()
-
-        definition = OntologyDefinition(
-            name="induced",
-            description="Auto-generated",
-            concepts=[
-                OntologyConcept(
-                    name="revenue",
-                    description="Total income",
-                    indicators=["revenue", "sales", "income"],
-                    typical_role="measure",
-                    temporal_behavior="additive",
-                ),
-            ],
-        )
-
-        path = loader.save("test_save", definition)
-
-        assert path.exists()
-        data = yaml.safe_load(path.read_text())
-        assert data["name"] == "induced"
-        assert len(data["concepts"]) == 1
-        assert data["concepts"][0]["name"] == "revenue"
-
-    def test_save_invalidates_cache(self, tmp_path: Path) -> None:
-        """Test save() clears the cache for the vertical."""
-        loader = OntologyLoader(verticals_dir=tmp_path)
-
-        # Write initial ontology
-        vertical_dir = tmp_path / "cached_test"
-        vertical_dir.mkdir()
-        initial = OntologyDefinition(name="v1", concepts=[])
-        loader.save("cached_test", initial)
-
-        # Load to populate cache
-        loaded = loader.load("cached_test")
-        assert loaded is not None
-        assert loaded.name == "v1"
-
-        # Save updated version
-        updated = OntologyDefinition(
-            name="v2",
-            concepts=[OntologyConcept(name="test", indicators=["test"])],
-        )
-        loader.save("cached_test", updated)
-
-        # Load again — should get v2, not cached v1
-        reloaded = loader.load("cached_test")
-        assert reloaded is not None
-        assert reloaded.name == "v2"
-        assert len(reloaded.concepts) == 1

--- a/packages/engine/tests/unit/core/test_overlay.py
+++ b/packages/engine/tests/unit/core/test_overlay.py
@@ -161,6 +161,151 @@ class TestApplyNullValue:
         assert merged["standard_nulls"] == []
 
 
+class TestApplyConcept:
+    """``concept`` rows upsert-replace into a vertical ontology's ``concepts:`` list.
+
+    Used by user teach AND by ``_adhoc`` cold-start induction (DAT-371) —
+    induction writes one row per induced concept instead of a YAML file.
+    """
+
+    def teardown_method(self) -> None:
+        reset_overlay_resolver_for_tests()
+
+    def test_appends_new_concept_to_empty_baseline(self) -> None:
+        """Empty ``_adhoc`` baseline + one concept row materializes that concept."""
+        base = {"name": "_adhoc", "concepts": []}
+        set_overlay_resolver(
+            lambda: [
+                OverlayRow(
+                    type="concept",
+                    payload={
+                        "vertical": "_adhoc",
+                        "name": "revenue",
+                        "description": "Total income",
+                        "indicators": ["revenue", "sales"],
+                        "typical_role": "measure",
+                    },
+                )
+            ]
+        )
+        merged = apply_overlay("verticals/_adhoc/ontology.yaml", base)
+        assert merged["concepts"] == [
+            {
+                "name": "revenue",
+                "description": "Total income",
+                "indicators": ["revenue", "sales"],
+                "typical_role": "measure",
+            }
+        ]
+        # ``vertical`` is the routing key, never leaks into the merged concept.
+        assert "vertical" not in merged["concepts"][0]
+
+    def test_appends_alongside_existing_concepts(self) -> None:
+        base = {
+            "name": "finance",
+            "concepts": [{"name": "revenue", "indicators": ["rev"]}],
+        }
+        set_overlay_resolver(
+            lambda: [
+                OverlayRow(
+                    type="concept",
+                    payload={
+                        "vertical": "finance",
+                        "name": "cost",
+                        "indicators": ["cost", "expense"],
+                    },
+                )
+            ]
+        )
+        merged = apply_overlay("verticals/finance/ontology.yaml", base)
+        assert [c["name"] for c in merged["concepts"]] == ["revenue", "cost"]
+        # Existing concept untouched.
+        assert merged["concepts"][0] == {"name": "revenue", "indicators": ["rev"]}
+
+    def test_same_name_replaces_in_place(self) -> None:
+        """Upsert-replace by name: a later row for the same concept wins."""
+        base = {
+            "name": "finance",
+            "concepts": [{"name": "revenue", "indicators": ["old"], "typical_role": "measure"}],
+        }
+        set_overlay_resolver(
+            lambda: [
+                OverlayRow(
+                    type="concept",
+                    payload={
+                        "vertical": "finance",
+                        "name": "revenue",
+                        "indicators": ["new"],
+                    },
+                )
+            ]
+        )
+        merged = apply_overlay("verticals/finance/ontology.yaml", base)
+        revenue = next(c for c in merged["concepts"] if c["name"] == "revenue")
+        # Replaced wholesale — old ``typical_role`` is gone.
+        assert revenue == {"name": "revenue", "indicators": ["new"]}
+
+    def test_skips_row_targeting_other_vertical(self) -> None:
+        base = {"concepts": []}
+        set_overlay_resolver(
+            lambda: [
+                OverlayRow(
+                    type="concept",
+                    payload={"vertical": "marketing", "name": "campaign"},
+                )
+            ]
+        )
+        merged = apply_overlay("verticals/finance/ontology.yaml", base)
+        # No row for finance → identity short-circuit (no concept rows for vertical).
+        assert merged is base
+
+    def test_row_without_name_is_ignored(self) -> None:
+        base = {"concepts": []}
+        set_overlay_resolver(
+            lambda: [
+                OverlayRow(
+                    type="concept",
+                    payload={"vertical": "_adhoc", "description": "no name"},
+                )
+            ]
+        )
+        merged = apply_overlay("verticals/_adhoc/ontology.yaml", base)
+        assert merged["concepts"] == []
+
+    def test_concept_rows_apply_before_property_patches(self) -> None:
+        """Dispatcher applies concept rows first, then concept_property patches on top.
+
+        Pins the order documented in :func:`apply_overlay`: a concept
+        row may freshly insert a concept, then a property row may patch a
+        field on that same just-inserted concept in the same merge pass.
+        """
+        base = {"name": "_adhoc", "concepts": []}
+        set_overlay_resolver(
+            lambda: [
+                OverlayRow(
+                    type="concept",
+                    payload={"vertical": "_adhoc", "name": "revenue", "indicators": ["rev"]},
+                ),
+                OverlayRow(
+                    type="concept_property",
+                    payload={
+                        "vertical": "_adhoc",
+                        "concept": "revenue",
+                        "property": "typical_role",
+                        "value": "measure",
+                    },
+                ),
+            ]
+        )
+        merged = apply_overlay("verticals/_adhoc/ontology.yaml", base)
+        revenue = next(c for c in merged["concepts"] if c["name"] == "revenue")
+        assert revenue == {
+            "name": "revenue",
+            "indicators": ["rev"],
+            "typical_role": "measure",
+        }
+
+
 class TestApplyConceptProperty:
     """``concept_property`` rows patch a field on a named concept entry.
 


### PR DESCRIPTION
[DAT-371](https://real-dataraum.atlassian.net/browse/DAT-371) — E3b follow-up to DAT-343. Unblocks DAT-339 user testing.

## Summary
- DAT-343 made the baked-in config root bind-mounted `:ro`, but `semantic_per_column._ensure_adhoc_ontology` was still calling `loader.save("_adhoc", …)` and crashing with `OSError: Read-only file system` on any cold-start run that didn't pick a stock vertical.
- Induced concepts now persist as `ConfigOverlay` rows (`type="concept"`, payload includes `vertical="_adhoc"`); the layered loader materializes them via a new `_apply_concept` applier in `dataraum.core.overlay`.
- `OntologyLoader.load` is routed through `load_yaml_config` so the overlay applies; the in-loader cache is dropped (live reads must reflect freshly-inserted rows). `OntologyLoader.save` is deleted.
- Ships a `verticals/_adhoc/ontology.yaml` baseline (`concepts: []`) so `_adhoc` is a first-class empty vertical, not a special-cased missing file.
- Cockpit `concept` payload promoted from `GenericPayload` to typed `ConceptPayload` mirroring `OntologyConcept`.
- Integration smoke (`drive-add-source.ts`) flipped back from `vertical: "finance"` (DAT-371 workaround pin) to `vertical: "_adhoc"`. The smoke becomes the real DAT-371 acceptance test.

## Notable deviation from the refined spec
- The locked approach said `ctx.session.flush()` after inserting the rows. That's insufficient: the overlay resolver opens its own session via `manager.session_scope()`, and Postgres READ COMMITTED isolation means a flush in one transaction is invisible to another. I used `ctx.session.commit()` instead — also a crash-safety win (the LLM induction call is expensive, and a later phase failure now short-circuits the re-run via the `existing.concepts` check). Documented inline.

## Test plan
- [x] Engine unit: new `TestApplyConcept` (6 cases) + updated dispatcher tests — `tests/unit/core/test_overlay.py` (28 pass).
- [x] Engine unit: ontology loader tests updated (cache test removed, baseline-empty `_adhoc` test added) — `tests/unit/analysis/semantic/test_ontology_loader.py` (5 pass).
- [x] Engine unit: full `tests/unit` testmon sweep — 1313 pass.
- [x] Engine: `ruff check` + `mypy` clean.
- [x] Cockpit unit: `ConceptPayload` validation (7 cases) — `src/tools/teach.test.ts` (30 pass).
- [x] Cockpit: `biome check` clean.
- [ ] **User-driven smoke (real LLM call, do not run unattended):** `drive-add-source.ts` integration smoke with `_adhoc`. The first run should induce + persist concept rows; the second run should short-circuit via the existing-concepts check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)