### PR TITLE
refactor(DAT-410): scope detect/readiness by the session's tables, not source_id

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,31 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-02: DAT-410 — detect/readiness scope by the session's tables, not `source_id`
+
+Behavior-preserving runtime refactor: the terminal `detect` step (`run_detectors`) +
+`persist_readiness` now scope by the run-session's `session_tables` (DAT-407's rail)
+instead of `Table.source_id`. **No detector logic, threshold, rollup, or readiness
+band/driver computation changed** — only the *table-set the same detectors run over*
+and the *delete-before-insert scope* of `entropy_readiness`.
+
+### dataraum-eval
+- **Expectation: readiness output is byte-identical for add_source.** A single-source
+  add_source run's `session_tables` is exactly that source's freshly-typed tables (linked
+  in the `typing` phase, same transaction as the `Table` row), so `run_detectors` +
+  `persist_readiness` see the identical table set as the prior `source_id`-scoped code.
+- **Calibrate / guard**: re-run the readiness snapshot calibration and confirm
+  `entropy_readiness` rows (band, `worst_intent_risk`, intents, drivers) and detector
+  recall do **not** move. This is the no-regression gate for the change; any drift is a bug.
+- **Signature change** (engine-internal, not an eval surface): `persist_readiness(session, source_id, session_id)` → `persist_readiness(session, session_id, table_ids)`. New helper `tables_for_session(session, session_id) -> list[str]`.
+- **Improved (not a regression)**: a per-table teach replay now clears only that table's
+  `entropy_readiness` rows (delete scoped by `table_id`), not the whole source's.
+- **Multi-source note**: the change makes the layer multi-source-ready but add_source is
+  still single-source; multi-source detect (begin_session) is wired in DAT-408. The
+  `run_detector_post_step` `source_id` anchor is intentionally kept here (harmless for
+  single-source); DAT-408 drops it.
+- **Status**: pending
+
 ## 2026-06-02: DAT-406 — add_source progress via `@workflow.query get_progress` (parent-level)
 
 Adds a read-only parent-level progress surface to `addSourceWorkflow` and reshapes

--- a/packages/engine/src/dataraum/entropy/db_models.py
+++ b/packages/engine/src/dataraum/entropy/db_models.py
@@ -92,7 +92,7 @@ class EntropyReadinessRecord(Base):
     its persisted snapshot — one per analyzed column — for the cockpit ``why`` /
     ``look`` tools (read via Drizzle) and as agent context. Self-refreshing: the
     terminal detect step re-runs on every (re-)measure and rewrites these rows
