### PR TITLE
feat(DAT-400): bound the agent run_sql in-context sample

### DIFF
--- a/packages/cockpit/src/duckdb/agent-sample.test.ts
+++ b/packages/cockpit/src/duckdb/agent-sample.test.ts
@@ -1,0 +1,72 @@
+import type { Json } from "@duckdb/node-api";
+import { describe, expect, it } from "vitest";
+
+import {
+	AGENT_SAMPLE_BYTE_BUDGET,
+	AGENT_SAMPLE_ROWS,
+	boundSampleBytes,
+} from "./agent-sample";
+
+// Pure byte-budget bound for the agent's in-context run_sql sample (DAT-400).
+// No DB — the row + byte clamp is exercised end-to-end against a real DuckLake
+// in run-sql.integration.test.ts.
+
+describe("boundSampleBytes (DAT-400)", () => {
+	it("keeps every row when the sample fits the budget", () => {
+		const rows: Record<string, Json>[] = [
+			{ id: 1, name: "a" },
+			{ id: 2, name: "b" },
+			{ id: 3, name: "c" },
+		];
+		const result = boundSampleBytes(rows, 1024);
+		expect(result.truncated).toBe(false);
+		expect(result.rows).toEqual(rows);
+	});
+
+	it("trims rows once the cumulative serialized size exceeds the budget", () => {
+		// Each row serializes to a known, equal size; pick a budget that admits
+		// exactly two of them.
+		const row: Record<string, Json> = { v: "x".repeat(40) };
+		const oneSize = JSON.stringify(row).length;
+		const rows = Array.from({ length: 10 }, () => ({ ...row }));
+
+		const result = boundSampleBytes(rows, oneSize * 2 + 1);
+		expect(result.truncated).toBe(true);
+		expect(result.rows).toHaveLength(2);
+	});
+
+	it("preserves WHOLE rows — never splits a row mid-value", () => {
+		const rows: Record<string, Json>[] = [
+			{ wide: "y".repeat(100), n: 1 },
+			{ wide: "z".repeat(100), n: 2 },
+		];
+		const result = boundSampleBytes(rows, JSON.stringify(rows[0]).length + 5);
+		expect(result.truncated).toBe(true);
+		// Exactly the first whole row survives; the partial second row is dropped,
+		// not truncated into a half object.
+		expect(result.rows).toEqual([rows[0]]);
+	});
+
+	it("keeps the first row even when it alone exceeds the budget", () => {
+		// One over-budget row + the truncated flag beats returning nothing.
+		const rows: Record<string, Json>[] = [
+			{ huge: "q".repeat(500) },
+			{ huge: "r".repeat(500) },
+		];
+		const result = boundSampleBytes(rows, 10);
+		expect(result.rows).toHaveLength(1);
+		expect(result.rows[0]).toEqual(rows[0]);
+		expect(result.truncated).toBe(true);
+	});
+
+	it("reports not-truncated on an empty result", () => {
+		const result = boundSampleBytes([]);
+		expect(result.rows).toEqual([]);
+		expect(result.truncated).toBe(false);
+	});
+
+	it("exposes a row cap and a byte budget sized for an LLM context window", () => {
+		expect(AGENT_SAMPLE_ROWS).toBe(200);
+		expect(AGENT_SAMPLE_BYTE_BUDGET).toBe(256 * 1024);
+	});
+});

