### PR TITLE
DAT-414: version typed/quarantine materialization DDL

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,26 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-04: DAT-414 — versioned typed/quarantine materialization DDL
+
+Phase 2 of the versioned-metadata epic (DAT-412), Slice A typed/quarantine only.
+
+- **No behavior change to calibrate.** The typed/quarantine `CREATE OR REPLACE TABLE … AS
+  SELECT` that typing executes is **byte-identical** to before — the only additions are
+  (a) persisting that DDL string as a new `MaterializationRecipe` row stamped with the
+  run's `run_id`, and (b) a new `rebuild_from_recipe` / `reset_to_run` API that
+  re-executes a stored DDL. Detector inputs, decided types, quarantine contents, and
+  readiness are all unchanged. Recall/precision suites should be unaffected.
+- **New table:** `materialization_recipes` (grain `(table_id, layer, run_id)`, columns
+  `target_fqn`, `ddl`, `depends_on`). Auto-created via `create_all`; nullable `run_id`
+  mirrors `type_decisions`. No eval read of it is required.
+- **One non-determinism note** if eval ever round-trips a quarantine table: the quarantine
+  DDL stamps `_quarantined_at` via `CURRENT_TIMESTAMP`, so re-executing the *same* recipe
+  produces a fresh audit timestamp — the **data** rows round-trip identically, the clock
+  advances. Compare quarantine on data columns, not `_quarantined_at`.
+- **Calibrate:** nothing new required. If the existing add_source detector-recall suite is
+  re-run after bumping the engine submodule, expect no movement from this ticket.
+
 ## 2026-06-04: DAT-409 — relationship teach write-loop + overlay-contract unification
 
 Slice 2.0c. The relationship-overlay write path (teach → materialize → keeper) plus a

--- a/.claude/platform-status.md
+++ b/.claude/platform-status.md
@@ -7,6 +7,7 @@ Row is added when a lane opens its PR; removed when the PR merges.
 |---|---|---|---|---|---|
 | DAT-354 | .worktrees/DAT-354 | feat/DAT-354-chat-tool-result-chips | (pending — lead opens) | none (cockpit-only: chat tool-result chips + canvas-rehydration mechanism) | pushed, awaiting PR |
 | DAT-352 | .worktrees/DAT-352 | feat/DAT-352-measure-progress-rehydration | (pending — lead opens) | mirrors engine ProgressSnapshot (DAT-406) into temporal/types.ts | pushed, awaiting PR — SALVAGED: impl agent looped on result-emit (context exhaustion); work was committed + gates-green; verified independently (biome/tsc/345 unit tests + 3/3 review) then pushed |
