### PR TITLE
refactor(dat-376): split induction <-> grounding in semantic_per_column

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,55 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-05-29: DAT-376 — split induction ↔ grounding in `semantic_per_column` (structure-only)
+
+Detached the two LLM steps inside `semantic_per_column` into independently
+callable module-level functions, **in place** — no new pipeline stage, and
+the `add_source` surface (workflow names, activity names, phase order,
+`pipeline.yaml`, `contracts.py`) is byte-for-byte unchanged. This is a pure
+extract-then-rewire; the phase `_run` is now a thin composer over the two
+functions.
+
+### dataraum-eval
+
+- **Eval action: NO recalibration needed.** Recall is safe by construction —
+  nothing that produces detector/annotation content changed:
+  - The **ontology induction agent**, its prompt, and its tool schema are
+    untouched (the extracted `induce_adhoc_concepts` wraps the *same*
+    `OntologyInductionAgent.induce` call and the *same* per-concept
+    `ConfigOverlay(type="concept", payload={"vertical":"_adhoc", ...})`
+    insert + `session.commit()` as DAT-371's `_ensure_adhoc_ontology`).
+  - The **`ColumnAnnotationAgent`** (the grounding step's worker), its prompt,
+    its tool schema, and the `required_standard_fields` it receives from
+    `GraphLoader(vertical=ontology).get_all_abstract_fields()` are unchanged.
+  - **`persist_column_annotations`** row shapes are unchanged (reused verbatim).
+  - All five `semantic_per_column` detectors are unchanged.
+- **`replay_cleanup` is unchanged** — still drops `SemanticAnnotation` only and
+  NEVER the induced `concept` `ConfigOverlay` rows. A new regression test pins
+  this (`test_semantic_split_phases.py::TestPerColumnReplayCleanup`).
+
+### The new seam (for DAT-377 / DAT-378)
+
+`semantic_per_column` now composes two functions, both in
+`dataraum.analysis.semantic` (and re-exported from its `__init__`):
+
+- `induction.induce_adhoc_concepts(*, session, config, provider, renderer, table_ids) -> Result[int]`
+  — cold-start `_adhoc` ontology induction. Short-circuits (returns `Result.ok(0)`)
+  when concepts already exist; otherwise induces and inserts one `concept`
+  overlay row per concept, then commits. The `if ontology == "_adhoc":` gate
+  stays at the call site.
+- `processor.ground_columns(*, session, config, provider, renderer, table_ids, ontology, session_id) -> Result[int]`
+  — per-column annotation + `persist_column_annotations`, returns the row count.
+
+This is the seam DAT-377/378 act on: the **connect/frame relocation moves the
+induction CALL upstream** (induction belongs in `frame`, where the user declares
+concepts before data — see the `project_frame_stage_ontology` memory), leaving
+`add_source` / `semantic_per_column` calling **only** `ground_columns`. No
+content change to either step is implied by that move — purely *where* the
+induction call lives.
+
+- **Status**: pending
+
 ## 2026-05-28: DAT-371 — `_adhoc` ontology induction moves to `concept` overlay rows
 
 Follow-up to DAT-343 that unblocks DAT-339 user testing. The baked-in

--- a/packages/engine/src/dataraum/analysis/semantic/__init__.py
+++ b/packages/engine/src/dataraum/analysis/semantic/__init__.py
@@ -13,6 +13,10 @@ from dataraum.analysis.semantic.db_models import (
 from dataraum.analysis.semantic.db_models import (
     TableEntity,
 )
+from dataraum.analysis.semantic.induction import (
+    OntologyInductionAgent,
+    induce_adhoc_concepts,
+)
 from dataraum.analysis.semantic.models import (
     ColumnAnnotationOutput,
     EntityDetection,
@@ -27,6 +31,7 @@ from dataraum.analysis.semantic.ontology import (
     OntologyLoader,
 )
 from dataraum.analysis.semantic.processor import (
+    ground_columns,
     persist_column_annotations,
     synthesize_and_store_tables,
 )
@@ -35,6 +40,9 @@ __all__ = [
     # Main entry points
     "persist_column_annotations",
     "synthesize_and_store_tables",
+    "ground_columns",
+    "induce_adhoc_concepts",
+    "OntologyInductionAgent",
     "SemanticAgent",
     "ColumnAnnotationAgent",
     # Ontology

--- a/packages/engine/src/dataraum/analysis/semantic/induction.py
+++ b/packages/engine/src/dataraum/analysis/semantic/induction.py
@@ -11,6 +11,7 @@ phase for concept mapping on the same pipeline run.
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Session
 
@@ -25,6 +26,11 @@ from dataraum.llm.providers.base import (
     Message,
     ToolDefinition,
 )
+
+if TYPE_CHECKING:
+    from dataraum.llm.config import LLMConfig
+    from dataraum.llm.prompts import PromptRenderer
+    from dataraum.llm.providers.base import LLMProvider
 
 logger = get_logger(__name__)
 
@@ -123,3 +129,70 @@ class OntologyInductionAgent(LLMFeature):
             name=definition.name,
         )
         return Result.ok(definition)
+
+
+def induce_adhoc_concepts(
+    *,
+    session: Session,
+    config: LLMConfig,
+    provider: LLMProvider,
+    renderer: PromptRenderer,
+    table_ids: list[str],
+) -> Result[int]:
+    """Induce an ``_adhoc`` ontology and persist it as ``concept`` overlay rows.
+
+    DAT-376: extracted verbatim from ``SemanticPerColumnPhase._ensure_adhoc_ontology``
+    so the cold-start induction step is independently callable (the connect/frame
+    relocation moves this CALL upstream; ``ground_columns`` then runs alone).
+
+    DAT-371: the baked-in config root is bind-mounted read-only, so the
+    old "write YAML back to ``verticals/_adhoc/ontology.yaml``" path
+    crashes on cold start. Induced concepts now land as one
+    ``config_overlay`` row per concept (``type="concept"``,
+    ``payload={"vertical": "_adhoc", **concept.model_dump()}``,
+    workspace-scoped — ``session_id=None``); the layered loader
+    materializes them on every subsequent ontology read via
+    :func:`dataraum.core.overlay._apply_concept`.
+
+    Returns:
+        ``Result.ok(count)`` with the number of concept overlay rows inserted
+        (``0`` for the short-circuit when concepts already exist), or
+        ``Result.fail`` on induction failure.
+    """
+    from dataraum.analysis.semantic.ontology import OntologyLoader
+    from dataraum.storage import ConfigOverlay
+
+    # Short-circuit: re-read through the layered loader so already-
+    # induced concept rows count as "the ontology exists". This is
+    # what makes a re-run after a successful induction idempotent.
+    existing = OntologyLoader().load("_adhoc")
+    if existing is not None and existing.concepts:
+        return Result.ok(0)
+
+    induction = OntologyInductionAgent(
+        config=config, provider=provider, prompt_renderer=renderer
+    ).induce(session=session, table_ids=table_ids)
+    if not induction.success:
+        return Result.fail(f"Ontology induction failed: {induction.error}")
+    if not induction.value or not induction.value.concepts:
+        return Result.fail("Ontology induction returned no concepts.")
+
+    count = 0
+    for concept in induction.value.concepts:
+        session.add(
+            ConfigOverlay(
+                session_id=None,  # workspace-scoped: induction is not per-session
+                type="concept",
+                payload={"vertical": "_adhoc", **concept.model_dump(exclude_none=True)},
+            )
+        )
+        count += 1
+    # Commit so the resolver (which leases its own session via
+    # session_scope) can see the newly inserted rows on the next
+    # load. Postgres READ COMMITTED means a flush alone wouldn't make
+    # the rows visible across sessions. Committing here is also a
+    # crash-safety win: induction is expensive (LLM call); if a later
+    # phase fails, the next run short-circuits this branch via the
+    # ``existing.concepts`` check above.
+    session.commit()
+    return Result.ok(count)

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -5,10 +5,15 @@ Orchestrates semantic analysis using the SemanticAgent and stores results.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import duckdb
 from sqlalchemy.orm import Session
+
+if TYPE_CHECKING:
+    from dataraum.llm.config import LLMConfig
+    from dataraum.llm.prompts import PromptRenderer
+    from dataraum.llm.providers.base import LLMProvider
 
 from dataraum.analysis.relationships.db_models import Relationship as RelationshipModel
 from dataraum.analysis.relationships.evaluator import (
@@ -192,6 +197,75 @@ def persist_column_annotations(
             )
             count += 1
     return count
+
+
+def ground_columns(
+    *,
+    session: Session,
+    config: LLMConfig,
+    provider: LLMProvider,
+    renderer: PromptRenderer,
+    table_ids: list[str],
+    ontology: str,
+    session_id: str,
+) -> Result[int]:
+    """Annotate columns against ``ontology`` and persist ``SemanticAnnotation`` rows.
+
+    DAT-376: extracted verbatim from the grounding tail of
+    ``SemanticPerColumnPhase._run``. Grounding maps each column to its semantic
+    role, entity type, business term, and ontology concept — it assumes the
+    ontology already exists (cold-start ``_adhoc`` induction is a separate
+    upstream step, :func:`induce_adhoc_concepts`).
+
+    Args:
+        session: Database session.
+        config: Loaded LLM config (gates on ``features.column_annotation``).
+        provider: LLM provider (resolves the annotation model tier).
+        renderer: Prompt renderer for the annotation agent.
+        table_ids: Typed tables to annotate.
+        ontology: Vertical name the columns map their concepts into.
+        session_id: Per-session FK for the persisted annotation rows.
+
+    Returns:
+        ``Result.ok(count)`` with the number of annotation rows persisted, or
+        ``Result.fail`` with the same messages the phase surfaced before.
+    """
+    from dataraum.analysis.semantic.column_agent import ColumnAnnotationAgent
+    from dataraum.analysis.semantic.ontology import OntologyLoader
+    from dataraum.graphs.loader import GraphLoader
+
+    col_config = config.features.column_annotation
+    if not col_config or not col_config.enabled:
+        return Result.fail("Column annotation is disabled in config.")
+
+    # Standard-field concepts required by active metric graphs, so the model
+    # prioritizes mapping those concepts to actual columns.
+    metric_loader = GraphLoader(vertical=ontology)
+    metric_loader.load_all()
+    required_standard_fields = sorted(metric_loader.get_all_abstract_fields())
+
+    agent = ColumnAnnotationAgent(config=config, provider=provider, prompt_renderer=renderer)
+    annotation_result = agent.annotate(
+        session=session,
+        table_ids=table_ids,
+        ontology=ontology,
+        required_standard_fields=required_standard_fields,
+    )
+    if not annotation_result.success or not annotation_result.value:
+        return Result.fail(f"Column annotation failed: {annotation_result.error}")
+
+    ontology_def = OntologyLoader().load(ontology)
+    model_name = provider.get_model_for_tier(col_config.model_tier)
+
+    count = persist_column_annotations(
+        session,
+        annotation_result.value,
+        table_ids,
+        annotated_by=model_name,
+        session_id=session_id,
+        ontology_def=ontology_def,
+    )
+    return Result.ok(count)
 
 
 def synthesize_and_store_tables(

--- a/packages/engine/src/dataraum/pipeline/phases/semantic_per_column_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/semantic_per_column_phase.py
@@ -13,24 +13,18 @@ Cross-table reasoning (entities, relationships) moves to ``semantic_per_table``.
 from __future__ import annotations
 
 from types import ModuleType
-from typing import TYPE_CHECKING
 
 from sqlalchemy import delete, func, select
 
-from dataraum.analysis.semantic.column_agent import ColumnAnnotationAgent
 from dataraum.analysis.semantic.db_models import SemanticAnnotation
-from dataraum.analysis.semantic.processor import persist_column_annotations
+from dataraum.analysis.semantic.induction import induce_adhoc_concepts
+from dataraum.analysis.semantic.processor import ground_columns
 from dataraum.core.logging import get_logger
 from dataraum.llm import PromptRenderer, create_provider, load_llm_config
 from dataraum.pipeline.base import PhaseContext, PhaseResult
 from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.registry import analysis_phase
 from dataraum.storage import Column, Table
-
-if TYPE_CHECKING:
-    from dataraum.llm.config import LLMConfig
-    from dataraum.llm.prompts import PromptRenderer as PromptRendererType
-    from dataraum.llm.providers.base import LLMProvider
 
 logger = get_logger(__name__)
 
@@ -129,6 +123,14 @@ class SemanticPerColumnPhase(BasePhase):
         return None
 
     def _run(self, ctx: PhaseContext) -> PhaseResult:
+        """Resolve config, induce ``_adhoc`` concepts on cold start, then ground.
+
+        A thin composer (DAT-376): the two LLM steps live as module-level
+        functions — :func:`induce_adhoc_concepts` (cold-start ontology) and
+        :func:`ground_columns` (per-column annotation). The ``_adhoc`` gate
+        stays here at the call site; the connect/frame relocation (DAT-377/378)
+        will move the induction CALL upstream and leave this phase grounding only.
+        """
         table_ids = self._typed_table_ids(ctx)
         if not table_ids:
             return PhaseResult.failed("No typed tables found. Run typing phase first.")
@@ -137,10 +139,6 @@ class SemanticPerColumnPhase(BasePhase):
             config = load_llm_config()
         except FileNotFoundError as e:
             return PhaseResult.failed(f"LLM config not found: {e}")
-
-        col_config = config.features.column_annotation
-        if not col_config or not col_config.enabled:
-            return PhaseResult.failed("Column annotation is disabled in config.")
 
         provider_config = config.providers.get(config.active_provider)
         if not provider_config:
@@ -162,106 +160,32 @@ class SemanticPerColumnPhase(BasePhase):
         # induced ontology before columns can map to concepts. (Moved here from
         # the monolithic phase — concept mapping is now per-column.)
         if ontology == "_adhoc":
-            induction_error = self._ensure_adhoc_ontology(
-                ctx, config, provider, renderer, table_ids
+            induction = induce_adhoc_concepts(
+                session=ctx.session,
+                config=config,
+                provider=provider,
+                renderer=renderer,
+                table_ids=table_ids,
             )
-            if induction_error:
-                return PhaseResult.failed(induction_error)
+            if not induction.success:
+                return PhaseResult.failed(induction.error or "Ontology induction failed")
 
-        # Standard-field concepts required by active metric graphs, so the model
-        # prioritizes mapping those concepts to actual columns.
-        from dataraum.graphs.loader import GraphLoader
-
-        metric_loader = GraphLoader(vertical=ontology)
-        metric_loader.load_all()
-        required_standard_fields = sorted(metric_loader.get_all_abstract_fields())
-
-        agent = ColumnAnnotationAgent(config=config, provider=provider, prompt_renderer=renderer)
-        annotation_result = agent.annotate(
+        grounding = ground_columns(
             session=ctx.session,
+            config=config,
+            provider=provider,
+            renderer=renderer,
             table_ids=table_ids,
             ontology=ontology,
-            required_standard_fields=required_standard_fields,
-        )
-        if not annotation_result.success or not annotation_result.value:
-            return PhaseResult.failed(f"Column annotation failed: {annotation_result.error}")
-
-        from dataraum.analysis.semantic.ontology import OntologyLoader
-
-        ontology_def = OntologyLoader().load(ontology)
-        model_name = provider.get_model_for_tier(col_config.model_tier)
-
-        count = persist_column_annotations(
-            ctx.session,
-            annotation_result.value,
-            table_ids,
-            annotated_by=model_name,
             session_id=ctx.require_session_id(),
-            ontology_def=ontology_def,
         )
+        if not grounding.success:
+            return PhaseResult.failed(grounding.error or "Column annotation failed")
 
+        count = grounding.unwrap()
         return PhaseResult.success(
             outputs={"annotations": count, "tables_analyzed": len(table_ids)},
             records_processed=count,
             records_created=count,
             summary=f"{count} column annotations",
         )
-
-    def _ensure_adhoc_ontology(
-        self,
-        ctx: PhaseContext,
-        config: LLMConfig,
-        provider: LLMProvider,
-        renderer: PromptRendererType,
-        table_ids: list[str],
-    ) -> str | None:
-        """Induce an ``_adhoc`` ontology and persist it as ``concept`` overlay rows.
-
-        DAT-371: the baked-in config root is bind-mounted read-only, so the
-        old "write YAML back to ``verticals/_adhoc/ontology.yaml``" path
-        crashes on cold start. Induced concepts now land as one
-        ``config_overlay`` row per concept (``type="concept"``,
-        ``payload={"vertical": "_adhoc", **concept.model_dump()}``,
-        workspace-scoped — ``session_id=None``); the layered loader
-        materializes them on every subsequent ontology read via
-        :func:`dataraum.core.overlay._apply_concept`.
-
-        Returns the error string on induction failure, ``None`` on
-        success (including the short-circuit when concepts already exist).
-        """
-        from dataraum.analysis.semantic.induction import OntologyInductionAgent
-        from dataraum.analysis.semantic.ontology import OntologyLoader
-        from dataraum.storage import ConfigOverlay
-
-        # Short-circuit: re-read through the layered loader so already-
-        # induced concept rows count as "the ontology exists". This is
-        # what makes a re-run after a successful induction idempotent.
-        existing = OntologyLoader().load("_adhoc")
-        if existing is not None and existing.concepts:
-            return None
-
-        induction = OntologyInductionAgent(
-            config=config, provider=provider, prompt_renderer=renderer
-        ).induce(session=ctx.session, table_ids=table_ids)
-        if not induction.success:
-            return f"Ontology induction failed: {induction.error}"
-        if not induction.value or not induction.value.concepts:
-            return "Ontology induction returned no concepts."
-
-        for concept in induction.value.concepts:
-            ctx.session.add(
-                ConfigOverlay(
-                    session_id=None,  # workspace-scoped: induction is not per-session
-                    type="concept",
-                    payload={"vertical": "_adhoc", **concept.model_dump(exclude_none=True)},
-                )
-            )
-        # Commit so the resolver (which leases its own session via
-        # session_scope) can see the newly inserted rows on the next
-        # load. Postgres READ COMMITTED means a flush alone wouldn't make
-        # the rows visible across sessions. Committing here is also a
-        # crash-safety win: induction is expensive (LLM call); if a later
-        # phase fails, the next run short-circuits this branch via the
-        # ``existing.concepts`` check above.
-        ctx.session.commit()
-        return None

--- a/packages/engine/tests/unit/analysis/semantic/test_grounding_step.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_grounding_step.py
@@ -1,0 +1,154 @@
+"""Unit tests for the extracted ``ground_columns`` step (DAT-376).
+
+Pins the structure-only extraction of the grounding tail of
+``SemanticPerColumnPhase._run``: a mocked ``ColumnAnnotationAgent`` whose output
+is persisted as ``SemanticAnnotation`` rows (returning the count), and the
+disabled-config gate. ``persist_column_annotations`` itself is exercised by
+``test_phase_split.py`` and reused untouched here.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy import select
+
+from dataraum.analysis.semantic.db_models import SemanticAnnotation as AnnotationDB
+from dataraum.analysis.semantic.models import (
+    ColumnAnnotationOutput,
+    ColumnSemanticOutput,
+    TableColumnAnnotation,
+)
+from dataraum.analysis.semantic.processor import ground_columns
+from dataraum.core.models.base import Result
+from dataraum.storage import Column, Source, Table
+from tests.conftest import baseline_session_id
+
+
+def _table_with_columns(session, name: str, columns: list[str]) -> Table:
+    src = Source(name=f"src_{name}", source_type="csv")
+    session.add(src)
+    session.flush()
+    table = Table(source_id=src.source_id, table_name=name, layer="typed", row_count=10)
+    session.add(table)
+    session.flush()
+    for pos, col in enumerate(columns):
+        session.add(
+            Column(
+                table_id=table.table_id, column_name=col, column_position=pos, raw_type="VARCHAR"
+            )
+        )
+    session.flush()
+    return table
+
+
+def _col(name: str, role: str) -> ColumnSemanticOutput:
+    return ColumnSemanticOutput(
+        column_name=name,
+        semantic_role=role,
+        entity_type=f"{name}_entity",
+        business_term=name.title(),
+        description=f"{name} column",
+        confidence=0.9,
+    )
+
+
+def _enabled_config() -> MagicMock:
+    config = MagicMock()
+    config.features.column_annotation = SimpleNamespace(enabled=True, model_tier="balanced")
+    return config
+
+
+class TestGroundColumns:
+    @patch("dataraum.analysis.semantic.ontology.OntologyLoader")
+    @patch("dataraum.graphs.loader.GraphLoader")
+    @patch("dataraum.analysis.semantic.column_agent.ColumnAnnotationAgent")
+    def test_persists_annotations_and_returns_count(
+        self,
+        mock_agent_cls: MagicMock,
+        mock_graph_cls: MagicMock,
+        mock_ontology_cls: MagicMock,
+        session,
+    ) -> None:
+        table = _table_with_columns(session, "customers", ["customer_id", "revenue"])
+
+        mock_graph_cls.return_value.get_all_abstract_fields.return_value = set()
+        mock_ontology_cls.return_value.load.return_value = None
+        mock_agent_cls.return_value.annotate.return_value = Result.ok(
+            ColumnAnnotationOutput(
+                tables=[
+                    TableColumnAnnotation(
+                        table_name="customers",
+                        columns=[_col("customer_id", "key"), _col("revenue", "measure")],
+                    )
+                ]
+            )
+        )
+
+        provider = MagicMock()
+        provider.get_model_for_tier.return_value = "test-model"
+
+        result = ground_columns(
+            session=session,
+            config=_enabled_config(),
+            provider=provider,
+            renderer=MagicMock(),
+            table_ids=[table.table_id],
+            ontology="finance",
+            session_id=baseline_session_id(),
+        )
+        session.flush()
+
+        assert result.success
+        assert result.value == 2
+        rows = session.execute(select(AnnotationDB)).scalars().all()
+        assert len(rows) == 2
+        assert {r.semantic_role for r in rows} == {"key", "measure"}
+        assert all(r.annotated_by == "test-model" for r in rows)
+        # Standard-field concepts come from the active metric graphs for `finance`.
+        mock_graph_cls.assert_called_once_with(vertical="finance")
+
+    def test_disabled_config_gate_fails(self, session) -> None:
+        config = MagicMock()
+        config.features.column_annotation = SimpleNamespace(enabled=False, model_tier="balanced")
+
+        result = ground_columns(
+            session=session,
+            config=config,
+            provider=MagicMock(),
+            renderer=MagicMock(),
+            table_ids=["t1"],
+            ontology="finance",
+            session_id=baseline_session_id(),
+        )
+
+        assert not result.success
+        assert "disabled" in (result.error or "").lower()
+        assert session.execute(select(AnnotationDB)).scalars().all() == []
+
+    @patch("dataraum.analysis.semantic.ontology.OntologyLoader")
+    @patch("dataraum.graphs.loader.GraphLoader")
+    @patch("dataraum.analysis.semantic.column_agent.ColumnAnnotationAgent")
+    def test_propagates_agent_failure(
+        self,
+        mock_agent_cls: MagicMock,
+        mock_graph_cls: MagicMock,
+        mock_ontology_cls: MagicMock,
+        session,
+    ) -> None:
+        mock_graph_cls.return_value.get_all_abstract_fields.return_value = set()
+        mock_agent_cls.return_value.annotate.return_value = Result.fail("annotation LLM down")
+
+        result = ground_columns(
+            session=session,
+            config=_enabled_config(),
+            provider=MagicMock(),
+            renderer=MagicMock(),
+            table_ids=["t1"],
+            ontology="finance",
+            session_id=baseline_session_id(),
+        )
+
+        assert not result.success
+        assert "annotation LLM down" in (result.error or "")

--- a/packages/engine/tests/unit/analysis/semantic/test_induction_step.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_induction_step.py
@@ -1,0 +1,119 @@
+"""Unit tests for the extracted ``induce_adhoc_concepts`` step (DAT-376).
+
+Pins the structure-only extraction of the cold-start ``_adhoc`` induction from
+``SemanticPerColumnPhase._ensure_adhoc_ontology``: the short-circuit when
+concepts already exist, the one-overlay-row-per-induced-concept insert, and
+failure propagation. The induction agent / LLM call itself is mocked — its
+behaviour is covered by ``test_induction.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy import select
+
+from dataraum.analysis.semantic.induction import induce_adhoc_concepts
+from dataraum.analysis.semantic.ontology import OntologyConcept, OntologyDefinition
+from dataraum.core.models.base import Result
+from dataraum.storage import ConfigOverlay
+
+
+def _concept(name: str) -> OntologyConcept:
+    return OntologyConcept(name=name, description=f"{name} concept", typical_role="measure")
+
+
+class TestInduceAdhocConcepts:
+    @patch("dataraum.analysis.semantic.induction.OntologyInductionAgent")
+    @patch("dataraum.analysis.semantic.ontology.OntologyLoader")
+    def test_short_circuits_when_concepts_already_exist(
+        self, mock_loader_cls: MagicMock, mock_agent_cls: MagicMock, session
+    ) -> None:
+        # Existing _adhoc ontology already has concepts -> induce must not run.
+        mock_loader_cls.return_value.load.return_value = OntologyDefinition(
+            name="_adhoc", concepts=[_concept("revenue")]
+        )
+
+        result = induce_adhoc_concepts(
+            session=session,
+            config=MagicMock(),
+            provider=MagicMock(),
+            renderer=MagicMock(),
+            table_ids=["t1"],
+        )
+
+        assert result.success
+        assert result.value == 0
+        mock_agent_cls.assert_not_called()
+        assert session.execute(select(ConfigOverlay)).scalars().all() == []
+
+    @patch("dataraum.analysis.semantic.induction.OntologyInductionAgent")
+    @patch("dataraum.analysis.semantic.ontology.OntologyLoader")
+    def test_inserts_one_concept_overlay_row_per_induced_concept(
+        self, mock_loader_cls: MagicMock, mock_agent_cls: MagicMock, session
+    ) -> None:
+        # Cold start: no existing ontology -> induce, then one overlay row each.
+        mock_loader_cls.return_value.load.return_value = None
+        mock_agent_cls.return_value.induce.return_value = Result.ok(
+            OntologyDefinition(name="induced", concepts=[_concept("revenue"), _concept("region")])
+        )
+
+        result = induce_adhoc_concepts(
+            session=session,
+            config=MagicMock(),
+            provider=MagicMock(),
+            renderer=MagicMock(),
+            table_ids=["t1"],
+        )
+
+        assert result.success
+        assert result.value == 2
+        rows = session.execute(select(ConfigOverlay)).scalars().all()
+        assert len(rows) == 2
+        assert all(r.type == "concept" for r in rows)
+        # NB: production passes session_id=None (workspace-scoped); the conftest
+        # before_flush hook autofills it for direct-constructed rows, so it isn't
+        # asserted here. The load-bearing surface is type + payload.
+        assert {r.payload["name"] for r in rows} == {"revenue", "region"}
+        assert all(r.payload["vertical"] == "_adhoc" for r in rows)
+
+    @patch("dataraum.analysis.semantic.induction.OntologyInductionAgent")
+    @patch("dataraum.analysis.semantic.ontology.OntologyLoader")
+    def test_propagates_induction_failure(
+        self, mock_loader_cls: MagicMock, mock_agent_cls: MagicMock, session
+    ) -> None:
+        mock_loader_cls.return_value.load.return_value = None
+        mock_agent_cls.return_value.induce.return_value = Result.fail("LLM down")
+
+        result = induce_adhoc_concepts(
+            session=session,
+            config=MagicMock(),
+            provider=MagicMock(),
+            renderer=MagicMock(),
+            table_ids=["t1"],
+        )
+
+        assert not result.success
+        assert "LLM down" in (result.error or "")
+        assert session.execute(select(ConfigOverlay)).scalars().all() == []
+
+    @patch("dataraum.analysis.semantic.induction.OntologyInductionAgent")
+    @patch("dataraum.analysis.semantic.ontology.OntologyLoader")
+    def test_fails_when_induction_returns_no_concepts(
+        self, mock_loader_cls: MagicMock, mock_agent_cls: MagicMock, session
+    ) -> None:
+        mock_loader_cls.return_value.load.return_value = None
+        mock_agent_cls.return_value.induce.return_value = Result.ok(
+            OntologyDefinition(name="induced", concepts=[])
+        )
+
+        result = induce_adhoc_concepts(
+            session=session,
+            config=MagicMock(),
+            provider=MagicMock(),
+            renderer=MagicMock(),
+            table_ids=["t1"],
+        )
+
+        assert not result.success
+        assert "no concepts" in (result.error or "").lower()

--- a/packages/engine/tests/unit/pipeline/test_semantic_split_phases.py
+++ b/packages/engine/tests/unit/pipeline/test_semantic_split_phases.py
@@ -7,13 +7,14 @@ here we pin the skip gates that decide whether each phase re-runs.
 from __future__ import annotations
 
 import duckdb
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from dataraum.analysis.semantic.db_models import SemanticAnnotation, TableEntity
 from dataraum.pipeline.base import PhaseContext
 from dataraum.pipeline.phases.semantic_per_column_phase import SemanticPerColumnPhase
 from dataraum.pipeline.phases.semantic_per_table_phase import SemanticPerTablePhase
-from dataraum.storage import Column, Source, Table
+from dataraum.storage import Column, ConfigOverlay, Source, Table
 from tests.conftest import baseline_session_id
 
 
@@ -81,6 +82,38 @@ class TestPerColumnShouldSkip:
         assert SemanticPerColumnPhase().should_skip(_ctx(session, duckdb_conn, src.source_id)) == (
             "All columns already have semantic annotations"
         )
+
+
+class TestPerColumnReplayCleanup:
+    def test_drops_annotation_but_leaves_concept_overlay(
+        self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+    ) -> None:
+        """DAT-376: replay_cleanup wipes SemanticAnnotation, never concept rows.
+
+        Induced ``_adhoc`` concepts live as workspace-scoped ``concept``
+        ConfigOverlay rows (DAT-371). A reduce replay must re-annotate columns
+        against the *existing* ontology — it must not delete the induced
+        concepts that ontology is built from.
+        """
+        src = _source(session)
+        t1 = _typed_table(session, src.source_id, "t1", ["a"])
+        _annotate(session, t1)
+        overlay = ConfigOverlay(
+            session_id=None,
+            type="concept",
+            payload={"vertical": "_adhoc", "name": "revenue"},
+        )
+        session.add(overlay)
+        session.flush()
+
+        SemanticPerColumnPhase().replay_cleanup(_ctx(session, duckdb_conn, src.source_id), [])
+        session.flush()
+
+        assert session.execute(select(SemanticAnnotation)).scalars().all() == []
+        overlays = session.execute(select(ConfigOverlay)).scalars().all()
+        assert len(overlays) == 1
+        assert overlays[0].type == "concept"
+        assert overlays[0].payload["name"] == "revenue"
 
 
 class TestPerTableShouldSkip:


### PR DESCRIPTION
Detach the two LLM steps inside semantic_per_column into independently callable module-level functions, in place. No new pipeline stage; the add_source surface (workflow/activity names, phase order, pipeline.yaml, contracts.py) is byte-for-byte unchanged.

- induction.induce_adhoc_concepts(): cold-start _adhoc induction, extracted verbatim from SemanticPerColumnPhase._ensure_adhoc_ontology (short-circuit on existing concepts, per-concept ConfigOverlay insert, trailing commit).
- processor.ground_columns(): per-column annotation tail + persist, returns the row count.
- _run is now a thin composer: resolve config/provider/renderer/ontology, gate _adhoc -> induce_adhoc_concepts, then ground_columns.
- replay_cleanup unchanged (drops SemanticAnnotation only, never concept rows); add a regression test pinning that.
- Both functions exported from analysis/semantic/__init__.

Structure-only: induction agent/prompt/tool-schema, ColumnAnnotationAgent, persist_column_annotations row shapes, and all five detectors are unchanged, so recall is safe by construction (no recalibration). Handoff updated for DAT-377/378 (the connect/frame relocation moves the induction CALL upstream).