### PR TITLE
feat(cockpit): DAT-367 cockpit-owned DuckDB read verbs (run_sql + pro…

### DIFF
--- a/packages/cockpit/bun.lock
+++ b/packages/cockpit/bun.lock
@@ -6,6 +6,7 @@
       "name": "dataraum-cockpit",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.97.1",
+        "@duckdb/node-api": "^1.5.3-r.2",
         "@mantine/core": "^9.2.2",
         "@mantine/hooks": "^9.2.2",
         "@tailwindcss/vite": "^4.3.0",
@@ -110,6 +111,26 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.11.0", "", {}, "sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg=="],
+
+    "@duckdb/node-api": ["@duckdb/node-api@1.5.3-r.2", "", { "dependencies": { "@duckdb/node-bindings": "1.5.3-r.2" } }, "sha512-xjn6W9n8Sn9PaYmzrB6ayidNLQHpqNKdaRz4gx3yVoLUkrsIebQC1M1jV3BR8KqXj5P0RX4wLs8Tg/fK2ZQmNA=="],
+
+    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.3-r.2", "", { "dependencies": { "detect-libc": "^2.1.2" }, "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.3-r.2", "@duckdb/node-bindings-darwin-x64": "1.5.3-r.2", "@duckdb/node-bindings-linux-arm64": "1.5.3-r.2", "@duckdb/node-bindings-linux-arm64-musl": "1.5.3-r.2", "@duckdb/node-bindings-linux-x64": "1.5.3-r.2", "@duckdb/node-bindings-linux-x64-musl": "1.5.3-r.2", "@duckdb/node-bindings-win32-arm64": "1.5.3-r.2", "@duckdb/node-bindings-win32-x64": "1.5.3-r.2" } }, "sha512-bveKx+LfqRazcH8/MuCkMsbLVQKqr/EyuYRzaKpBcEvRYenw/TqK5+1N4fkMyoTv8ZukA4UYobymNYHqJUpdOA=="],
+
+    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.3-r.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5RQ3+fUZn+OvIJEfa1i/KngJHo5d6ilpjunsHfHdQy5F7r5pewDkPxRQno4xInPqGukMibKDoMdpzCKnymFJtw=="],
+
+    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.3-r.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-E7Pc+do8kj82+hHXkp4mxfw9Kqfe6V5FUT2EMoRsacbvhuoM1AeZxOj9jknh23IoNxPtn3S2tKnD1krL0v0I7A=="],
+
+    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.3-r.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-R8RKkNgVL4kHodot1krfbB4XQ+bA90LPsnN1Lm5J03QJlFgNlezul0H2U1UuvEaKUBPWDQj8g9Yt4hhKKKX0zw=="],
+
+    "@duckdb/node-bindings-linux-arm64-musl": ["@duckdb/node-bindings-linux-arm64-musl@1.5.3-r.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-P9lTyML8M6pS300fJbnMNFSBhojC0xJcvGvuR44xd//NqaHk9EwcPIs4+r2ek4LP5uugm7konVZ3VMr0BOKujw=="],
+
+    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.3-r.2", "", { "os": "linux", "cpu": "x64" }, "sha512-6vYTXgIqnWEjlNZX/AveTU7EzicuGATOdy8ncUbBIDxoC9cIrjoIqQc37COKEyT5IHjLIt25MllJtags96vvxA=="],
+
+    "@duckdb/node-bindings-linux-x64-musl": ["@duckdb/node-bindings-linux-x64-musl@1.5.3-r.2", "", { "os": "linux", "cpu": "x64" }, "sha512-V9kPvbMoJENvPo82LOzfhZ+KilFe1K8TKrksFmHe1Sy2pduNUVnxC+T4OQuOu4sqyCCVqVYRXe3pqTzKa/hCYg=="],
+
+    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.3-r.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-CjKqTI0WfRxwLgz8FV4fej/wkijPQnRgDk93aQlWQ+/+EwB9EnwQW3yfUy4Rs8cFjQkxkwlL5azoSR973l8U6w=="],
+
+    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.3-r.2", "", { "os": "win32", "cpu": "x64" }, "sha512-/oxN8ZFf2LxhForL+Uc+lEqnzHNvhSEsu3blnk3zu73rKTbD/WvPYIecrenb1ysApRK9ElGxitIYFx8PBuVKxg=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/packages/cockpit/package.json
+++ b/packages/cockpit/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.97.1",
+    "@duckdb/node-api": "^1.5.3-r.2",
     "@mantine/core": "^9.2.2",
     "@mantine/hooks": "^9.2.2",
     "@tailwindcss/vite": "^4.3.0",

--- a/packages/cockpit/src/config.test.ts
+++ b/packages/cockpit/src/config.test.ts
@@ -8,6 +8,7 @@ const REQUIRED: Record<string, string> = {
 	METADATA_DATABASE_URL: "postgresql://u:p@localhost:5432/meta",
 	DATARAUM_WORKSPACE_ID: "00000000-0000-0000-0000-000000000001",
 	DATARAUM_LAKE_PATH: "/var/lib/dataraum/lake",
+	DUCKLAKE_CATALOG_URL: "postgresql://u:p@localhost:5432/lake_catalog",
 	ANTHROPIC_API_KEY: "sk-ant-test",
 };
 
@@ -40,6 +41,7 @@ describe("cockpit config (DAT-363)", () => {
 		expect(config.cockpitDatabaseUrl).toBe(REQUIRED.COCKPIT_DATABASE_URL);
 		expect(config.metadataDatabaseUrl).toBe(REQUIRED.METADATA_DATABASE_URL);
 		expect(config.dataraumWorkspaceId).toBe(REQUIRED.DATARAUM_WORKSPACE_ID);
+		expect(config.ducklakeCatalogUrl).toBe(REQUIRED.DUCKLAKE_CATALOG_URL);
 		expect(config.anthropicApiKey).toBe(REQUIRED.ANTHROPIC_API_KEY);
 		expect(config.temporalHost).toBeUndefined();
 		// Temporal Web UI URL defaults to the compose dev address.

--- a/packages/cockpit/src/config.ts
+++ b/packages/cockpit/src/config.ts
@@ -19,7 +19,14 @@ const ConfigSchema = z.object({
 	// Plain non-empty string (not .uuid()) to match the engine, which accepts
 	// stable non-UUID ids (e.g. "test"); both sides must agree on the value.
 	dataraumWorkspaceId: z.string().min(1),
+	// DuckLake data path — the filesystem dir where DuckLake writes parquet.
+	// The engine writes here; the cockpit ATTACHes it READ_ONLY (DAT-367).
 	dataraumLakePath: z.string().min(1),
+	// DuckLake catalog (Postgres) URL — the metadata DB the cockpit ATTACHes
+	// to read the lake (DAT-367). The engine bootstraps + owns it; the cockpit
+	// opens it READ_ONLY. Bare `postgresql://` libpq form (DuckDB's postgres
+	// extension wants it), NOT the SQLAlchemy `postgresql+psycopg://` scheme.
+	ducklakeCatalogUrl: z.string().min(1),
 
 	// --- LLM (required) ---
 	anthropicApiKey: z.string().min(1),
@@ -42,6 +49,7 @@ function loadConfig(): Config {
 		metadataDatabaseUrl: process.env.METADATA_DATABASE_URL,
 		dataraumWorkspaceId: process.env.DATARAUM_WORKSPACE_ID,
 		dataraumLakePath: process.env.DATARAUM_LAKE_PATH,
+		ducklakeCatalogUrl: process.env.DUCKLAKE_CATALOG_URL,
 		anthropicApiKey: process.env.ANTHROPIC_API_KEY,
 		temporalHost: process.env.TEMPORAL_HOST,
 		temporalNamespace: process.env.TEMPORAL_NAMESPACE,

--- a/packages/cockpit/src/duckdb/credentials.test.ts
+++ b/packages/cockpit/src/duckdb/credentials.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveCredential } from "./credentials";
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe("resolveCredential (DAT-367)", () => {
+	it("resolves DATARAUM_<NAME>_URL by upper-cased source name", () => {
+		vi.stubEnv("DATARAUM_ORDERS_URL", "postgres://u:p@host:5432/db");
+		const resolved = resolveCredential("orders");
+		expect(resolved).toEqual({
+			url: "postgres://u:p@host:5432/db",
+			source: "env",
+		});
+	});
+
+	it("upper-cases a mixed-case source name", () => {
+		vi.stubEnv("DATARAUM_SALESDB_URL", "mysql://localhost/sales");
+		expect(resolveCredential("salesDb")?.url).toBe("mysql://localhost/sales");
+	});
+
+	it("returns null when no env var is set (caller fails loud)", () => {
+		vi.stubEnv("DATARAUM_MISSING_URL", undefined as unknown as string);
+		expect(resolveCredential("missing")).toBeNull();
+	});
+
+	it("treats an empty-string env var as unset", () => {
+		vi.stubEnv("DATARAUM_BLANK_URL", "");
+		expect(resolveCredential("blank")).toBeNull();
+	});
+});

--- a/packages/cockpit/src/duckdb/credentials.ts
+++ b/packages/cockpit/src/duckdb/credentials.ts
@@ -1,0 +1,56 @@
+// Per-source credential resolution (DAT-367, re-homed from the engine's
+// `core/credentials.py`).
+//
+// Database sources (the `probe` verb) need a connection URL resolved by source
+// NAME at query time, not at boot — the per-source URLs are dynamic
+// (`DATARAUM_<NAME>_URL`) and not enumerable as static config fields, so they
+// live OUTSIDE the typed Zod config (DAT-363) and are read directly here.
+//
+// Resolution is a single-provider chain today (env only). The chain shape is
+// retained so a future secrets-manager provider can slot in without touching
+// callers. Resolved URLs are SECRETS: never log them, never return them to the
+// chat agent or serialize them into a tool result.
+
+export interface ResolvedCredential {
+	/** The resolved connection URL. Never serialize this to a tool result. */
+	url: string;
+	/** Which provider resolved it (currently always "env"). */
+	source: string;
+}
+
+interface CredentialProvider {
+	resolve(sourceName: string): ResolvedCredential | null;
+}
+
+/** Resolve `DATARAUM_<SOURCE_NAME>_URL` from the process environment. */
+class EnvProvider implements CredentialProvider {
+	resolve(sourceName: string): ResolvedCredential | null {
+		const key = `DATARAUM_${sourceName.toUpperCase()}_URL`;
+		const url = process.env[key];
+		if (url) {
+			return { url, source: "env" };
+		}
+		return null;
+	}
+}
+
+const PROVIDERS: CredentialProvider[] = [new EnvProvider()];
+
+/**
+ * Resolve a connection URL for a database source by name.
+ *
+ * Walks the provider chain and returns the first match, or `null` if no
+ * provider has a credential for the source (the caller fails loud with an
+ * actionable "set DATARAUM_<NAME>_URL" message — never silently).
+ */
+export function resolveCredential(
+	sourceName: string,
+): ResolvedCredential | null {
+	for (const provider of PROVIDERS) {
+		const result = provider.resolve(sourceName);
+		if (result !== null) {
+			return result;
+		}
+	}
+	return null;
+}

--- a/packages/cockpit/src/duckdb/lake.ts
+++ b/packages/cockpit/src/duckdb/lake.ts
@@ -1,0 +1,113 @@
+// Cockpit-owned DuckDB connection to the DuckLake lake (DAT-367).
+//
+// The engine OWNS the lake — it bootstraps the DuckLake catalog (Postgres) and
+// writes parquet to the shared DATA_PATH through the Temporal pipeline. The
+// cockpit is a READER: it ATTACHes the same catalog + data path READ_ONLY for
+// the interactive read verbs (`run_sql`, `look_table` samples, traffic-light
+// aggregations) and the future `connect` schema-sniff (DAT-381). Mirror of the
+// engine's `server/storage.py` bootstrap, minus the write-side concerns.
+//
+// Cross-process read consistency: DuckLake keeps committed table state in its
+// Postgres catalog and writes immutable parquet snapshots to DATA_PATH. A
+// reader on a SEPARATE process/instance (this cockpit) ATTACHing the same
+// catalog observes the latest COMMITTED snapshot — it does not share the
+// engine's in-memory write buffer. Two consequences, both acceptable for the
+// read verbs: (1) writes the engine has buffered but not CHECKPOINTed are not
+// yet visible here; the engine checkpoints at activity boundaries, so the
+// cockpit reads stage-complete state, which is exactly what the chat agent
+// reasons over. (2) Opening READ_ONLY means the cockpit never contends for the
+// catalog's write path. See the DAT-367 PR body for the full caveat.
+//
+// Lifecycle: one lazily-opened instance + connection per process (the simplest
+// correct model — DuckDB connections are not thread-affine here and Node is
+// single-threaded for our purposes). `getLakeConnection()` opens on first call
+// and memoizes; `closeLake()` tears it down (tests, graceful shutdown).
+
+import { type DuckDBConnection, DuckDBInstance } from "@duckdb/node-api";
+
+import { config } from "../config";
+import { escapeSqlLiteral, pgUrlToLibpq } from "./sql-escape";
+
+// Alias the DuckLake catalog is ATTACHed under. Matches the engine's
+// `LAKE_CATALOG_ALIAS` so fully-qualified names (`lake.typed.orders`) resolve
+// identically on both sides.
+export const LAKE_ALIAS = "lake";
+
+let instancePromise: Promise<DuckDBInstance> | null = null;
+let connectionPromise: Promise<DuckDBConnection> | null = null;
+
+async function openConnection(): Promise<DuckDBConnection> {
+	if (!instancePromise) {
+		// A fresh in-memory instance owns the ATTACH. Using a per-cockpit-process
+		// instance (not `fromCache`) is fine: the cockpit ATTACHes the lake
+		// exactly once, so there is no same-process double-ATTACH to guard.
+		instancePromise = DuckDBInstance.create(":memory:");
+	}
+	const instance = await instancePromise;
+	const conn = await instance.connect();
+
+	const libpq = pgUrlToLibpq(config.ducklakeCatalogUrl);
+	const dataPath = escapeSqlLiteral(config.dataraumLakePath);
+	const attachSql =
+		`ATTACH 'ducklake:postgres:${libpq}' AS ${LAKE_ALIAS} ` +
+		`(DATA_PATH '${dataPath}', READ_ONLY)`;
+
+	// The container image pre-installs the ducklake extension; LOAD is enough
+	// there. INSTALL is attempted first and tolerated-on-failure so a local dev
+	// run without the cached extension still works (it falls through to LOAD,
+	// which errors loudly if the extension is genuinely missing).
+	try {
+		await conn.run("INSTALL ducklake");
+	} catch {
+		// Extension already present (offline/air-gapped image) — LOAD will
+		// surface a real "not found" below if it truly isn't installed.
+	}
+	await conn.run("LOAD ducklake");
+	await conn.run(attachSql);
+	return conn;
+}
+
+/**
+ * Return the process-wide DuckLake reader connection, opening it on first call.
+ *
+ * The connection is memoized — every caller shares one connection for the life
+ * of the process. Reusable by any read verb (`run_sql`) or the future
+ * schema-sniff tool. Fails loud if the catalog is unreachable or the ATTACH
+ * fails (the rejected promise is cleared so a later call can retry).
+ */
+export function getLakeConnection(): Promise<DuckDBConnection> {
+	if (!connectionPromise) {
+		connectionPromise = openConnection().catch((err) => {
+			// Clear the memo so a transient failure (catalog briefly unreachable)
+			// doesn't wedge the process into a permanently-rejected state.
+			connectionPromise = null;
+			throw err;
+		});
+	}
+	return connectionPromise;
+}
+
+/**
+ * Close the lake connection + instance and reset the memo. Idempotent.
+ * For graceful shutdown and test teardown.
+ */
+export async function closeLake(): Promise<void> {
+	const conn = connectionPromise;
+	const inst = instancePromise;
+	connectionPromise = null;
+	instancePromise = null;
+	if (conn) {
+		try {
+			(await conn).closeSync();
+		} catch {
+			// Already closed / never opened cleanly — nothing to do.
+		}
+	}
+	if (inst) {
+		try {
+			(await inst).closeSync();
+		} catch {
+			// Same.
+		}
+	}
+}

--- a/packages/cockpit/src/duckdb/probe.integration.test.ts
+++ b/packages/cockpit/src/duckdb/probe.integration.test.ts
@@ -1,0 +1,85 @@
+// Real in-process DuckDB integration for probe (DAT-367).
+//
+// Exercises the full probe path against a real sqlite source: credential
+// resolution (DATARAUM_<NAME>_URL) → INSTALL/LOAD sqlite → ATTACH READ_ONLY →
+// USE → wrapped SELECT → DETACH → JSON result. sqlite is the cheapest of the
+// supported backends to stand up hermetically (a file, no server); the ATTACH
+// machinery is shared across all four backends.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DuckDBInstance } from "@duckdb/node-api";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { probe } from "./probe";
+
+let dir: string;
+let dbfile: string;
+
+beforeAll(async () => {
+	dir = mkdtempSync(join(tmpdir(), "probe-it-"));
+	dbfile = join(dir, "src.sqlite");
+
+	// Build a real sqlite source file with the sqlite extension.
+	const inst = await DuckDBInstance.create(":memory:");
+	const c = await inst.connect();
+	await c.run("INSTALL sqlite");
+	await c.run("LOAD sqlite");
+	await c.run(`ATTACH '${dbfile}' AS s (TYPE SQLITE)`);
+	await c.run("CREATE TABLE s.main.widgets(id INTEGER, name VARCHAR)");
+	await c.run(
+		"INSERT INTO s.main.widgets VALUES (1,'gear'),(2,'cog'),(3,'bolt')",
+	);
+	await c.run("DETACH s");
+	c.closeSync();
+	inst.closeSync();
+
+	vi.stubEnv("DATARAUM_WIDGETS_URL", dbfile);
+});
+
+afterAll(() => {
+	vi.unstubAllEnvs();
+	if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("probe against a real sqlite source (DAT-367)", () => {
+	it("resolves credentials by name, attaches READ_ONLY, returns rows", async () => {
+		const result = await probe({
+			source_name: "widgets",
+			backend: "sqlite",
+			sql: "SELECT id, name FROM widgets ORDER BY id",
+		});
+		expect(result.columns).toEqual(["id", "name"]);
+		// The sqlite extension surfaces INTEGER columns as BIGINT; getRowObjectsJson
+		// serializes BIGINT losslessly as a string ("1"), not a JS number.
+		expect(result.rows).toEqual([
+			{ id: "1", name: "gear" },
+			{ id: "2", name: "cog" },
+			{ id: "3", name: "bolt" },
+		]);
+	});
+
+	it("honors the limit cap", async () => {
+		const result = await probe({
+			source_name: "widgets",
+			backend: "sqlite",
+			sql: "SELECT id FROM widgets ORDER BY id",
+			limit: 1,
+		});
+		expect(result.rowCount).toBe(1);
+	});
+
+	it("fails loud when no credential is set for the source", async () => {
+		await expect(
+			probe({ source_name: "unknown_src", backend: "sqlite", sql: "SELECT 1" }),
+		).rejects.toThrow(/DATARAUM_UNKNOWN_SRC_URL/);
+	});
+
+	it("rejects an unsupported backend", async () => {
+		await expect(
+			probe({ source_name: "widgets", backend: "oracle", sql: "SELECT 1" }),
+		).rejects.toThrow(/Unsupported backend/);
+	});
+});

--- a/packages/cockpit/src/duckdb/probe.ts
+++ b/packages/cockpit/src/duckdb/probe.ts
@@ -1,0 +1,141 @@
+// `probe` — read-only SQL against an external database source via DuckDB
+// ATTACH (READ_ONLY), cockpit-side (DAT-367, re-homed from the engine's
+// `sources/backends.py`).
+//
+// The agent uses `probe` to look at a configured DB source BEFORE materializing
+// it into the lake — schema sniffing, sample reads, sanity SELECTs. Credentials
+// are resolved by source name (`resolveCredential`); the URL is a SECRET and is
+// never echoed back.
+//
+// Isolation: probe opens its OWN throwaway in-memory DuckDB connection per call
+// and DETACHes/closes in a finally. It never touches the long-lived lake reader
+// connection, so an external ATTACH can't leak into lake-catalog state.
+
+import { DuckDBInstance } from "@duckdb/node-api";
+
+import { resolveCredential } from "./credentials";
+import type { QueryResult } from "./query-result";
+import { readerToResult } from "./query-result";
+import { escapeSqlLiteral } from "./sql-escape";
+
+// DuckDB extension name per backend.
+const BACKEND_EXTENSIONS: Record<string, string> = {
+	mssql: "mssql",
+	postgres: "postgres",
+	mysql: "mysql",
+	sqlite: "sqlite",
+};
+
+// DuckDB ATTACH `TYPE` per backend.
+const BACKEND_ATTACH_TYPES: Record<string, string> = {
+	mssql: "MSSQL",
+	postgres: "POSTGRES",
+	mysql: "MYSQL",
+	sqlite: "SQLITE",
+};
+
+// Default schema to `USE` after ATTACH so user SQL referencing `schema.table`
+// resolves without an alias prefix. Mirrors the engine's map.
+const BACKEND_DEFAULT_SCHEMA: Record<string, string> = {
+	mssql: "dbo",
+	postgres: "public",
+	mysql: "main",
+	sqlite: "main",
+};
+
+// mssql is community-maintained; the rest live in DuckDB's core repo.
+const COMMUNITY_EXTENSIONS = new Set(["mssql"]);
+
+export const SUPPORTED_BACKENDS = Object.keys(BACKEND_EXTENSIONS);
+
+const ATTACH_ALIAS = "src";
+
+export interface ProbeInput {
+	/** Source name — the key for `DATARAUM_<NAME>_URL` credential lookup. */
+	source_name: string;
+	/** Backend kind: one of `mssql`, `postgres`, `mysql`, `sqlite`. */
+	backend: string;
+	/** Read-only SQL to run against the attached source. */
+	sql: string;
+	/**
+	 * Row cap. The query is wrapped so the agent can't accidentally pull a huge
+	 * result into the chat context. Defaults to 1000.
+	 */
+	limit?: number;
+}
+
+const DEFAULT_PROBE_LIMIT = 1000;
+
+/**
+ * Run read-only SQL against an external database source.
+ *
+ * Resolves credentials by source name, ATTACHes the source READ_ONLY in a
+ * throwaway connection, `USE`s the backend's default schema, runs the SQL
+ * (wrapped in a `LIMIT`), and DETACHes. Fails loud — unknown backend, missing
+ * credential, or a failed ATTACH/SELECT all throw with an actionable message.
+ *
+ * The returned {@link QueryResult} contains only column metadata + JSON-safe
+ * rows; the connection URL is never included.
+ */
+export async function probe(input: ProbeInput): Promise<QueryResult> {
+	const backend = input.backend.toLowerCase();
+	if (!(backend in BACKEND_EXTENSIONS)) {
+		throw new Error(
+			`Unsupported backend '${input.backend}'. Supported: ${SUPPORTED_BACKENDS.join(", ")}.`,
+		);
+	}
+
+	const credential = resolveCredential(input.source_name);
+	if (credential === null) {
+		throw new Error(
+			`No credentials found for source '${input.source_name}'. ` +
+				`Set DATARAUM_${input.source_name.toUpperCase()}_URL in the environment.`,
+		);
+	}
+
+	const extension = BACKEND_EXTENSIONS[backend];
+	const attachType = BACKEND_ATTACH_TYPES[backend];
+	const defaultSchema = BACKEND_DEFAULT_SCHEMA[backend];
+	const limit = input.limit ?? DEFAULT_PROBE_LIMIT;
+
+	const instance = await DuckDBInstance.create(":memory:");
+	const conn = await instance.connect();
+	try {
+		if (COMMUNITY_EXTENSIONS.has(extension)) {
+			await conn.run(`INSTALL ${extension} FROM community`);
+		} else {
+			await conn.run(`INSTALL ${extension}`);
+		}
+		await conn.run(`LOAD ${extension}`);
+
+		const safeUrl = escapeSqlLiteral(credential.url);
+		await conn.run(
+			`ATTACH '${safeUrl}' AS ${ATTACH_ALIAS} (TYPE ${attachType}, READ_ONLY)`,
+		);
+		try {
+			await conn.run(`USE ${ATTACH_ALIAS}.${defaultSchema}`);
+			// Wrap the user SQL in a subquery + LIMIT so a probe can never pull an
+			// unbounded result into the chat context. READ_ONLY already blocks
+			// writes at the engine level.
+			const reader = await conn.runAndReadAll(
+				`SELECT * FROM (${input.sql}) AS _probe LIMIT ${limit}`,
+			);
+			return readerToResult(reader);
+		} finally {
+			try {
+				await conn.run(`DETACH ${ATTACH_ALIAS}`);
+			} catch {
+				// Best-effort cleanup; the connection is closed below regardless.
+			}
+		}
+	} catch (err) {
+		throw new Error(
+			`Probe of source '${input.source_name}' (${backend}) failed: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		);
+	} finally {
+		conn.closeSync();
+		instance.closeSync();
+	}
+}

--- a/packages/cockpit/src/duckdb/query-result.ts
+++ b/packages/cockpit/src/duckdb/query-result.ts
@@ -1,0 +1,40 @@
+// Shared query-result shape for the cockpit DuckDB read verbs (DAT-367).
+//
+// Result shape decision (open question in the ticket): the ticket floated Arrow
+// IPC streaming (`Connection.arrowIPCStream`). That method belongs to the
+// DEPRECATED `duckdb` package, NOT the neo `@duckdb/node-api` driver we use —
+// neo has no `arrowIPCStream`. Its idiomatic surface is the DuckDBResultReader,
+// whose `getRowObjectsJson()` returns LOSSLESSLY JSON-serializable row objects
+// (bigints → strings, dates → ISO strings, nested types → plain JSON). That is
+// exactly what the chat agent and the canvas widgets consume, so we default to
+// materialized JSON-safe row objects rather than Arrow IPC. Result sets here
+// are interactive-scale (samples, aggregations, LIMITed reads), so eager
+// materialization is the simplest correct choice; if a future consumer needs
+// true streaming, neo's `streamAndRead*` slots in behind this same shape.
+
+import type { DuckDBResultReader, Json } from "@duckdb/node-api";
+
+export interface QueryResult {
+	/** Column names in result order. */
+	columns: string[];
+	/** Rows as JSON-safe objects keyed by column name. */
+	rows: Record<string, Json>[];
+	/** Number of rows returned (after any LIMIT). */
+	rowCount: number;
+}
+
+/**
+ * Materialize a fully-read {@link DuckDBResultReader} into a {@link QueryResult}.
+ *
+ * Uses `getRowObjectsJson()` so every value is JSON-serializable — safe to
+ * stream straight into an SSE chat response or a canvas widget without a
+ * bespoke per-type encoder.
+ */
+export function readerToResult(reader: DuckDBResultReader): QueryResult {
+	const rows = reader.getRowObjectsJson();
+	return {
+		columns: reader.columnNames(),
+		rows,
+		rowCount: rows.length,
+	};
+}

--- a/packages/cockpit/src/duckdb/run-sql.integration.test.ts
+++ b/packages/cockpit/src/duckdb/run-sql.integration.test.ts
@@ -1,0 +1,115 @@
+// Real in-process DuckDB integration for run_sql (DAT-367).
+//
+// Exercises the actual `runSql` path — LIMIT wrapping, param binding,
+// reader→JSON conversion — against a REAL DuckLake lake. A "writer" connection
+// (standing in for the engine) creates + populates `lake.typed.*`, commits, and
+// closes; a SEPARATE reader connection (the cockpit's lake connection) then
+// reads it back. This is the cross-process read-consistency claim made concrete:
+// a fresh DuckDB instance ATTACHing the same DuckLake catalog + data path sees
+// the committed snapshot.
+//
+// We use a local DuckLake catalog file (not Postgres) so the test is hermetic —
+// the production cockpit ATTACHes a Postgres catalog, but the read semantics
+// (committed-snapshot visibility across instances) are identical. We mock
+// `getLakeConnection` to point at the temp lake; the rest of `runSql` is real.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { type DuckDBConnection, DuckDBInstance } from "@duckdb/node-api";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+let dir: string;
+let readerConn: DuckDBConnection;
+let readerInstance: DuckDBInstance;
+
+// Mock the lake module so `runSql` resolves to our temp-lake reader connection
+// instead of the config-driven Postgres-catalog one.
+vi.mock("./lake", () => ({
+	getLakeConnection: () => Promise.resolve(readerConn),
+}));
+
+beforeAll(async () => {
+	dir = mkdtempSync(join(tmpdir(), "runsql-it-"));
+	const dataPath = join(dir, "data");
+	const catalog = join(dir, "catalog.ducklake");
+
+	// --- Writer (engine stand-in): create, populate, commit, close. ---
+	const writerInstance = await DuckDBInstance.create(":memory:");
+	const writer = await writerInstance.connect();
+	try {
+		await writer.run("INSTALL ducklake");
+	} catch {
+		// already present
+	}
+	await writer.run("LOAD ducklake");
+	await writer.run(
+		`ATTACH 'ducklake:${catalog}' AS lake (DATA_PATH '${dataPath}')`,
+	);
+	await writer.run("CREATE SCHEMA IF NOT EXISTS lake.typed");
+	await writer.run(
+		"CREATE TABLE lake.typed.orders(id INTEGER, customer VARCHAR, amount INTEGER)",
+	);
+	await writer.run(
+		"INSERT INTO lake.typed.orders VALUES (1,'acme',100),(2,'beta',200),(3,'acme',50)",
+	);
+	writer.closeSync();
+	writerInstance.closeSync();
+
+	// --- Reader (cockpit): a fresh instance, READ_ONLY, sees committed data. ---
+	readerInstance = await DuckDBInstance.create(":memory:");
+	readerConn = await readerInstance.connect();
+	await readerConn.run("LOAD ducklake");
+	await readerConn.run(
+		`ATTACH 'ducklake:${catalog}' AS lake (DATA_PATH '${dataPath}', READ_ONLY)`,
+	);
+});
+
+afterAll(() => {
+	readerConn?.closeSync();
+	readerInstance?.closeSync();
+	if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("runSql over a real DuckLake lake (DAT-367)", () => {
+	it("reads committed lake.typed data written by a separate instance", async () => {
+		const { runSql } = await import("./run-sql");
+		const result = await runSql({
+			sql: "SELECT id, customer, amount FROM lake.typed.orders ORDER BY id",
+		});
+		expect(result.columns).toEqual(["id", "customer", "amount"]);
+		expect(result.rowCount).toBe(3);
+		expect(result.rows[0]).toEqual({ id: 1, customer: "acme", amount: 100 });
+	});
+
+	it("returns JSON-safe row objects (aggregation)", async () => {
+		const { runSql } = await import("./run-sql");
+		const result = await runSql({
+			sql: "SELECT customer, sum(amount) AS total FROM lake.typed.orders GROUP BY customer ORDER BY customer",
+		});
+		expect(result.rows).toEqual([
+			// sum() yields a HUGEINT → JSON-serialized as a string by getRowObjectsJson.
+			{ customer: "acme", total: "150" },
+			{ customer: "beta", total: "200" },
+		]);
+	});
+
+	it("binds positional params", async () => {
+		const { runSql } = await import("./run-sql");
+		const result = await runSql({
+			sql: "SELECT id FROM lake.typed.orders WHERE customer = $1 ORDER BY id",
+			params: ["acme"],
+		});
+		expect(result.rows).toEqual([{ id: 1 }, { id: 3 }]);
+	});
+
+	it("caps the result with the LIMIT wrapper", async () => {
+		const { runSql } = await import("./run-sql");
+		const result = await runSql({
+			sql: "SELECT id FROM lake.typed.orders ORDER BY id",
+			limit: 2,
+		});
+		expect(result.rowCount).toBe(2);
+	});
+});

--- a/packages/cockpit/src/duckdb/run-sql.ts
+++ b/packages/cockpit/src/duckdb/run-sql.ts
@@ -1,0 +1,49 @@
+// `run_sql` — DuckDB SQL over the lake, cockpit-side (DAT-367).
+//
+// The interactive read verb the chat agent leans on: `look_table` sample reads,
+// traffic-light aggregations, ad-hoc SELECTs over the typed/raw/quarantine
+// layers. Runs against the shared, READ_ONLY-ATTACHed DuckLake reader
+// connection (`getLakeConnection`) — the engine owns writes; the cockpit only
+// reads committed lake state.
+//
+// Tables are addressed by their fully-qualified lake name, e.g.
+// `lake.typed.orders` (the `lake` alias matches the engine's catalog alias).
+
+import { getLakeConnection } from "./lake";
+import type { QueryResult } from "./query-result";
+import { readerToResult } from "./query-result";
+
+export interface RunSqlInput {
+	/** DuckDB SQL to run over the lake (read-only). */
+	sql: string;
+	/**
+	 * Optional positional bind values for `$1`, `$2`, … placeholders. Use these
+	 * for any user/agent-derived literal rather than string-concatenating into
+	 * the SQL.
+	 */
+	params?: (string | number | boolean | null)[];
+	/**
+	 * Row cap so a broad SELECT can't flood the chat context. Defaults to 1000.
+	 * Applied as a wrapping `LIMIT`.
+	 */
+	limit?: number;
+}
+
+const DEFAULT_LIMIT = 1000;
+
+/**
+ * Run read-only SQL against the lake and return JSON-safe rows.
+ *
+ * The query is wrapped in `SELECT * FROM (<sql>) LIMIT <n>` so every result is
+ * bounded. The lake connection is ATTACHed READ_ONLY, so writes fail at the
+ * engine level — this is a read verb by construction, not by convention.
+ */
+export async function runSql(input: RunSqlInput): Promise<QueryResult> {
+	const conn = await getLakeConnection();
+	const limit = input.limit ?? DEFAULT_LIMIT;
+	const wrapped = `SELECT * FROM (${input.sql}) AS _run_sql LIMIT ${limit}`;
+	const reader = input.params
+		? await conn.runAndReadAll(wrapped, input.params)
+		: await conn.runAndReadAll(wrapped);
+	return readerToResult(reader);
+}

--- a/packages/cockpit/src/duckdb/sql-escape.test.ts
+++ b/packages/cockpit/src/duckdb/sql-escape.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { escapeSqlLiteral, pgUrlToLibpq } from "./sql-escape";
+
+// These two helpers are the load-bearing string surgery for the DuckLake
+// ATTACH; they mirror the engine's `_pg_url_to_libpq` / `_escape_sql_literal`
+// and must agree with it (both sides attach the same catalog).
+
+describe("pgUrlToLibpq (DAT-367)", () => {
+	it("converts a full postgresql URL to libpq keyword-value form", () => {
+		expect(
+			pgUrlToLibpq("postgresql://dataraum:secret@postgres:5432/lake_catalog"),
+		).toBe(
+			"dbname=lake_catalog host=postgres port=5432 user=dataraum password=secret",
+		);
+	});
+
+	it("percent-decodes credentials (no quoting needed for @ or /)", () => {
+		// libpq only requires single-quoting for whitespace / quote / backslash;
+		// `@` and `/` pass through bare.
+		expect(pgUrlToLibpq("postgresql://u%40corp:p%2Fw@h:5432/db")).toBe(
+			"dbname=db host=h port=5432 user=u@corp password=p/w",
+		);
+	});
+
+	it("single-quotes and escapes a password containing whitespace", () => {
+		const out = pgUrlToLibpq("postgresql://u:pa%20ss@h:5432/db");
+		expect(out).toContain("password='pa ss'");
+	});
+
+	it("omits absent parts (no port, no password)", () => {
+		expect(pgUrlToLibpq("postgresql://u@h/db")).toBe("dbname=db host=h user=u");
+	});
+});
+
+describe("escapeSqlLiteral (DAT-367)", () => {
+	it("escapes single quotes and backslashes", () => {
+		expect(escapeSqlLiteral("/var/li'b\\lake")).toBe("/var/li\\'b\\\\lake");
+	});
+
+	it("leaves a clean path untouched", () => {
+		expect(escapeSqlLiteral("/var/lib/dataraum/lake")).toBe(
+			"/var/lib/dataraum/lake",
+		);
+	});
+});

--- a/packages/cockpit/src/duckdb/sql-escape.ts
+++ b/packages/cockpit/src/duckdb/sql-escape.ts
@@ -1,0 +1,41 @@
+// DuckDB connection-string + SQL-literal escaping helpers (DAT-367).
+//
+// Pure string surgery for building DuckLake/ATTACH statements. Kept in its own
+// module (no `config` import) so it can be used by both the lake reader and the
+// probe path without dragging in the boot-time-validated config — and so it is
+// unit-testable without a stubbed environment. Mirrors the engine's
+// `_pg_url_to_libpq` / `_escape_sql_literal` (both sides build the same ATTACH).
+
+/**
+ * Convert a `postgresql://user:pass@host:port/db` URL to libpq keyword-value
+ * form (`dbname=... host=... port=... user=... password=...`), which DuckLake's
+ * postgres-catalog ATTACH expects.
+ *
+ * Values containing whitespace or a quote/backslash are single-quoted and
+ * escaped, matching libpq's connection-string grammar.
+ */
+export function pgUrlToLibpq(url: string): string {
+	const u = new URL(url);
+	const parts: string[] = [];
+	const db = decodeURIComponent(u.pathname.replace(/^\//, ""));
+	if (db) parts.push(`dbname=${quoteLibpq(db)}`);
+	if (u.hostname) parts.push(`host=${quoteLibpq(u.hostname)}`);
+	if (u.port) parts.push(`port=${u.port}`);
+	if (u.username)
+		parts.push(`user=${quoteLibpq(decodeURIComponent(u.username))}`);
+	if (u.password)
+		parts.push(`password=${quoteLibpq(decodeURIComponent(u.password))}`);
+	return parts.join(" ");
+}
+
+function quoteLibpq(value: string): string {
+	if (value === "" || /[\s'\\]/.test(value)) {
+		return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+	}
+	return value;
+}
+
+/** Backslash-escape `\` and `'` for safe single-quoted SQL interpolation. */
+export function escapeSqlLiteral(value: string): string {
+	return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}

--- a/packages/cockpit/src/tools/README.md
+++ b/packages/cockpit/src/tools/README.md
@@ -15,8 +15,23 @@ Phase 1 of the DAT-339 pivot (DAT-353).
 ```
 chat.ts  ──registry──→  tools/<name>.ts  ──┬──→  src/db/metadata/  (Drizzle, engine substrate read)
                                             ├──→  src/db/cockpit/   (Drizzle, chat history / ui_state)
-                                            └──→  fetch("/measure" | "/query" | "/probe")  (engine kernel)
+                                            └──→  src/duckdb/        (cockpit-owned DuckDB read verbs)
 ```
+
+The interactive DuckDB read verbs are **cockpit-owned** (DAT-367) — there is no
+HTTP round-trip to the engine for them. `run_sql` / `probe` are thin LLM-facing
+wrappers in `tools/`; the connection lifecycle + query logic live in
+`src/duckdb/` (neo driver `@duckdb/node-api`):
+
+- `src/duckdb/lake.ts` — lazily-opened, process-wide DuckDB connection that
+  ATTACHes the engine's DuckLake catalog **READ_ONLY**. `getLakeConnection()`
+  is reusable by any read verb and by the future `connect` schema-sniff (DAT-381).
+- `src/duckdb/run-sql.ts` — `runSql` over the lake (`lake.typed.*`, etc.).
+- `src/duckdb/probe.ts` — `probe` against an external DB source via a throwaway
+  READ_ONLY ATTACH; credentials resolved by source name in
+  `src/duckdb/credentials.ts` (`DATARAUM_<NAME>_URL`, re-homed from the engine).
+- `src/duckdb/query-result.ts` — shared JSON-safe `{columns, rows, rowCount}`
+  result shape (neo `getRowObjectsJson()`; not Arrow IPC — see that file).
 
 Tools are the **only** layer that touches engine state. The chat handler
 streams Anthropic responses and runs tools when the model emits `tool_use`;
@@ -26,20 +41,19 @@ React components never reach across to the engine directly.
 
 > One tool wraps N engine operations. N tools share M backends.
 
-- A single tool can compose multiple drizzle queries, a kernel `/query`
-  call, and a `/measure` SSE follow-up before returning to the agent. The
-  tool is the unit the LLM reasons about; the boundary is intent
-  (`look_table`, `add_source`), not protocol (`run_drizzle_query`,
-  `call_kernel`).
-- The same drizzle helper or kernel verb is fair game for many tools —
-  shared helpers live in `src/db/metadata/` (for Drizzle-backed reads)
-  and a future `src/kernel/` (for kernel-verb fetch wrappers when slice 2
-  needs them). Don't reach across to another tool's internal helpers.
+- A single tool can compose multiple drizzle queries and a `run_sql` read
+  over the lake before returning to the agent. The tool is the unit the LLM
+  reasons about; the boundary is intent (`look_table`, `add_source`), not
+  protocol (`run_drizzle_query`, `run_sql`).
+- The same drizzle helper or DuckDB read verb is fair game for many tools —
+  shared helpers live in `src/db/metadata/` (for Drizzle-backed reads) and
+  `src/duckdb/` (for the cockpit-owned DuckDB read verbs). Don't reach across
+  to another tool's internal helpers.
 - **No openapi-fetch.** Pre-pivot the cockpit consumed a generated REST
   client; that surface (and the `codegen` script) retired in DAT-339 Phase 0c.
-  Tools call the kernel verbs (`/measure`, `/query`, `/probe`) via a
-  hand-written `fetch` wrapper, and read metadata directly via the
-  Drizzle introspected schema.
+  The DuckDB read verbs (`run_sql`, `probe`) are cockpit-owned (DAT-367,
+  `src/duckdb/`); metadata reads go directly via the Drizzle introspected
+  schema. No HTTP to the engine for reads.
 
 ## File layout convention
 

--- a/packages/cockpit/src/tools/probe.ts
+++ b/packages/cockpit/src/tools/probe.ts
@@ -1,0 +1,48 @@
+// probe tool (DAT-367) — the agent runs read-only SQL against an external
+// database source BEFORE it is materialized into the lake.
+//
+// Thin LLM-facing wrapper over `duckdb/probe`. Credentials are resolved by
+// source name from `DATARAUM_<NAME>_URL` and never surfaced to the agent.
+
+import type { Tool } from "@anthropic-ai/sdk/resources/messages";
+
+import { type ProbeInput, probe, SUPPORTED_BACKENDS } from "../duckdb/probe";
+import type { QueryResult } from "../duckdb/query-result";
+
+export const definition: Tool = {
+	name: "probe",
+	description:
+		"Run read-only SQL against an external database source (not yet in the " +
+		"lake) via a READ_ONLY DuckDB ATTACH — for schema sniffing and sample " +
+		"reads before ingest. Credentials are resolved by source name from the " +
+		"environment and are never exposed. The result is capped (default 1000 " +
+		`rows). Supported backends: ${SUPPORTED_BACKENDS.join(", ")}.`,
+	input_schema: {
+		type: "object",
+		properties: {
+			source_name: {
+				type: "string",
+				description:
+					"Configured source name; the key for the DATARAUM_<NAME>_URL credential.",
+			},
+			backend: {
+				type: "string",
+				enum: SUPPORTED_BACKENDS,
+				description: "Database backend kind.",
+			},
+			sql: {
+				type: "string",
+				description: "Read-only SQL to run against the attached source.",
+			},
+			limit: {
+				type: "integer",
+				description: "Max rows to return (default 1000).",
+			},
+		},
+		required: ["source_name", "backend", "sql"],
+	},
+};
+
+export async function handler(input: ProbeInput): Promise<QueryResult> {
+	return probe(input);
+}

--- a/packages/cockpit/src/tools/run_sql.ts
+++ b/packages/cockpit/src/tools/run_sql.ts
@@ -1,0 +1,47 @@
+// run_sql tool (DAT-367) — the agent runs read-only DuckDB SQL over the lake.
+//
+// Thin LLM-facing wrapper over `duckdb/run-sql`. The core query logic +
+// connection lifecycle live in `src/duckdb/` so the same lake connection is
+// reusable by non-tool callers (e.g. the future schema-sniff for DAT-381).
+
+import type { Tool } from "@anthropic-ai/sdk/resources/messages";
+
+import type { QueryResult } from "../duckdb/query-result";
+import { type RunSqlInput, runSql } from "../duckdb/run-sql";
+
+export const definition: Tool = {
+	name: "run_sql",
+	description:
+		"Run read-only DuckDB SQL over the data lake and return JSON rows. " +
+		"Address tables by their fully-qualified lake name, e.g. " +
+		"`lake.typed.<table>` (type-resolved), `lake.raw.<table>` (VARCHAR " +
+		"staging), or `lake.quarantine.<table>` (failed casts). The result is " +
+		"capped (default 1000 rows); pass `limit` to change it. Use `params` " +
+		"for any literal value instead of concatenating it into the SQL.",
+	input_schema: {
+		type: "object",
+		properties: {
+			sql: {
+				type: "string",
+				description: "DuckDB SQL to run (read-only).",
+			},
+			params: {
+				type: "array",
+				description:
+					"Optional positional bind values for $1, $2, … placeholders.",
+				items: {
+					type: ["string", "number", "boolean", "null"],
+				},
+			},
+			limit: {
+				type: "integer",
+				description: "Max rows to return (default 1000).",
+			},
+		},
+		required: ["sql"],
+	},
+};
+
+export async function handler(input: RunSqlInput): Promise<QueryResult> {
+	return runSql(input);
+}

--- a/packages/infra/docker-compose.yml
+++ b/packages/infra/docker-compose.yml
@@ -196,6 +196,13 @@ services:
       # them via DuckLake from the same path. Same volume mounted on
       # both containers; same in-container path for symmetry.
       DATARAUM_LAKE_PATH: /var/lib/dataraum/lake
+      # DuckLake catalog (DAT-367) — the cockpit ATTACHes the same DuckLake
+      # catalog the engine-worker owns, READ_ONLY, for the interactive read
+      # verbs (run_sql). Same value as the engine-worker's DUCKLAKE_CATALOG_URL
+      # (bare postgresql:// libpq form — DuckDB's postgres extension wants it,
+      # not the +psycopg SQLAlchemy scheme) and the same DATARAUM_LAKE_PATH
+      # data path above.
+      DUCKLAKE_CATALOG_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${DUCKLAKE_CATALOG_DB}
       # Config (DAT-361) — read-only access to vertical YAMLs for future UX
       # hints ("which concept did the agent bind to?"). No consumers yet; the
       # mount + path are plumbing. Same package, same path as the engine.


### PR DESCRIPTION
…be) + TS credential resolution

Implements the interactive DuckDB read verbs cockpit-side (TS/Bun, neo @duckdb/node-api), out of the Python pipeline engine, per the 2026-05-26 decision and the 2026-05-29 foundation re-scope.

- src/duckdb/lake.ts — lazily-opened, process-wide DuckDB connection that ATTACHes the engine's DuckLake catalog READ_ONLY (mirrors the engine's server/storage bootstrap). getLakeConnection() is reusable by run_sql and the future connect schema-sniff (DAT-381); closeLake() for teardown.
- src/duckdb/run-sql.ts — runSql over the lake; LIMIT-wrapped, param-bound.
- src/duckdb/probe.ts — probe an external DB source via a throwaway READ_ONLY ATTACH (mssql/postgres/mysql/sqlite); DETACHes + closes per call.
- src/duckdb/credentials.ts — per-source credential resolution re-homed from the engine's CredentialChain (DATARAUM_<NAME>_URL by source name).
- src/duckdb/query-result.ts — shared JSON-safe {columns, rows, rowCount} via neo getRowObjectsJson() (the neo driver has no arrowIPCStream — that was the deprecated `duckdb` pkg; default to materialized JSON-safe rows).
- src/duckdb/sql-escape.ts — config-free libpq/SQL-literal escaping helpers.
- src/tools/{run_sql,probe}.ts — thin LLM-facing Tool wrappers.
- config.ts — adds required DUCKLAKE_CATALOG_URL (the catalog the cockpit ATTACHes); compose wires it for the cockpit service.

Cross-process read consistency: a separate DuckDB instance (the cockpit) ATTACHing the same DuckLake catalog + data path sees the latest COMMITTED snapshot; opening READ_ONLY means no write contention. Proven by the run-sql integration test (writer instance commits, reader instance reads).

Tests: real in-process DuckDB integration for run_sql (over a temp DuckLake lake) and probe (over a real sqlite source), plus unit tests for credential resolution and the libpq/SQL escaping. Full cockpit gate set green.