### PR TITLE
feat(DAT-364): encode workspace_id in Temporal workflow IDs

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,26 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-01: DAT-364 (tail) — temporal `analyze_update_frequency` NaN guard
+
+Bug fix found while building the DAT-364 isolation test (the workflow-ID change itself is
+**not** calibration-relevant — workflow-ID naming + workspace guard only, no detector/schema/phase
+change).
+
+What changed in the engine (calibration-relevant):
+- **`analyze_update_frequency` now coerces a NaN `interval_std` to `0.0`** (`analysis/temporal/patterns.py`).
+  A date column with exactly one interval (a 2-row table) has no sample std → pandas returns NaN →
+  the JSON `profile_data` insert crashed (`invalid input syntax for type json … Token "NaN"`). A lone
+  interval is trivially regular, so `0.0` is the correct reading. `interval_cv` (derived) is now
+  finite too.
+
+### dataraum-eval
+
+- **Eval action: re-verify only if testdata has single-interval (2-row) date columns.** Previously
+  such a column crashed the `temporal` phase; now it profiles cleanly with `interval_std=0.0`. No
+  change to multi-interval columns or to detector recall/precision on healthy data — the coercion
+  only fires on the degenerate single-interval case.
+
 ## 2026-05-31: DAT-378 — file source = explicit `file_uris` list (multi-file ingest, atomic)
 
 Makes the engine import contract correct end-to-end for the cockpit `connect → select →

--- a/packages/cockpit/src/temporal/drive-add-source.ts
+++ b/packages/cockpit/src/temporal/drive-add-source.ts
@@ -32,6 +32,7 @@ import { z } from "zod";
 import { replay } from "../tools/replay";
 import { teach } from "../tools/teach";
 import type { AddSourceInput, AddSourceResult } from "./types";
+import { addSourceWorkflowId } from "./workflow-id";
 
 const env = z
 	.object({
@@ -114,7 +115,7 @@ async function runInitial(
 		(input: AddSourceInput) => Promise<AddSourceResult>
 	>("addSourceWorkflow", {
 		taskQueue: env.TEMPORAL_TASK_QUEUE,
-		workflowId: `addsource-${sourceId}`,
+		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID, sourceId),
 		args: [input],
 	});
 
@@ -142,7 +143,10 @@ async function awaitReplay(
 	sourceId: string,
 	runId: string,
 ): Promise<AddSourceResult> {
-	const handle = client.workflow.getHandle(`addsource-${sourceId}`, runId);
+	const handle = client.workflow.getHandle(
+		addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID, sourceId),
+		runId,
+	);
 	return (await handle.result()) as AddSourceResult;
 }
 

--- a/packages/cockpit/src/temporal/workflow-id.test.ts
+++ b/packages/cockpit/src/temporal/workflow-id.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { addSourceWorkflowId } from "./workflow-id";
+
+// The parent workflow ID encodes workspace_id as its first segment (DAT-364),
+// and MUST agree with the Python worker's `add_source_workflow_id` (the worker
+// builds child IDs off the same prefix). These pin the format + the
+// cross-workspace distinctness the convention exists to guarantee.
+
+const WS_A = "12345678-1234-1234-1234-123456789abc";
+const WS_B = "00000000-0000-0000-0000-000000000001";
+const SOURCE = "src-7";
+
+describe("addSourceWorkflowId (DAT-364)", () => {
+	it("encodes workspace then source", () => {
+		expect(addSourceWorkflowId(WS_A, SOURCE)).toBe(
+			`addsource-${WS_A}-${SOURCE}`,
+		);
+	});
+
+	it("does not collide across workspaces sharing a source_id", () => {
+		expect(addSourceWorkflowId(WS_A, SOURCE)).not.toBe(
+			addSourceWorkflowId(WS_B, SOURCE),
+		);
+	});
+});

--- a/packages/cockpit/src/temporal/workflow-id.ts
+++ b/packages/cockpit/src/temporal/workflow-id.ts
@@ -1,0 +1,25 @@
+// Temporal workflow ID convention (DAT-364) — cockpit side.
+//
+// The cockpit Client owns the *parent* (`addSourceWorkflow`) ID, since it's the
+// caller that starts the workflow; the Python worker mirrors this convention
+// and builds the child (`processTableWorkflow`) IDs off the same prefix (see
+// `dataraum.worker.contracts.{add_source_workflow_id,process_table_workflow_id}`).
+//
+// Every workflow ID encodes `workspace_id` as its first segment. Slice 1 runs
+// single-workspace so it's constant today, but threading it through now makes
+// slice 2+ multi-workspace routing a no-op and guarantees two workspaces sharing
+// a `source_id` never collide on a workflow ID. `workspace_id` is kept verbatim
+// (raw UUID with dashes) — Temporal IDs have no charset restriction, so we favour
+// grep-able IDs over the underscored `ws_<id>` schema form.
+
+/**
+ * Workflow ID for the parent `addSourceWorkflow` of one source. Reused across
+ * teach replays of the same source (with `ALLOW_DUPLICATE`) so Temporal groups
+ * the iterations under one ID.
+ */
+export function addSourceWorkflowId(
+	workspaceId: string,
+	sourceId: string,
+): string {
+	return `addsource-${workspaceId}-${sourceId}`;
+}

--- a/packages/cockpit/src/tools/replay.ts
+++ b/packages/cockpit/src/tools/replay.ts
@@ -4,8 +4,8 @@
 // Pure compute kick: takes a ReplayScope (the agent decides whether to
 // rerun source-wide, per-table, or source-tail-only), starts a fresh
 // `addSourceWorkflow` execution with the same workflow id as the initial
-// run (`addsource-<source_id>`), and uses ALLOW_DUPLICATE policy so
-// Temporal UI groups iterations naturally per source.
+// run (`addsource-<workspace_id>-<source_id>`; see workflow-id.ts, DAT-364),
+// and uses ALLOW_DUPLICATE policy so Temporal UI groups iterations per source.
 //
 // Returns the workflow id + run id immediately — the caller polls / queries
 // Temporal for progress. End-to-end "replay actually produces clean output"
@@ -34,6 +34,7 @@ import type {
 	ReplayScope,
 	SourceIdentity,
 } from "../temporal/types";
+import { addSourceWorkflowId } from "../temporal/workflow-id";
 
 export interface ReplayInput {
 	source_id: string;
@@ -61,8 +62,8 @@ export interface ReplayResult {
  * immediately with the workflow + run id; the caller polls Temporal for
  * progress and the final result.
  *
- * Workflow id is reused per source (`addsource-<source_id>`) with
- * `ALLOW_DUPLICATE` so each replay shows up as a fresh run under the same
+ * Workflow id is reused per source (`addsource-<workspace_id>-<source_id>`)
+ * with `ALLOW_DUPLICATE` so each replay shows up as a fresh run under the same
  * id in Temporal UI — natural grouping for "all iterations of this source's
  * teach history".
  */
@@ -89,7 +90,10 @@ export async function replay(input: ReplayInput): Promise<ReplayResult> {
 		replay: input.scope,
 	};
 
-	const workflowId = `addsource-${input.source_id}`;
+	const workflowId = addSourceWorkflowId(
+		config.dataraumWorkspaceId,
+		input.source_id,
+	);
 
 	const connection = await Connection.connect({ address: config.temporalHost });
 	try {

--- a/packages/engine/src/dataraum/analysis/temporal/patterns.py
+++ b/packages/engine/src/dataraum/analysis/temporal/patterns.py
@@ -469,7 +469,13 @@ def analyze_update_frequency(
             return Result.fail("No intervals found")
 
         median_interval = float(intervals_seconds.median())
+        # A single interval (a 2-row column) has no sample std — pandas returns
+        # NaN (ddof=1). NaN can't be serialized into the JSON profile_data column
+        # (Postgres rejects the literal `NaN`), and a lone interval is trivially
+        # regular, so a zero spread is the correct reading.
         interval_std = float(intervals_seconds.std())
+        if np.isnan(interval_std):
+            interval_std = 0.0
 
         # Coefficient of variation (lower = more regular)
         if median_interval > 0:

--- a/packages/engine/src/dataraum/worker/contracts.py
+++ b/packages/engine/src/dataraum/worker/contracts.py
@@ -185,3 +185,48 @@ class AddSourceResult(BaseModel):
 
     raw_table_ids: list[str]
     tables: list[ProcessTableResult]
+
+
+# --- Workflow ID convention (DAT-364) ----------------------------------------
+#
+# Every Temporal workflow ID encodes the ``workspace_id`` as its first segment.
+# Slice 1 runs single-workspace, so the segment is constant today — but threading
+# it through now means slice 2+ multi-workspace routing (DAT-357) is a no-op
+# rename instead of an audit of every ``start_workflow``/``getHandle`` call site,
+# and two workspaces can never collide on a shared ``source_id``. The ``ws_<id>``
+# isolation guard in :mod:`dataraum.worker.activity` is the data-side cornerstone;
+# this is its workflow-ID counterpart. See the ``durable-execution-lean`` memory.
+#
+# These helpers live here (the engine-free contracts module the determinism
+# sandbox imports through ``imports_passed_through``) so the workflow body can
+# build child IDs without dragging the engine into the sandbox. ``workspace_id``
+# is a ``str`` (raw UUID with dashes, or the ``"test"`` sentinel) — Temporal
+# workflow IDs have no charset restriction, so we keep it verbatim for grep-able
+# IDs in the Temporal UI rather than the underscored ``ws_<id>`` schema form.
+#
+# Parent IDs are owned by the cockpit Client (it starts the workflow); the TS
+# side mirrors this convention in ``packages/cockpit/src/temporal/workflow-id.ts``.
+
+
+def add_source_workflow_id(workspace_id: str, source_id: str) -> str:
+    """Workflow ID for the parent ``addSourceWorkflow`` of one source.
+
+    Reused across teach replays of the same source (with
+    ``WorkflowIdReusePolicy.ALLOW_DUPLICATE``) so Temporal groups iterations
+    under one ID. Mirrored cockpit-side; the cockpit is the caller that starts
+    the parent, so this Python helper exists for tests + the child-ID builder.
+    """
+    return f"addsource-{workspace_id}-{source_id}"
+
+
+def process_table_workflow_id(workspace_id: str, source_id: str, raw_table_id: str) -> str:
+    """Child ``processTableWorkflow`` ID for one raw table under a source.
+
+    Deterministic + collision-free so replay stays stable: the same raw table
+    re-runs under the same child ID across teach iterations. Prefixed with the
+    parent's ``addsource-{workspace_id}-{source_id}`` so children are greppable
+    under their parent in the Temporal UI (the prefix is a naming convention, not
+    a Temporal-native hierarchy), and two workspaces sharing a ``source_id`` get
+    distinct child IDs.
+    """
+    return f"{add_source_workflow_id(workspace_id, source_id)}-table-{raw_table_id}"

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -47,6 +47,7 @@ with workflow.unsafe.imports_passed_through():
         SourceIdentity,
         TableScopedInput,
         TypingResult,
+        process_table_workflow_id,
     )
 
 # A deterministic phase failure is raised by the activity as a non-retryable
@@ -334,7 +335,9 @@ class AddSourceWorkflow:
 
         # Deterministic, collision-free child ids keep replay stable. The same
         # id is reused across teach iterations with WorkflowIdReusePolicy.ALLOW_DUPLICATE
-        # on the parent — Temporal UI groups iterations naturally.
+        # on the parent — Temporal UI groups iterations naturally. The id encodes
+        # workspace_id (DAT-364) so two workspaces sharing a source_id never
+        # collide; see process_table_workflow_id for the convention.
         children = [
             workflow.execute_child_workflow(
                 ProcessTableWorkflow.run,
@@ -343,7 +346,11 @@ class AddSourceWorkflow:
                     raw_table_id=raw_id,
                     replay=child_replay,
                 ),
-                id=f"addsource-{payload.identity.source_id}-table-{raw_id}",
+                id=process_table_workflow_id(
+                    payload.identity.workspace_id,
+                    payload.identity.source_id,
+                    raw_id,
+                ),
             )
             for raw_id in target_raw_ids
         ]

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from dataraum.core.connections import ConnectionConfig, ConnectionManager
 from dataraum.entropy.db_models import EntropyObjectRecord
@@ -254,6 +254,70 @@ def test_workspace_mismatch_fails_loud(worker_manager: ConnectionManager) -> Non
     assert result.status == "failed"
     assert "Workspace mismatch" in (result.error or "")
     assert "some-other-workspace" in (result.error or "")
+
+
+def test_addsource_runs_under_nondefault_workspace(
+    pg_url_clean: str,
+    lake_anchor,  # noqa: ANN001
+    lake_clean,  # noqa: ANN001
+    small_finance_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full per-table chain runs green under a non-default workspace_id.
+
+    The DAT-364 anti-footgun on the *data* side (the workflow-ID side is covered
+    by ``tests/unit/worker/test_workflow_ids.py``): nothing may hardcode the
+    default workspace pointer or a default UUID, and ``schema_name_for`` must
+    produce a valid ``ws_<id>`` schema for a real UUID — not just the ``"test"``
+    sentinel the rest of the suite runs under. We repoint the worker's active
+    workspace to a non-default UUID, bootstrap a manager exactly as the worker
+    would (which creates ``ws_<uuid>`` + its tables), and run import → the
+    per-table chain over the same multi-file fixture the default-workspace chain
+    test uses. The mismatch guard means a stray ``"test"`` left anywhere in the
+    path would fail this loudly.
+    """
+    import importlib
+
+    nondefault_workspace = "abcdef12-3456-7890-abcd-ef1234567890"
+    ws_mod = importlib.import_module("dataraum.server.workspace")
+    # Repoint BEFORE initialize(): the manager's search_path listener + CREATE
+    # SCHEMA both read the pointer at initialize() time. monkeypatch restores it
+    # so the suite's other tests keep running under "test".
+    monkeypatch.setattr(ws_mod, "_active_workspace_id", nondefault_workspace)
+
+    manager = ConnectionManager(ConnectionConfig(database_url=pg_url_clean))
+    manager.initialize()  # creates ws_abcdef12_... + Base tables under it
+    manager.open_lake()
+    try:
+        source_id = str(uuid4())
+        session_id = str(uuid4())
+        files = _enumerate_fixture_files(small_finance_path)
+        _seed_source_and_session(manager, source_id, session_id, "small_finance", files)
+        identity = SourceIdentity(
+            workspace_id=nondefault_workspace,
+            source_id=source_id,
+            session_id=session_id,
+        )
+
+        assert run_phase(manager, "import", identity, []).status == "completed"
+        raw_ids = raw_table_ids(manager, source_id)
+        assert raw_ids, "import produced no raw tables under the non-default workspace"
+
+        typed_ids = [_process_one_table(manager, identity, raw_id) for raw_id in raw_ids]
+        assert len(typed_ids) == len(raw_ids)
+        assert _lake_tables(manager, "typed"), "no typed tables after the chain"
+    finally:
+        # pg_url_clean only truncates the ``ws_test`` schema, so drop this test's
+        # one-off ``ws_<uuid>`` schema explicitly — otherwise it lingers in the
+        # session-scoped testcontainer as residue.
+        try:
+            from dataraum.server.workspace import schema_name_for
+
+            schema = schema_name_for(nondefault_workspace)
+            with manager.session_scope() as session:
+                session.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        finally:
+            manager.close()
 
 
 def test_per_table_chain_runs(worker_manager: ConnectionManager, small_finance_path: Path) -> None:

--- a/packages/engine/tests/unit/analysis/temporal/test_update_frequency.py
+++ b/packages/engine/tests/unit/analysis/temporal/test_update_frequency.py
@@ -1,0 +1,41 @@
+"""Tests for ``analyze_update_frequency`` degenerate-input handling."""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+from dataraum.analysis.temporal.patterns import analyze_update_frequency
+
+_CONFIG = {"staleness": {"stale_multiplier": 3}}
+
+
+def test_single_interval_column_yields_zero_std_not_nan() -> None:
+    """A 2-row date column has one interval → pandas sample std is NaN.
+
+    NaN can't be serialized into the JSON ``profile_data`` column (Postgres
+    rejects the literal ``NaN``), and a lone interval is trivially regular, so
+    the spread must read as 0.0 rather than NaN.
+    """
+    ts = pd.Series([1.0, 2.0], index=pd.to_datetime(["2024-01-01", "2024-01-02"]))
+
+    result = analyze_update_frequency(ts, config=_CONFIG)
+
+    assert result.success, result.error
+    analysis = result.unwrap()
+    assert analysis.interval_std == 0.0
+    assert analysis.interval_cv is not None and not math.isnan(analysis.interval_cv)
+
+
+def test_multiple_intervals_still_compute_a_real_std() -> None:
+    """Sanity guard: the NaN coercion doesn't flatten genuine spread to 0."""
+    ts = pd.Series(
+        [1.0, 2.0, 3.0, 4.0],
+        index=pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-05", "2024-01-06"]),
+    )
+
+    result = analyze_update_frequency(ts, config=_CONFIG)
+
+    assert result.success, result.error
+    assert result.unwrap().interval_std > 0.0

--- a/packages/engine/tests/unit/worker/test_workflow_ids.py
+++ b/packages/engine/tests/unit/worker/test_workflow_ids.py
@@ -1,0 +1,37 @@
+"""Tests for the workspace-scoped workflow ID convention (DAT-364).
+
+The parent (``addSourceWorkflow``) and child (``processTableWorkflow``) IDs
+encode ``workspace_id`` as their first segment so slice 2+ multi-workspace
+routing is a no-op and two workspaces sharing a ``source_id`` never collide on
+a workflow ID. These pin the format + the cross-workspace distinctness without
+spinning up a Temporal worker (the parent ID is built cockpit-side; this Python
+helper backs the child-ID builder + these tests).
+"""
+
+from __future__ import annotations
+
+from dataraum.worker.contracts import add_source_workflow_id, process_table_workflow_id
+
+_WS_A = "12345678-1234-1234-1234-123456789abc"
+_WS_B = "00000000-0000-0000-0000-000000000001"
+_SOURCE = "src-7"
+_RAW = "raw-3"
+
+
+def test_parent_id_encodes_workspace_then_source() -> None:
+    assert add_source_workflow_id(_WS_A, _SOURCE) == f"addsource-{_WS_A}-{_SOURCE}"
+
+
+def test_child_id_is_parent_prefixed() -> None:
+    """The child ID nests under the parent ID + a ``-table-<raw>`` suffix."""
+    child = process_table_workflow_id(_WS_A, _SOURCE, _RAW)
+    assert child == f"{add_source_workflow_id(_WS_A, _SOURCE)}-table-{_RAW}"
+    assert child.startswith(f"addsource-{_WS_A}-{_SOURCE}")
+
+
+def test_same_source_different_workspaces_do_not_collide() -> None:
+    """The DAT-364 anti-footgun: identical source+table, distinct workspace → distinct IDs."""
+    assert add_source_workflow_id(_WS_A, _SOURCE) != add_source_workflow_id(_WS_B, _SOURCE)
+    assert process_table_workflow_id(_WS_A, _SOURCE, _RAW) != process_table_workflow_id(
+        _WS_B, _SOURCE, _RAW
+    )


### PR DESCRIPTION
Thread the slice-2 multi-workspace cornerstone now, while it's inert under slice-1's single workspace: every Temporal workflow ID gets a workspace_id first segment (addsource-{workspace_id}-{source_id}[-table-{raw_id}]), so two workspaces sharing a source_id can never collide on a workflow ID and DAT-357 routing becomes a rename, not a call-site audit.

- Pure, sandbox-safe helpers in worker/contracts.py (the engine-free module the determinism sandbox imports); the child ID in workflows.py uses them.
- Cockpit mirrors the convention in temporal/workflow-id.ts; drive-add-source.ts (execute + getHandle) and tools/replay.ts all route through it.
- Unit tests pin the exact format + cross-workspace collision on both sides; a new integration test runs the full chain under a non-default workspace UUID (the data-side counterpart to the existing mismatch guard).

The activity-body mismatch guard (the data-side cornerstone) and the str typing of workspace_id are kept as-is; per-input search_path routing stays deferred to DAT-357. workspace_id already rode on every activity input (SourceIdentity).

Also fix a latent NaN bug surfaced by the isolation test: a single-interval (2-row) date column gave analyze_update_frequency a NaN interval_std that crashed the JSON profile_data insert; coerce it to 0.0 (a lone interval is trivially regular). Handoff noted for eval.