### PR TITLE
feat(DAT-354): chat tool-result chips + clickable canvas rehydration

### DIFF
--- a/packages/cockpit/src/ui/cockpit/chat-rail.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/chat-rail.test.tsx
@@ -35,8 +35,20 @@ vi.mock("@tanstack/ai-react", () => ({
 }));
 
 function CanvasProbe() {
-	const { canvasState } = useCockpit();
-	return <div data-testid="canvas-kind">{canvasState.kind}</div>;
+	const { canvasState, pinnedCallId, returnToLive } = useCockpit();
+	return (
+		<div>
+			<div data-testid="canvas-kind">{canvasState.kind}</div>
+			<div data-testid="pinned-call">{pinnedCallId ?? "live"}</div>
+			<button
+				type="button"
+				data-testid="probe-return-to-live"
+				onClick={returnToLive}
+			>
+				return
+			</button>
+		</div>
+	);
 }
 
 function renderRail() {
@@ -48,6 +60,57 @@ function renderRail() {
 			</CockpitProvider>
 		</MantineProvider>,
 	);
+}
+
+// A single completed list_sources call → source-list canvas.
+function sourcesCall(id: string, name = "orders") {
+	return {
+		id: `m-${id}`,
+		role: "assistant",
+		parts: [
+			{
+				type: "tool-call",
+				id,
+				name: "list_sources",
+				state: "complete",
+				output: [
+					{
+						source_id: "s1",
+						name,
+						source_type: "file",
+						status: null,
+						backend: null,
+						created_at: "2026-01-01T00:00:00.000Z",
+					},
+				],
+			},
+		],
+	};
+}
+
+// A single completed list_tables call → table-list canvas.
+function tablesCall(id: string) {
+	return {
+		id: `m-${id}`,
+		role: "assistant",
+		parts: [
+			{
+				type: "tool-call",
+				id,
+				name: "list_tables",
+				state: "complete",
+				output: [
+					{
+						table_id: "t1",
+						source_id: "s1",
+						table_name: "orders",
+						layer: "typed",
+						row_count: 42,
+					},
+				],
+			},
+		],
+	};
 }
 
 describe("ChatRail (DAT-353)", () => {
@@ -84,30 +147,7 @@ describe("ChatRail (DAT-353)", () => {
 	});
 
 	it("projects a list_sources tool result onto the source-list canvas", () => {
-		h.messages = [
-			{
-				id: "a1",
-				role: "assistant",
-				parts: [
-					{
-						type: "tool-call",
-						id: "c1",
-						name: "list_sources",
-						state: "complete",
-						output: [
-							{
-								source_id: "s1",
-								name: "orders",
-								source_type: "file",
-								status: null,
-								backend: null,
-								created_at: "2026-01-01T00:00:00.000Z",
-							},
-						],
-					},
-				],
-			},
-		];
+		h.messages = [sourcesCall("c1")];
 		renderRail();
 		expect(screen.getByTestId("canvas-kind").textContent).toBe("source-list");
 		expect(screen.getByTestId("tool-call-c1")).toBeTruthy();
@@ -177,5 +217,311 @@ describe("ChatRail (DAT-353)", () => {
 		expect(screen.getByTestId("canvas-kind").textContent).toBe("loading");
 
 		vi.unstubAllGlobals();
+	});
+});
+
+describe("ChatRail tool-result chips (DAT-354)", () => {
+	beforeEach(() => {
+		h.messages = [];
+		h.isLoading = false;
+		h.error = undefined;
+		h.sendMessage.mockClear();
+		h.addToolApprovalResponse.mockClear();
+	});
+	afterEach(() => cleanup());
+
+	// One completed call per canvas tool + its expected readable summary substring.
+	const canvasCases: Array<{
+		name: string;
+		state: string;
+		arguments?: string;
+		output: unknown;
+		summary: string;
+	}> = [
+		{
+			name: "list_sources",
+			state: "complete",
+			output: [{ source_id: "s1" }],
+			summary: "1 source",
+		},
+		{
+			name: "list_tables",
+			state: "complete",
+			output: [{ table_id: "t1" }, { table_id: "t2" }],
+			summary: "2 tables",
+		},
+		{
+			name: "look_table",
+			state: "complete",
+			output: {
+				table_id: "t1",
+				table_name: "orders",
+				analyzed: true,
+				pending_teaches: 0,
+				columns: [{}, {}],
+			},
+			summary: "orders — 2 columns",
+		},
+		{
+			name: "why_column",
+			state: "complete",
+			output: {
+				column_id: "col1",
+				column_name: "amount",
+				table_name: "orders",
+				found: true,
+				band: "ready",
+				intents: [],
+				evidence: [],
+			},
+			summary: "amount (orders) — ready",
+		},
+		{
+			name: "connect",
+			state: "complete",
+			output: {
+				sourceKind: "file",
+				source: "people.csv",
+				tables: [{ name: "people" }],
+			},
+			summary: "people.csv — 1 table",
+		},
+		{
+			name: "frame",
+			state: "complete",
+			output: { vertical: "ecommerce", concepts: [{}, {}, {}] },
+			summary: "ecommerce — 3 concepts",
+		},
+		{
+			name: "select",
+			state: "complete",
+			output: { source_id: "s1", name: "orders", source_type: "file" },
+			summary: "orders (file)",
+		},
+		{
+			name: "run_sql",
+			state: "complete",
+			arguments: JSON.stringify({ sql: "SELECT * FROM lake.typed.orders" }),
+			output: { columns: [], rows: [], rowCount: 0 },
+			summary: "SELECT * FROM lake.typed.orders",
+		},
+	];
+
+	it.each(canvasCases)("renders a type-aware, no-JSON summary for $name", ({
+		name,
+		state,
+		arguments: args,
+		output,
+		summary,
+	}) => {
+		h.messages = [
+			{
+				id: "m1",
+				role: "assistant",
+				parts: [
+					{ type: "tool-call", id: "c1", name, state, arguments: args, output },
+				],
+			},
+		];
+		renderRail();
+		const el = screen.getByTestId("tool-call-summary-c1");
+		expect(el.textContent).toContain(summary);
+		// No raw JSON dump in the rail.
+		expect(screen.getByTestId("chat-messages").textContent).not.toContain(
+			'"output"',
+		);
+	});
+
+	it.each([
+		"probe",
+		"teach",
+		"replay",
+	])("renders %s as a display-only chip (no rehydrate target)", (name) => {
+		h.messages = [
+			{
+				id: "m1",
+				role: "assistant",
+				parts: [
+					{
+						type: "tool-call",
+						id: "c1",
+						name,
+						state: "complete",
+						arguments: JSON.stringify({ type: "null_value", payload: {} }),
+						output: { ok: true },
+					},
+				],
+			},
+		];
+		renderRail();
+		// A display-only chip exposes no clickable rehydrate handle.
+		expect(screen.queryByTestId("tool-chip-c1")).toBeNull();
+	});
+
+	it("clicking a canvas-tool chip pins by call-id and projects that call's result", () => {
+		// Two completed calls: list_tables is latest (live projection), list_sources
+		// is the earlier one we want to rehydrate.
+		h.messages = [sourcesCall("c-sources"), tablesCall("c-tables")];
+		renderRail();
+		// Live: the latest (list_tables) is projected.
+		expect(screen.getByTestId("canvas-kind").textContent).toBe("table-list");
+		expect(screen.getByTestId("pinned-call").textContent).toBe("live");
+
+		// Click the earlier list_sources chip → pin + project that call's result.
+		fireEvent.click(screen.getByTestId("tool-chip-c-sources"));
+		expect(screen.getByTestId("pinned-call").textContent).toBe("c-sources");
+		expect(screen.getByTestId("canvas-kind").textContent).toBe("source-list");
+	});
+
+	it("a non-canvas (display-only) chip click is a no-op", () => {
+		h.messages = [
+			{
+				id: "m1",
+				role: "assistant",
+				parts: [
+					{
+						type: "tool-call",
+						id: "c1",
+						name: "teach",
+						state: "complete",
+						arguments: JSON.stringify({ type: "null_value", payload: {} }),
+						output: { overlay_id: "ov1", type: "null_value" },
+					},
+				],
+			},
+		];
+		renderRail();
+		// No clickable handle, and clicking the card text leaves the canvas live.
+		expect(screen.queryByTestId("tool-chip-c1")).toBeNull();
+		fireEvent.click(screen.getByTestId("tool-call-c1"));
+		expect(screen.getByTestId("pinned-call").textContent).toBe("live");
+	});
+
+	it("THE REVERSAL GUARD: while pinned, a freshly streamed tool-result does NOT change the canvas", () => {
+		h.messages = [sourcesCall("c-sources")];
+		const { rerender } = renderRail();
+		// Pin to the list_sources result.
+		fireEvent.click(screen.getByTestId("tool-chip-c-sources"));
+		expect(screen.getByTestId("canvas-kind").textContent).toBe("source-list");
+		expect(screen.getByTestId("pinned-call").textContent).toBe("c-sources");
+
+		// A NEW tool result streams in (list_tables) while pinned. Force the
+		// re-render that the SDK message update would trigger.
+		h.messages = [sourcesCall("c-sources"), tablesCall("c-tables")];
+		rerender(
+			<MantineProvider env="test">
+				<CockpitProvider>
+					<ChatRail />
+					<CanvasProbe />
+				</CockpitProvider>
+			</MantineProvider>,
+		);
+		// Canvas STAYS pinned on the historical result — the live projection is
+		// suppressed while pinned.
+		expect(screen.getByTestId("canvas-kind").textContent).toBe("source-list");
+		expect(screen.getByTestId("pinned-call").textContent).toBe("c-sources");
+	});
+
+	it("returnToLive re-projects the latest EVEN WHEN it equals the last projected value", () => {
+		// Single result. The pre-pin live projection is source-list; after pinning
+		// to a DIFFERENT-but-same-kind earlier result and returning to live, the
+		// dedupe must NOT suppress the snap-back.
+		h.messages = [sourcesCall("c1", "alpha")];
+		renderRail();
+		// Live projection happened: source-list, dedupe ref now holds its key.
+		expect(screen.getByTestId("canvas-kind").textContent).toBe("source-list");
+
+		// Manually flip the canvas to something else, then pin to c1, then return.
+		// Pin to c1 (its result is the SAME source-list the live ref already holds).
+		fireEvent.click(screen.getByTestId("tool-chip-c1"));
+		expect(screen.getByTestId("pinned-call").textContent).toBe("c1");
+
+		// Return to live. The latest result equals the pre-pin projected value;
+		// the guard must still re-project it (not be suppressed by a stale ref).
+		fireEvent.click(screen.getByTestId("probe-return-to-live"));
+		expect(screen.getByTestId("pinned-call").textContent).toBe("live");
+		expect(screen.getByTestId("canvas-kind").textContent).toBe("source-list");
+	});
+
+	it("returnToLive snaps to the NEWEST result after a pin+stream", () => {
+		h.messages = [sourcesCall("c-sources")];
+		const { rerender } = renderRail();
+		fireEvent.click(screen.getByTestId("tool-chip-c-sources"));
+		// A newer result streamed while pinned.
+		h.messages = [sourcesCall("c-sources"), tablesCall("c-tables")];
+		rerender(
+			<MantineProvider env="test">
+				<CockpitProvider>
+					<ChatRail />
+					<CanvasProbe />
+				</CockpitProvider>
+			</MantineProvider>,
+		);
+		// Still pinned to the old source-list.
+		expect(screen.getByTestId("canvas-kind").textContent).toBe("source-list");
+		// Return to live → snaps to the newest (table-list).
+		fireEvent.click(screen.getByTestId("probe-return-to-live"));
+		expect(screen.getByTestId("pinned-call").textContent).toBe("live");
+		expect(screen.getByTestId("canvas-kind").textContent).toBe("table-list");
+	});
+
+	it("renders a readable teach chip from arguments at approval time AND keeps Approve/Deny", () => {
+		h.messages = [
+			{
+				id: "m1",
+				role: "assistant",
+				parts: [
+					{
+						type: "tool-call",
+						id: "c1",
+						name: "teach",
+						state: "approval-requested",
+						approval: { id: "ap1", needsApproval: true },
+						arguments: JSON.stringify({
+							type: "null_value",
+							payload: { sentinel: "N/A" },
+						}),
+					},
+				],
+			},
+		];
+		renderRail();
+		// The {type, payload} is readable — type name + the payload's field keys.
+		const summary =
+			screen.getByTestId("tool-call-summary-c1").textContent ?? "";
+		expect(summary).toContain("null_value");
+		expect(summary).toContain("sentinel");
+		// No raw JSON dump.
+		expect(summary).not.toContain('"payload"');
+		// Approve/Deny still present and wired.
+		fireEvent.click(screen.getByTestId("tool-approve-c1"));
+		expect(h.addToolApprovalResponse).toHaveBeenCalledWith({
+			id: "ap1",
+			approved: true,
+		});
+	});
+
+	it("renders the completed teach chip as {overlay_id, type} (display-only)", () => {
+		h.messages = [
+			{
+				id: "m1",
+				role: "assistant",
+				parts: [
+					{
+						type: "tool-call",
+						id: "c1",
+						name: "teach",
+						state: "complete",
+						arguments: JSON.stringify({ type: "null_value", payload: {} }),
+						output: { overlay_id: "ov-123", type: "null_value" },
+					},
+				],
+			},
+		];
+		renderRail();
+		const summary =
+			screen.getByTestId("tool-call-summary-c1").textContent ?? "";
+		expect(summary).toContain("null_value");
+		expect(summary).toContain("ov-123");
 	});
 });

--- a/packages/cockpit/src/ui/cockpit/chat-rail.tsx
+++ b/packages/cockpit/src/ui/cockpit/chat-rail.tsx
@@ -16,47 +16,72 @@ import {
 	Box,
 	Button,
 	Card,
-	Collapse,
 	Group,
 	Loader,
 	Stack,
 	Text,
 	Textarea,
 } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
 import { fetchServerSentEvents, useChat } from "@tanstack/ai-react";
 import { SendHorizontal } from "lucide-react";
 import { type FormEvent, useEffect, useRef, useState } from "react";
 import { useCockpit } from "#/ui/cockpit/cockpit-state";
-import { canvasFromMessages } from "#/ui/cockpit/tool-result-to-canvas";
+import { isCanvasTool, toolChipSummary } from "#/ui/cockpit/tool-chip-summary";
+import {
+	canvasFromCallId,
+	canvasFromMessages,
+} from "#/ui/cockpit/tool-result-to-canvas";
 import { UploadDropzone } from "#/ui/cockpit/upload-dropzone";
 import { tokens } from "#/ui/theme";
 
 // The untyped tool-call part shape (we register tools server-side, so useChat
-// sees them untyped). Narrowed off `part.type === "tool-call"`.
+// sees them untyped). Narrowed off `part.type === "tool-call"`. `arguments` is
+// the SDK's JSON-encoded call input, carried in EVERY state (incl. approval-
+// requested) — the chip summary reads it so teach/replay are readable before
+// they run.
 interface ToolCallPart {
 	type: "tool-call";
 	id: string;
 	name: string;
 	state: string;
 	approval?: { id: string; needsApproval: boolean; approved?: boolean };
+	arguments?: unknown;
 	output?: unknown;
+}
+
+/** Lift a tool-call's parsed input off the SDK part's JSON `arguments` string. */
+function parseArguments(raw: unknown): unknown {
+	if (typeof raw !== "string") return raw ?? undefined;
+	try {
+		return JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
 }
 
 function ToolCallCard({
 	part,
 	onApprove,
+	onRehydrate,
 }: {
 	part: ToolCallPart;
 	onApprove: (approvalId: string, approved: boolean) => void;
+	onRehydrate: (callId: string) => void;
 }) {
-	const [opened, { toggle }] = useDisclosure(false);
 	const done = part.state === "complete";
 	const approvalId = part.approval?.id;
 	const awaitingApproval =
 		part.state === "approval-requested" &&
 		approvalId !== undefined &&
 		part.approval?.approved === undefined;
+
+	// A canvas-producing tool's chip rehydrates the focus canvas to THIS call's
+	// result on click (pins by call-id). Only once complete — an in-flight call
+	// has no result to project. probe / teach / replay map to no canvas member,
+	// so their chips are display-only (no click).
+	const clickable = done && isCanvasTool(part.name);
+	const input = parseArguments(part.arguments);
+	const summary = toolChipSummary(part.name, input, part.output);
 
 	return (
 		<Card
@@ -68,16 +93,29 @@ function ToolCallCard({
 			<Group
 				justify="space-between"
 				wrap="nowrap"
-				onClick={toggle}
-				style={{ cursor: "pointer" }}
+				onClick={clickable ? () => onRehydrate(part.id) : undefined}
+				style={clickable ? { cursor: "pointer" } : undefined}
+				data-testid={clickable ? `tool-chip-${part.id}` : undefined}
 			>
-				<Text size="sm" fw={600}>
-					{part.name}
-				</Text>
-				{done ? (
-					<Text size="xs" c="dimmed">
-						{opened ? "hide" : "show"}
+				<Box style={{ minWidth: 0 }}>
+					<Text size="sm" fw={600}>
+						{part.name}
 					</Text>
+					<Text
+						size="xs"
+						c="dimmed"
+						truncate
+						data-testid={`tool-call-summary-${part.id}`}
+					>
+						{summary}
+					</Text>
+				</Box>
+				{done ? (
+					clickable ? (
+						<Text size="xs" c="blue">
+							view
+						</Text>
+					) : null
 				) : (
 					<Loader size="xs" />
 				)}
@@ -102,24 +140,12 @@ function ToolCallCard({
 					</Button>
 				</Group>
 			)}
-
-			<Collapse expanded={opened && part.output !== undefined}>
-				<Text
-					size="xs"
-					c="dimmed"
-					ff="monospace"
-					style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}
-					data-testid={`tool-call-result-${part.id}`}
-				>
-					{JSON.stringify(part.output, null, 2)}
-				</Text>
-			</Collapse>
 		</Card>
 	);
 }
 
 export function ChatRail() {
-	const { setCanvasState } = useCockpit();
+	const { setCanvasState, pinCanvas, pinnedCallId } = useCockpit();
 	const { messages, sendMessage, isLoading, error, addToolApprovalResponse } =
 		useChat({ connection: fetchServerSentEvents("/api/chat") });
 	const [input, setInput] = useState("");
@@ -129,15 +155,39 @@ export function ChatRail() {
 	// projection usually hasn't changed (same tool result). Dedupe by value so we
 	// don't churn the canvas on every token — re-setting an equal result-grid
 	// made it re-issue its stream.
+	//
+	// Pinned mode (DAT-354): when the user has clicked an earlier result chip
+	// (`pinnedCallId` set) the canvas is showing HISTORY, so we suppress the
+	// always-project-latest behavior — a freshly-streamed result must NOT clobber
+	// the pinned view. CRITICAL: while pinned we also reset the dedupe ref to
+	// null. On return-to-live (`pinnedCallId` → null) the effect re-fires (the
+	// pin is in the deps) and re-projects the latest UNCONDITIONALLY — even when
+	// the newest result equals the pre-pin projected value, which a stale ref
+	// would otherwise suppress, leaving return-to-live showing nothing. The pin
+	// is a primitive string, so adding it to the deps keeps them stable.
 	const lastProjectedRef = useRef<string | null>(null);
 	useEffect(() => {
+		if (pinnedCallId) {
+			lastProjectedRef.current = null;
+			return;
+		}
 		const next = canvasFromMessages(messages);
 		if (!next) return;
 		const key = JSON.stringify(next);
 		if (key === lastProjectedRef.current) return;
 		lastProjectedRef.current = key;
 		setCanvasState(next);
-	}, [messages, setCanvasState]);
+	}, [messages, setCanvasState, pinnedCallId]);
+
+	// A result-chip click pins the canvas to that call's result. We resolve the
+	// canvas from the call id (reusing the same toolResultToCanvas mapper) and
+	// pin in one dispatch. A call that maps to no canvas member (display-only
+	// tool, or a not-yet-complete call) yields null → no-op.
+	const onRehydrate = (callId: string) => {
+		const canvas = canvasFromCallId(messages, callId);
+		if (!canvas) return;
+		pinCanvas(callId, canvas);
+	};
 
 	// Surface a stream error on the canvas.
 	useEffect(() => {
@@ -205,6 +255,7 @@ export function ChatRail() {
 										onApprove={(approvalId, approved) =>
 											void addToolApprovalResponse({ id: approvalId, approved })
 										}
+										onRehydrate={onRehydrate}
 									/>
 								);
 							}

--- a/packages/cockpit/src/ui/cockpit/cockpit-state.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-state.test.tsx
@@ -39,4 +39,30 @@ describe("cockpit-state (DAT-347)", () => {
 	it("throws when useCockpit is read outside a provider", () => {
 		expect(() => renderHook(() => useCockpit())).toThrow(/CockpitProvider/);
 	});
+
+	it("defaults to live (no pin)", () => {
+		const { result } = renderHook(() => useCockpit(), { wrapper });
+		expect(result.current.pinnedCallId).toBeNull();
+	});
+
+	it("pinCanvas sets the pin AND the canvas in one dispatch", () => {
+		const { result } = renderHook(() => useCockpit(), { wrapper });
+		act(() =>
+			result.current.pinCanvas("call-7", { kind: "source-list", sources: [] }),
+		);
+		expect(result.current.pinnedCallId).toBe("call-7");
+		expect(result.current.canvasState).toEqual({
+			kind: "source-list",
+			sources: [],
+		});
+	});
+
+	it("returnToLive clears the pin (leaving the canvas for the rail to re-project)", () => {
+		const { result } = renderHook(() => useCockpit(), { wrapper });
+		act(() =>
+			result.current.pinCanvas("call-7", { kind: "source-list", sources: [] }),
+		);
+		act(() => result.current.returnToLive());
+		expect(result.current.pinnedCallId).toBeNull();
+	});
 });

--- a/packages/cockpit/src/ui/cockpit/cockpit-state.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-state.tsx
@@ -20,17 +20,30 @@ import type { CanvasState } from "#/ui/cockpit/canvas-state";
 interface CockpitState {
 	activeStage: Stage;
 	canvasState: CanvasState;
+	// Canvas-rehydration pin (DAT-354). When non-null the canvas is showing a
+	// PAST tool result (the user clicked an earlier result chip), addressed by
+	// its tool-call id. The chat rail's always-project-latest effect short-
+	// circuits while pinned, so a freshly-streamed result does NOT clobber the
+	// history view; `returnToLive()` clears the pin and snaps back to the newest
+	// result. null = live (project the latest).
+	pinnedCallId: string | null;
 }
 
 type CockpitAction =
 	| { type: "setActiveStage"; stage: Stage }
-	| { type: "setCanvasState"; canvasState: CanvasState };
+	| { type: "setCanvasState"; canvasState: CanvasState }
+	// Pin the canvas to a specific past tool-call's result. Carries the canvas
+	// to show so the pin + the projection land in one dispatch (no transient
+	// state where the pin is set but the canvas still shows live).
+	| { type: "pinCanvas"; callId: string; canvasState: CanvasState }
+	| { type: "returnToLive" };
 
 // Default: the only interactive stage in C1, with an empty canvas waiting for
-// the first tool result.
+// the first tool result. Live by default (no pin).
 const INITIAL_STATE: CockpitState = {
 	activeStage: "add_source",
 	canvasState: { kind: "empty" },
+	pinnedCallId: null,
 };
 
 function cockpitReducer(
@@ -42,12 +55,26 @@ function cockpitReducer(
 			return { ...state, activeStage: action.stage };
 		case "setCanvasState":
 			return { ...state, canvasState: action.canvasState };
+		case "pinCanvas":
+			return {
+				...state,
+				pinnedCallId: action.callId,
+				canvasState: action.canvasState,
+			};
+		case "returnToLive":
+			// Clear the pin only; the chat rail's projection effect re-fires off
+			// the now-null pin and re-projects the latest result (it force-resets
+			// its dedupe while pinned, so the snap-back works even when the newest
+			// result equals the pre-pin one).
+			return { ...state, pinnedCallId: null };
 	}
 }
 
 interface CockpitContextValue extends CockpitState {
 	setActiveStage: (stage: Stage) => void;
 	setCanvasState: (canvasState: CanvasState) => void;
+	pinCanvas: (callId: string, canvasState: CanvasState) => void;
+	returnToLive: () => void;
 }
 
 const CockpitContext = createContext<CockpitContextValue | null>(null);
@@ -69,10 +96,25 @@ export function CockpitProvider({ children }: { children: ReactNode }) {
 			dispatch({ type: "setCanvasState", canvasState }),
 		[],
 	);
+	const pinCanvas = useCallback(
+		(callId: string, canvasState: CanvasState) =>
+			dispatch({ type: "pinCanvas", callId, canvasState }),
+		[],
+	);
+	const returnToLive = useCallback(
+		() => dispatch({ type: "returnToLive" }),
+		[],
+	);
 
 	const value = useMemo<CockpitContextValue>(
-		() => ({ ...state, setActiveStage, setCanvasState }),
-		[state, setActiveStage, setCanvasState],
+		() => ({
+			...state,
+			setActiveStage,
+			setCanvasState,
+			pinCanvas,
+			returnToLive,
+		}),
+		[state, setActiveStage, setCanvasState, pinCanvas, returnToLive],
 	);
 
 	return (

--- a/packages/cockpit/src/ui/cockpit/cockpit-view.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-view.test.tsx
@@ -2,8 +2,9 @@
 
 import { MantineProvider } from "@mantine/core";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useEffect } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { CockpitProvider } from "#/ui/cockpit/cockpit-state";
+import { CockpitProvider, useCockpit } from "#/ui/cockpit/cockpit-state";
 import { CockpitView } from "#/ui/cockpit/cockpit-view";
 
 // CockpitView mounts ChatRail, which calls useChat (network on real use). The
@@ -68,5 +69,43 @@ describe("CockpitView (DAT-347)", () => {
 			metaKey: true,
 		});
 		expect(document.activeElement).toBe(canvas);
+	});
+});
+
+describe("CockpitView history banner (DAT-354)", () => {
+	afterEach(() => cleanup());
+
+	// Pins the canvas on mount so we can assert the banner is gated on the pin.
+	function PinOnMount() {
+		const { pinCanvas } = useCockpit();
+		useEffect(() => {
+			pinCanvas("c1", { kind: "source-list", sources: [] });
+		}, [pinCanvas]);
+		return null;
+	}
+
+	it("hides the banner when live (no pin)", () => {
+		render(
+			<MantineProvider env="test">
+				<CockpitProvider>
+					<CockpitView />
+				</CockpitProvider>
+			</MantineProvider>,
+		);
+		expect(screen.queryByTestId("history-banner")).toBeNull();
+	});
+
+	it("shows the banner only while pinned and clears the pin on Return to live", () => {
+		render(
+			<MantineProvider env="test">
+				<CockpitProvider>
+					<PinOnMount />
+					<CockpitView />
+				</CockpitProvider>
+			</MantineProvider>,
+		);
+		expect(screen.getByTestId("history-banner")).toBeTruthy();
+		fireEvent.click(screen.getByTestId("return-to-live"));
+		expect(screen.queryByTestId("history-banner")).toBeNull();
 	});
 });

--- a/packages/cockpit/src/ui/cockpit/cockpit-view.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-view.tsx
@@ -8,7 +8,7 @@
 // input (mod+/) and the canvas (mod+.) without colliding with the shell's ⌘K.
 // All sizes/colors read from theme tokens — no hardcoded px/hex.
 
-import { Box, Group, Stack } from "@mantine/core";
+import { Box, Button, Group, Stack, Text } from "@mantine/core";
 import { useHotkeys } from "@mantine/hooks";
 import { useRef } from "react";
 import { ChatRail } from "#/ui/cockpit/chat-rail";
@@ -18,7 +18,7 @@ import { StageNavigator } from "#/ui/cockpit/stage-navigator";
 import { tokens } from "#/ui/theme";
 
 export function CockpitView() {
-	const { canvasState } = useCockpit();
+	const { canvasState, pinnedCallId, returnToLive } = useCockpit();
 	const chatRef = useRef<HTMLDivElement>(null);
 	const canvasRef = useRef<HTMLDivElement>(null);
 
@@ -64,6 +64,37 @@ export function CockpitView() {
 				data-testid="region-work"
 			>
 				<StageNavigator />
+				{/* Rehydration banner (DAT-354): shown only while the canvas is pinned
+				    to a past tool result, so the user knows they're viewing history and
+				    can snap back to the latest live result. */}
+				{pinnedCallId && (
+					<Group
+						justify="space-between"
+						wrap="nowrap"
+						gap="sm"
+						data-testid="history-banner"
+						style={{
+							backgroundColor: tokens.colors.surface,
+							borderWidth: 1,
+							borderStyle: "solid",
+							borderColor: tokens.colors.border,
+							borderRadius: tokens.radii.sm,
+							padding: tokens.spacing.xs,
+						}}
+					>
+						<Text size="sm" c="dimmed">
+							Viewing history
+						</Text>
+						<Button
+							size="xs"
+							variant="light"
+							onClick={returnToLive}
+							data-testid="return-to-live"
+						>
+							Return to live
+						</Button>
+					</Group>
+				)}
 				<Box
 					ref={canvasRef}
 					tabIndex={-1}

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	CANVAS_TOOLS,
+	isCanvasTool,
+	teachChipSummary,
+	toolChipSummary,
+} from "./tool-chip-summary";
+
+describe("isCanvasTool", () => {
+	it("marks the 8 canvas-producing tools clickable", () => {
+		expect(CANVAS_TOOLS.size).toBe(8);
+		for (const name of [
+			"list_sources",
+			"list_tables",
+			"look_table",
+			"why_column",
+			"connect",
+			"frame",
+			"select",
+			"run_sql",
+		]) {
+			expect(isCanvasTool(name)).toBe(true);
+		}
+	});
+
+	it("marks probe / teach / replay display-only", () => {
+		for (const name of ["probe", "teach", "replay", "unknown"]) {
+			expect(isCanvasTool(name)).toBe(false);
+		}
+	});
+});
+
+describe("toolChipSummary — completed canvas tools (no JSON, readable)", () => {
+	it("list_sources counts sources (singular/plural)", () => {
+		expect(toolChipSummary("list_sources", {}, [{}])).toBe("1 source");
+		expect(toolChipSummary("list_sources", {}, [{}, {}])).toBe("2 sources");
+	});
+
+	it("list_tables counts tables and notes the source filter", () => {
+		expect(toolChipSummary("list_tables", {}, [{}, {}])).toBe("2 tables");
+		expect(toolChipSummary("list_tables", { source_id: "s9" }, [{}])).toBe(
+			"1 table in s9",
+		);
+	});
+
+	it("look_table names the table + column count + analyzed state", () => {
+		expect(
+			toolChipSummary(
+				"look_table",
+				{},
+				{
+					table_name: "orders",
+					analyzed: true,
+					columns: [{}, {}],
+				},
+			),
+		).toBe("orders — 2 columns");
+		expect(
+			toolChipSummary(
+				"look_table",
+				{},
+				{
+					table_name: "orders",
+					analyzed: false,
+					columns: [{}],
+				},
+			),
+		).toBe("orders — 1 column, not yet analyzed");
+	});
+
+	it("why_column names the column + table + band", () => {
+		expect(
+			toolChipSummary(
+				"why_column",
+				{},
+				{
+					column_name: "amount",
+					table_name: "orders",
+					found: true,
+					band: "investigate",
+				},
+			),
+		).toBe("amount (orders) — investigate");
+		expect(toolChipSummary("why_column", {}, { found: false })).toBe(
+			"column not found",
+		);
+	});
+
+	it("connect names the source + table count", () => {
+		expect(
+			toolChipSummary("connect", {}, { source: "people.csv", tables: [{}] }),
+		).toBe("people.csv — 1 table");
+	});
+
+	it("frame names the vertical + concept count", () => {
+		expect(
+			toolChipSummary(
+				"frame",
+				{},
+				{ vertical: "ecommerce", concepts: [{}, {}] },
+			),
+		).toBe("ecommerce — 2 concepts");
+	});
+
+	it("select names the source + type", () => {
+		expect(
+			toolChipSummary("select", {}, { name: "orders", source_type: "file" }),
+		).toBe("orders (file)");
+	});
+
+	it("run_sql shows the SQL from the call input (truncated, flattened)", () => {
+		expect(
+			toolChipSummary("run_sql", { sql: "SELECT 1" }, { rowCount: 0 }),
+		).toBe("SELECT 1");
+		const long = `SELECT ${"x".repeat(100)}`;
+		const summary = toolChipSummary("run_sql", { sql: long }, { rowCount: 0 });
+		expect(summary.length).toBeLessThanOrEqual(60);
+		expect(summary.endsWith("…")).toBe(true);
+	});
+
+	it("never includes raw JSON braces from the output", () => {
+		const summary = toolChipSummary(
+			"connect",
+			{},
+			{
+				source: "x",
+				tables: [{ name: "t" }],
+			},
+		);
+		expect(summary).not.toContain("{");
+		expect(summary).not.toContain('"');
+	});
+});
+
+describe("toolChipSummary — streaming / pre-result states", () => {
+	it("renders a neutral running label before the result arrives", () => {
+		expect(toolChipSummary("list_sources", {}, undefined)).toBe(
+			"listing sources…",
+		);
+		expect(toolChipSummary("connect", {}, undefined)).toBe("connecting…");
+		expect(toolChipSummary("run_sql", {}, undefined)).toBe("running query…");
+	});
+});
+
+describe("teachChipSummary (display-only, readable at every state)", () => {
+	it("reads {type, payload} from arguments at approval time", () => {
+		expect(
+			teachChipSummary(
+				{ type: "null_value", payload: { sentinel: "N/A" } },
+				undefined,
+			),
+		).toBe("teach null_value {sentinel}");
+	});
+
+	it("reads {overlay_id, type} once complete", () => {
+		expect(
+			teachChipSummary(
+				{ type: "null_value", payload: {} },
+				{ overlay_id: "ov-7", type: "null_value" },
+			),
+		).toBe("taught null_value → ov-7");
+	});
+
+	it("surfaces a structured validation error", () => {
+		expect(
+			teachChipSummary(
+				{ type: "null_value", payload: {} },
+				{ error: "payload.sentinel is required" },
+			),
+		).toContain("teach rejected");
+	});
+
+	it("degrades to a neutral label with no arguments yet", () => {
+		expect(teachChipSummary(undefined, undefined)).toBe("teach…");
+	});
+});
+
+describe("toolChipSummary — replay / probe (display-only)", () => {
+	it("replay shows scope + source before run, run id after", () => {
+		expect(
+			toolChipSummary("replay", { source_id: "src1", scope: "all" }, undefined),
+		).toBe("replay src1 (all)");
+		expect(
+			toolChipSummary(
+				"replay",
+				{ source_id: "src1", scope: "all" },
+				{
+					run_id: "r9",
+				},
+			),
+		).toBe("replay (all) — run r9");
+	});
+
+	it("probe shows the source name + row count", () => {
+		expect(
+			toolChipSummary("probe", { source_name: "pg" }, { rowCount: 3 }),
+		).toBe("probe on pg — 3 rows");
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -1,0 +1,160 @@
+// Tool-call chip summaries (DAT-354).
+//
+// A pure, no-React mapper from a tool call's {name, input, output} to a compact,
+// HUMAN-READABLE one-liner — never raw JSON. The chat rail renders each tool
+// card as a chip showing this summary instead of a `<Collapse>` JSON dump.
+//
+// `clickable` marks the canvas-producing tools (the 8 whose result rehydrates
+// the focus canvas via toolResultToCanvas). The non-canvas tools (probe / teach
+// / replay) are display-only — they read in the rail but never project, so a
+// click on them is a no-op. This set is the inverse of toolResultToCanvas's
+// `default: return null`, kept here as data so the rail stays declarative.
+//
+// Input is lifted off the SDK part's `arguments` string (present in EVERY state,
+// including approval-requested) so a teach chip is readable at approval time —
+// `{type, payload}` before it runs, `{overlay_id, type}` once complete. Output
+// is the part's `output` (undefined until the call completes).
+
+import type { ConnectSchema } from "#/duckdb/connect";
+import type { FrameResult } from "#/tools/frame";
+import type { SourceSummary } from "#/tools/list-sources";
+import type { TableSummary } from "#/tools/list-tables";
+import type { LookTableResult } from "#/tools/look-table";
+import type { SelectResult } from "#/tools/select";
+import type { TeachResult } from "#/tools/teach";
+import type { WhyColumnResult } from "#/tools/why-column";
+
+/** The tool names whose result rehydrates the focus canvas (clickable chips). */
+export const CANVAS_TOOLS: ReadonlySet<string> = new Set([
+	"list_sources",
+	"list_tables",
+	"look_table",
+	"why_column",
+	"connect",
+	"frame",
+	"select",
+	"run_sql",
+]);
+
+/** A tool whose result maps to a canvas member → its chip is clickable. */
+export function isCanvasTool(toolName: string): boolean {
+	return CANVAS_TOOLS.has(toolName);
+}
+
+function plural(n: number, noun: string): string {
+	return `${n} ${noun}${n === 1 ? "" : "s"}`;
+}
+
+function truncate(s: string, max = 60): string {
+	const flat = s.replace(/\s+/g, " ").trim();
+	return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat;
+}
+
+/**
+ * A compact, no-JSON summary of one tool call. `input` is the parsed call
+ * arguments (may be undefined before they stream in); `output` is the result
+ * (undefined until the call completes). Falls back to a neutral "running…" /
+ * "done" string when the relevant payload isn't present yet, so a streaming or
+ * approval-gated call still renders something readable.
+ */
+export function toolChipSummary(
+	toolName: string,
+	input: unknown,
+	output: unknown,
+): string {
+	const done = output !== undefined;
+	switch (toolName) {
+		case "list_sources": {
+			if (!done) return "listing sources…";
+			const sources = (output as SourceSummary[]) ?? [];
+			return plural(sources.length, "source");
+		}
+		case "list_tables": {
+			const src = (input as { source_id?: string } | undefined)?.source_id;
+			if (!done) return src ? `listing tables for ${src}…` : "listing tables…";
+			const tables = (output as TableSummary[]) ?? [];
+			return src
+				? `${plural(tables.length, "table")} in ${src}`
+				: plural(tables.length, "table");
+		}
+		case "look_table": {
+			const r = output as LookTableResult | undefined;
+			if (!r) return "reading table readiness…";
+			const cols = plural(r.columns.length, "column");
+			return r.analyzed
+				? `${r.table_name} — ${cols}`
+				: `${r.table_name} — ${cols}, not yet analyzed`;
+		}
+		case "why_column": {
+			const r = output as WhyColumnResult | undefined;
+			if (!r) return "explaining column…";
+			if (!r.found) return "column not found";
+			const band = r.band ?? "not analyzed";
+			return `${r.column_name} (${r.table_name}) — ${band}`;
+		}
+		case "connect": {
+			const s = output as ConnectSchema | undefined;
+			if (!s) return "connecting…";
+			return `${s.source} — ${plural(s.tables.length, "table")}`;
+		}
+		case "frame": {
+			const f = output as FrameResult | undefined;
+			if (!f) return "framing concepts…";
+			return `${f.vertical} — ${plural(f.concepts.length, "concept")}`;
+		}
+		case "select": {
+			const s = output as SelectResult | undefined;
+			if (!s) return "registering source…";
+			return `${s.name} (${s.source_type})`;
+		}
+		case "run_sql": {
+			const sql = (input as { sql?: string } | undefined)?.sql;
+			if (typeof sql === "string" && sql.length > 0) return truncate(sql);
+			return done ? "query run" : "running query…";
+		}
+		case "probe": {
+			const args = input as { source_name?: string; sql?: string } | undefined;
+			const where = args?.source_name ? ` on ${args.source_name}` : "";
+			const out = output as { rowCount?: number } | undefined;
+			if (out && typeof out.rowCount === "number") {
+				return `probe${where} — ${plural(out.rowCount, "row")}`;
+			}
+			return `probe${where}…`;
+		}
+		case "teach":
+			return teachChipSummary(input, output);
+		case "replay": {
+			const args = input as { source_id?: string; scope?: string } | undefined;
+			const scope = args?.scope ? ` (${args.scope})` : "";
+			const out = output as { run_id?: string } | undefined;
+			if (out?.run_id) return `replay${scope} — run ${out.run_id}`;
+			return args?.source_id ? `replay ${args.source_id}${scope}` : "replay…";
+		}
+		default:
+			return toolName;
+	}
+}
+
+/**
+ * The teach chip is readable at every state (DAT-354): at approval time it
+ * shows the proposed `{type, payload}` lifted off `arguments`; once complete it
+ * shows `{overlay_id, type}`. Display-only — teach maps to no canvas member.
+ */
+export function teachChipSummary(input: unknown, output: unknown): string {
+	const result = output as TeachResult | { error?: string } | undefined;
+	if (result && "overlay_id" in result && result.overlay_id) {
+		return `taught ${result.type} → ${result.overlay_id}`;
+	}
+	if (result && "error" in result && result.error) {
+		return `teach rejected: ${truncate(result.error)}`;
+	}
+	const args = input as
+		| { type?: string; payload?: Record<string, unknown> }
+		| undefined;
+	if (args?.type) {
+		const keys = args.payload ? Object.keys(args.payload) : [];
+		const fields = keys.length > 0 ? ` {${keys.join(", ")}}` : "";
+		return `teach ${args.type}${fields}`;
+	}
+	return "teach…";
+}

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
@@ -2,6 +2,7 @@ import type { UIMessage } from "@tanstack/ai-react";
 import { describe, expect, it } from "vitest";
 
 import {
+	canvasFromCallId,
 	canvasFromMessages,
 	toolResultToCanvas,
 } from "./tool-result-to-canvas";
@@ -291,5 +292,109 @@ describe("canvasFromMessages", () => {
 			]),
 		];
 		expect(canvasFromMessages(messages)?.kind).toBe("table-list");
+	});
+});
+
+describe("canvasFromCallId (DAT-354 rehydration)", () => {
+	const twoCalls = [
+		msg([
+			{
+				type: "tool-call",
+				id: "c1",
+				name: "list_sources",
+				arguments: "{}",
+				state: "complete",
+				output: [{ source_id: "s1" }],
+			},
+			{
+				type: "tool-call",
+				id: "c2",
+				name: "list_tables",
+				arguments: "{}",
+				state: "complete",
+				output: [{ table_id: "t1" }],
+			},
+		]),
+	];
+
+	it("resolves an EARLIER call's result, not just the latest", () => {
+		// The latest is list_tables (c2); addressing c1 by id rehydrates the
+		// earlier source-list.
+		expect(canvasFromCallId(twoCalls, "c1")?.kind).toBe("source-list");
+		expect(canvasFromCallId(twoCalls, "c2")?.kind).toBe("table-list");
+	});
+
+	it("reads run_sql's call arguments for the result-grid, like canvasFromMessages", () => {
+		const messages = [
+			msg([
+				{
+					type: "tool-call",
+					id: "q1",
+					name: "run_sql",
+					arguments: JSON.stringify({ sql: "SELECT 1" }),
+					state: "complete",
+					output: { columns: [], rows: [], rowCount: 0 },
+				},
+			]),
+		];
+		expect(canvasFromCallId(messages, "q1")).toEqual({
+			kind: "result-grid",
+			sql: "SELECT 1",
+		});
+	});
+
+	it("reads a result from a correlated tool-result part", () => {
+		const messages = [
+			msg([
+				{
+					type: "tool-call",
+					id: "c1",
+					name: "list_tables",
+					arguments: "{}",
+					state: "complete",
+				},
+				{
+					type: "tool-result",
+					toolCallId: "c1",
+					content: JSON.stringify([{ table_id: "t1" }]),
+				},
+			]),
+		];
+		expect(canvasFromCallId(messages, "c1")?.kind).toBe("table-list");
+	});
+
+	it("returns null for an unknown call id", () => {
+		expect(canvasFromCallId(twoCalls, "nope")).toBeNull();
+	});
+
+	it("returns null for a not-yet-complete call (no output)", () => {
+		const messages = [
+			msg([
+				{
+					type: "tool-call",
+					id: "c1",
+					name: "list_sources",
+					arguments: "{}",
+					state: "partial-call",
+				},
+			]),
+		];
+		expect(canvasFromCallId(messages, "c1")).toBeNull();
+	});
+
+	it("returns null for a display-only tool (teach maps to no canvas member)", () => {
+		const messages = [
+			msg([
+				{
+					type: "tool-call",
+					id: "c1",
+					name: "teach",
+					arguments: JSON.stringify({ type: "null_value", payload: {} }),
+					state: "complete",
+					output: { overlay_id: "ov1", type: "null_value" },
+				},
+			]),
+		];
+		expect(canvasFromCallId(messages, "c1")).toBeNull();
 	});
 });

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -136,6 +136,50 @@ export function canvasFromMessages(
 }
 
 /**
+ * Resolve ONE specific tool-call by its id and map it to the canvas (DAT-354
+ * rehydration). Walks the message list for the call's name + input and its
+ * completed output (tolerating both the `output`-on-the-call shape and a
+ * correlated `tool-result` part, mirroring `canvasFromMessages`), then reuses
+ * the same `toolResultToCanvas` mapper. Returns null when the call id isn't
+ * found, hasn't completed, or maps to no canvas member (teach/replay/probe) —
+ * the caller then leaves the canvas unchanged (those chips are display-only).
+ */
+export function canvasFromCallId(
+	messages: ReadonlyArray<UIMessage>,
+	callId: string,
+): CanvasState | null {
+	let name: string | undefined;
+	let input: unknown;
+	let output: unknown;
+	let hasOutput = false;
+
+	for (const message of messages) {
+		for (const part of message.parts) {
+			if (part.type === "tool-call" && part.id === callId) {
+				name = part.name;
+				input = parseToolArguments(part);
+				if (part.output !== undefined) {
+					output = part.output;
+					hasOutput = true;
+				}
+			} else if (part.type === "tool-result" && part.toolCallId === callId) {
+				let parsed: unknown = part.content;
+				try {
+					parsed = JSON.parse(part.content);
+				} catch {
+					// content wasn't JSON — keep the raw string.
+				}
+				output = parsed;
+				hasOutput = true;
+			}
+		}
+	}
+
+	if (name === undefined || !hasOutput) return null;
+	return toolResultToCanvas(name, output, input);
+}
+
+/**
  * Lift a tool-call's input off the part's JSON `arguments` string (the SDK
  * carries the call input there). Tolerates a missing or non-JSON value →
  * undefined. The `run_sql` → result-grid mapping needs this: the grid re-issues


### PR DESCRIPTION
CH2 chat surface for the agentic cockpit — three additive cockpit/TS pieces, all under src/ui/cockpit/, no engine and no other lane's files.

1. Canvas rehydration. cockpit-state gains `pinnedCallId: string | null` with a `pinCanvas(callId, canvasState)` (pin + project in one dispatch) and a `returnToLive()` API. chat-rail's always-project-latest effect short-circuits while pinned so a freshly-streamed result does NOT clobber the history view. CRITICAL (the reversal guard): while pinned the effect also resets its dedupe ref to null and keeps `pinnedCallId` in its deps, so return-to-live re-projects the latest UNCONDITIONALLY — even when the newest result equals the pre-pin projected value, which a stale ref would otherwise suppress (→ blank canvas). A chip click resolves the call by id via the new `canvasFromCallId`, reusing the same toolResultToCanvas mapper (per-call-id addressing, not new mapping).

2. Type-aware chips. ToolCallCard drops the raw-JSON <Collapse> for a compact, per-tool human-readable summary (tool-chip-summary.ts — pure, no React). The 8 canvas-producing tools are clickable-to-rehydrate; probe/teach/replay are display-only. The existing Approve/Deny block is preserved verbatim (frame/ select/teach/replay), independent of clickability — an approval-gated canvas tool shows approve/deny while pending AND becomes a clickable result chip once complete.

3. Readable teach chip. Renders {type, payload} from part.arguments at approval time (arguments is carried in every SDK state incl. approval-requested) and {overlay_id, type} once complete — display-only (teach maps to no canvas member, so it is never clickable-to-rehydrate).

cockpit-view shows a "Viewing history / Return to live" banner next to FocusCanvas only while pinned.

Tests: streaming-token unit tests at the mocked-useChat SDK boundary cover the reversal guard (pin → push new tool-result → canvas STAYS pinned; returnToLive re-projects even when latest == last-projected; snap-to-newest), per-tool chip summaries, canvasFromCallId addressing, the readable teach chip + preserved Approve/Deny, and the history banner. 371/371 unit tests green; biome + tsc clean.

Lane-smoke (Playwright pin→stream→return-to-live) deferred — real-LLM gated, not authorized this lane; the exact sequence is covered deterministically by the unit tests. Live browser path covered post-merge by integration/journey smoke.