### PR TITLE
fix(entropy): restore relationship_entropy recall + scope rel detectors to defined catalog (DAT-405)

### DIFF
--- a/packages/engine/src/dataraum/entropy/detectors/loaders.py
+++ b/packages/engine/src/dataraum/entropy/detectors/loaders.py
@@ -236,15 +236,22 @@ def load_relationship_for_pair(
 def load_session_relationships(
     session: Session, session_id: str, run_id: str | None = None
 ) -> list[dict[str, Any]]:
-    """This run's relationships for a session (DAT-408) — join-path ambiguity needs the set.
+    """This run's **defined** relationships for a session (DAT-408) — the join-path set.
 
-    Scoped to ``run_id`` (the current run's catalog) so coexisting prior-run rows
-    don't double-count; ``None`` (tests) reads the session unscoped.
+    "Defined" = ``detection_method != 'candidate'`` (the catalog contract in
+    db_models.py / relationships.utils): join-path ambiguity is measured among the
+    LLM-selected relationships, not the ephemeral structural candidates — two bare
+    candidates between the same two tables are not a real ambiguous join. Scoped to
+    ``run_id`` (the current run's catalog) so coexisting prior-run rows don't
+    double-count; ``None`` (tests) reads the session unscoped.
     """
     from dataraum.analysis.relationships.db_models import Relationship
     from dataraum.storage import Table
 
-    stmt = select(Relationship).where(Relationship.session_id == session_id)
+    stmt = select(Relationship).where(
+        Relationship.session_id == session_id,
+        Relationship.detection_method != "candidate",
+    )
     if run_id is not None:
         stmt = stmt.where(Relationship.run_id == run_id)
     rels = list(session.execute(stmt).scalars())

--- a/packages/engine/src/dataraum/entropy/detectors/structural/relationship_entropy.py
+++ b/packages/engine/src/dataraum/entropy/detectors/structural/relationship_entropy.py
@@ -64,7 +64,11 @@ class RelationshipEntropyDetector(EntropyDetector):
             run_id=context.run_id,
         )
         if rel is not None:
-            context.analysis_results["relationship"] = rel
+            # Store under the declared RELATIONSHIPS key so can_run() (which gates on
+            # required_analyses) finds it — detect() reads the same key. Storing under
+            # a different key ("relationship") left can_run permanently False → the
+            # detector was silently skipped (zero recall). Found by DAT-405 calibration.
+            context.analysis_results[AnalysisKey.RELATIONSHIPS] = rel
 
     def detect(self, context: DetectorContext) -> list[EntropyObject]:
         """Detect relationship-quality entropy for the focal relationship (DAT-408).
@@ -93,7 +97,7 @@ class RelationshipEntropyDetector(EntropyDetector):
         # RI boost factor: sqrt amplifies small orphan rates
         ri_boost = detector_config.get("ri_boost", True)
 
-        rel = context.get_analysis("relationship", None)
+        rel = context.get_analysis(AnalysisKey.RELATIONSHIPS, None)
         if not rel:
             return []
 

--- a/packages/engine/src/dataraum/entropy/engine.py
+++ b/packages/engine/src/dataraum/entropy/engine.py
@@ -161,6 +161,14 @@ def run_detector_post_step(
                 # keeps the from-endpoint anchor (object table_id) inside table_ids so
                 # the run_id-scoped delete reliably clears it on retry.
                 Relationship.session_id == session_id,
+                # Defined catalog only (DAT-408 contract — see db_models.py /
+                # relationships.utils): the LLM in semantic_per_table is the selector,
+                # so the relationship detectors measure what it confirmed (llm +
+                # materialized manual/keeper), NOT the ephemeral structural
+                # ``candidate`` superset. Enumerating bare candidates as focal pairs
+                # manufactured join-path ambiguity the schema doesn't have and scored
+                # spurious relationship_entropy. Found by DAT-405 calibration.
+                Relationship.detection_method != "candidate",
                 Relationship.from_table_id.in_(table_ids),
                 Relationship.to_table_id.in_(table_ids),
             )

--- a/packages/engine/tests/unit/entropy/test_structural_detectors.py
+++ b/packages/engine/tests/unit/entropy/test_structural_detectors.py
@@ -212,7 +212,11 @@ class TestRelationshipEntropyDetector:
             from_column_id="c_fk",
             to_column_id="c_pk",
             analysis_results={
-                "relationship": {
+                # Key MUST match the detector's required_analyses (AnalysisKey.RELATIONSHIPS):
+                # can_run() gates on it and detect() reads it. The old singular "relationship"
+                # key left can_run() False in production -> the detector was silently skipped
+                # (zero recall), which these detect()-only tests couldn't see (DAT-405).
+                "relationships": {
                     "from_table": "orders",
                     "to_table": "customers",
                     "relationship_type": "foreign_key",


### PR DESCRIPTION
## Summary

Found by **dataraum-eval DAT-405** calibration of the DAT-408 relationship migration — driving `beginSessionWorkflow` against ground-truth injections surfaced two bugs that unit tests + the orphaned-detector guard couldn't catch.

### 1. `relationship_entropy` had zero recall
`load_data` populated `analysis_results["relationship"]` (singular) while `required_analyses = [AnalysisKey.RELATIONSHIPS]` (`"relationships"`), so `can_run()` was **always False** → the detector was silently skipped. The `detect()`-only unit tests bypassed `can_run`, so they never saw it. Aligned `load_data` + `detect` on `AnalysisKey.RELATIONSHIPS` and updated the test context key.

### 2. `join_path_determinism` over-fired on bare candidates
The focal-pair enumeration (`engine.py`) and `load_session_relationships` (`loaders.py`) read the full catalog **including ephemeral `candidate` rows**, manufacturing join-path ambiguity the schema doesn't have (**12 / 25** pairs false-flagged on canonical finance data). The LLM in `semantic_per_table` is the selector; the detectors must read the **defined** catalog (`detection_method != 'candidate'`) — the contract already documented in `db_models.py` / `relationships.utils`. Scoped both reads to defined-only.

## Verification (beginSessionWorkflow on detection-v1)
| detector | before | after |
|---|---|---|
| `relationship_entropy` | 0 objects (skipped) | 9 objects; `payments.invoice_id → invoices.invoice_id` = **0.447** (left_RI 80.06 / 20% orphans, sqrt-boosted) |
| `join_path_determinism` | 12 ambiguous (false) | **0 ambiguous**, all deterministic |

Unit tests: 129 pass (`-k "relationship or join_path or snapshot"`); ruff + mypy clean on changed files.

## Follow-up
- Real-ambiguity *recall* for `join_path` (two real FK paths the LLM confirms both) is still to be proven via a dataraum-eval `add_duplicate_fk_paths` fixture (Stage B) — the defined-only cut makes ambiguity recall depend on LLM confirmation of both legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)