### PR TITLE
fix(engine): GraphLoader tolerates framed verticals (no on-disk dir)

### DIFF
--- a/packages/engine/src/dataraum/graphs/loader.py
+++ b/packages/engine/src/dataraum/graphs/loader.py
@@ -62,9 +62,18 @@ class GraphLoader:
         if graphs_dir is None:
             if vertical is None:
                 raise ValueError("vertical is required when graphs_dir is not provided")
-            from dataraum.core.vertical import VerticalConfig
+            from dataraum.core.config import get_config_dir
 
-            graphs_dir = VerticalConfig(vertical).base_dir
+            # Resolve the vertical's dir WITHOUT VerticalConfig's fail-loud
+            # existence check. A framed vertical (declared via the cockpit `frame`
+            # stage — its concepts live in config_overlay, with no on-disk
+            # directory) legitimately ships no metric graphs. `load_all` already
+            # returns {} for a missing dir, so resolving the path here and letting
+            # load_all handle absence is what lets grounding run for a framed
+            # vertical instead of crashing in the constructor (the `add_source`
+            # semantic phase grounds against framed concepts via the overlay-aware
+            # OntologyLoader, then asks GraphLoader for metric standard-fields).
+            graphs_dir = get_config_dir("verticals") / vertical
         self.graphs_dir = graphs_dir
         self.graphs: dict[str, TransformationGraph] = {}
         self._load_errors: list[GraphLoadError] = []

--- a/packages/engine/tests/unit/graphs/test_loader.py
+++ b/packages/engine/tests/unit/graphs/test_loader.py
@@ -23,6 +23,22 @@ class TestGraphLoaderBasics:
         with pytest.raises(ValueError, match="vertical is required"):
             GraphLoader()
 
+    def test_loader_init_framed_vertical_no_dir_does_not_raise(self) -> None:
+        """A framed vertical (cockpit `frame` overlay-only, no on-disk dir) must
+        NOT crash the constructor — it legitimately ships no metric graphs.
+
+        Regression: the `add_source` semantic phase grounds a framed vertical's
+        columns (concepts resolved via the overlay-aware OntologyLoader) and then
+        asks GraphLoader for metric standard-fields. The old fail-loud
+        `VerticalConfig` crashed the whole phase with
+        `FileNotFoundError: .../verticals/<framed> does not exist`. The path now
+        resolves and `load_all` degrades to an empty graph set.
+        """
+        loader = GraphLoader(vertical="a_framed_vertical_with_no_on_disk_dir")
+        assert loader.graphs_dir.name == "a_framed_vertical_with_no_on_disk_dir"
+        assert loader.load_all() == {}
+        assert not loader.get_all_abstract_fields()
+
     def test_loader_init_custom_path(self, tmp_path: Path) -> None:
         """Loader accepts custom path."""
         loader = GraphLoader(graphs_dir=tmp_path)


### PR DESCRIPTION
A framed vertical (declared via the cockpit `frame` stage — its concepts live in config_overlay, with no on-disk `verticals/<name>/` directory) crashed add_source's `semantic_per_column` phase. `ground_columns` builds a `GraphLoader(vertical=…)` to fetch metric standard-fields, and the constructor resolved the dir through `VerticalConfig`, which fails loud on a missing directory — even though `load_all()` already returns `{}` for one.

Resolve the path via `get_config_dir` without the existence assertion; a framed vertical legitimately ships no metric graphs, so `load_all` degrades to an empty graph set and grounding proceeds against the overlay concepts instead of raising "Vertical 'X' not found: …/verticals/X does not exist. Available verticals: …".

The overlay-aware OntologyLoader concept-check already passed for the framed vertical; this was the one filesystem-only loader left in the grounding path.

Reported by a user creating a new (framed) vertical during Add source.