### PR TITLE
fix(infra): bind dev compose ports to 0.0.0.0 for sandbox port-forwar…

### DIFF
--- a/packages/infra/docker-compose.yml
+++ b/packages/infra/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ../engine/docker/postgres-init/:/docker-entrypoint-initdb.d/:ro
     ports:
-      - "127.0.0.1:5432:5432"
+      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
@@ -82,7 +82,7 @@ services:
     volumes:
       - ./dynamicconfig:/etc/temporal/config/dynamicconfig:ro
     ports:
-      - "127.0.0.1:7233:7233"
+      - "7233:7233"
     healthcheck:
       # `nc -z` is what the canonical sample uses for the server image (it ships
       # no `temporal` CLI). The create-namespace one-shot below does the real
@@ -129,7 +129,7 @@ services:
       TEMPORAL_ADDRESS: temporal:7233
       TEMPORAL_CORS_ORIGINS: http://localhost:3000
     ports:
-      - "127.0.0.1:8080:8080"
+      - "8080:8080"
 
   # Engine Temporal activity worker (DAT-344). The engine is a pure activity
   # worker now — no Starlette shell, no HTTP port. It bootstraps one workspace
@@ -215,7 +215,7 @@ services:
       # Read-only config (DAT-361) — see DATARAUM_CONFIG_PATH above.
       - ${HOST_CONFIG_DIR:-../dataraum-config}:/opt/dataraum/config:ro
     ports:
-      - "127.0.0.1:3000:3000"
+      - "3000:3000"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "--spider", "http://localhost:3000/"]
       interval: 10s


### PR DESCRIPTION
…ding

The published ports for postgres, temporal, temporal-ui, and cockpit were prefixed with `127.0.0.1:`, so inside the dev sandbox they bound only to the sandbox's loopback. `sbx ports <sandbox> --publish <port>:<port>/tcp` forwards the host port to the sandbox's `eth0`, not loopback — so the host browser couldn't reach the cockpit at :3000 or the Temporal UI at :8080 despite the sandbox port-publish working as documented.

Drop the prefix (defaults to 0.0.0.0) on the four published dev ports. The trade is the published ports become reachable on any interface of the docker host; for the sandboxed dev loop that's the point. If a locked-down prod-style binding is needed later, it belongs in a docker-compose.override.yml rather than the shared dev file.

Verified: drive-add-source.ts smoke runs end-to-end against the restarted stack (initial _adhoc cold-start induction + two teaches + typing replay with typed_table_ids change + post-replay overlay count sanity) — no regressions from the binding change.