--- a/packages/cockpit/src/duckdb/agent-sample.ts
+++ b/packages/cockpit/src/duckdb/agent-sample.ts
@@ -1,0 +1,75 @@
+// Agent-path in-context sample bound for `run_sql` (DAT-400).
+//
+// The agent's `run_sql` feeds its result rows straight back into the LLM
+// context (the TanStack AI `chat()` loop re-serializes the tool `output` into
+// the next model turn). A broad `SELECT *` — e.g. `SELECT * FROM range(60000)`
+// — therefore floods the window even though the human-facing grid handles it
+// fine via the decoupled streaming `/api/run-sql` path. This bound applies ONLY
+// to the agent sample; the grid re-issues the SQL independently and is NOT
+// affected (GRID_DEFAULT_CAP = 50_000, virtualized).
+//
+// Two hard clamps sit ON TOP of the shared `clampRowLimit` (limit.ts) — they do
+// NOT change that shared policy (probe/connect still use their own explicit
+// limits):
+//
+//   - AGENT_SAMPLE_ROWS — a row cap, independent of the requested `limit`.
+//   - AGENT_SAMPLE_BYTE_BUDGET — a serialized-size budget, because a few wide
+//     VARCHAR/TEXT/STRUCT/LIST rows can blow the window even under the row cap.
+//
+// When EITHER bound trims the result, the caller surfaces a `truncated` signal
+// so the model knows the full result lives in the grid and can pivot the user
+// there / refine via aggregation.
+
+import type { Json } from "@duckdb/node-api";
+
+/** Row cap on the agent's in-context sample, independent of the requested `limit`. */
+export const AGENT_SAMPLE_ROWS = 200;
+
+/**
+ * Serialized-byte budget on the agent's in-context sample (~256 KB of
+ * `JSON.stringify(rows)`). Complements {@link AGENT_SAMPLE_ROWS}: a handful of
+ * wide TEXT/STRUCT/LIST rows can exceed the window even well under the row cap.
+ */
+export const AGENT_SAMPLE_BYTE_BUDGET = 256 * 1024;
+
+/** Result of bounding a row sample for the agent context. */
+export interface BoundedSample {
+	/** The rows kept after applying the row + byte bounds. */
+	rows: Record<string, Json>[];
+	/**
+	 * `true` when EITHER bound dropped at least one row — the model should pivot
+	 * the user to the grid (which has the full result) and/or refine the query.
+	 */
+	truncated: boolean;
+}
+
+/**
+ * Bound a materialized row sample by the serialized-byte budget.
+ *
+ * Keeps WHOLE rows (never splits a row mid-value) up to {@link byteBudget}
+ * bytes of `JSON.stringify`d content. The budget is measured against the
+ * cumulative serialized length of the rows kept so far; the first row is always
+ * kept even if it alone exceeds the budget (returning zero rows would be less
+ * useful to the model than one over-budget row plus the `truncated` flag).
+ *
+ * Pure (no DB) so it's unit-tested directly.
+ */
+export function boundSampleBytes(
+	rows: Record<string, Json>[],
+	byteBudget = AGENT_SAMPLE_BYTE_BUDGET,
+): BoundedSample {
+	const kept: Record<string, Json>[] = [];
+	let used = 0;
+	for (const row of rows) {
+		// `,` between elements is a negligible over-estimate; sizing on the row's
+		// own JSON length is the robust, encoding-agnostic measure of how much it
+		// costs the context window.
+		const size = JSON.stringify(row).length;
+		if (kept.length > 0 && used + size > byteBudget) {
+			return { rows: kept, truncated: true };
+		}
+		kept.push(row);
+		used += size;
+	}
+	return { rows: kept, truncated: false };
+}

--- a/packages/cockpit/src/duckdb/run-sql.integration.test.ts
+++ b/packages/cockpit/src/duckdb/run-sql.integration.test.ts
@@ -112,4 +112,38 @@ describe("runSql over a real DuckLake lake (DAT-367)", () => {
 		});
 		expect(result.rowCount).toBe(2);
 	});
+
+	it("bounds the agent sample at AGENT_SAMPLE_ROWS with truncated set (DAT-400)", async () => {
+		const { runSql } = await import("./run-sql");
+		const { AGENT_SAMPLE_ROWS } = await import("./agent-sample");
+		// A large generated result far exceeding the agent sample cap. A huge
+		// `limit` must NOT raise the in-context sample — the bound is independent
+		// of the requested limit.
+		const result = await runSql({
+			sql: "SELECT i AS n FROM range(60000) AS t(i)",
+			limit: 50_000,
+		});
+		expect(result.rowCount).toBe(AGENT_SAMPLE_ROWS);
+		expect(result.rows).toHaveLength(AGENT_SAMPLE_ROWS);
+		expect(result.truncated).toBe(true);
+	});
+
+	it("does NOT report truncated for an exact-fit / small result (no false positive)", async () => {
+		const { runSql } = await import("./run-sql");
+		const { AGENT_SAMPLE_ROWS } = await import("./agent-sample");
+		// A small result is complete.
+		const small = await runSql({
+			sql: "SELECT id FROM lake.typed.orders ORDER BY id",
+		});
+		expect(small.rowCount).toBe(3);
+		expect(small.truncated).toBe(false);
+
+		// An EXACT-fit result (exactly AGENT_SAMPLE_ROWS rows) is also complete —
+		// the peek-one-past-cap probe must not flag it.
+		const exact = await runSql({
+			sql: `SELECT i AS n FROM range(${AGENT_SAMPLE_ROWS}) AS t(i)`,
+		});
+		expect(exact.rowCount).toBe(AGENT_SAMPLE_ROWS);
+		expect(exact.truncated).toBe(false);
+	});
 });

