### PR TITLE
Cockpit polish: hide engine internals in the chat/canvas UI

### DIFF
--- a/packages/cockpit/src/lib/display-names.test.ts
+++ b/packages/cockpit/src/lib/display-names.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+	displayTableName,
+	humanizeIdentifier,
+	prettyJson,
+} from "#/lib/display-names";
+
+describe("displayTableName", () => {
+	it("strips the exact `<source>__` prefix when the source name is known", () => {
+		expect(
+			displayTableName("finance_data__trial_balance", "finance_data"),
+		).toBe("trial_balance");
+	});
+
+	it("falls back to dropping up to the first `__` when no source name is given", () => {
+		expect(displayTableName("detection_v1__bank_transactions")).toBe(
+			"bank_transactions",
+		);
+	});
+
+	it("leaves a name without a `__` separator untouched", () => {
+		expect(displayTableName("payments")).toBe("payments");
+		expect(displayTableName("payments", "finance")).toBe("payments");
+	});
+
+	it("only strips the first segment (logical names with `__` survive)", () => {
+		expect(displayTableName("src__a__b")).toBe("a__b");
+	});
+});
+
+describe("humanizeIdentifier", () => {
+	it("sentence-cases a dotted snake_case path", () => {
+		expect(humanizeIdentifier("semantic.business_meaning.naming_clarity")).toBe(
+			"Semantic business meaning naming clarity",
+		);
+	});
+
+	it("sentence-cases a single snake_case token", () => {
+		expect(humanizeIdentifier("null_ratio")).toBe("Null ratio");
+		expect(humanizeIdentifier("type_fidelity")).toBe("Type fidelity");
+	});
+
+	it("returns an empty string for empty/garbage input so callers can fall back", () => {
+		expect(humanizeIdentifier("")).toBe("");
+		expect(humanizeIdentifier("._.")).toBe("");
+	});
+});
+
+describe("prettyJson", () => {
+	it("indents valid JSON with two spaces", () => {
+		expect(prettyJson('[{"metric":"undeclared_ratio","value":0.8}]')).toBe(
+			'[\n  {\n    "metric": "undeclared_ratio",\n    "value": 0.8\n  }\n]',
+		);
+	});
+
+	it("returns the original string unchanged when it is not valid JSON", () => {
+		expect(prettyJson("not json")).toBe("not json");
+	});
+
+	it("returns an empty string for empty input", () => {
+		expect(prettyJson("")).toBe("");
+	});
+});

--- a/packages/cockpit/src/lib/display-names.ts
+++ b/packages/cockpit/src/lib/display-names.ts
@@ -1,0 +1,55 @@
+// Display helpers that turn engine-internal identifiers into the names a person
+// reads. The engine stores physical tables as `<source>__<table>` and reports
+// dimensions/detectors as dotted snake_case paths; widgets render the human form
+// while the raw value stays in the underlying tool JSON. Pure (no React/DB) so
+// each is unit-testable in isolation.
+
+/**
+ * Drop the engine's `<source>__` physical-table prefix for display, e.g.
+ * `finance_data__trial_balance` → `trial_balance`. When the source name is known
+ * we strip exactly that prefix; otherwise we fall back to dropping everything up
+ * to and including the first `__` (the source segment never contains `__`).
+ */
+export function displayTableName(
+	tableName: string,
+	sourceName?: string,
+): string {
+	if (sourceName) {
+		const prefix = `${sourceName}__`;
+		if (tableName.startsWith(prefix)) return tableName.slice(prefix.length);
+	}
+	const i = tableName.indexOf("__");
+	return i >= 0 ? tableName.slice(i + 2) : tableName;
+}
+
+/**
+ * Humanize a snake_case / dotted identifier into a readable label: split on `_`
+ * and `.`, then sentence-case the whole thing (only the first word is
+ * capitalized). `semantic.business_meaning.naming_clarity` → "Semantic business
+ * meaning naming clarity"; `null_ratio` → "Null ratio". An empty/garbage input
+ * returns "" so the caller can fall back to the raw token.
+ */
+export function humanizeIdentifier(token: string): string {
+	const words = token
+		.split(/[._]+/)
+		.map((w) => w.trim())
+		.filter(Boolean);
+	if (words.length === 0) return "";
+	const joined = words.join(" ");
+	return joined.charAt(0).toUpperCase() + joined.slice(1);
+}
+
+/**
+ * Pretty-print a compact JSON string (a detector's evidence blob) with 2-space
+ * indentation. Returns the original string unchanged when it isn't valid JSON —
+ * detectors are free to emit a plain string, and a parse failure must never blank
+ * the cell.
+ */
+export function prettyJson(raw: string): string {
+	if (!raw) return "";
+	try {
+		return JSON.stringify(JSON.parse(raw), null, 2);
+	} catch {
+		return raw;
+	}
+}

