### PR TITLE
feat(DAT-394): one terminal detect step + persisted per-intent readiness

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -44,11 +44,14 @@ What changed in the engine (calibration-relevant):
   removed activity names would otherwise non-determinism-fail mid-history. No `patched()` guard
   added (dev-acceptable).
 
-### Cockpit (cross-PACKAGE — not in this branch)
+### Cockpit (cross-PACKAGE — DONE in this branch)
 
-- **Drizzle metadata mirror must be re-pulled** (`bun run db:pull:metadata`, against a **fresh**
-  DB) to expose `entropy_readiness` to the cockpit `why`/`look` tools (DAT-353). The engine
-  schema is the source; the cockpit TS mirror is regenerated, not hand-edited.
+- **Drizzle metadata mirror re-pulled** (`src/db/metadata/{schema,relations}.ts` now expose
+  `entropy_readiness`) so the compose-smoke Drizzle drift check stays green and the cockpit
+  `why`/`look` tools (DAT-353) can read it. Regenerated via `bun run db:pull:metadata` from a
+  fresh isolated schema built by the branch's `create_all` — diff is exactly the new table +
+  relations (no schema-name churn). The engine schema is the source; the mirror is generated,
+  never hand-edited.
 
 ### dataraum-testdata (hints)
 

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,56 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-01: DAT-394 — one terminal `detect` step + persisted per-intent readiness
+
+Collapses detector execution into a single source-wide `detect` activity and persists
+the readiness-v2 rollup. The BBN was already retired (DAT-393); this lands its
+persistence + simplifies where detectors run.
+
+What changed in the engine (calibration-relevant):
+- **Activity rename: `detect_table` + `detect_source` → a single `detect`.** Detectors no
+  longer run per-table at the child tail (`detect_table`) or in a separate parent step
+  (`detect_source`). One `detect` activity in `addSourceWorkflow`, after
+  `semantic_per_column`, runs the **union of all wired detectors source-wide**
+  (`run_detectors`, `table_ids=None`). The set is unchanged — `type_fidelity`, `null_ratio`
+  (was detect_table) + `business_meaning`, `unit_entropy`, `temporal_entropy`,
+  `outlier_rate`, `benford` (was detect_source). **Detector scores are byte-for-byte
+  unchanged** — only the execution site/timing moved (rationale: nothing reads entropy
+  mid-run; the split bought no parallelism). The per-table analytics fan-out
+  (`typing→…→temporal`) is unchanged.
+- **New `entropy_readiness` table** (one row per analyzed column, written by `detect`):
+  collapsed `band` (ready/investigate/blocked — the contract-gate signal) + `worst_intent_risk`
+  + `intents` JSONB (`[{intent, band, risk, drivers:[{node,state,impact_delta}]}]`, the
+  query/aggregation/reporting split) + `top_drivers` JSONB + FKs. Delete-before-insert scoped
+  to `source_id` → self-refreshing on any replay.
+
+### dataraum-eval
+
+- **Eval action: confirm detector-score PARITY (the bar for this PR).** The execution site
+  moved, the scoring did not — `test_detector_precision` baselines must be unchanged. Any
+  delta is a bug in the move, not expected drift. Drive a run the same way (`addSourceWorkflow`);
+  the new `detect` step is internal to the workflow.
+- **Harness/fixture update: activity names changed.** Anything that invokes activities by name
+  or inspects Temporal history for `detect_table` / `detect_source` must switch to the single
+  `detect`. A replay still always re-runs the reduce + `detect` at the parent tail (unchanged
+  semantics; `detect` is never a `from_phase` entry point).
+- **New end-to-end surface to verify:** `entropy_readiness` now lets eval assert the readiness
+  shape directly (per-column band + per-intent breakdown). On clean below-floor data `intents`
+  is legitimately empty (band `ready`); richness appears as detector scores cross the 0.3 floor.
+- **Deploy note (dev): drain in-flight `addSourceWorkflow` runs before deploying** — the
+  removed activity names would otherwise non-determinism-fail mid-history. No `patched()` guard
+  added (dev-acceptable).
+
+### Cockpit (cross-PACKAGE — not in this branch)
+
+- **Drizzle metadata mirror must be re-pulled** (`bun run db:pull:metadata`, against a **fresh**
+  DB) to expose `entropy_readiness` to the cockpit `why`/`look` tools (DAT-353). The engine
+  schema is the source; the cockpit TS mirror is regenerated, not hand-edited.
+
+### dataraum-testdata (hints)
+
+- None. No detector or fixture surface changed.
+
 ## 2026-06-01: DAT-364 (tail) — temporal `analyze_update_frequency` NaN guard
 
 Bug fix found while building the DAT-364 isolation test (the workflow-ID change itself is

--- a/packages/cockpit/src/db/metadata/relations.ts
+++ b/packages/cockpit/src/db/metadata/relations.ts
@@ -23,6 +23,7 @@ export const relations = defineRelations(schema, (r) => ({
 		}),
 		enrichedViewss: r.many.enrichedViews(),
 		entropyObjectss: r.many.entropyObjects(),
+		entropyReadinesss: r.many.entropyReadiness(),
 		fixLedgers: r.many.fixLedger(),
 		sources: r.one.sources({
 			from: r.investigationSessions.sourceId,
@@ -108,6 +109,7 @@ export const relations = defineRelations(schema, (r) => ({
 					"investigationSessions_sessionId_sources_sourceId_via_detectedBusinessCycles",
 			}),
 		entropyObjectss: r.many.entropyObjects(),
+		entropyReadinesss: r.many.entropyReadiness(),
 		fixLedgers: r.many.fixLedger(),
 		investigationSessionssSourceId: r.many.investigationSessions({
 			alias: "investigationSessions_sourceId_sources_sourceId",
@@ -129,6 +131,7 @@ export const relations = defineRelations(schema, (r) => ({
 			alias: "enrichedViews_viewTableId_tables_tableId",
 		}),
 		entropyObjectss: r.many.entropyObjects(),
+		entropyReadinesss: r.many.entropyReadiness(),
 		relationshipssFromTableId: r.many.relationships({
 			alias: "relationships_fromTableId_tables_tableId",
 		}),
@@ -178,6 +181,7 @@ export const relations = defineRelations(schema, (r) => ({
 		}),
 		derivedColumnss: r.many.derivedColumns(),
 		entropyObjectss: r.many.entropyObjects(),
+		entropyReadinesss: r.many.entropyReadiness(),
 		relationshipssFromColumnId: r.many.relationships({
 			alias: "relationships_fromColumnId_columns_columnId",
 		}),
@@ -277,6 +281,24 @@ export const relations = defineRelations(schema, (r) => ({
 		}),
 		tables: r.one.tables({
 			from: r.entropyObjects.tableId,
+			to: r.tables.tableId,
+		}),
+	},
+	entropyReadiness: {
+		columns: r.one.columns({
+			from: r.entropyReadiness.columnId,
+			to: r.columns.columnId,
+		}),
+		investigationSessions: r.one.investigationSessions({
+			from: r.entropyReadiness.sessionId,
+			to: r.investigationSessions.sessionId,
+		}),
+		sources: r.one.sources({
+			from: r.entropyReadiness.sourceId,
+			to: r.sources.sourceId,
+		}),
+		tables: r.one.tables({
+			from: r.entropyReadiness.tableId,
 			to: r.tables.tableId,
 		}),
 	},

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -340,6 +340,48 @@ export const entropyObjects = metadataSchema.table(
 	],
 );
 
+export const entropyReadiness = metadataSchema.table(
+	"entropy_readiness",
+	{
+		readinessId: varchar("readiness_id").primaryKey(),
+		sessionId: varchar("session_id")
+			.notNull()
+			.references(() => investigationSessions.sessionId),
+		sourceId: varchar("source_id")
+			.notNull()
+			.references(() => sources.sourceId),
+		tableId: varchar("table_id").references(() => tables.tableId, {
+			onDelete: "cascade",
+		}),
+		columnId: varchar("column_id").references(() => columns.columnId, {
+			onDelete: "cascade",
+		}),
+		band: varchar().notNull(),
+		worstIntentRisk: doublePrecision("worst_intent_risk").notNull(),
+		intents: jsonb(),
+		topDrivers: jsonb("top_drivers"),
+		computedAt: timestamp("computed_at").notNull(),
+	},
+	(table) => [
+		index("idx_readiness_column").using(
+			"btree",
+			table.columnId.asc().nullsLast(),
+		),
+		index("idx_readiness_source").using(
+			"btree",
+			table.sourceId.asc().nullsLast(),
+		),
+		index("idx_readiness_table").using(
+			"btree",
+			table.tableId.asc().nullsLast(),
+		),
+		index("ix_entropy_readiness_session_id").using(
+			"btree",
+			table.sessionId.asc().nullsLast(),
+		),
+	],
+);
+
 export const fixLedger = metadataSchema.table(
 	"fix_ledger",
 	{

--- a/packages/engine/src/dataraum/core/connections.py
+++ b/packages/engine/src/dataraum/core/connections.py
@@ -410,6 +410,7 @@ class ConnectionManager:
         """Import all DB model modules to register them with SQLAlchemy."""
         # Core models not owned by any phase
         from dataraum.documentation import db_models as _fixes  # noqa: F401
+        from dataraum.entropy import db_models as _entropy  # noqa: F401
         from dataraum.investigation import db_models as _investigation  # noqa: F401
 
         # Phase-owned models: auto-discovered from registry

--- a/packages/engine/src/dataraum/entropy/db_models.py
+++ b/packages/engine/src/dataraum/entropy/db_models.py
@@ -2,6 +2,7 @@
 
 SQLAlchemy models for persisting entropy measurements:
 - EntropyObjectRecord: Individual entropy measurements
+- EntropyReadinessRecord: Per-column readiness rollup (DAT-394)
 """
 
 from __future__ import annotations
@@ -81,3 +82,55 @@ Index("idx_entropy_table", EntropyObjectRecord.table_id)
 Index("idx_entropy_column", EntropyObjectRecord.column_id)
 Index("idx_entropy_score", EntropyObjectRecord.score)
 Index("idx_entropy_source_detector", EntropyObjectRecord.source_id, EntropyObjectRecord.detector_id)
+
+
+class EntropyReadinessRecord(Base):
+    """Persisted per-column readiness, written by the terminal ``detect`` step (DAT-394).
+
+    The transparent readiness-v2 rollup (``entropy/views/network_context.py``)
+    rolls detector scores up the network into per-intent readiness. This row is
+    its persisted snapshot — one per analyzed column — for the cockpit ``why`` /
+    ``look`` tools (read via Drizzle) and as agent context. Self-refreshing: the
+    terminal detect step re-runs on every (re-)measure and rewrites these rows
+    (delete-before-insert scoped to ``source_id``).
+
+    ``band`` is the collapsed worst-of-intents band the contract gate already
+    consumes; ``intents`` carries the per-intent breakdown (query / aggregation /
+    reporting) the rollup keeps first-class.
+    """
+
+    __tablename__ = "entropy_readiness"
+
+    readiness_id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=lambda: str(uuid4())
+    )
+    # Per-run FK, consistent with EntropyObjectRecord.session_id.
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
+
+    # Scope — one readiness row per analyzed column.
+    source_id: Mapped[str | None] = mapped_column(ForeignKey("sources.source_id"))
+    table_id: Mapped[str | None] = mapped_column(ForeignKey("tables.table_id", ondelete="CASCADE"))
+    column_id: Mapped[str | None] = mapped_column(
+        ForeignKey("columns.column_id", ondelete="CASCADE")
+    )
+
+    # Collapsed worst-of-intents band ("ready" / "investigate" / "blocked") — the
+    # signal the contract gate consumes — plus the worst per-intent risk behind it.
+    band: Mapped[str] = mapped_column(String, nullable=False, default="ready")
+    worst_intent_risk: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+
+    # Per-intent breakdown: [{intent, band, risk, drivers: [{node, state, impact_delta}]}].
+    intents: Mapped[list[dict[str, Any]] | None] = mapped_column(JSON_TYPE)
+    # Column-level ranked drivers (collapsed per-node impact_delta): [{node, state, impact_delta}].
+    top_drivers: Mapped[list[dict[str, Any]] | None] = mapped_column(JSON_TYPE)
+
+    computed_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(UTC)
+    )
+
+
+Index("idx_readiness_source", EntropyReadinessRecord.source_id)
+Index("idx_readiness_table", EntropyReadinessRecord.table_id)
+Index("idx_readiness_column", EntropyReadinessRecord.column_id)

--- a/packages/engine/src/dataraum/entropy/db_models.py
+++ b/packages/engine/src/dataraum/entropy/db_models.py
@@ -109,8 +109,9 @@ class EntropyReadinessRecord(Base):
         ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
     )
 
-    # Scope — one readiness row per analyzed column.
-    source_id: Mapped[str | None] = mapped_column(ForeignKey("sources.source_id"))
+    # Scope — one readiness row per analyzed column. ``source_id`` is the
+    # delete-before-insert scope key and is always set, so it is NOT NULL.
+    source_id: Mapped[str] = mapped_column(ForeignKey("sources.source_id"), nullable=False)
     table_id: Mapped[str | None] = mapped_column(ForeignKey("tables.table_id", ondelete="CASCADE"))
     column_id: Mapped[str | None] = mapped_column(
         ForeignKey("columns.column_id", ondelete="CASCADE")

--- a/packages/engine/src/dataraum/entropy/readiness.py
+++ b/packages/engine/src/dataraum/entropy/readiness.py
@@ -83,11 +83,11 @@ def _column_id_map(session: Session, table_ids: list[str]) -> dict[str, tuple[st
     Mirrors the target string the detectors write (``engine.py`` builds it as
     ``f"column:{table.table_name}.{col.column_name}"``).
     """
-    table_name_by_id: dict[str, str] = dict(
-        session.execute(
-            select(Table.table_id, Table.table_name).where(Table.table_id.in_(table_ids))
-        ).tuples()
-    )
+    table_name_by_id: dict[str, str] = {}
+    for table_id, table_name in session.execute(
+        select(Table.table_id, Table.table_name).where(Table.table_id.in_(table_ids))
+    ):
+        table_name_by_id[table_id] = table_name
     out: dict[str, tuple[str, str]] = {}
     for table_id, column_name, column_id in session.execute(
         select(Column.table_id, Column.column_name, Column.column_id).where(

--- a/packages/engine/src/dataraum/entropy/readiness.py
+++ b/packages/engine/src/dataraum/entropy/readiness.py
@@ -1,0 +1,130 @@
+"""Persist per-column readiness — the terminal detect step's snapshot (DAT-394).
+
+The readiness-v2 rollup (``entropy/views/network_context.py``) rolls the persisted
+entropy objects up the network into per-column, per-intent readiness.
+:func:`persist_readiness` writes that rollup to ``entropy_readiness`` (one row per
+analyzed column) so the cockpit ``why`` / ``look`` tools read it via Drizzle with no
+engine round-trip, and as agent context.
+
+Self-refreshing: called from the terminal ``detect`` step (which re-runs on every
+(re-)measure), it delete-before-inserts scoped to the source, so a teach->replay
+overwrites the rows with no stale leftovers.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from dataraum.core.logging import get_logger
+from dataraum.entropy.db_models import EntropyReadinessRecord
+from dataraum.entropy.views.network_context import ColumnNetworkResult, build_for_network
+from dataraum.storage import Column, Table
+
+logger = get_logger(__name__)
+
+
+def persist_readiness(session: Session, source_id: str, session_id: str) -> int:
+    """Compute + persist per-column readiness for a source's typed tables.
+
+    Delete-before-insert scoped to ``source_id`` (replay-safe): the prior rows are
+    cleared even when the new rollup is empty. The caller owns the transaction
+    (commit happens at its ``session_scope`` exit). Returns the rows written.
+    """
+    typed_table_ids = [
+        row[0]
+        for row in session.execute(
+            select(Table.table_id).where(Table.source_id == source_id, Table.layer == "typed")
+        )
+    ]
+
+    # Replay-safe refresh: clear this source's prior readiness rows first.
+    session.execute(
+        delete(EntropyReadinessRecord).where(EntropyReadinessRecord.source_id == source_id)
+    )
+    if not typed_table_ids:
+        return 0
+
+    ctx = build_for_network(session, typed_table_ids)
+    if not ctx.columns:
+        return 0
+
+    target_to_ids = _column_id_map(session, typed_table_ids)
+
+    rows: list[EntropyReadinessRecord] = []
+    for target, col in ctx.columns.items():
+        ids = target_to_ids.get(target)
+        if ids is None:
+            # A column target the rollup produced but we can't map back to a
+            # Column row (e.g. a renamed/dropped column) — skip, don't guess.
+            logger.debug("readiness_target_unresolved", target=target)
+            continue
+        table_id, column_id = ids
+        rows.append(
+            EntropyReadinessRecord(
+                session_id=session_id,
+                source_id=source_id,
+                table_id=table_id,
+                column_id=column_id,
+                band=col.readiness,
+                worst_intent_risk=round(col.worst_intent_p_high, 4),
+                intents=_intents_payload(col),
+                top_drivers=_top_drivers_payload(col),
+            )
+        )
+
+    session.add_all(rows)
+    return len(rows)
+
+
+def _column_id_map(session: Session, table_ids: list[str]) -> dict[str, tuple[str, str]]:
+    """Map ``"column:{table_name}.{column_name}"`` -> ``(table_id, column_id)``.
+
+    Mirrors the target string the detectors write (``engine.py`` builds it as
+    ``f"column:{table.table_name}.{col.column_name}"``).
+    """
+    table_name_by_id: dict[str, str] = dict(
+        session.execute(
+            select(Table.table_id, Table.table_name).where(Table.table_id.in_(table_ids))
+        ).tuples()
+    )
+    out: dict[str, tuple[str, str]] = {}
+    for table_id, column_name, column_id in session.execute(
+        select(Column.table_id, Column.column_name, Column.column_id).where(
+            Column.table_id.in_(table_ids)
+        )
+    ):
+        table_name = table_name_by_id.get(table_id)
+        if table_name is None:
+            continue
+        out[f"column:{table_name}.{column_name}"] = (table_id, column_id)
+    return out
+
+
+def _intents_payload(col: ColumnNetworkResult) -> list[dict[str, object]]:
+    """Per-intent breakdown: band + risk + ranked drivers, one entry per intent."""
+    return [
+        {
+            "intent": i.intent_name,
+            "band": i.readiness,
+            "risk": round(i.p_high, 4),
+            "drivers": [
+                {"node": d.node, "state": d.state, "impact_delta": round(d.impact_delta, 4)}
+                for d in i.drivers
+            ],
+        }
+        for i in col.intents
+    ]
+
+
+def _top_drivers_payload(col: ColumnNetworkResult) -> list[dict[str, object]]:
+    """Column-level non-clean nodes ranked by collapsed impact_delta."""
+    ranked = sorted(
+        (ne for ne in col.node_evidence if ne.state != "low"),
+        key=lambda ne: ne.impact_delta,
+        reverse=True,
+    )
+    return [
+        {"node": ne.node_name, "state": ne.state, "impact_delta": round(ne.impact_delta, 4)}
+        for ne in ranked
+    ]

--- a/packages/engine/src/dataraum/entropy/views/network_context.py
+++ b/packages/engine/src/dataraum/entropy/views/network_context.py
@@ -45,14 +45,30 @@ class DirectSignal:
 
 
 @dataclass
+class IntentDriver:
+    """One observed node's causal contribution to a specific intent's risk.
+
+    ``impact_delta`` is how much THIS intent's risk would drop if the node were
+    fixed to clean (from ``compute_priorities``' per-intent ``affected_intents``)
+    — the per-intent split the collapsed ``ColumnNodeEvidence.impact_delta`` (a
+    max across intents) loses.
+    """
+
+    node: str = ""
+    state: str = "low"
+    impact_delta: float = 0.0
+
+
+@dataclass
 class IntentReadiness:
-    """Posterior and readiness for an intent node."""
+    """Posterior and readiness for an intent node, with its ranked drivers."""
 
     intent_name: str = ""
     posterior: dict[str, float] = field(default_factory=dict)
     dominant_state: str = "low"
     p_high: float = 0.0
     readiness: str = "ready"
+    drivers: list[IntentDriver] = field(default_factory=list)
 
 
 @dataclass
@@ -259,6 +275,19 @@ def _build_column_result(
         # Risk is a single value, not a distribution; surface it as P(high).
         posterior = {"high": round(p_high, 4)}
         dominant = "high" if p_high > disc.medium_upper else "low"
+        # Per-intent drivers: nodes that lower THIS intent's risk, ranked by how
+        # much. ``affected_intents`` carries the per-intent split that the
+        # collapsed ColumnNodeEvidence.impact_delta (a max across intents) drops.
+        drivers = [
+            IntentDriver(
+                node=pr.node,
+                state=pr.current_state,
+                impact_delta=pr.affected_intents[intent_name],
+            )
+            for pr in priorities
+            if intent_name in pr.affected_intents
+        ]
+        drivers.sort(key=lambda d: d.impact_delta, reverse=True)
         intents.append(
             IntentReadiness(
                 intent_name=intent_name,
@@ -266,6 +295,7 @@ def _build_column_result(
                 dominant_state=dominant,
                 p_high=p_high,
                 readiness=readiness,
+                drivers=drivers,
             )
         )
 

--- a/packages/engine/src/dataraum/worker/__init__.py
+++ b/packages/engine/src/dataraum/worker/__init__.py
@@ -11,9 +11,8 @@ from __future__ import annotations
 
 from dataraum.worker.activity import (
     raw_table_ids,
+    run_detectors,
     run_phase,
-    run_source_detectors,
-    run_table_detectors,
     typed_table_id_for_raw,
 )
 from dataraum.worker.bootstrap import (
@@ -47,9 +46,8 @@ __all__ = [
     "TypingResult",
     "bootstrap_worker_substrate",
     "raw_table_ids",
+    "run_detectors",
     "run_phase",
-    "run_source_detectors",
-    "run_table_detectors",
     "shutdown_worker_substrate",
     "typed_table_id_for_raw",
 ]

--- a/packages/engine/src/dataraum/worker/activities.py
+++ b/packages/engine/src/dataraum/worker/activities.py
@@ -3,8 +3,8 @@
 Thin ``@activity.defn`` wrappers that translate the per-boundary contracts into
 calls on the Temporal-agnostic helpers in :mod:`dataraum.worker.activity`. They
 hold the worker's single :class:`ConnectionManager` (set at bootstrap) and name
-each activity after its pipeline.yaml phase (plus ``detect_table``) — so the
-workflows call them by that string, no shared catalogue.
+each activity after its pipeline.yaml phase (plus the terminal ``detect``) — so
+the workflows call them by that string, no shared catalogue.
 
 Activities are **sync** (``def``): Temporal runs them on the worker's
 ``ThreadPoolExecutor``, the SDK-recommended shape for blocking SQLAlchemy/DuckDB
@@ -28,10 +28,9 @@ from temporalio.exceptions import ApplicationError
 from dataraum.pipeline.base import PhaseStatus
 from dataraum.worker.activity import (
     raw_table_ids,
+    run_detectors,
     run_phase,
     run_replay_cleanup,
-    run_source_detectors,
-    run_table_detectors,
     typed_table_id_for_raw,
 )
 from dataraum.worker.contracts import (
@@ -105,19 +104,6 @@ class PhaseActivities:
         """Temporal activity — pattern/trend profiling of date/time columns."""
         return self._run_or_raise("temporal", payload.identity, [payload.table_id])
 
-    @activity.defn(name="detect_table")
-    def run_detect_table(self, payload: TableScopedInput) -> PhaseOutcome:
-        """Run the table-local detectors scoped to one typed table (DAT-370).
-
-        The stage-level detector step: runs once per ``ProcessTableWorkflow`` after
-        its analytics phases, scoped to the child's typed table — never per phase.
-        """
-        count = run_table_detectors(self._manager, payload.identity, payload.table_id)
-        return PhaseOutcome(
-            status=PhaseStatus.COMPLETED.value,
-            summary=f"{count} detector records for table {payload.table_id}",
-        )
-
     @activity.defn(name="semantic_per_column")
     def run_semantic_per_column(self, identity: SourceIdentity) -> PhaseOutcome:
         """Semantic-per-column activity — the source-level LLM reduce (roles, concepts, terms).
@@ -181,19 +167,20 @@ class PhaseActivities:
             summary=f"cleaned up {payload.phase_name} for {len(payload.table_ids)} table(s)",
         )
 
-    @activity.defn(name="detect_source")
-    def run_detect_source(self, identity: SourceIdentity) -> PhaseOutcome:
-        """Run the source-level detectors after the reduce (DAT-370 follow-up).
+    @activity.defn(name="detect")
+    def run_detect(self, identity: SourceIdentity) -> PhaseOutcome:
+        """Terminal detector pass — every wired detector once, source-wide (DAT-394).
 
-        The source-level analogue of ``detect_table``: runs ``semantic_per_column``'s
-        declared detectors once, source-wide, after the reduce. Without it those
-        detectors are declared in pipeline.yaml but never execute (the gap DAT-370
-        left when detectors moved off the per-phase path).
+        The single stage-level detect step: after the per-table fan-out and the
+        ``semantic_per_column`` reduce, run the union of all chain-declared detectors
+        over the whole source. Replaces the old per-table ``detect_table`` + parent
+        ``detect_source`` split — nothing consumes entropy mid-run, so one terminal
+        pass is correct and simpler. (DAT-394 phase 2 persists readiness here too.)
         """
-        count = run_source_detectors(self._manager, identity)
+        count = run_detectors(self._manager, identity)
         return PhaseOutcome(
             status=PhaseStatus.COMPLETED.value,
-            summary=f"{count} source-level detector records",
+            summary=f"{count} detector records for source {identity.source_id}",
         )
 
     def _run_or_raise(

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -305,7 +305,13 @@ def run_detectors(manager: ConnectionManager, identity: SourceIdentity) -> int:
         # transaction (DAT-394). flush() makes the just-added rows visible to the
         # rollup's repository select before we read them back.
         session.flush()
-        persist_readiness(session, identity.source_id, identity.session_id)
+        readiness_rows = persist_readiness(session, identity.source_id, identity.session_id)
+        logger.info(
+            "terminal_detect_done",
+            source_id=identity.source_id,
+            detector_records=total,
+            readiness_rows=readiness_rows,
+        )
     return total
 
 

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -26,6 +26,7 @@ from sqlalchemy import select
 from dataraum.core.config import load_phase_config
 from dataraum.core.logging import get_logger
 from dataraum.entropy.engine import run_detector_post_step
+from dataraum.entropy.readiness import persist_readiness
 from dataraum.pipeline.base import PhaseContext, PhaseStatus
 from dataraum.pipeline.pipeline_config import load_phase_declarations
 from dataraum.pipeline.registry import get_phase_class
@@ -300,6 +301,11 @@ def run_detectors(manager: ConnectionManager, identity: SourceIdentity) -> int:
                 session_id=identity.session_id,
                 table_ids=None,
             )
+        # Persist readiness from the freshly-written entropy objects, in the same
+        # transaction (DAT-394). flush() makes the just-added rows visible to the
+        # rollup's repository select before we read them back.
+        session.flush()
+        persist_readiness(session, identity.source_id, identity.session_id)
     return total
 
 

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -8,11 +8,11 @@ config, scoped to ``table_ids``), and runs the sync phase — without a schedule
 or ``PipelineRun``/``PhaseLog`` monitoring rows (Temporal's event history is the
 execution log).
 
-Detectors are **not** run here. Per DAT-370 they run once per workflow stage,
-not once per phase: :func:`run_table_detectors` runs the table-local detectors
-scoped to a single typed table at the tail of ``ProcessTableWorkflow``. The
-activity wrappers (:mod:`dataraum.worker.activities`) translate these
-Temporal-agnostic helpers into the per-boundary contracts.
+Detectors are **not** run here per phase. Per DAT-394 they run once per workflow
+in a single terminal step: :func:`run_detectors` runs every wired detector over
+the whole source after the fan-out + reduce. The activity wrappers
+(:mod:`dataraum.worker.activities`) translate these Temporal-agnostic helpers
+into the per-boundary contracts.
 """
 
 from __future__ import annotations
@@ -42,38 +42,34 @@ __all__ = [
     "PhaseRun",
     "declared_detector_ids",
     "raw_table_ids",
+    "run_detectors",
     "run_phase",
     "run_replay_cleanup",
-    "run_source_detectors",
-    "run_table_detectors",
     "typed_table_id_for_raw",
 ]
 
-# The table-local phases, in dependency order. ``detect_table`` runs the union
-# of the detectors these phases declare in pipeline.yaml (today: type_fidelity
-# from typing, null_ratio from statistics) — scoped to the one typed table, so
-# parallel child workflows never touch each other's detector rows.
+# The executed-chain phases that declare entropy detectors (DAT-394). The single
+# terminal ``detect`` activity runs the union of their detectors ONCE, source-wide
+# — after the per-table fan-out and the ``semantic_per_column`` reduce. Detectors
+# moved here from the old per-table ``detect_table`` + parent ``detect_source``
+# split: nothing reads entropy mid-run, there are no live detector->detector
+# ordering edges, and the split bought ~no parallelism (it ran two cheap structural
+# detectors), so one terminal pass is correct and simpler. Running once,
+# sequentially, makes the source-wide delete-before-insert safe (no concurrency)
+# and guarantees every detector's inputs are present.
 #
-# This is ``typing`` + ``workflows._ANALYTICS_PHASES`` (typing is here for its
-# type_fidelity detector but is scheduled separately as the id-minting step).
-# ``tests/unit/worker/test_phase_constants.py`` pins that relationship so a new
-# table-local phase can't be added to the workflow without its detectors running.
-_TABLE_LOCAL_PHASES = (
+# Source of truth is the executed chain in ``workflows.py`` (``typing`` +
+# ``_ANALYTICS_PHASES`` in the child, ``semantic_per_column`` in the parent).
+# ``tests/unit/worker/test_phase_constants.py`` pins that no chain-declared
+# detector is orphaned (the regression eval caught when DAT-370 first split them).
+_DETECTOR_PHASES = (
     "typing",
     "statistics",
     "column_eligibility",
     "statistical_quality",
     "temporal",
+    "semantic_per_column",
 )
-
-# The source-level phases whose detectors run once, after the per-table fan-out,
-# in the parent's ``detect_source`` step. ``semantic_per_column`` is a
-# source-global reduce, so its detectors (business_meaning, unit_entropy,
-# temporal_entropy, outlier_rate, benford) read the whole source's typed tables
-# and run once — no concurrency, so the source-wide delete-before-insert is safe.
-# Kept in sync with the workflow + checked against pipeline.yaml by
-# ``tests/unit/worker/test_phase_constants.py`` (no declared chain detector orphaned).
-_SOURCE_LEVEL_PHASES = ("semantic_per_column",)
 
 
 @dataclass
@@ -275,63 +271,34 @@ def run_replay_cleanup(
     )
 
 
-def run_table_detectors(
-    manager: ConnectionManager,
-    identity: SourceIdentity,
-    table_id: str,
-) -> int:
-    """Run the table-local detectors scoped to one typed table.
+def run_detectors(manager: ConnectionManager, identity: SourceIdentity) -> int:
+    """Run every wired detector once, source-wide — the terminal ``detect`` step.
 
-    The stage-level replacement for the per-phase detector post-steps (DAT-370):
-    runs the union of the detectors the table-local phases declare in
-    pipeline.yaml, each scoped to ``table_id`` via ``run_detector_post_step``'s
-    ``table_ids`` filter. Scoping the delete-before-insert to the single table is
-    what lets parallel child workflows run their detectors without colliding on
-    the shared ``(source_id, detector_id)`` rows.
+    The single stage-level detector pass (DAT-394): runs the union of the detectors
+    the executed chain phases declare (``_DETECTOR_PHASES``) over all the source's
+    typed tables (``table_ids=None``). It runs once, sequentially, after the
+    per-table fan-out and the ``semantic_per_column`` reduce — so the source-wide
+    delete-before-insert is safe (no concurrency) and every detector's inputs are
+    present. Replaces the old per-table ``detect_table`` + parent ``detect_source``
+    split: nothing reads entropy mid-run, so there is no reason to detect earlier.
     """
-    return _run_detectors(manager, identity, _TABLE_LOCAL_PHASES, [table_id])
-
-
-def run_source_detectors(manager: ConnectionManager, identity: SourceIdentity) -> int:
-    """Run the source-level detectors once, after the per-table fan-out.
-
-    The parent's ``detect_source`` step: runs the detectors the source-level
-    phases declare (``semantic_per_column``'s business_meaning / unit_entropy /
-    temporal_entropy / outlier_rate / benford), source-wide (``table_ids=None``).
-    Its ontology induction is source-global and it is a single sequential step in
-    the parent — no concurrency — so the source-wide delete-before-insert is safe.
-    Without this step those detectors would be declared but never executed (the
-    gap DAT-370 left when it moved detectors off the per-phase path).
-    """
-    return _run_detectors(manager, identity, _SOURCE_LEVEL_PHASES, None)
-
-
-def _run_detectors(
-    manager: ConnectionManager,
-    identity: SourceIdentity,
-    phase_names: Iterable[str],
-    table_ids: list[str] | None,
-) -> int:
-    """Run the detectors declared by ``phase_names``, scoped to ``table_ids``.
-
-    ``table_ids=None`` runs each detector source-wide; a single-element list
-    scopes it to that typed table. Shared by :func:`run_table_detectors` and
-    :func:`run_source_detectors`.
-    """
-    detector_ids = declared_detector_ids(phase_names)
+    detector_ids = declared_detector_ids(_DETECTOR_PHASES)
     if not detector_ids:
         return 0
 
     total = 0
     with manager.session_scope() as session, manager.duckdb_cursor() as cursor:
         for detector_id in detector_ids:
+            # ``table_ids=None`` = source-wide: safe because this runs once,
+            # sequentially, after the fan-out — no concurrent writers to collide
+            # on the shared ``(source_id, detector_id)`` delete-before-insert.
             total += run_detector_post_step(
                 session,
                 identity.source_id,
                 detector_id,
                 cursor,
                 session_id=identity.session_id,
-                table_ids=table_ids,
+                table_ids=None,
             )
     return total
 

--- a/packages/engine/src/dataraum/worker/contracts.py
+++ b/packages/engine/src/dataraum/worker/contracts.py
@@ -56,8 +56,8 @@ class ReplayScope(BaseModel):
             to those raw table ids (per-table replays like
             ``type_pattern``). An empty list ``[]`` means "no children" —
             used for source-tail-only replays (``concept_property``) where
-            the parent re-runs ``semantic_per_column`` + ``detect_source``
-            without re-typing anything.
+            the parent re-runs ``semantic_per_column`` + the terminal
+            ``detect`` step without re-typing anything.
     """
 
     from_phase: str
@@ -68,7 +68,7 @@ class PhaseOutcome(BaseModel):
     """Lean per-activity result: outcome + human summary.
 
     Returned by the activities that don't mint an id (the analytics phases,
-    ``detect_table``, ``semantic_per_column``). A deterministic phase *failure*
+    ``semantic_per_column``, the terminal ``detect``). A deterministic phase *failure*
     never travels in here — it is raised as a non-retryable ``ApplicationError``
     by the activity wrapper — so a returned outcome is always ``completed`` or
     ``skipped``. Carries no ``table_ids``/``outputs`` god-fields.
@@ -149,10 +149,10 @@ class ReplayCleanupInput(BaseModel):
 
 
 class TableScopedInput(BaseModel):
-    """Input to the analytics activities + ``detect_table`` — one typed table.
+    """Input to the per-table analytics activities — one typed table.
 
     ``table_id`` is the *typed* table id from :class:`TypingResult`; the phase
-    scopes its work (and the detect step its measurements) to exactly this table.
+    scopes its work to exactly this table.
     """
 
     identity: SourceIdentity

--- a/packages/engine/src/dataraum/worker/main.py
+++ b/packages/engine/src/dataraum/worker/main.py
@@ -84,9 +84,8 @@ async def run_worker() -> None:
                     phase_activities.run_column_eligibility,
                     phase_activities.run_statistical_quality,
                     phase_activities.run_temporal,
-                    phase_activities.run_detect_table,
                     phase_activities.run_semantic_per_column,
-                    phase_activities.run_detect_source,
+                    phase_activities.run_detect,
                     # DAT-343 replay activities — lookups when phases are
                     # skipped on replay + per-phase cleanup before re-runs.
                     phase_activities.lookup_raw_table_ids,
@@ -121,9 +120,8 @@ async def run_worker() -> None:
                     "column_eligibility",
                     "statistical_quality",
                     "temporal",
-                    "detect_table",
                     "semantic_per_column",
-                    "detect_source",
+                    "detect",
                     "lookup_raw_table_ids",
                     "lookup_typed_table_id",
                     "replay_cleanup_for_phase",

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -76,6 +76,10 @@ _ANALYTICS_PHASES = (
 # the ones the child body invokes. ``ReplayScope.from_phase`` always names a
 # phase listed in one of these tuples — anything else is a programmer error
 # on the cockpit side.
+# ``detect`` is intentionally absent from both orders: like ``semantic_per_column``
+# it ALWAYS re-runs at the parent tail (the workflow body owns that, not
+# ``_runs_under``), so it is never a valid ``ReplayScope.from_phase`` entry point.
+# Adding it here would make it gatable and break the always-runs invariant.
 _PARENT_PHASE_ORDER = ("import", "semantic_per_column")
 _CHILD_PHASE_ORDER = ("typing", *_ANALYTICS_PHASES)
 

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -13,16 +13,18 @@ Topology (DAT-370): the table is the unit of work.
       fan-out via asyncio.gather:
         ProcessTableWorkflow(raw_id) for each raw id         [child, per table]
       semantic_per_column()                                  (source-level reduce)
+      detect()                                               (single terminal detector pass)
 
     ProcessTableWorkflow(raw_table_id)                       [child]
       typing(raw_id) -> typed_id
       statistics -> column_eligibility -> statistical_quality -> temporal   (typed_id)
-      detect_table(typed_id)                                 (stage-level detectors)
 
 The child gives per-table history isolation + bounded parent history, and
 ``typed_id`` is threaded through the child's messages (persisted in history,
-replayed verbatim). Detectors run once at the tail of the stage, scoped to the
-child's typed table — not per phase (DAT-370).
+replayed verbatim). Detectors run once at the very end, source-wide, in the
+parent's terminal ``detect`` step — not per phase, not per table (DAT-394:
+nothing reads entropy mid-run, so detection has no reason to run before the run
+ends; this collapsed the old per-table ``detect_table`` + parent ``detect_source``).
 """
 
 from __future__ import annotations
@@ -57,9 +59,10 @@ _RETRY = RetryPolicy(maximum_attempts=5, non_retryable_error_types=["PhaseFailed
 _TIMEOUT = timedelta(minutes=10)
 
 # The table-local analytics phases, in dependency order. ``typing`` precedes
-# them (it mints the typed id); ``detect_table`` follows (stage-level detectors).
-# The detect step aggregates detectors over ``activity._TABLE_LOCAL_PHASES`` =
-# ``("typing", *_ANALYTICS_PHASES)``; ``test_phase_constants.py`` pins the link.
+# them (it mints the typed id). Detectors no longer run at the child's tail; the
+# single terminal ``detect`` step (parent) runs the union of the detectors these
+# phases + ``semantic_per_column`` declare (``activity._DETECTOR_PHASES``);
+# ``test_phase_constants.py`` pins that no chain-declared detector is orphaned.
 _ANALYTICS_PHASES = (
     "statistics",
     "column_eligibility",
@@ -74,7 +77,7 @@ _ANALYTICS_PHASES = (
 # phase listed in one of these tuples — anything else is a programmer error
 # on the cockpit side.
 _PARENT_PHASE_ORDER = ("import", "semantic_per_column")
-_CHILD_PHASE_ORDER = ("typing", *_ANALYTICS_PHASES, "detect_table")
+_CHILD_PHASE_ORDER = ("typing", *_ANALYTICS_PHASES)
 
 
 def _at_or_after(phase: str, from_phase: str, order: tuple[str, ...]) -> bool:
@@ -185,10 +188,11 @@ def _phase_reruns_on_replay(phase: str, replay: ReplayScope) -> bool:
 class ProcessTableWorkflow:
     """Run the table-local chain for one raw table, then complete.
 
-    Initial run (``payload.replay is None``): ``typing`` mints the typed id,
-    the analytics phases run scoped to it, a single stage-level
-    ``detect_table`` runs the table-local detectors. The typed id travels in
-    the activity results, so it is in history and replayed verbatim.
+    Initial run (``payload.replay is None``): ``typing`` mints the typed id and
+    the analytics phases run scoped to it. The typed id travels in the activity
+    results, so it is in history and replayed verbatim. Detectors do NOT run
+    here — they run once, source-wide, in the parent's terminal ``detect`` step
+    (DAT-394).
 
     Teach replay (``payload.replay`` set; DAT-343): gates each phase on
     ``replay.from_phase``'s position in ``_CHILD_PHASE_ORDER``; if the chain
@@ -244,15 +248,6 @@ class ProcessTableWorkflow:
                 retry_policy=_RETRY,
             )
 
-        if _runs_under("detect_table", replay, _CHILD_PHASE_ORDER):
-            await workflow.execute_activity(
-                "detect_table",
-                scoped,
-                result_type=PhaseOutcome,
-                start_to_close_timeout=_TIMEOUT,
-                retry_policy=_RETRY,
-            )
-
         return ProcessTableResult(
             raw_table_id=payload.raw_table_id,
             typed_table_id=typed_table_id,
@@ -267,7 +262,8 @@ class AddSourceWorkflow:
     source's raw tables, the workflow fans out one
     :class:`ProcessTableWorkflow` per raw id via ``asyncio.gather`` and waits
     for all to complete, then ``semantic_per_column`` runs once as the
-    source-level reduce (followed by ``detect_source`` for its detectors).
+    source-level reduce (followed by the terminal ``detect`` step that runs all
+    detectors source-wide).
 
     Teach replay (``payload.replay`` set; DAT-343): per-stage gates +
     fan-out scope follow ``replay``:
@@ -280,9 +276,9 @@ class AddSourceWorkflow:
         empty list = no children at all — source-tail-only replays like
         ``concept_property``). Children carry ``replay`` so they gate
         their own activities.
-      * ``semantic_per_column`` + ``detect_source`` always re-run on any
+      * ``semantic_per_column`` + the terminal ``detect`` always re-run on any
         replay (the source-level reduce benefits from the widening data
-        breadth — see the DAT-343 refine).
+        breadth — see the DAT-343 refine; ``detect`` is cheap + idempotent).
 
     The data-dependent fan-out is driven off ``imported.raw_table_ids``
     (recorded in history whether ``import`` ran or was looked up), so
@@ -356,13 +352,12 @@ class AddSourceWorkflow:
         ]
         tables: list[ProcessTableResult] = list(await asyncio.gather(*children))
 
-        # Source-level reduce + its detectors: ALWAYS run, on both initial
-        # runs and any replay. Per the DAT-343 refine, re-running the reduce
-        # over the (possibly widened) source data is strictly better than
-        # skipping it. ``detect_source`` is cheap + idempotent
-        # (delete-before-insert) so it joins the always-runs set.
-        # ``_maybe_replay_cleanup`` is still gated on
-        # ``replay.from_phase == "semantic_per_column"`` — it only fires for
+        # Source-level reduce + the terminal detector pass: ALWAYS run, on both
+        # initial runs and any replay. Per the DAT-343 refine, re-running the
+        # reduce over the (possibly widened) source data is strictly better than
+        # skipping it. ``detect`` is cheap + idempotent (delete-before-insert) so
+        # it joins the always-runs set. ``_maybe_replay_cleanup`` is still gated
+        # on ``replay.from_phase == "semantic_per_column"`` — it only fires for
         # the concept_property entry case.
         await _maybe_replay_cleanup("semantic_per_column", replay, payload.identity, [])
         await workflow.execute_activity(
@@ -372,8 +367,11 @@ class AddSourceWorkflow:
             start_to_close_timeout=_TIMEOUT,
             retry_policy=_RETRY,
         )
+        # Single terminal detector pass (DAT-394): runs every wired detector
+        # source-wide after the reduce, then persists readiness. Replaces the old
+        # per-table detect_table + parent detect_source.
         await workflow.execute_activity(
-            "detect_source",
+            "detect",
             payload.identity,
             result_type=PhaseOutcome,
             start_to_close_timeout=_TIMEOUT,

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -28,7 +28,7 @@ import pytest
 from sqlalchemy import select, text
 
 from dataraum.core.connections import ConnectionConfig, ConnectionManager
-from dataraum.entropy.db_models import EntropyObjectRecord
+from dataraum.entropy.db_models import EntropyObjectRecord, EntropyReadinessRecord
 from dataraum.investigation.db_models import InvestigationSession
 from dataraum.storage import Source, Table
 from dataraum.worker import (
@@ -371,6 +371,70 @@ def test_per_table_chain_runs(worker_manager: ConnectionManager, small_finance_p
     # fan-out. Offline (no LLM), so only the structural detectors persist rows;
     # that is enough to prove the terminal step runs and writes per-table records.
     assert run_detectors(worker_manager, identity) > 0, "terminal detect produced no records"
+
+
+def test_terminal_detect_persists_per_column_readiness_and_replay_overwrites(
+    worker_manager: ConnectionManager, small_finance_path: Path
+) -> None:
+    """The terminal detect step writes entropy_readiness per column; re-run overwrites (DAT-394).
+
+    Drives the production path (per-table chains → terminal ``run_detectors``) on a
+    multi-file source, then asserts the readiness snapshot: one row per analyzed
+    column, FK-resolved, valid band, per-intent JSONB payload shape. Re-running the
+    terminal step (what every replay does) must delete-before-insert — overwrite,
+    not accumulate stale duplicates.
+    """
+    source_id = str(uuid4())
+    session_id = str(uuid4())
+    files = _enumerate_fixture_files(small_finance_path)
+    _seed_source_and_session(worker_manager, source_id, session_id, "small_finance", files)
+    identity = _identity(source_id, session_id)
+
+    assert run_phase(worker_manager, "import", identity, []).status == "completed"
+    raw_ids = raw_table_ids(worker_manager, source_id)
+    typed_ids = {_process_one_table(worker_manager, identity, raw_id) for raw_id in raw_ids}
+
+    # Terminal detect: writes entropy_objects AND persists readiness in one pass.
+    assert run_detectors(worker_manager, identity) > 0
+
+    with worker_manager.session_scope() as session:
+        rows = list(
+            session.execute(
+                select(EntropyReadinessRecord).where(
+                    EntropyReadinessRecord.source_id == source_id
+                )
+            ).scalars()
+        )
+
+    assert rows, "terminal detect persisted no entropy_readiness rows"
+    column_ids = [r.column_id for r in rows]
+    assert all(cid is not None for cid in column_ids), "readiness row missing column_id FK"
+    assert len(column_ids) == len(set(column_ids)), "duplicate readiness rows for a column"
+    for r in rows:
+        assert r.table_id in typed_ids, "readiness row points to a non-source table"
+        assert r.band in ("ready", "investigate", "blocked")
+        # JSONB payloads — intents may be empty on clean data (all signals below
+        # the detection floor), but the shape must hold when present.
+        assert isinstance(r.intents, list)
+        for intent in r.intents:
+            assert {"intent", "band", "risk", "drivers"} <= intent.keys()
+            assert isinstance(intent["drivers"], list)
+    first_count = len(rows)
+
+    # Re-run the terminal detect (the replay path always re-runs it): the
+    # delete-before-insert scoped to source_id must overwrite, not duplicate.
+    assert run_detectors(worker_manager, identity) > 0
+    with worker_manager.session_scope() as session:
+        second_count = len(
+            list(
+                session.execute(
+                    select(EntropyReadinessRecord).where(
+                        EntropyReadinessRecord.source_id == source_id
+                    )
+                ).scalars()
+            )
+        )
+    assert second_count == first_count, "readiness rows not overwritten on re-run (stale duplicates)"
 
 
 def test_parallel_tables_do_not_conflict_and_terminal_detect_covers_all(

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -8,10 +8,11 @@ the testcontainer Postgres + a real DuckLake (``lake_anchor``), not SQLite or
 mocks — the substrate reconstitution is exactly what's under test.
 
 DAT-370 makes the table the unit of work: ``import`` enumerates raw tables,
-``typing`` mints one typed id per raw table, the analytics phases run scoped to a
-single typed table, and ``detect_table`` runs the table-local detectors scoped to
-that table. These tests drive that per-table path directly (the production
-workflows fan it out across child workflows).
+``typing`` mints one typed id per raw table, and the analytics phases run scoped
+to a single typed table. Detectors run once, source-wide, in the terminal
+``detect`` step after the fan-out (DAT-394 — ``run_detectors``). These tests
+drive that path directly (the production workflows fan the chains out across
+child workflows, then run one terminal detect in the parent).
 """
 
 from __future__ import annotations
@@ -33,16 +34,16 @@ from dataraum.storage import Source, Table
 from dataraum.worker import (
     SourceIdentity,
     raw_table_ids,
+    run_detectors,
     run_phase,
-    run_source_detectors,
-    run_table_detectors,
     typed_table_id_for_raw,
 )
 
 # The table-local analytics phases wrapped as activities, in dependency order.
-# ``typing`` precedes them (it mints the typed id); ``detect_table`` follows.
-# ``semantic_per_column`` (the source-level LLM reduce) is exercised separately,
-# gated behind a real key.
+# ``typing`` precedes them (it mints the typed id). Detectors no longer run per
+# table — the single terminal ``detect`` step (``run_detectors``) runs them once,
+# source-wide, after the fan-out + reduce (DAT-394). ``semantic_per_column`` (the
+# source-level LLM reduce) is exercised separately, gated behind a real key.
 _ANALYTICS_PHASES = (
     "statistics",
     "column_eligibility",
@@ -50,8 +51,9 @@ _ANALYTICS_PHASES = (
     "temporal",
 )
 
-# The table-local detectors the stage-level detect step runs (pipeline.yaml:
-# type_fidelity from typing, null_ratio from statistics).
+# The table-local detectors (pipeline.yaml: type_fidelity from typing, null_ratio
+# from statistics) — they end up attached per typed table after the terminal
+# source-wide detect step.
 _TABLE_LOCAL_DETECTORS = {"type_fidelity", "null_ratio"}
 
 _LIVE_LLM_ENV = "DATARAUM_LIVE_LLM_TEST"
@@ -169,8 +171,9 @@ def _process_one_table(
 ) -> str:
     """Run the table-local chain for one raw table — the ProcessTableWorkflow body.
 
-    typing(raw) -> typed_id -> analytics phases (typed_id) -> detect_table(typed_id).
-    Returns the typed table id. Asserts each step completed.
+    typing(raw) -> typed_id -> analytics phases (typed_id). Detectors do NOT run
+    here (DAT-394) — they run once, source-wide, in the terminal ``detect`` step
+    after the fan-out. Returns the typed table id. Asserts each step completed.
     """
     typing = run_phase(manager, "typing", identity, [raw_table_id])
     assert typing.status == "completed", f"typing failed: {typing.error}"
@@ -186,7 +189,6 @@ def _process_one_table(
         # only raises on FAILED.
         assert result.status in ("completed", "skipped"), f"{phase} failed: {result.error}"
 
-    run_table_detectors(manager, identity, typed_id)
     return typed_id
 
 
@@ -323,14 +325,14 @@ def test_addsource_runs_under_nondefault_workspace(
 def test_per_table_chain_runs(worker_manager: ConnectionManager, small_finance_path: Path) -> None:
     """The full table-local chain runs green per table on a multi-FILE source.
 
-    Drives the production worker path (``run_phase`` + ``run_table_detectors``,
-    not the retired ``PipelineTestHarness``) on the one long-lived manager. The
-    source is seeded with a multi-URI ``connection_config['file_uris']`` list (the
-    DAT-378 shape the cockpit ``select`` stage writes): ONE ``import`` activity
-    loops the per-URI loader and yields >1 raw tables. Then the
-    typing→analytics→detect chain runs scoped per raw table — the sequential
-    shape of the ProcessTableWorkflow fan-out, which falls out of the >1 raw
-    tables with no Temporal-contract change.
+    Drives the production worker path (``run_phase`` + the terminal
+    ``run_detectors``, not the retired ``PipelineTestHarness``) on the one
+    long-lived manager. The source is seeded with a multi-URI
+    ``connection_config['file_uris']`` list (the DAT-378 shape the cockpit
+    ``select`` stage writes): ONE ``import`` activity loops the per-URI loader and
+    yields >1 raw tables. Then the typing→analytics chain runs scoped per raw
+    table — the sequential shape of the ProcessTableWorkflow fan-out — and a
+    single terminal ``detect`` runs the detectors once, source-wide (DAT-394).
     """
     source_id = str(uuid4())
     session_id = str(uuid4())
@@ -365,25 +367,29 @@ def test_per_table_chain_runs(worker_manager: ConnectionManager, small_finance_p
     assert len(typed_ids) == len(raw_ids)
     assert _lake_tables(worker_manager, "typed"), "no typed tables after the chain"
 
+    # Single terminal detect step (DAT-394): one source-wide pass after the
+    # fan-out. Offline (no LLM), so only the structural detectors persist rows;
+    # that is enough to prove the terminal step runs and writes per-table records.
+    assert run_detectors(worker_manager, identity) > 0, "terminal detect produced no records"
 
-def test_parallel_tables_do_not_conflict_and_detectors_stay_table_scoped(
+
+def test_parallel_tables_do_not_conflict_and_terminal_detect_covers_all(
     worker_manager: ConnectionManager, small_finance_path: Path
 ) -> None:
-    """Per-table chains run concurrently; the stage detect step stays table-scoped.
+    """Per-table analytics chains run concurrently; one terminal detect covers all.
 
-    The DAT-370 concurrency + correctness assertion, over the DAT-378 multi-file
-    source. The source is seeded with a multi-URI ``file_uris`` list, so ONE
-    ``import`` activity yields >1 raw tables; then each raw table's full chain
-    (typing→analytics→detect) runs on its own thread — the fan-out the parent
-    does with child workflows. Each ``run_phase`` / ``run_table_detectors`` call
-    leases its own DuckDB cursor (an independent channel to the shared lake), so
-    DuckLake reconciles the writers via MVCC.
+    The DAT-370 concurrency assertion (analytics fan-out) + the DAT-394 terminal
+    detect, over the DAT-378 multi-file source. The source is seeded with a
+    multi-URI ``file_uris`` list, so ONE ``import`` activity yields >1 raw tables;
+    then each raw table's typing→analytics chain runs on its own thread — the
+    fan-out the parent does with child workflows. Each ``run_phase`` call leases
+    its own DuckDB cursor (an independent channel to the shared lake), so DuckLake
+    reconciles the writers via MVCC.
 
-    The detector step is the part the per-phase post-step couldn't do safely:
-    ``run_detector_post_step`` deletes-before-inserts on ``(source_id,
-    detector_id)``. Scoped to one table, parallel children touch only their own
-    rows — so every typed table ends up with its table-local detector records and
-    none clobbers a sibling. We assert exactly that partition.
+    Detectors no longer run per table (DAT-394): a single terminal
+    ``run_detectors`` pass runs them once, source-wide, after the fan-out. We
+    assert it lands each typed table's full table-local detector set — proving the
+    one source-wide pass covers every table that the concurrent chains produced.
     """
     source_id = str(uuid4())
     session_id = str(uuid4())
@@ -397,8 +403,8 @@ def test_parallel_tables_do_not_conflict_and_detectors_stay_table_scoped(
     assert len(raw_ids) > 1, "one import over a multi-URI source must yield >1 raw tables"
     assert len(raw_ids) == len(files), "each enumerated URI maps to one raw table"
 
-    # Fan the per-table chains out across threads — concurrent typing + analytics
-    # + detect against the shared lake from independent cursors.
+    # Fan the per-table analytics chains out across threads — concurrent typing +
+    # analytics against the shared lake from independent cursors.
     with ThreadPoolExecutor(max_workers=len(raw_ids)) as executor:
         futures = [
             executor.submit(_process_one_table, worker_manager, identity, raw_id)
@@ -408,10 +414,12 @@ def test_parallel_tables_do_not_conflict_and_detectors_stay_table_scoped(
 
     assert len(typed_ids) == len(raw_ids), "each raw table maps to a distinct typed table"
 
+    # One terminal source-wide detect pass after the fan-out (DAT-394).
+    assert run_detectors(worker_manager, identity) > 0, "terminal detect produced no records"
+
     # Every detector record belongs to one of this source's typed tables (no
-    # orphan / cross-table clobber), and each typed table carries the full set of
-    # table-local detectors — proof the scoped delete-before-insert didn't wipe a
-    # sibling's rows under concurrency.
+    # orphan), and each typed table carries the full table-local detector set —
+    # proof the single source-wide pass reached every table the fan-out produced.
     with worker_manager.session_scope() as session:
         rows = session.execute(
             select(EntropyObjectRecord.table_id, EntropyObjectRecord.detector_id).where(
@@ -426,8 +434,8 @@ def test_parallel_tables_do_not_conflict_and_detectors_stay_table_scoped(
         detectors_by_table[table_id].add(detector_id)
 
     assert set(detectors_by_table) == typed_ids, (
-        "some typed table is missing all its detector records — a concurrent "
-        "scoped delete clobbered a sibling"
+        "some typed table is missing all its detector records — the terminal "
+        "source-wide detect did not reach every table"
     )
     for table_id, detectors in detectors_by_table.items():
         assert detectors == _TABLE_LOCAL_DETECTORS, (
@@ -467,8 +475,8 @@ def test_semantic_per_column_reduce_runs_live(
     result = run_phase(worker_manager, "semantic_per_column", identity, [])
     assert result.status == "completed", f"semantic_per_column failed: {result.error}"
 
-    # Source-level detect step (detect_source) runs semantic_per_column's declared
-    # detectors after the reduce — the path DAT-370 originally orphaned. With real
-    # annotations present it should persist records.
-    records = run_source_detectors(worker_manager, identity)
-    assert records > 0, "detect_source produced no source-level detector records"
+    # Terminal detect step (DAT-394) runs all wired detectors source-wide after the
+    # reduce — including semantic_per_column's (business_meaning, unit_entropy, …).
+    # With real annotations present it should persist records.
+    records = run_detectors(worker_manager, identity)
+    assert records > 0, "terminal detect produced no detector records"

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -411,6 +411,7 @@ def test_terminal_detect_persists_per_column_readiness_and_replay_overwrites(
     assert all(cid is not None for cid in column_ids), "readiness row missing column_id FK"
     assert len(column_ids) == len(set(column_ids)), "duplicate readiness rows for a column"
     for r in rows:
+        assert r.source_id == source_id, "readiness row missing/incorrect source_id FK"
         assert r.table_id in typed_ids, "readiness row points to a non-source table"
         assert r.band in ("ready", "investigate", "blocked")
         # JSONB payloads — intents may be empty on clean data (all signals below

--- a/packages/engine/tests/unit/entropy/views/test_network_context.py
+++ b/packages/engine/tests/unit/entropy/views/test_network_context.py
@@ -285,6 +285,37 @@ class TestPerColumnAssembly:
         # Risk is a single value surfaced as P(high), not a full distribution.
         assert intent.posterior["high"] == pytest.approx(intent.p_high, abs=1e-4)
 
+    def test_intent_carries_per_intent_drivers(self, small_network):
+        """Each intent lists the observed nodes that lower ITS risk, ranked (DAT-394)."""
+        objects = [
+            make_entropy_object(
+                layer="structural",
+                dimension="types",
+                sub_dimension="root_a",
+                score=0.8,
+                target="column:t.c1",
+            ),
+            make_entropy_object(
+                layer="value",
+                dimension="nulls",
+                sub_dimension="root_b",
+                score=0.7,
+                target="column:t.c1",
+            ),
+        ]
+        result = assemble_network_context(objects, small_network)
+        intent = result.columns["column:t.c1"].intents[0]
+
+        # Both observed roots feed leaf_z through child_x, so both are drivers.
+        driver_nodes = {d.node for d in intent.drivers}
+        assert driver_nodes == {"root_a", "root_b"}
+        # Each driver carries its discretized state and a positive per-intent impact.
+        assert all(d.impact_delta > 0 for d in intent.drivers)
+        assert all(d.state == "high" for d in intent.drivers)
+        # Ranked by impact, descending.
+        deltas = [d.impact_delta for d in intent.drivers]
+        assert deltas == sorted(deltas, reverse=True)
+
     def test_table_target_becomes_direct_signal(self, small_network):
         """Table-level objects always become direct signals."""
         objects = [

--- a/packages/engine/tests/unit/worker/test_phase_constants.py
+++ b/packages/engine/tests/unit/worker/test_phase_constants.py
@@ -1,33 +1,32 @@
-"""Guard the phase-list constants that the detect steps depend on (DAT-370).
+"""Guard the phase-list constant the terminal detect step depends on (DAT-394).
 
-The child workflow schedules the analytics phases from
-``workflows._ANALYTICS_PHASES``; the stage-level detect steps run detectors for
-``activity._TABLE_LOCAL_PHASES`` (``detect_table``, per typed table) and
-``activity._SOURCE_LEVEL_PHASES`` (``detect_source``, once after the reduce).
+The single terminal ``detect`` activity runs the union of the detectors declared
+by ``activity._DETECTOR_PHASES`` — the executed-chain phases (the child's
+``typing`` + ``_ANALYTICS_PHASES`` and the parent's ``semantic_per_column``
+reduce), source-wide, once, after the fan-out + reduce.
 
 Two invariants are pinned here:
-1. ``_TABLE_LOCAL_PHASES`` is ``("typing", *_ANALYTICS_PHASES)``.
+1. ``_DETECTOR_PHASES`` covers the executed chain: ``typing`` + the analytics
+   phases + ``semantic_per_column``.
 2. **No detector a chain phase declares in pipeline.yaml is orphaned** — every
-   such detector runs in one of the two detect steps. This is the regression the
+   such detector runs in the terminal detect step. This is the regression the
    original DAT-370 cut introduced and eval caught: ``semantic_per_column``
    declared five detectors but, having moved off the per-phase path, was in no
-   detect step, so they never executed.
+   detect step, so they never executed. (DAT-394 collapsed the two detect steps
+   into one, but the no-orphan property must still hold.)
 """
 
 from __future__ import annotations
 
 from dataraum.pipeline.pipeline_config import load_phase_declarations
-from dataraum.worker.activity import (
-    _SOURCE_LEVEL_PHASES,
-    _TABLE_LOCAL_PHASES,
-    declared_detector_ids,
-)
+from dataraum.worker.activity import _DETECTOR_PHASES, declared_detector_ids
 from dataraum.worker.workflows import _ANALYTICS_PHASES
 
 # The analysis phases the workflows actually execute: import + the child's
 # typing/analytics chain + the parent's source-level reduce. Source of truth is
 # workflows.py (parent + child ``run`` bodies); kept here independently so a
-# detector-bearing chain phase that isn't wired into a detect step is caught.
+# detector-bearing chain phase that isn't wired into the terminal detect step is
+# caught.
 _CHAIN_PHASES = (
     "import",
     "typing",
@@ -36,13 +35,13 @@ _CHAIN_PHASES = (
 )
 
 
-def test_table_local_phases_are_typing_plus_the_analytics_chain() -> None:
-    assert _TABLE_LOCAL_PHASES == ("typing", *_ANALYTICS_PHASES)
+def test_detector_phases_cover_the_executed_chain() -> None:
+    assert _DETECTOR_PHASES == ("typing", *_ANALYTICS_PHASES, "semantic_per_column")
 
 
 def test_no_chain_phase_detector_is_orphaned() -> None:
-    """Every detector a chain phase declares runs in detect_table or detect_source."""
-    detect_step_phases = set(_TABLE_LOCAL_PHASES) | set(_SOURCE_LEVEL_PHASES)
+    """Every detector a chain phase declares runs in the terminal detect step."""
+    detect_step_phases = set(_DETECTOR_PHASES)
     declarations = load_phase_declarations()
 
     for phase in _CHAIN_PHASES:
@@ -50,15 +49,16 @@ def test_no_chain_phase_detector_is_orphaned() -> None:
         if not decl or not decl.detectors:
             continue
         assert phase in detect_step_phases, (
-            f"phase '{phase}' declares detectors {decl.detectors} but is in no "
-            "detect step (detect_table / detect_source) — they would never run"
+            f"phase '{phase}' declares detectors {decl.detectors} but is not in "
+            "the terminal detect step (_DETECTOR_PHASES) — they would never run"
         )
 
 
-def test_source_level_detectors_resolve_to_the_semantic_reduce() -> None:
-    """detect_source picks up semantic_per_column's declared detectors."""
-    assert _SOURCE_LEVEL_PHASES == ("semantic_per_column",)
-    assert set(declared_detector_ids(_SOURCE_LEVEL_PHASES)) == {
+def test_terminal_detect_step_runs_every_wired_detector() -> None:
+    """The terminal step picks up the union of the executed chain's detectors."""
+    assert set(declared_detector_ids(_DETECTOR_PHASES)) == {
+        "type_fidelity",
+        "null_ratio",
         "business_meaning",
         "unit_entropy",
         "temporal_entropy",

--- a/packages/engine/tests/unit/worker/test_replay_scope.py
+++ b/packages/engine/tests/unit/worker/test_replay_scope.py
@@ -35,11 +35,10 @@ class TestPhaseOrders:
     def test_parent_order_is_import_then_reduce(self) -> None:
         assert _PARENT_PHASE_ORDER == ("import", "semantic_per_column")
 
-    def test_child_order_is_typing_then_analytics_then_detect_table(self) -> None:
+    def test_child_order_is_typing_then_analytics(self) -> None:
         assert _CHILD_PHASE_ORDER == (
             "typing",
             *_ANALYTICS_PHASES,
-            "detect_table",
         )
 
 
@@ -51,7 +50,7 @@ class TestAtOrAfter:
 
     def test_phases_after_from_phase_run(self) -> None:
         assert _at_or_after("statistics", "typing", _CHILD_PHASE_ORDER) is True
-        assert _at_or_after("detect_table", "typing", _CHILD_PHASE_ORDER) is True
+        assert _at_or_after("temporal", "typing", _CHILD_PHASE_ORDER) is True
 
     def test_phases_before_from_phase_skip(self) -> None:
         assert _at_or_after("typing", "statistics", _CHILD_PHASE_ORDER) is False
@@ -84,7 +83,7 @@ class TestRunsUnder:
         # in the parent chain → both parent phases return False from
         # ``_runs_under``. The parent's workflow body owns the "always re-run
         # the source-level reduce" decision separately (semantic_per_column +
-        # detect_source aren't gated on ``_runs_under`` in the parent body).
+        # the terminal detect aren't gated on ``_runs_under`` in the parent body).
         assert _runs_under("import", replay, _PARENT_PHASE_ORDER) is False
         assert _runs_under("semantic_per_column", replay, _PARENT_PHASE_ORDER) is False
 


### PR DESCRIPTION
**Epic:** DAT-392 (retire the entropy BBN → readiness-v2) · **Design:** [DD/29163521](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/29163521) · refined + investigated 2026-06-01.

Two coupled changes, plus the cockpit mirror regen the CI drift-check requires.

## 1. Collapse detector execution into one terminal step
Replaces the per-table `detect_table` (child workflow) + parent `detect_source` with a **single source-wide `detect` activity** in `AddSourceWorkflow`, after `semantic_per_column`, running the union of all chain-declared detectors once (`run_detectors` / `_DETECTOR_PHASES`).

A 4-way code investigation established this is safe: nothing reads entropy mid-run (every consumer — `graph_execution`, the query/graph agents — is query-time/cockpit-side); there are no live detector→detector ordering edges; and the split bought ~no parallelism (`detect_table` ran two cheap structural detectors). Running once, sequentially, keeps the source-wide delete-before-insert collision-free and guarantees every detector's inputs exist. **Detector scores are unchanged** — only the execution site moved. The per-table analytics fan-out (`typing→…→temporal`) is untouched.

- drops the `_TABLE_LOCAL_PHASES`/`_SOURCE_LEVEL_PHASES` split + `detect_table` from `_CHILD_PHASE_ORDER`
- `test_phase_constants` rewritten to a single no-orphan invariant; replay-scope + integration tests adapted

## 2. Persist per-intent readiness in that step
New `entropy_readiness` table — one row per analyzed column: collapsed `band` (the contract-gate signal) + `worst_intent_risk` + `intents` JSONB (`[{intent, band, risk, drivers:[{node,state,impact_delta}]}]`, the query/aggregation/reporting split kept first-class) + `top_drivers` JSONB. Written by the terminal `detect` step (flush + delete-before-insert scoped to source → replay-safe). `IntentReadiness` gained an additive `drivers` field from `compute_priorities.affected_intents` (the per-intent split the collapsed `impact_delta` discarded) — the three `EntropyForNetwork` consumers are untouched.

This is the substrate the DAT-353 `why`/`look` tools read via Drizzle.

## 3. Cockpit Drizzle mirror
`src/db/metadata/{schema,relations}.ts` re-pulled to expose `entropy_readiness` (keeps the compose-smoke drift check green). Diff is exactly the new table + relations.

## Verification
- ruff + mypy + vulture clean; **578 unit + 7 integration** (testcontainers Postgres/DuckLake) green, incl. a real persistence + replay-overwrite test
- **senior-code-reviewer: APPROVE**; **spec-compliance-reviewer: all 5 ACs met**, scope respected (scoring/`network.yaml`/`rollup.py` untouched, out-of-scope `top_fix` absent)
- `.claude/handoff.md` updated

## Follow-ups (not in this PR)
- **dataraum-eval: confirm detector-score parity** — the bar for the topology move (execution site changed, scoring didn't). Documented in `handoff.md`.
- **Deploy note:** drain in-flight `addSourceWorkflow` runs before deploying (removed activity names would non-determinism-fail mid-history; dev-acceptable, no `patched()` guard).
- `top_fix` + cross-column aggregates + wiring the orphaned detectors → DAT-396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)