+| DAT-414 | .worktrees/DAT-414 | feat/DAT-414-versioned-typing-ddl | #213 | none (engine-internal: typed/quarantine materialization DDL; "Cross-repo: None expected") | lane smoke green (4 real-DuckLake tests), 62 affected tests green, gates clean, awaiting review — reviewer subagents not spawnable from background lane (no Agent tool); self-reviewed |
 
 _(previously merged: DAT-320 #110, DAT-324 #111, DAT-321 #113, DAT-323 #114, DAT-325 #115, DAT-358 #128, DAT-340 #129, DAT-339 substrate #132, bun toolchain #133, DAT-400 #191, DAT-406 #192)_
 

--- a/packages/cockpit/src/db/metadata/relations.ts
+++ b/packages/cockpit/src/db/metadata/relations.ts
@@ -26,6 +26,14 @@ export const relations = defineRelations(schema, (r) => ({
 		entropyReadinesss: r.many.entropyReadiness(),
 		fixLedgers: r.many.fixLedger(),
 		investigationStepss: r.many.investigationSteps(),
+		tablessViaMaterializationRecipes: r.many.tables({
+			from: r.investigationSessions.sessionId.through(
+				r.materializationRecipes.sessionId,
+			),
+			to: r.tables.tableId.through(r.materializationRecipes.tableId),
+			alias:
+				"investigationSessions_sessionId_tables_tableId_via_materializationRecipes",
+		}),
 		sourcessViaQueryExecutions: r.many.sources({
 			from: r.investigationSessions.sessionId.through(
 				r.queryExecutions.sessionId,
@@ -129,6 +137,11 @@ export const relations = defineRelations(schema, (r) => ({
 		}),
 		entropyObjectss: r.many.entropyObjects(),
 		entropyReadinesss: r.many.entropyReadiness(),
+		investigationSessionssViaMaterializationRecipes:
+			r.many.investigationSessions({
+				alias:
+					"investigationSessions_sessionId_tables_tableId_via_materializationRecipes",
+			}),
 		relationshipssFromTableId: r.many.relationships({
 			alias: "relationships_fromTableId_tables_tableId",
 		}),

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -470,6 +470,40 @@ export const investigationSteps = metadataSchema.table(
 	],
 );
 
+export const materializationRecipes = metadataSchema.table(
+	"materialization_recipes",
+	{
+		recipeId: varchar("recipe_id").primaryKey(),
+		sessionId: varchar("session_id")
+			.notNull()
+			.references(() => investigationSessions.sessionId),
+		tableId: varchar("table_id")
+			.notNull()
+			.references(() => tables.tableId, { onDelete: "cascade" }),
+		layer: varchar().notNull(),
+		runId: varchar("run_id"),
+		targetFqn: varchar("target_fqn").notNull(),
+		ddl: varchar().notNull(),
+		dependsOn: json("depends_on"),
+		createdAt: timestamp("created_at").notNull(),
+	},
+	(table) => [
+		index("idx_materialization_recipes_table").using(
+			"btree",
+			table.tableId.asc().nullsLast(),
+		),
+		index("ix_materialization_recipes_session_id").using(
+			"btree",
+			table.sessionId.asc().nullsLast(),
+		),
+		unique("uq_materialization_recipe_table_layer_run").on(
+			table.tableId,
+			table.layer,
+			table.runId,
+		),
+	],
+);
+
 export const metadataSnapshotHead = metadataSchema.table(
 	"metadata_snapshot_head",
 	{

--- a/packages/engine/src/dataraum/analysis/typing/db_models.py
+++ b/packages/engine/src/dataraum/analysis/typing/db_models.py
@@ -143,7 +143,9 @@ class MaterializationRecipe(Base):
     string typing executes to build a physical DuckDB table — versioned as
     metadata. The DuckDB lake itself stays latest-only; only the DDL string is
     versioned, stamped with the run that emitted it. Re-executing a stored row
-    rebuilds the physical artifact identically, and a reset-to-prior-run replays
+    reproduces the artifact's data — the recipe versions the *transformation*,
+    not the data, so DDL-written audit columns (the quarantine ``_quarantined_at``
+    ``CURRENT_TIMESTAMP``) re-stamp on rebuild — and a reset-to-prior-run replays
     the prior run's stored DDL **without** re-deriving the typing phase.
 
     Grain ``(table_id, layer, run_id)``: one recipe per produced layer

--- a/packages/engine/src/dataraum/analysis/typing/db_models.py
+++ b/packages/engine/src/dataraum/analysis/typing/db_models.py
@@ -3,6 +3,7 @@
 SQLAlchemy models for type inference persistence:
 - TypeCandidate: Detected type candidates with confidence scores
 - TypeDecision: Final type decision (automatic or human override)
+- MaterializationRecipe: Versioned typed/quarantine ``CREATE TABLE`` DDL (DAT-414)
 
 These models form the persisted interface between the typing module
 and downstream modules (statistics, semantic analysis).
@@ -135,6 +136,68 @@ class TypeDecision(Base):
     column: Mapped[Column] = relationship(back_populates="type_decision")
 
 
+class MaterializationRecipe(Base):
+    """Versioned ``CREATE TABLE`` DDL for a physical typed/quarantine artifact (DAT-414).
+
+    The materialization *recipe* — the ``CREATE OR REPLACE TABLE … AS SELECT``
+    string typing executes to build a physical DuckDB table — versioned as
+    metadata. The DuckDB lake itself stays latest-only; only the DDL string is
+    versioned, stamped with the run that emitted it. Re-executing a stored row
+    rebuilds the physical artifact identically, and a reset-to-prior-run replays
+    the prior run's stored DDL **without** re-deriving the typing phase.
+
+    Grain ``(table_id, layer, run_id)``: one recipe per produced layer
+    (``typed`` / ``quarantine``) per typed Table per run. ``table_id`` is the
+    *typed* Table id (stable across re-types, DAT-373) — the physical artifact
+    the DDL produces — not the raw input table.
+
+    ``depends_on`` lists the bare DuckDB names this DDL reads from (typed/
+    quarantine both read the raw layer), so a rebuild can re-execute a chain in
+    dependency order. Single-level for typed/quarantine today; the field
+    future-proofs the view-DDL chains in Slice B (DAT-415).
+    """
+
+    __tablename__ = "materialization_recipes"
+    # One recipe per (typed table, produced layer, run). The run axis lets two
+    # coexisting runs' recipes for the same artifact live side by side; the
+    # promoted snapshot head names which run is current (DAT-413).
+    __table_args__ = (
+        UniqueConstraint(
+            "table_id", "layer", "run_id", name="uq_materialization_recipe_table_layer_run"
+        ),
+    )
+
+    recipe_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id: Mapped[str] = mapped_column(
+        ForeignKey("investigation_sessions.session_id"), nullable=False, index=True
+    )
+    # The typed Table whose physical artifact this DDL materializes. CASCADE so a
+    # dropped typed Table takes its recipes with it.
+    table_id: Mapped[str] = mapped_column(
+        ForeignKey("tables.table_id", ondelete="CASCADE"), nullable=False
+    )
+    # Produced lake layer: ``"typed"`` or ``"quarantine"``.
+    layer: Mapped[str] = mapped_column(String, nullable=False)
+    # Snapshot version axis (DAT-413): the run that emitted this DDL. Nullable to
+    # mirror TypeDecision/TypeCandidate (a non-run caller writes a NULL run).
+    run_id: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    # The fully-qualified DuckDB target the DDL creates
+    # (e.g. ``lake.typed."csv__orders"``), captured so a rebuild can verify /
+    # reference the artifact without recomposing the name.
+    target_fqn: Mapped[str] = mapped_column(String, nullable=False)
+    # The exact ``CREATE OR REPLACE TABLE … AS SELECT`` string, re-executed
+    # verbatim to rebuild the physical artifact.
+    ddl: Mapped[str] = mapped_column(String, nullable=False)
+    # Bare DuckDB names this DDL reads from, for dependency-order rebuild.
+    depends_on: Mapped[list[str] | None] = mapped_column(JSON)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(UTC)
+    )
+
+
 # Indexes for efficient queries
 Index("idx_type_candidates_column", TypeCandidate.column_id)
 Index("idx_type_decisions_column", TypeDecision.column_id)
+Index("idx_materialization_recipes_table", MaterializationRecipe.table_id)

--- a/packages/engine/src/dataraum/analysis/typing/recipe.py
+++ b/packages/engine/src/dataraum/analysis/typing/recipe.py
@@ -22,6 +22,7 @@ from sqlalchemy import select
 
 from dataraum.analysis.typing.db_models import MaterializationRecipe
 from dataraum.core.logging import get_logger
+from dataraum.storage import Table
 from dataraum.storage.snapshot_head import head_run_id
 from dataraum.storage.upsert import upsert
 
@@ -49,7 +50,10 @@ def store_recipe(
     at-least-once retry (same ``run_id``) is idempotent — re-running typing
     overwrites the run's recipe rather than duplicating it — while a NEW run's
     recipe coexists with prior runs'. The promoted snapshot head names which run
-    is current (DAT-413).
+    is current (DAT-413). ``run_id=None`` (non-run callers) is NOT dedup-keyed —
+    Postgres treats a NULL ``run_id`` as distinct in the unique constraint, so
+    repeated NULL-run writes accrue rows; the Temporal path always stamps a
+    ``run_id``, so production never hits this.
 
     Args:
         session: Active SQLAlchemy session.
@@ -129,6 +133,42 @@ def _order_by_dependency(recipes: list[MaterializationRecipe]) -> list[Materiali
     return ordered
 
 
+def _load_recipes(session: Session, table_id: str, run_id: str) -> list[MaterializationRecipe]:
+    """The stored recipes for one ``(table_id, run_id)`` grain (empty if none)."""
+    return list(
+        session.execute(
+            select(MaterializationRecipe).where(
+                MaterializationRecipe.table_id == table_id,
+                MaterializationRecipe.run_id == run_id,
+            )
+        ).scalars()
+    )
+
+
+def _replay(
+    duckdb_conn: duckdb.DuckDBPyConnection, recipes: list[MaterializationRecipe]
+) -> list[str]:
+    """Re-execute recipes in dependency order, atomically.
+
+    Wrapped in one DuckDB transaction so a mid-chain failure rolls the whole
+    rebuild back rather than leaving the lake half-materialized. The set is
+    independent today (typed/quarantine read only the raw layer), but the
+    all-or-nothing guarantee is load-bearing once the multi-level view chains land
+    on this substrate (Slice B, DAT-415).
+    """
+    rebuilt: list[str] = []
+    duckdb_conn.execute("BEGIN TRANSACTION")
+    try:
+        for recipe in _order_by_dependency(recipes):
+            duckdb_conn.execute(recipe.ddl)
+            rebuilt.append(recipe.target_fqn)
+    except Exception:
+        duckdb_conn.execute("ROLLBACK")
+        raise
+    duckdb_conn.execute("COMMIT")
+    return rebuilt
+
+
 def rebuild_from_recipe(
     session: Session,
     duckdb_conn: duckdb.DuckDBPyConnection,
@@ -136,17 +176,19 @@ def rebuild_from_recipe(
     table_id: str,
     run_id: str,
 ) -> list[str]:
-    """Rebuild a typed Table's physical artifacts from a run's stored DDL.
+    """Rebuild one Table's physical artifact from a run's stored DDL.
 
     Re-executes the ``(table_id, run_id)`` recipes against DuckDB in dependency
-    order, recreating the physical ``typed``/``quarantine`` tables exactly as the
-    original run produced them. No typing re-derivation — the versioned DDL string
-    is the source of truth.
+    order, reproducing the table's DATA as the original run produced it — no
+    typing re-derivation. The recipe versions the *transformation*, not the data:
+    a faithful re-execution reproduces identical rows, while audit columns the DDL
+    writes (the quarantine ``_quarantined_at`` ``CURRENT_TIMESTAMP``) re-stamp to
+    the rebuild time.
 
     Args:
         session: Active SQLAlchemy session.
         duckdb_conn: DuckDB connection to execute the DDL against.
-        table_id: The typed Table whose artifacts to rebuild.
+        table_id: The Table whose artifact to rebuild.
         run_id: The run whose stored recipes to replay.
 
     Returns:
@@ -155,25 +197,13 @@ def rebuild_from_recipe(
     Raises:
         RuntimeError: If no recipe is stored for ``(table_id, run_id)``.
     """
-    recipes = list(
-        session.execute(
-            select(MaterializationRecipe).where(
-                MaterializationRecipe.table_id == table_id,
-                MaterializationRecipe.run_id == run_id,
-            )
-        ).scalars()
-    )
+    recipes = _load_recipes(session, table_id, run_id)
     if not recipes:
         raise RuntimeError(
             f"No materialization recipe for table {table_id} at run {run_id} — "
             "nothing to rebuild (was the recipe stored during typing?)."
         )
-
-    rebuilt: list[str] = []
-    for recipe in _order_by_dependency(recipes):
-        duckdb_conn.execute(recipe.ddl)
-        rebuilt.append(recipe.target_fqn)
-
+    rebuilt = _replay(duckdb_conn, recipes)
     logger.info(
         "materialization_rebuilt",
         table_id=table_id,
@@ -192,27 +222,72 @@ def reset_to_run(
 ) -> list[str]:
     """Reset a typed Table's physical artifacts to a prior run (DAT-414 AC#3).
 
-    Flips the typing snapshot head for ``table:{table_id}`` to ``run_id`` and
-    re-executes that run's stored materialization DDL, rebuilding the physical
-    DuckDB tables from the versioned recipe **without** a full phase
-    re-derivation. The lake is latest-only, so "reset" means re-materializing the
-    target run's recipe over the current physical table.
+    Re-executes ``run_id``'s stored materialization DDL — for the typed artifact
+    AND its quarantine sibling — then flips the typing snapshot head for
+    ``table:{table_id}`` to ``run_id``. Typed and quarantine are separate Table
+    rows (distinct ``table_id``s) for one logical table, so the reset rebuilds the
+    pair together in one transaction; resetting only the typed half would leave the
+    lake at typed@``run_id`` / quarantine@whatever-materialized-last. No phase
+    re-derivation — the versioned recipe is the source of truth; the lake is
+    latest-only, so "reset" re-materializes the target run's recipe over the
+    current physical tables.
+
+    ``table_id`` is the *typed* Table id (the head key). A run with no cast
+    failures — or the strongly-typed copy — has no quarantine recipe, so only the
+    typed artifact is rebuilt.
 
     Args:
         session: Active SQLAlchemy session.
         duckdb_conn: DuckDB connection to execute the DDL against.
         table_id: The typed Table to reset.
-        run_id: The run to reset the physical artifact to.
+        run_id: The run to reset the physical artifacts to.
 
     Returns:
         The ``target_fqn``s rebuilt, in execution order.
 
     Raises:
-        RuntimeError: If no recipe is stored for ``(table_id, run_id)``.
+        RuntimeError: If no recipe is stored for the typed ``(table_id, run_id)``.
     """
-    rebuilt = rebuild_from_recipe(session, duckdb_conn, table_id=table_id, run_id=run_id)
+    recipes = _load_recipes(session, table_id, run_id)
+    if not recipes:
+        raise RuntimeError(
+            f"No materialization recipe for table {table_id} at run {run_id} — "
+            "nothing to reset (was the recipe stored during typing?)."
+        )
+    # The pair resets together: pull the quarantine sibling's recipes (if this run
+    # produced one) so the lake can't end up typed@run / quarantine@another-run.
+    quarantine_id = _quarantine_sibling_id(session, table_id)
+    if quarantine_id is not None and quarantine_id != table_id:
+        recipes += _load_recipes(session, quarantine_id, run_id)
+    rebuilt = _replay(duckdb_conn, recipes)
     _point_head(session, table_id, run_id)
+    logger.info(
+        "materialization_reset",
+        table_id=table_id,
+        run_id=run_id,
+        artifacts=len(rebuilt),
+    )
     return rebuilt
+
+
+def _quarantine_sibling_id(session: Session, typed_table_id: str) -> str | None:
+    """The quarantine Table id sharing the typed table's ``(source, name)``, or ``None``.
+
+    Typed and quarantine are separate Table rows for one logical table,
+    discriminated by ``layer``; a reset rebuilds the pair together. A run with no
+    cast failures — or the strongly-typed copy — produces no quarantine artifact.
+    """
+    typed = session.get(Table, typed_table_id)
+    if typed is None:
+        return None
+    quarantine = session.execute(
+        select(Table).where(
+            Table.source_id == typed.source_id,
+            Table.table_name == typed.table_name,
+            Table.layer == "quarantine",
+        )
+    ).scalar_one_or_none()
+    return quarantine.table_id if quarantine is not None else None
 
 
 def _point_head(session: Session, table_id: str, run_id: str) -> None:

--- a/packages/engine/src/dataraum/analysis/typing/recipe.py
+++ b/packages/engine/src/dataraum/analysis/typing/recipe.py
@@ -1,0 +1,256 @@
+"""Versioned materialization recipes for typed/quarantine artifacts (DAT-414).
+
+Typing materializes its physical DuckDB tables by executing a
+``CREATE OR REPLACE TABLE … AS SELECT`` string. This module captures that string
+as versioned metadata: :func:`store_recipe` persists it stamped with the run's
+``run_id``, and :func:`rebuild_from_recipe` re-executes a stored run's DDL to
+rebuild the physical artifact — **without** re-deriving the typing phase.
+
+Two consumers:
+- The typing phase, which after building each typed/quarantine table records the
+  exact DDL it just executed (emit → store → execute).
+- A physical reset/rebuild, which flips the snapshot head to a prior run and
+  replays that run's stored DDL in dependency order (the lake is latest-only, so
+  a reset is a re-materialization from the versioned recipe, not a re-typing).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from dataraum.analysis.typing.db_models import MaterializationRecipe
+from dataraum.core.logging import get_logger
+from dataraum.storage.snapshot_head import head_run_id
+from dataraum.storage.upsert import upsert
+
+if TYPE_CHECKING:
+    import duckdb
+    from sqlalchemy.orm import Session
+
+logger = get_logger(__name__)
+
+
+def store_recipe(
+    session: Session,
+    *,
+    session_id: str,
+    table_id: str,
+    layer: str,
+    run_id: str | None,
+    target_fqn: str,
+    ddl: str,
+    depends_on: list[str] | None = None,
+) -> None:
+    """Persist the ``CREATE TABLE`` DDL for one typed/quarantine artifact.
+
+    Upserts on the ``(table_id, layer, run_id)`` grain so a Temporal
+    at-least-once retry (same ``run_id``) is idempotent — re-running typing
+    overwrites the run's recipe rather than duplicating it — while a NEW run's
+    recipe coexists with prior runs'. The promoted snapshot head names which run
+    is current (DAT-413).
+
+    Args:
+        session: Active SQLAlchemy session.
+        session_id: Owning investigation session.
+        table_id: The *typed* Table id whose physical artifact the DDL produces
+            (stable across re-types, DAT-373).
+        layer: Produced lake layer — ``"typed"`` or ``"quarantine"``.
+        run_id: The run that emitted this DDL (DAT-413). ``None`` for non-run
+            callers, matching the TypeDecision/TypeCandidate convention.
+        target_fqn: Fully-qualified DuckDB target the DDL creates.
+        ddl: The exact ``CREATE OR REPLACE TABLE … AS SELECT`` string.
+        depends_on: Fully-qualified DuckDB names this DDL reads from
+            (e.g. ``lake.raw."x"``), for dependency-order rebuild. Layer-qualified
+            so a rebuild never confuses the raw input with the same-bare-named
+            typed/quarantine artifacts. ``None`` is stored as no dependency.
+    """
+    upsert(
+        session,
+        MaterializationRecipe,
+        [
+            {
+                "session_id": session_id,
+                "table_id": table_id,
+                "layer": layer,
+                "run_id": run_id,
+                "target_fqn": target_fqn,
+                "ddl": ddl,
+                "depends_on": depends_on,
+            }
+        ],
+        index_elements=["table_id", "layer", "run_id"],
+    )
+
+
+def _order_by_dependency(recipes: list[MaterializationRecipe]) -> list[MaterializationRecipe]:
+    """Order recipes so a DDL runs after the artifacts it reads from.
+
+    Each recipe's ``target_fqn`` is matched against the ``depends_on`` of the
+    others. Both are fully-qualified DuckDB names (``lake.<layer>."<bare>"``), so
+    the match is layer-aware — a typed recipe depending on ``lake.raw."x"`` does
+    NOT spuriously match a quarantine recipe producing ``lake.quarantine."x"``
+    (raw/typed/quarantine share the same bare name; only the schema differs).
+    Typed/quarantine both read only the raw layer (not each other), so the set is
+    independent today; the topological pass future-proofs the multi-level view
+    chains in Slice B (DAT-415). A dependency that is not itself a recipe in the
+    set (e.g. the raw table) is treated as already present.
+    """
+    # Map each recipe by the fully-qualified target it produces, so a dependent's
+    # ``depends_on`` FQN can reference it precisely.
+    produced: dict[str, MaterializationRecipe] = {r.target_fqn: r for r in recipes}
+
+    ordered: list[MaterializationRecipe] = []
+    # Key visited/placed sets on Python object identity, not ``recipe_id``: an
+    # unpersisted recipe (constructed but not yet flushed) has a NULL PK, so all
+    # would collapse to one key. ``id()`` is stable for the duration of this call.
+    placed: set[int] = set()
+
+    def _visit(recipe: MaterializationRecipe, seen: set[int]) -> None:
+        key = id(recipe)
+        if key in placed:
+            return
+        if key in seen:
+            # A cycle is a bug in the recipe graph — break it rather than recurse
+            # forever; the artifact still materializes (its deps just may lag).
+            logger.warning("materialization_recipe_cycle", target_fqn=recipe.target_fqn)
+            return
+        seen.add(key)
+        for dep in recipe.depends_on or []:
+            dep_recipe = produced.get(dep)
+            if dep_recipe is not None:
+                _visit(dep_recipe, seen)
+        placed.add(key)
+        ordered.append(recipe)
+
+    for r in recipes:
+        _visit(r, set())
+    return ordered
+
+
+def rebuild_from_recipe(
+    session: Session,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    *,
+    table_id: str,
+    run_id: str,
+) -> list[str]:
+    """Rebuild a typed Table's physical artifacts from a run's stored DDL.
+
+    Re-executes the ``(table_id, run_id)`` recipes against DuckDB in dependency
+    order, recreating the physical ``typed``/``quarantine`` tables exactly as the
+    original run produced them. No typing re-derivation — the versioned DDL string
+    is the source of truth.
+
+    Args:
+        session: Active SQLAlchemy session.
+        duckdb_conn: DuckDB connection to execute the DDL against.
+        table_id: The typed Table whose artifacts to rebuild.
+        run_id: The run whose stored recipes to replay.
+
+    Returns:
+        The ``target_fqn``s rebuilt, in execution order.
+
+    Raises:
+        RuntimeError: If no recipe is stored for ``(table_id, run_id)``.
+    """
+    recipes = list(
+        session.execute(
+            select(MaterializationRecipe).where(
+                MaterializationRecipe.table_id == table_id,
+                MaterializationRecipe.run_id == run_id,
+            )
+        ).scalars()
+    )
+    if not recipes:
+        raise RuntimeError(
+            f"No materialization recipe for table {table_id} at run {run_id} — "
+            "nothing to rebuild (was the recipe stored during typing?)."
+        )
+
+    rebuilt: list[str] = []
+    for recipe in _order_by_dependency(recipes):
+        duckdb_conn.execute(recipe.ddl)
+        rebuilt.append(recipe.target_fqn)
+
+    logger.info(
+        "materialization_rebuilt",
+        table_id=table_id,
+        run_id=run_id,
+        artifacts=len(rebuilt),
+    )
+    return rebuilt
+
+
+def reset_to_run(
+    session: Session,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    *,
+    table_id: str,
+    run_id: str,
+) -> list[str]:
+    """Reset a typed Table's physical artifacts to a prior run (DAT-414 AC#3).
+
+    Flips the typing snapshot head for ``table:{table_id}`` to ``run_id`` and
+    re-executes that run's stored materialization DDL, rebuilding the physical
+    DuckDB tables from the versioned recipe **without** a full phase
+    re-derivation. The lake is latest-only, so "reset" means re-materializing the
+    target run's recipe over the current physical table.
+
+    Args:
+        session: Active SQLAlchemy session.
+        duckdb_conn: DuckDB connection to execute the DDL against.
+        table_id: The typed Table to reset.
+        run_id: The run to reset the physical artifact to.
+
+    Returns:
+        The ``target_fqn``s rebuilt, in execution order.
+
+    Raises:
+        RuntimeError: If no recipe is stored for ``(table_id, run_id)``.
+    """
+    rebuilt = rebuild_from_recipe(session, duckdb_conn, table_id=table_id, run_id=run_id)
+    _point_head(session, table_id, run_id)
+    return rebuilt
+
+
+def _point_head(session: Session, table_id: str, run_id: str) -> None:
+    """Flip the ``(table:{id}, "typing")`` snapshot head to ``run_id``.
+
+    Mirrors ``worker.activity._upsert_head`` but scoped to the single typing
+    head a physical reset re-points — inserts at ``version=0`` if absent, else
+    re-points + bumps the version. Kept local to the typing module so a reset
+    does not depend on the worker package.
+    """
+    from datetime import UTC, datetime
+
+    from dataraum.storage.snapshot_head import MetadataSnapshotHead
+
+    target = f"table:{table_id}"
+    stage = "typing"
+    now = datetime.now(UTC)
+    head = session.execute(
+        select(MetadataSnapshotHead).where(
+            MetadataSnapshotHead.target == target,
+            MetadataSnapshotHead.stage == stage,
+        )
+    ).scalar_one_or_none()
+    if head is None:
+        session.add(
+            MetadataSnapshotHead(
+                target=target, stage=stage, run_id=run_id, promoted_at=now, version=0
+            )
+        )
+    else:
+        head.run_id = run_id
+        head.promoted_at = now
+        head.version = head.version + 1
+
+
+def current_typing_run(session: Session, table_id: str) -> str | None:
+    """The promoted typing ``run_id`` for ``table_id``, or ``None`` (DAT-413).
+
+    Convenience over ``head_run_id`` for the typing stage's head key.
+    """
+    return head_run_id(session, f"table:{table_id}", "typing")

--- a/packages/engine/src/dataraum/analysis/typing/resolution.py
+++ b/packages/engine/src/dataraum/analysis/typing/resolution.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session, selectinload
 from dataraum.analysis.typing.db_models import TypeCandidate, TypeDecision
 from dataraum.analysis.typing.models import ColumnCastResult, TypeResolutionResult
 from dataraum.analysis.typing.patterns import Pattern, load_pattern_config
+from dataraum.analysis.typing.recipe import store_recipe
 from dataraum.core.logging import get_logger
 from dataraum.core.models.base import ColumnRef, DataType, Result
 from dataraum.storage import Column, Table
@@ -407,12 +408,14 @@ def resolve_types(
             )
             session.add(type_decision)
 
-    # Generate and execute SQL
+    # Emit → store → execute (DAT-414): build the materialization DDL strings
+    # first, persist them as versioned recipes stamped with ``run_id`` (so a
+    # reset-to-prior-run can replay them without re-typing), then execute. The
+    # executed SQL is byte-identical to before — only the persist step is new.
+    typed_sql = _generate_typed_table_sql(raw_target, typed_target, specs)
+    quarantine_sql = _generate_quarantine_sql(raw_target, quarantine_target, specs)
     try:
-        typed_sql = _generate_typed_table_sql(raw_target, typed_target, specs)
         duckdb_conn.execute(typed_sql)
-
-        quarantine_sql = _generate_quarantine_sql(raw_target, quarantine_target, specs)
         duckdb_conn.execute(quarantine_sql)
     except Exception as e:
         logger.error("type_resolution_sql_error", table=table.table_name, error=str(e))
@@ -439,6 +442,32 @@ def resolve_types(
         session, table, "quarantine", bare, quarantine_rows
     )
     session.flush()
+
+    # Persist the versioned materialization recipes (DAT-414): one per produced
+    # layer, keyed on the *typed* Table id (stable across re-types) and stamped
+    # with this run. Both DDLs read the raw layer, so ``depends_on`` names the raw
+    # FQN (layer-qualified, so the dependency-order rebuild never confuses it with
+    # the same-bare-named typed/quarantine artifacts).
+    store_recipe(
+        session,
+        session_id=session_id,
+        table_id=typed_table_record.table_id,
+        layer="typed",
+        run_id=run_id,
+        target_fqn=typed_target,
+        ddl=typed_sql,
+        depends_on=[raw_target],
+    )
+    store_recipe(
+        session,
+        session_id=session_id,
+        table_id=quarantine_table_record.table_id,
+        layer="quarantine",
+        run_id=run_id,
+        target_fqn=quarantine_target,
+        ddl=quarantine_sql,
+        depends_on=[raw_target],
+    )
 
     # Reconcile typed columns — UPDATE in place / insert new / delete dropped,
     # so existing typed Column ids survive a re-type.

--- a/packages/engine/src/dataraum/pipeline/phases/typing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/typing_phase.py
@@ -127,10 +127,12 @@ class TypingPhase(BasePhase):
         raw_target = f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("raw")}."{bare}"'
         typed_target = f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("typed")}."{bare}"'
 
-        # Create typed table as direct copy (types already correct)
-        ctx.duckdb_conn.execute(
-            f"CREATE OR REPLACE TABLE {typed_target} AS SELECT * FROM {raw_target}"
-        )
+        # Emit → store → execute (DAT-414): the strongly-typed copy is a plain
+        # ``CREATE OR REPLACE … AS SELECT *``. Capture the DDL string so it is
+        # versioned like the untyped path's recipes (stored below, once the typed
+        # Table id is reconciled); the executed SQL is unchanged.
+        typed_sql = f"CREATE OR REPLACE TABLE {typed_target} AS SELECT * FROM {raw_target}"
+        ctx.duckdb_conn.execute(typed_sql)
 
         # Get row count
         row_count_result = ctx.duckdb_conn.execute(
@@ -150,6 +152,23 @@ class TypingPhase(BasePhase):
         ctx.session.flush()
         typed_table = reconcile_typed_table(ctx.session, table, "typed", bare, row_count)
         ctx.session.flush()
+
+        # Persist the versioned materialization recipe (DAT-414) for the
+        # strongly-typed copy. Only a ``typed`` artifact exists here (no cast can
+        # fail → no quarantine table). Keyed on the stable typed Table id, stamped
+        # with the run, reading the raw layer.
+        from dataraum.analysis.typing.recipe import store_recipe
+
+        store_recipe(
+            ctx.session,
+            session_id=ctx.require_session_id(),
+            table_id=typed_table.table_id,
+            layer="typed",
+            run_id=ctx.run_id,
+            target_fqn=typed_target,
+            ddl=typed_sql,
+            depends_on=[raw_target],
+        )
 
         desired = [
             (

--- a/packages/engine/tests/integration/pipeline/test_materialization_recipe.py
+++ b/packages/engine/tests/integration/pipeline/test_materialization_recipe.py
@@ -1,0 +1,291 @@
+"""DAT-414 — versioned typed/quarantine materialization DDL (round-trip + reset).
+
+Exercised against a real DuckLake substrate, mirroring ``test_replay_cross_stage``:
+
+1. **Persist + stamp** (AC#1) — after typing, the typed AND quarantine
+   ``CREATE TABLE`` DDL strings are stored as ``MaterializationRecipe`` rows
+   stamped with the run's ``run_id``, keyed on the *typed* Table id.
+
+2. **Round-trip** (AC#2) — DROPping the physical typed table then re-executing
+   the stored DDL via ``rebuild_from_recipe`` recreates the DuckDB table
+   identically (same rows, same types).
+
+3. **Reset-to-prior-run** (AC#3) — after a second run re-types the table under a
+   fresh ``run_id`` (different decided types → different DDL), ``reset_to_run``
+   flips the typing snapshot head back to the first run and re-materializes the
+   physical artifact from that run's stored DDL — WITHOUT re-running typing.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import duckdb
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from dataraum.analysis.typing import infer_type_candidates, resolve_types
+from dataraum.analysis.typing.db_models import MaterializationRecipe
+from dataraum.analysis.typing.recipe import (
+    current_typing_run,
+    rebuild_from_recipe,
+    reset_to_run,
+)
+from dataraum.sources.csv import CSVLoader
+from dataraum.sources.csv.null_values import load_null_value_config
+from dataraum.storage import Source, Table
+from tests.conftest import baseline_session_id
+
+
+@pytest.fixture
+def simple_csv(tmp_path):
+    """A CSV whose ``amount`` is overwhelmingly numeric with ONE cast-failing row.
+
+    9/10 ``amount`` values parse as numeric, so the column resolves to a numeric
+    type (above the 0.85 confidence threshold); the lone ``"oops"`` then fails
+    the resolved-type TRY_CAST and lands in quarantine — so the quarantine table
+    is non-empty and the round-trip proves BOTH artifacts rebuild.
+    """
+    csv_file = tmp_path / "orders.csv"
+    rows = "\n".join(f"{i},{i * 10}.0" for i in range(1, 10))
+    csv_file.write_text(f"id,amount\n{rows}\n10,oops\n")
+    return csv_file
+
+
+def _seed_source(
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    session: Session,
+    csv_path,
+) -> str:
+    """Seed a Source row + stage a CSV via the production loader; return raw table id."""
+    source_uri = f"file://{csv_path}"
+    source_id = f"src-recipe-{uuid4().hex[:8]}"
+    session.add(
+        Source(
+            source_id=source_id,
+            name=f"recipe_source_{uuid4().hex[:8]}",
+            source_type="csv",
+            connection_config={"path": source_uri},
+        )
+    )
+    session.flush()
+
+    loader = CSVLoader()
+    load_result = loader._load_single_file(
+        source_uri=source_uri,
+        source_id=source_id,
+        source_name=session.get(Source, source_id).name,
+        duckdb_conn=duckdb_conn,
+        session=session,
+        null_config=load_null_value_config(),
+    )
+    assert load_result.success, load_result.error
+    return load_result.unwrap().table_id
+
+
+def _resolve(
+    raw_table_id: str,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    session: Session,
+    run_id: str,
+) -> str:
+    """Infer + resolve types under ``run_id``; return the typed table id."""
+    raw_table = session.get(Table, raw_table_id)
+    assert raw_table is not None
+    infer = infer_type_candidates(
+        raw_table, duckdb_conn, session, session_id=baseline_session_id(), run_id=run_id
+    )
+    assert infer.success, infer.error
+    session.flush()
+    resolve = resolve_types(
+        raw_table_id,
+        duckdb_conn,
+        session,
+        min_confidence=0.85,
+        session_id=baseline_session_id(),
+        run_id=run_id,
+    )
+    assert resolve.success, resolve.error
+    return resolve.unwrap().typed_table_id
+
+
+def _recipes(
+    session: Session, typed_table_id: str, run_id: str
+) -> dict[str, MaterializationRecipe]:
+    """The stored recipes for a typed table at a run, keyed by produced layer."""
+    rows = session.execute(
+        select(MaterializationRecipe).where(
+            MaterializationRecipe.table_id == typed_table_id,
+            MaterializationRecipe.run_id == run_id,
+        )
+    ).scalars()
+    return {r.layer: r for r in rows}
+
+
+def _quarantine_table_id(session: Session, raw_table_id: str) -> str:
+    """The quarantine Table id sharing this raw table's (source, name)."""
+    raw = session.get(Table, raw_table_id)
+    assert raw is not None
+    q = session.execute(
+        select(Table).where(
+            Table.source_id == raw.source_id,
+            Table.table_name == raw.table_name,
+            Table.layer == "quarantine",
+        )
+    ).scalar_one()
+    return q.table_id
+
+
+def _rows(duckdb_conn: duckdb.DuckDBPyConnection, fqn: str) -> list[tuple]:
+    """Data rows of a table, cast to text so DuckDB never materializes a TIMESTAMP.
+
+    ``SELECT *`` over a quarantine table (which carries ``_quarantined_at
+    TIMESTAMP``) would pull a Python ``datetime`` through DuckDB's optional
+    ``pytz`` path; casting every column to VARCHAR keeps the comparison a pure
+    string round-trip and dependency-free.
+
+    ``_quarantined_at`` is excluded: the quarantine DDL stamps it via
+    ``CURRENT_TIMESTAMP``, so a faithful re-execution of the *same* recipe
+    deliberately produces a fresh timestamp — the DATA round-trips identically,
+    the audit clock advances.
+    """
+    cols = [
+        c[0]
+        for c in duckdb_conn.execute(f"DESCRIBE SELECT * FROM {fqn}").fetchall()
+        if c[0] != "_quarantined_at"
+    ]
+    select_list = ", ".join(f'CAST("{c}" AS VARCHAR)' for c in cols)
+    return sorted(duckdb_conn.execute(f"SELECT {select_list} FROM {fqn}").fetchall(), key=str)
+
+
+def _column_types(duckdb_conn: duckdb.DuckDBPyConnection, fqn: str) -> dict[str, str]:
+    """name -> DuckDB type for a materialized table (proves the cast survived)."""
+    rows = duckdb_conn.execute(f"DESCRIBE SELECT * FROM {fqn}").fetchall()
+    return {r[0]: r[1] for r in rows}
+
+
+class TestRecipePersistedAndStamped:
+    """AC#1 — typed + quarantine DDL persisted, stamped with run_id."""
+
+    def test_typing_stores_run_stamped_recipes(self, simple_csv, duckdb_conn, session) -> None:
+        raw_id = _seed_source(duckdb_conn, session, simple_csv)
+        run_id = "run-A"
+        typed_id = _resolve(raw_id, duckdb_conn, session, run_id)
+        quarantine_id = _quarantine_table_id(session, raw_id)
+
+        typed_recipes = _recipes(session, typed_id, run_id)
+        assert "typed" in typed_recipes
+        typed_recipe = typed_recipes["typed"]
+        assert typed_recipe.run_id == run_id
+        assert typed_recipe.ddl.startswith("CREATE OR REPLACE TABLE")
+        assert "AS SELECT" in typed_recipe.ddl
+        assert typed_recipe.depends_on  # reads the raw layer
+
+        quarantine_recipes = _recipes(session, quarantine_id, run_id)
+        assert "quarantine" in quarantine_recipes
+        assert quarantine_recipes["quarantine"].run_id == run_id
+        assert quarantine_recipes["quarantine"].ddl.startswith("CREATE OR REPLACE TABLE")
+
+
+class TestRoundTrip:
+    """AC#2 — re-executing stored DDL rebuilds the physical table identically."""
+
+    def test_rebuild_recreates_typed_and_quarantine(self, simple_csv, duckdb_conn, session) -> None:
+        raw_id = _seed_source(duckdb_conn, session, simple_csv)
+        run_id = "run-A"
+        typed_id = _resolve(raw_id, duckdb_conn, session, run_id)
+        quarantine_id = _quarantine_table_id(session, raw_id)
+
+        typed_fqn = _recipes(session, typed_id, run_id)["typed"].target_fqn
+        quarantine_fqn = _recipes(session, quarantine_id, run_id)["quarantine"].target_fqn
+
+        # Snapshot the freshly-materialized state.
+        typed_rows_before = _rows(duckdb_conn, typed_fqn)
+        typed_types_before = _column_types(duckdb_conn, typed_fqn)
+        quarantine_rows_before = _rows(duckdb_conn, quarantine_fqn)
+
+        # DROP both physical artifacts — the lake is now missing them.
+        duckdb_conn.execute(f"DROP TABLE {typed_fqn}")
+        duckdb_conn.execute(f"DROP TABLE {quarantine_fqn}")
+
+        # Rebuild each from its stored DDL — no re-typing.
+        rebuilt_typed = rebuild_from_recipe(session, duckdb_conn, table_id=typed_id, run_id=run_id)
+        rebuilt_quar = rebuild_from_recipe(
+            session, duckdb_conn, table_id=quarantine_id, run_id=run_id
+        )
+        assert typed_fqn in rebuilt_typed
+        assert quarantine_fqn in rebuilt_quar
+
+        # Identical rows AND types after the round-trip.
+        assert _rows(duckdb_conn, typed_fqn) == typed_rows_before
+        assert _column_types(duckdb_conn, typed_fqn) == typed_types_before
+        assert _rows(duckdb_conn, quarantine_fqn) == quarantine_rows_before
+        # The cast-failing row ("oops") landed in quarantine, so it is non-empty.
+        assert len(quarantine_rows_before) >= 1
+
+
+class TestResetToPriorRun:
+    """AC#3 — reset rebuilds from a prior run's DDL without re-deriving typing."""
+
+    def test_reset_flips_head_and_rematerializes(self, simple_csv, duckdb_conn, session) -> None:
+        raw_id = _seed_source(duckdb_conn, session, simple_csv)
+
+        # Run A produces the typed artifact + stores its recipe.
+        typed_id = _resolve(raw_id, duckdb_conn, session, "run-A")
+        typed_fqn = _recipes(session, typed_id, "run-A")["typed"].target_fqn
+        rows_run_a = _rows(duckdb_conn, typed_fqn)
+        types_run_a = _column_types(duckdb_conn, typed_fqn)
+        assert rows_run_a  # sanity: the artifact has data
+
+        # Diverge the PHYSICAL table from run A — as if a later run (or a manual
+        # edit) replaced it. The lake is latest-only, so "reset" must restore run
+        # A's artifact purely from its stored DDL.
+        duckdb_conn.execute(f"DELETE FROM {typed_fqn}")
+        assert _rows(duckdb_conn, typed_fqn) == []
+        # Point the head elsewhere so we can prove reset flips it back.
+        from dataraum.analysis.typing.recipe import _point_head
+
+        _point_head(session, typed_id, "run-Z")
+        session.flush()
+        assert current_typing_run(session, typed_id) == "run-Z"
+
+        # Reset to run A — re-executes run A's stored DDL + flips the typing head.
+        # Crucially: NO infer/resolve call here, so this is NOT a re-derivation —
+        # the versioned recipe is the only source of truth for the rebuild.
+        rebuilt = reset_to_run(session, duckdb_conn, table_id=typed_id, run_id="run-A")
+        assert typed_fqn in rebuilt
+
+        # The physical artifact is restored to run A (rows + types) and the typing
+        # head now names run A.
+        assert _rows(duckdb_conn, typed_fqn) == rows_run_a
+        assert _column_types(duckdb_conn, typed_fqn) == types_run_a
+        assert current_typing_run(session, typed_id) == "run-A"
+
+    def test_two_real_runs_coexist_then_reset(self, simple_csv, duckdb_conn, session) -> None:
+        """A real second typing run coexists with the first; reset replays run A.
+
+        Exercises the DAT-373 (stable typed id) × DAT-414 (run-versioned recipe)
+        interaction end-to-end: re-typing the SAME raw table under a fresh run_id
+        reuses the typed Table id but stores a SEPARATE recipe row — both runs'
+        recipes coexist, and a reset re-executes the older run's stored DDL.
+        """
+        raw_id = _seed_source(duckdb_conn, session, simple_csv)
+
+        typed_id = _resolve(raw_id, duckdb_conn, session, "run-A")
+        typed_fqn = _recipes(session, typed_id, "run-A")["typed"].target_fqn
+        rows_run_a = _rows(duckdb_conn, typed_fqn)
+
+        # Re-type the SAME raw table under a new run — stable typed id (DAT-373),
+        # but a coexisting recipe under run-B (DAT-414).
+        typed_id_b = _resolve(raw_id, duckdb_conn, session, "run-B")
+        assert typed_id_b == typed_id
+
+        assert _recipes(session, typed_id, "run-A")["typed"].run_id == "run-A"
+        assert _recipes(session, typed_id, "run-B")["typed"].run_id == "run-B"
+
+        # Corrupt the live artifact, then reset to run A purely from its recipe.
+        duckdb_conn.execute(f"DELETE FROM {typed_fqn}")
+        reset_to_run(session, duckdb_conn, table_id=typed_id, run_id="run-A")
+        assert _rows(duckdb_conn, typed_fqn) == rows_run_a
+        assert current_typing_run(session, typed_id) == "run-A"

--- a/packages/engine/tests/integration/pipeline/test_materialization_recipe.py
+++ b/packages/engine/tests/integration/pipeline/test_materialization_recipe.py
@@ -32,6 +32,8 @@ from dataraum.analysis.typing.recipe import (
     rebuild_from_recipe,
     reset_to_run,
 )
+from dataraum.pipeline.base import PhaseContext
+from dataraum.pipeline.phases.typing_phase import TypingPhase
 from dataraum.sources.csv import CSVLoader
 from dataraum.sources.csv.null_values import load_null_value_config
 from dataraum.storage import Source, Table
@@ -231,18 +233,24 @@ class TestResetToPriorRun:
     def test_reset_flips_head_and_rematerializes(self, simple_csv, duckdb_conn, session) -> None:
         raw_id = _seed_source(duckdb_conn, session, simple_csv)
 
-        # Run A produces the typed artifact + stores its recipe.
+        # Run A produces the typed + quarantine artifacts + stores their recipes.
         typed_id = _resolve(raw_id, duckdb_conn, session, "run-A")
+        quarantine_id = _quarantine_table_id(session, raw_id)
         typed_fqn = _recipes(session, typed_id, "run-A")["typed"].target_fqn
+        quarantine_fqn = _recipes(session, quarantine_id, "run-A")["quarantine"].target_fqn
         rows_run_a = _rows(duckdb_conn, typed_fqn)
         types_run_a = _column_types(duckdb_conn, typed_fqn)
-        assert rows_run_a  # sanity: the artifact has data
+        quarantine_rows_run_a = _rows(duckdb_conn, quarantine_fqn)
+        assert rows_run_a  # sanity: the typed artifact has data
+        assert quarantine_rows_run_a  # the cast-failing "oops" row landed in quarantine
 
-        # Diverge the PHYSICAL table from run A — as if a later run (or a manual
-        # edit) replaced it. The lake is latest-only, so "reset" must restore run
-        # A's artifact purely from its stored DDL.
+        # Diverge BOTH physical tables from run A — as if a later run (or a manual
+        # edit) replaced them. The lake is latest-only, so "reset" must restore run
+        # A's PAIR purely from the stored DDL — typed AND quarantine together.
         duckdb_conn.execute(f"DELETE FROM {typed_fqn}")
+        duckdb_conn.execute(f"DELETE FROM {quarantine_fqn}")
         assert _rows(duckdb_conn, typed_fqn) == []
+        assert _rows(duckdb_conn, quarantine_fqn) == []
         # Point the head elsewhere so we can prove reset flips it back.
         from dataraum.analysis.typing.recipe import _point_head
 
@@ -250,16 +258,17 @@ class TestResetToPriorRun:
         session.flush()
         assert current_typing_run(session, typed_id) == "run-Z"
 
-        # Reset to run A — re-executes run A's stored DDL + flips the typing head.
-        # Crucially: NO infer/resolve call here, so this is NOT a re-derivation —
-        # the versioned recipe is the only source of truth for the rebuild.
+        # Reset to run A — re-executes run A's stored DDL (typed + quarantine) and
+        # flips the typing head. Crucially: NO infer/resolve call here, so this is
+        # NOT a re-derivation — the versioned recipe is the only source of truth.
         rebuilt = reset_to_run(session, duckdb_conn, table_id=typed_id, run_id="run-A")
         assert typed_fqn in rebuilt
+        assert quarantine_fqn in rebuilt  # the pair resets together, not just typed
 
-        # The physical artifact is restored to run A (rows + types) and the typing
-        # head now names run A.
+        # Both physical artifacts are restored to run A and the typing head names it.
         assert _rows(duckdb_conn, typed_fqn) == rows_run_a
         assert _column_types(duckdb_conn, typed_fqn) == types_run_a
+        assert _rows(duckdb_conn, quarantine_fqn) == quarantine_rows_run_a
         assert current_typing_run(session, typed_id) == "run-A"
 
     def test_two_real_runs_coexist_then_reset(self, simple_csv, duckdb_conn, session) -> None:
@@ -289,3 +298,40 @@ class TestResetToPriorRun:
         reset_to_run(session, duckdb_conn, table_id=typed_id, run_id="run-A")
         assert _rows(duckdb_conn, typed_fqn) == rows_run_a
         assert current_typing_run(session, typed_id) == "run-A"
+
+
+class TestStronglyTypedRecipe:
+    """AC#1 (strongly-typed path) — the parquet/DB copy also stores a recipe."""
+
+    def test_strongly_typed_promote_stores_recipe(self, simple_csv, duckdb_conn, session) -> None:
+        """``_promote_strongly_typed`` versions its ``CREATE TABLE`` like the untyped path.
+
+        The strongly-typed branch (parquet / typed DB sources) is a plain
+        ``SELECT *`` copy with no quarantine. Parquet/DB loaders register real
+        ``raw_type``s; the CSV loader stages VARCHAR, so flip one column to a
+        non-VARCHAR type to model a strongly-typed source, then drive the branch
+        directly and assert the recipe is persisted + run-stamped.
+        """
+        raw_id = _seed_source(duckdb_conn, session, simple_csv)
+        raw_table = session.get(Table, raw_id)
+        assert raw_table is not None
+        raw_table.columns[0].raw_type = "BIGINT"
+        session.flush()
+
+        ctx = PhaseContext(
+            session=session,
+            duckdb_conn=duckdb_conn,
+            source_id=raw_table.source_id,
+            table_ids=[raw_id],
+            session_id=baseline_session_id(),
+            run_id="run-strong",
+        )
+        typed_id, _ = TypingPhase()._promote_strongly_typed(raw_table, ctx)
+
+        recipes = _recipes(session, typed_id, "run-strong")
+        assert "typed" in recipes
+        assert recipes["typed"].run_id == "run-strong"
+        assert recipes["typed"].ddl.startswith("CREATE OR REPLACE TABLE")
+        assert "AS SELECT" in recipes["typed"].ddl
+        # A strongly-typed copy can't fail a cast → no quarantine artifact/recipe.
+        assert "quarantine" not in recipes

--- a/packages/engine/tests/unit/analysis/typing/test_recipe.py
+++ b/packages/engine/tests/unit/analysis/typing/test_recipe.py
@@ -1,0 +1,159 @@
+"""Unit tests for the DAT-414 materialization-recipe store + dependency order.
+
+These pin the write-side contract directly (in-memory SQLite), complementing the
+real-DuckDB round-trip/reset integration tests:
+
+- ``store_recipe`` upserts on ``(table_id, layer, run_id)`` — a same-run re-store
+  overwrites (Temporal at-least-once idempotency); a new run COEXISTS.
+- ``_order_by_dependency`` runs a recipe AFTER the recipes it reads from, keyed
+  on the fully-qualified target (layer-aware), and tolerates deps that are not
+  themselves recipes (e.g. the raw table).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, event, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from dataraum.analysis.typing.db_models import MaterializationRecipe
+from dataraum.analysis.typing.recipe import _order_by_dependency, store_recipe
+from dataraum.storage import init_database
+
+
+@pytest.fixture
+def session_factory():
+    """In-memory SQLite with all tables; FKs off so we skip parent rows."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _pragma(dbapi_conn, _record):  # noqa: ANN001, ANN202
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=OFF")
+        cur.close()
+
+    init_database(engine)
+    factory = sessionmaker(bind=engine)
+    try:
+        yield factory
+    finally:
+        engine.dispose()
+
+
+def _store(session, *, table_id, layer, run_id, ddl, target_fqn, depends_on=None):  # noqa: ANN001
+    store_recipe(
+        session,
+        session_id="sess-1",
+        table_id=table_id,
+        layer=layer,
+        run_id=run_id,
+        target_fqn=target_fqn,
+        ddl=ddl,
+        depends_on=depends_on,
+    )
+
+
+def _all(session_factory):  # noqa: ANN001
+    with session_factory() as s:
+        return list(s.execute(select(MaterializationRecipe)).scalars().all())
+
+
+def test_store_recipe_persists_run_stamped_row(session_factory):
+    with session_factory() as s:
+        _store(
+            s,
+            table_id="tbl-1",
+            layer="typed",
+            run_id="run-A",
+            ddl="CREATE OR REPLACE TABLE x AS SELECT 1",
+            target_fqn='lake.typed."x"',
+            depends_on=['lake.raw."x"'],
+        )
+        s.commit()
+
+    rows = _all(session_factory)
+    assert len(rows) == 1
+    (row,) = rows
+    assert row.table_id == "tbl-1"
+    assert row.layer == "typed"
+    assert row.run_id == "run-A"
+    assert row.target_fqn == 'lake.typed."x"'
+    assert row.depends_on == ['lake.raw."x"']
+
+
+def test_store_recipe_same_run_overwrites(session_factory):
+    """A re-store at the same (table, layer, run) overwrites — at-least-once safe."""
+    with session_factory() as s:
+        _store(s, table_id="tbl-1", layer="typed", run_id="run-A", ddl="V1", target_fqn="fqn-1")
+        s.commit()
+    with session_factory() as s:
+        _store(s, table_id="tbl-1", layer="typed", run_id="run-A", ddl="V2", target_fqn="fqn-1")
+        s.commit()
+
+    rows = _all(session_factory)
+    assert len(rows) == 1
+    assert rows[0].ddl == "V2"
+
+
+def test_store_recipe_new_run_coexists(session_factory):
+    """A different run for the same artifact COEXISTS (versioned, not overwritten)."""
+    with session_factory() as s:
+        _store(s, table_id="tbl-1", layer="typed", run_id="run-A", ddl="A", target_fqn="fqn-1")
+        _store(s, table_id="tbl-1", layer="typed", run_id="run-B", ddl="B", target_fqn="fqn-1")
+        s.commit()
+
+    rows = _all(session_factory)
+    assert {r.run_id for r in rows} == {"run-A", "run-B"}
+    assert {r.ddl for r in rows} == {"A", "B"}
+
+
+def test_store_recipe_distinct_layers_coexist(session_factory):
+    """typed + quarantine for the same table/run are distinct rows."""
+    with session_factory() as s:
+        _store(s, table_id="tbl-1", layer="typed", run_id="run-A", ddl="T", target_fqn="t-fqn")
+        _store(s, table_id="tbl-1", layer="quarantine", run_id="run-A", ddl="Q", target_fqn="q-fqn")
+        s.commit()
+
+    rows = _all(session_factory)
+    assert {r.layer for r in rows} == {"typed", "quarantine"}
+
+
+def _recipe(target_fqn, depends_on=None):  # noqa: ANN001
+    return MaterializationRecipe(
+        session_id="s",
+        table_id="t",
+        layer="typed",
+        run_id="r",
+        target_fqn=target_fqn,
+        ddl=f"-- {target_fqn}",
+        depends_on=depends_on,
+    )
+
+
+class TestOrderByDependency:
+    def test_dependency_runs_before_dependent(self):
+        base = _recipe('lake.raw."x"')  # produced by an upstream recipe in-set
+        dependent = _recipe('lake.typed."x"', depends_on=['lake.raw."x"'])
+        ordered = _order_by_dependency([dependent, base])
+        assert ordered.index(base) < ordered.index(dependent)
+
+    def test_unknown_dependency_is_tolerated(self):
+        """A dep that is not itself a recipe (e.g. the raw table) is 'already present'."""
+        only = _recipe('lake.typed."x"', depends_on=['lake.raw."x"'])
+        ordered = _order_by_dependency([only])
+        assert ordered == [only]
+
+    def test_same_bare_different_layer_does_not_self_depend(self):
+        """typed + quarantine share the bare name; FQN keying keeps them independent."""
+        typed = _recipe('lake.typed."x"', depends_on=['lake.raw."x"'])
+        quarantine = _recipe('lake.quarantine."x"', depends_on=['lake.raw."x"'])
+        ordered = _order_by_dependency([typed, quarantine])
+        # Both placed exactly once, neither depends on the other.
+        assert set(ordered) == {typed, quarantine}
+        assert len(ordered) == 2


### PR DESCRIPTION
## Task

[DAT-414](https://real-dataraum.atlassian.net/browse/DAT-414) — Phase 2: Versioned materialization DDL (typed/quarantine). Epic DAT-412 · design Confluence DD/30113794.

Builds on the DAT-413 snapshot substrate (run_id minting, `MetadataSnapshotHead` head pointer, `head_run_id`, `promote_run`) already on `main`.

## Contract consumed

None. Ticket: "Cross-repo: None expected" — lake materialization is internal, no detector-input change beyond Phase 1.

## What changed

Typing now versions its **materialization recipe** (the `CREATE TABLE` DDL string), not the data. The DuckDB lake stays latest-only.

- **New `MaterializationRecipe` model** (`analysis/typing/db_models.py`) — grain `(table_id, layer, run_id)`, columns `target_fqn`, `ddl`, `depends_on`. Auto-registered via `create_all` (no Alembic in this engine); nullable `run_id` mirrors `TypeDecision`.
- **`analysis/typing/recipe.py`** — `store_recipe` (upsert on the grain), `rebuild_from_recipe` (re-execute a run's stored DDL in dependency order), `reset_to_run` (rebuild + flip the typing snapshot head), `current_typing_run` (head resolver).
- **Both materialization paths re-seamed to emit → store → execute:** the untyped path (`resolution.py`, typed + quarantine) and the strongly-typed path (`typing_phase.py`, typed only — a `SELECT *` copy never fails a cast). The **executed SQL is byte-identical** to before; only the persist step is new, so behavior is preserved (no detector/eval impact).
- `depends_on` is keyed on **fully-qualified** targets (`lake.raw."x"`), so the same-bare-named raw/typed/quarantine artifacts never self-confuse in rebuild order.

## Acceptance criteria

- [x] After typing, the typed/quarantine materialization DDL string is persisted and stamped with the run's `run_id`.
- [x] Re-executing a stored DDL rebuilds the physical DuckDB table identically (round-trip test).
- [x] Reset-to-prior-run rebuilds the physical artifact from stored DDL **without** a full phase re-derivation.
- [x] Engine + integration tests green.

## Lane smoke

Recipe round-trip + reset against the real DuckLake-on-Postgres substrate:

```
$ uv run pytest tests/integration/pipeline/test_materialization_recipe.py -v
test_typing_stores_run_stamped_recipes      PASSED   # AC#1 persist + stamp
test_rebuild_recreates_typed_and_quarantine PASSED   # AC#2 round-trip (rows + types identical)
test_reset_flips_head_and_rematerializes    PASSED   # AC#3 reset without re-derivation
test_two_real_runs_coexist_then_reset       PASSED   # DAT-373 × DAT-414: coexisting recipes, reset replays older run
4 passed
```

Full affected sweep (typing + pipeline-scope + worker substrate + cross-stage replay + recipe): **62 passed**. Gates green: `ruff format` / `ruff check` / `mypy` / `vulture`.

## Notes for review

- **No Agent tool in this background lane**, so the `senior-code-reviewer` / `spec-compliance-reviewer` subagents could not be spawned from here (documented constraint). A rigorous self-review was done in their place; top-level independent review before merge is the lead's call.
- One by-design non-determinism: the quarantine DDL stamps `_quarantined_at` via `CURRENT_TIMESTAMP`, so a faithful re-execution advances that audit clock while the **data** round-trips identically. The round-trip test compares quarantine on data columns (handoff notes this for eval).

## Other lanes in flight

`gh pr list` (open): none. DAT-402 (the orchestrator's concurrent foreground work) has no PR open yet. Expected-disjoint surfaces: this lane touches typing materialization DDL (`analysis/typing/`, `pipeline/phases/typing_phase.py`); DAT-402 touches enriched_views / entropy_readiness / cockpit. Shared-file risk: only `storage/models.py` (the `Table` model) is a plausible overlap — **this lane does NOT modify it** (the recipe is a separate model + FK), so no merge conflict expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)