### PR TITLE
chore: retire stale FastAPI/Starlette docstrings; rename gitignore te…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ spike/
 data/
 test_output/
 pipeline_output/
-pipeline_testdata/
+testdata/
 examples/*
 !examples/*.ipynb
 prototypes/

--- a/packages/engine/src/dataraum/core/connections.py
+++ b/packages/engine/src/dataraum/core/connections.py
@@ -6,7 +6,7 @@ latter scoped via ``session_id`` FK).
 
 DuckDB-side post-DAT-341: managers obtain a fresh DuckDB connection from
 the process-wide DuckLake anchor (:mod:`dataraum.server.storage`). The
-anchor must be bootstrapped before any manager initializes (FastAPI
+anchor must be bootstrapped before any manager initializes (worker
 startup, or the ``lake_anchor`` test fixture). Each manager's connection
 has its own ``USE``/search_path state but shares the DuckLake catalog
 (schemas, tables) with every other connection to the same named in-memory

--- a/packages/engine/src/dataraum/core/settings.py
+++ b/packages/engine/src/dataraum/core/settings.py
@@ -98,8 +98,8 @@ class Settings(BaseSettings):
 def get_settings() -> Settings:
     """Return the process-wide settings singleton, validating env on first call.
 
-    Call this once at boot (the Starlette lifespan / future Temporal worker
-    entrypoint) so a misconfigured deployment fails loud before serving.
+    Call this once at boot (the Temporal worker entrypoint) so a
+    misconfigured deployment fails loud before serving.
     """
     return Settings()  # type: ignore[call-arg]
 

--- a/packages/engine/src/dataraum/server/storage.py
+++ b/packages/engine/src/dataraum/server/storage.py
@@ -1,4 +1,4 @@
-"""DuckLake bootstrap and shared in-memory anchor for the FastAPI process.
+"""DuckLake bootstrap and shared in-memory anchor for the worker process.
 
 DuckLake stores data as parquet files on an object store (DATA_PATH is an
 ``s3://`` URI — DAT-388) with metadata in a Postgres catalog database. DuckDB
@@ -9,7 +9,7 @@ connection must first register the S3 secret + ``httpfs`` (see
 Connection model (post-DAT-323):
 
 * One named in-memory DuckDB database, `:memory:dataraum_lake`, lives for the
-  lifetime of the FastAPI process. We open one *anchor* connection at startup
+  lifetime of the worker process. We open one *anchor* connection at startup
   that is never used for queries — its sole purpose is to keep the named
   database alive (DuckDB tears down a named in-memory database once the last
   connection to it closes).
@@ -21,7 +21,7 @@ Connection model (post-DAT-323):
   schema isolation without re-paying ATTACH cost.
 
 Tests bootstrap the anchor against a testcontainer Postgres + a tmp_path
-DATA_PATH; the FastAPI app does the same against the compose stack.
+DATA_PATH; the worker does the same against the compose stack.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
…stdata entry

The engine is a Temporal activity worker with no HTTP surface; docstrings in storage.py/connections.py/settings.py still described a FastAPI/Starlette process lifecycle. Align them with the worker entrypoint.