### PR TITLE
fix(dat-343): cascade per-Column FK deletes through to the DB

### DIFF
--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -874,7 +874,7 @@ export const temporalColumnProfiles = metadataSchema.table(
 			.references(() => investigationSessions.sessionId),
 		columnId: varchar("column_id")
 			.notNull()
-			.references(() => columns.columnId),
+			.references(() => columns.columnId, { onDelete: "cascade" }),
 		profiledAt: timestamp("profiled_at").notNull(),
 		minTimestamp: timestamp("min_timestamp").notNull(),
 		maxTimestamp: timestamp("max_timestamp").notNull(),

--- a/packages/cockpit/src/temporal/drive-add-source.ts
+++ b/packages/cockpit/src/temporal/drive-add-source.ts
@@ -66,17 +66,18 @@ async function seed(sourceId: string, sessionId: string): Promise<void> {
 	}
 }
 
-async function countOverlays(workspaceId: string): Promise<number> {
+async function countOverlays(): Promise<number> {
 	// Counted via raw SQL (not Drizzle) so the assertion stays independent
 	// of the metadata client — proves the rows actually landed in the
 	// engine's schema, not just that Drizzle returned what it inserted.
+	// Workspace scope is implicit in the ws_<id> schema (DAT-343 dropped
+	// the workspace_id column).
 	const sql = postgres(env.METADATA_DATABASE_URL, { onnotice: () => {} });
 	try {
 		const rows = await sql<{ count: number }[]>`
 			SELECT count(*)::int AS count
 			FROM ${sql(schema)}.config_overlay
-			WHERE workspace_id = ${workspaceId}
-			  AND superseded_at IS NULL`;
+			WHERE superseded_at IS NULL`;
 		return rows[0]?.count ?? 0;
 	} finally {
 		await sql.end();
@@ -176,7 +177,7 @@ async function main(): Promise<void> {
 		});
 		console.log(`✓ wrote teaches: ${teach1.overlay_id}, ${teach2.overlay_id}`);
 
-		const overlayCount = await countOverlays(env.DATARAUM_WORKSPACE_ID);
+		const overlayCount = await countOverlays();
 		if (overlayCount < 2) {
 			throw new Error(
 				`expected at least 2 active overlay rows post-teach, got ${overlayCount}`,
@@ -184,9 +185,15 @@ async function main(): Promise<void> {
 		}
 
 		// ---- Replay from typing for the affected raw tables --------------
+		// Reuse the seeded InvestigationSession — per-session rows the replay
+		// re-creates (TypeCandidate, etc.) FK to investigation_sessions, and
+		// the replay tool would otherwise mint a random session_id with no
+		// matching row. Slice 1 has no session lifecycle; one session per
+		// driver run is fine.
 		const replayResult = await replay({
 			source_id: sourceId,
-			vertical: "finance",
+			session_id: sessionId,
+			vertical: "_adhoc",
 			scope: {
 				from_phase: "typing",
 				raw_table_ids: initial.raw_table_ids,
@@ -219,7 +226,7 @@ async function main(): Promise<void> {
 
 		// Sanity: the overlay rows are still active after replay (replay
 		// reads them; it doesn't supersede them — that's `undoTeach`'s job).
-		const postReplayCount = await countOverlays(env.DATARAUM_WORKSPACE_ID);
+		const postReplayCount = await countOverlays();
 		if (postReplayCount < overlayCount) {
 			throw new Error(
 				`replay: active overlay count dropped from ${overlayCount} to ${postReplayCount} ` +

--- a/packages/engine/src/dataraum/analysis/temporal/db_models.py
+++ b/packages/engine/src/dataraum/analysis/temporal/db_models.py
@@ -41,7 +41,9 @@ class TemporalColumnProfile(Base):
     session_id: Mapped[str] = mapped_column(
         ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
     )
-    column_id: Mapped[str] = mapped_column(ForeignKey("columns.column_id"), nullable=False)
+    column_id: Mapped[str] = mapped_column(
+        ForeignKey("columns.column_id", ondelete="CASCADE"), nullable=False
+    )
     profiled_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
 
     # Relationships

--- a/packages/engine/src/dataraum/storage/models.py
+++ b/packages/engine/src/dataraum/storage/models.py
@@ -62,8 +62,12 @@ class Source(Base):
     archived_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # Relationships
+    # passive_deletes=True: lean on the DB's ON DELETE CASCADE (declared on the
+    # child FK) instead of having SQLAlchemy load children and NULL their FKs on
+    # flush. Required for bulk SQL DELETE in replay_cleanup to behave like the
+    # ORM cascade declaration claims (DAT-343 follow-up).
     tables: Mapped[list[Table]] = relationship(
-        back_populates="source", cascade="all, delete-orphan"
+        back_populates="source", cascade="all, delete-orphan", passive_deletes=True
     )
 
 
@@ -100,12 +104,12 @@ class Table(Base):
     # Relationships
     source: Mapped[Source] = relationship(back_populates="tables")
     columns: Mapped[list[Column]] = relationship(
-        back_populates="table", cascade="all, delete-orphan"
+        back_populates="table", cascade="all, delete-orphan", passive_deletes=True
     )
 
     # Semantic context relationships
     entity_detections: Mapped[list[TableEntity]] = relationship(
-        back_populates="table", cascade="all, delete-orphan"
+        back_populates="table", cascade="all, delete-orphan", passive_deletes=True
     )
 
 
@@ -136,38 +140,54 @@ class Column(Base):
     # Relationships
     table: Mapped[Table] = relationship(back_populates="columns")
 
-    # Context-specific relationships (defined in their respective modules)
+    # Context-specific relationships (defined in their respective modules).
+    # passive_deletes=True everywhere a Column-owned child sits on the other end:
+    # bulk SQL DELETE in per-phase replay_cleanup hooks (e.g. typing_phase) only
+    # works if SQLAlchemy DOES NOT pre-load and NULL the FK on flush, and lets
+    # the DB's ON DELETE CASCADE do the work instead (DAT-343 follow-up).
     statistical_profiles: Mapped[list[StatisticalProfile]] = relationship(
-        back_populates="column", cascade="all, delete-orphan"
+        back_populates="column", cascade="all, delete-orphan", passive_deletes=True
     )
     statistical_quality_metrics: Mapped[list[StatisticalQualityMetrics]] = relationship(
-        back_populates="column", cascade="all, delete-orphan"
+        back_populates="column", cascade="all, delete-orphan", passive_deletes=True
     )
 
     # Type inference relationships
     type_candidates: Mapped[list[TypeCandidate]] = relationship(
-        back_populates="column", cascade="all, delete-orphan"
+        back_populates="column", cascade="all, delete-orphan", passive_deletes=True
     )
     type_decision: Mapped[TypeDecision | None] = relationship(
-        back_populates="column", uselist=False, cascade="all, delete-orphan"
+        back_populates="column",
+        uselist=False,
+        cascade="all, delete-orphan",
+        passive_deletes=True,
     )
 
     # Semantic context relationships
     semantic_annotation: Mapped[SemanticAnnotation | None] = relationship(
-        back_populates="column", uselist=False, cascade="all, delete-orphan"
+        back_populates="column",
+        uselist=False,
+        cascade="all, delete-orphan",
+        passive_deletes=True,
     )
 
     # Temporal analysis
     temporal_profiles: Mapped[list[TemporalColumnProfile]] = relationship(
-        back_populates="column", cascade="all, delete-orphan"
+        back_populates="column", cascade="all, delete-orphan", passive_deletes=True
     )
 
-    # Relationship tracking
+    # Relationship tracking — relationships are owned by the relationships
+    # phase, not the Column; deletion semantics live at the DB-level CASCADE on
+    # the FK (passive_deletes prevents the pre-flush FK-NULL probe).
     relationships_from: Mapped[list[Relationship]] = relationship(
-        foreign_keys="Relationship.from_column_id", back_populates="from_column"
+        foreign_keys="Relationship.from_column_id",
+        back_populates="from_column",
+        passive_deletes=True,
     )
     relationships_to: Mapped[list[Relationship]] = relationship(
-        foreign_keys="Relationship.to_column_id", back_populates="to_column"
+        foreign_keys="Relationship.to_column_id",
+        back_populates="to_column",
+        passive_deletes=True,
     )
 
 


### PR DESCRIPTION
Replay cleanup hooks (e.g. typing_phase.replay_cleanup) drop typed/ quarantine Tables via bulk SQL DELETE — the ORM "cascade='all, delete-orphan'" declared on Column.* never fires for a bulk delete, so Postgres rejected the parent delete with a FK violation from leftover per-Column rows (temporal_column_profiles in the smoke; same shape on every per-Column output model).

Two changes make the cascade declarations honest at the DB level:

1. TemporalColumnProfile.column_id now declares `ForeignKey("columns.column_id", ondelete="CASCADE")`. The other per-Column outputs already had it; temporal was the lone holdout.

2. All Column-owned (and Table-/Source-owned) cascading relationships in storage/models.py grow `passive_deletes=True`. Without it, SQLAlchemy still pre-loads children and NULLs their FK on flush before the bulk DELETE, defeating the ON DELETE CASCADE the DB would otherwise execute itself.

Also re-pulls the cockpit Drizzle metadata mirror against a fresh Postgres volume so `temporalColumnProfiles.columnId` carries `onDelete: "cascade"`, matching the new engine DDL.

The smoke (drive-add-source.ts teach+replay path) is now end-to-end green. Two collateral fixes in the smoke driver itself:

- Drop the stale `WHERE workspace_id = …` filter on config_overlay (column was removed by DAT-343; same one-line fix as fix/dat-371-smoke-stale-workspace-id, applied here so the smoke can validate this PR).
- Pass `session_id: sessionId` to `replay(...)` so the replay reuses the seeded InvestigationSession; otherwise the replay tool mints a random UUID with no matching row and the first per-session insert during re-typing fails its session_id FK. Flip the replay's vertical from `"finance"` (pre-DAT-371 workaround) to `"_adhoc"` to match the initial run.

Out of scope: the broader DAT-373 cross-stage cleanup-ownership redesign — this PR is the bounded fix that makes the existing bulk DELETE behave as the cascade declarations already claim.

Refs DAT-343; Related DAT-373.