### PR TITLE
refactor(DAT-399 D): persisted readiness as the single source of truth

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,23 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-01: DAT-399 (D) — persisted readiness as the single source of truth
+
+Make the engine's query-time consumers READ the persisted `entropy_readiness` band
+instead of recomputing the noisy-OR rollup at query time. The rollup now runs exactly
+once, at the terminal `detect` step. **Behavior-preserving — no calibration impact expected.**
+
+What changed in the engine:
+- **Query-time consumers stop recomputing the rollup.** `entropy/views/query_context.py::build_for_query` (the contract gate) and `graphs/context.py` (ContextDocument assembly) no longer call `build_for_readiness`. They now read `load_persisted_readiness` (reconstructs the banded view from the `entropy_readiness` rows) for the band/counts/overall_readiness, and `build_column_evidence` (rollup-free raw evidence) for the contract `dimension_scores` + `avg_entropy_score`. `build_for_readiness` (the full noisy-OR) survives ONLY as the `detect` step's computation via `persist_readiness`.
+- **Why scores are unchanged:** the contract gate's `dimension_scores` only ever read raw per-node `score`/`dimension_path` + direct signals — they never went through the noisy-OR. `build_column_evidence` is the same score-assembly code with the rollup skipped, so `dimension_scores` are byte-identical. Contracts also read `ColumnSummary.readiness` (a blocked column blocks every contract); that band is threaded in via the new `network_to_column_summaries(..., band_by_target=...)` override, sourced from the persisted rows.
+- **No schema / Drizzle-mirror change** — slice D is read-only against the existing `entropy_readiness` table.
+
+### dataraum-eval
+- **Eval action: re-verify contract-gate parity (should be unchanged).** The contract path is calibration-sensitive, but this is a behavior-preserving read-path swap: `entropy_objects`, all detector scores, the rollup, the bands, and contract `dimension_scores` are identical. An engine integration parity test (`test_persisted_readiness_is_single_source_of_truth`) asserts persisted-band == live-rollup AND contract `dimension_scores`/readiness identical, on real data. If any eval harness imported `build_for_readiness` for query-time contract summaries, switch to `build_column_evidence` + `band_by_target` (mirrors `_build_column_summaries` in `tests/integration/test_contracts.py`).
+
+### dataraum-testdata (hints)
+- None.
+
 ## 2026-06-01: DAT-399 (A+B+C) — retire BBN-era scaffolding, self-describing drivers, readiness-vocabulary rename
 
 Cleanup + extend + rename on top of DAT-394. **Behavior-preserving for detector scores** — no calibration impact expected.

