### PR TITLE
feat(DAT-385-P3): server-side column sort for the streaming result grid

### DIFF
--- a/packages/cockpit/src/duckdb/stream-sql.integration.test.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.integration.test.ts
@@ -20,7 +20,9 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
 	type AbortSignalLike,
+	buildGridQuery,
 	clampGridCap,
+	type GridSort,
 	type ResultFrame,
 	type StreamableResult,
 	streamNdjson,
@@ -35,8 +37,11 @@ async function streamQuery(
 	sql: string,
 	cap: number,
 	params?: (string | number | boolean | null)[],
+	sort?: GridSort,
 ): Promise<ResultFrame[]> {
-	const wrapped = `SELECT * FROM (${sql}) AS _run_sql`;
+	// Compose through buildGridQuery — exactly what the route does — so the sort
+	// path is exercised against the real driver, not a hand-wrapped string.
+	const wrapped = buildGridQuery(sql, sort);
 	const result = (await (params
 		? readerConn.stream(wrapped, params)
 		: readerConn.stream(wrapped))) as unknown as StreamableResult;
@@ -226,6 +231,39 @@ describe("streamNdjson over a real DuckLake lake (DAT-385)", () => {
 		const total = batches.reduce((s, b) => s + (b.t === "b" ? b.n : 0), 0);
 		expect(total).toBe(5000);
 		expect(frames.at(-1)).toEqual({ t: "f", rows: 5000 });
+	});
+
+	it("applies a server-side sort (DESC) over the wrapped query", async () => {
+		const sort: GridSort = { column: "amount", dir: "desc" };
+		const frames = await streamQuery(
+			"SELECT id, customer, amount FROM lake.typed.orders",
+			1000,
+			undefined,
+			sort,
+		);
+		const batch = frames[1];
+		if (batch.t !== "b") throw new Error("expected batch");
+		// amount DESC: 50.50 (id 3), 10.00 (id 1), 9.99 (id 2).
+		expect(batch.cols[0]).toEqual([3, 1, 2]);
+		expect(batch.cols[2]).toEqual(["50.50", "10.00", "9.99"]);
+	});
+
+	it("sorts BEFORE the cap, so a truncated result still shows the true top-N", async () => {
+		// `big` is range(5000); ORDER BY n DESC then cap at 3 must surface the
+		// global top — 4999, 4998, 4997 — NOT the first 3 streamed rows. This is
+		// the whole reason sort is server-side, not client-side over the window.
+		// (range() is BIGINT → JSON-safe STRING via the bigint→string coercion.)
+		const sort: GridSort = { column: "n", dir: "desc" };
+		const frames = await streamQuery(
+			"SELECT n FROM lake.typed.big",
+			3,
+			undefined,
+			sort,
+		);
+		const batch = frames[1];
+		if (batch.t !== "b") throw new Error("expected batch");
+		expect(batch.cols[0]).toEqual(["4999", "4998", "4997"]);
+		expect(frames.at(-1)).toEqual({ t: "f", rows: 3, truncated: true, cap: 3 });
 	});
 
 	it("emits an in-band error footer for a bad query (HTTP would stay 200)", async () => {

--- a/packages/cockpit/src/duckdb/stream-sql.test.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.test.ts
@@ -6,9 +6,11 @@ import { describe, expect, it } from "vitest";
 
 import { HARD_ROW_CEILING } from "#/duckdb/limit";
 import {
+	buildGridQuery,
 	clampGridCap,
 	encodeFrame,
 	GRID_DEFAULT_CAP,
+	quoteIdentifier,
 	type ResultFrame,
 	type StreamableChunk,
 	type StreamableResult,
@@ -88,6 +90,56 @@ describe("clampGridCap (design §5.5)", () => {
 
 	it("floors a fractional cap", () => {
 		expect(clampGridCap(10.9)).toBe(10);
+	});
+});
+
+describe("quoteIdentifier", () => {
+	it("wraps a plain name in double quotes", () => {
+		expect(quoteIdentifier("amount")).toBe('"amount"');
+	});
+
+	it("doubles embedded quotes so a name can never break out of the literal", () => {
+		// A column literally named `weird"name` (or an injection attempt) is quoted,
+		// not escaped-then-concatenated: the embedded `"` is doubled.
+		expect(quoteIdentifier('weird"name')).toBe('"weird""name"');
+		expect(quoteIdentifier('x" ; DROP TABLE t --')).toBe(
+			'"x"" ; DROP TABLE t --"',
+		);
+	});
+});
+
+describe("buildGridQuery (design §7.3 — server-side sort)", () => {
+	it("wraps the query unchanged when there is no sort", () => {
+		expect(buildGridQuery("SELECT * FROM lake.typed.orders")).toBe(
+			"SELECT * FROM (SELECT * FROM lake.typed.orders) AS _run_sql",
+		);
+		expect(buildGridQuery("SELECT 1", null)).toBe(
+			"SELECT * FROM (SELECT 1) AS _run_sql",
+		);
+	});
+
+	it("appends an ORDER BY on the quoted column for asc/desc", () => {
+		expect(
+			buildGridQuery("SELECT id, amount FROM t", {
+				column: "amount",
+				dir: "asc",
+			}),
+		).toBe(
+			'SELECT * FROM (SELECT id, amount FROM t) AS _run_sql ORDER BY "amount" ASC',
+		);
+		expect(
+			buildGridQuery("SELECT id FROM t", { column: "id", dir: "desc" }),
+		).toBe('SELECT * FROM (SELECT id FROM t) AS _run_sql ORDER BY "id" DESC');
+	});
+
+	it("quotes the sort column so a hostile name can't inject", () => {
+		const out = buildGridQuery("SELECT * FROM t", {
+			column: 'x" ; DROP TABLE t --',
+			dir: "asc",
+		});
+		expect(out).toBe(
+			'SELECT * FROM (SELECT * FROM t) AS _run_sql ORDER BY "x"" ; DROP TABLE t --" ASC',
+		);
 	});
 });
 

--- a/packages/cockpit/src/duckdb/stream-sql.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.ts
@@ -53,6 +53,49 @@ export function clampGridCap(cap?: number): number {
 	return Math.min(floored, HARD_ROW_CEILING);
 }
 
+// --- Query composition (design §7.3 — server-side sort, DAT-385 P3) ----------
+
+/**
+ * A single-column sort the grid asks the server to apply. `column` is an OUTPUT
+ * column name of the user's query (the grid only offers names it received in the
+ * stream header); `dir` is the sort direction.
+ */
+export interface GridSort {
+	column: string;
+	dir: "asc" | "desc";
+}
+
+/**
+ * Quote `name` as a DuckDB identifier: wrap in double quotes and double any
+ * embedded quote. This is the ONLY safe way to interpolate a column name into
+ * SQL — the grid's sort column is user/agent-influenced (it's an output column
+ * of arbitrary `run_sql`), so it can never be concatenated raw. A bogus name
+ * still can't inject; it just yields a binder error the stream reports in-band.
+ */
+export function quoteIdentifier(name: string): string {
+	return `"${name.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Wrap the user's `sql` as the grid's effective query, optionally appending a
+ * server-side `ORDER BY`.
+ *
+ * Sort MUST be server-side, not client-side: the grid caps at
+ * {@link GRID_DEFAULT_CAP} and can truncate, so sorting only the streamed window
+ * would sort an arbitrary first-N slice of a larger result. Ordering the wrapped
+ * query applies the sort BEFORE the cap, so the grid shows the true top-N.
+ *
+ * Sort carries NO bind values, so this never perturbs the caller's positional
+ * `params` ($1, $2, …) — they bind against the inner `sql` exactly as before.
+ * (Filter values, which WOULD need param renumbering, are a later phase.)
+ */
+export function buildGridQuery(sql: string, sort?: GridSort | null): string {
+	const base = `SELECT * FROM (${sql}) AS _run_sql`;
+	if (!sort) return base;
+	const dir = sort.dir === "desc" ? "DESC" : "ASC";
+	return `${base} ORDER BY ${quoteIdentifier(sort.column)} ${dir}`;
+}
+
 // --- Wire protocol (design §4) -----------------------------------------------
 
 /**

--- a/packages/cockpit/src/routes/api/run-sql.ts
+++ b/packages/cockpit/src/routes/api/run-sql.ts
@@ -14,8 +14,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { getLakeConnection } from "../../duckdb/lake";
 import {
+	buildGridQuery,
 	clampGridCap,
 	encodeFrame,
+	type GridSort,
 	type StreamableResult,
 	streamNdjson,
 } from "../../duckdb/stream-sql";
@@ -36,6 +38,42 @@ interface RunSqlStreamBody {
 	 * materialization.
 	 */
 	cap?: number;
+	/**
+	 * Optional server-side single-column sort (DAT-385 P3). Applied to the wrapped
+	 * query so it orders the FULL result before the cap, not just the streamed
+	 * window. `column` must be an output column name of `sql`; the server quotes
+	 * it as an identifier, so a bad name yields a binder error, never injection.
+	 */
+	sort?: GridSort;
+}
+
+/** Validate an optional sort field; returns the sort, null (absent), or an error. */
+function parseSort(
+	raw: unknown,
+): { sort: GridSort | null } | { error: string } {
+	if (raw === undefined || raw === null) return { sort: null };
+	// `typeof [] === "object"`, so reject arrays explicitly — otherwise a JSON
+	// array falls through to the column check and yields a misleading error.
+	if (typeof raw !== "object" || Array.isArray(raw))
+		return { error: "Field 'sort' must be an object." };
+	const { column, dir } = raw as { column?: unknown; dir?: unknown };
+	// Bound the length: a validated field must not accept an arbitrarily large
+	// string that would balloon the SQL handed to DuckDB (a column name this long
+	// is never a real output column anyway).
+	if (
+		typeof column !== "string" ||
+		column.length === 0 ||
+		column.length > 256
+	) {
+		return {
+			error:
+				"Field 'sort.column' is required and must be a non-empty string (max 256 chars).",
+		};
+	}
+	if (dir !== "asc" && dir !== "desc") {
+		return { error: "Field 'sort.dir' must be 'asc' or 'desc'." };
+	}
+	return { sort: { column, dir } };
 }
 
 let queryCounter = 0;
@@ -67,6 +105,9 @@ export const Route = createFileRoute("/api/run-sql")({
 					return badRequest("Field 'sql' is required and must be a string.");
 				}
 
+				const sortResult = parseSort(body.sort);
+				if ("error" in sortResult) return badRequest(sortResult.error);
+
 				const cap = clampGridCap(body.cap);
 				const queryId = nextQueryId();
 				const params = body.params;
@@ -80,7 +121,7 @@ export const Route = createFileRoute("/api/run-sql")({
 				// SQL parse/bind error that surfaces here can still become a 400
 				// (e.g. malformed `sql`). Once the ReadableStream starts flushing the
 				// status is locked at 200 and mid-stream errors go in the footer.
-				const wrapped = `SELECT * FROM (${body.sql}) AS _run_sql`;
+				const wrapped = buildGridQuery(body.sql, sortResult.sort);
 				let result: StreamableResult;
 				try {
 					const conn = await getLakeConnection();

--- a/packages/cockpit/src/ui/cockpit/widgets/result-grid.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/result-grid.test.tsx
@@ -13,11 +13,12 @@
 // path is exercised by the ColumnStore unit tests (ndjson-stream.test.ts).
 
 import { MantineProvider } from "@mantine/core";
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ColumnStore } from "#/duckdb/ndjson-stream";
-import { ResultGridView } from "#/ui/cockpit/widgets/result-grid";
+import type { GridSort } from "#/duckdb/stream-sql";
+import { cycleSort, ResultGridView } from "#/ui/cockpit/widgets/result-grid";
 import { theme } from "#/ui/theme";
 
 function seeded(): ColumnStore {
@@ -42,6 +43,36 @@ function renderView(store: ColumnStore, fatal?: string | null) {
 		</MantineProvider>,
 	);
 }
+
+function renderSortable(
+	store: ColumnStore,
+	sort: GridSort | null,
+	onToggleSort: (column: string) => void,
+) {
+	render(
+		<MantineProvider theme={theme} env="test">
+			<ResultGridView store={store} sort={sort} onToggleSort={onToggleSort} />
+		</MantineProvider>,
+	);
+}
+
+describe("cycleSort (DAT-385 P3 sort state machine)", () => {
+	it("cycles unsorted → asc → desc → unsorted on the same column", () => {
+		expect(cycleSort(null, "amount")).toEqual({ column: "amount", dir: "asc" });
+		expect(cycleSort({ column: "amount", dir: "asc" }, "amount")).toEqual({
+			column: "amount",
+			dir: "desc",
+		});
+		expect(cycleSort({ column: "amount", dir: "desc" }, "amount")).toBeNull();
+	});
+
+	it("starts a different column at asc, abandoning the previous sort", () => {
+		expect(cycleSort({ column: "amount", dir: "desc" }, "id")).toEqual({
+			column: "id",
+			dir: "asc",
+		});
+	});
+});
 
 describe("ResultGridView (DAT-385 P2)", () => {
 	afterEach(() => cleanup());
@@ -74,5 +105,34 @@ describe("ResultGridView (DAT-385 P2)", () => {
 		const err = screen.getByTestId("canvas-result-grid-error");
 		expect(err.textContent).toContain("connection refused");
 		expect(screen.getByText("error")).toBeTruthy();
+	});
+
+	it("fires onToggleSort with the clicked column name (DAT-385 P3)", () => {
+		const store = seeded();
+		store.apply({ t: "f", rows: 3 });
+		const onToggleSort = vi.fn();
+		renderSortable(store, null, onToggleSort);
+		fireEvent.click(screen.getByTestId("canvas-result-grid-header-name"));
+		expect(onToggleSort).toHaveBeenCalledWith("name");
+	});
+
+	it("shows a direction indicator on the active sort column", () => {
+		const store = seeded();
+		store.apply({ t: "f", rows: 3 });
+		renderSortable(store, { column: "id", dir: "asc" }, vi.fn());
+		// The ascending glyph rides the sorted column header; the OTHER header has
+		// no indicator. (Body rows are virtualized away in headless DOM — header
+		// is the layout-independent surface, see the file note.)
+		expect(screen.getByLabelText("sorted ascending")).toBeTruthy();
+		expect(screen.queryByLabelText("sorted descending")).toBeNull();
+	});
+
+	it("renders static (non-clickable) headers when onToggleSort is omitted", () => {
+		const store = seeded();
+		store.apply({ t: "f", rows: 3 });
+		renderView(store);
+		// No sort indicators and no crash without the callback.
+		expect(screen.queryByLabelText("sorted ascending")).toBeNull();
+		expect(screen.queryByLabelText("sorted descending")).toBeNull();
 	});
 });

--- a/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
@@ -1,18 +1,23 @@
-// Result-grid widget (DAT-385 P2) — the human-facing SQL result surface.
+// Result-grid widget (DAT-385 P2 grid + P3 server-side sort) — the human-facing
+// SQL result surface.
 //
-// Splits cleanly in two:
+// Splits cleanly in three:
 //   - ResultGridView: PURE render of a ColumnStore via TanStack Table with
-//     index-rows + accessorFn (no row-object rematerialization). Trivially
-//     testable with a pre-seeded store, no I/O.
-//   - ResultGridWidget: owns the I/O — POSTs the carried SQL to the P1
-//     `/api/run-sql` NDJSON endpoint, folds frames into a ColumnStore as they
-//     arrive, and aborts the fetch on unmount/query-change (the server then
-//     emits a `cancelled` footer). The only widget that does I/O — the baseline
-//     widgets are static — so the streaming state is contained here.
+//     index-rows + accessorFn (no row-object rematerialization). Headers are
+//     interactive when given `onToggleSort`. Trivially testable, no I/O.
+//   - ResultGridWidget: the registered entry. Owns the BASE query (the agent's
+//     run_sql call) and `key`s the inner grid on it, so a new agent query
+//     remounts the grid and resets the sort cleanly.
+//   - StreamingGrid: owns the I/O + the grid-local sort. POSTs sql+params+sort
+//     to the P1 `/api/run-sql` NDJSON endpoint, folds frames into a ColumnStore
+//     as they arrive, and aborts the fetch on unmount/query-change/sort-change
+//     (the server then emits a `cancelled` footer).
 //
-// P2 scope: read-only, server-side sort/filter is P3. The body IS virtualized
-// (only the visible window hits the DOM) — load-bearing for the 50k streaming
-// cap, not optional.
+// Sort is SERVER-SIDE (re-issue with ORDER BY), not a client reorder: the grid
+// caps at 50k and can truncate, so the sort must run before the cap to show the
+// true top-N. Filter + keyset paging stay deferred (a connected, researched P3/P4
+// effort). The body IS virtualized (only the visible window hits the DOM) —
+// load-bearing for the 50k streaming cap, not optional.
 
 import type { Json } from "@duckdb/node-api";
 import { Alert, Badge, Group, Table, Text } from "@mantine/core";
@@ -24,8 +29,9 @@ import {
 	useReactTable,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ColumnStore, readNdjsonStream } from "#/duckdb/ndjson-stream";
+import type { GridSort } from "#/duckdb/stream-sql";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
 
 // §7.3 hook: carry the neo column type metadata on each TanStack column. P2
@@ -55,13 +61,37 @@ const STATUS_COLOR = {
 	error: "red",
 } as const;
 
-/** Pure presentation of a (possibly still-filling) ColumnStore. */
+/**
+ * The next sort after a header click: unsorted → asc → desc → unsorted. Clicking
+ * a DIFFERENT column starts that column at asc. Pure, so the state machine is
+ * unit-testable without the streaming widget.
+ */
+export function cycleSort(
+	current: GridSort | null,
+	column: string,
+): GridSort | null {
+	if (!current || current.column !== column) return { column, dir: "asc" };
+	if (current.dir === "asc") return { column, dir: "desc" };
+	return null;
+}
+
+/** Pure presentation of a (possibly still-filling) ColumnStore.
+ *
+ * `sort` + `onToggleSort` make the column headers interactive (DAT-385 P3): a
+ * click asks the OWNER to re-issue the query with a new server-side sort. The
+ * view itself never reorders rows — sort runs before the cap, server-side, so a
+ * truncated result still shows the true top-N. Omit `onToggleSort` (e.g. in a
+ * pure-render test) and the headers stay static. */
 export function ResultGridView({
 	store,
 	fatal,
+	sort,
+	onToggleSort,
 }: {
 	store: ColumnStore;
 	fatal?: string | null;
+	sort?: GridSort | null;
+	onToggleSort?: (column: string) => void;
 }) {
 	// Index-rows: TanStack Table iterates row indices; each accessor reads its
 	// column array at that index — O(1), no row objects ever built.
@@ -149,14 +179,44 @@ export function ResultGridView({
 					<Table striped highlightOnHover stickyHeader>
 						<Table.Thead>
 							<Table.Tr>
-								{table.getFlatHeaders().map((header) => (
-									<Table.Th key={header.id}>
-										{flexRender(
-											header.column.columnDef.header,
-											header.getContext(),
-										)}
-									</Table.Th>
-								))}
+								{table.getFlatHeaders().map((header) => {
+									const name = String(header.column.columnDef.header ?? "");
+									const active = sort?.column === name;
+									const clickable = onToggleSort !== undefined;
+									return (
+										<Table.Th
+											key={header.id}
+											onClick={clickable ? () => onToggleSort(name) : undefined}
+											style={
+												clickable
+													? { cursor: "pointer", userSelect: "none" }
+													: undefined
+											}
+											data-testid={`canvas-result-grid-header-${name}`}
+										>
+											<Group gap={4} wrap="nowrap">
+												{flexRender(
+													header.column.columnDef.header,
+													header.getContext(),
+												)}
+												{active && (
+													<Text
+														span
+														size="xs"
+														c="dimmed"
+														aria-label={
+															sort.dir === "asc"
+																? "sorted ascending"
+																: "sorted descending"
+														}
+													>
+														{sort.dir === "asc" ? "▲" : "▼"}
+													</Text>
+												)}
+											</Group>
+										</Table.Th>
+									);
+								})}
 							</Table.Tr>
 						</Table.Thead>
 						<Table.Tbody>
@@ -198,31 +258,66 @@ export function ResultGridView({
 	);
 }
 
-/** The registered widget: streams `/api/run-sql` for the carried query. */
+/**
+ * The registered widget. Owns the BASE query (the agent's `run_sql` call) and
+ * remounts the inner grid whenever that query changes, via a value-stable `key`.
+ *
+ * The remount is deliberate: the inner grid holds the grid-local sort state, and
+ * remounting on a new base query resets the sort cleanly to "unsorted" without a
+ * reset effect (which would fire a redundant second stream). The agent's
+ * `state.sql`/`params` stay immutable — sort is a VIEW concern, never written
+ * back to the canvas state.
+ */
 export function ResultGridWidget({
 	state,
 }: {
 	state: Extract<CanvasState, { kind: "result-grid" }>;
 }) {
-	const storeRef = useRef(new ColumnStore());
-	const [, bump] = useState(0);
-	const [fatal, setFatal] = useState<string | null>(null);
-
-	// Value-stable query identity: ChatRail re-dispatches a fresh canvasState
-	// object on every message tick, so keying the stream effect on object
-	// identity would re-fire (and re-stream) constantly. Serialize sql+params so
-	// the effect only re-runs when the QUERY actually changes.
-	const queryKey = useMemo(
+	// ChatRail re-dispatches a fresh canvasState object on every message tick;
+	// serialize sql+params so a new `key` is produced only when the QUERY actually
+	// changes, not on per-tick object churn.
+	const baseKey = useMemo(
 		() => JSON.stringify([state.sql, state.params ?? null]),
 		[state.sql, state.params],
 	);
+	return <StreamingGrid key={baseKey} sql={state.sql} params={state.params} />;
+}
+
+/** Streams `/api/run-sql` for the carried query and owns the grid-local sort. */
+function StreamingGrid({
+	sql,
+	params,
+}: {
+	sql: string;
+	params?: (string | number | boolean | null)[];
+}) {
+	const storeRef = useRef(new ColumnStore());
+	const [, bump] = useState(0);
+	const [fatal, setFatal] = useState<string | null>(null);
+	// Grid-local view state: which column the SERVER should order by. Reset to
+	// null on a new base query (this component remounts — see ResultGridWidget).
+	const [sort, setSort] = useState<GridSort | null>(null);
+
+	// Header click cycles the sort for that column: unsorted → asc → desc →
+	// unsorted. Switching to a different column starts at asc.
+	// Stable identity (setSort is stable, no deps) so a future React.memo on the
+	// view doesn't re-render the grid on every sort-irrelevant parent render.
+	const toggleSort = useCallback((column: string) => {
+		setSort((cur) => cycleSort(cur, column));
+	}, []);
+
+	// Value-stable request identity: re-stream iff sql, params, OR sort changed.
+	// Parse them back out inside the effect so the effect's ONLY dependency is the
+	// key — no stale closures, no churn from ChatRail's fresh objects.
+	const requestKey = useMemo(
+		() => JSON.stringify([sql, params ?? null, sort]),
+		[sql, params, sort],
+	);
 	useEffect(() => {
-		// Parse the query back out of the value-stable key so the effect's ONLY
-		// dependency is the key itself — re-stream iff the query actually changed,
-		// never on ChatRail's per-tick fresh-object churn.
-		const [sql, params] = JSON.parse(queryKey) as [
+		const [qSql, qParams, qSort] = JSON.parse(requestKey) as [
 			string,
 			(string | number | boolean | null)[] | null,
+			GridSort | null,
 		];
 		const store = new ColumnStore();
 		storeRef.current = store;
@@ -235,7 +330,11 @@ export function ResultGridWidget({
 				const res = await fetch("/api/run-sql", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ sql, params: params ?? undefined }),
+					body: JSON.stringify({
+						sql: qSql,
+						params: qParams ?? undefined,
+						sort: qSort ?? undefined,
+					}),
 					signal: ac.signal,
 				});
 				if (!res.ok || !res.body) {
@@ -247,13 +346,20 @@ export function ResultGridWidget({
 					bump((v) => v + 1);
 				});
 			} catch (err) {
-				// An aborted fetch (unmount / new query) is expected — not an error.
+				// An aborted fetch (unmount / new query / new sort) is expected.
 				if (ac.signal.aborted) return;
 				setFatal(err instanceof Error ? err.message : String(err));
 			}
 		})();
 		return () => ac.abort();
-	}, [queryKey]);
+	}, [requestKey]);
 
-	return <ResultGridView store={storeRef.current} fatal={fatal} />;
+	return (
+		<ResultGridView
+			store={storeRef.current}
+			fatal={fatal}
+			sort={sort}
+			onToggleSort={toggleSort}
+		/>
+	);
 }


### PR DESCRIPTION
Click a result-grid header to sort: cycle none→asc→desc→none, with a ▲/▼ indicator on the active column. Sort is SERVER-SIDE (re-issue the query with ORDER BY), not a client reorder of the streamed window — the grid caps at 50k and can truncate, so the sort must run before the cap to show the true top-N (proven by a sort-before-cap integration test).

- stream-sql.ts: pure `buildGridQuery(sql, sort?)` + `quoteIdentifier` (identifier injection neutralized) + `GridSort`. Sort carries no binds, so positional `params` are unperturbed.
- run-sql.ts: optional `sort` field + `parseSort` validation (rejects arrays, bounds column length, dir ∈ {asc,desc}) → 400 on malformed.
- result-grid.tsx: split into keyed `ResultGridWidget` → `StreamingGrid` (owns grid-local sort + the re-stream effect; remount-on-new-query resets sort with no redundant fetch) → pure `ResultGridView` (clickable headers). `cycleSort` extracted as a pure, unit-tested state machine. Sort is a VIEW concern — the agent's sql/params/canvas-state stay immutable.

Filter + keyset/infinite-scroll paging stay deferred to a connected, researched P3/P4 effort. 293 unit + 11 stream-sql integration green; biome + tsc clean.