### PR TITLE
feat(cockpit): DAT-367 register run_sql + probe as agent tools

### DIFF
--- a/packages/cockpit/src/routes/api/chat.test.ts
+++ b/packages/cockpit/src/routes/api/chat.test.ts
@@ -29,7 +29,14 @@ describe("chat route wiring (DAT-353)", () => {
 		const opts = buildChatOptions([{ role: "user", content: "hi" }]);
 		const names = opts.tools.map((t: { name: string }) => t.name);
 		expect(new Set(names)).toEqual(
-			new Set(["list_sources", "list_tables", "teach", "replay"]),
+			new Set([
+				"list_sources",
+				"list_tables",
+				"run_sql",
+				"probe",
+				"teach",
+				"replay",
+			]),
 		);
 	});
 

--- a/packages/cockpit/src/tools/probe.ts
+++ b/packages/cockpit/src/tools/probe.ts
@@ -1,48 +1,53 @@
 // probe tool (DAT-367) — the agent runs read-only SQL against an external
 // database source BEFORE it is materialized into the lake.
 //
-// Thin LLM-facing wrapper over `duckdb/probe`. Credentials are resolved by
-// source name from `DATARAUM_<NAME>_URL` and never surfaced to the agent.
+// Thin LLM-facing wrapper over `duckdb/probe`, registered as a TanStack AI
+// `toolDefinition().server(...)` so it lands in the agent loop (registry.ts).
+// Credentials are resolved by source name from `DATARAUM_<NAME>_URL` and never
+// surfaced to the agent. Read-only → no `needsApproval`.
 
-import type { Tool } from "@anthropic-ai/sdk/resources/messages";
+import { toolDefinition } from "@tanstack/ai";
+import { z } from "zod";
 
-import { type ProbeInput, probe, SUPPORTED_BACKENDS } from "../duckdb/probe";
-import type { QueryResult } from "../duckdb/query-result";
+import { HARD_ROW_CEILING } from "../duckdb/limit";
+import { probe, SUPPORTED_BACKENDS } from "../duckdb/probe";
 
-export const definition: Tool = {
+// QueryResult shape ({columns, rows, rowCount}). `rows` is intentionally
+// permissive — `probe` returns `Record<string, Json>[]` (arbitrary JSON-safe
+// values), so we keep the value type as `z.unknown()` rather than enumerating
+// per-column types we can't know ahead of the query.
+const QueryResultSchema = z.object({
+	columns: z.array(z.string()),
+	rows: z.array(z.record(z.string(), z.unknown())),
+	rowCount: z.number(),
+});
+
+export const probeTool = toolDefinition({
 	name: "probe",
 	description:
 		"Run read-only SQL against an external database source (not yet in the " +
 		"lake) via a READ_ONLY DuckDB ATTACH — for schema sniffing and sample " +
 		"reads before ingest. Credentials are resolved by source name from the " +
 		"environment and are never exposed. The result is capped (default 1000 " +
-		`rows). Supported backends: ${SUPPORTED_BACKENDS.join(", ")}.`,
-	input_schema: {
-		type: "object",
-		properties: {
-			source_name: {
-				type: "string",
-				description:
-					"Configured source name; the key for the DATARAUM_<NAME>_URL credential.",
-			},
-			backend: {
-				type: "string",
-				enum: SUPPORTED_BACKENDS,
-				description: "Database backend kind.",
-			},
-			sql: {
-				type: "string",
-				description: "Read-only SQL to run against the attached source.",
-			},
-			limit: {
-				type: "integer",
-				description: "Max rows to return (default 1000).",
-			},
-		},
-		required: ["source_name", "backend", "sql"],
-	},
-};
-
-export async function handler(input: ProbeInput): Promise<QueryResult> {
-	return probe(input);
-}
+		"rows, hard ceiling 200000). Supported backends: " +
+		`${SUPPORTED_BACKENDS.join(", ")}.`,
+	inputSchema: z.object({
+		source_name: z
+			.string()
+			.describe(
+				"Configured source name; the key for the DATARAUM_<NAME>_URL credential.",
+			),
+		backend: z
+			.enum(SUPPORTED_BACKENDS as [string, ...string[]])
+			.describe("Database backend kind."),
+		sql: z
+			.string()
+			.describe("Read-only SQL to run against the attached source."),
+		limit: z
+			.number()
+			.max(HARD_ROW_CEILING)
+			.optional()
+			.describe("Max rows to return (default 1000, capped at 200000)."),
+	}),
+	outputSchema: QueryResultSchema,
+}).server((input) => probe(input));

