### PR TITLE
chore(skills): bias toward ownership over corporate caution

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -14,13 +14,24 @@ $ARGUMENTS is a Jira issue identifier, a description of the agreed approach, or 
 ## Before you start
 
 1. Verify there IS an agreed approach — from a `/refine` session, user discussion, or a clear spec. If not, run `/refine` first.
-2. Create or update the plan with explicit scope:
+2. Classify size: S / M / L / XL.
+   - **S (obvious, ~1–3 files):** skip the plan ceremony. Make the change, leave it green, done. A formal DO-change/DO-NOT-change list for a one-liner is theater.
+   - **M:** lightweight plan, single session.
+   - **L/XL:** full plan with explicit scope (below) + user sign-off before code.
+3. For M+, create or update the plan with explicit scope:
    ```
-   DO change: [list every file]
-   DO NOT change: [list files that must stay untouched]
+   DO change: [the files this work touches]
+   DO NOT change: [large/unrelated areas that must stay untouched — NOT a cage]
    ```
-3. Classify size: S / M / L / XL
-4. For M+: get explicit user sign-off on the plan before writing code
+4. For M+: get explicit user sign-off on the plan before writing code.
+
+### Scope is a fence against *unrelated* sprawl — not a cage
+
+`DO NOT change` exists to stop you from wandering into unrelated subsystems mid-task. It does **not** forbid:
+- **Design-implied cleanup** — deleting dead code, removing a retired field, adapting its tests. That's in-scope, not an "adjacent-edit violation" (see CLAUDE.md sizing note + "Default to the clean cut").
+- **An obvious correctness fix you spot in your blast radius** — a clear one-line bug in a file you're already editing. Fix it and note it in the checkpoint. Leaving a bug you can see "because it's not in the ticket" is the corporate failure mode, not discipline. A ticket is a pointer to work, not a permission boundary.
+
+If a fix is large or genuinely unrelated, *that's* when you note it for a separate item rather than expanding scope.
 
 ## Phase execution
 
@@ -49,9 +60,15 @@ After each phase: tests must be green. If they're not, fix the code (not the tes
 
 ---
 
-## Psychological safety
+## Psychological safety — and its counterweight
 
 These are not just allowed. They are EXPECTED. They are the EFFICIENT path.
+
+**But stopping is not free, and "ask the user" is not the safe default — it's a real cost too.** Every escalation spends the user's attention and your momentum. The bar for stopping is a *genuine* fork or a *real* blocker, not a routine decision you could resolve with a grep, a sensible default, or by following the agreed design. The senior-engineer move is to **solve the problem and report the outcome**, not to narrate every micro-step and wait for a nod. Default to action; reserve the stop conditions below for when they truly fire.
+
+**Don't spin in dependency circles.** If you find yourself "blocked by" a prerequisite, the answer is usually to *do the prerequisite*, build a thin vertical slice, or attack the real problem directly — not to report "blocked" and stall. Time-box deliberation: if you've spent longer deciding how to approach something than it would take to just try the obvious path and learn, try it. An over-thought, entry-level answer arrived at slowly is worse than a direct attempt that produces real information.
+
+The stop conditions below are about *honesty when something is genuinely wrong* — not a license to bail on tractable work:
 
 **"This is harder than I expected."**
 Say it immediately. Do not power through hoping it gets easier. It won't. The user can help, adjust scope, or change approach. Powering through produces bad code that needs rework.
@@ -74,7 +91,9 @@ Delete it and say so. A test that verifies mocking scaffolding is worse than no 
 **"I'm keeping dead code because removing it breaks tests."**
 STOP. Delete the dead code. Delete or rewrite the test. Note it in the checkpoint. Dead code kept for tests is technical debt that compounds.
 
-**The most expensive mistake is declaring done when you're not.** It forces the user to discover the problem later, in a new session, with lost context. Stopping early and being honest is ALWAYS cheaper.
+**The most expensive mistake is declaring done when you're not.** It forces the user to discover the problem later, in a new session, with lost context. Stopping early and being honest is cheaper than a false "done."
+
+**The second most expensive mistake is escalating what you could have solved.** Asking the user to make a call you had the context to make yourself, or stopping on a routine fork, burns the same trust from the other direction. Honesty about being stuck and ownership of what you can resolve are the *same* virtue — calibrate which one the moment calls for.
 
 ---
 