--- a/packages/cockpit/src/lib/display-names.ts
+++ b/packages/cockpit/src/lib/display-names.ts
@@ -7,8 +7,11 @@
 /**
  * Drop the engine's `<source>__` physical-table prefix for display, e.g.
  * `finance_data__trial_balance` → `trial_balance`. When the source name is known
- * we strip exactly that prefix; otherwise we fall back to dropping everything up
- * to and including the first `__` (the source segment never contains `__`).
+ * we try to strip exactly that prefix; otherwise (or if it doesn't match — the
+ * stored prefix is the *sanitized* source name, so a raw name with spaces/caps
+ * won't match) we fall back to dropping everything up to and including the first
+ * `__`. The engine sanitizes both segments and collapses underscore runs, so a
+ * physical name has exactly one `__` separator and the fallback is always safe.
  */
 export function displayTableName(
 	tableName: string,

--- a/packages/cockpit/src/tools/list-verticals.test.ts
+++ b/packages/cockpit/src/tools/list-verticals.test.ts
@@ -121,24 +121,38 @@ describe("listVerticals (DAT-411)", () => {
 		]);
 	});
 
-	it("counts a builtin's concepts as ontology + overlay (so _adhoc reports its induced concepts)", async () => {
-		h.dirEntries = [dir("_adhoc")];
-		// _adhoc ships an empty ontology — its concepts come from the overlay.
+	it("counts a builtin's concepts as ontology + overlay", async () => {
+		h.dirEntries = [dir("finance")];
+		h.files["/cfg/verticals/finance/ontology.yaml"] = JSON.stringify({
+			description: "Finance",
+			concepts: [{ name: "revenue" }, { name: "cogs" }],
+		});
+		// Overlay rows naming the vertical add on top of its on-disk concepts.
+		h.overlayRows = [{ vertical: "finance", n: 3 }];
+
+		const [finance] = await listVerticals();
+		expect(finance).toMatchObject({
+			name: "finance",
+			kind: "builtin",
+			concept_count: 5, // 2 ontology + 3 overlay
+		});
+	});
+
+	it("hides underscore-prefixed seeds (_adhoc) from the listing — builtin scan and framed fallback alike", async () => {
+		h.dirEntries = [dir("finance"), dir("_adhoc")];
+		h.files["/cfg/verticals/finance/ontology.yaml"] = JSON.stringify({
+			description: "Finance",
+			concepts: [{ name: "revenue" }],
+		});
 		h.files["/cfg/verticals/_adhoc/ontology.yaml"] = JSON.stringify({
 			concepts: [],
 		});
+		// _adhoc carries overlay concepts too — assert it's filtered from BOTH the
+		// builtin scan and the framed fallback (never re-added as "framed").
 		h.overlayRows = [{ vertical: "_adhoc", n: 5 }];
 
-		const [adhoc] = await listVerticals();
-		expect(adhoc).toMatchObject({
-			name: "_adhoc",
-			kind: "builtin",
-			description: null,
-			concept_count: 5,
-			has_cycles: false,
-			has_validations: false,
-			has_metrics: false,
-		});
+		const result = await listVerticals();
+		expect(result.map((v) => v.name)).toEqual(["finance"]);
 	});
 
 	it("includes framed verticals (overlay names with no directory), sorted builtins-first", async () => {
@@ -151,7 +165,7 @@ describe("listVerticals (DAT-411)", () => {
 			concepts: [],
 		});
 		// "sales" is framed (in the overlay, no directory); _adhoc is a builtin
-		// that also has overlay concepts.
+		// that also has overlay concepts — it stays hidden in both roles.
 		h.overlayRows = [
 			{ vertical: "sales", n: 4 },
 			{ vertical: "_adhoc", n: 2 },
@@ -159,7 +173,6 @@ describe("listVerticals (DAT-411)", () => {
 
 		const result = await listVerticals();
 		expect(result.map((v) => [v.name, v.kind, v.concept_count])).toEqual([
-			["_adhoc", "builtin", 2],
 			["finance", "builtin", 1],
 			["sales", "framed", 4],
 		]);

--- a/packages/cockpit/src/tools/list-verticals.ts
+++ b/packages/cockpit/src/tools/list-verticals.ts
@@ -129,6 +129,10 @@ async function builtinVerticals(
 	const out: Vertical[] = [];
 	for (const entry of entries) {
 		if (!entry.isDirectory()) continue;
+		// Underscore-prefixed directories are internal seeds, not user-pickable
+		// verticals — `_adhoc` is the induction substrate, not a domain the agent
+		// should offer or count. Hide it from the listing everywhere.
+		if (entry.name.startsWith("_")) continue;
 		const dir = join(root, entry.name);
 		const onto = await readOntology(join(dir, "ontology.yaml"));
 		out.push({
@@ -153,7 +157,12 @@ export async function listVerticals(): Promise<Vertical[]> {
 	const builtinNames = new Set(builtins.map((v) => v.name));
 
 	const framed: Vertical[] = [...overlayCounts.entries()]
-		.filter(([vertical]) => vertical && !builtinNames.has(vertical))
+		// Same hide rule as builtins: `_adhoc` carries concept overlay rows, so
+		// without this it would reappear here as a "framed" vertical.
+		.filter(
+			([vertical]) =>
+				vertical && !vertical.startsWith("_") && !builtinNames.has(vertical),
+		)
 		.map(([vertical, n]) => ({
 			name: vertical,
 			kind: "framed" as const,

--- a/packages/cockpit/src/ui/cockpit/chat-rail.tsx
+++ b/packages/cockpit/src/ui/cockpit/chat-rail.tsx
@@ -123,7 +123,7 @@ function ToolCallCard({
 			>
 				<Box style={{ minWidth: 0 }}>
 					<Text size="sm" fw={600}>
-						{toolLabel(part.name)}
+						{toolLabel(part.name, done)}
 					</Text>
 					<Text
 						size="xs"

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -21,6 +21,23 @@ describe("toolLabel", () => {
 		expect(toolLabel("some_new_tool")).toBe("Some new tool");
 		expect(toolLabel("")).toBe("Working");
 	});
+
+	it("flips a progressive verb to its settled form once the call is done", () => {
+		// In-progress title (done=false) stays present-tense…
+		expect(toolLabel("select")).toBe("Registering source");
+		expect(toolLabel("connect")).toBe("Reading source");
+		// …and flips to a settled form when the call completes.
+		expect(toolLabel("select", true)).toBe("Registered source");
+		expect(toolLabel("connect", true)).toBe("Source schema");
+		expect(toolLabel("teach", true)).toBe("Taught");
+		expect(toolLabel("replay", true)).toBe("Re-ran");
+	});
+
+	it("leaves already-settled noun titles unchanged when done", () => {
+		// Tools whose label is already a noun read fine in both states — no flip.
+		expect(toolLabel("list_tables", true)).toBe("Workspace tables");
+		expect(toolLabel("run_sql", true)).toBe("Query");
+	});
 });
 
 describe("isCanvasTool", () => {

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -137,6 +137,20 @@ describe("toolChipSummary — completed canvas tools (no JSON, readable)", () =>
 		).toBe("people.csv — 1 table");
 	});
 
+	it("connect shows a file source's filename, not the full s3:// URI", () => {
+		expect(
+			toolChipSummary(
+				"connect",
+				{},
+				{
+					sourceKind: "file",
+					source: "s3://dataraum-lake/uploads/da833c2e/trial_balance.csv",
+					tables: [{}],
+				},
+			),
+		).toBe("trial_balance.csv — 1 table");
+	});
+
 	it("frame names the vertical + concept count", () => {
 		expect(
 			toolChipSummary(

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -18,6 +18,7 @@
 // is the part's `output` (undefined until the call completes).
 
 import type { ConnectSchema } from "#/duckdb/connect";
+import { displayTableName } from "#/lib/display-names";
 import type { FrameResult } from "#/tools/frame";
 import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
@@ -62,12 +63,25 @@ const TOOL_LABELS: Record<string, string> = {
 	upload: "File upload",
 };
 
+// Past-tense / settled titles for the few tools whose default label reads as an
+// in-progress verb. Once the call completes the chip flips to these so a finished
+// card never says "Registering source" — the rest of TOOL_LABELS are already
+// nouns ("Workspace tables", "Query") that read fine in both states.
+const TOOL_LABELS_DONE: Record<string, string> = {
+	connect: "Source schema",
+	select: "Registered source",
+	teach: "Taught",
+	replay: "Re-ran",
+};
+
 /**
- * The plain-language title for a tool call. Falls back to a humanized form of the
+ * The plain-language title for a tool call. When `done`, a progressive verb flips
+ * to its settled form (TOOL_LABELS_DONE). Falls back to a humanized form of the
  * tool name (underscores → spaces, sentence case) so an unmapped future tool
  * still never shows a raw snake_case verb.
  */
-export function toolLabel(toolName: string): string {
+export function toolLabel(toolName: string, done = false): string {
+	if (done && TOOL_LABELS_DONE[toolName]) return TOOL_LABELS_DONE[toolName];
 	const mapped = TOOL_LABELS[toolName];
 	if (mapped) return mapped;
 	const spaced = toolName.replace(/_/g, " ").trim();
@@ -127,16 +141,17 @@ export function toolChipSummary(
 			const r = output as LookTableResult | undefined;
 			if (!r || !Array.isArray(r.columns)) return "reading table readiness…";
 			const cols = plural(r.columns.length, "column");
+			const table = displayTableName(r.table_name);
 			return r.analyzed
-				? `${r.table_name} — ${cols}`
-				: `${r.table_name} — ${cols}, not yet analyzed`;
+				? `${table} — ${cols}`
+				: `${table} — ${cols}, not yet analyzed`;
 		}
 		case "why_column": {
 			const r = output as WhyColumnResult | undefined;
 			if (!r) return "explaining column…";
 			if (!r.found) return "column not found";
 			const band = r.band ?? "not analyzed";
-			return `${r.column_name} (${r.table_name}) — ${band}`;
+			return `${r.column_name} (${displayTableName(r.table_name)}) — ${band}`;
 		}
 		case "connect": {
 			const s = output as ConnectSchema | undefined;

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -19,6 +19,7 @@
 
 import type { ConnectSchema } from "#/duckdb/connect";
 import { displayTableName } from "#/lib/display-names";
+import { fileName } from "#/lib/file-uri";
 import type { FrameResult } from "#/tools/frame";
 import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
@@ -160,7 +161,10 @@ export function toolChipSummary(
 			// connecting rather than crashing on `.length` (the multi-file drag-drop
 			// crash). The complete result always carries the array.
 			if (!s || !Array.isArray(s.tables)) return "connecting…";
-			return `${s.source} — ${plural(s.tables.length, "table")}`;
+			// A file source's `source` is the full `s3://…/<id>/<name>` URI — show the
+			// filename, not the bucket/prefix plumbing (a database source is a name).
+			const src = s.sourceKind === "file" ? fileName(s.source) : s.source;
+			return `${src} — ${plural(s.tables.length, "table")}`;
 		}
 		case "frame": {
 			const f = output as FrameResult | undefined;

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -199,6 +199,9 @@ export function toolChipSummary(
 		default:
 			// Never surface a raw snake_case verb as the summary — humanize unmapped
 			// tools the same way the title does (look_relationships → "Look relationships").
+			// NOTE: when relationship tools (look_relationships / why_relationship) get
+			// explicit cases, run their `from_table_name`/`to_table_name` through
+			// `displayTableName` — their output carries the raw `<source>__table` form.
 			return toolLabel(toolName);
 	}
 }

--- a/packages/cockpit/src/ui/cockpit/widgets/column-why.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/column-why.test.tsx
@@ -85,6 +85,26 @@ describe("ColumnWhyWidget (DAT-351)", () => {
 		).toContain("undeclared_ratio");
 	});
 
+	it("falls back to a dash for an evidence row with an empty dimension path (no blank cell)", () => {
+		renderWidget({
+			...analyzed,
+			evidence: [
+				{
+					dimension_path: "",
+					detector_id: "mystery_detector",
+					score: 0.5,
+					detail: "",
+				},
+			],
+			signal_count: 1,
+		});
+		// Empty dimension → a dash, not a hollow cell; the detector still humanizes.
+		expect(
+			screen.getByTestId("canvas-column-why-evidence").textContent,
+		).toContain("—");
+		expect(screen.getByText("Mystery detector")).toBeTruthy();
+	});
+
 	it("shows the not-analyzed note when the column is found but has no readiness row", () => {
 		renderWidget({
 			...analyzed,

--- a/packages/cockpit/src/ui/cockpit/widgets/column-why.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/column-why.test.tsx
@@ -73,9 +73,16 @@ describe("ColumnWhyWidget (DAT-351)", () => {
 		expect(screen.getByTestId("canvas-column-why-signals").textContent).toMatch(
 			/Based on 1 signal\b/,
 		);
-		// The evidence table carries the dimension + detector.
+		// The evidence table carries the humanized dimension + detector, with the
+		// raw dotted path kept beneath as a technical subtitle.
 		expect(screen.getByTestId("canvas-column-why-evidence")).toBeTruthy();
-		expect(screen.getByText("unit_entropy")).toBeTruthy();
+		expect(screen.getByText("Unit entropy")).toBeTruthy();
+		expect(screen.getByText("Unit declaration")).toBeTruthy();
+		expect(screen.getByText("semantic.units.unit_declaration")).toBeTruthy();
+		// The JSON detail blob is pretty-printed (technical, but readable).
+		expect(
+			screen.getByTestId("canvas-column-why-evidence").textContent,
+		).toContain("undeclared_ratio");
 	});
 
 	it("shows the not-analyzed note when the column is found but has no readiness row", () => {

--- a/packages/cockpit/src/ui/cockpit/widgets/column-why.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/column-why.tsx
@@ -5,7 +5,12 @@
 //
 // Reads theme/tokens only; the row type is a type-only import (erased).
 
-import { Alert, Badge, Group, Stack, Table, Text } from "@mantine/core";
+import { Alert, Badge, Code, Group, Stack, Table, Text } from "@mantine/core";
+import {
+	displayTableName,
+	humanizeIdentifier,
+	prettyJson,
+} from "#/lib/display-names";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
 
 const INTENT_LABEL: Record<string, string> = {
@@ -75,7 +80,7 @@ export function ColumnWhyWidget({
 				<Text size="sm" fw={600}>
 					{why.column_name}{" "}
 					<Text span c="dimmed">
-						· {why.table_name}
+						· {displayTableName(why.table_name)}
 					</Text>
 				</Text>
 				<BandBadge band={why.band} />
@@ -143,32 +148,51 @@ export function ColumnWhyWidget({
 							</Table.Tr>
 						</Table.Thead>
 						<Table.Tbody>
-							{why.evidence.map((e) => (
-								<Table.Tr key={`${e.dimension_path}-${e.detector_id}`}>
-									<Table.Td>
-										<Text span size="xs">
-											{e.dimension_path}
-										</Text>
-									</Table.Td>
-									<Table.Td>
-										<Text span size="xs" c="dimmed">
-											{e.detector_id}
-										</Text>
-									</Table.Td>
-									<Table.Td>{e.score.toFixed(2)}</Table.Td>
-									<Table.Td>
-										<Text
-											span
-											size="xs"
-											c="dimmed"
-											ff="monospace"
-											style={{ wordBreak: "break-word" }}
-										>
-											{e.detail || "—"}
-										</Text>
-									</Table.Td>
-								</Table.Tr>
-							))}
+							{why.evidence.map((e) => {
+								// Lead with the readable dimension (the last path segment,
+								// humanized) and keep the full dotted path as a dimmed,
+								// technical subtitle — "Naming clarity" over the raw
+								// `semantic.business_meaning.naming_clarity`.
+								const dimLeaf = e.dimension_path.split(".").at(-1) ?? "";
+								return (
+									<Table.Tr key={`${e.dimension_path}-${e.detector_id}`}>
+										<Table.Td>
+											<Stack gap={0}>
+												<Text span size="xs">
+													{humanizeIdentifier(dimLeaf) || e.dimension_path}
+												</Text>
+												<Text span size="xs" c="dimmed" ff="monospace">
+													{e.dimension_path}
+												</Text>
+											</Stack>
+										</Table.Td>
+										<Table.Td>
+											<Text span size="xs" c="dimmed">
+												{humanizeIdentifier(e.detector_id) || e.detector_id}
+											</Text>
+										</Table.Td>
+										<Table.Td>{e.score.toFixed(2)}</Table.Td>
+										<Table.Td>
+											{e.detail ? (
+												<Code
+													block
+													style={{
+														fontSize: 11,
+														maxHeight: 200,
+														overflow: "auto",
+													}}
+												>
+													{prettyJson(e.detail)}
+												</Code>
+											) : (
+												<Text span size="xs" c="dimmed">
+													—
+												</Text>
+											)}
+										</Table.Td>
+									</Table.Tr>
+								);
+							})}
 						</Table.Tbody>
 					</Table>
 				</Table.ScrollContainer>

--- a/packages/cockpit/src/ui/cockpit/widgets/column-why.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/column-why.tsx
@@ -159,11 +159,18 @@ export function ColumnWhyWidget({
 										<Table.Td>
 											<Stack gap={0}>
 												<Text span size="xs">
-													{humanizeIdentifier(dimLeaf) || e.dimension_path}
+													{humanizeIdentifier(dimLeaf) ||
+														e.dimension_path ||
+														"—"}
 												</Text>
-												<Text span size="xs" c="dimmed" ff="monospace">
-													{e.dimension_path}
-												</Text>
+												{/* Raw dotted path as a technical subtitle — skip it
+												    entirely when empty so the cell doesn't show a blank
+												    monospace line. */}
+												{e.dimension_path && (
+													<Text span size="xs" c="dimmed" ff="monospace">
+														{e.dimension_path}
+													</Text>
+												)}
 											</Stack>
 										</Table.Td>
 										<Table.Td>
@@ -178,8 +185,13 @@ export function ColumnWhyWidget({
 													block
 													style={{
 														fontSize: 11,
+														maxWidth: 360,
 														maxHeight: 200,
 														overflow: "auto",
+														// Wrap so a long blob (or a plain-string detail
+														// that isn't JSON) doesn't force the table wider.
+														whiteSpace: "pre-wrap",
+														wordBreak: "break-word",
 													}}
 												>
 													{prettyJson(e.detail)}

--- a/packages/cockpit/src/ui/cockpit/widgets/inventory-grouping.ts
+++ b/packages/cockpit/src/ui/cockpit/widgets/inventory-grouping.ts
@@ -7,6 +7,7 @@
 // (typed) as the representative, surfacing the quarantine layer only as a count.
 // Pure (no React/DB) so the grouping is unit-testable.
 
+import { displayTableName } from "#/lib/display-names";
 import type { InventoryTable } from "#/tools/list-tables";
 
 export interface LogicalTable {
@@ -26,16 +27,13 @@ export interface LogicalTable {
 	layers: InventoryTable[];
 }
 
-/** Strip the `${sourceName}__` prefix the engine prepends to physical tables. */
+/** Strip the `${sourceName}__` prefix the engine prepends to physical tables.
+ * Thin alias over the shared `displayTableName` (kept for the call sites here). */
 export function logicalTableName(
 	tableName: string,
 	sourceName: string,
 ): string {
-	const prefix = `${sourceName}__`;
-	if (tableName.startsWith(prefix)) return tableName.slice(prefix.length);
-	// Generic fallback: drop everything up to and including the first `__`.
-	const i = tableName.indexOf("__");
-	return i >= 0 ? tableName.slice(i + 2) : tableName;
+	return displayTableName(tableName, sourceName);
 }
 
 const BAND_LABELS: Record<string, string> = {

--- a/packages/cockpit/src/ui/cockpit/widgets/measure-progress.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/measure-progress.test.tsx
@@ -240,6 +240,141 @@ describe("MeasureProgressWidget (DAT-352)", () => {
 		);
 	});
 
+	it("shows a live caption during the no-tally reduce phases (semantic / detect)", () => {
+		h.queryResult = {
+			data: {
+				phase: "semantic_per_column",
+				tables_total: 3,
+				tables_completed: 3,
+				tables: [],
+				failure: null,
+				status: "RUNNING",
+				done: false,
+			},
+			error: undefined,
+			isLoading: false,
+		};
+		renderWidget();
+		expect(
+			screen.getByTestId("measure-progress-caption").textContent,
+		).toContain("Analyzing column semantics");
+		// A reduce phase has no fan-out tally.
+		expect(screen.queryByTestId("measure-progress-tally")).toBeNull();
+	});
+
+	it("does NOT show the reduce caption during the per-table fan-out (the tally owns it)", () => {
+		h.queryResult = {
+			data: {
+				phase: "processing_tables",
+				tables_total: 4,
+				tables_completed: 2,
+				tables: [],
+				failure: null,
+				status: "RUNNING",
+				done: false,
+			},
+			error: undefined,
+			isLoading: false,
+		};
+		renderWidget();
+		expect(screen.queryByTestId("measure-progress-caption")).toBeNull();
+	});
+
+	it("the done alert names how many tables were imported and analyzed", () => {
+		h.queryResult = {
+			data: {
+				phase: "done",
+				tables_total: 3,
+				tables_completed: 3,
+				tables: [
+					{
+						raw_table_id: "r1",
+						name: "finance_data__payments",
+						status: "done",
+					},
+					{
+						raw_table_id: "r2",
+						name: "finance_data__invoices",
+						status: "done",
+					},
+					{
+						raw_table_id: "r3",
+						name: "finance_data__fx_rates",
+						status: "done",
+					},
+				],
+				failure: null,
+				status: "COMPLETED",
+				done: true,
+			},
+			error: undefined,
+			isLoading: false,
+		};
+		renderWidget();
+		expect(screen.getByTestId("measure-progress-done").textContent).toContain(
+			"3 tables imported and analyzed",
+		);
+	});
+
+	it("falls back to a generic done line when the snapshot carried no table list", () => {
+		h.queryResult = {
+			data: {
+				phase: "done",
+				tables_total: 0,
+				tables_completed: 0,
+				tables: [],
+				failure: null,
+				status: "COMPLETED",
+				done: true,
+			},
+			error: undefined,
+			isLoading: false,
+		};
+		renderWidget();
+		expect(screen.getByTestId("measure-progress-done").textContent).toContain(
+			"the source is imported and analyzed",
+		);
+	});
+
+	it("strips the `<source>__` prefix from table names in the list AND the failure message", () => {
+		h.queryResult = {
+			data: {
+				phase: "processing_tables",
+				tables_total: 2,
+				tables_completed: 1,
+				tables: [
+					{
+						raw_table_id: "r1",
+						name: "finance_data__trial_balance",
+						status: "done",
+					},
+					{
+						raw_table_id: "r2",
+						name: "finance_data__journal_lines",
+						status: "failed",
+					},
+				],
+				failure: {
+					message: "typing failed: bad cast",
+					phase: "processing_tables",
+					table_id: "r2",
+				},
+				status: "FAILED",
+				done: true,
+			},
+			error: undefined,
+			isLoading: false,
+		};
+		renderWidget();
+		const list = screen.getByTestId("measure-progress-tables");
+		expect(list.textContent).toContain("trial_balance");
+		expect(list.textContent).not.toContain("finance_data__trial_balance");
+		// The failure path strips the prefix too — the bug the review caught.
+		const alert = screen.getByTestId("measure-progress-failed");
+		expect(alert.textContent).toContain("journal_lines");
+		expect(alert.textContent).not.toContain("finance_data__journal_lines");
+	});
+
 	it("surfaces a query error", () => {
 		h.queryResult = {
 			data: undefined,

--- a/packages/cockpit/src/ui/cockpit/widgets/measure-progress.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/measure-progress.tsx
@@ -53,11 +53,11 @@ function phaseLabel(phase: string): string {
 	return PHASES.find((p) => p.key === phase)?.label ?? phase;
 }
 
-// Live caption for the phases that DON'T fan out per table — `semantic_per_column`
-// and `detect` each run as ONE source-level reduce activity (workflows.py), so the
-// table tally is frozen and there's no per-row signal. The caption keeps the
-// surface alive ("still working, here's on what") instead of dead air. Phases that
-// have their own signal (processing_tables → tally) are intentionally absent.
+// Live caption for the phases that carry NO per-table signal: `import` (before the
+// fan-out exists) and `semantic_per_column` / `detect` (each ONE source-level
+// reduce activity, workflows.py). For these the table tally is frozen/empty, so the
+// caption keeps the surface alive ("still working, here's on what") instead of dead
+// air. `processing_tables` is intentionally absent — it has its own tally bar.
 const PHASE_CAPTION: Record<string, string> = {
 	import: "Importing rows…",
 	semantic_per_column: "Analyzing column semantics across all tables…",
@@ -278,10 +278,12 @@ function failureMessage(data: AddSourceProgress): string {
 		return `The add source run ended in ${data.status.toLowerCase()} at the ${data.phase} phase.`;
 	}
 	if (f.table_id) {
+		// Same name-display rule as the live list — strip the `<source>__` prefix so
+		// a FAILED run reads `trial_balance`, not `finance_data__trial_balance`.
 		const name =
 			data.tables.find((t) => t.raw_table_id === f.table_id)?.name ??
 			`table ${f.table_id.slice(0, 8)}`;
-		return `Add source failed on ${name}: ${f.message}`;
+		return `Add source failed on ${displayTableName(name)}: ${f.message}`;
 	}
 	return `Add source failed during ${phaseLabel(f.phase)}: ${f.message}`;
 }

--- a/packages/cockpit/src/ui/cockpit/widgets/measure-progress.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/measure-progress.tsx
@@ -24,6 +24,7 @@ import {
 } from "@mantine/core";
 import { useQuery } from "@tanstack/react-query";
 import { Check, X } from "lucide-react";
+import { displayTableName } from "#/lib/display-names";
 import type { AddSourceProgress, TableStep } from "#/temporal/progress";
 import { PROGRESS_DONE_PHASE } from "#/temporal/types";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
@@ -51,6 +52,17 @@ function phaseIndex(phase: string): number {
 function phaseLabel(phase: string): string {
 	return PHASES.find((p) => p.key === phase)?.label ?? phase;
 }
+
+// Live caption for the phases that DON'T fan out per table — `semantic_per_column`
+// and `detect` each run as ONE source-level reduce activity (workflows.py), so the
+// table tally is frozen and there's no per-row signal. The caption keeps the
+// surface alive ("still working, here's on what") instead of dead air. Phases that
+// have their own signal (processing_tables → tally) are intentionally absent.
+const PHASE_CAPTION: Record<string, string> = {
+	import: "Importing rows…",
+	semantic_per_column: "Analyzing column semantics across all tables…",
+	detect: "Scoring readiness across all columns…",
+};
 
 /** The leading status glyph for one fanned-out table row. */
 function TableStatusIcon({ status }: { status: TableStep["status"] }) {
@@ -197,6 +209,17 @@ export function MeasureProgressWidget({
 				</Stack>
 			)}
 
+			{/* The reduce phases (semantic / detect) have no per-table signal — show
+			    an indeterminate caption so the surface isn't dead air while they run. */}
+			{!data.done && !showTally && PHASE_CAPTION[data.phase] && (
+				<Group gap="xs" wrap="nowrap" data-testid="measure-progress-caption">
+					<Loader size="xs" />
+					<Text size="xs" c="dimmed">
+						{PHASE_CAPTION[data.phase]}
+					</Text>
+				</Group>
+			)}
+
 			{/* The named steps behind the count — which tables are running / done /
 			    failed. Scrolls past a handful so a wide source can't blow out the
 			    canvas. */}
@@ -218,7 +241,7 @@ export function MeasureProgressWidget({
 									truncate
 									data-testid={`measure-table-${t.raw_table_id}`}
 								>
-									{t.name}
+									{displayTableName(t.name)}
 								</Text>
 							</Group>
 						))}
@@ -228,7 +251,11 @@ export function MeasureProgressWidget({
 
 			{succeeded && (
 				<Alert color="green" data-testid="measure-progress-done">
-					Add source complete — readiness is ready to inspect.
+					{data.tables.length > 0
+						? `Done — ${data.tables.length} table${
+								data.tables.length === 1 ? "" : "s"
+							} imported and analyzed. Ask about any table to see its readiness.`
+						: "Done — the source is imported and analyzed."}
 				</Alert>
 			)}
 

--- a/packages/cockpit/src/ui/cockpit/widgets/schema-preview.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/schema-preview.tsx
@@ -12,6 +12,7 @@ import {
 	Text,
 	TextInput,
 } from "@mantine/core";
+import { fileName } from "#/lib/file-uri";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
 
 function formatSample(value: unknown): string {
@@ -26,6 +27,11 @@ export function SchemaPreviewWidget({
 	state: Extract<CanvasState, { kind: "schema-preview" }>;
 }) {
 	const { schema } = state;
+	// A file source's `source` is the full `s3://bucket/uploads/<id>/<name>` URI —
+	// the bucket/prefix plumbing isn't what the user reads, so show the filename.
+	// A database source's `source` is already a plain name; leave it as-is.
+	const sourceLabel =
+		schema.sourceKind === "file" ? fileName(schema.source) : schema.source;
 	if (schema.tables.length === 0) {
 		return (
 			<Text c="dimmed" size="sm" data-testid="canvas-schema-preview-empty">
@@ -37,7 +43,7 @@ export function SchemaPreviewWidget({
 		<Stack gap="md" data-testid="canvas-schema-preview">
 			<Group gap="xs">
 				<Badge variant="light">{schema.sourceKind}</Badge>
-				<Text fw={600}>{schema.source}</Text>
+				<Text fw={600}>{sourceLabel}</Text>
 			</Group>
 
 			{schema.tables.map((t) => (

--- a/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
@@ -8,6 +8,7 @@
 // code in the client bundle).
 
 import { Alert, Anchor, Badge, Group, Stack, Table, Text } from "@mantine/core";
+import { displayTableName } from "#/lib/display-names";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
 import { useCockpitActions } from "#/ui/cockpit/cockpit-state";
 
@@ -77,11 +78,14 @@ export function TableReadinessWidget({
 		);
 	};
 
+	// Show the plain table name, never the engine's `<source>__table` physical id.
+	const tableLabel = displayTableName(readiness.table_name);
+
 	if (readiness.columns.length === 0) {
 		return (
 			<Text c="dimmed" size="sm" data-testid="canvas-table-readiness-empty">
 				{readiness.table_name
-					? `No columns found for ${readiness.table_name}.`
+					? `No columns found for ${tableLabel}.`
 					: "No such table."}
 			</Text>
 		);
@@ -90,7 +94,7 @@ export function TableReadinessWidget({
 	return (
 		<Stack gap="xs" data-testid="canvas-table-readiness">
 			<Text size="sm" fw={600}>
-				{readiness.table_name} — readiness
+				{tableLabel} — readiness
 			</Text>
 
 			{!readiness.analyzed && (


### PR DESCRIPTION
Review round 2 on the chat redesign (#212), from a stakeholder screenshot pass. **Display-only** — no behavior, data, or contract changes. Raw engine identifiers, the `_adhoc` induction seed, and in-progress verbs were leaking into the UI.

## Fixes (issue → change)
- **S3 path shown as the FILE header** → `schema-preview` shows the filename for file sources (`s3://…/<id>/trial_balance.csv` → `trial_balance.csv`); DB sources keep their plain name.
- **`_adhoc` counted in "Domains — 2 verticals (2 builtin)"** → `list_verticals` filters underscore-prefixed seeds from **both** the builtin scan and the framed-overlay fallback (`_adhoc` carries overlay concepts, so it would otherwise resurface as "framed"). → "finance, 1 builtin".
- **"Registering source" stays present-tense after completion** → `toolLabel(name, done)` flips progressive verbs to settled forms (`select`→"Registered source", `connect`→"Source schema", `teach`→"Taught", `replay`→"Re-ran"); chat-rail passes `done`.
- **`finance_data__trial_balance` leaking into titles / progress rows / chips** → new `lib/display-names.ts#displayTableName` strips the `<source>__` prefix; applied in table-readiness + column-why titles, the add-source progress checklist (incl. the failure message), and the look_table/why_column chip summaries. `inventory-grouping#logicalTableName` now delegates to it.
- **column-why: dotted `semantic.business_meaning.naming_clarity` / raw `business_meaning`, pure-JSON Detail** → humanized Dimension/Detector (dotted path kept as a technical subtitle), pretty-printed + wrapped JSON Detail.
- **"Add source complete — readiness is ready to inspect" (nonsense) + dead air during semantic** → concrete completion line ("N tables imported and analyzed…"); a live caption for the reduce phases (`semantic_per_column` / `detect`) that have no per-table signal. (Researched: the engine runs `semantic_per_column` as **one** source-level reduce activity, so there are genuinely no per-column events to show without an engine change.)

## Not in this PR (need product decisions)
- **Data model (source = S3 folder vs. run vs. typed-tables-into-a-session)** — a real design question, not polish. → `/ideate` (relates to the `source_identity_reimport_flaw` note).
- **Resizable canvas drawer** — "nice if easy"; moderate effort (drag handle + persisted width).
- **Chat prose still renders raw `s3://` paths / `column_id … why_column tool`** — those are auto-generated agent-driver messages; cleaning them needs a display-text-vs-model-text split in the message model.

## Review
Senior + strict reviewers run; strict's NEEDS WORK (a failure-path name leak + missing tests on the new behaviors) addressed and **re-verified APPROVED**. New `display-names` unit tests + coverage for every new behavior.

Gates: **524 vitest pass**, biome clean, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)