--- a/packages/engine/src/dataraum/entropy/views/__init__.py
+++ b/packages/engine/src/dataraum/entropy/views/__init__.py
@@ -1,8 +1,12 @@
 """Entropy views module - caller-specific context builders.
 
 Layer 3 of the entropy framework - provides stable APIs for different consumers:
-- build_for_query(): For query agent (query/agent.py)
-- build_for_readiness(): For the readiness + evidence view (graphs/context.py)
+- build_for_query(): contract gate for the query agent.
+- load_persisted_readiness(): query-time readiness band — reads the snapshot the
+  terminal detect step persisted (the single source of truth, DAT-399 slice D).
+- build_column_evidence(): rollup-free raw evidence for the contract gate.
+- build_for_readiness(): the full noisy-OR rollup — the detect step's computation
+  (via persist_readiness), NOT a query-time path.
 
 Each builder returns a view tailored to the caller's needs,
 ensuring typed tables enforcement and appropriate data structure.
@@ -16,7 +20,9 @@ from dataraum.entropy.views.readiness_context import (
     ColumnNodeEvidence,
     ColumnReadinessResult,
     EntropyForReadiness,
+    build_column_evidence,
     build_for_readiness,
+    load_persisted_readiness,
 )
 
 __all__ = [
@@ -27,5 +33,7 @@ __all__ = [
     "ColumnReadinessResult",
     "ColumnNodeEvidence",
     "EntropyForReadiness",
+    "build_column_evidence",
     "build_for_readiness",
+    "load_persisted_readiness",
 ]

--- a/packages/engine/src/dataraum/entropy/views/query_context.py
+++ b/packages/engine/src/dataraum/entropy/views/query_context.py
@@ -25,7 +25,8 @@ from dataraum.entropy.contracts import (
 )
 from dataraum.entropy.views.readiness_context import (
     EntropyForReadiness,
-    build_for_readiness,
+    build_column_evidence,
+    load_persisted_readiness,
 )
 
 if TYPE_CHECKING:
@@ -123,24 +124,26 @@ def build_for_query(
             confidence_level=ConfidenceLevel.YELLOW,
         )
 
-    # Build readiness context (handles typed table enforcement internally)
-    readiness_ctx = build_for_readiness(session, table_ids)
+    # Single source of truth: read the band the terminal detect step persisted,
+    # rather than recomputing the noisy-OR per query (DAT-399 slice D).
+    persisted = load_persisted_readiness(session, table_ids)
 
-    if not readiness_ctx.columns:
+    if not persisted.columns:
         return EntropyForQuery(
-            overall_readiness=readiness_ctx.overall_readiness or "ready",
+            overall_readiness=persisted.overall_readiness or "ready",
             confidence_level=ConfidenceLevel.GREEN,  # No entropy data = assume good
         )
 
-    # Derive readiness counts from network
-    overall_readiness = readiness_ctx.overall_readiness
-    high_entropy_count = readiness_ctx.columns_blocked + readiness_ctx.columns_investigate
-    critical_entropy_count = readiness_ctx.columns_blocked
+    # Derive readiness counts from the persisted band
+    overall_readiness = persisted.overall_readiness
+    high_entropy_count = persisted.columns_blocked + persisted.columns_investigate
+    critical_entropy_count = persisted.columns_blocked
 
-    overall_entropy_score: float | None = readiness_ctx.avg_entropy_score
-
-    # Convert network results to ColumnSummary for contract evaluation
-    column_summaries = network_to_column_summaries(readiness_ctx)
+    # Contract gate: raw dimension scores (rollup-free) + the persisted band.
+    evidence = build_column_evidence(session, table_ids)
+    overall_entropy_score: float | None = evidence.avg_entropy_score
+    band_by_target = {target: col.readiness for target, col in persisted.columns.items()}
+    column_summaries = network_to_column_summaries(evidence, band_by_target=band_by_target)
 
     # Evaluate contracts
     contract_name: str | None = None
@@ -195,14 +198,25 @@ def build_for_query(
 
 def network_to_column_summaries(
     readiness_ctx: EntropyForReadiness,
+    *,
+    band_by_target: dict[str, str] | None = None,
 ) -> dict[str, ColumnSummary]:
     """Convert network results to ColumnSummary for contract evaluation.
 
     Contracts evaluate raw dimension scores, which we extract from
     the network's per-node evidence AND direct signals (unmapped detectors).
+    They also read each column's readiness band (a blocked column blocks every
+    contract). The raw scores never go through the noisy-OR, so the query-time
+    gate feeds this the rollup-free :func:`build_column_evidence` for scores and
+    passes ``band_by_target`` (the persisted band) for readiness — keeping the
+    rollup to one computation (DAT-399 slice D). When ``band_by_target`` is
+    omitted, the band is taken from ``readiness_ctx`` itself (e.g. detect-time
+    callers passing the full rollup).
 
     Args:
-        readiness_ctx: EntropyForReadiness with per-column results
+        readiness_ctx: EntropyForReadiness supplying per-column node evidence.
+        band_by_target: Optional ``target -> band`` from the persisted readiness;
+            overrides ``readiness_ctx``'s per-column band when present.
 
     Returns:
         Dict mapping "table.column" to ColumnSummary with dimension_scores populated