--- a/packages/cockpit/src/duckdb/run-sql.ts
+++ b/packages/cockpit/src/duckdb/run-sql.ts
@@ -9,6 +9,9 @@
 // Tables are addressed by their fully-qualified lake name, e.g.
 // `lake.typed.orders` (the `lake` alias matches the engine's catalog alias).
 
+import type { Json } from "@duckdb/node-api";
+
+import { AGENT_SAMPLE_ROWS, boundSampleBytes } from "./agent-sample";
 import { getLakeConnection } from "./lake";
 import { clampRowLimit } from "./limit";
 import type { QueryResult } from "./query-result";
@@ -32,20 +35,86 @@ export interface RunSqlInput {
 }
 
 /**
- * Run read-only SQL against the lake and return JSON-safe rows.
+ * The agent-facing `run_sql` result. Extends the shared {@link QueryResult}
+ * with a `truncated` signal: the in-context sample is bounded ON TOP of the
+ * requested `limit` (see {@link AGENT_SAMPLE_ROWS} / the serialized-byte budget
+ * in `agent-sample.ts`), so the model needs to know when what it sees is a
+ * partial view and the full result lives in the human grid.
+ */
+export interface AgentQueryResult extends QueryResult {
+	/**
+	 * `true` when the agent's in-context sample was trimmed below the full
+	 * result — either by the row cap or the serialized-byte budget. The model
+	 * should pivot the user to the streaming grid (which fetches the full result
+	 * independently) and/or refine the query via aggregation. `rowCount` reflects
+	 * the trimmed sample, NOT the full result size.
+	 */
+	truncated: boolean;
+}
+
+/**
+ * Run read-only SQL against the lake and return a JSON-safe, context-bounded
+ * sample for the agent.
  *
  * The query is wrapped in `SELECT * FROM (<sql>) LIMIT <n>` so every result is
- * bounded — the limit defaults to {@link DEFAULT_ROW_LIMIT} and is clamped to
- * {@link HARD_ROW_CEILING} regardless of what the caller asks for. The lake
- * connection is ATTACHed READ_ONLY, so writes fail at the engine level — this
- * is a read verb by construction, not by convention.
+ * bounded by the requested `limit` (defaulted via {@link DEFAULT_ROW_LIMIT},
+ * clamped to {@link HARD_ROW_CEILING}). ON TOP of that, the AGENT path applies
+ * a second, smaller bound so a broad `SELECT *` can't flood the LLM context
+ * window even when the requested `limit` is large:
+ *
+ *   - a hard {@link AGENT_SAMPLE_ROWS} row cap, AND
+ *   - a serialized-byte budget (so wide TEXT/STRUCT/LIST rows can't blow the
+ *     window even under the row cap).
+ *
+ * To detect truncation WITHOUT a false positive on an exact-fit result, the
+ * effective LIMIT peeks one row past the agent cap; an over-cap read marks the
+ * sample `truncated`. The human-facing grid is decoupled — it re-issues the SQL
+ * over the stateless `/api/run-sql` stream (GRID_DEFAULT_CAP = 50_000,
+ * virtualized) — so this bound shrinks ONLY what the model sees, never the user.
+ *
+ * The lake connection is ATTACHed READ_ONLY, so writes fail at the engine
+ * level — this is a read verb by construction, not by convention.
  */