--- a/.claude/skills/refine/SKILL.md
+++ b/.claude/skills/refine/SKILL.md
@@ -15,6 +15,15 @@ $ARGUMENTS is a Jira issue identifier (e.g., "DAT-175"), a topic description, or
 
 If the user has a rough idea that doesn't have a Jira issue or design doc yet, suggest `/ideate` first — that's where design documents and epic structure get created. `/refine` works on an existing, scoped work item.
 
+## Step 0: Triage — does this need refining at all?
+
+Refinement is for work that is **genuinely ambiguous, risky, or large**. It is not a toll every change has to pay. Before the full pass, make a fast call:
+
+- **Clear and small** (S: ~1–3 files, obvious correct path, no cross-repo or contract risk) → **don't refine. Just do it** (or go straight to `/implement`). State the one-line approach in a sentence and act. Paying the reality-check / risk-matrix / options ceremony on a tractable change is the corporate failure mode this project rejects — see "Default to the clean cut" and "Decide, don't hedge" in CLAUDE.md.
+- **Genuinely uncertain or M+** (you can't yet name the simplest correct path, or the spec might be wrong, or it touches contracts/eval/multiple modules) → run the full pass below. This is where refinement earns its keep.
+
+When in doubt, do the cheapest thing that resolves the doubt — a five-minute grep, not a meeting. Deliberation has a cost too; don't spend more time deciding how to approach a problem than the problem would take to solve.
+
 ## Step 1: Gather context
 
 - If a Jira issue: fetch the issue AND linked Confluence pages via Jira MCP

--- a/.claude/skills/smoke/SKILL.md
+++ b/.claude/skills/smoke/SKILL.md
@@ -21,10 +21,10 @@ allowed-tools:
 
 You just implemented or changed a cockpit surface, an engine kernel verb, or both. Now USE it. Not to verify correctness (that's eval's job) — to feel what the UX is like.
 
-**IMPORTANT:**
-- If you changed **engine Python code**, the engine container loaded the old code — rebuild + restart it before smoke: `docker compose -f packages/infra/docker-compose.yml up -d --build control-plane`.
-- If you only changed **cockpit code** and `pnpm dev` is running, Vite hot-reloads — no restart needed.
-- If the **engine added or changed SQLAlchemy models**, refresh the cockpit's Drizzle metadata client: `(cd packages/cockpit && DATARAUM_WORKSPACE_ID=<id> METADATA_DATABASE_URL=<url> pnpm db:pull:metadata)`.
+**IMPORTANT — cockpit smoke runs against the CONTAINER, never host `vite dev`/`bun run dev`/`pnpm dev`:**
+- The cockpit imports the DuckDB **neo** driver (`@duckdb/node-api` → a native `@duckdb/node-bindings-*/duckdb.node`). `vite dev`/rolldown **cannot bundle that native binary** and dies at boot — `[UNLOADABLE_DEPENDENCY] … stream did not contain valid UTF-8`. Only the **prod container build** externalizes it (`vite.config` `nitro({ rollupConfig: { external: [/^@duckdb\/node-bindings-/] } })` + the Dockerfile copies `node_modules/@duckdb`). So **don't reach for hot-reload** — build + run the cockpit container from the branch under test (step 1). This recurs every time someone tries `dev`; don't relearn it.
+- If you changed **engine Python code**, rebuild + restart its container before smoke: `docker compose -f packages/infra/docker-compose.yml up -d --build engine-worker` (the engine is a Temporal worker — service `engine-worker`, no HTTP / no `control-plane`).
+- If the **engine added or changed SQLAlchemy models**, refresh the cockpit's Drizzle metadata client (`bun run db:pull:metadata`) against a fresh DB before the smoke.
 
 ## Input
 
@@ -49,11 +49,23 @@ A quick, informal test drive. Like kicking the tires after a change. You're not 
 ### 1. Bring up the stack
 
 ```bash
-docker compose -f packages/infra/docker-compose.yml up -d --wait
-curl -fsS http://localhost:8000/health
+# Backend + a cockpit container. `env -u ANTHROPIC_API_KEY` so a stale shell key
+# doesn't shadow the .env one (compose var precedence has bitten us).
+env -u ANTHROPIC_API_KEY docker compose -f packages/infra/docker-compose.yml up -d --wait
+# Engine health = the Temporal worker heartbeat (no HTTP endpoint):
+docker compose -f packages/infra/docker-compose.yml run --rm --no-deps \
+  --entrypoint temporal temporal-admin-tools \
+  worker list --namespace default --address temporal:7233          # → Status: Running
 ```
 
-For UI iteration: also run `pnpm dev` in `packages/cockpit/` (hot-reload). For pure REST smoke: skip the cockpit, hit the engine directly.
+**Smoking a branch (not `main`):** the compose `cockpit` build context is the canonical `packages/cockpit` (= `main`), so a fresh `up` smokes `main`'s cockpit, not your branch. To smoke a branch, build the image from THAT checkout/worktree and recreate the service with it — do NOT host-`dev` it (see the duckdb-neo note above):
+
+```bash
+docker build -t infra-cockpit <checkout>/packages/cockpit --build-arg VITE_ENGINE_API_URL=http://localhost:8000
+env -u ANTHROPIC_API_KEY docker compose -f packages/infra/docker-compose.yml up -d --no-build --force-recreate cockpit
+```
+
+A chat smoke makes a **real LLM call** (the agent needs a valid `ANTHROPIC_API_KEY`) — ask before running it unprompted. For a pure engine/REST check, skip the cockpit.
 
 ### 2. Drive the cockpit via Playwright MCP
 
@@ -92,6 +104,7 @@ This tests the *flow* between page + chat + tools, not just one surface.
 - Type a question the engine can't answer — does the agent fail gracefully?
 - Reload mid-stream — does the page recover?
 - Open the network panel: is anything 404-ing? Any unhandled 500s?
+- **Push it to realistic scale.** Run something that returns a *large* result set — thousands to tens of thousands of rows, not the 5-row demo. Does the surface **virtualize / paginate / cap**, or does it try to render every row into the DOM? Watch for a frozen tab, multi-second render, runaway memory, or a scrollbar implying tens of thousands of live DOM nodes. **Dumping an unbounded result set into the page is a bug, not "fine"** — a practitioner's real query returns big data, and "it rendered" ≠ "it's usable." If you catch yourself thinking *"50k rows displayed, works,"* that *is* the finding to report, not a pass.
 
 ### 5. Share impressions
 

--- a/.claude/skills/take/SKILL.md
+++ b/.claude/skills/take/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: take
-description: Take a single DAT-294 task end-to-end as one parallel lane — worktree, refine, implement, lane-smoke, PR. Invoke once per task. Launch N concurrently via the Agent tool with isolation:worktree.
+description: Take a single independently-mergeable task end-to-end as one parallel lane — worktree, refine, implement, lane-smoke, PR. Invoke once per task. Launch N concurrently via the Agent tool with isolation:worktree.
 allowed-tools:
   - Read
   - Write
@@ -20,23 +20,23 @@ allowed-tools:
 
 # Take: $ARGUMENTS
 
-You are taking a single DAT-294 task end-to-end as one parallel lane. **One task = one worktree = one branch = one PR = one focused session.**
+You are taking a single task end-to-end as one parallel lane. **One task = one worktree = one branch = one PR = one focused session.**
 
 This skill exists so the user can launch N lanes in parallel via the Agent tool with `isolation: "worktree"` — each agent inherits this skill and runs independently. Without a skill there is no parallelism unit; with it, multiple lanes ship from one orchestrator message.
 
-The full enforcement rules live in `CLAUDE.md → "Parallel platform work runbook"`. This skill executes that runbook. If you find this skill and the runbook diverging, the runbook wins — open a PR to align them.
+`/take` is a **mechanism**, not a specific epic. It was first built for the DAT-294 wave, but nothing about it is tied to that epic — it works for any task that can be merged on its own branch: a top-level ticket, a child, or a sub-item of a larger ticket. (If a parallel-work runbook exists in CLAUDE.md, follow it; if this skill and that runbook diverge, the runbook wins — open a PR to align them.)
 
-**When to use `/take` today:** reserved for genuinely parallel platform lanes. The v1 plan (post-spine cockpit + engine REST) ships PR-per-step on a shared branch — single stream, no contract-lock gate, just use `/refine` + `/implement` directly. Reach for `/take` when a future wave decomposes into 2+ independently-mergeable tasks that touch separate code areas.
+**When to reach for `/take`:** when 2+ tasks can be implemented and merged *independently* and touch *separate* code areas, so running them as concurrent worktree lanes is faster than one stream. For single-stream work — even a multi-step feature on one shared branch — skip the lane machinery and just use `/refine` + `/implement` directly. The deciding question is "are these independently mergeable?", not "which epic is this under?"
 
 ## Input
 
-$ARGUMENTS is a Jira task identifier under DAT-294 (a direct child or a child of a sub-epic). Refuse to start if the ticket is not under DAT-294.
+$ARGUMENTS is a Jira task identifier (or a sub-item of one). The only gates that matter are below: the task is **independently mergeable** and its blocking dependencies are **Done**. Being a sub-item of a larger ticket, or living outside any particular epic, is **not** a reason to refuse — a lane targets a unit of independently-mergeable work, wherever it sits in the ticket hierarchy.
 
 ## Step 1: Pre-check (lane can open)
 
 Before touching any code:
 
-1. **Fetch the task ticket.** Confirm: parent is a DAT-294 phase, status is To Do or In Progress, every `is blocked by` dependency is Done. Surface the blocker list and STOP if any is not Done.
+1. **Fetch the task ticket.** Confirm: status is To Do or In Progress, and every `is blocked by` dependency is Done. Surface the blocker list and STOP only if a *real* blocking dependency is not Done — not because of where the ticket sits in the hierarchy. If a dependency is itself small and unblocked, consider whether the right move is to take it first rather than stall.
 2. **Check for existing worktree** at `.worktrees/{task-id}/`. If branch matches `feat/{task-id}-{slug}` → resume it. If branch is something else → STOP and ask. **Note:** worktrees live INSIDE the main repo at `.worktrees/{task-id}/` (gitignored). This is load-bearing for the review gate — subagents spawned by `/implement` inherit the orchestrator's `$CLAUDE_PROJECT_DIR` and can only `Read` paths underneath it, so a sibling worktree at `../dataraum-context.worktrees/...` is invisible to them and the review gate fails silently.
 3. **Check for existing PR** via `gh pr list --search "{task-id} in:title"`. If open → the lane is already in flight. STOP and ask.
 4. **Check the status board** `.claude/platform-status.md`. STOP if another active lane claims this task or a contract this task touches.
@@ -178,18 +178,18 @@ The orchestrator session does NOT touch code — it only:
 
 ## When NOT to use /take
 
-- Non-platform work (single-stream library work): use `/refine` + `/implement` directly
-- Spikes (DAT-295/296/297/298): throwaway exploration — no worktree isolation needed
-- Contract-lock PRs: separate flow — small, focused, reviewer-heavy, not phased
-- S-size bug fixes inside an already-merged task: normal feature branch on `main`
+- Single-stream work: use `/refine` + `/implement` directly. This includes a multi-step feature that ships PR-per-step on one shared branch — that's one stream, not parallel lanes.
+- Spikes / throwaway exploration: no worktree isolation needed.
+- Contract-lock PRs: separate flow — small, focused, reviewer-heavy, not phased.
+- S-size bug fixes inside an already-merged task: normal feature branch, just do it.
 
 ## Rules
 
 - One task per worktree, one worktree per task
-- Contract locked BEFORE the lane opens — no exceptions
+- If the task names a contract, it's locked BEFORE the lane opens — no exceptions
 - Lane smoke is mandatory; integration smoke is informational
 - Do not edit contracts from inside a lane
-- Do not reach into other lanes' code
-- Three-strikes rule applies — stop and report, don't power through
+- **Don't collide with another *in-flight* lane:** don't edit files a concurrently-open lane owns (check `platform-status.md`). This is about avoiding parallel-merge conflicts between *running* lanes — it is NOT a rule against touching code outside your ticket's nominal scope. A design-implied or obviously-correct change in your blast radius is fair game (see `/implement` → "Scope is a fence, not a cage").
+- Three-strikes rule applies — stop and report, don't power through. But "blocked by a small unblocked dependency" is a cue to *take the dependency*, not to stall.
 - The lane closes when the PR opens, not when it merges
 - Update `.claude/platform-status.md` so the user sees all lanes at once

--- a/packages/cockpit/CLAUDE.md
+++ b/packages/cockpit/CLAUDE.md
@@ -43,6 +43,16 @@ TanStack **Start** (React 19) · **Router** / **Query** · **Mantine v9** + **Ta
 - **Temporal is Client-only on the cockpit side** — use `@temporalio/client` from server functions to start/signal/query workflows; the workflows themselves are **Python** (`packages/engine/src/dataraum/worker/workflows.py`). No `@temporalio/worker` or `@temporalio/workflow` in the cockpit, hence no native core-bridge (stays alpine). **Bun ≥ 1.3.14** still pinned.
 - Env only through `config.ts` (never `process.env`). One Mantine component per widget; Tailwind for layout. Routes that need data use `loader: queryClient.ensureQueryData(...)` so SSR dehydrates.
 
+## UI quality bar — build for practitioner data, not demo data
+
+A widget that "renders" is not done. The user's real query returns big, messy data, and the bar is **usable at that scale**, not "it displayed something in the 5-row demo." Before you call a data surface finished, design for these up front — they are requirements, not polish:
+
+- **Never render an unbounded result set into the DOM.** Any list/grid/table that can hold a large result set **virtualizes** (the result grid uses `@tanstack/react-virtual`) or paginates/caps. Dumping 50k rows into the page is a bug — it freezes the tab and burns memory. "It rendered all 50k" is the failure, not the success.
+- **Loading, empty, and error states are part of the widget**, not afterthoughts. A surface with no empty state or no error state is incomplete.
+- **Perceived performance:** stream/skeleton long operations; don't block the UI on a slow query. Big payloads cross the wire in a bounded/columnar shape (see the run_sql streaming-grid design), not one giant JSON blob.
+
+If you notice yourself thinking "this works" about a surface you only tried with toy data, that's the cue to push it to realistic scale — which is exactly what `/smoke` step 4 checks.
+
 ## Driving the UI from a session
 
 Playwright MCP is registered per-project in `~/.claude.json` (stdio, `npx @playwright/mcp@latest`) — browser tools are available automatically when the dev server is up on `:3000`. Bring up engine + `bun run dev`, then point the agent at a page; edits land hot via Vite.


### PR DESCRIPTION
## Why

Five workflow behaviors had drifted toward defensive, permission-seeking, scope-fenced conduct — the *corporate* failure mode the project's own CLAUDE.md + memory already reject ("Default to the clean cut", "Decide, don't hedge", "quick fix → just do it"). The philosophy was right; the **skills** still encoded an older posture and were overriding it. Observed in the wild:

- An agent refused a **sub-item** because it "wasn't its own task."
- An agent wouldn't use `/take` because the ticket wasn't under DAT-294.
- One-liner fixes deferred because "not in ticket scope."
- Dependency-circle spinning + an entry-level answer arrived at slowly — while the eval agent knocked out a hard stats problem in 45 min.
- A 50k-row DB result dumped into an HTML grid and deemed "fine."

## Changes

| Skill | Fix |
|---|---|
| **take** | Decouple from DAT-294 — it's a reusable *parallel-lane mechanism*, not an epic. Drop the "refuse if not under DAT-294" gate; a lane targets any independently-mergeable unit (top-level, child, or **sub-item**). Reframe "don't reach into other lanes' code" as *don't collide with a concurrently in-flight lane* — not a ban on touching code outside nominal ticket scope. Fix the dangling "Parallel platform work runbook" reference. |
| **refine** | New Step 0 triage — clear & small → don't refine, just do it. Full pass is for genuinely ambiguous/risky/M+ work. "Deliberation has a cost too." |
| **implement** | S-size skips the plan ceremony. `DO NOT change` carries CLAUDE.md's full nuance (fence *unrelated* sprawl; design-implied cleanup + obvious in-blast-radius fixes are in-scope). Rebalance "psychological safety" with a counterweight: escalating-what-you-could-solve and stalling "blocked by" a small prereq cost the same trust as a false "done". Default to solving; reserve stops for genuine forks. |
| **smoke** + **cockpit/CLAUDE.md** | Close the UI-scale gap. `smoke` step 4 now pushes surfaces to *realistic* scale (does it virtualize/paginate/cap, or freeze on 50k rows?); cockpit/CLAUDE.md adds an up-front UI quality bar. |

## Note for the reviewer

`smoke/SKILL.md` also carries the in-flight **container / duckdb-neo step-1 rewrite** that was already uncommitted in the working tree (pulled in so this PR doesn't revert it). The grid instance itself is already being virtualized in separate uncommitted cockpit WIP — these changes are the *systemic* prevention, not the one-off fix.

Docs/skills only — no code, no CI gates touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)