### PR TITLE
feat(cockpit): DAT-385 P1 — streaming /api/run-sql columnar NDJSON en…

### DIFF
--- a/packages/cockpit/Dockerfile
+++ b/packages/cockpit/Dockerfile
@@ -51,9 +51,17 @@ ENV NODE_ENV=production \
 # oven/bun:1-alpine ships without wget; add it for the healthcheck.
 RUN apk add --no-cache wget
 
-# Nitro produces a self-contained server bundle at .output/server/index.mjs
-# — runtime needs nothing else from the build stage.
+# Nitro produces a self-contained server bundle at .output/server/index.mjs.
 COPY --from=build /app/.output ./.output
+
+# …except DuckDB's native binding: `@duckdb/node-bindings-*` is externalized
+# from the bundle (vite.config.ts — the `.node` binary can't be bundled), so the
+# matching platform package must be present in node_modules at runtime. These
+# packages are pure binary (no transitive deps); `bun` resolves the runtime
+# `require('@duckdb/node-bindings-<plat>/duckdb.node')` from /app/node_modules.
+# The deps stage installs the binding for THIS image's platform/libc (alpine =
+# musl), which matches the runner — so the binary loads.
+COPY --from=deps /app/node_modules/@duckdb ./node_modules/@duckdb
 
 EXPOSE 3000
 

--- a/packages/cockpit/src/duckdb/stream-sql.integration.test.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.integration.test.ts
@@ -1,0 +1,197 @@
+// Real in-process DuckDB integration for the streaming grid path (DAT-385 P1).
+//
+// Exercises `streamNdjson` against a REAL neo `conn.stream()` over a REAL
+// DuckLake lake — the lazy chunk path, JSON-safe type coercion, the columnar
+// reshaping, cap/truncation, and the in-band error footer. Mirrors
+// `run-sql.integration.test.ts`: a writer connection (engine stand-in) creates +
+// commits `lake.typed.*`; a separate READ_ONLY reader (the cockpit) streams it.
+//
+// Hermetic: a local DuckLake catalog FILE (not Postgres). The read semantics —
+// committed-snapshot visibility across instances — are identical to production.
+// Self-skips nothing extra: it needs no external service, only the native addon,
+// so it runs under the `integration` project (kept out of the default unit run).
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { type DuckDBConnection, DuckDBInstance } from "@duckdb/node-api";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+	clampGridCap,
+	type ResultFrame,
+	type StreamableResult,
+	streamNdjson,
+} from "./stream-sql";
+
+let dir: string;
+let readerConn: DuckDBConnection;
+let readerInstance: DuckDBInstance;
+
+/** Stream a SQL query through the real driver + streamNdjson, collecting frames. */
+async function streamQuery(
+	sql: string,
+	cap: number,
+	params?: (string | number | boolean | null)[],
+): Promise<ResultFrame[]> {
+	const wrapped = `SELECT * FROM (${sql}) AS _run_sql`;
+	const result = (await (params
+		? readerConn.stream(wrapped, params)
+		: readerConn.stream(wrapped))) as unknown as StreamableResult;
+	const frames: ResultFrame[] = [];
+	for await (const line of streamNdjson(result, cap, "q_it")) {
+		frames.push(JSON.parse(line) as ResultFrame);
+	}
+	return frames;
+}
+
+beforeAll(async () => {
+	dir = mkdtempSync(join(tmpdir(), "stream-sql-it-"));
+	const dataPath = join(dir, "data");
+	const catalog = join(dir, "catalog.ducklake");
+
+	const writerInstance = await DuckDBInstance.create(":memory:");
+	const writer = await writerInstance.connect();
+	try {
+		await writer.run("INSTALL ducklake");
+	} catch {
+		// already present
+	}
+	await writer.run("LOAD ducklake");
+	await writer.run(
+		`ATTACH 'ducklake:${catalog}' AS lake (DATA_PATH '${dataPath}')`,
+	);
+	await writer.run("CREATE SCHEMA IF NOT EXISTS lake.typed");
+	await writer.run(
+		"CREATE TABLE lake.typed.orders(id INTEGER, customer VARCHAR, amount DECIMAL(18,2), created_at TIMESTAMP)",
+	);
+	await writer.run(
+		"INSERT INTO lake.typed.orders VALUES " +
+			"(1,'acme',10.00,TIMESTAMP '2026-05-01 09:00:00')," +
+			"(2,'beta',9.99,TIMESTAMP '2026-05-02 10:30:00')," +
+			"(3,'acme',50.50,TIMESTAMP '2026-05-03 11:15:00')",
+	);
+	// A wider table to exercise multi-chunk streaming (DuckDB chunks ~2048 rows).
+	await writer.run(
+		"CREATE TABLE lake.typed.big AS SELECT range AS n FROM range(5000)",
+	);
+	writer.closeSync();
+	writerInstance.closeSync();
+
+	readerInstance = await DuckDBInstance.create(":memory:");
+	readerConn = await readerInstance.connect();
+	await readerConn.run("LOAD ducklake");
+	await readerConn.run(
+		`ATTACH 'ducklake:${catalog}' AS lake (DATA_PATH '${dataPath}', READ_ONLY)`,
+	);
+});
+
+afterAll(() => {
+	readerConn?.closeSync();
+	readerInstance?.closeSync();
+	if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("streamNdjson over a real DuckLake lake (DAT-385)", () => {
+	it("streams header / batch / footer with type fidelity", async () => {
+		const frames = await streamQuery(
+			"SELECT id, customer, amount, created_at FROM lake.typed.orders ORDER BY id",
+			1000,
+		);
+
+		const header = frames[0];
+		if (header.t !== "h") throw new Error("expected header first");
+		expect(header.columns).toEqual(["id", "customer", "amount", "created_at"]);
+		// neo's columnTypesJson() returns STRUCTURED type metadata (not bare type
+		// strings as the design sketch illustrated): a `typeId` per column plus
+		// width/scale for parameterized types. That richer shape is exactly what
+		// drives client cell formatting (right-align numbers, decimal places).
+		expect(Array.isArray(header.types)).toBe(true);
+		const types = header.types as Array<Record<string, unknown>>;
+		expect(types).toHaveLength(4);
+		// DECIMAL(18,2) carries its width + scale so the grid can format precisely.
+		expect(types[2]).toMatchObject({ width: 18, scale: 2 });
+		// Every column reports a numeric typeId.
+		for (const t of types) {
+			expect(typeof t.typeId).toBe("number");
+		}
+
+		// One batch for 3 rows, then a clean footer.
+		const batch = frames[1];
+		if (batch.t !== "b") throw new Error("expected batch second");
+		expect(batch.n).toBe(3);
+		// Columnar: cols[colIndex][rowIndex].
+		expect(batch.cols[0]).toEqual([1, 2, 3]);
+		expect(batch.cols[1]).toEqual(["acme", "beta", "acme"]);
+		// DECIMAL → JSON-safe string (lossless), TIMESTAMP → ISO-ish string.
+		expect(batch.cols[2]).toEqual(["10.00", "9.99", "50.50"]);
+		expect(typeof batch.cols[3][0]).toBe("string");
+
+		expect(frames.at(-1)).toEqual({ t: "f", rows: 3 });
+	});
+
+	it("coerces HUGEINT (sum) to a JSON-safe string", async () => {
+		const frames = await streamQuery(
+			"SELECT sum(amount) AS total FROM lake.typed.orders",
+			1000,
+		);
+		const batch = frames[1];
+		if (batch.t !== "b") throw new Error("expected batch");
+		expect(batch.cols[0]).toEqual(["70.49"]);
+	});
+
+	it("binds positional params", async () => {
+		const frames = await streamQuery(
+			"SELECT id FROM lake.typed.orders WHERE customer = $1 ORDER BY id",
+			1000,
+			["acme"],
+		);
+		const batch = frames[1];
+		if (batch.t !== "b") throw new Error("expected batch");
+		expect(batch.cols[0]).toEqual([1, 3]);
+	});
+
+	it("streams a multi-chunk result and totals the rows in the footer", async () => {
+		const frames = await streamQuery("SELECT n FROM lake.typed.big", 10_000);
+		const batches = frames.filter((f) => f.t === "b");
+		// 5000 rows over ~2048-row chunks → more than one batch.
+		expect(batches.length).toBeGreaterThan(1);
+		const total = batches.reduce((s, b) => s + (b.t === "b" ? b.n : 0), 0);
+		expect(total).toBe(5000);
+		expect(frames.at(-1)).toEqual({ t: "f", rows: 5000 });
+	});
+
+	it("truncates at the cap and reports it in the footer", async () => {
+		const cap = clampGridCap(100);
+		const frames = await streamQuery("SELECT n FROM lake.typed.big", cap);
+		const batches = frames.filter((f) => f.t === "b");
+		const total = batches.reduce((s, b) => s + (b.t === "b" ? b.n : 0), 0);
+		expect(total).toBe(100);
+		expect(frames.at(-1)).toEqual({
+			t: "f",
+			rows: 100,
+			truncated: true,
+			cap: 100,
+		});
+	});
+
+	it("emits an in-band error footer for a bad query (HTTP would stay 200)", async () => {
+		// `conn.stream` is lazy, so a binder error surfaces on first fetchChunk —
+		// streamNdjson catches it and reports it in the footer rather than throwing.
+		let frames: ResultFrame[] = [];
+		try {
+			frames = await streamQuery(
+				"SELECT no_such_col FROM lake.typed.orders",
+				1000,
+			);
+		} catch {
+			// If the driver throws at stream() prepare time instead, that's also a
+			// valid surface; the route returns a 400 before streaming in that case.
+			return;
+		}
+		const footer = frames.at(-1);
+		if (footer?.t !== "f") throw new Error("expected footer");
+		expect(footer.error).toBeTruthy();
+	});
+});

--- a/packages/cockpit/src/duckdb/stream-sql.integration.test.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.integration.test.ts
@@ -176,6 +176,16 @@ describe("streamNdjson over a real DuckLake lake (DAT-385)", () => {
 		});
 	});
 