-export async function runSql(input: RunSqlInput): Promise<QueryResult> {
+export async function runSql(input: RunSqlInput): Promise<AgentQueryResult> {
 	const conn = await getLakeConnection();
-	const limit = clampRowLimit(input.limit);
-	const wrapped = `SELECT * FROM (${input.sql}) AS _run_sql LIMIT ${limit}`;
+	// The agent sample never needs more than AGENT_SAMPLE_ROWS regardless of the
+	// requested `limit`; fetch one extra row to distinguish a capped result from
+	// an exact-fit one (cheap — the read stops at the LIMIT).
+	const requested = clampRowLimit(input.limit);
+	const effective = Math.min(requested, AGENT_SAMPLE_ROWS);
+	const wrapped = `SELECT * FROM (${input.sql}) AS _run_sql LIMIT ${effective + 1}`;
 	const reader = input.params
 		? await conn.runAndReadAll(wrapped, input.params)
 		: await conn.runAndReadAll(wrapped);
-	return readerToResult(reader);
+	const base = readerToResult(reader);
+
+	return boundAgentSample(base, effective);
+}
+
+/**
+ * Apply the agent-path row + byte bounds to a materialized result.
+ *
+ * `base.rows` was read with `LIMIT effective + 1`, so a length over `effective`
+ * means the underlying result had more rows than the cap → `truncated`. After
+ * the row cap, the serialized-byte budget can trim further (and also set
+ * `truncated`). Returns the trimmed sample with a `rowCount` reflecting the
+ * rows the model actually sees.
+ */
+function boundAgentSample(
+	base: QueryResult,
+	effective: number,
+): AgentQueryResult {
+	const overRowCap = base.rows.length > effective;
+	const rowCapped: Record<string, Json>[] = overRowCap
+		? base.rows.slice(0, effective)
+		: base.rows;
+
+	const { rows, truncated: byteTruncated } = boundSampleBytes(rowCapped);
+
+	return {
+		columns: base.columns,
+		rows,
+		rowCount: rows.length,
+		truncated: overRowCap || byteTruncated,
+	};
 }

--- a/packages/cockpit/src/tools/run_sql.test.ts
+++ b/packages/cockpit/src/tools/run_sql.test.ts
@@ -1,0 +1,49 @@
+// run_sql tool schema (DAT-400). No DB — this pins the AGENT-FACING contract:
+// `truncated` MUST be a validated field on the tool's outputSchema, because the
+// TanStack AI chat() loop validates the tool `output` against that schema
+// before feeding it back into model context. A `truncated` that lived only as a
+// runtime property (absent from the schema) would be stripped and the model
+// would never learn the sample was bounded.
+//
+// Importing the tool transitively pulls config.ts + the Postgres metadata
+// client (via the duckdb modules' import graph), so mock both — see
+// registry.test.ts / look-table.test.ts.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("#/config", () => ({ config: {} }));
+vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
+
+import { runSqlTool } from "./run_sql";
+
+describe("run_sql tool outputSchema (DAT-400)", () => {
+	it("declares `truncated` as a required boolean on the validated output", () => {
+		const outputSchema = runSqlTool.outputSchema;
+		// The tool must declare an output schema at all — chat() only validates
+		// (and forwards) `output` when one is present.
+		expect(outputSchema).toBeDefined();
+		if (!outputSchema) return;
+
+		// A result WITHOUT `truncated` must fail validation — proving the field is
+		// a real part of the schema (so the SDK feeds it to the model), not an
+		// extra property that would be silently dropped.
+		const missing = outputSchema.safeParse({
+			columns: ["n"],
+			rows: [{ n: 1 }],
+			rowCount: 1,
+		});
+		expect(missing.success).toBe(false);
+
+		// With `truncated` it validates, and the value round-trips.
+		const ok = outputSchema.safeParse({
+			columns: ["n"],
+			rows: [{ n: 1 }],
+			rowCount: 1,
+			truncated: true,
+		});
+		expect(ok.success).toBe(true);
+		if (ok.success) {
+			expect(ok.data.truncated).toBe(true);
+		}
+	});
+});

--- a/packages/cockpit/src/tools/run_sql.ts
+++ b/packages/cockpit/src/tools/run_sql.ts
@@ -9,18 +9,34 @@
 import { toolDefinition } from "@tanstack/ai";
 import { z } from "zod";
 
+import { AGENT_SAMPLE_ROWS } from "../duckdb/agent-sample";
 import { HARD_ROW_CEILING } from "../duckdb/limit";
 import { runSql } from "../duckdb/run-sql";
 
-// QueryResult shape ({columns, rows, rowCount}). `rows` is intentionally
-// permissive — `runSql` returns `Record<string, Json>[]` (arbitrary JSON-safe
-// values via the neo driver's getRowObjectsJson), so we keep the value type as
-// `z.unknown()` rather than enumerating per-column types we can't know ahead of
-// the query.
+// Agent-result shape ({columns, rows, rowCount, truncated}). `rows` is
+// intentionally permissive — `runSql` returns `Record<string, Json>[]`
+// (arbitrary JSON-safe values via the neo driver's getRowObjectsJson), so we
+// keep the value type as `z.unknown()` rather than enumerating per-column types
+// we can't know ahead of the query.
+//
+// `truncated` MUST be a real field on this schema (not an extra runtime
+// property): the TanStack AI `chat()` loop feeds the tool's VALIDATED `output`
+// back into model context, so a property absent from the schema would be
+// stripped before the model ever sees the signal (DAT-400).
 const QueryResultSchema = z.object({
 	columns: z.array(z.string()),
 	rows: z.array(z.record(z.string(), z.unknown())),
 	rowCount: z.number(),
+	truncated: z
+		.boolean()
+		.describe(
+			"True when this in-context sample was trimmed below the full result " +
+				"(by the row or serialized-size bound). The COMPLETE result is " +
+				"already streaming in the result grid the user sees — do NOT re-run " +
+				"with a larger limit to get more rows into chat; instead point the " +
+				"user at the grid and/or refine via aggregation (GROUP BY, COUNT, " +
+				"summary stats).",
+		),
 });
 
 export const runSqlTool = toolDefinition({
@@ -29,10 +45,15 @@ export const runSqlTool = toolDefinition({
 		"Run read-only DuckDB SQL over the data lake and return JSON rows. " +
 		"Address tables by their fully-qualified lake name, e.g. " +
 		"`lake.typed.<table>` (type-resolved), `lake.raw.<table>` (VARCHAR " +
-		"staging), or `lake.quarantine.<table>` (failed casts). The result is " +
-		"capped (default 1000 rows, hard ceiling 200000); pass `limit` to change " +
-		"it within that ceiling. Use `params` for any literal value instead of " +
-		"concatenating it into the SQL.",
+		"staging), or `lake.quarantine.<table>` (failed casts). The rows you " +
+		`receive are a BOUNDED in-context SAMPLE (at most ${AGENT_SAMPLE_ROWS} ` +
+		"rows, and trimmed further if the serialized result is large) — they are " +
+		"for YOUR inspection, not the user's full answer. When `truncated` is " +
+		"true the full result is already streaming in the result grid the user " +
+		"sees; point them there and/or refine via aggregation rather than asking " +
+		"for more raw rows. `limit` bounds the underlying query but does NOT " +
+		"raise the in-context sample. Use `params` for any literal value instead " +
+		"of concatenating it into the SQL.",
 	inputSchema: z.object({
 		sql: z.string().describe("DuckDB SQL to run (read-only)."),
 		params: z


### PR DESCRIPTION
The agent's run_sql feeds its result rows straight back into the LLM context (the TanStack AI chat() loop re-serializes the tool output into the next turn), so a broad SELECT — e.g. SELECT * FROM range(60000) — floods the window even though the human grid handles it fine via the decoupled streaming /api/run-sql path.

Bound the AGENT path only, independently of the requested `limit` and of the grid's cap:

- AGENT_SAMPLE_ROWS (200): a hard row cap on top of clampRowLimit.
- AGENT_SAMPLE_BYTE_BUDGET (~256 KB): a serialized-size budget so wide TEXT/STRUCT/LIST rows can't blow the window even under the row cap.
- A `truncated` boolean is added as a REAL field on run_sql's QueryResultSchema (chat() validates `output` against the schema before feeding it back, so an off-schema property would be stripped) telling the model the full result is in the grid — pivot the user there / refine via aggregation instead of re-running for more raw rows.

To avoid a false `truncated` on an exact-fit result, the effective LIMIT peeks one row past the cap; an over-cap read marks the sample truncated.

The shared clampRowLimit constants in limit.ts are unchanged — probe and connect share that path with their own explicit limits. The grid path is untouched: tool-result-to-canvas re-issues the SQL from the call input over /api/run-sql (GRID_DEFAULT_CAP=50_000, virtualized), so the human still sees the full result.

Tests: pure byte-budget unit test (agent-sample.test.ts), a schema assertion that `truncated` is a validated output field (run_sql.test.ts), and integration cases over a real DuckLake (run-sql.integration.test.ts) asserting the range(60000) sample caps at 200 with truncated set and that exact-fit/small results are NOT flagged.