-    (delete-before-insert scoped to ``source_id``).
+    (delete-before-insert scoped to ``table_id`` — the session's table set, DAT-410).
 
     ``band`` is the collapsed worst-of-intents band the contract gate already
     consumes; ``intents`` carries the per-intent breakdown (query / aggregation /
@@ -109,8 +109,9 @@ class EntropyReadinessRecord(Base):
         ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
     )
 
-    # Scope — one readiness row per analyzed column. ``source_id`` is the
-    # delete-before-insert scope key and is always set, so it is NOT NULL.
+    # Scope — one readiness row per analyzed column. ``source_id`` is the per-row
+    # FK stamp, derived per-table (always set, NOT NULL); ``table_id`` is the
+    # delete-before-insert scope key (DAT-410).
     source_id: Mapped[str] = mapped_column(ForeignKey("sources.source_id"), nullable=False)
     table_id: Mapped[str | None] = mapped_column(ForeignKey("tables.table_id", ondelete="CASCADE"))
     column_id: Mapped[str | None] = mapped_column(

--- a/packages/engine/src/dataraum/entropy/readiness.py
+++ b/packages/engine/src/dataraum/entropy/readiness.py
@@ -52,7 +52,9 @@ def persist_readiness(session: Session, session_id: str, table_ids: list[str]) -
     source_by_table: dict[str, str] = dict(
         session.execute(
             select(Table.table_id, Table.source_id).where(Table.table_id.in_(table_ids))
-        ).tuples()
+        )
+        .tuples()
+        .all()
     )
 
     rows: list[EntropyReadinessRecord] = []

--- a/packages/engine/src/dataraum/entropy/readiness.py
+++ b/packages/engine/src/dataraum/entropy/readiness.py
@@ -36,12 +36,13 @@ def persist_readiness(session: Session, session_id: str, table_ids: list[str]) -
     row's ``source_id`` is derived per-table so a multi-source session's rows stay
     well-formed. Returns the rows written.
     """
+    if not table_ids:
+        return 0
+
     # Replay-safe refresh: clear these tables' prior readiness rows first.
     session.execute(
         delete(EntropyReadinessRecord).where(EntropyReadinessRecord.table_id.in_(table_ids))
     )
-    if not table_ids:
-        return 0
 
     ctx = build_for_readiness(session, table_ids)
     if not ctx.columns:

--- a/packages/engine/src/dataraum/entropy/readiness.py
+++ b/packages/engine/src/dataraum/entropy/readiness.py
@@ -49,12 +49,11 @@ def persist_readiness(session: Session, session_id: str, table_ids: list[str]) -
         return 0
 
     target_to_ids = _column_id_map(session, table_ids)
-    source_by_table = {
-        table_id: source_id
-        for table_id, source_id in session.execute(
+    source_by_table: dict[str, str] = dict(
+        session.execute(
             select(Table.table_id, Table.source_id).where(Table.table_id.in_(table_ids))
-        )
-    }
+        ).tuples()
+    )
 
     rows: list[EntropyReadinessRecord] = []
     for target, col in ctx.columns.items():

--- a/packages/engine/src/dataraum/entropy/readiness.py
+++ b/packages/engine/src/dataraum/entropy/readiness.py
@@ -7,8 +7,8 @@ analyzed column) so the cockpit ``why`` / ``look`` tools read it via Drizzle wit
 engine round-trip, and as agent context.
 
 Self-refreshing: called from the terminal ``detect`` step (which re-runs on every
-(re-)measure), it delete-before-inserts scoped to the source, so a teach->replay
-overwrites the rows with no stale leftovers.
+(re-)measure), it delete-before-inserts scoped to the session's table set, so a
+teach->replay overwrites the rows with no stale leftovers.
 """
 
 from __future__ import annotations
@@ -24,32 +24,36 @@ from dataraum.storage import Column, Table
 logger = get_logger(__name__)
 
 
-def persist_readiness(session: Session, source_id: str, session_id: str) -> int:
-    """Compute + persist per-column readiness for a source's typed tables.
+def persist_readiness(session: Session, session_id: str, table_ids: list[str]) -> int:
+    """Compute + persist per-column readiness for the session's typed tables.
 
-    Delete-before-insert scoped to ``source_id`` (replay-safe): the prior rows are
-    cleared even when the new rollup is empty. The caller owns the transaction
-    (commit happens at its ``session_scope`` exit). Returns the rows written.
+    Delete-before-insert scoped to ``table_ids`` — the session's tables (DAT-410),
+    not a source. Replay-safe: the prior rows for these tables are cleared even
+    when the new rollup is empty, and a per-table replay clears only that table's
+    rows (not the whole source's). For ``add_source`` the set is one source's
+    typed tables, so the result is identical to the prior source-scoped behaviour.
+    The caller owns the transaction (commit at its ``session_scope`` exit). Each
+    row's ``source_id`` is derived per-table so a multi-source session's rows stay
+    well-formed. Returns the rows written.
     """
-    typed_table_ids = [
-        row[0]
-        for row in session.execute(
-            select(Table.table_id).where(Table.source_id == source_id, Table.layer == "typed")
-        )
-    ]
-
-    # Replay-safe refresh: clear this source's prior readiness rows first.
+    # Replay-safe refresh: clear these tables' prior readiness rows first.
     session.execute(
-        delete(EntropyReadinessRecord).where(EntropyReadinessRecord.source_id == source_id)
+        delete(EntropyReadinessRecord).where(EntropyReadinessRecord.table_id.in_(table_ids))
     )
-    if not typed_table_ids:
+    if not table_ids:
         return 0
 
-    ctx = build_for_readiness(session, typed_table_ids)
+    ctx = build_for_readiness(session, table_ids)
     if not ctx.columns:
         return 0
 
-    target_to_ids = _column_id_map(session, typed_table_ids)
+    target_to_ids = _column_id_map(session, table_ids)
+    source_by_table = {
+        table_id: source_id
+        for table_id, source_id in session.execute(
+            select(Table.table_id, Table.source_id).where(Table.table_id.in_(table_ids))
+        )
+    }
 
     rows: list[EntropyReadinessRecord] = []
     for target, col in ctx.columns.items():
@@ -63,7 +67,7 @@ def persist_readiness(session: Session, source_id: str, session_id: str) -> int:
         rows.append(
             EntropyReadinessRecord(
                 session_id=session_id,
-                source_id=source_id,
+                source_id=source_by_table[table_id],
                 table_id=table_id,
                 column_id=column_id,
                 band=col.readiness,

--- a/packages/engine/src/dataraum/investigation/__init__.py
+++ b/packages/engine/src/dataraum/investigation/__init__.py
@@ -5,7 +5,11 @@ from dataraum.investigation.db_models import (
     InvestigationStep,
     SessionTable,
 )
-from dataraum.investigation.queries import link_session_tables, sources_for_session
+from dataraum.investigation.queries import (
+    link_session_tables,
+    sources_for_session,
+    tables_for_session,
+)
 
 __all__ = [
     "InvestigationSession",
@@ -13,4 +17,5 @@ __all__ = [
     "SessionTable",
     "link_session_tables",
     "sources_for_session",
+    "tables_for_session",
 ]

--- a/packages/engine/src/dataraum/investigation/queries.py
+++ b/packages/engine/src/dataraum/investigation/queries.py
@@ -35,6 +35,30 @@ def link_session_tables(session: Session, session_id: str, table_ids: Iterable[s
     return len(ids)
 
 
+def tables_for_session(session: Session, session_id: str) -> list[str]:
+    """Return the typed-table ids a session composes, via ``session_tables``.
+
+    The relational scope key for the analysis/readiness layer (DAT-410): the
+    detect step + readiness persist run over *these* tables, not "a source's
+    typed tables". For ``add_source`` the set is one source's freshly-typed
+    tables (linked by ``typing``); for ``begin_session`` it is the user's
+    selection, which may span sources.
+
+    Args:
+        session: active SQLAlchemy session bound to the ``ws_<id>`` schema.
+        session_id: the investigation-session id to resolve.
+
+    Returns:
+        The linked ``typed`` table ids (empty if the session links none).
+    """
+    rows = session.execute(
+        select(Table.table_id)
+        .join(SessionTable, SessionTable.table_id == Table.table_id)
+        .where(SessionTable.session_id == session_id, Table.layer == "typed")
+    )
+    return [table_id for (table_id,) in rows]
+
+
 def sources_for_session(session: Session, session_id: str) -> set[str]:
     """Return the distinct source ids of the tables a session composes.
 

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -27,6 +27,7 @@ from dataraum.core.config import load_phase_config
 from dataraum.core.logging import get_logger
 from dataraum.entropy.engine import run_detector_post_step
 from dataraum.entropy.readiness import persist_readiness
+from dataraum.investigation.queries import tables_for_session
 from dataraum.pipeline.base import PhaseContext, PhaseStatus
 from dataraum.pipeline.pipeline_config import load_phase_declarations
 from dataraum.pipeline.registry import get_phase_class
@@ -273,15 +274,15 @@ def run_replay_cleanup(
 
 
 def run_detectors(manager: ConnectionManager, identity: SourceIdentity) -> int:
-    """Run every wired detector once, source-wide — the terminal ``detect`` step.
+    """Run every wired detector once over the run-session's tables — the terminal ``detect`` step.
 
     The single stage-level detector pass (DAT-394): runs the union of the detectors
-    the executed chain phases declare (``_DETECTOR_PHASES``) over all the source's
-    typed tables (``table_ids=None``). It runs once, sequentially, after the
-    per-table fan-out and the ``semantic_per_column`` reduce — so the source-wide
-    delete-before-insert is safe (no concurrency) and every detector's inputs are
-    present. Replaces the old per-table ``detect_table`` + parent ``detect_source``
-    split: nothing reads entropy mid-run, so there is no reason to detect earlier.
+    the executed chain phases declare (``_DETECTOR_PHASES``) over the tables the run's
+    session composes (``session_tables``, DAT-407/410) — for ``add_source`` that is
+    exactly the source's freshly-typed tables, so the scope is identical to the prior
+    source-wide pass. It runs once, sequentially, after the per-table fan-out and the
+    ``semantic_per_column`` reduce — so the delete-before-insert is safe (no
+    concurrency) and every detector's inputs are present.
     """
     detector_ids = declared_detector_ids(_DETECTOR_PHASES)
     if not detector_ids:
@@ -289,23 +290,34 @@ def run_detectors(manager: ConnectionManager, identity: SourceIdentity) -> int:
 
     total = 0
     with manager.session_scope() as session, manager.duckdb_cursor() as cursor:
+        table_ids = tables_for_session(session, identity.session_id)
+        if not table_ids:
+            # add_source links its typed tables in ``typing`` (same transaction as
+            # the Table row), so an empty set here means the session has no tables —
+            # nothing to detect. Log it: a populated source with no links is a bug.
+            logger.warning(
+                "detect_no_session_tables",
+                source_id=identity.source_id,
+                session_id=identity.session_id,
+            )
+            return 0
         for detector_id in detector_ids:
-            # ``table_ids=None`` = source-wide: safe because this runs once,
-            # sequentially, after the fan-out — no concurrent writers to collide
-            # on the shared ``(source_id, detector_id)`` delete-before-insert.
+            # Scoped to the session's tables. The single terminal pass runs once,
+            # sequentially after the fan-out — no concurrent writers to collide on
+            # the per-(detector, table) delete-before-insert.
             total += run_detector_post_step(
                 session,
                 identity.source_id,
                 detector_id,
                 cursor,
                 session_id=identity.session_id,
-                table_ids=None,
+                table_ids=table_ids,
             )
         # Persist readiness from the freshly-written entropy objects, in the same
         # transaction (DAT-394). flush() makes the just-added rows visible to the
         # rollup's repository select before we read them back.
         session.flush()
-        readiness_rows = persist_readiness(session, identity.source_id, identity.session_id)
+        readiness_rows = persist_readiness(session, identity.session_id, table_ids)
         logger.info(
             "terminal_detect_done",
             source_id=identity.source_id,

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -51,14 +51,16 @@ __all__ = [
 ]
 
 # The executed-chain phases that declare entropy detectors (DAT-394). The single
-# terminal ``detect`` activity runs the union of their detectors ONCE, source-wide
-# — after the per-table fan-out and the ``semantic_per_column`` reduce. Detectors
-# moved here from the old per-table ``detect_table`` + parent ``detect_source``
-# split: nothing reads entropy mid-run, there are no live detector->detector
-# ordering edges, and the split bought ~no parallelism (it ran two cheap structural
-# detectors), so one terminal pass is correct and simpler. Running once,
-# sequentially, makes the source-wide delete-before-insert safe (no concurrency)
-# and guarantees every detector's inputs are present.
+# terminal ``detect`` activity runs the union of their detectors ONCE over the
+# run-session's tables — after the per-table fan-out and the ``semantic_per_column``
+# reduce. Detectors moved here from the old per-table ``detect_table`` + parent
+# ``detect_source`` split: nothing reads entropy mid-run, there are no live
+# detector->detector ordering edges, and the split bought ~no parallelism (it ran
+# two cheap structural detectors), so one terminal pass is correct and simpler.
+# Running once, sequentially, makes the delete-before-insert safe (no concurrency)
+# and guarantees every detector's inputs are present: ``entropy_objects`` deletes by
+# ``(source_id, detector_id)`` scoped to the table set, ``entropy_readiness`` deletes
+# by ``table_id.in_()`` (the session's tables, DAT-410).
 #
 # Source of truth is the executed chain in ``workflows.py`` (``typing`` +
 # ``_ANALYTICS_PHASES`` in the child, ``semantic_per_column`` in the parent).

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -420,7 +420,8 @@ def test_terminal_detect_persists_per_column_readiness_and_replay_overwrites(
     first_count = len(rows)
 
     # Re-run the terminal detect (the replay path always re-runs it): the
-    # delete-before-insert scoped to source_id must overwrite, not duplicate.
+    # delete-before-insert scoped to the session's tables (DAT-410) must
+    # overwrite, not duplicate. (Single-source run: session tables = source tables.)
     assert run_detectors(worker_manager, identity) > 0
     with worker_manager.session_scope() as session:
         second_count = len(

--- a/packages/engine/tests/unit/entropy/test_persist_readiness_scope.py
+++ b/packages/engine/tests/unit/entropy/test_persist_readiness_scope.py
@@ -1,0 +1,61 @@
+"""persist_readiness scope key — the session's table set, not source_id (DAT-410).
+
+A per-table replay (``persist_readiness`` over a single table) must clear only that
+table's ``entropy_readiness`` rows; a sibling table's rows under the same source
+survive. This is the isolation property the source-scoped delete could not give.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from dataraum.entropy.db_models import EntropyReadinessRecord
+from dataraum.entropy.readiness import persist_readiness
+from dataraum.storage import Source
+from dataraum.storage.models import Table
+from tests.conftest import baseline_session_id
+
+
+def _readiness_row(session: Session, table_id: str, source_id: str) -> None:
+    session.add(
+        EntropyReadinessRecord(
+            session_id=baseline_session_id(),
+            source_id=source_id,
+            table_id=table_id,
+            column_id=None,
+            band="ready",
+            worst_intent_risk=0.0,
+        )
+    )
+
+
+def test_per_table_replay_clears_only_its_own_rows(session: Session) -> None:
+    """Re-persisting one table of a two-table source leaves the other's rows intact."""
+    session.add(Source(source_id="src_x", name="src_x", source_type="csv"))
+    for tid in ("tbl_a", "tbl_b"):
+        session.add(Table(table_id=tid, source_id="src_x", table_name=tid, layer="typed"))
+    session.flush()
+    _readiness_row(session, "tbl_a", "src_x")
+    _readiness_row(session, "tbl_b", "src_x")
+    session.flush()
+
+    # A per-table replay scoped to tbl_a only. No entropy objects exist, so the
+    # rollup is empty and nothing is re-inserted — but the delete must touch only
+    # tbl_a (DAT-410: delete-before-insert by table_id, not source_id).
+    persist_readiness(session, baseline_session_id(), ["tbl_a"])
+    session.flush()
+
+    remaining = {r.table_id for r in session.query(EntropyReadinessRecord).all()}
+    assert remaining == {"tbl_b"}, "sibling table's readiness must survive a per-table replay"
+
+
+def test_empty_table_set_is_a_noop(session: Session) -> None:
+    """An empty scope clears nothing (and never touches the DB)."""
+    session.add(Source(source_id="src_y", name="src_y", source_type="csv"))
+    session.add(Table(table_id="tbl_c", source_id="src_y", table_name="tbl_c", layer="typed"))
+    session.flush()
+    _readiness_row(session, "tbl_c", "src_y")
+    session.flush()
+
+    assert persist_readiness(session, baseline_session_id(), []) == 0
+    assert session.query(EntropyReadinessRecord).filter_by(table_id="tbl_c").count() == 1

--- a/packages/engine/tests/unit/investigation/test_session_tables.py
+++ b/packages/engine/tests/unit/investigation/test_session_tables.py
@@ -13,7 +13,11 @@ from datetime import UTC, datetime
 import pytest
 from sqlalchemy.orm import Session
 
-from dataraum.investigation import link_session_tables, sources_for_session
+from dataraum.investigation import (
+    link_session_tables,
+    sources_for_session,
+    tables_for_session,
+)
 from dataraum.investigation.db_models import InvestigationSession, SessionTable
 from dataraum.storage import Source
 from dataraum.storage.models import Table
@@ -136,3 +140,33 @@ def test_link_session_tables_empty_is_noop(seeded: Session) -> None:
 
     assert link_session_tables(seeded, "sess_empty_link", []) == 0
     assert seeded.query(SessionTable).filter_by(session_id="sess_empty_link").count() == 0
+
+
+# --- tables_for_session (the detect/readiness scope key, DAT-410) -----------
+
+
+def test_tables_for_session_returns_linked_typed_tables(seeded: Session) -> None:
+    _make_session(seeded, "sess_scope")
+    _link(seeded, "sess_scope", "t_a1")
+    _link(seeded, "sess_scope", "t_b1")
+    seeded.flush()
+
+    assert set(tables_for_session(seeded, "sess_scope")) == {"t_a1", "t_b1"}
+
+
+def test_tables_for_session_empty_when_no_links(seeded: Session) -> None:
+    _make_session(seeded, "sess_none")
+    seeded.flush()
+
+    assert tables_for_session(seeded, "sess_none") == []
+
+
+def test_tables_for_session_excludes_raw_layer(seeded: Session) -> None:
+    """A link to a non-typed table is not returned (scope is typed only)."""
+    seeded.add(Table(table_id="t_raw", source_id="src_a", table_name="t_raw", layer="raw"))
+    _make_session(seeded, "sess_raw")
+    _link(seeded, "sess_raw", "t_a1")
+    _link(seeded, "sess_raw", "t_raw")
+    seeded.flush()
+
+    assert tables_for_session(seeded, "sess_raw") == ["t_a1"]


### PR DESCRIPTION
## What

The terminal `detect` step (`run_detectors`) + `persist_readiness` now scope by the **run-session's `session_tables`** (DAT-407's rail) instead of `Table.source_id`. Behavior-preserving on add_source; makes the analysis/readiness layer multi-source-ready for begin_session (consumed by DAT-408).

## Why it's behavior-preserving

A single-source add_source run's `session_tables` is exactly that source's freshly-typed tables (linked in the `typing` phase, same transaction as the `Table` row), so `run_detectors` + `persist_readiness` see the identical table set as the prior `source_id`-scoped code. Proven by the existing detect-path integration tests (`test_phase_activity.py`, `test_contracts.py` — 22 integration passed).

## Changes

- `tables_for_session(session, session_id)` helper (sibling of `sources_for_session`).
- `run_detectors`: reads the session's tables, passes them as `table_ids` to the detector post-steps + `persist_readiness`; defensive warning if a run's session has no links. **Kept** `run_detector_post_step`'s `source_id` anchor (harmless for single-source; the multi-source anchor-drop lands in DAT-408).
- `persist_readiness(session, session_id, table_ids)`: delete-before-insert by `table_id.in_(...)`; per-row `source_id` derived per-table. A per-table replay now clears only that table's rows.

## Eval / handoff

Behavior-preserving — the guard is that the readiness snapshot (bands/drivers) + detector recall do **not** move. `handoff.md` updated for dataraum-eval.

## Tests

Full engine unit suite (1313) + detect-path integration (8 passed) green; mypy/ruff/vulture clean. Both reviewers approved; added a per-table-replay isolation unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)