+	it("does NOT mark truncated when the cap equals the full row count", async () => {
+		// `big` has exactly 5000 rows; a cap of 5000 is a full set, not a cut-off
+		// one. The footer must read clean — the post-cap peek finds no more rows.
+		const frames = await streamQuery("SELECT n FROM lake.typed.big", 5000);
+		const batches = frames.filter((f) => f.t === "b");
+		const total = batches.reduce((s, b) => s + (b.t === "b" ? b.n : 0), 0);
+		expect(total).toBe(5000);
+		expect(frames.at(-1)).toEqual({ t: "f", rows: 5000 });
+	});
+
 	it("emits an in-band error footer for a bad query (HTTP would stay 200)", async () => {
 		// `conn.stream` is lazy, so a binder error surfaces on first fetchChunk —
 		// streamNdjson catches it and reports it in the footer rather than throwing.

--- a/packages/cockpit/src/duckdb/stream-sql.integration.test.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.integration.test.ts
@@ -19,6 +19,7 @@ import { type DuckDBConnection, DuckDBInstance } from "@duckdb/node-api";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
+	type AbortSignalLike,
 	clampGridCap,
 	type ResultFrame,
 	type StreamableResult,
@@ -42,6 +43,36 @@ async function streamQuery(
 	const frames: ResultFrame[] = [];
 	for await (const line of streamNdjson(result, cap, "q_it")) {
 		frames.push(JSON.parse(line) as ResultFrame);
+	}
+	return frames;
+}
+
+/**
+ * Stream a query but flip the abort signal the moment the first batch frame
+ * lands, mirroring the route's mutable `{ aborted }` flag (run-sql.ts) and the
+ * grid closing mid-stream. The generator checks `signal.aborted` at the NEXT
+ * chunk boundary, so the loop stops within one chunk and the footer carries
+ * `cancelled: true`.
+ */
+async function streamQueryAbortingAfterFirstBatch(
+	sql: string,
+	cap: number,
+): Promise<ResultFrame[]> {
+	const wrapped = `SELECT * FROM (${sql}) AS _run_sql`;
+	const result = (await readerConn.stream(
+		wrapped,
+	)) as unknown as StreamableResult;
+	const signal: { aborted: boolean } = { aborted: false };
+	const frames: ResultFrame[] = [];
+	for await (const line of streamNdjson(
+		result,
+		cap,
+		"q_it",
+		signal as AbortSignalLike,
+	)) {
+		const frame = JSON.parse(line) as ResultFrame;
+		frames.push(frame);
+		if (frame.t === "b") signal.aborted = true;
 	}
 	return frames;
 }
@@ -75,6 +106,17 @@ beforeAll(async () => {
 	// A wider table to exercise multi-chunk streaming (DuckDB chunks ~2048 rows).
 	await writer.run(
 		"CREATE TABLE lake.typed.big AS SELECT range AS n FROM range(5000)",
+	);
+	// Nested types (design §12 must-verify): a LIST column and a STRUCT column,
+	// to confirm JsonDuckDBValueConverter coerces them to plain JSON arrays /
+	// objects (not opaque driver handles).
+	await writer.run(
+		"CREATE TABLE lake.typed.nested(id INTEGER, tags VARCHAR[], meta STRUCT(a INTEGER, b VARCHAR))",
+	);
+	await writer.run(
+		"INSERT INTO lake.typed.nested VALUES " +
+			"(1, ['x','y'], {'a': 10, 'b': 'hello'})," +
+			"(2, [], {'a': 20, 'b': 'world'})",
 	);
 	writer.closeSync();
 	writerInstance.closeSync();
@@ -203,5 +245,63 @@ describe("streamNdjson over a real DuckLake lake (DAT-385)", () => {
 		const footer = frames.at(-1);
 		if (footer?.t !== "f") throw new Error("expected footer");
 		expect(footer.error).toBeTruthy();
+	});
+
+	it("coerces LIST and STRUCT columns to JSON-safe values", async () => {
+		const frames = await streamQuery(
+			"SELECT id, tags, meta FROM lake.typed.nested ORDER BY id",
+			1000,
+		);
+
+		const header = frames[0];
+		if (header.t !== "h") throw new Error("expected header first");
+		expect(header.columns).toEqual(["id", "tags", "meta"]);
+
+		const batch = frames[1];
+		if (batch.t !== "b") throw new Error("expected batch second");
+		expect(batch.n).toBe(2);
+		expect(batch.cols[0]).toEqual([1, 2]);
+		// LIST → plain JS array (empty list stays an empty array, not null).
+		expect(batch.cols[1]).toEqual([["x", "y"], []]);
+		// STRUCT → nested plain object, exactly what getRowObjectsJson produces.
+		expect(batch.cols[2]).toEqual([
+			{ a: 10, b: "hello" },
+			{ a: 20, b: "world" },
+		]);
+
+		expect(frames.at(-1)).toEqual({ t: "f", rows: 2 });
+	});
+
+	it("stops within one chunk on abort and leaves the connection reusable", async () => {
+		// Abort the moment the first batch lands; the generator re-checks the
+		// signal at the next chunk boundary, so it stops after at most one more
+		// chunk of work. With a 10k cap (above the full 5000 rows) the stream
+		// would otherwise run to completion — proving the cut is the abort, not
+		// the cap.
+		const frames = await streamQueryAbortingAfterFirstBatch(
+			"SELECT n FROM lake.typed.big",
+			10_000,
+		);
+
+		const footer = frames.at(-1);
+		if (footer?.t !== "f") throw new Error("expected footer");
+		expect(footer.cancelled).toBe(true);
+		expect(footer.truncated).toBeUndefined();
+		// Far fewer than the full 5000 rows — the loop broke early.
+		expect(footer.rows).toBeLessThan(5000);
+		expect(footer.rows).toBeGreaterThan(0);
+
+		// The shared READ_ONLY reader must be healthy after an aborted stream:
+		// a second query on the SAME connection returns correct results.
+		const after = await streamQuery(
+			"SELECT id, customer FROM lake.typed.orders ORDER BY id",
+			1000,
+		);
+		const batch = after[1];
+		if (batch.t !== "b") throw new Error("expected batch");
+		expect(batch.n).toBe(3);
+		expect(batch.cols[0]).toEqual([1, 2, 3]);
+		expect(batch.cols[1]).toEqual(["acme", "beta", "acme"]);
+		expect(after.at(-1)).toEqual({ t: "f", rows: 3 });
 	});
 });

--- a/packages/cockpit/src/duckdb/stream-sql.test.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.test.ts
@@ -4,11 +4,11 @@
 
 import { describe, expect, it } from "vitest";
 
+import { HARD_ROW_CEILING } from "#/duckdb/limit";
 import {
 	clampGridCap,
 	encodeFrame,
 	GRID_DEFAULT_CAP,
-	GRID_HARD_CEILING,
 	type ResultFrame,
 	type StreamableChunk,
 	type StreamableResult,
@@ -74,9 +74,9 @@ describe("clampGridCap (design §5.5)", () => {
 		expect(clampGridCap(1234)).toBe(1234);
 	});
 
-	it("clamps above the hard ceiling to 200k", () => {
-		expect(clampGridCap(999_999)).toBe(GRID_HARD_CEILING);
-		expect(clampGridCap(GRID_HARD_CEILING + 1)).toBe(200_000);
+	it("clamps above the shared hard ceiling (HARD_ROW_CEILING, DAT-384)", () => {
+		expect(clampGridCap(999_999)).toBe(HARD_ROW_CEILING);
+		expect(clampGridCap(HARD_ROW_CEILING + 1)).toBe(200_000);
 	});
 
 	it("floors a non-positive or non-finite cap to at least 1", () => {
@@ -182,7 +182,7 @@ describe("streamNdjson cap + truncation", () => {
 		expect(frames[2]).toEqual({ t: "f", rows: 3, truncated: true, cap: 3 });
 	});
 
-	it("stops pulling further chunks once the cap is hit", async () => {
+	it("peeks exactly one chunk past the cap to confirm truncation, then stops", async () => {
 		let pulls = 0;
 		const result: StreamableResult = {
 			columnNames: () => ["id"],
@@ -193,9 +193,26 @@ describe("streamNdjson cap + truncation", () => {
 			},
 		};
 		const frames = await collect(result, 2);
-		// Exactly one chunk consumed (it filled the cap); no extra pull.
-		expect(pulls).toBe(1);
+		// One chunk filled the cap; one peek confirmed there's genuinely more.
+		// No third pull — peak memory stays ≈ one chunk.
+		expect(pulls).toBe(2);
 		expect(frames.at(-1)).toEqual({ t: "f", rows: 2, truncated: true, cap: 2 });
+	});
+
+	it("does NOT mark truncated when the result is exactly the cap (full set)", async () => {
+		// First chunk fills the cap exactly; the peek returns the end sentinel.
+		const result = fakeResult(["id"], ["INTEGER"], [[[1, 2, 3]]]);
+		const frames = await collect(result, 3);
+		expect(frames[1]).toEqual({ t: "b", n: 3, cols: [[1, 2, 3]] });
+		// Clean footer — no `truncated`, no `cap`.
+		expect(frames.at(-1)).toEqual({ t: "f", rows: 3 });
+	});
+
+	it("does NOT mark truncated when a zero-row sentinel follows an exact-cap chunk", async () => {
+		// The peek returns a 0-row chunk (neo's historical end sentinel), not null.
+		const result = fakeResult(["id"], ["INTEGER"], [[[1, 2, 3]], [[]]]);
+		const frames = await collect(result, 3);
+		expect(frames.at(-1)).toEqual({ t: "f", rows: 3 });
 	});
 
 	it("emits an in-band error footer when fetchChunk throws (still HTTP 200)", async () => {
@@ -257,6 +274,28 @@ describe("streamNdjson cancellation", () => {
 		// First chunk emitted; loop checks aborted before pulling a second.
 		expect(pulls).toBe(1);
 		expect(frames.map((f) => f.t)).toEqual(["h", "b", "f"]);
-		expect(frames.at(-1)).toEqual({ t: "f", rows: 1 });
+		// Footer flags the early stop so a consumer can tell a partial body from a
+		// clean finish.
+		expect(frames.at(-1)).toEqual({ t: "f", rows: 1, cancelled: true });
+	});
+
+	it("flags cancelled before any chunk when aborted up front", async () => {
+		const signal = { aborted: true };
+		let pulls = 0;
+		const result: StreamableResult = {
+			columnNames: () => ["id"],
+			columnTypesJson: () => ["INTEGER"],
+			fetchChunk: async () => {
+				pulls += 1;
+				return new FakeChunk([[1]]);
+			},
+		};
+		const frames = await collect(result, 1000, "q_test", signal);
+		// Aborted before the loop pulled anything: header, then a cancelled footer.
+		expect(pulls).toBe(0);
+		expect(frames).toEqual([
+			{ t: "h", columns: ["id"], types: ["INTEGER"], queryId: "q_test" },
+			{ t: "f", rows: 0, cancelled: true },
+		]);
 	});
 });

--- a/packages/cockpit/src/duckdb/stream-sql.test.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.test.ts
@@ -1,0 +1,262 @@
+// Unit tests for the pure streaming core (DAT-385 P1). No real DuckDB, no
+// native addon — we drive `streamNdjson` with a fake StreamableResult and assert
+// the cap clamp, the chunk→columnar reshaping, and header/batch/footer framing.
+
+import { describe, expect, it } from "vitest";
+
+import {
+	clampGridCap,
+	encodeFrame,
+	GRID_DEFAULT_CAP,
+	GRID_HARD_CEILING,
+	type ResultFrame,
+	type StreamableChunk,
+	type StreamableResult,
+	streamNdjson,
+} from "./stream-sql";
+
+// --- A fake chunk/result that mirrors neo's surface ------------------------
+
+class FakeChunk implements StreamableChunk {
+	constructor(private readonly cols: (string | number | null)[][]) {}
+	get rowCount(): number {
+		return this.cols[0]?.length ?? 0;
+	}
+	// The real chunk applies the converter per value; our fake values are already
+	// JSON-safe, so we pass them through unchanged (the converter is only invoked
+	// for type coercion, which the integration test exercises for real).
+	convertColumns<T>(): (T | null)[][] {
+		return this.cols as unknown as (T | null)[][];
+	}
+}
+
+/** A result that hands out `chunks` in order, then `null`. */
+function fakeResult(
+	columns: string[],
+	types: string[],
+	chunks: (string | number | null)[][][],
+): StreamableResult {
+	let i = 0;
+	return {
+		columnNames: () => columns,
+		columnTypesJson: () => types,
+		fetchChunk: async () => {
+			if (i >= chunks.length) return null;
+			const c = chunks[i];
+			i += 1;
+			return new FakeChunk(c);
+		},
+	};
+}
+
+/** Collect a streamNdjson run into parsed frames. */
+async function collect(
+	result: StreamableResult,
+	cap: number,
+	queryId = "q_test",
+	signal?: { aborted: boolean },
+): Promise<ResultFrame[]> {
+	const frames: ResultFrame[] = [];
+	for await (const line of streamNdjson(result, cap, queryId, signal)) {
+		expect(line.endsWith("\n")).toBe(true);
+		frames.push(JSON.parse(line) as ResultFrame);
+	}
+	return frames;
+}
+
+describe("clampGridCap (design §5.5)", () => {
+	it("defaults an absent cap to the grid default (50k, not the agent's 1000)", () => {
+		expect(clampGridCap()).toBe(GRID_DEFAULT_CAP);
+		expect(clampGridCap(undefined)).toBe(50_000);
+	});
+
+	it("passes through a value within range", () => {
+		expect(clampGridCap(1234)).toBe(1234);
+	});
+
+	it("clamps above the hard ceiling to 200k", () => {
+		expect(clampGridCap(999_999)).toBe(GRID_HARD_CEILING);
+		expect(clampGridCap(GRID_HARD_CEILING + 1)).toBe(200_000);
+	});
+
+	it("floors a non-positive or non-finite cap to at least 1", () => {
+		expect(clampGridCap(0)).toBe(1);
+		expect(clampGridCap(-5)).toBe(1);
+		expect(clampGridCap(Number.NaN)).toBe(GRID_DEFAULT_CAP);
+		expect(clampGridCap(Number.POSITIVE_INFINITY)).toBe(GRID_DEFAULT_CAP);
+	});
+
+	it("floors a fractional cap", () => {
+		expect(clampGridCap(10.9)).toBe(10);
+	});
+});
+
+describe("encodeFrame", () => {
+	it("serializes one frame per line with a trailing newline", () => {
+		expect(encodeFrame({ t: "f", rows: 3 })).toBe('{"t":"f","rows":3}\n');
+	});
+});
+
+describe("streamNdjson framing", () => {
+	it("emits header, one batch per chunk, then a clean footer", async () => {
+		const result = fakeResult(
+			["id", "name"],
+			["INTEGER", "VARCHAR"],
+			[
+				[
+					[1, 2],
+					["a", "b"],
+				],
+				[[3], ["c"]],
+			],
+		);
+		const frames = await collect(result, 1000);
+
+		expect(frames[0]).toEqual({
+			t: "h",
+			columns: ["id", "name"],
+			types: ["INTEGER", "VARCHAR"],
+			queryId: "q_test",
+		});
+		expect(frames[1]).toEqual({
+			t: "b",
+			n: 2,
+			cols: [
+				[1, 2],
+				["a", "b"],
+			],
+		});
+		expect(frames[2]).toEqual({ t: "b", n: 1, cols: [[3], ["c"]] });
+		expect(frames[3]).toEqual({ t: "f", rows: 3 });
+		expect(frames).toHaveLength(4);
+	});
+
+	it("treats columnar batches as cols[colIndex][rowIndex]", async () => {
+		const result = fakeResult(
+			["a", "b", "c"],
+			["INTEGER", "INTEGER", "INTEGER"],
+			[
+				[
+					[1, 4],
+					[2, 5],
+					[3, 6],
+				],
+			],
+		);
+		const frames = await collect(result, 1000);
+		const batch = frames[1];
+		if (batch.t !== "b") throw new Error("expected batch");
+		// Two rows (1,2,3) and (4,5,6) stored column-major.
+		expect(batch.cols).toEqual([
+			[1, 4],
+			[2, 5],
+			[3, 6],
+		]);
+		expect(batch.n).toBe(2);
+	});
+
+	it("always emits a footer even with zero chunks", async () => {
+		const result = fakeResult(["id"], ["INTEGER"], []);
+		const frames = await collect(result, 1000);
+		expect(frames).toEqual([
+			{ t: "h", columns: ["id"], types: ["INTEGER"], queryId: "q_test" },
+			{ t: "f", rows: 0 },
+		]);
+	});
+
+	it("stops on a zero-row chunk (neo's end sentinel) without emitting a batch", async () => {
+		const result = fakeResult(["id"], ["INTEGER"], [[[]]]);
+		const frames = await collect(result, 1000);
+		expect(frames).toEqual([
+			{ t: "h", columns: ["id"], types: ["INTEGER"], queryId: "q_test" },
+			{ t: "f", rows: 0 },
+		]);
+	});
+});
+
+describe("streamNdjson cap + truncation", () => {
+	it("slices the chunk that crosses the cap and marks truncated", async () => {
+		const result = fakeResult(["id"], ["INTEGER"], [[[1, 2, 3, 4, 5]]]);
+		const frames = await collect(result, 3);
+		expect(frames[1]).toEqual({ t: "b", n: 3, cols: [[1, 2, 3]] });
+		expect(frames[2]).toEqual({ t: "f", rows: 3, truncated: true, cap: 3 });
+	});
+
+	it("stops pulling further chunks once the cap is hit", async () => {
+		let pulls = 0;
+		const result: StreamableResult = {
+			columnNames: () => ["id"],
+			columnTypesJson: () => ["INTEGER"],
+			fetchChunk: async () => {
+				pulls += 1;
+				return new FakeChunk([[1, 2]]);
+			},
+		};
+		const frames = await collect(result, 2);
+		// Exactly one chunk consumed (it filled the cap); no extra pull.
+		expect(pulls).toBe(1);
+		expect(frames.at(-1)).toEqual({ t: "f", rows: 2, truncated: true, cap: 2 });
+	});
+
+	it("emits an in-band error footer when fetchChunk throws (still HTTP 200)", async () => {
+		const result: StreamableResult = {
+			columnNames: () => ["id"],
+			columnTypesJson: () => ["INTEGER"],
+			fetchChunk: async () => {
+				throw new Error("Binder Error: no such column");
+			},
+		};
+		const frames = await collect(result, 1000);
+		expect(frames[0].t).toBe("h");
+		expect(frames[1]).toEqual({
+			t: "f",
+			rows: 0,
+			error: "Binder Error: no such column",
+		});
+	});
+
+	it("reports rows emitted before a mid-stream failure in the error footer", async () => {
+		let i = 0;
+		const result: StreamableResult = {
+			columnNames: () => ["id"],
+			columnTypesJson: () => ["INTEGER"],
+			fetchChunk: async () => {
+				i += 1;
+				if (i === 1) return new FakeChunk([[1, 2]]);
+				throw new Error("IO Error mid-stream");
+			},
+		};
+		const frames = await collect(result, 1000);
+		expect(frames[1]).toEqual({ t: "b", n: 2, cols: [[1, 2]] });
+		expect(frames[2]).toEqual({
+			t: "f",
+			rows: 2,
+			error: "IO Error mid-stream",
+		});
+	});
+});
+
+describe("streamNdjson cancellation", () => {
+	it("breaks at the next chunk boundary when the signal is aborted", async () => {
+		const signal = { aborted: false };
+		let pulls = 0;
+		const result: StreamableResult = {
+			columnNames: () => ["id"],
+			columnTypesJson: () => ["INTEGER"],
+			fetchChunk: async () => {
+				pulls += 1;
+				if (pulls === 1) {
+					// Simulate the client going away after the first chunk.
+					signal.aborted = true;
+					return new FakeChunk([[1]]);
+				}
+				return new FakeChunk([[99]]);
+			},
+		};
+		const frames = await collect(result, 1000, "q_test", signal);
+		// First chunk emitted; loop checks aborted before pulling a second.
+		expect(pulls).toBe(1);
+		expect(frames.map((f) => f.t)).toEqual(["h", "b", "f"]);
+		expect(frames.at(-1)).toEqual({ t: "f", rows: 1 });
+	});
+});

--- a/packages/cockpit/src/duckdb/stream-sql.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.ts
@@ -1,0 +1,210 @@
+// Streaming `run_sql` for the human/grid consumer (DAT-385 P1).
+//
+// A SEPARATE result path from the agent-facing `run-sql.ts`: that one
+// materializes a small, LIMIT-bounded JSON blob for the chat agent's context;
+// THIS one streams a potentially large result as columnar NDJSON so a big
+// result never lands in server RAM as one blob. See
+// `plans/run-sql-streaming-design.md` §4–5.
+//
+// Why columnar NDJSON, not Arrow: the neo driver (`@duckdb/node-api`) has NO
+// Arrow surface (`grep -ri arrow` over its lib → nothing; the C-API Arrow
+// bindings are commented out). Its chunk getters already return materialized JS
+// heap, so zero-copy Arrow is impossible anyway. We stream one DuckDB chunk
+// (~2048 rows) per NDJSON line of JSON-safe column arrays, reusing the same
+// `JsonDuckDBValueConverter` coercion (bigint→string, dates→ISO, nested→plain
+// JSON) that `query-result.ts` already relies on.
+//
+// This module is the PURE core: the frame protocol, the cap clamp, and the
+// chunk→columnar generator. It depends only on a minimal `StreamableResult`
+// shape (what neo's `conn.stream()` returns), so it is unit-testable with a fake
+// result — no real DuckDB, no native addon. The route (`routes/api/run-sql.ts`)
+// wires `getLakeConnection` + `conn.stream` + the `ReadableStream` and
+// cancellation around `streamNdjson`.
+
+import {
+	type DuckDBValueConverter,
+	type Json,
+	JsonDuckDBValueConverter,
+} from "@duckdb/node-api";
+
+// --- Cap clamp (design §5.5) -------------------------------------------------
+
+/**
+ * Grid default cap. Intentionally larger than the agent tool's 1000 (run-sql.ts
+ * DEFAULT_LIMIT): the grid is a human browsing surface, not an LLM context, so
+ * it streams far more before truncating.
+ */
+export const GRID_DEFAULT_CAP = 50_000;
+
+// TODO(DAT-384): dedupe the 200k ceiling once limit.ts (clampRowLimit /
+// HARD_ROW_CEILING) lands on main; until then keep this grid-local so this lane
+// doesn't import an in-flight module.
+export const GRID_HARD_CEILING = 200_000;
+
+/**
+ * Clamp a client-requested cap to `[1, GRID_HARD_CEILING]`, defaulting an absent
+ * cap to {@link GRID_DEFAULT_CAP}. A client can never ask for an unbounded — or
+ * a non-positive — materialization. Mirrors `min(cap ?? 50_000, 200_000)` from
+ * the design, with a floor so a 0/negative cap can't stream nothing forever.
+ */
+export function clampGridCap(cap?: number): number {
+	if (cap === undefined || !Number.isFinite(cap)) {
+		return GRID_DEFAULT_CAP;
+	}
+	const floored = Math.max(1, Math.floor(cap));
+	return Math.min(floored, GRID_HARD_CEILING);
+}
+
+// --- Wire protocol (design §4) -----------------------------------------------
+
+/**
+ * First line, always: column names + DuckDB type metadata + the query handle.
+ *
+ * `types` is neo's `columnTypesJson()` — STRUCTURED, JSON-safe type metadata
+ * (one `{ typeId, … }` object per column, with `width`/`scale` for parameterized
+ * types like DECIMAL), NOT bare type strings. The design §4 sketch illustrated
+ * string types; the real driver returns this richer shape, which is strictly
+ * better for driving client cell formatting (alignment, decimal places).
+ */
+export interface HeaderFrame {
+	t: "h";
+	columns: string[];
+	types: Json;
+	queryId: string;
+}
+
+/** One per DuckDB chunk: column-major, JSON-safe, equal-length arrays. */
+export interface BatchFrame {
+	t: "b";
+	/** Row count carried in this batch (after any cap slicing). */
+	n: number;
+	/** `cols[colIndex][rowIndex]` — mirrors `getColumns*()` ordering. */
+	cols: (Json | null)[][];
+}
+
+/**
+ * Last line, always — even on cap or error. The client uses this to distinguish
+ * "finished cleanly", "hit the cap" (`truncated`), and "failed mid-stream"
+ * (`error`). The HTTP status stays 200; the body is the source of truth.
+ */
+export interface FooterFrame {
+	t: "f";
+	/** Total rows emitted across all batches. */
+	rows: number;
+	/** Set when the stream stopped at the cap. */
+	truncated?: boolean;
+	/** Echoed cap when truncated, so the client can show "first N of many". */
+	cap?: number;
+	/** DuckDB error message when the stream failed mid-flight. */
+	error?: string;
+}
+
+export type ResultFrame = HeaderFrame | BatchFrame | FooterFrame;
+
+// --- Minimal driver surface --------------------------------------------------
+
+/** One DuckDB chunk — the subset of `DuckDBDataChunk` we touch. */
+export interface StreamableChunk {
+	readonly rowCount: number;
+	convertColumns<T>(converter: DuckDBValueConverter<T>): (T | null)[][];
+}
+
+/**
+ * The subset of neo's `DuckDBResult` (returned by `conn.stream()`) this core
+ * needs. `fetchChunk()` returns the next lazily-produced chunk, or `null` at the
+ * end of the result.
+ */
+export interface StreamableResult {
+	columnNames(): string[];
+	columnTypesJson(): Json;
+	fetchChunk(): Promise<StreamableChunk | null>;
+}
+
+/** Set by the route's `ReadableStream.cancel()` so the loop can break early. */
+export interface AbortSignalLike {
+	readonly aborted: boolean;
+}
+
+// --- The streaming generator -------------------------------------------------
+
+/**
+ * Stringify a frame as one NDJSON line (trailing `\n` included). Exported for
+ * the route's enqueue path and for unit tests.
+ */
+export function encodeFrame(frame: ResultFrame): string {
+	return `${JSON.stringify(frame)}\n`;
+}
+
+/** Slice every column array to its first `n` rows (cap landed mid-chunk). */
+function sliceCols(cols: (Json | null)[][], n: number): (Json | null)[][] {
+	return cols.map((col) => col.slice(0, n));
+}
+
+/**
+ * Drive a lazy {@link StreamableResult} to completion, yielding NDJSON lines:
+ * one header, one batch per chunk (sliced/stopped at `cap`), then exactly one
+ * footer (clean, `truncated`, or `error`). Never throws — a mid-stream DuckDB
+ * failure is reported in the footer frame, because the HTTP body has likely
+ * already begun flushing (the status can't change after the first byte).
+ *
+ * Cancellation: `signal.aborted` is checked at each chunk boundary, so an
+ * aborted stream stops within at most one chunk of wasted work. An aborted
+ * stream still yields a footer so a consumer reading the partial body sees a
+ * clean terminator.
+ *
+ * Peak memory ≈ one chunk: the caller flushes each yielded line before pulling
+ * the next, giving natural backpressure.
+ */
+export async function* streamNdjson(
+	result: StreamableResult,
+	cap: number,
+	queryId: string,
+	signal?: AbortSignalLike,
+): AsyncGenerator<string> {
+	yield encodeFrame({
+		t: "h",
+		columns: result.columnNames(),
+		types: result.columnTypesJson(),
+		queryId,
+	});
+
+	let rows = 0;
+	let truncated = false;
+	try {
+		for (;;) {
+			if (signal?.aborted) break;
+			const chunk = await result.fetchChunk();
+			// neo returns null (and historically a 0-row chunk) at the end.
+			if (chunk === null || chunk.rowCount === 0) break;
+
+			const remaining = cap - rows;
+			if (remaining <= 0) {
+				truncated = true;
+				break;
+			}
+
+			const cols = chunk.convertColumns<Json>(JsonDuckDBValueConverter);
+			const take = Math.min(chunk.rowCount, remaining);
+			yield encodeFrame({
+				t: "b",
+				n: take,
+				cols: take < chunk.rowCount ? sliceCols(cols, take) : cols,
+			});
+			rows += take;
+
+			if (rows >= cap) {
+				truncated = true;
+				break;
+			}
+		}
+		yield encodeFrame(
+			truncated ? { t: "f", rows, truncated, cap } : { t: "f", rows },
+		);
+	} catch (err) {
+		yield encodeFrame({
+			t: "f",
+			rows,
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}

--- a/packages/cockpit/src/duckdb/stream-sql.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.ts
@@ -26,6 +26,7 @@ import {
 	type Json,
 	JsonDuckDBValueConverter,
 } from "@duckdb/node-api";
+import { HARD_ROW_CEILING } from "#/duckdb/limit";
 
 // --- Cap clamp (design §5.5) -------------------------------------------------
 
@@ -36,23 +37,20 @@ import {
  */
 export const GRID_DEFAULT_CAP = 50_000;
 
-// TODO(DAT-384): dedupe the 200k ceiling once limit.ts (clampRowLimit /
-// HARD_ROW_CEILING) lands on main; until then keep this grid-local so this lane
-// doesn't import an in-flight module.
-export const GRID_HARD_CEILING = 200_000;
-
 /**
- * Clamp a client-requested cap to `[1, GRID_HARD_CEILING]`, defaulting an absent
+ * Clamp a client-requested cap to `[1, HARD_ROW_CEILING]`, defaulting an absent
  * cap to {@link GRID_DEFAULT_CAP}. A client can never ask for an unbounded — or
- * a non-positive — materialization. Mirrors `min(cap ?? 50_000, 200_000)` from
- * the design, with a floor so a 0/negative cap can't stream nothing forever.
+ * a non-positive — materialization. The 200k ceiling is shared with the agent
+ * tool ({@link HARD_ROW_CEILING}, DAT-384); only the *default* differs (the grid
+ * streams far more before truncating). A floor of 1 keeps a 0/negative cap from
+ * streaming nothing forever.
  */
 export function clampGridCap(cap?: number): number {
 	if (cap === undefined || !Number.isFinite(cap)) {
 		return GRID_DEFAULT_CAP;
 	}
 	const floored = Math.max(1, Math.floor(cap));
-	return Math.min(floored, GRID_HARD_CEILING);
+	return Math.min(floored, HARD_ROW_CEILING);
 }
 
 // --- Wire protocol (design §4) -----------------------------------------------
@@ -83,18 +81,28 @@ export interface BatchFrame {
 }
 
 /**
- * Last line, always — even on cap or error. The client uses this to distinguish
- * "finished cleanly", "hit the cap" (`truncated`), and "failed mid-stream"
+ * Last line, always — even on cap, cancel, or error. The client uses this to
+ * distinguish "finished cleanly", "hit the cap" (`truncated`), "stopped early
+ * because the client went away" (`cancelled`), and "failed mid-stream"
  * (`error`). The HTTP status stays 200; the body is the source of truth.
  */
 export interface FooterFrame {
 	t: "f";
 	/** Total rows emitted across all batches. */
 	rows: number;
-	/** Set when the stream stopped at the cap. */
+	/**
+	 * Set when the stream stopped because there are genuinely more rows than the
+	 * cap. Confirmed by peeking one chunk past the cap, so an exact-cap result
+	 * (no further rows) reads as a clean finish, not a truncation.
+	 */
 	truncated?: boolean;
 	/** Echoed cap when truncated, so the client can show "first N of many". */
 	cap?: number;
+	/**
+	 * Set when an abort (the grid closed / navigated away) stopped the stream
+	 * before its natural end — distinguishes a partial body from a clean finish.
+	 */
+	cancelled?: boolean;
 	/** DuckDB error message when the stream failed mid-flight. */
 	error?: string;
 }
@@ -170,19 +178,18 @@ export async function* streamNdjson(
 
 	let rows = 0;
 	let truncated = false;
+	let cancelled = false;
 	try {
 		for (;;) {
-			if (signal?.aborted) break;
+			if (signal?.aborted) {
+				cancelled = true;
+				break;
+			}
 			const chunk = await result.fetchChunk();
 			// neo returns null (and historically a 0-row chunk) at the end.
 			if (chunk === null || chunk.rowCount === 0) break;
 
 			const remaining = cap - rows;
-			if (remaining <= 0) {
-				truncated = true;
-				break;
-			}
-
 			const cols = chunk.convertColumns<Json>(JsonDuckDBValueConverter);
 			const take = Math.min(chunk.rowCount, remaining);
 			yield encodeFrame({
@@ -193,12 +200,25 @@ export async function* streamNdjson(
 			rows += take;
 
 			if (rows >= cap) {
-				truncated = true;
+				// At the cap. Don't assume truncation: a result of exactly `cap`
+				// rows is a full set, not a cut-off one. Peek one more chunk (peak
+				// memory stays ≈ one chunk) and only flag `truncated` if there is
+				// genuinely more. The chunk that crossed the cap was sliced above,
+				// so any rows in a further chunk are rows we'd have dropped.
+				if (take < chunk.rowCount) {
+					// The current chunk itself still held rows past the cap.
+					truncated = true;
+				} else {
+					const next = await result.fetchChunk();
+					truncated = next !== null && next.rowCount > 0;
+				}
 				break;
 			}
 		}
 		yield encodeFrame(
-			truncated ? { t: "f", rows, truncated, cap } : { t: "f", rows },
+			truncated
+				? { t: "f", rows, truncated, cap, ...(cancelled && { cancelled }) }
+				: { t: "f", rows, ...(cancelled && { cancelled }) },
 		);
 	} catch (err) {
 		yield encodeFrame({

--- a/packages/cockpit/src/routeTree.gen.ts
+++ b/packages/cockpit/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as appRouteRouteImport } from './routes/(app)/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ApiChatRouteImport } from './routes/api/chat'
+import { Route as ApiRunSqlRouteImport } from './routes/api/run-sql'
 import { Route as appSettingsRouteImport } from './routes/(app)/settings'
 import { Route as appWorkspaceWsIdRouteRouteImport } from './routes/(app)/workspace/$wsId/route'
 import { Route as appWorkspaceWsIdWorkflowsRouteImport } from './routes/(app)/workspace/$wsId/workflows'
@@ -32,6 +33,11 @@ const IndexRoute = IndexRouteImport.update({
 const ApiChatRoute = ApiChatRouteImport.update({
   id: '/api/chat',
   path: '/api/chat',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiRunSqlRoute = ApiRunSqlRouteImport.update({
+  id: '/api/run-sql',
+  path: '/api/run-sql',
   getParentRoute: () => rootRouteImport,
 } as any)
 const appSettingsRoute = appSettingsRouteImport.update({
@@ -77,6 +83,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/settings': typeof appSettingsRoute
   '/api/chat': typeof ApiChatRoute
+  '/api/run-sql': typeof ApiRunSqlRoute
   '/workspace/$wsId': typeof appWorkspaceWsIdRouteRouteWithChildren
   '/workspace/$wsId/cockpit': typeof appWorkspaceWsIdCockpitRoute
   '/workspace/$wsId/governance': typeof appWorkspaceWsIdGovernanceRoute
@@ -88,6 +95,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/settings': typeof appSettingsRoute
   '/api/chat': typeof ApiChatRoute
+  '/api/run-sql': typeof ApiRunSqlRoute
   '/workspace/$wsId': typeof appWorkspaceWsIdRouteRouteWithChildren
   '/workspace/$wsId/cockpit': typeof appWorkspaceWsIdCockpitRoute
   '/workspace/$wsId/governance': typeof appWorkspaceWsIdGovernanceRoute
@@ -101,6 +109,7 @@ export interface FileRoutesById {
   '/(app)': typeof appRouteRouteWithChildren
   '/(app)/settings': typeof appSettingsRoute
   '/api/chat': typeof ApiChatRoute
+  '/api/run-sql': typeof ApiRunSqlRoute
   '/(app)/workspace/$wsId': typeof appWorkspaceWsIdRouteRouteWithChildren
   '/(app)/workspace/$wsId/cockpit': typeof appWorkspaceWsIdCockpitRoute
   '/(app)/workspace/$wsId/governance': typeof appWorkspaceWsIdGovernanceRoute
@@ -114,6 +123,7 @@ export interface FileRouteTypes {
     | '/'
     | '/settings'
     | '/api/chat'
+    | '/api/run-sql'
     | '/workspace/$wsId'
     | '/workspace/$wsId/cockpit'
     | '/workspace/$wsId/governance'
@@ -125,6 +135,7 @@ export interface FileRouteTypes {
     | '/'
     | '/settings'
     | '/api/chat'
+    | '/api/run-sql'
     | '/workspace/$wsId'
     | '/workspace/$wsId/cockpit'
     | '/workspace/$wsId/governance'
@@ -137,6 +148,7 @@ export interface FileRouteTypes {
     | '/(app)'
     | '/(app)/settings'
     | '/api/chat'
+    | '/api/run-sql'
     | '/(app)/workspace/$wsId'
     | '/(app)/workspace/$wsId/cockpit'
     | '/(app)/workspace/$wsId/governance'
@@ -149,6 +161,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   appRouteRoute: typeof appRouteRouteWithChildren
   ApiChatRoute: typeof ApiChatRoute
+  ApiRunSqlRoute: typeof ApiRunSqlRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -172,6 +185,13 @@ declare module '@tanstack/react-router' {
       path: '/api/chat'
       fullPath: '/api/chat'
       preLoaderRoute: typeof ApiChatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/run-sql': {
+      id: '/api/run-sql'
+      path: '/api/run-sql'
+      fullPath: '/api/run-sql'
+      preLoaderRoute: typeof ApiRunSqlRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/(app)/settings': {
@@ -265,6 +285,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   appRouteRoute: appRouteRouteWithChildren,
   ApiChatRoute: ApiChatRoute,
+  ApiRunSqlRoute: ApiRunSqlRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/packages/cockpit/src/routes/api/run-sql.ts
+++ b/packages/cockpit/src/routes/api/run-sql.ts
@@ -88,7 +88,8 @@ export const Route = createFileRoute("/api/run-sql")({
 						? conn.stream(wrapped, params)
 						: conn.stream(wrapped))) as unknown as StreamableResult;
 				} catch (err) {
-					return badRequest(err instanceof Error ? err.message : String(err));
+					console.error("run-sql prepare failed", err);
+					return badRequest("Invalid SQL or parameters.");
 				}
 
 				const enc = new TextEncoder();

--- a/packages/cockpit/src/routes/api/run-sql.ts
+++ b/packages/cockpit/src/routes/api/run-sql.ts
@@ -75,11 +75,21 @@ export const Route = createFileRoute("/api/run-sql")({
 				// level (READ_ONLY ATTACH, defense in depth). `stream()` is lazy: it
 				// does NOT materialize the whole result, so peak memory ≈ one chunk.
 				// Same positional-bind rule as the agent tool.
-				const conn = await getLakeConnection();
+				//
+				// Prepare time is BEFORE the first byte: a connection failure or a
+				// SQL parse/bind error that surfaces here can still become a 400
+				// (e.g. malformed `sql`). Once the ReadableStream starts flushing the
+				// status is locked at 200 and mid-stream errors go in the footer.
 				const wrapped = `SELECT * FROM (${body.sql}) AS _run_sql`;
-				const result = (await (params
-					? conn.stream(wrapped, params)
-					: conn.stream(wrapped))) as unknown as StreamableResult;
+				let result: StreamableResult;
+				try {
+					const conn = await getLakeConnection();
+					result = (await (params
+						? conn.stream(wrapped, params)
+						: conn.stream(wrapped))) as unknown as StreamableResult;
+				} catch (err) {
+					return badRequest(err instanceof Error ? err.message : String(err));
+				}
 
 				const enc = new TextEncoder();
 				// Flipped by cancel() (grid closed / navigated away). streamNdjson

--- a/packages/cockpit/src/routes/api/run-sql.ts
+++ b/packages/cockpit/src/routes/api/run-sql.ts
@@ -1,0 +1,136 @@
+// Streaming `run_sql` endpoint for the human/grid consumer (DAT-385 P1).
+//
+// A SEPARATE channel from the chat SSE (`/api/chat`, `text/event-stream`): this
+// is `application/x-ndjson`, streaming a query result chunk-by-chunk as columnar
+// NDJSON so a large grid result never materializes as one JSON blob. The chat
+// SSE carries only a lightweight handle; the grid fetches the payload here on
+// its own channel (design §3). See `plans/run-sql-streaming-design.md` §5.
+//
+// This route is the thin I/O shell: parse the request, open the READ_ONLY lake
+// reader, kick off neo's lazy `conn.stream()`, and pump `streamNdjson` into a
+// `ReadableStream`. All the protocol/cap/framing logic lives in the pure,
+// unit-tested `duckdb/stream-sql.ts`.
+
+import { createFileRoute } from "@tanstack/react-router";
+import { getLakeConnection } from "../../duckdb/lake";
+import {
+	clampGridCap,
+	encodeFrame,
+	type StreamableResult,
+	streamNdjson,
+} from "../../duckdb/stream-sql";
+
+/** Request body for `POST /api/run-sql`. */
+interface RunSqlStreamBody {
+	/** DuckDB SQL to run over the lake (read-only). */
+	sql: string;
+	/**
+	 * Optional positional bind values for `$1`, `$2`, … placeholders. Same
+	 * parameterization rule as the agent tool (`run-sql.ts`): pass any
+	 * user/agent-derived literal here, never string-concatenated into `sql`.
+	 */
+	params?: (string | number | boolean | null)[];
+	/**
+	 * Optional row cap. Clamped server-side to `[1, 200_000]`, defaulting to the
+	 * grid's 50_000 (clampGridCap) so a client can't request an unbounded
+	 * materialization.
+	 */
+	cap?: number;
+}
+
+let queryCounter = 0;
+
+/** Short, monotonic per-process handle for correlating logs/frames. */
+function nextQueryId(): string {
+	queryCounter += 1;
+	return `q_${queryCounter.toString(36)}_${Date.now().toString(36)}`;
+}
+
+function badRequest(message: string): Response {
+	return new Response(JSON.stringify({ error: message }), {
+		status: 400,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+export const Route = createFileRoute("/api/run-sql")({
+	server: {
+		handlers: {
+			POST: async ({ request }: { request: Request }) => {
+				let body: RunSqlStreamBody;
+				try {
+					body = (await request.json()) as RunSqlStreamBody;
+				} catch {
+					return badRequest("Request body must be JSON.");
+				}
+				if (typeof body.sql !== "string" || body.sql.trim() === "") {
+					return badRequest("Field 'sql' is required and must be a string.");
+				}
+
+				const cap = clampGridCap(body.cap);
+				const queryId = nextQueryId();
+				const params = body.params;
+
+				// Reuse the shared READ_ONLY lake reader — writes fail at the engine
+				// level (READ_ONLY ATTACH, defense in depth). `stream()` is lazy: it
+				// does NOT materialize the whole result, so peak memory ≈ one chunk.
+				// Same positional-bind rule as the agent tool.
+				const conn = await getLakeConnection();
+				const wrapped = `SELECT * FROM (${body.sql}) AS _run_sql`;
+				const result = (await (params
+					? conn.stream(wrapped, params)
+					: conn.stream(wrapped))) as unknown as StreamableResult;
+
+				const enc = new TextEncoder();
+				// Flipped by cancel() (grid closed / navigated away). streamNdjson
+				// checks it at each chunk boundary, so it stops within one chunk.
+				const aborted = { aborted: false };
+
+				const stream = new ReadableStream<Uint8Array>({
+					async start(controller) {
+						try {
+							for await (const line of streamNdjson(
+								result,
+								cap,
+								queryId,
+								aborted,
+							)) {
+								controller.enqueue(enc.encode(line));
+							}
+						} catch (err) {
+							// streamNdjson handles DuckDB errors in-band (footer frame);
+							// this guard only catches an enqueue/controller failure, e.g.
+							// the client already went away. Emit a best-effort footer.
+							try {
+								controller.enqueue(
+									enc.encode(
+										encodeFrame({
+											t: "f",
+											rows: 0,
+											error: err instanceof Error ? err.message : String(err),
+										}),
+									),
+								);
+							} catch {
+								// Controller already closed — nothing more we can do.
+							}
+						} finally {
+							controller.close();
+						}
+					},
+					cancel() {
+						aborted.aborted = true;
+					},
+				});
+
+				return new Response(stream, {
+					status: 200,
+					headers: {
+						"Content-Type": "application/x-ndjson",
+						"Cache-Control": "no-cache, no-transform",
+					},
+				});
+			},
+		},
+	},
+});

--- a/packages/cockpit/vite.config.ts
+++ b/packages/cockpit/vite.config.ts
@@ -8,7 +8,23 @@ import { defineConfig } from "vite";
 
 const config = defineConfig({
 	resolve: { tsconfigPaths: true },
-	plugins: [devtools(), tailwindcss(), tanstackStart(), nitro(), viteReact()],
+	plugins: [
+		devtools(),
+		tailwindcss(),
+		tanstackStart(),
+		// Keep DuckDB's NATIVE binary out of the server bundle. `@duckdb/node-api`
+		// → `@duckdb/node-bindings` loads a platform-specific
+		// `@duckdb/node-bindings-<plat>/duckdb.node` via a runtime `require`; if
+		// Nitro/Rolldown tries to bundle that `.node`, the build dies with
+		// `UNLOADABLE_DEPENDENCY … stream did not contain valid UTF-8` (it can't read
+		// the binary as a module — duckdb/duckdb-node-neo#231). We externalize ONLY
+		// the platform binding packages (`@duckdb/node-bindings-*`): the wrapper +
+		// `node-bindings` JS (and `detect-libc`) still get bundled, and the `.node`
+		// is `require`d at runtime. The runner image must therefore carry those
+		// binding packages in node_modules — see packages/cockpit/Dockerfile.
+		nitro({ rollupConfig: { external: [/^@duckdb\/node-bindings-/] } }),
+		viteReact(),
+	],
 	server: {
 		proxy: {
 			// Dev-only: same-origin /api requests on :3000 proxy to the Python


### PR DESCRIPTION
…dpoint

Adds the human/grid-facing streaming SQL path, separate from the chat SSE channel. POST /api/run-sql returns application/x-ndjson, streaming one DuckDB chunk per line as JSON-safe column arrays so a large result never materializes as one blob.

- duckdb/stream-sql.ts: pure core — grid cap clamp (default 50_000, ceiling 200_000), the header/batch/footer frame protocol, and the chunk→columnar NDJSON generator driving neo's lazy conn.stream() via fetchChunk (NOT runAndReadAll). Peak memory ~ one chunk; cap-slice + truncation; in-band error footer (HTTP stays 200); cancellation via an abort flag checked at each chunk boundary.
- routes/api/run-sql.ts: thin TanStack Start handler — parse {sql,params?,cap?}, reuse the READ_ONLY lake reader (defense-in-depth), pump streamNdjson into a ReadableStream with cancel() wiring.
- Unit tests (clamp, columnar reshaping, framing, truncation, error footer, cancellation) + a real-DuckLake integration test (type fidelity, HUGEINT/ DECIMAL/TIMESTAMP coercion, params, multi-chunk, cap, in-band error).

Wire header carries neo columnTypesJson() structured type metadata (typeId + width/scale), which is richer than the design's illustrative string sketch and better drives client cell formatting. Grid cap ceiling left grid-local with a TODO(DAT-384) to dedupe once limit.ts lands. P2–P4 out of scope.