### PR TITLE
fix(cockpit): guard connect/frame against partial results (multi-file…

### DIFF
--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -151,6 +151,22 @@ describe("toolChipSummary — streaming / pre-result states", () => {
 		expect(toolChipSummary("connect", {}, undefined)).toBe("connecting…");
 		expect(toolChipSummary("run_sql", {}, undefined)).toBe("running query…");
 	});
+
+	it("treats a truthy-but-PARTIAL result as still running (no .length crash)", () => {
+		// The SDK can surface a partial/streaming or errored tool output: truthy but
+		// missing its array. Accessing `.tables.length` / `.concepts.length` /
+		// `.columns.length` on it crashed the chat rail (the multi-file drag-drop
+		// crash). These must degrade to the running label, not throw.
+		expect(toolChipSummary("connect", {}, { source: "people.csv" })).toBe(
+			"connecting…",
+		);
+		expect(toolChipSummary("frame", {}, { vertical: "finance" })).toBe(
+			"framing concepts…",
+		);
+		expect(toolChipSummary("look_table", {}, { table_name: "orders" })).toBe(
+			"reading table readiness…",
+		);
+	});
 });
 
 describe("teachChipSummary (display-only, readable at every state)", () => {

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -167,6 +167,14 @@ describe("toolChipSummary — streaming / pre-result states", () => {
 			"reading table readiness…",
 		);
 	});
+
+	it("treats a truthy NON-array list output as empty (no .filter crash)", () => {
+		// list_* outputs are arrays; a partial/errored truthy non-array reached
+		// `.filter`/`.length` → "e.filter is not a function" crashed the rail.
+		expect(toolChipSummary("list_sources", {}, {})).toBe("no available inputs");
+		expect(toolChipSummary("list_verticals", {}, {})).toBe("no verticals");
+		expect(toolChipSummary("list_tables", {}, {})).toBe("0 tables");
+	});
 });
 
 describe("teachChipSummary (display-only, readable at every state)", () => {

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -59,7 +59,12 @@ export function toolChipSummary(
 	switch (toolName) {
 		case "list_sources": {
 			if (!done) return "listing available inputs…";
-			const sources = (output as AvailableSource[]) ?? [];
+			// `Array.isArray` not `?? []`: a partial/streaming or errored output can be
+			// a truthy NON-array, which `?? []` wouldn't catch → `.filter` then throws
+			// "e.filter is not a function" and crashes the rail. Degrade to empty.
+			const sources = Array.isArray(output)
+				? (output as AvailableSource[])
+				: [];
 			if (sources.length === 0) return "no available inputs";
 			const dbs = sources.filter((s) => s.kind === "database").length;
 			const files = sources.filter((s) => s.kind === "file").length;
@@ -70,7 +75,7 @@ export function toolChipSummary(
 		}
 		case "list_verticals": {
 			if (!done) return "listing verticals…";
-			const verticals = (output as Vertical[]) ?? [];
+			const verticals = Array.isArray(output) ? (output as Vertical[]) : [];
 			if (verticals.length === 0) return "no verticals";
 			const builtin = verticals.filter((v) => v.kind === "builtin").length;
 			const framed = verticals.filter((v) => v.kind === "framed").length;
@@ -82,7 +87,7 @@ export function toolChipSummary(
 		case "list_tables": {
 			const src = (input as { source_id?: string } | undefined)?.source_id;
 			if (!done) return src ? `listing tables for ${src}…` : "listing tables…";
-			const tables = (output as InventoryTable[]) ?? [];
+			const tables = Array.isArray(output) ? (output as InventoryTable[]) : [];
 			return src
 				? `${plural(tables.length, "table")} in ${src}`
 				: plural(tables.length, "table");

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -89,7 +89,7 @@ export function toolChipSummary(
 		}
 		case "look_table": {
 			const r = output as LookTableResult | undefined;
-			if (!r) return "reading table readiness…";
+			if (!r || !Array.isArray(r.columns)) return "reading table readiness…";
 			const cols = plural(r.columns.length, "column");
 			return r.analyzed
 				? `${r.table_name} — ${cols}`
@@ -104,12 +104,16 @@ export function toolChipSummary(
 		}
 		case "connect": {
 			const s = output as ConnectSchema | undefined;
-			if (!s) return "connecting…";
+			// `output` can be a truthy-but-PARTIAL object while the result streams in
+			// (tables not populated yet) — treat a missing tables array as still
+			// connecting rather than crashing on `.length` (the multi-file drag-drop
+			// crash). The complete result always carries the array.
+			if (!s || !Array.isArray(s.tables)) return "connecting…";
 			return `${s.source} — ${plural(s.tables.length, "table")}`;
 		}
 		case "frame": {
 			const f = output as FrameResult | undefined;
-			if (!f) return "framing concepts…";
+			if (!f || !Array.isArray(f.concepts)) return "framing concepts…";
 			return `${f.vertical} — ${plural(f.concepts.length, "concept")}`;
 		}
 		case "select": {

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
@@ -220,8 +220,15 @@ describe("toolResultToCanvas", () => {
 		expect(toolResultToCanvas("replay", {})).toBeNull();
 	});
 
-	it("tolerates a missing result array", () => {
-		expect(toolResultToCanvas("list_sources", undefined)).toEqual({
+	it("returns null for a missing or NON-array list result (no .filter/.reduce crash)", () => {
+		// A partial/streaming or errored output can be undefined or a truthy
+		// NON-array; projecting it crashed SourceList/Inventory on .filter/.reduce/
+		// .length ("e.filter is not a function"). Leave the canvas unchanged.
+		expect(toolResultToCanvas("list_sources", undefined)).toBeNull();
+		expect(toolResultToCanvas("list_sources", {})).toBeNull();
+		expect(toolResultToCanvas("list_tables", { error: "x" })).toBeNull();
+		// A genuine empty array still projects (correctly an empty source-list).
+		expect(toolResultToCanvas("list_sources", [])).toEqual({
 			kind: "source-list",
 			sources: [],
 		});

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
@@ -116,6 +116,14 @@ describe("toolResultToCanvas", () => {
 		expect(toolResultToCanvas("connect", null)).toBeNull();
 	});
 
+	it("returns null for a PARTIAL connect result (no tables array — no SchemaPreview crash)", () => {
+		// A truthy-but-partial/streaming or errored connect output has no `tables`
+		// array; projecting it crashed SchemaPreview on `schema.tables.length` (the
+		// multi-file drag-drop crash). Leave the canvas unchanged until complete.
+		expect(toolResultToCanvas("connect", { source: "people.csv" })).toBeNull();
+		expect(toolResultToCanvas("connect", {})).toBeNull();
+	});
+
 	it("maps frame to a concept-frame canvas (DAT-382)", () => {
 		const frame = {
 			vertical: "_adhoc",
@@ -137,6 +145,10 @@ describe("toolResultToCanvas", () => {
 
 	it("returns null for a missing frame result (canvas unchanged)", () => {
 		expect(toolResultToCanvas("frame", null)).toBeNull();
+	});
+
+	it("returns null for a PARTIAL frame result (no concepts array)", () => {
+		expect(toolResultToCanvas("frame", { vertical: "finance" })).toBeNull();
 	});
 
 	it("maps run_sql to a result-grid from the CALL INPUT (sql + params)", () => {

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -51,13 +51,21 @@ const PROJECTORS: Record<string, CanvasProjector> = {
 	// The per-column explanation; a missing result leaves the canvas as-is.
 	why_column: (result) =>
 		result ? { kind: "column-why", why: result as WhyColumnResult } : null,
-	// null/undefined → leave the canvas unchanged (a failed connect surfaces its
-	// error in the chat rail, not as an empty preview).
+	// Only project once the result is a COMPLETE schema (a `tables` array): a
+	// partial/streaming or errored connect output is truthy-but-tables-less, and
+	// projecting it crashes SchemaPreview on `schema.tables.length` (the multi-file
+	// drag-drop crash). Not-yet-complete → leave the canvas unchanged (the last
+	// good preview stays; a failed connect surfaces its error in the chat rail).
 	connect: (result) =>
-		result ? { kind: "schema-preview", schema: result as ConnectSchema } : null,
-	// Declared concepts render as the ConceptFrame widget; missing → unchanged.
+		Array.isArray((result as { tables?: unknown } | null)?.tables)
+			? { kind: "schema-preview", schema: result as ConnectSchema }
+			: null,
+	// Declared concepts render as the ConceptFrame widget; only once the result
+	// carries a `concepts` array (same partial-output guard as connect).
 	frame: (result) =>
-		result ? { kind: "concept-frame", frame: result as FrameResult } : null,
+		Array.isArray((result as { concepts?: unknown } | null)?.concepts)
+			? { kind: "concept-frame", frame: result as FrameResult }
+			: null,
 	// The persisted Source descriptor renders as SelectedSource; a missing result
 	// (e.g. a rejected duplicate-basename select) leaves the canvas unchanged.
 	select: (result) =>

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -34,14 +34,17 @@ type CanvasProjector = (result: unknown, input: unknown) => CanvasState | null;
  * (teach / probe) project nothing → their chips are display-only.
  */
 const PROJECTORS: Record<string, CanvasProjector> = {
-	list_sources: (result) => ({
-		kind: "source-list",
-		sources: (result as AvailableSource[]) ?? [],
-	}),
-	list_tables: (result) => ({
-		kind: "workspace-inventory",
-		tables: (result as InventoryTable[]) ?? [],
-	}),
+	// Project only a real array — a partial/streaming or errored output can be a
+	// truthy NON-array, and the SourceList/Inventory widgets call .filter/.reduce/
+	// .length on it ("e.filter is not a function"). Non-array → leave unchanged.
+	list_sources: (result) =>
+		Array.isArray(result)
+			? { kind: "source-list", sources: result as AvailableSource[] }
+			: null,
+	list_tables: (result) =>
+		Array.isArray(result)
+			? { kind: "workspace-inventory", tables: result as InventoryTable[] }
+			: null,
 	// The per-table readiness grid; a missing result (e.g. an errored read)
 	// leaves the canvas unchanged.
 	look_table: (result) =>


### PR DESCRIPTION
… drag-drop crash)

Crash on multi-file upload: "undefined is not an object (evaluating 'e.tables.length')". A connect tool output can be truthy-but-PARTIAL (present before its `tables` array streams in, or an errored shape). Two render paths accessed `.tables.length` on it:

- tool-chip-summary: the connect chip guards `if (!s)` then does `s.tables.length` — a partial output (no tables) crashed the always-rendered chat rail. Same for the frame (`f.concepts.length`) and look_table (`r.columns.length`) chips.
- tool-result-to-canvas: the connect projector cast `result as ConnectSchema` whenever truthy, projecting a tables-less schema into SchemaPreview which then crashed on `schema.tables.length`. Same for the frame → concept-frame projector.

Treat a result missing its array as still-in-progress: the chip shows the running label; the projector returns null (last good preview stays). The complete result always carries the array. Surfaced via multi-file drag-drop (a concurrent-connect timing window); guards the crash regardless of the exact trigger.

Could not reproduce the native file-drop timing in the harness (Playwright can't simulate an OS file drop); these are the only client-side `*.tables.length` sites, both now guarded + unit-tested with partial outputs.