### PR TITLE
refactor(dat-373): stable typed Column ids + owner-scoped per-phase r…

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,68 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-05-29: DAT-373 — stable typed Column ids + owner-scoped per-phase replay_cleanup (Option A)
+
+Fixes the cross-stage data-loss hazard DAT-343 flagged: a type-teach replay used
+to (a) drop the typed `Table` and cascade-wipe **every** per-Column row of **every**
+stage, and (b) re-mint fresh `uuid4` typed Column ids on each re-type (orphaning
+any other stage's per-Column rows even if cleanup were scoped). Both are fixed so
+a future `begin_session` (DAT-356) / frame-ground (DAT-377) per-Column finding
+survives an `add_source` teach. **No schema migration** (the `owner_stage`
+discriminator, Option B, is a deferred fast-follow — not done here).
+
+What changed in the engine:
+- **Stable typed identity.** `resolve_types` + `TypingPhase._promote_strongly_typed`
+  now RECONCILE the typed/quarantine `Table` + `Column` rows by
+  `(source_id, table_name, layer)` / `(table_id, column_name)` — reuse + UPDATE in
+  place, delete columns no longer present, insert genuinely new ones — instead of
+  drop+recreate. Typed Table id AND typed Column ids are **unchanged across a
+  re-type**. New shared helpers `reconcile_typed_table` / `reconcile_typed_columns`
+  in `analysis/typing/resolution.py`.
+- **`typing.replay_cleanup` is now in-place + owner-scoped.** It KEEPS the typed
+  `Table`/`Column` rows; clears only typing-owned `TypeCandidate`/`TypeDecision`
+  (raw + typed copies) and drops the DuckDB typed/quarantine tables (rebuilt by
+  `_run`'s `CREATE OR REPLACE`). It NO LONGER deletes the typed `Table`, so it no
+  longer cascade-wipes `StatisticalProfile` / `SemanticAnnotation` / temporal /
+  quality / eligibility rows.
+- **Per-phase owner-scoped `replay_cleanup`** added to `statistics`,
+  `column_eligibility`, `statistical_quality`, `temporal` — each deletes only its
+  OWN per-Column rows scoped to the replay's typed `table_ids`. The workflow now
+  invokes `replay_cleanup_for_phase` for **every** phase that re-runs under a
+  replay (`_maybe_replay_cleanup` gated by the new `_phase_reruns_on_replay`), not
+  just `from_phase`; the source-level reduce always self-cleans.
+- **`typing.should_skip`** now treats a typed table as "done" only if its columns
+  still carry a `TypeDecision` (the row cleanup clears) — the surviving typed
+  `Table` row alone is no longer the signal.
+- **`BasePhase.replay_cleanup` docstring** now states the ownership contract:
+  delete ONLY your own rows scoped to `table_ids`; NEVER delete a parent `Table`
+  you don't exclusively own; the Table-delete cascade is reserved for
+  `import`/source teardown.
+
+### dataraum-eval
+
+- **Eval action: NO recalibration needed.** No detector, prompt, threshold, or
+  annotation-content change. Recall is unaffected: the re-type produces the same
+  typed data + the same `TypeDecision`/`TypeCandidate` content as before; only the
+  row identity (reuse vs. fresh uuid4) and the cleanup scope changed.
+- **Eval-fixture flag:** any fixture or assertion that relied on a re-type
+  **minting new typed `column_id`s** (or a new typed `table_id`) is now WRONG —
+  ids are stable across replays. The cockpit integration smoke
+  (`packages/cockpit/src/temporal/drive-add-source.ts`) asserted "every
+  typed_table_id CHANGED" as proof `replay_cleanup` fired; that assertion must
+  flip to assert ids are STABLE and that a seeded foreign per-Column row survives.
+  Not changed in this lane (cross-PACKAGE, TS, not run here).
+
+### Tests
+
+- RED→GREEN hazard test + in-place semantics in
+  `tests/unit/pipeline/test_phase_replay_cleanup.py`.
+- Stable-id + downstream-skip update in `tests/unit/pipeline/test_typing_phase.py`.
+- `_phase_reruns_on_replay` predicate in `tests/unit/worker/test_replay_scope.py`.
+- New `tests/integration/pipeline/test_replay_cross_stage.py`: re-type keeps typed
+  ids stable AND a simulated begin_session `SemanticAnnotation` on a typed column
+  survives a re-type + statistics rebuild (real DuckLake substrate).
+
 ## 2026-05-29: DAT-376 — split induction ↔ grounding in `semantic_per_column` (structure-only)
 
 Detached the two LLM steps inside `semantic_per_column` into independently

--- a/packages/engine/src/dataraum/analysis/typing/resolution.py
+++ b/packages/engine/src/dataraum/analysis/typing/resolution.py
@@ -11,12 +11,13 @@ The quarantine pattern:
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from uuid import uuid4
 
 import duckdb
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session, selectinload
 
 from dataraum.analysis.typing.db_models import TypeCandidate, TypeDecision
@@ -86,6 +87,100 @@ def _resolve_pattern(
         inferred_type=parts[0].inferred_type,
         standardization_expr=coalesce_expr,
     )
+
+
+def reconcile_typed_table(
+    session: Session,
+    raw_table: Table,
+    layer: str,
+    duckdb_path: str,
+    row_count: int,
+) -> Table:
+    """Find-or-create the ``layer`` Table for ``raw_table`` and refresh its stats.
+
+    Stable typed identity (DAT-373 Option A): a re-type REUSES the existing
+    ``typed`` / ``quarantine`` ``Table`` row (matched by
+    ``(source_id, table_name, layer)`` — unique per ``uq_source_table_layer``)
+    rather than minting a fresh ``table_id``. Reusing the row keeps the typed
+    Table id — and the Column ids reconciled under it — stable across teach
+    replays, so other stages' per-Column rows stay attached. Only the
+    ``row_count`` (and ``duckdb_path``, defensively) are refreshed in place.
+    """
+    existing = session.execute(
+        select(Table).where(
+            Table.source_id == raw_table.source_id,
+            Table.table_name == raw_table.table_name,
+            Table.layer == layer,
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        existing.duckdb_path = duckdb_path
+        existing.row_count = row_count
+        return existing
+
+    created = Table(
+        table_id=str(uuid4()),
+        source_id=raw_table.source_id,
+        table_name=raw_table.table_name,
+        layer=layer,
+        duckdb_path=duckdb_path,
+        row_count=row_count,
+    )
+    session.add(created)
+    return created
+
+
+def reconcile_typed_columns(
+    session: Session,
+    typed_table: Table,
+    desired: Sequence[tuple[str, str | None, int, str | None, str]],
+) -> dict[str, str]:
+    """Reconcile ``typed_table``'s Columns to ``desired``, keeping ids stable.
+
+    ``desired`` is the target column set as
+    ``(column_name, original_name, column_position, raw_type, resolved_type)``
+    tuples (``raw_type`` may be ``None`` for source-typed columns). Existing
+    columns matched by ``column_name`` are UPDATED in place
+    (id preserved); columns no longer desired are deleted; genuinely new
+    columns are inserted. Returns ``column_name -> column_id`` for the full
+    reconciled set so callers can attach typing's own derived rows.
+
+    Keeping ids stable is what lets a re-type avoid orphaning another stage's
+    per-Column rows (DAT-373 Option A).
+    """
+    current = {c.column_name: c for c in typed_table.columns}
+    desired_names = {d[0] for d in desired}
+
+    # Delete columns that are no longer present in the re-typed table.
+    for name, col in list(current.items()):
+        if name not in desired_names:
+            session.delete(col)
+
+    column_map: dict[str, str] = {}
+    for column_name, original_name, position, raw_type, resolved_type in desired:
+        existing = current.get(column_name)
+        if existing is not None:
+            existing.original_name = original_name
+            existing.column_position = position
+            existing.raw_type = raw_type
+            existing.resolved_type = resolved_type
+            column_map[column_name] = existing.column_id
+        else:
+            new_id = str(uuid4())
+            session.add(
+                Column(
+                    column_id=new_id,
+                    table_id=typed_table.table_id,
+                    column_name=column_name,
+                    original_name=original_name,
+                    column_position=position,
+                    raw_type=raw_type,
+                    resolved_type=resolved_type,
+                )
+            )
+            column_map[column_name] = new_id
+
+    return column_map
 
 
 @dataclass
@@ -327,70 +422,50 @@ def resolve_types(
     quarantine_result = duckdb_conn.execute(f"SELECT COUNT(*) FROM {quarantine_target}").fetchone()
     quarantine_rows = quarantine_result[0] if quarantine_result else 0
 
-    # Create metadata records for typed and quarantine tables.
-    # All three layer records share the same bare ``duckdb_path``;
-    # ``layer`` discriminates which schema they live in.
-    typed_table_record = Table(
-        table_id=str(uuid4()),
-        source_id=table.source_id,
-        table_name=table.table_name,
-        layer="typed",
-        duckdb_path=bare,
-        row_count=typed_rows,
+    # Reconcile the typed + quarantine metadata records (DAT-373 Option A):
+    # reuse the existing rows for this (source, table_name, layer) when a teach
+    # re-types, keeping ``table_id`` + Column ids stable so other stages'
+    # per-Column rows stay attached. All three layer records share the same bare
+    # ``duckdb_path``; ``layer`` discriminates which schema they live in. The
+    # session must be flushed before reconcile so the typed Table's existing
+    # Columns are loadable (the reconcile reads ``typed_table.columns``).
+    session.flush()
+    typed_table_record = reconcile_typed_table(
+        session, table, "typed", bare, typed_rows
     )
-    session.add(typed_table_record)
-
-    quarantine_table_record = Table(
-        table_id=str(uuid4()),
-        source_id=table.source_id,
-        table_name=table.table_name,
-        layer="quarantine",
-        duckdb_path=bare,
-        row_count=quarantine_rows,
+    quarantine_table_record = reconcile_typed_table(
+        session, table, "quarantine", bare, quarantine_rows
     )
-    session.add(quarantine_table_record)
+    session.flush()
 
-    # Create column records for typed table
-    typed_column_map: dict[str, str] = {}  # column_name -> typed_column_id
-    for i, spec in enumerate(specs):
-        typed_col_id = str(uuid4())
-        raw_col = raw_col_by_id[spec.column_id]
-        typed_col = Column(
-            column_id=typed_col_id,
-            table_id=typed_table_record.table_id,
-            column_name=spec.column_name,
-            original_name=raw_col.original_name,
-            column_position=i,
-            raw_type="VARCHAR",
-            resolved_type=spec.data_type.value,
+    # Reconcile typed columns — UPDATE in place / insert new / delete dropped,
+    # so existing typed Column ids survive a re-type.
+    typed_desired = [
+        (
+            spec.column_name,
+            raw_col_by_id[spec.column_id].original_name,
+            i,
+            "VARCHAR",
+            spec.data_type.value,
         )
-        session.add(typed_col)
-        typed_column_map[spec.column_name] = typed_col_id
+        for i, spec in enumerate(specs)
+    ]
+    typed_column_map = reconcile_typed_columns(session, typed_table_record, typed_desired)
 
-    # Create column records for quarantine table (all columns + _quarantined_at)
-    for i, spec in enumerate(specs):
-        raw_col = raw_col_by_id[spec.column_id]
-        quarantine_col = Column(
-            column_id=str(uuid4()),
-            table_id=quarantine_table_record.table_id,
-            column_name=spec.column_name,
-            original_name=raw_col.original_name,
-            column_position=i,
-            raw_type="VARCHAR",
-            resolved_type="VARCHAR",  # Quarantine keeps original VARCHAR
+    # Reconcile quarantine columns (all columns kept VARCHAR + the _quarantined_at meta col).
+    quarantine_desired = [
+        (
+            spec.column_name,
+            raw_col_by_id[spec.column_id].original_name,
+            i,
+            "VARCHAR",
+            "VARCHAR",  # Quarantine keeps original VARCHAR
         )
-        session.add(quarantine_col)
-
-    # Add _quarantined_at column
-    quarantine_meta_col = Column(
-        column_id=str(uuid4()),
-        table_id=quarantine_table_record.table_id,
-        column_name="_quarantined_at",
-        column_position=len(specs),
-        raw_type="TIMESTAMP",
-        resolved_type="TIMESTAMP",
-    )
-    session.add(quarantine_meta_col)
+        for i, spec in enumerate(specs)
+    ]
+    quarantine_desired.append(("_quarantined_at", None, len(specs), "TIMESTAMP", "TIMESTAMP"))
+    reconcile_typed_columns(session, quarantine_table_record, quarantine_desired)
+    session.flush()
 
     # Compute per-column quarantine metrics and update raw TypeCandidates
     # BEFORE copying to typed columns, so copies include the fields.
@@ -434,6 +509,19 @@ def resolve_types(
     # Raw columns keep originals (audit trail); typed columns get copies so
     # downstream consumers can query by typed column_id directly.
     # Note: quarantine_count/rate are already set on raw TypeCandidates above.
+    #
+    # The typed columns are now reused across re-types (stable ids, DAT-373), so
+    # clear any prior copies first — otherwise the fresh TypeDecision insert would
+    # hit ``uq_column_type_decision`` (one decision per column). Self-contained
+    # idempotency: correct even when called outside the workflow's replay_cleanup.
+    typed_col_ids = list(typed_column_map.values())
+    if typed_col_ids:
+        session.execute(
+            delete(TypeCandidate).where(TypeCandidate.column_id.in_(typed_col_ids))
+        )
+        session.execute(delete(TypeDecision).where(TypeDecision.column_id.in_(typed_col_ids)))
+        session.flush()
+
     for raw_col in table.columns:
         target_col_id = typed_column_map.get(raw_col.column_name)
         if target_col_id is None:

--- a/packages/engine/src/dataraum/analysis/typing/resolution.py
+++ b/packages/engine/src/dataraum/analysis/typing/resolution.py
@@ -430,9 +430,7 @@ def resolve_types(
     # session must be flushed before reconcile so the typed Table's existing
     # Columns are loadable (the reconcile reads ``typed_table.columns``).
     session.flush()
-    typed_table_record = reconcile_typed_table(
-        session, table, "typed", bare, typed_rows
-    )
+    typed_table_record = reconcile_typed_table(session, table, "typed", bare, typed_rows)
     quarantine_table_record = reconcile_typed_table(
         session, table, "quarantine", bare, quarantine_rows
     )
@@ -516,9 +514,7 @@ def resolve_types(
     # idempotency: correct even when called outside the workflow's replay_cleanup.
     typed_col_ids = list(typed_column_map.values())
     if typed_col_ids:
-        session.execute(
-            delete(TypeCandidate).where(TypeCandidate.column_id.in_(typed_col_ids))
-        )
+        session.execute(delete(TypeCandidate).where(TypeCandidate.column_id.in_(typed_col_ids)))
         session.execute(delete(TypeDecision).where(TypeDecision.column_id.in_(typed_col_ids)))
         session.flush()
 

--- a/packages/engine/src/dataraum/pipeline/phases/base.py
+++ b/packages/engine/src/dataraum/pipeline/phases/base.py
@@ -39,24 +39,38 @@ class BasePhase(ABC):
         ...
 
     def replay_cleanup(self, ctx: PhaseContext, table_ids: list[str]) -> None:
-        """Drop this phase's outputs so a replay from here starts fresh (DAT-343).
+        """Clear this phase's OWN outputs so a replay re-runs it cleanly (DAT-343/373).
 
-        Invoked by the worker activity wrapper **before** ``run`` when the
-        workflow's ``replay.from_phase`` equals this phase's name. The
-        purpose is to clear whatever would make ``should_skip`` return a
-        "already done" reason — typically the phase's own DB rows plus any
-        DuckDB artifacts it owns.
+        Invoked by the worker (``replay_cleanup_for_phase`` activity) **before**
+        ``run`` for EVERY phase that re-executes under a replay — not just the
+        ``from_phase``. The purpose is to clear whatever would make this phase's
+        ``should_skip`` return an "already done" reason, so the re-run rebuilds
+        its outputs against the (possibly re-typed) data.
 
-        Default: no-op. Phases that ARE replay entry points (today:
-        ``import``, ``typing``, ``semantic_per_column``) override; everything
-        downstream of a from_phase rides on cascade-delete through
-        ``Column.cascade='all, delete-orphan'`` from the cleaned-up rows.
+        Ownership contract (DAT-373 — read before adding/changing an override):
+
+        - **Delete ONLY your own per-Column / per-Table rows**, scoped to
+          ``table_ids`` (or source-wide on the empty-list shape). The
+          per-phase pattern is "delete-own-rows-by-column_id for the columns of
+          the typed tables in scope".
+        - **NEVER delete a parent ``Table`` you do not exclusively own.** Typing
+          reuses the typed ``Table`` + ``Column`` rows in place (stable identity)
+          precisely so other stages' per-Column findings stay attached. The
+          Table-delete cascade (``Table`` → ``Column`` → every per-Column row)
+          is reserved for ``import`` / source teardown, where dropping the whole
+          source IS the intent — never for a phase-local re-run.
+        - Cross-stage data (e.g. ``begin_session`` / frame-ground findings on a
+          typed column) belongs to OTHER stages and MUST survive your cleanup.
+
+        Default: no-op (a phase with no replay-relevant outputs, e.g. a pure
+        DuckDB-view builder whose ``_run`` is ``CREATE OR REPLACE``-idempotent).
 
         Args:
             ctx: phase context (session + DuckDB cursor + source_id).
             table_ids: replay scope. Empty list = source-wide cleanup
-                (matches the source-level reduce shape); a single-element
-                list scopes to that raw table id (table-local replays).
+                (matches the source-level reduce shape); a single-element list
+                scopes to one table id — a raw table id for ``typing`` /
+                ``import``, a typed table id for the table-local analytics phases.
         """
         return None
 

--- a/packages/engine/src/dataraum/pipeline/phases/column_eligibility_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/column_eligibility_phase.py
@@ -10,7 +10,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from dataraum.analysis.eligibility.config import load_eligibility_config
 from dataraum.analysis.eligibility.db_models import ColumnEligibilityRecord
@@ -53,6 +53,26 @@ class ColumnEligibilityPhase(BasePhase):
         from dataraum.analysis.eligibility import db_models
 
         return [db_models]
+
+    def replay_cleanup(self, ctx: PhaseContext, table_ids: list[str]) -> None:
+        """Delete this phase's ColumnEligibilityRecord rows for the scoped tables (DAT-373).
+
+        Owner-scoped by ``table_id``: drops only the eligibility records of the
+        typed tables in ``table_ids`` so the re-run (after a re-type) re-evaluates
+        eligibility against the freshly-typed columns. The re-typed DuckDB table
+        is rebuilt with its full column set, so any columns this phase previously
+        dropped are present again for re-evaluation. Never touches another phase's
+        per-Column rows.
+        """
+        typed_tables = self._typed_tables(ctx)
+        if not typed_tables:
+            return
+        ctx.session.execute(
+            delete(ColumnEligibilityRecord).where(
+                ColumnEligibilityRecord.table_id.in_([t.table_id for t in typed_tables])
+            )
+        )
+        ctx.session.flush()
 
     def should_skip(self, ctx: PhaseContext) -> str | None:
         """Skip if the scoped tables' columns all have eligibility records."""

--- a/packages/engine/src/dataraum/pipeline/phases/statistical_quality_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/statistical_quality_phase.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from types import ModuleType
 from typing import TYPE_CHECKING
 
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 
 from dataraum.analysis.statistics import assess_statistical_quality
 from dataraum.analysis.statistics.quality_db_models import StatisticalQualityMetrics
@@ -43,6 +43,33 @@ class StatisticalQualityPhase(BasePhase):
         from dataraum.analysis.statistics import quality_db_models
 
         return [quality_db_models]
+
+    def replay_cleanup(self, ctx: PhaseContext, table_ids: list[str]) -> None:
+        """Delete this phase's StatisticalQualityMetrics for the scoped tables (DAT-373).
+
+        Owner-scoped: drops only the quality metrics whose column belongs to a
+        typed table in ``table_ids`` so the re-run (after a re-type) recomputes
+        Benford / outlier metrics against the freshly-typed data. Never touches
+        any other phase's per-Column rows.
+        """
+        typed_tables = self._typed_tables(ctx)
+        if not typed_tables:
+            return
+        column_ids = list(
+            ctx.session.execute(
+                select(Column.column_id).where(
+                    Column.table_id.in_([t.table_id for t in typed_tables])
+                )
+            ).scalars()
+        )
+        if not column_ids:
+            return
+        ctx.session.execute(
+            delete(StatisticalQualityMetrics).where(
+                StatisticalQualityMetrics.column_id.in_(column_ids)
+            )
+        )
+        ctx.session.flush()
 
     def should_skip(self, ctx: PhaseContext) -> str | None:
         """Skip if the scoped tables' numeric columns all have quality metrics."""

--- a/packages/engine/src/dataraum/pipeline/phases/statistics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/statistics_phase.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from types import ModuleType
 from typing import TYPE_CHECKING
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from dataraum.analysis.statistics import profile_statistics
 from dataraum.analysis.statistics.db_models import StatisticalProfile
@@ -44,6 +44,33 @@ class StatisticsPhase(BasePhase):
         from dataraum.analysis.statistics import db_models
 
         return [db_models]
+
+    def replay_cleanup(self, ctx: PhaseContext, table_ids: list[str]) -> None:
+        """Delete this phase's StatisticalProfile rows for the scoped tables (DAT-373).
+
+        Owner-scoped: drops only the profiles whose column belongs to a typed
+        table in ``table_ids`` so the re-run (after a re-type) recomputes them
+        against the freshly-typed data. The typed ``Table``/``Column`` rows
+        survive the re-type now (stable identity), so without this self-clean
+        ``should_skip`` would see the stale profiles and bail. Never touches any
+        other phase's per-Column rows.
+        """
+        typed_tables = self._typed_tables(ctx)
+        if not typed_tables:
+            return
+        column_ids = list(
+            ctx.session.execute(
+                select(Column.column_id).where(
+                    Column.table_id.in_([t.table_id for t in typed_tables])
+                )
+            ).scalars()
+        )
+        if not column_ids:
+            return
+        ctx.session.execute(
+            delete(StatisticalProfile).where(StatisticalProfile.column_id.in_(column_ids))
+        )
+        ctx.session.flush()
 
     def should_skip(self, ctx: PhaseContext) -> str | None:
         """Skip if the scoped typed tables already have profiles."""

--- a/packages/engine/src/dataraum/pipeline/phases/temporal_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/temporal_phase.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from types import ModuleType
 from typing import TYPE_CHECKING
 
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 
 from dataraum.analysis.temporal import TemporalColumnProfile, profile_temporal
 from dataraum.core.logging import get_logger
@@ -45,6 +45,32 @@ class TemporalPhase(BasePhase):
         from dataraum.analysis.temporal import db_models
 
         return [db_models]
+
+    def replay_cleanup(self, ctx: PhaseContext, table_ids: list[str]) -> None:
+        """Delete this phase's TemporalColumnProfile rows for the scoped tables (DAT-373).
+
+        Owner-scoped: drops only the temporal profiles whose column belongs to a
+        typed table in ``table_ids`` so the re-run (after a re-type) recomputes
+        them against the freshly-typed data. ``_run`` is a pure insert, so this
+        self-clean is also what keeps a replay from double-inserting profiles.
+        Never touches any other phase's per-Column rows.
+        """
+        typed_tables = self._typed_tables(ctx)
+        if not typed_tables:
+            return
+        column_ids = list(
+            ctx.session.execute(
+                select(Column.column_id).where(
+                    Column.table_id.in_([t.table_id for t in typed_tables])
+                )
+            ).scalars()
+        )
+        if not column_ids:
+            return
+        ctx.session.execute(
+            delete(TemporalColumnProfile).where(TemporalColumnProfile.column_id.in_(column_ids))
+        )
+        ctx.session.flush()
 
     def should_skip(self, ctx: PhaseContext) -> str | None:
         """Skip if the scoped tables have no temporal columns or all are profiled."""

--- a/packages/engine/src/dataraum/pipeline/phases/typing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/typing_phase.py
@@ -11,6 +11,7 @@ the source types are trusted directly.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from types import ModuleType
 from typing import TYPE_CHECKING
 from uuid import uuid4
@@ -54,30 +55,36 @@ class TypingPhase(BasePhase):
         return [db_models]
 
     def replay_cleanup(self, ctx: PhaseContext, table_ids: list[str]) -> None:
-        """Drop the typed/quarantine state for raw tables in ``table_ids`` (DAT-343).
+        """Clear typing's OWN state in place for raw tables in ``table_ids`` (DAT-373).
 
         Triggered when a teach (e.g. ``type_pattern``) requires re-typing
         one or more raw tables. Scoped to ``table_ids`` (raw table ids from
         ``replay.raw_table_ids``) so parallel siblings in a fan-out keep
         their typed state.
 
-        Drops, in order:
-            1. ``TypeCandidate`` / ``TypeDecision`` rows for the raw columns
-               in scope — these are FK'd to the raw Column (not the typed
-               Column), so the cascade through the typed Table delete below
-               doesn't reach them; we delete them explicitly so re-inference
-               gets a clean slate.
-            2. The matching typed ``Table`` row (looked up by name in the
-               ``typed`` layer). Cascade deletes its Columns and every
-               per-column derived row (statistical profiles, quality
-               metrics, semantic annotations, temporal profiles,
-               relationships).
-            3. Any leftover quarantine ``Table`` row by the same name.
-            4. The DuckDB ``lake.typed.<bare>`` and ``lake.quarantine.<bare>``
-               tables. ``CREATE OR REPLACE`` on the next run would overwrite
-               them, but we drop them explicitly to keep ``DROP TABLE IF
-               EXISTS`` idempotent against schema drift between teach
-               iterations.
+        Owner-scoped, in-place (DAT-373 Option A). The typed/quarantine
+        ``Table`` and ``Column`` rows are **kept** — ``_run`` reconciles them
+        in place on the re-type, keeping their ids stable so other stages'
+        per-Column rows (begin_session / frame-ground findings, etc.) stay
+        attached. The cascade-drop of the whole typed ``Table`` is reserved
+        for ``import`` / source teardown, NOT a re-type.
+
+        Clears only typing-owned state:
+            1. ``TypeCandidate`` / ``TypeDecision`` rows for the raw AND typed
+               columns in scope. The raw rows are typing's inference audit;
+               the typed rows are typing's copies (``resolve_types`` writes
+               one ``TypeDecision`` per typed column, guarded by
+               ``uq_column_type_decision``). Both are deleted so the re-run's
+               fresh inserts get a clean slate.
+            2. The DuckDB ``lake.typed.<bare>`` / ``lake.quarantine.<bare>``
+               tables. ``CREATE OR REPLACE`` on the next run rebuilds them;
+               we drop them explicitly to keep ``DROP TABLE IF EXISTS``
+               idempotent against schema drift between teach iterations.
+
+        It does NOT touch ``StatisticalProfile`` / ``SemanticAnnotation`` /
+        temporal / quality / eligibility rows — those belong to their phases,
+        which own their own ``replay_cleanup`` and run after typing on the
+        replay.
 
         Empty ``table_ids`` means source-wide — re-types every raw table.
         """
@@ -92,36 +99,33 @@ class TypingPhase(BasePhase):
         if not raw_tables:
             return
 
-        # 1: drop TypeCandidate/TypeDecision for the raw columns in scope.
-        raw_col_ids = list(
+        # 1: clear TypeCandidate/TypeDecision for the raw columns AND the typed
+        # columns sharing the raw table_name. Typed/quarantine columns are
+        # reached by joining the typed/quarantine Table rows (same table_name).
+        names = [t.table_name for t in raw_tables]
+        owned_table_ids = list(
             ctx.session.execute(
-                select(Column.column_id).where(
-                    Column.table_id.in_([t.table_id for t in raw_tables])
+                select(Table.table_id).where(
+                    Table.source_id == ctx.source_id,
+                    Table.table_name.in_(names),
+                    Table.layer.in_(["raw", "typed", "quarantine"]),
                 )
             ).scalars()
         )
-        if raw_col_ids:
+        col_ids = list(
             ctx.session.execute(
-                delete(TypeCandidate).where(TypeCandidate.column_id.in_(raw_col_ids))
-            )
-            ctx.session.execute(delete(TypeDecision).where(TypeDecision.column_id.in_(raw_col_ids)))
-
-        # 2 + 3: drop typed/quarantine Tables sharing the raw table_name —
-        # typed and quarantine each have at most one row per name per source,
-        # so we match by (source_id, table_name, layer).
-        names = [t.table_name for t in raw_tables]
-        ctx.session.execute(
-            delete(Table).where(
-                Table.source_id == ctx.source_id,
-                Table.table_name.in_(names),
-                Table.layer.in_(["typed", "quarantine"]),
-            )
+                select(Column.column_id).where(Column.table_id.in_(owned_table_ids))
+            ).scalars()
         )
-        ctx.session.flush()
+        if col_ids:
+            ctx.session.execute(delete(TypeCandidate).where(TypeCandidate.column_id.in_(col_ids)))
+            ctx.session.execute(delete(TypeDecision).where(TypeDecision.column_id.in_(col_ids)))
+            ctx.session.flush()
 
-        # 4: drop the DuckDB typed/quarantine tables for these bare names.
+        # 2: drop the DuckDB typed/quarantine tables for these bare names.
         # The raw row carries the canonical bare name (``<source>__<table>``),
-        # and typed/quarantine share it (post-DAT-341).
+        # and typed/quarantine share it (post-DAT-341). The Postgres typed +
+        # quarantine Table/Column rows are intentionally left in place.
         for raw in raw_tables:
             if not raw.duckdb_path:
                 continue
@@ -130,12 +134,22 @@ class TypingPhase(BasePhase):
                 ctx.duckdb_conn.execute(f"DROP TABLE IF EXISTS {fqn}")
 
     def should_skip(self, ctx: PhaseContext) -> str | None:
-        """Skip if typed tables already exist for the targeted raw tables.
+        """Skip if the targeted raw tables are already typed.
 
         When ``ctx.table_ids`` is set (per-table teach replay), only the
         requested raw tables are considered — so a targeted untyped table
         still runs even if its sibling tables are already typed.
+
+        A typed table counts as "done" only if its columns still carry the
+        ``TypeDecision`` rows ``_run`` writes (DAT-373). The typed ``Table``
+        row now survives a re-type replay (stable identity), so its mere
+        presence is no longer the signal: ``replay_cleanup`` clears the typed
+        columns' ``TypeDecision`` in place, and an empty/decisionless typed
+        table re-types. This is the Postgres signal ``replay_cleanup`` deletes,
+        keeping skip and cleanup in lock-step.
         """
+        from dataraum.analysis.typing.db_models import TypeDecision
+
         stmt = select(Table).where(
             Table.source_id == ctx.source_id,
             Table.layer == "raw",
@@ -150,16 +164,27 @@ class TypingPhase(BasePhase):
             if not raw_tables:
                 return "No raw tables match the requested table_ids filter"
 
-        # Check if all (targeted) raw tables have corresponding typed tables
+        # A targeted raw table needs typing if it has no typed counterpart OR
+        # that counterpart's columns have lost their TypeDecisions (post-cleanup).
         for raw_table in raw_tables:
-            typed_stmt = select(Table).where(
-                Table.source_id == ctx.source_id,
-                Table.table_name == raw_table.table_name,
-                Table.layer == "typed",
-            )
-            typed_table = ctx.session.execute(typed_stmt).scalar_one_or_none()
+            typed_table = ctx.session.execute(
+                select(Table).where(
+                    Table.source_id == ctx.source_id,
+                    Table.table_name == raw_table.table_name,
+                    Table.layer == "typed",
+                )
+            ).scalar_one_or_none()
             if not typed_table:
                 return None  # At least one table needs typing
+
+            has_decision = ctx.session.execute(
+                select(TypeDecision.decision_id)
+                .join(Column, Column.column_id == TypeDecision.column_id)
+                .where(Column.table_id == typed_table.table_id)
+                .limit(1)
+            ).first()
+            if has_decision is None:
+                return None  # Typed row exists but was cleaned for a re-type
 
         return "All tables already typed"
 
@@ -215,34 +240,63 @@ class TypingPhase(BasePhase):
         ).fetchone()
         row_count = row_count_result[0] if row_count_result else 0
 
-        # Create typed Table record
-        typed_table_id = str(uuid4())
-        typed_table = Table(
-            table_id=typed_table_id,
-            source_id=table.source_id,
-            table_name=table.table_name,
-            layer="typed",
-            duckdb_path=bare,
-            row_count=row_count,
+        # Reconcile the typed Table + Column rows (DAT-373 Option A): reuse the
+        # existing rows for this (source, table_name, "typed") so a re-type keeps
+        # the typed Table id + Column ids stable. The reconcile helpers live in
+        # resolve_types alongside the untyped path so both share one identity rule.
+        from dataraum.analysis.typing.resolution import (
+            reconcile_typed_columns,
+            reconcile_typed_table,
         )
-        ctx.session.add(typed_table)
 
-        # Create Column records for the typed table, using raw_type as resolved_type
+        ctx.session.flush()
+        typed_table = reconcile_typed_table(ctx.session, table, "typed", bare, row_count)
+        ctx.session.flush()
+
+        desired = [
+            (
+                col.column_name,
+                col.original_name,
+                col.column_position,
+                col.raw_type,
+                col.raw_type or "VARCHAR",
+            )
+            for col in table.columns
+        ]
+        column_map = reconcile_typed_columns(ctx.session, typed_table, desired)
+        ctx.session.flush()
+
+        # Stamp a TypeDecision per typed column. Strongly-typed columns are
+        # "trusted source" decisions; writing them keeps the typed-table skip
+        # signal uniform with the untyped path (``should_skip`` treats a typed
+        # table with no TypeDecisions as needing a re-type — DAT-373). On a
+        # re-type the stable column ids are reused, so clear prior copies first
+        # to respect ``uq_column_type_decision``.
+        from dataraum.analysis.typing.db_models import TypeDecision
+
+        typed_col_ids = list(column_map.values())
+        if typed_col_ids:
+            ctx.session.execute(
+                delete(TypeDecision).where(TypeDecision.column_id.in_(typed_col_ids))
+            )
+            ctx.session.flush()
+
         type_decisions: dict[str, str] = {}
         for col in table.columns:
-            resolved_type = col.raw_type or "VARCHAR"
-            new_col_id = str(uuid4())
-            typed_col = Column(
-                column_id=new_col_id,
-                table_id=typed_table_id,
-                column_name=col.column_name,
-                original_name=col.original_name,
-                column_position=col.column_position,
-                raw_type=col.raw_type,
-                resolved_type=resolved_type,
+            resolved = col.raw_type or "VARCHAR"
+            typed_col_id = column_map[col.column_name]
+            ctx.session.add(
+                TypeDecision(
+                    decision_id=str(uuid4()),
+                    session_id=ctx.require_session_id(),
+                    column_id=typed_col_id,
+                    decided_type=resolved,
+                    decision_source="automatic",
+                    decided_at=datetime.now(UTC),
+                    decision_reason="strongly-typed source (types trusted)",
+                )
             )
-            ctx.session.add(typed_col)
-            type_decisions[new_col_id] = resolved_type
+            type_decisions[typed_col_id] = resolved
 
         logger.debug(
             "strongly_typed_promoted",
@@ -251,7 +305,7 @@ class TypingPhase(BasePhase):
             rows=row_count,
         )
 
-        return typed_table_id, type_decisions
+        return typed_table.table_id, type_decisions
 
     def _resolve_target_table_ids(self, ctx: PhaseContext) -> list[str]:
         """Resolve which raw table_ids to type for this run.

--- a/packages/engine/src/dataraum/worker/contracts.py
+++ b/packages/engine/src/dataraum/worker/contracts.py
@@ -119,27 +119,28 @@ class TypingResult(BaseModel):
 
 
 class ReplayCleanupInput(BaseModel):
-    """Input to the ``replay_cleanup_for_phase`` activity (DAT-343).
+    """Input to the ``replay_cleanup_for_phase`` activity (DAT-343 / DAT-373).
 
-    Carried by the workflow when it's about to enter the ``from_phase`` of
-    a teach replay; the activity invokes the phase's ``replay_cleanup``
-    so the phase's existing ``should_skip`` doesn't bail on a re-run.
+    Carried by the workflow before EVERY phase that re-executes under a teach
+    replay (DAT-373), not just the ``from_phase``; the activity invokes that
+    phase's owner-scoped ``replay_cleanup`` so its existing ``should_skip``
+    doesn't bail on the re-run. Pre-DAT-373 only the entry phase was cleaned and
+    downstream phases rode the now-removed typed-Table cascade.
 
     Attributes:
         identity: source identity header (same as every other phase activity).
-        phase_name: which phase's ``replay_cleanup`` to invoke — must equal
-            the workflow's ``replay.from_phase``.
+        phase_name: which phase's ``replay_cleanup`` to invoke — one of the
+            chain phases at-or-after ``replay.from_phase`` (plus the always-rerun
+            source-level reduce).
         table_ids: scope passed through to the phase's ``replay_cleanup``.
-            An empty list collapses two distinct workflow shapes onto the
-            same wire value: (1) source-wide replays where
-            ``replay.raw_table_ids is None`` (e.g. ``null_value`` →
-            ``ImportPhase.replay_cleanup``, which ignores the scope and
-            drops everything for the source); and (2) source-tail-only
-            replays where ``replay.raw_table_ids == []`` (e.g.
-            ``concept_property`` → ``SemanticPerColumnPhase.replay_cleanup``,
-            which is intrinsically source-wide). Per-table replays
-            (``type_pattern``) carry a single raw_table_id so the typing
-            cleanup can narrow.
+            For ``typing`` / ``import`` this is the raw table id(s); for the
+            table-local analytics phases it is the typed table id their rows
+            hang off. An empty list collapses two source-wide shapes onto one
+            wire value: (1) ``replay.raw_table_ids is None`` (e.g. ``null_value``
+            → ``ImportPhase.replay_cleanup``, which ignores the scope and drops
+            everything for the source); and (2) ``replay.raw_table_ids == []``
+            (e.g. ``concept_property`` → ``SemanticPerColumnPhase.replay_cleanup``,
+            intrinsically source-wide).
     """
 
     identity: SourceIdentity

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -133,15 +133,23 @@ async def _maybe_replay_cleanup(
     identity: SourceIdentity,
     table_ids: list[str],
 ) -> None:
-    """Invoke ``replay_cleanup_for_phase`` when ``phase`` is the replay entry.
+    """Invoke ``replay_cleanup_for_phase`` for every phase that re-runs on a replay.
 
-    The first phase that runs on a teach replay (``replay.from_phase``) needs
-    its prior outputs cleaned so its existing ``should_skip`` doesn't bail.
-    On the initial run (``replay is None``), nothing to clean. Downstream
-    phases of a replay ride on the entry phase's cascade — no per-phase
-    cleanup needed there either.
+    Each chain phase owns its outputs and clears them in place before the
+    re-run, so its existing ``should_skip`` doesn't bail (DAT-373). Pre-DAT-373
+    only the entry phase (``replay.from_phase``) was cleaned and everything
+    downstream rode on the entry phase's cascade-delete through the dropped
+    typed ``Table``. With stable typed identity that cascade is gone, so each
+    phase at-or-after ``from_phase`` cleans its own per-Column rows (scoped to
+    ``table_ids``) — owner-scoped, never cross-stage.
+
+    On the initial run (``replay is None``), nothing to clean. The phase order
+    used to gate this is the chain ``phase`` belongs to; ``_runs_under`` (which
+    the caller already used to decide whether ``phase`` runs) and this share the
+    same at-or-after predicate, so cleanup fires exactly for the phases that
+    re-execute.
     """
-    if replay is None or replay.from_phase != phase:
+    if replay is None or not _phase_reruns_on_replay(phase, replay):
         return
     await workflow.execute_activity(
         "replay_cleanup_for_phase",
@@ -154,6 +162,22 @@ async def _maybe_replay_cleanup(
         start_to_close_timeout=_TIMEOUT,
         retry_policy=_RETRY,
     )
+
+
+def _phase_reruns_on_replay(phase: str, replay: ReplayScope) -> bool:
+    """True iff ``phase`` re-executes under ``replay`` (so it must self-clean).
+
+    A phase re-runs when it is at-or-after ``from_phase`` in whichever chain it
+    belongs to. ``semantic_per_column`` is the exception: the parent body always
+    re-runs the source-level reduce on ANY replay (the "widening breadth" rule),
+    so it must always self-clean too. Pure logic over workflow input →
+    deterministic.
+    """
+    if phase == "semantic_per_column":
+        return True
+    if phase in _CHILD_PHASE_ORDER:
+        return _at_or_after(phase, replay.from_phase, _CHILD_PHASE_ORDER)
+    return _at_or_after(phase, replay.from_phase, _PARENT_PHASE_ORDER)
 
 
 @workflow.defn(name="processTableWorkflow")
@@ -207,6 +231,10 @@ class ProcessTableWorkflow:
         for phase in _ANALYTICS_PHASES:
             if not _runs_under(phase, replay, _CHILD_PHASE_ORDER):
                 continue
+            # Owner-scoped self-clean before re-run: each analytics phase clears
+            # its own per-Column rows for THIS typed table so its ``should_skip``
+            # doesn't bail (DAT-373). Scope is the typed id its rows hang off.
+            await _maybe_replay_cleanup(phase, replay, payload.identity, [typed_table_id])
             await workflow.execute_activity(
                 phase,
                 scoped,

--- a/packages/engine/tests/integration/pipeline/test_replay_cross_stage.py
+++ b/packages/engine/tests/integration/pipeline/test_replay_cross_stage.py
@@ -58,9 +58,7 @@ def _resolve_once(
     """Infer + resolve types for a raw table, returning the typed table id."""
     raw_table = session.get(Table, staged_table_id)
     assert raw_table is not None
-    infer = infer_type_candidates(
-        raw_table, duckdb_conn, session, session_id=baseline_session_id()
-    )
+    infer = infer_type_candidates(raw_table, duckdb_conn, session, session_id=baseline_session_id())
     assert infer.success, infer.error
     session.flush()
     resolve = resolve_types(
@@ -142,14 +140,10 @@ class TestCrossStageSurvival:
         assert result.status == PhaseStatus.COMPLETED, result.error
 
         with harness.session_factory() as session:
-            typed_table = session.execute(
-                select(Table).where(Table.layer == "typed")
-            ).scalar_one()
+            typed_table = session.execute(select(Table).where(Table.layer == "typed")).scalar_one()
             typed_table_id = typed_table.table_id
             id_col = session.execute(
-                select(Column).where(
-                    Column.table_id == typed_table_id, Column.column_name == "id"
-                )
+                select(Column).where(Column.table_id == typed_table_id, Column.column_name == "id")
             ).scalar_one()
             id_col_id = id_col.column_id
             # Simulate a begin_session / frame-ground finding attached to the

--- a/packages/engine/tests/integration/pipeline/test_replay_cross_stage.py
+++ b/packages/engine/tests/integration/pipeline/test_replay_cross_stage.py
@@ -1,0 +1,212 @@
+"""DAT-373 — stable typed Column identity + cross-stage data survival on replay.
+
+Two guarantees, exercised against a real DuckLake substrate:
+
+1. **Stable identity** — re-running ``resolve_types`` on a raw table REUSES the
+   existing typed ``Table`` + ``Column`` rows (ids unchanged) instead of minting
+   fresh uuid4 ids. This is what lets a teach re-type avoid orphaning another
+   stage's per-Column rows.
+
+2. **Cross-stage survival** — a simulated ``begin_session`` / frame-ground
+   per-Column finding (a ``SemanticAnnotation`` here) attached to a typed column
+   survives a ``type_pattern``-style re-type: typing's ``replay_cleanup`` clears
+   only its own rows in place, and the downstream analytics phases self-clean
+   only their own rows.
+
+These replace the pre-DAT-373 invariant (the integration smoke asserted every
+typed_table_id CHANGED on replay — proof the typed Table was dropped). The new
+invariant is the opposite: typed ids are STABLE and foreign per-Column rows live.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import duckdb
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from dataraum.analysis.semantic.db_models import SemanticAnnotation
+from dataraum.analysis.statistics.db_models import StatisticalProfile
+from dataraum.analysis.typing import infer_type_candidates, resolve_types
+from dataraum.core.models import SourceConfig
+from dataraum.pipeline.base import PhaseStatus
+from dataraum.pipeline.phases.statistics_phase import StatisticsPhase
+from dataraum.pipeline.phases.typing_phase import TypingPhase
+from dataraum.sources.csv import CSVLoader
+from dataraum.storage import Column, Table
+from tests.conftest import baseline_session_id
+
+
+@pytest.fixture
+def simple_csv(tmp_path):
+    """A small CSV with a clean integer id column and a numeric amount."""
+    csv_file = tmp_path / "orders.csv"
+    csv_file.write_text(
+        "id,amount,note\n1,10.5,a\n2,20.0,b\n3,30.25,c\n4,40.0,d\n",
+    )
+    return csv_file
+
+
+def _resolve_once(
+    staged_table_id: str,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    session: Session,
+) -> str:
+    """Infer + resolve types for a raw table, returning the typed table id."""
+    raw_table = session.get(Table, staged_table_id)
+    assert raw_table is not None
+    infer = infer_type_candidates(
+        raw_table, duckdb_conn, session, session_id=baseline_session_id()
+    )
+    assert infer.success, infer.error
+    session.flush()
+    resolve = resolve_types(
+        staged_table_id,
+        duckdb_conn,
+        session,
+        min_confidence=0.85,
+        session_id=baseline_session_id(),
+    )
+    assert resolve.success, resolve.error
+    return resolve.unwrap().typed_table_id
+
+
+def _typed_column_ids(session: Session, typed_table_id: str) -> dict[str, str]:
+    rows = session.execute(
+        select(Column.column_name, Column.column_id).where(Column.table_id == typed_table_id)
+    ).all()
+    return dict(rows)
+
+
+class TestStableTypedIdentity:
+    """Re-typing reuses the typed Table + Column rows (ids unchanged)."""
+
+    def test_second_resolve_keeps_table_and_column_ids(
+        self, simple_csv, duckdb_conn, session
+    ) -> None:
+        loader = CSVLoader()
+        config = SourceConfig(name="orders", source_type="csv", path=str(simple_csv))
+        load_result = loader.load(config, duckdb_conn, session)
+        assert load_result.success
+        staging = load_result.unwrap()
+        staged = staging.tables[0]
+
+        first_typed_id = _resolve_once(staged.table_id, duckdb_conn, session)
+        first_cols = _typed_column_ids(session, first_typed_id)
+        assert first_cols  # sanity
+
+        # Re-type the SAME raw table (a type_pattern teach re-runs typing).
+        # Clear typing's own rows in place first, exactly as the replay does.
+        TypingPhase().replay_cleanup(
+            _CleanupCtx(session, duckdb_conn, staging.source_id),
+            [staged.table_id],
+        )
+        second_typed_id = _resolve_once(staged.table_id, duckdb_conn, session)
+        second_cols = _typed_column_ids(session, second_typed_id)
+
+        # The typed Table id and every typed Column id are UNCHANGED.
+        assert second_typed_id == first_typed_id
+        assert second_cols == first_cols
+
+
+class _CleanupCtx:
+    """Minimal PhaseContext stand-in for invoking replay_cleanup directly.
+
+    ``replay_cleanup`` only reads ``session`` / ``duckdb_conn`` / ``source_id``
+    plus ``_typed_tables`` (which uses ``source_id`` + ``table_ids``); the rest
+    of ``PhaseContext`` is unused by the cleanup path.
+    """
+
+    def __init__(self, session, duckdb_conn, source_id) -> None:
+        self.session = session
+        self.duckdb_conn = duckdb_conn
+        self.source_id = source_id
+        self.table_ids: list[str] = []
+        self.config: dict = {}
+        self.session_id = baseline_session_id()
+
+
+class TestCrossStageSurvival:
+    """A foreign per-Column row survives a re-type through the phase chain."""
+
+    def test_semantic_annotation_survives_retype(self, harness, simple_csv) -> None:
+        # Import + type the source through the harness (real substrate).
+        result = harness.run_import(source_path=simple_csv, source_name="orders")
+        assert result.status == PhaseStatus.COMPLETED, result.error
+        result = harness.run_phase("typing")
+        assert result.status == PhaseStatus.COMPLETED, result.error
+        result = harness.run_phase("statistics")
+        assert result.status == PhaseStatus.COMPLETED, result.error
+
+        with harness.session_factory() as session:
+            typed_table = session.execute(
+                select(Table).where(Table.layer == "typed")
+            ).scalar_one()
+            typed_table_id = typed_table.table_id
+            id_col = session.execute(
+                select(Column).where(
+                    Column.table_id == typed_table_id, Column.column_name == "id"
+                )
+            ).scalar_one()
+            id_col_id = id_col.column_id
+            # Simulate a begin_session / frame-ground finding attached to the
+            # typed column — a stage NOT in the add_source chain.
+            session.add(
+                SemanticAnnotation(
+                    annotation_id=str(uuid4()),
+                    column_id=id_col_id,
+                    semantic_role="identifier",
+                    annotation_source="teach",
+                    annotated_at=datetime.now(UTC),
+                )
+            )
+            session.commit()
+
+        # Re-type the table (type_pattern teach) + re-run statistics, mirroring
+        # the workflow's replay: each phase self-cleans only its own rows.
+        raw_table_id = None
+        with harness.session_factory() as session:
+            raw_table_id = session.execute(
+                select(Table.table_id).where(Table.layer == "raw")
+            ).scalar_one()
+
+        with harness.session_factory() as session:
+            TypingPhase().replay_cleanup(
+                _CleanupCtx(session, harness.duckdb_conn, harness.source_id),
+                [raw_table_id],
+            )
+            session.commit()
+        result = harness.run_phase("typing", table_ids=[raw_table_id])
+        assert result.status == PhaseStatus.COMPLETED, result.error
+
+        with harness.session_factory() as session:
+            StatisticsPhase().replay_cleanup(
+                _CleanupCtx(session, harness.duckdb_conn, harness.source_id),
+                [typed_table_id],
+            )
+            session.commit()
+        result = harness.run_phase("statistics", table_ids=[typed_table_id])
+        assert result.status == PhaseStatus.COMPLETED, result.error
+
+        with harness.session_factory() as session:
+            # The typed column id is stable AND the foreign annotation survives.
+            surviving_col = session.execute(
+                select(Column.column_id).where(
+                    Column.table_id == typed_table_id, Column.column_name == "id"
+                )
+            ).scalar_one()
+            assert surviving_col == id_col_id
+            annotation = session.execute(
+                select(SemanticAnnotation).where(SemanticAnnotation.column_id == id_col_id)
+            ).first()
+            assert annotation is not None, "re-type wiped a foreign per-Column row"
+            # Statistics rebuilt its own rows (owner-scoped self-clean → re-run).
+            profiles = session.execute(
+                select(StatisticalProfile)
+                .join(Column, Column.column_id == StatisticalProfile.column_id)
+                .where(Column.table_id == typed_table_id)
+            ).all()
+            assert profiles, "statistics did not rebuild after re-type"

--- a/packages/engine/tests/unit/pipeline/test_phase_replay_cleanup.py
+++ b/packages/engine/tests/unit/pipeline/test_phase_replay_cleanup.py
@@ -224,29 +224,35 @@ class TestImportPhaseReplayCleanup:
 
 
 class TestTypingPhaseReplayCleanup:
-    """``typing.replay_cleanup`` drops typed/quarantine for the scoped raw tables."""
+    """``typing.replay_cleanup`` clears typing's own state IN PLACE (DAT-373).
 
-    def test_scoped_to_table_ids_drops_matching_typed(self, session: Session) -> None:
+    The typed/quarantine ``Table`` + ``Column`` rows survive a re-type (stable
+    identity); only typing-owned ``TypeCandidate`` / ``TypeDecision`` rows and the
+    DuckDB typed/quarantine tables are cleared.
+    """
+
+    def test_scoped_to_table_ids_keeps_typed_table(self, session: Session) -> None:
         source, raw, typed = _seed_source_with_tables(session)
         ctx = _make_ctx(session, source.source_id)
 
         TypingPhase().replay_cleanup(ctx, [raw.table_id])
 
-        # The typed Table row matching the raw is gone.
+        # The typed Table row matching the raw SURVIVES with the same id —
+        # ``_run`` reconciles it in place on the re-type.
         remaining_typed = session.execute(
             select(Table).where(Table.source_id == source.source_id, Table.layer == "typed")
-        ).all()
-        assert remaining_typed == []
-        # The raw Table row stays — only typing's outputs are cleaned.
+        ).scalar_one()
+        assert remaining_typed.table_id == typed.table_id
+        # The raw Table row stays too.
         remaining_raw = session.execute(
             select(Table).where(Table.source_id == source.source_id, Table.layer == "raw")
         ).all()
         assert len(remaining_raw) == 1
 
-    def test_leaves_sibling_typed_tables_alone(self, session: Session) -> None:
-        """A teach on table A must not clobber table B's typed state."""
-        source, raw_a, typed_a = _seed_source_with_tables(session)
-        # Add a sibling pair (different table_name).
+    def test_leaves_sibling_table_decisions_alone(self, session: Session) -> None:
+        """A teach on table A must not clear table B's typing state."""
+        source, raw_a, _typed_a = _seed_source_with_tables(session)
+        # Add a sibling pair (different table_name) with a typed column + decision.
         raw_b = Table(
             table_id=str(uuid4()),
             source_id=source.source_id,
@@ -263,45 +269,78 @@ class TestTypingPhaseReplayCleanup:
         )
         session.add_all([raw_b, typed_b])
         session.flush()
+        typed_b_col = Column(
+            column_id=str(uuid4()),
+            table_id=typed_b.table_id,
+            column_name="customer_id",
+            column_position=0,
+            raw_type="VARCHAR",
+            resolved_type="BIGINT",
+        )
+        session.add(typed_b_col)
+        session.flush()
+        session.add(
+            TypeDecision(
+                decision_id=str(uuid4()),
+                column_id=typed_b_col.column_id,
+                decided_type="BIGINT",
+                decision_source="automatic",
+                decided_at=datetime.now(UTC),
+            )
+        )
+        session.flush()
         ctx = _make_ctx(session, source.source_id)
 
         TypingPhase().replay_cleanup(ctx, [raw_a.table_id])
 
-        # typed_a is gone; typed_b survives.
+        # Both typed tables survive; sibling B's TypeDecision is untouched.
         remaining = {
             row.table_name
             for row in session.execute(
                 select(Table).where(Table.source_id == source.source_id, Table.layer == "typed")
             ).scalars()
         }
-        assert remaining == {"customers"}
+        assert remaining == {"orders", "customers"}
+        assert (
+            session.execute(
+                select(TypeDecision).where(TypeDecision.column_id == typed_b_col.column_id)
+            ).first()
+            is not None
+        )
 
-    def test_empty_table_ids_means_source_wide(self, session: Session) -> None:
-        source, raw_a, _typed_a = _seed_source_with_tables(session)
-        raw_b = Table(
-            table_id=str(uuid4()),
-            source_id=source.source_id,
-            table_name="customers",
-            layer="raw",
-            duckdb_path=f"{source.name}__customers",
+    def test_empty_table_ids_clears_source_wide_decisions(self, session: Session) -> None:
+        source, raw_a, typed_a = _seed_source_with_tables(session)
+        # Seed a TypeDecision on the typed column so we can prove it's cleared.
+        typed_a_col_id = session.execute(
+            select(Column.column_id).where(Column.table_id == typed_a.table_id)
+        ).scalar_one()
+        session.add(
+            TypeDecision(
+                decision_id=str(uuid4()),
+                column_id=typed_a_col_id,
+                decided_type="BIGINT",
+                decision_source="automatic",
+                decided_at=datetime.now(UTC),
+            )
         )
-        typed_b = Table(
-            table_id=str(uuid4()),
-            source_id=source.source_id,
-            table_name="customers",
-            layer="typed",
-            duckdb_path=f"{source.name}__customers",
-        )
-        session.add_all([raw_b, typed_b])
         session.flush()
         ctx = _make_ctx(session, source.source_id)
 
         TypingPhase().replay_cleanup(ctx, [])
 
-        remaining_typed = session.execute(
-            select(Table).where(Table.source_id == source.source_id, Table.layer == "typed")
-        ).all()
-        assert remaining_typed == []
+        # Typed table survives; its decision is cleared (source-wide re-type).
+        assert (
+            session.execute(
+                select(Table).where(Table.source_id == source.source_id, Table.layer == "typed")
+            ).scalar_one().table_id
+            == typed_a.table_id
+        )
+        assert (
+            session.execute(
+                select(TypeDecision).where(TypeDecision.column_id == typed_a_col_id)
+            ).all()
+            == []
+        )
 
     def test_drops_type_candidates_for_raw_columns(self, session: Session) -> None:
         source, raw, typed = _seed_source_with_tables(session)
@@ -370,6 +409,108 @@ class TestTypingPhaseReplayCleanup:
         ).all()
         assert len(remaining) == 1
         assert ctx.duckdb_conn.statements == []  # type: ignore[attr-defined]
+
+    def test_preserves_typed_table_and_columns(self, session: Session) -> None:
+        """The typed Table + its Column rows survive a re-type (DAT-373 Option A).
+
+        Pre-DAT-373 the cleanup dropped the typed ``Table`` and cascade-wiped
+        every Column. With stable typed identity, ``replay_cleanup`` rebuilds
+        only the DuckDB data + typing's own Postgres rows in place — the typed
+        ``Table`` and ``Column`` rows (and their ids) are kept so other stages'
+        per-Column findings stay attached.
+        """
+        source, raw, typed = _seed_source_with_tables(session)
+        typed_col_id = session.execute(
+            select(Column.column_id).where(Column.table_id == typed.table_id)
+        ).scalar_one()
+        ctx = _make_ctx(session, source.source_id)
+
+        TypingPhase().replay_cleanup(ctx, [raw.table_id])
+
+        # The typed Table row and its Column survive with the SAME ids.
+        surviving_typed = session.execute(
+            select(Table).where(Table.source_id == source.source_id, Table.layer == "typed")
+        ).scalar_one()
+        assert surviving_typed.table_id == typed.table_id
+        surviving_col = session.execute(
+            select(Column.column_id).where(Column.table_id == typed.table_id)
+        ).scalar_one()
+        assert surviving_col == typed_col_id
+
+    def test_preserves_other_stage_per_column_rows(self, session: Session) -> None:
+        """A type-teach replay must NOT wipe another stage's per-Column rows (DAT-373).
+
+        The hazard: a future stage (``begin_session`` / frame-ground) attaches a
+        ``SemanticAnnotation`` (here standing in for any other-stage per-Column
+        finding) to a typed column. A ``type_pattern`` teach re-typing that table
+        must leave the annotation intact — typing owns only its own rows, not the
+        whole typed ``Table``. Pre-DAT-373 the cascade through the dropped typed
+        ``Table`` wiped it; now the row survives.
+        """
+        source, raw, typed = _seed_source_with_tables(session)
+        typed_col_id = session.execute(
+            select(Column.column_id).where(Column.table_id == typed.table_id)
+        ).scalar_one()
+        _seed_semantic_annotation(session, typed_col_id)
+        ctx = _make_ctx(session, source.source_id)
+
+        TypingPhase().replay_cleanup(ctx, [raw.table_id])
+
+        surviving = session.execute(
+            select(SemanticAnnotation).where(SemanticAnnotation.column_id == typed_col_id)
+        ).first()
+        assert surviving is not None, (
+            "type-teach replay wiped another stage's per-Column row "
+            "(cross-stage data loss — DAT-373 hazard)"
+        )
+
+    def test_drops_type_candidates_for_typed_columns(self, session: Session) -> None:
+        """Typing's own copies on the typed column are cleared (in-place rebuild).
+
+        ``resolve_types`` copies ``TypeCandidate`` / ``TypeDecision`` onto the
+        typed column. Because the typed ``Column`` now survives the replay, the
+        cleanup must delete those copies explicitly so the re-run's fresh inserts
+        don't collide with the ``uq_column_type_decision`` unique constraint.
+        """
+        source, raw, typed = _seed_source_with_tables(session)
+        typed_col_id = session.execute(
+            select(Column.column_id).where(Column.table_id == typed.table_id)
+        ).scalar_one()
+        session.add(
+            TypeCandidate(
+                candidate_id=str(uuid4()),
+                column_id=typed_col_id,
+                detected_at=datetime.now(UTC),
+                data_type="BIGINT",
+                confidence=0.9,
+            )
+        )
+        session.add(
+            TypeDecision(
+                decision_id=str(uuid4()),
+                column_id=typed_col_id,
+                decided_type="BIGINT",
+                decision_source="automatic",
+                decided_at=datetime.now(UTC),
+            )
+        )
+        session.flush()
+        ctx = _make_ctx(session, source.source_id)
+
+        TypingPhase().replay_cleanup(ctx, [raw.table_id])
+
+        assert (
+            session.execute(
+                select(TypeCandidate).where(TypeCandidate.column_id == typed_col_id)
+            ).all()
+            == []
+        )
+        assert (
+            session.execute(
+                select(TypeDecision).where(TypeDecision.column_id == typed_col_id)
+            ).all()
+            == []
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/engine/tests/unit/pipeline/test_phase_replay_cleanup.py
+++ b/packages/engine/tests/unit/pipeline/test_phase_replay_cleanup.py
@@ -332,7 +332,9 @@ class TestTypingPhaseReplayCleanup:
         assert (
             session.execute(
                 select(Table).where(Table.source_id == source.source_id, Table.layer == "typed")
-            ).scalar_one().table_id
+            )
+            .scalar_one()
+            .table_id
             == typed_a.table_id
         )
         assert (

--- a/packages/engine/tests/unit/pipeline/test_typing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_typing_phase.py
@@ -11,14 +11,16 @@ These exercise the filter resolution + skip logic directly via a constructed
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import duckdb
 from sqlalchemy.orm import Session
 
+from dataraum.analysis.typing.db_models import TypeDecision
 from dataraum.pipeline.base import PhaseContext
 from dataraum.pipeline.phases.typing_phase import TypingPhase
-from dataraum.storage.models import Source, Table
+from dataraum.storage.models import Column, Source, Table
 
 
 def _make_source(session: Session) -> Source:
@@ -31,6 +33,38 @@ def _make_source(session: Session) -> Source:
 def _make_table(session: Session, source_id: str, name: str, layer: str = "raw") -> Table:
     table = Table(source_id=source_id, table_name=name, layer=layer, row_count=10)
     session.add(table)
+    session.flush()
+    return table
+
+
+def _make_typed_table(session: Session, source_id: str, name: str) -> Table:
+    """A fully-typed table: a typed Table + one Column carrying a TypeDecision.
+
+    Post-DAT-373 a typed ``Table`` row alone is no longer the "done" signal —
+    its columns must still carry the ``TypeDecision`` rows ``_run`` writes (the
+    rows ``replay_cleanup`` clears for a re-type). ``should_skip`` only treats a
+    table as typed when that decision is present.
+    """
+    table = _make_table(session, source_id, name, layer="typed")
+    col = Column(
+        column_id=str(uuid4()),
+        table_id=table.table_id,
+        column_name="c0",
+        column_position=0,
+        raw_type="VARCHAR",
+        resolved_type="BIGINT",
+    )
+    session.add(col)
+    session.flush()
+    session.add(
+        TypeDecision(
+            decision_id=str(uuid4()),
+            column_id=col.column_id,
+            decided_type="BIGINT",
+            decision_source="automatic",
+            decided_at=datetime.now(UTC),
+        )
+    )
     session.flush()
     return table
 
@@ -140,7 +174,7 @@ class TestShouldSkip:
     ) -> None:
         src = _make_source(session)
         _make_table(session, src.source_id, "t1")
-        _make_table(session, src.source_id, "t1", layer="typed")
+        _make_typed_table(session, src.source_id, "t1")
 
         reason = TypingPhase().should_skip(_ctx(session, duckdb_conn, src.source_id))
         assert reason == "All tables already typed"
@@ -150,8 +184,37 @@ class TestShouldSkip:
     ) -> None:
         src = _make_source(session)
         _make_table(session, src.source_id, "t1")
-        _make_table(session, src.source_id, "t1", layer="typed")
+        _make_typed_table(session, src.source_id, "t1")
         _make_table(session, src.source_id, "t2")  # raw, no typed → must run
+
+        reason = TypingPhase().should_skip(_ctx(session, duckdb_conn, src.source_id))
+        assert reason is None
+
+    def test_decisionless_typed_table_re_types(
+        self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+    ) -> None:
+        """A typed table whose decisions were cleared (post-cleanup) re-types.
+
+        Post-DAT-373 the typed ``Table`` row survives ``replay_cleanup``, so its
+        mere presence can't gate skipping — only its columns' ``TypeDecision``
+        rows do. A typed table with a column but no decision (the cleaned-up
+        state) must re-run.
+        """
+        src = _make_source(session)
+        _make_table(session, src.source_id, "t1")
+        typed = _make_table(session, src.source_id, "t1", layer="typed")
+        # A typed column but NO TypeDecision — exactly the post-cleanup state.
+        session.add(
+            Column(
+                column_id=str(uuid4()),
+                table_id=typed.table_id,
+                column_name="c0",
+                column_position=0,
+                raw_type="VARCHAR",
+                resolved_type="BIGINT",
+            )
+        )
+        session.flush()
 
         reason = TypingPhase().should_skip(_ctx(session, duckdb_conn, src.source_id))
         assert reason is None
@@ -162,9 +225,9 @@ class TestShouldSkip:
         # The core DAT-342 case: t1+t2 typed, replay targets t3 (untyped).
         src = _make_source(session)
         _make_table(session, src.source_id, "t1")
-        _make_table(session, src.source_id, "t1", layer="typed")
+        _make_typed_table(session, src.source_id, "t1")
         _make_table(session, src.source_id, "t2")
-        _make_table(session, src.source_id, "t2", layer="typed")
+        _make_typed_table(session, src.source_id, "t2")
         t3 = _make_table(session, src.source_id, "t3")
 
         reason = TypingPhase().should_skip(
@@ -177,7 +240,7 @@ class TestShouldSkip:
     ) -> None:
         src = _make_source(session)
         t1 = _make_table(session, src.source_id, "t1")
-        _make_table(session, src.source_id, "t1", layer="typed")
+        _make_typed_table(session, src.source_id, "t1")
         _make_table(session, src.source_id, "t2")  # untyped sibling, but not targeted
 
         reason = TypingPhase().should_skip(

--- a/packages/engine/tests/unit/worker/test_replay_scope.py
+++ b/packages/engine/tests/unit/worker/test_replay_scope.py
@@ -23,6 +23,7 @@ from dataraum.worker.workflows import (
     _PARENT_PHASE_ORDER,
     _VALID_REPLAY_PHASES,
     _at_or_after,
+    _phase_reruns_on_replay,
     _runs_under,
     _validate_replay,
 )
@@ -111,6 +112,40 @@ class TestRunsUnder:
     def test_typing_replay_runs_every_analytics_phase(self, phase: str) -> None:
         replay = ReplayScope(from_phase="typing", raw_table_ids=["raw-1"])
         assert _runs_under(phase, replay, _CHILD_PHASE_ORDER) is True
+
+
+class TestPhaseRerunsOnReplay:
+    """Every phase that re-executes under a replay must self-clean (DAT-373).
+
+    Pre-DAT-373 only the entry phase cleaned and downstream rode the typed-Table
+    cascade. With stable typed identity that cascade is gone, so each phase
+    at-or-after ``from_phase`` clears its own rows. ``_phase_reruns_on_replay``
+    decides who cleans; it must agree with ``_runs_under`` for the chain phases
+    plus always-clean the always-rerun reduce.
+    """
+
+    def test_typing_replay_cleans_every_child_phase(self) -> None:
+        replay = ReplayScope(from_phase="typing", raw_table_ids=["raw-1"])
+        for phase in _CHILD_PHASE_ORDER:
+            assert _phase_reruns_on_replay(phase, replay) is True
+
+    def test_analytics_replay_skips_earlier_phases(self) -> None:
+        # A replay from "statistical_quality" should NOT clean typing/statistics.
+        replay = ReplayScope(from_phase="statistical_quality", raw_table_ids=["raw-1"])
+        assert _phase_reruns_on_replay("typing", replay) is False
+        assert _phase_reruns_on_replay("statistics", replay) is False
+        assert _phase_reruns_on_replay("statistical_quality", replay) is True
+        assert _phase_reruns_on_replay("temporal", replay) is True
+
+    def test_reduce_always_cleans_on_any_replay(self) -> None:
+        # The source-level reduce always re-runs (widening breadth) → always cleans.
+        for from_phase in ("import", "typing", "semantic_per_column"):
+            replay = ReplayScope(from_phase=from_phase)
+            assert _phase_reruns_on_replay("semantic_per_column", replay) is True
+
+    def test_import_replay_cleans_import(self) -> None:
+        replay = ReplayScope(from_phase="import", raw_table_ids=None)
+        assert _phase_reruns_on_replay("import", replay) is True
 
 
 class TestReplayScopeContract:


### PR DESCRIPTION
…eplay_cleanup

A type-teach replay used to drop the typed Table (cascade-wiping every per-Column row of every stage) and re-mint fresh uuid4 typed Column ids on each re-type (orphaning other stages' per-Column rows even if cleanup were scoped). Both are fixed (DAT-373 Option A, no schema migration) so a future begin_session (DAT-356) / frame-ground (DAT-377) per-Column finding survives an add_source teach.

- Stable typed identity: resolve_types + TypingPhase._promote_strongly_typed reconcile typed/quarantine Table + Column rows by (source_id, table_name, layer) / (table_id, column_name) — reuse + UPDATE in place, delete dropped, insert new — instead of drop+recreate. Shared reconcile_typed_table / reconcile_typed_columns helpers.
- typing.replay_cleanup is now in-place + owner-scoped: keeps the typed Table/Column rows, clears only typing-owned TypeCandidate/TypeDecision (raw + typed copies) and drops the DuckDB typed/quarantine tables. No longer cascade-wipes StatisticalProfile / SemanticAnnotation / temporal / quality / eligibility.
- Per-phase owner-scoped replay_cleanup on statistics, column_eligibility, statistical_quality, temporal (delete-own-rows-by-column_id for the scoped typed tables). The workflow now invokes replay_cleanup_for_phase for every phase that re-runs under a replay (_phase_reruns_on_replay), not just from_phase; the source-level reduce always self-cleans.
- typing.should_skip treats a typed table as done only if its columns still carry a TypeDecision (the row cleanup clears); the surviving typed Table row alone is no longer the signal.
- BasePhase.replay_cleanup docstring states the ownership contract: delete ONLY your own rows scoped to table_ids; never delete a parent Table you don't exclusively own; the Table-delete cascade is reserved for import/teardown.

Tests: RED->GREEN hazard + in-place semantics (test_phase_replay_cleanup), stable-id + downstream-skip (test_typing_phase), _phase_reruns_on_replay (test_replay_scope), new integration test_replay_cross_stage (stable ids + foreign per-Column row survives a re-type on a real DuckLake substrate).

No detector/prompt/threshold change -> recall unaffected. Eval fixtures that relied on a re-type minting new typed column_id/table_id are now wrong (ids are stable); the cockpit drive-add-source smoke assertion must flip (cross-package, not in this lane). Handoff updated.