@@ -220,10 +234,15 @@ def network_to_column_summaries(
             if ne.dimension_path:
                 dimension_scores[ne.dimension_path] = ne.score
 
+        readiness = (
+            band_by_target.get(target, col_result.readiness)
+            if band_by_target is not None
+            else col_result.readiness
+        )
         summary = ColumnSummary(
             column_name=column_name,
             table_name=table_name,
-            readiness=col_result.readiness,
+            readiness=readiness,
             dimension_scores=dimension_scores,
         )
         summaries[col_key] = summary

--- a/packages/engine/src/dataraum/entropy/views/query_context.py
+++ b/packages/engine/src/dataraum/entropy/views/query_context.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -28,9 +28,6 @@ from dataraum.entropy.views.readiness_context import (
     build_column_evidence,
     load_persisted_readiness,
 )
-
-if TYPE_CHECKING:
-    pass
 
 logger = get_logger(__name__)
 

--- a/packages/engine/src/dataraum/entropy/views/readiness_context.py
+++ b/packages/engine/src/dataraum/entropy/views/readiness_context.py
@@ -518,6 +518,10 @@ def load_persisted_readiness(
     :func:`build_column_evidence` for that); reconstructed ``node_evidence``
     carries only the non-clean driver nodes, which is exactly what the band
     consumers read (``high_entropy_dimensions``).
+
+    Precondition: the terminal detect step has run. Query time always follows
+    detect in the workflow, so empty here means "no readiness yet" and is
+    treated as ready — same as a genuinely clean source.
     """
     if not table_ids:
         return EntropyForReadiness()
@@ -600,8 +604,10 @@ def _record_to_column_result(target: str, rec: EntropyReadinessRecord) -> Column
         for i in (rec.intents or [])
     ]
     # Persisted top_drivers are exactly the non-clean nodes — what the band
-    # consumers read as node_evidence (high_entropy_dimensions). Raw score is
-    # not persisted; band consumers don't read it.
+    # consumers read as node_evidence (high_entropy_dimensions). Raw per-node
+    # ``score`` is NOT persisted, so it stays 0.0 here: this reconstructed result
+    # must only feed consumers that don't read ``ne.score`` (the band view). For
+    # contract dimension_scores, use build_column_evidence (which has real scores).
     top_drivers = rec.top_drivers or []
     node_evidence = [
         ColumnNodeEvidence(

--- a/packages/engine/src/dataraum/entropy/views/readiness_context.py
+++ b/packages/engine/src/dataraum/entropy/views/readiness_context.py
@@ -12,10 +12,12 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from dataraum.core.logging import get_logger
 from dataraum.entropy.core.storage import EntropyRepository
+from dataraum.entropy.db_models import EntropyReadinessRecord
 from dataraum.entropy.models import EntropyObject
 from dataraum.entropy.network.bridge import (
     build_dimension_path_to_node_map,
@@ -24,6 +26,7 @@ from dataraum.entropy.network.bridge import (
 )
 from dataraum.entropy.network.model import EntropyNetwork
 from dataraum.entropy.network.rollup import compute_priorities, roll_up
+from dataraum.storage import Column, Table
 
 logger = get_logger(__name__)
 
@@ -172,6 +175,8 @@ def _build_column_result(
     objects: list[EntropyObject],
     network: EntropyNetwork,
     path_map: dict[str, str],
+    *,
+    compute_rollup: bool = True,
 ) -> tuple[ColumnReadinessResult | None, list[DirectSignal]]:
     """Run network inference for a single column's objects.
 
@@ -180,6 +185,12 @@ def _build_column_result(
         objects: EntropyObjects for this column only.
         network: The entropy network.
         path_map: Pre-built dimension_path -> node_name map.
+        compute_rollup: Run the noisy-OR rollup (intents + causal priorities).
+            When False, only the raw per-node evidence + direct signals are
+            built — the cheap half the contract gate needs at query time, which
+            never went through the rollup. The persisted ``entropy_readiness``
+            rows are the source of truth for the banded result, so the rollup
+            runs only at the terminal ``detect`` step (DAT-399 slice D).
 
     Returns:
         Tuple of (ColumnReadinessResult or None, list of DirectSignals).
@@ -211,22 +222,23 @@ def _build_column_result(
         for node, score in scores.items()
     }
 
-    # Roll observed scores up the DAG. Unobserved nodes with no resolved parents
-    # are simply absent — no prior leakage, so no subgraph pruning is needed.
-    risk = roll_up(network.config, scores, _pmap=network.parent_map, _order=network.topo_order)
-
-    # Causal fix priorities: how much each observed node lowers intent risk.
-    priorities = compute_priorities(network.config, scores, low_upper=disc.low_upper)
-
-    # Build ColumnNodeEvidence for each observed node
-    # Build lookups: node_name -> source object, node_name -> impact_delta
+    # Build lookup: node_name -> source object (for raw score + evidence).
     node_to_obj: dict[str, EntropyObject] = {}
     for obj in mapped:
         node_name = path_map.get(obj.dimension_path)
         if node_name:
             node_to_obj[node_name] = obj
 
-    node_to_delta: dict[str, float] = {pr.node: pr.impact_delta for pr in priorities}
+    risk: dict[str, float] = {}
+    priorities: list[Any] = []
+    node_to_delta: dict[str, float] = {}
+    if compute_rollup:
+        # Roll observed scores up the DAG. Unobserved nodes with no resolved
+        # parents are simply absent — no prior leakage, so no subgraph pruning.
+        risk = roll_up(network.config, scores, _pmap=network.parent_map, _order=network.topo_order)
+        # Causal fix priorities: how much each observed node lowers intent risk.
+        priorities = compute_priorities(network.config, scores, low_upper=disc.low_upper)
+        node_to_delta = {pr.node: pr.impact_delta for pr in priorities}
 
     node_evidence: list[ColumnNodeEvidence] = []
     for node_name, state in states.items():
@@ -317,6 +329,8 @@ def _build_column_result(
 def assemble_readiness_context(
     objects: list[EntropyObject],
     network: EntropyNetwork,
+    *,
+    compute_rollup: bool = True,
 ) -> EntropyForReadiness:
     """Assemble readiness context from entropy objects and network.
 
@@ -326,6 +340,9 @@ def assemble_readiness_context(
     Args:
         objects: All EntropyObject instances for the tables being analyzed.
         network: The entropy network.
+        compute_rollup: Run the noisy-OR rollup. When False, per-column results
+            carry only raw node evidence (no intents/bands) — the cheap evidence
+            half for the query-time contract gate (DAT-399 slice D).
 
     Returns:
         EntropyForReadiness with per-column results + source-wide summaries.
@@ -360,6 +377,7 @@ def assemble_readiness_context(
             target_objects,
             network,
             path_map,
+            compute_rollup=compute_rollup,
         )
         all_direct_signals.extend(col_signals)
         if col_result is not None:
@@ -419,14 +437,32 @@ def assemble_readiness_context(
 # ---------------------------------------------------------------------------
 
 
+def _load_entropy_objects(session: Session, table_ids: list[str]) -> list[EntropyObject]:
+    """Load entropy objects for the typed tables among ``table_ids`` (or empty)."""
+    if not table_ids:
+        return []
+
+    repo = EntropyRepository(session)
+    typed_table_ids = repo.get_typed_table_ids(table_ids)
+    if not typed_table_ids:
+        logger.warning("No typed tables found for readiness context")
+        return []
+
+    entropy_objects = repo.load_for_tables(typed_table_ids, enforce_typed=True)
+    if not entropy_objects:
+        logger.debug("No entropy objects found for readiness context")
+    return entropy_objects
+
+
 def build_for_readiness(
     session: Session,
     table_ids: list[str],
 ) -> EntropyForReadiness:
-    """Build entropy context for the readiness view.
+    """Build the full readiness rollup (intents + bands) for typed tables.
 
-    Loads entropy data for typed tables and assembles the readiness context
-    joining rollup results with source evidence.
+    Runs the noisy-OR rollup. This is the terminal ``detect`` step's computation
+    (persisted to ``entropy_readiness``); query-time consumers read the persisted
+    band instead and use :func:`build_column_evidence` for the contract gate.
 
     Args:
         session: SQLAlchemy session.
@@ -435,20 +471,167 @@ def build_for_readiness(
     Returns:
         EntropyForReadiness with computed context.
     """
+    entropy_objects = _load_entropy_objects(session, table_ids)
+    if not entropy_objects:
+        return EntropyForReadiness()
+    return assemble_readiness_context(entropy_objects, EntropyNetwork())
+
+
+def build_column_evidence(
+    session: Session,
+    table_ids: list[str],
+) -> EntropyForReadiness:
+    """Build raw per-column entropy evidence WITHOUT the noisy-OR rollup.
+
+    The contract gate (``query_context.network_to_column_summaries``) only reads
+    raw per-node scores + direct signals, never the rollup. This loads exactly
+    that — the cheap half — so the rollup is computed once, at ``detect``, not
+    re-run per query (DAT-399 slice D). ``avg_entropy_score`` is raw-derived and
+    so still populated; intents/bands are intentionally empty.
+
+    Args:
+        session: SQLAlchemy session.
+        table_ids: List of table IDs to include.
+
+    Returns:
+        EntropyForReadiness with per-column node evidence + direct signals only.
+    """
+    entropy_objects = _load_entropy_objects(session, table_ids)
+    if not entropy_objects:
+        return EntropyForReadiness()
+    return assemble_readiness_context(entropy_objects, EntropyNetwork(), compute_rollup=False)
+
+
+def load_persisted_readiness(
+    session: Session,
+    table_ids: list[str],
+) -> EntropyForReadiness:
+    """Reconstruct the banded readiness view from persisted ``entropy_readiness``.
+
+    The single source of truth for the band/intents/drivers (DAT-399 slice D):
+    the terminal ``detect`` step ran the rollup once and persisted it, so query
+    time reads those rows rather than recomputing. Reconstructs the same
+    ``EntropyForReadiness`` shape the band consumers (graph context, query
+    counts) already read, keyed by ``column:{table}.{column}`` target.
+
+    Per-node raw ``score`` is not persisted (the contract gate uses
+    :func:`build_column_evidence` for that); reconstructed ``node_evidence``
+    carries only the non-clean driver nodes, which is exactly what the band
+    consumers read (``high_entropy_dimensions``).
+    """
     if not table_ids:
         return EntropyForReadiness()
 
-    repo = EntropyRepository(session)
-
-    typed_table_ids = repo.get_typed_table_ids(table_ids)
-    if not typed_table_ids:
-        logger.warning("No typed tables found for readiness context")
+    records = list(
+        session.execute(
+            select(EntropyReadinessRecord).where(EntropyReadinessRecord.table_id.in_(table_ids))
+        ).scalars()
+    )
+    if not records:
         return EntropyForReadiness()
 
-    entropy_objects = repo.load_for_tables(typed_table_ids, enforce_typed=True)
-    if not entropy_objects:
-        logger.debug("No entropy objects found for readiness context")
-        return EntropyForReadiness()
+    target_by_ids = _target_by_ids(session, table_ids)
 
-    network = EntropyNetwork()
-    return assemble_readiness_context(entropy_objects, network)
+    columns: dict[str, ColumnReadinessResult] = {}
+    for rec in records:
+        if rec.table_id is None or rec.column_id is None:
+            continue
+        target = target_by_ids.get((rec.table_id, rec.column_id))
+        if target is None:
+            # Column row the readiness record points at no longer resolves
+            # (renamed/dropped) — skip, don't guess.
+            continue
+        columns[target] = _record_to_column_result(target, rec)
+
+    columns_blocked = sum(1 for c in columns.values() if c.readiness == "blocked")
+    columns_investigate = sum(1 for c in columns.values() if c.readiness == "investigate")
+    columns_ready = sum(1 for c in columns.values() if c.readiness == "ready")
+    if columns_blocked > 0:
+        overall_readiness = "blocked"
+    elif columns_investigate > 0:
+        overall_readiness = "investigate"
+    else:
+        overall_readiness = "ready"
+
+    return EntropyForReadiness(
+        columns=columns,
+        total_columns=len(columns),
+        columns_blocked=columns_blocked,
+        columns_investigate=columns_investigate,
+        columns_ready=columns_ready,
+        overall_readiness=overall_readiness,
+    )
+
+
+def _target_by_ids(session: Session, table_ids: list[str]) -> dict[tuple[str, str], str]:
+    """Map ``(table_id, column_id)`` -> ``"column:{table_name}.{column_name}"``.
+
+    Inverse of the target string the detectors write (``engine.py`` builds it as
+    ``f"column:{table.table_name}.{col.column_name}"``).
+    """
+    table_name_by_id: dict[str, str] = {}
+    for table_id, table_name in session.execute(
+        select(Table.table_id, Table.table_name).where(Table.table_id.in_(table_ids))
+    ):
+        table_name_by_id[table_id] = table_name
+
+    out: dict[tuple[str, str], str] = {}
+    for table_id, column_id, column_name in session.execute(
+        select(Column.table_id, Column.column_id, Column.column_name).where(
+            Column.table_id.in_(table_ids)
+        )
+    ):
+        table_name = table_name_by_id.get(table_id)
+        if table_name is None:
+            continue
+        out[(table_id, column_id)] = f"column:{table_name}.{column_name}"
+    return out
+
+
+def _record_to_column_result(target: str, rec: EntropyReadinessRecord) -> ColumnReadinessResult:
+    """Reconstruct a ColumnReadinessResult from a persisted readiness row."""
+    intents = [
+        IntentReadiness(
+            intent_name=i.get("intent", ""),
+            risk=i.get("risk", 0.0),
+            readiness=i.get("band", "ready"),
+            drivers=[_driver_from_dict(d) for d in i.get("drivers", [])],
+        )
+        for i in (rec.intents or [])
+    ]
+    # Persisted top_drivers are exactly the non-clean nodes — what the band
+    # consumers read as node_evidence (high_entropy_dimensions). Raw score is
+    # not persisted; band consumers don't read it.
+    top_drivers = rec.top_drivers or []
+    node_evidence = [
+        ColumnNodeEvidence(
+            node_name=d.get("node", ""),
+            dimension_path=d.get("dimension_path", ""),
+            label=d.get("label", ""),
+            state=d.get("state", "low"),
+            impact_delta=d.get("impact_delta", 0.0),
+        )
+        for d in top_drivers
+    ]
+    return ColumnReadinessResult(
+        target=target,
+        node_evidence=node_evidence,
+        intents=intents,
+        top_priority_node=top_drivers[0].get("node", "") if top_drivers else "",
+        top_priority_impact=top_drivers[0].get("impact_delta", 0.0) if top_drivers else 0.0,
+        nodes_observed=len(node_evidence),
+        nodes_high=sum(1 for ne in node_evidence if ne.state == "high"),
+        worst_intent_risk=rec.worst_intent_risk,
+        readiness=rec.band,
+    )
+
+
+def _driver_from_dict(d: dict[str, Any]) -> IntentDriver:
+    """Reconstruct an IntentDriver from a persisted driver dict."""
+    return IntentDriver(
+        node=d.get("node", ""),
+        dimension_path=d.get("dimension_path", ""),
+        label=d.get("label", ""),
+        state=d.get("state", "low"),
+        impact_delta=d.get("impact_delta", 0.0),
+    )

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -583,17 +583,20 @@ def build_execution_context(
         relationships=rel_list_for_topology,
     )
 
-    # 16. Build entropy context from the readiness rollup (typed tables enforced internally)
+    # 16. Build entropy context. The band is the single source of truth the
+    # terminal detect step persisted (DAT-399 slice D) — read it, don't recompute
+    # the noisy-OR. The contract gate uses the rollup-free raw evidence + that band.
     from dataraum.entropy.views.readiness_context import (
         ColumnReadinessResult,
-        build_for_readiness,
+        build_column_evidence,
+        load_persisted_readiness,
     )
 
-    readiness_ctx = build_for_readiness(session, table_ids)
+    persisted = load_persisted_readiness(session, table_ids)
 
-    # Build column-level entropy lookup from readiness results
+    # Build column-level entropy lookup from the persisted readiness
     column_entropy_lookup: dict[str, dict[str, Any]] = {}
-    for target, col_result in readiness_ctx.columns.items():
+    for target, col_result in persisted.columns.items():
         # target is "column:table.col", extract "table.col"
         col_key = target.removeprefix("column:")
         column_entropy_lookup[col_key] = _column_readiness_to_dict(col_result)
@@ -601,36 +604,39 @@ def build_execution_context(
     # Build table-level entropy lookup aggregated from per-column readiness results
     table_entropy_lookup: dict[str, dict[str, Any]] = {}
     _table_columns: dict[str, list[ColumnReadinessResult]] = {}
-    for target, col_result in readiness_ctx.columns.items():
+    for target, col_result in persisted.columns.items():
         col_key = target.removeprefix("column:")
         tbl_name = col_key.split(".")[0] if "." in col_key else col_key
         _table_columns.setdefault(tbl_name, []).append(col_result)
     for tbl_name, col_results in _table_columns.items():
         table_entropy_lookup[tbl_name] = _table_readiness_to_dict(tbl_name, col_results)
 
-    # Build entropy summary from the readiness context
+    # Build entropy summary from the persisted readiness
     entropy_summary_dict: dict[str, Any] = {
-        "overall_readiness": readiness_ctx.overall_readiness,
-        "high_entropy_count": readiness_ctx.columns_blocked + readiness_ctx.columns_investigate,
-        "critical_entropy_count": readiness_ctx.columns_blocked,
-        "columns_blocked": readiness_ctx.columns_blocked,
-        "columns_investigate": readiness_ctx.columns_investigate,
-        "columns_ready": readiness_ctx.columns_ready,
+        "overall_readiness": persisted.overall_readiness,
+        "high_entropy_count": persisted.columns_blocked + persisted.columns_investigate,
+        "critical_entropy_count": persisted.columns_blocked,
+        "columns_blocked": persisted.columns_blocked,
+        "columns_investigate": persisted.columns_investigate,
+        "columns_ready": persisted.columns_ready,
         "readiness_blockers": [
             t.removeprefix("column:")
-            for t, c in readiness_ctx.columns.items()
+            for t, c in persisted.columns.items()
             if c.readiness == "blocked"
         ],
     }
 
-    # 16b. Build column summaries for contract evaluation (reuses readiness_ctx)
+    # 16b. Build column summaries for contract evaluation: raw dimension scores
+    # from the rollup-free evidence, readiness band from the persisted rows.
     from dataraum.entropy.views.query_context import network_to_column_summaries
 
-    column_summaries = network_to_column_summaries(readiness_ctx)
+    evidence = build_column_evidence(session, table_ids)
+    band_by_target = {target: col.readiness for target, col in persisted.columns.items()}
+    column_summaries = network_to_column_summaries(evidence, band_by_target=band_by_target)
 
-    # 16c. Overall entropy score from readiness context
+    # 16c. Overall entropy score from the raw evidence
     overall_entropy_score: float | None = (
-        readiness_ctx.avg_entropy_score if readiness_ctx.total_columns > 0 else None
+        evidence.avg_entropy_score if evidence.total_columns > 0 else None
     )
 
     # 17. Build table contexts

--- a/packages/engine/tests/integration/test_contracts.py
+++ b/packages/engine/tests/integration/test_contracts.py
@@ -17,7 +17,10 @@ from dataraum.entropy.contracts import (
     list_contracts,
 )
 from dataraum.entropy.views.query_context import network_to_column_summaries
-from dataraum.entropy.views.readiness_context import build_for_readiness
+from dataraum.entropy.views.readiness_context import (
+    build_column_evidence,
+    build_for_readiness,
+)
 
 from .conftest import PipelineTestHarness
 
@@ -28,10 +31,21 @@ def _build_column_summaries(
     harness: PipelineTestHarness,
     table_ids: list[str],
 ) -> dict[str, ColumnSummary]:
-    """Build column summaries from test harness via network."""
+    """Build column summaries the way the production contract gate does.
+
+    Mirrors ``build_for_query`` / ``graphs.context`` (DAT-399 slice D): raw
+    dimension scores from the rollup-free ``build_column_evidence``, readiness
+    band threaded in via ``band_by_target``. This harness writes entropy_objects
+    but does not run the terminal detect step's ``persist_readiness``, so the
+    band is sourced from a live ``build_for_readiness`` rollup here — its
+    equality with the persisted band is proven separately by the worker parity
+    integration test.
+    """
     with harness.session_factory() as session:
-        readiness_ctx = build_for_readiness(session, table_ids)
-        return network_to_column_summaries(readiness_ctx)
+        band_ctx = build_for_readiness(session, table_ids)
+        band_by_target = {target: col.readiness for target, col in band_ctx.columns.items()}
+        evidence = build_column_evidence(session, table_ids)
+        return network_to_column_summaries(evidence, band_by_target=band_by_target)
 
 
 class TestContractListAndStructure:

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -400,9 +400,7 @@ def test_terminal_detect_persists_per_column_readiness_and_replay_overwrites(
     with worker_manager.session_scope() as session:
         rows = list(
             session.execute(
-                select(EntropyReadinessRecord).where(
-                    EntropyReadinessRecord.source_id == source_id
-                )
+                select(EntropyReadinessRecord).where(EntropyReadinessRecord.source_id == source_id)
             ).scalars()
         )
 
@@ -435,7 +433,70 @@ def test_terminal_detect_persists_per_column_readiness_and_replay_overwrites(
                 ).scalars()
             )
         )
-    assert second_count == first_count, "readiness rows not overwritten on re-run (stale duplicates)"
+    assert second_count == first_count, (
+        "readiness rows not overwritten on re-run (stale duplicates)"
+    )
+
+
+def test_persisted_readiness_is_single_source_of_truth(
+    worker_manager: ConnectionManager, small_finance_path: Path
+) -> None:
+    """Query-time reads of the persisted band match the live rollup (DAT-399 slice D).
+
+    After terminal detect persists readiness, the query-time consumers no longer
+    recompute the noisy-OR: they read ``load_persisted_readiness`` for the band and
+    ``build_column_evidence`` (rollup-free) for the contract gate. Both must equal
+    what the full ``build_for_readiness`` rollup produced — proving the persisted
+    snapshot IS the source of truth and the contract dimension_scores are unchanged
+    (calibration-preserving).
+    """
+    from dataraum.entropy.views.query_context import network_to_column_summaries
+    from dataraum.entropy.views.readiness_context import (
+        build_column_evidence,
+        build_for_readiness,
+        load_persisted_readiness,
+    )
+
+    source_id = str(uuid4())
+    session_id = str(uuid4())
+    files = _enumerate_fixture_files(small_finance_path)
+    _seed_source_and_session(worker_manager, source_id, session_id, "small_finance", files)
+    identity = _identity(source_id, session_id)
+
+    assert run_phase(worker_manager, "import", identity, []).status == "completed"
+    raw_ids = raw_table_ids(worker_manager, source_id)
+    typed_ids = sorted({_process_one_table(worker_manager, identity, raw_id) for raw_id in raw_ids})
+    assert run_detectors(worker_manager, identity) > 0
+
+    with worker_manager.session_scope() as session:
+        live = build_for_readiness(session, typed_ids)
+        persisted = load_persisted_readiness(session, typed_ids)
+
+        # Band parity: same columns, same band + worst_intent_risk per column.
+        assert persisted.columns.keys() == live.columns.keys()
+        assert persisted.columns, "expected at least one column with readiness"
+        for target, live_col in live.columns.items():
+            pcol = persisted.columns[target]
+            assert pcol.readiness == live_col.readiness, target
+            assert pcol.worst_intent_risk == round(live_col.worst_intent_risk, 4), target
+            assert {i.intent_name for i in pcol.intents} == {
+                i.intent_name for i in live_col.intents
+            }, target
+        assert persisted.overall_readiness == live.overall_readiness
+        assert persisted.columns_blocked == live.columns_blocked
+        assert persisted.columns_investigate == live.columns_investigate
+
+        # Contract parity: rollup-free evidence + persisted band yields identical
+        # dimension_scores AND readiness (the calibration-preserving invariant).
+        live_summaries = network_to_column_summaries(live)
+        band_by_target = {t: c.readiness for t, c in persisted.columns.items()}
+        evidence_summaries = network_to_column_summaries(
+            build_column_evidence(session, typed_ids), band_by_target=band_by_target
+        )
+        assert evidence_summaries.keys() == live_summaries.keys()
+        for key, live_summary in live_summaries.items():
+            assert evidence_summaries[key].dimension_scores == live_summary.dimension_scores, key
+            assert evidence_summaries[key].readiness == live_summary.readiness, key
 
 
 def test_parallel_tables_do_not_conflict_and_terminal_detect_covers_all(

--- a/packages/engine/tests/unit/entropy/views/test_readiness_context.py
+++ b/packages/engine/tests/unit/entropy/views/test_readiness_context.py
@@ -136,6 +136,46 @@ class TestPerColumnAssembly:
         assert "root_a" in node_names
         assert "root_b" in node_names
 
+    def test_compute_rollup_false_keeps_evidence_drops_intents(self, small_network):
+        """Rollup-free assembly (DAT-399 slice D) yields raw evidence, no bands.
+
+        The query-time contract gate uses this cheap half: node evidence (raw
+        scores keyed by dimension_path) must survive, while the noisy-OR products
+        (intents, per-node impact_delta, banded readiness) are absent.
+        """
+        objects = [
+            make_entropy_object(
+                layer="structural",
+                dimension="types",
+                sub_dimension="root_a",
+                score=0.9,
+                target="column:t.c1",
+            ),
+        ]
+        full = assemble_readiness_context(objects, small_network)
+        cheap = assemble_readiness_context(objects, small_network, compute_rollup=False)
+
+        # Same columns + same raw scores (the contract gate reads these).
+        assert cheap.columns.keys() == full.columns.keys()
+        full_scores = {
+            ne.dimension_path: ne.score for ne in full.columns["column:t.c1"].node_evidence
+        }
+        cheap_scores = {
+            ne.dimension_path: ne.score for ne in cheap.columns["column:t.c1"].node_evidence
+        }
+        assert cheap_scores == full_scores
+        # avg_entropy_score is raw-derived -> still populated and identical.
+        assert cheap.avg_entropy_score == full.avg_entropy_score
+
+        # Rollup products are absent on the cheap path.
+        cheap_col = cheap.columns["column:t.c1"]
+        assert cheap_col.intents == []
+        assert cheap_col.worst_intent_risk == 0.0
+        assert cheap_col.readiness == "ready"
+        assert all(ne.impact_delta == 0.0 for ne in cheap_col.node_evidence)
+        # ...but the full rollup did produce intents for the same input.
+        assert full.columns["column:t.c1"].intents
+
     def test_two_columns_independent_results(self, small_network):
         """Two columns with different scores -> independent results."""
         objects = [
@@ -381,6 +421,7 @@ class TestPerColumnAssembly:
         col = result.columns["column:t.c1"]
         ne = next(n for n in col.node_evidence if n.node_name == "root_a")
         assert ne.impact_delta == 0.0
+
 
 # ===================================================================
 # E. Assembly with full_network (15-node)


### PR DESCRIPTION
## What

DAT-399 slice D. The terminal `detect` step already persists the per-column readiness rollup to `entropy_readiness` (DAT-394). This makes the engine's **query-time** consumers read that persisted band instead of recomputing the noisy-OR rollup — so the rollup runs **exactly once**, at detect. Closes the "two rollup code paths that can drift" gap and makes engine query-band == persisted-band == cockpit why/look band.

## How

- **`readiness_context.py`**: `compute_rollup` flag splits the cheap raw-evidence half from the noisy-OR. New `build_column_evidence` (rollup-free, for the contract gate), `load_persisted_readiness` (reconstructs the banded `EntropyForReadiness` from `entropy_readiness` rows), shared `_load_entropy_objects`.
- **`query_context.build_for_query` + `graphs/context.py`**: band / counts / `overall_readiness` from `load_persisted_readiness`; contract `dimension_scores` + `avg_entropy_score` from `build_column_evidence`. The persisted band is threaded into contract eval via a new `network_to_column_summaries(..., band_by_target=...)` override (contracts read `ColumnSummary.readiness` — a blocked column blocks every contract).

## Why it's behavior-preserving (calibration-safe)

- Contract `dimension_scores` only ever read **raw** per-node scores + direct signals — they never went through the noisy-OR. `build_column_evidence` is the *same* score-assembly code with the rollup skipped → `dimension_scores` byte-identical.
- Bands are deterministic from `entropy_objects` → persisted band == live recompute.
- Integration parity test (`test_persisted_readiness_is_single_source_of_truth`) asserts **both** on real data: persisted band == live rollup, and contract `dimension_scores`/readiness identical.

## Scope

- **No schema / Drizzle-mirror change** — read-only against the existing `entropy_readiness` table.
- Out of scope (deferred): DAT-396 (cross-table/dataset readiness, `top_fix`, wiring orphaned detectors).

## Tests / gates

- 1293 unit + the contract & worker integration suites green; ruff / mypy / vulture clean.
- Reviewers: senior **APPROVE**; spec **COMPLIANT** after fixing the two flagged fidelity gaps (contract-test now exercises the production scores path; `views/__init__` exports + docstrings updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)