--- a/packages/cockpit/src/tools/registry.test.ts
+++ b/packages/cockpit/src/tools/registry.test.ts
@@ -17,11 +17,18 @@ vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 import { tools } from "./registry";
 
 describe("tool registry (DAT-353)", () => {
-	it("registers the slice-1 toolset with unique names", () => {
+	it("registers the toolset with unique names", () => {
 		const names = tools.map((t) => t.name);
 		expect(names).toHaveLength(new Set(names).size); // no dupes
 		expect(new Set(names)).toEqual(
-			new Set(["list_sources", "list_tables", "teach", "replay"]),
+			new Set([
+				"list_sources",
+				"list_tables",
+				"run_sql",
+				"probe",
+				"teach",
+				"replay",
+			]),
 		);
 	});
 
@@ -32,5 +39,7 @@ describe("tool registry (DAT-353)", () => {
 		// Reads must NOT require approval — they run unattended in the loop.
 		expect(byName.get("list_sources")?.needsApproval ?? false).toBe(false);
 		expect(byName.get("list_tables")?.needsApproval ?? false).toBe(false);
+		expect(byName.get("run_sql")?.needsApproval ?? false).toBe(false);
+		expect(byName.get("probe")?.needsApproval ?? false).toBe(false);
 	});
 });

--- a/packages/cockpit/src/tools/registry.ts
+++ b/packages/cockpit/src/tools/registry.ts
@@ -7,12 +7,16 @@
 
 import { listSourcesTool } from "./list-sources";
 import { listTablesTool } from "./list-tables";
+import { probeTool } from "./probe";
 import { replayTool } from "./replay";
+import { runSqlTool } from "./run_sql";
 import { teachTool } from "./teach";
 
 export const tools = [
 	listSourcesTool,
 	listTablesTool,
+	runSqlTool,
+	probeTool,
 	teachTool,
 	replayTool,
 ] as const;

--- a/packages/cockpit/src/tools/run_sql.ts
+++ b/packages/cockpit/src/tools/run_sql.ts
@@ -1,47 +1,49 @@
 // run_sql tool (DAT-367) — the agent runs read-only DuckDB SQL over the lake.
 //
-// Thin LLM-facing wrapper over `duckdb/run-sql`. The core query logic +
-// connection lifecycle live in `src/duckdb/` so the same lake connection is
-// reusable by non-tool callers (e.g. the future schema-sniff for DAT-381).
+// Thin LLM-facing wrapper over `duckdb/run-sql`, registered as a TanStack AI
+// `toolDefinition().server(...)` so it lands in the agent loop (registry.ts).
+// The core query logic + connection lifecycle live in `src/duckdb/` so the same
+// lake connection is reusable by non-tool callers (e.g. the future schema-sniff
+// for DAT-381). Read-only → no `needsApproval`.
 
-import type { Tool } from "@anthropic-ai/sdk/resources/messages";
+import { toolDefinition } from "@tanstack/ai";
+import { z } from "zod";
 
-import type { QueryResult } from "../duckdb/query-result";
-import { type RunSqlInput, runSql } from "../duckdb/run-sql";
+import { HARD_ROW_CEILING } from "../duckdb/limit";
+import { runSql } from "../duckdb/run-sql";
 
-export const definition: Tool = {
+// QueryResult shape ({columns, rows, rowCount}). `rows` is intentionally
+// permissive — `runSql` returns `Record<string, Json>[]` (arbitrary JSON-safe
+// values via the neo driver's getRowObjectsJson), so we keep the value type as
+// `z.unknown()` rather than enumerating per-column types we can't know ahead of
+// the query.
+const QueryResultSchema = z.object({
+	columns: z.array(z.string()),
+	rows: z.array(z.record(z.string(), z.unknown())),
+	rowCount: z.number(),
+});
+
+export const runSqlTool = toolDefinition({
 	name: "run_sql",
 	description:
 		"Run read-only DuckDB SQL over the data lake and return JSON rows. " +
 		"Address tables by their fully-qualified lake name, e.g. " +
 		"`lake.typed.<table>` (type-resolved), `lake.raw.<table>` (VARCHAR " +
 		"staging), or `lake.quarantine.<table>` (failed casts). The result is " +
-		"capped (default 1000 rows); pass `limit` to change it. Use `params` " +
-		"for any literal value instead of concatenating it into the SQL.",
-	input_schema: {
-		type: "object",
-		properties: {
-			sql: {
-				type: "string",
-				description: "DuckDB SQL to run (read-only).",
-			},
-			params: {
-				type: "array",
-				description:
-					"Optional positional bind values for $1, $2, … placeholders.",
-				items: {
-					type: ["string", "number", "boolean", "null"],
-				},
-			},
-			limit: {
-				type: "integer",
-				description: "Max rows to return (default 1000).",
-			},
-		},
-		required: ["sql"],
-	},
-};
-
-export async function handler(input: RunSqlInput): Promise<QueryResult> {
-	return runSql(input);
-}
+		"capped (default 1000 rows, hard ceiling 200000); pass `limit` to change " +
+		"it within that ceiling. Use `params` for any literal value instead of " +
+		"concatenating it into the SQL.",
+	inputSchema: z.object({
+		sql: z.string().describe("DuckDB SQL to run (read-only)."),
+		params: z
+			.array(z.union([z.string(), z.number(), z.boolean(), z.null()]))
+			.optional()
+			.describe("Optional positional bind values for $1, $2, … placeholders."),
+		limit: z
+			.number()
+			.max(HARD_ROW_CEILING)
+			.optional()
+			.describe("Max rows to return (default 1000, capped at 200000)."),
+	}),
+	outputSchema: QueryResultSchema,
+}).server((input) => runSql(input));


### PR DESCRIPTION
The run_sql/probe DuckDB read verbs were implemented but unreachable: the tool files exported a raw @anthropic-ai/sdk Tool + handler, while the registry only collects TanStack AI toolDefinition().server() tools. Rewrite both as toolDefinition().server(...) (read-only, no needsApproval), reusing the existing runSql/probe cores unchanged, and register them in the tools array.

Cap visibility: the limit field now .describe()s the default + 200000 hard ceiling and .max(HARD_ROW_CEILING)s the input (runtime clamp unchanged).

Update registry.test.ts + chat.test.ts to the 6-tool set.