### PR TITLE
DAT-415 + DAT-402: revive enriched_views (view-DDL versioning) + table-grain readiness

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,55 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-04: DAT-415 + DAT-402 — enriched_views revival + table-grain readiness + view-DDL versioning
+
+begin_session Slice 2.1 (DAT-402) bundled with view-DDL versioning (DAT-415, Phase 2 Slice B
+of the versioned-metadata epic). Revives the dormant `enriched_views` phase as a run-versioned
+begin_session step and gives begin_session its first **table-grain readiness** signal.
+
+### dataraum-eval
+- **Changed:** `pipeline/phases/enriched_views_phase.py` (source-free re-seam, run-versioned,
+  recipe-backed DDL), `analysis/views/{recipe.py (new), db_models.py, builder.py}`,
+  `entropy/detectors/semantic/dimension_coverage.py` (scope view→table),
+  `entropy/views/readiness_context.py` + `entropy/readiness.py` (table-grain rollup + persist),
+  `worker/{workflows.py, activities.py, activity.py, main.py}` (new `enriched_views` activity in
+  the begin_session spine + `SESSION_DETECTOR_PHASES`), `core/sql_normalize.py` (new),
+  `analysis/typing/recipe.py` (`order_recipes_by_dependency` made public).
+- **Affects:** the **begin_session** path only — add_source is untouched (no `table:`-scoped
+  detector runs on `_DETECTOR_PHASES`; `enriched_views` is not in it). begin_session now runs
+  `relationships → semantic_per_table → session_materialize_overlays → enriched_views →
+  session_detect → …`, and `session_detect` runs `dimension_coverage` (newly wired) in addition
+  to the relationship detectors.
+- **Calibrate (the real gate — DAT-405):** `dimension_coverage` recall/precision at **table
+  grain**. It builds a grain-preserving LEFT JOIN view per fact table over its LLM-confirmed
+  dimension relationships, then scores the mean NULL rate across the joined dimension columns
+  (sqrt-boosted). Ground truth = the finance `break_referential_integrity` injection on
+  `payments.invoice_id` (~20% orphans): the enriched view's joined `invoices.*` columns are NULL
+  for orphaned rows → `dimension_coverage ≈ sqrt(0.2) ≈ 0.45` on **`table:payments`** → a
+  non-`ready` band (rolls into `query_intent` 0.5 / `reporting_intent` 0.6). Validate that a clean
+  join (no orphans) scores ~0 and the 20%-orphan case lands `investigate`. This is a NEW readiness
+  surface — there was no `table:` band before.
+- **Notes:**
+  - **New readiness rows:** `entropy_readiness` now carries `target = "table:{table_name}"` rows
+    (table FK set, **column_id NULL**) alongside the existing `column:` / `relationship:` rows.
+    Resolve the current run via the per-session head (`session:{id}`, stage `detect`) — same as
+    relationship readiness, NOT the per-table head. Engine reader: `load_table_readiness(session,
+    session_id)`.
+  - **Schema changes (need a fresh ws schema):** `enriched_views.view_sql` is **dropped** and
+    `enriched_views.run_id` **added**; `materialization_recipes` now also stores `layer="enriched"`
+    rows. `create_all` is additive — it will NOT drop `view_sql`, so a stale workspace whose
+    `enriched_views.view_sql` is still `NOT NULL` will **fail inserts**. Re-pull a clean schema
+    (`docker compose down -v`) before driving begin_session. (The eval's vendored engine submodule
+    is pinned pre-DAT-408 and uninitialized — bump it to current `main` first; see the eval
+    teach→keeper foundation notes.)
+  - **View determinism:** the enrichment LLM runs at temperature 0 and view DDL is sqlglot-canonical
+    + collision-free-named (`enriched_{source}__{table}`), so a re-run with the same confirmed joins
+    produces a byte-identical recipe (no spurious new version). Eval can diff recipe DDL to detect a
+    genuine view change across runs.
+  - **No add_source recall movement expected** from this ticket — if the add_source detector-recall
+    suite moves, that's a regression, not this change.
+- **Status:** pending
+
 ## 2026-06-04: DAT-414 — versioned typed/quarantine materialization DDL
 
 Phase 2 of the versioned-metadata epic (DAT-412), Slice A typed/quarantine only.

--- a/packages/cockpit/scripts/smoke-begin-session.ts
+++ b/packages/cockpit/scripts/smoke-begin-session.ts
@@ -30,7 +30,9 @@ import { metadataDb } from "#/db/metadata/client";
 import { investigationSessions, sources } from "#/db/metadata/schema";
 import { beginSession } from "#/tools/begin-session";
 import { lookRelationships } from "#/tools/look-relationships";
+import { lookTable } from "#/tools/look-table";
 import { whyRelationship } from "#/tools/why-relationship";
+import { whyTable } from "#/tools/why-table";
 import type { AddSourceInput, AddSourceResult } from "#/temporal/types";
 import { addSourceWorkflowId } from "#/temporal/workflow-id";
 
@@ -160,6 +162,39 @@ async function main(): Promise<void> {
 				`signals=${why.signal_count}` +
 				`\n  analysis: ${why.analysis.slice(0, 400)}${why.analysis.length > 400 ? "…" : ""}`,
 		);
+
+		// ---- look_table (session-head table-grain band) + why_table (DAT-415) -----
+		// Each typed table gets a begin_session whole-table readiness band (the
+		// dimension_coverage rollup), sealed at the session head; look_table surfaces
+		// it when passed the session_id, why_table explains it.
+		console.log("\nlook_table(table_readiness) per typed table:");
+		let analyzedTableId: string | null = null;
+		for (const tableId of tableIds) {
+			const lt = await lookTable({ table_id: tableId, session_id: begun.session_id });
+			const band = lt.table_readiness?.band ?? "—";
+			console.log(`  ${lt.table_name}: table_readiness.band=${band}`);
+			if (lt.table_readiness && analyzedTableId === null) analyzedTableId = tableId;
+		}
+		if (analyzedTableId === null) {
+			throw new Error(
+				"look_table returned no table_readiness for any session table — the " +
+					"table-grain rollup didn't seal at the session head (DAT-415).",
+			);
+		}
+
+		const wt = await whyTable({
+			session_id: begun.session_id,
+			table_id: analyzedTableId,
+		});
+		console.log(
+			`\nwhy_table(${wt.table_name}):` +
+				`\n  found=${wt.found} analyzed=${wt.analyzed} band=${wt.band} ` +
+				`signals=${wt.signal_count}` +
+				`\n  analysis: ${wt.analysis.slice(0, 400)}${wt.analysis.length > 400 ? "…" : ""}`,
+		);
+		if (!wt.found) {
+			throw new Error("why_table did not find the table-grain readiness row.");
+		}
 
 		console.log("\n✅ begin_session smoke passed");
 	} finally {

--- a/packages/cockpit/src/db/metadata/relationship-target.test.ts
+++ b/packages/cockpit/src/db/metadata/relationship-target.test.ts
@@ -9,6 +9,7 @@ import {
 	parseRelationshipTarget,
 	relationshipTargetKey,
 	sessionHeadTarget,
+	tableTargetKey,
 } from "./relationship-target";
 
 describe("relationshipTargetKey / parseRelationshipTarget (DAT-409)", () => {
@@ -41,6 +42,16 @@ describe("relationshipTargetKey / parseRelationshipTarget (DAT-409)", () => {
 		// >2 parts (engine's `len(parts) != 2` branch) — unreachable with real
 		// UUIDs (no `::`), but the guard must reject it rather than drop the tail.
 		expect(parseRelationshipTarget("relationship:a::b::c")).toBeNull();
+	});
+});
+
+describe("tableTargetKey (DAT-415)", () => {
+	it("builds the table:{name} key keyed on the table NAME", () => {
+		expect(tableTargetKey("smoke__payments")).toBe("table:smoke__payments");
+	});
+
+	it("is the inverse target a relationship parser rejects (distinct grain)", () => {
+		expect(parseRelationshipTarget(tableTargetKey("orders"))).toBeNull();
 	});
 });
 

--- a/packages/cockpit/src/db/metadata/relationship-target.ts
+++ b/packages/cockpit/src/db/metadata/relationship-target.ts
@@ -1,15 +1,19 @@
-// The relationship-readiness key grammar — the TS mirror of the engine's
-// `entropy/models.py` (`relationship_target_key` / `parse_relationship_target`)
-// and `storage/snapshot_head.py` (`session_head_target`). begin_session writes
-// relationship readiness/evidence under a `relationship:{from_col}::{to_col}`
-// target (DAT-408) and seals the run under a `session:{session_id}` head; the
-// readers here must build/parse those exact strings, so they live in one place
-// the same way the engine keeps one function per string.
+// The begin_session readiness key grammar — the TS mirror of the engine's
+// `entropy/models.py` (`relationship_target_key` / `parse_relationship_target`),
+// the `table:{name}` target the table-scoped detectors write (`engine.py` /
+// `readiness.py`, DAT-415), and `storage/snapshot_head.py`
+// (`session_head_target`). begin_session writes relationship readiness/evidence
+// under a `relationship:{from_col}::{to_col}` target (DAT-408) and table-grain
+// readiness under a `table:{table_name}` target (DAT-415), and seals the run
+// under a `session:{session_id}` head; the readers here must build/parse those
+// exact strings, so they live in one place the same way the engine keeps one
+// function per string.
 
 const REL_PREFIX = "relationship:";
 // `::` separates the two column UUIDs — a single `-` would be ambiguous inside a
 // UUID. Must match `_REL_SEP` in the engine.
 const REL_SEP = "::";
+const TABLE_PREFIX = "table:";
 
 /** The stable `relationship:{from_col}::{to_col}` readiness/evidence target. */
 export function relationshipTargetKey(
@@ -30,9 +34,17 @@ export function parseRelationshipTarget(
 	return { fromColumnId: parts[0], toColumnId: parts[1] };
 }
 
+/** The stable `table:{table_name}` table-grain readiness/evidence target (DAT-415).
+ * begin_session's `dimension_coverage` rolls up to this key; mirrors the engine's
+ * inline `f"table:{table.table_name}"` (`engine.py` / `readiness.py`). Keyed on the
+ * table NAME (not id), like the column target `column:{table}.{column}`. */
+export function tableTargetKey(tableName: string): string {
+	return `${TABLE_PREFIX}${tableName}`;
+}
+
 /** The snapshot-head key sealing a begin_session run (`session:{id}`). Relationship
- * readiness is sealed at session grain (one head per session run), NOT per-table
- * like column readiness — so its readers resolve the head by this key. */
+ * and table-grain readiness are sealed at session grain (one head per session run),
+ * NOT per-table like column readiness — so their readers resolve the head by this key. */
 export function sessionHeadTarget(sessionId: string): string {
 	return `session:${sessionId}`;
 }

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -278,7 +278,7 @@ export const enrichedViews = metadataSchema.table(
 			onDelete: "set null",
 		}),
 		viewName: varchar("view_name").notNull(),
-		viewSql: text("view_sql").notNull(),
+		runId: varchar("run_id"),
 		relationshipIds: json("relationship_ids"),
 		dimensionTableIds: json("dimension_table_ids"),
 		dimensionColumns: json("dimension_columns"),
@@ -287,6 +287,10 @@ export const enrichedViews = metadataSchema.table(
 		createdAt: timestamp("created_at").notNull(),
 	},
 	(table) => [
+		index("ix_enriched_views_run_id").using(
+			"btree",
+			table.runId.asc().nullsLast(),
+		),
 		index("ix_enriched_views_session_id").using(
 			"btree",
 			table.sessionId.asc().nullsLast(),

--- a/packages/cockpit/src/routes/api/chat.test.ts
+++ b/packages/cockpit/src/routes/api/chat.test.ts
@@ -35,6 +35,7 @@ describe("chat route wiring (DAT-353)", () => {
 				"list_verticals",
 				"look_table",
 				"why_column",
+				"why_table",
 				"look_relationships",
 				"why_relationship",
 				"run_sql",

--- a/packages/cockpit/src/tools/look-table.test.ts
+++ b/packages/cockpit/src/tools/look-table.test.ts
@@ -12,7 +12,12 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("#/config", () => ({ config: {} }));
 vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 
-import { projectColumnReadiness, type ReadinessRow } from "./look-table";
+import {
+	projectColumnReadiness,
+	projectTableBand,
+	type ReadinessRow,
+	type TableBandRow,
+} from "./look-table";
 
 function row(overrides: Partial<ReadinessRow> = {}): ReadinessRow {
 	return {
@@ -108,5 +113,77 @@ describe("projectColumnReadiness (DAT-350)", () => {
 		// The scalar band still comes through — it's a real column, just with a
 		// blob we couldn't parse.
 		expect(out.band).toBe("investigate");
+	});
+});
+
+function tableRow(overrides: Partial<TableBandRow> = {}): TableBandRow {
+	return {
+		band: "investigate",
+		worstIntentRisk: 0.42,
+		intents: [
+			{ intent: "query", band: "ready", risk: 0.1, drivers: [] },
+			{
+				intent: "reporting",
+				band: "investigate",
+				risk: 0.42,
+				drivers: [
+					{
+						node: "dimension_coverage",
+						dimension_path: "semantic.coverage.dimension_coverage",
+						label: "Dimension Coverage",
+						state: "high",
+						impact_delta: 0.3,
+					},
+				],
+			},
+		],
+		topDrivers: [
+			{
+				node: "dimension_coverage",
+				dimension_path: "semantic.coverage.dimension_coverage",
+				label: "Dimension Coverage",
+				state: "high",
+				impact_delta: 0.3,
+			},
+		],
+		...overrides,
+	};
+}
+
+describe("projectTableBand (DAT-415)", () => {
+	it("projects the table-grain band + per-intent bands (no drivers) + top drivers", () => {
+		const out = projectTableBand(tableRow());
+		expect(out.band).toBe("investigate");
+		expect(out.worst_intent_risk).toBe(0.42);
+		// The overview carries band + risk per intent only — drivers are why_table's.
+		expect(out.intents).toEqual([
+			{ intent: "query", band: "ready", risk: 0.1 },
+			{ intent: "reporting", band: "investigate", risk: 0.42 },
+		]);
+		expect(out.top_drivers).toEqual([
+			{ label: "Dimension Coverage", state: "high", impact_delta: 0.3 },
+		]);
+	});
+
+	it("caps top drivers at 3", () => {
+		const many = Array.from({ length: 6 }, (_, i) => ({
+			node: `n${i}`,
+			dimension_path: `p.${i}`,
+			label: `L${i}`,
+			state: "high",
+			impact_delta: 0.5 - i * 0.01,
+		}));
+		const out = projectTableBand(tableRow({ topDrivers: many }));
+		expect(out.top_drivers).toHaveLength(3);
+		expect(out.top_drivers.map((d) => d.label)).toEqual(["L0", "L1", "L2"]);
+	});
+
+	it("degrades a malformed JSONB blob to empty rather than throwing", () => {
+		const out = projectTableBand(
+			tableRow({ intents: "garbage", topDrivers: { not: "an array" } }),
+		);
+		expect(out.intents).toEqual([]);
+		expect(out.top_drivers).toEqual([]);
+		expect(out.band).toBe("investigate"); // scalar still comes through
 	});
 });

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -211,10 +211,32 @@ export async function lookTable(
 		};
 	}
 
-	// Readiness is versioned by run_id now (DAT-413): a column has one readiness
-	// row PER run, so resolve the PROMOTED detect snapshot for this table via the
-	// head pointer and join only that run's rows. No promoted run (never detected)
-	// → the join matches nothing and every column reads back unanalyzed.
+	// Three independent reads once the table is known: the per-column grid (its own
+	// add_source `table:{id}` head), the table-grain band (the begin_session
+	// `session:{id}` head — a different head), and the workspace teach count. Fan
+	// them out — they share no input, so sequential awaits only add latency to the
+	// hot path. table_readiness stays null without a session_id (add_source view).
+	const [cols, tableReadiness, pending] = await Promise.all([
+		loadColumnGrid(input.table_id),
+		input.session_id ? loadTableBand(input.session_id, table.tableName) : null,
+		getPendingOverlays(),
+	]);
+
+	return {
+		table_id: table.tableId,
+		table_name: table.tableName,
+		analyzed: cols.some((c) => c.band !== null),
+		pending_teaches: pending.length,
+		columns: cols,
+		table_readiness: tableReadiness,
+	};
+}
+
+/** Resolve a table's per-column readiness grid (the add_source view). Readiness is
+ * versioned by run_id (DAT-413): a column has one row PER run, so resolve the
+ * PROMOTED detect snapshot via the `table:{id}` head and LEFT JOIN only that run's
+ * rows — no promoted run (never detected) ⇒ every column reads back unanalyzed. */
+async function loadColumnGrid(tableId: string): Promise<ColumnReadiness[]> {
 	const [head] = await metadataDb
 		.select({ runId: metadataSnapshotHead.runId })
 		.from(metadataSnapshotHead)
@@ -222,7 +244,7 @@ export async function lookTable(
 			and(
 				// Head key generalized to a target string (DAT-408): column readiness
 				// is table-grain, so the key is `table:{id}`.
-				eq(metadataSnapshotHead.target, `table:${input.table_id}`),
+				eq(metadataSnapshotHead.target, `table:${tableId}`),
 				eq(metadataSnapshotHead.stage, "detect"),
 			),
 		)
@@ -249,31 +271,10 @@ export async function lookTable(
 					)
 				: sql`false`,
 		)
-		.where(eq(columns.tableId, input.table_id))
+		.where(eq(columns.tableId, tableId))
 		.orderBy(asc(columns.columnPosition));
 
-	const cols = rows.map(projectColumnReadiness);
-	// Table-grain band (DAT-415): only when inspecting inside a begin_session. It
-	// is sealed at the SESSION head (`session:{id}`), a different head than the
-	// per-column rows above (those are the table's add_source detect run), so it's
-	// a separate resolve — null when no session_id or no table-grain row.
-	const tableReadiness = input.session_id
-		? await loadTableBand(input.session_id, table.tableName)
-		: null;
-	// Workspace-wide count, NOT table-scoped: getPendingOverlays returns every
-	// un-superseded teach in the workspace (the helper leaves relevance to the
-	// caller). Surfaced as a coarse "a replay may be due" nudge — the description
-	// says as much so the agent doesn't over-claim it's specific to this table.
-	const pending = await getPendingOverlays();
-
-	return {
-		table_id: table.tableId,
-		table_name: table.tableName,
-		analyzed: cols.some((c) => c.band !== null),
-		pending_teaches: pending.length,
-		columns: cols,
-		table_readiness: tableReadiness,
-	};
+	return rows.map(projectColumnReadiness);
 }
 
 /** Resolve a session's table-grain readiness band for one table (DAT-415).

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -26,6 +26,10 @@ import {
 	ReadinessDriver,
 } from "../db/metadata/readiness-schemas";
 import {
+	sessionHeadTarget,
+	tableTargetKey,
+} from "../db/metadata/relationship-target";
+import {
 	columns,
 	entropyReadiness,
 	metadataSnapshotHead,
@@ -62,6 +66,18 @@ const ColumnReadiness = z.object({
 });
 export type ColumnReadiness = z.infer<typeof ColumnReadiness>;
 
+// The table-grain readiness band (DAT-415) — begin_session's `dimension_coverage`
+// rolled up for the whole table, sealed at the session head. Same overview shape
+// as a column (band + per-intent bands + top drivers), but for the table itself;
+// `why_table` drills into the full per-intent drivers + evidence.
+const TableReadiness = z.object({
+	band: z.string().nullable(),
+	worst_intent_risk: z.number().nullable(),
+	intents: z.array(IntentBand),
+	top_drivers: z.array(TopDriver),
+});
+export type TableReadiness = z.infer<typeof TableReadiness>;
+
 const LookTableResult = z.object({
 	table_id: z.string(),
 	table_name: z.string(),
@@ -71,6 +87,11 @@ const LookTableResult = z.object({
 	analyzed: z.boolean(),
 	pending_teaches: z.number(),
 	columns: z.array(ColumnReadiness),
+	// The table-grain band for the begin_session `session_id` passed in (DAT-415);
+	// null when no session_id was given or the session has no table-grain readiness
+	// for this table (never begun / table not in the session). The per-column grid
+	// above is add_source-grain; this is the begin_session whole-table rollup.
+	table_readiness: TableReadiness.nullable(),
 });
 export type LookTableResult = z.infer<typeof LookTableResult>;
 
@@ -121,8 +142,50 @@ export function projectColumnReadiness(row: ReadinessRow): ColumnReadiness {
 	};
 }
 
+/** One table-grain `entropy_readiness` row, as Drizzle returns it. */
+export interface TableBandRow {
+	band: string | null;
+	worstIntentRisk: number | null;
+	intents: unknown;
+	topDrivers: unknown;
+}
+
+/**
+ * Project the table-grain readiness row to the overview shape. Pure (no DB), the
+ * table analog of {@link projectColumnReadiness} minus the column identity: the
+ * per-intent overview keeps band + risk (drivers are why_table's drill-down), and
+ * the top drivers are capped + self-describing. A malformed JSONB blob degrades to
+ * empty rather than throwing.
+ */
+export function projectTableBand(row: TableBandRow): TableReadiness {
+	const intents = PersistedIntent.array().safeParse(row.intents);
+	const drivers = ReadinessDriver.array().safeParse(row.topDrivers);
+	return {
+		band: row.band ?? null,
+		worst_intent_risk: row.worstIntentRisk ?? null,
+		intents: intents.success
+			? intents.data.map((i) => ({
+					intent: i.intent,
+					band: i.band,
+					risk: i.risk,
+				}))
+			: [],
+		top_drivers: drivers.success
+			? drivers.data.slice(0, TOP_DRIVERS_SHOWN).map((d) => ({
+					label: d.label,
+					state: d.state,
+					impact_delta: d.impact_delta,
+				}))
+			: [],
+	};
+}
+
 export interface LookTableInput {
 	table_id: string;
+	// Optional: when this table is being inspected inside a begin_session, the
+	// session whose table-grain readiness to also surface (DAT-415). Omitted for a
+	// plain add_source column overview.
+	session_id?: string;
 }
 
 /** Per-column readiness for one table, plus a pending-teach hint. */
@@ -144,6 +207,7 @@ export async function lookTable(
 			analyzed: false,
 			pending_teaches: 0,
 			columns: [],
+			table_readiness: null,
 		};
 	}
 
@@ -189,6 +253,13 @@ export async function lookTable(
 		.orderBy(asc(columns.columnPosition));
 
 	const cols = rows.map(projectColumnReadiness);
+	// Table-grain band (DAT-415): only when inspecting inside a begin_session. It
+	// is sealed at the SESSION head (`session:{id}`), a different head than the
+	// per-column rows above (those are the table's add_source detect run), so it's
+	// a separate resolve — null when no session_id or no table-grain row.
+	const tableReadiness = input.session_id
+		? await loadTableBand(input.session_id, table.tableName)
+		: null;
 	// Workspace-wide count, NOT table-scoped: getPendingOverlays returns every
 	// un-superseded teach in the workspace (the helper leaves relevance to the
 	// caller). Surfaced as a coarse "a replay may be due" nudge — the description
@@ -201,7 +272,48 @@ export async function lookTable(
 		analyzed: cols.some((c) => c.band !== null),
 		pending_teaches: pending.length,
 		columns: cols,
+		table_readiness: tableReadiness,
 	};
+}
+
+/** Resolve a session's table-grain readiness band for one table (DAT-415).
+ * begin_session seals table readiness at the `session:{id}` detect head; read that
+ * promoted run's `table:{name}` row. Null when the session never sealed or this
+ * table carries no table-grain row in it. */
+async function loadTableBand(
+	sessionId: string,
+	tableName: string,
+): Promise<TableReadiness | null> {
+	const [head] = await metadataDb
+		.select({ runId: metadataSnapshotHead.runId })
+		.from(metadataSnapshotHead)
+		.where(
+			and(
+				eq(metadataSnapshotHead.target, sessionHeadTarget(sessionId)),
+				eq(metadataSnapshotHead.stage, "detect"),
+			),
+		)
+		.limit(1);
+	const headRunId = head?.runId ?? null;
+	if (!headRunId) return null;
+
+	const [row] = await metadataDb
+		.select({
+			band: entropyReadiness.band,
+			worstIntentRisk: entropyReadiness.worstIntentRisk,
+			intents: entropyReadiness.intents,
+			topDrivers: entropyReadiness.topDrivers,
+		})
+		.from(entropyReadiness)
+		.where(
+			and(
+				eq(entropyReadiness.sessionId, sessionId),
+				eq(entropyReadiness.runId, headRunId),
+				eq(entropyReadiness.target, tableTargetKey(tableName)),
+			),
+		)
+		.limit(1);
+	return row ? projectTableBand(row) : null;
 }
 
 export const lookTableTool = toolDefinition({
@@ -210,13 +322,22 @@ export const lookTableTool = toolDefinition({
 		"Show a table's per-column readiness — ready/investigate/blocked across the " +
 		"query, aggregation, and reporting intents — with the top quality drivers " +
 		"per column. Read-only; reflects the latest analysis (the calibrated, " +
-		"persisted band). pending_teaches counts un-applied teaches across the " +
-		"workspace (not scoped to this table); if > 0, suggest a `replay` before " +
+		"persisted band). Pass a begin_session session_id to also get the table's " +
+		"whole-table readiness band (table_readiness) from that session; use " +
+		"`why_table` to explain it. pending_teaches counts un-applied teaches across " +
+		"the workspace (not scoped to this table); if > 0, suggest a `replay` before " +
 		"trusting the bands. Use `why_column` to explain a specific column's band.",
 	inputSchema: z.object({
 		table_id: z
 			.string()
 			.describe("The table to inspect (a table_id from list_tables)."),
+		session_id: z
+			.string()
+			.optional()
+			.describe(
+				"Optional begin_session session_id — when set, also returns the " +
+					"table-grain readiness band sealed in that session.",
+			),
 	}),
 	outputSchema: LookTableResult,
 }).server((input) => lookTable(input));

--- a/packages/cockpit/src/tools/registry.test.ts
+++ b/packages/cockpit/src/tools/registry.test.ts
@@ -27,6 +27,7 @@ describe("tool registry (DAT-353)", () => {
 				"list_verticals",
 				"look_table",
 				"why_column",
+				"why_table",
 				"look_relationships",
 				"why_relationship",
 				"run_sql",
@@ -56,6 +57,7 @@ describe("tool registry (DAT-353)", () => {
 		expect(byName.get("list_verticals")?.needsApproval ?? false).toBe(false);
 		expect(byName.get("look_table")?.needsApproval ?? false).toBe(false);
 		expect(byName.get("why_column")?.needsApproval ?? false).toBe(false);
+		expect(byName.get("why_table")?.needsApproval ?? false).toBe(false);
 		expect(byName.get("look_relationships")?.needsApproval ?? false).toBe(
 			false,
 		);

--- a/packages/cockpit/src/tools/registry.ts
+++ b/packages/cockpit/src/tools/registry.ts
@@ -22,6 +22,7 @@ import { teachTool } from "./teach";
 import { uploadTool } from "./upload";
 import { whyColumnTool } from "./why-column";
 import { whyRelationshipTool } from "./why-relationship";
+import { whyTableTool } from "./why-table";
 import { workflowStatusTool } from "./workflow-status";
 
 export const tools = [
@@ -31,6 +32,7 @@ export const tools = [
 	uploadTool,
 	lookTableTool,
 	whyColumnTool,
+	whyTableTool,
 	lookRelationshipsTool,
 	whyRelationshipTool,
 	runSqlTool,

--- a/packages/cockpit/src/tools/why-table.test.ts
+++ b/packages/cockpit/src/tools/why-table.test.ts
@@ -1,0 +1,123 @@
+// Unit tests for why_table's pure data assembly (DAT-415). No DB, no LLM — the
+// Drizzle reads + the Anthropic synthesis are smoke-covered; here we pin the
+// per-intent driver pass-through, evidence dimension_path + detail rendering,
+// signal_count, and the found/analyzed distinctions.
+
+import { describe, expect, it, vi } from "vitest";
+
+// Importing the tool pulls config.ts + the metadata client + the anthropic
+// adapter; mock the env-dependent ones (sets no process.env — see registry.test.ts).
+vi.mock("#/config", () => ({ config: { anthropicApiKey: "test" } }));
+vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
+
+import {
+	projectWhyTable,
+	type WhyTableEvidenceRow,
+	type WhyTableReadinessRow,
+} from "./why-table";
+
+const TABLE_ID = "t_payments";
+const TABLE_NAME = "payments";
+
+function readiness(
+	overrides: Partial<WhyTableReadinessRow> = {},
+): WhyTableReadinessRow {
+	return {
+		band: "investigate",
+		worstIntentRisk: 0.42,
+		intents: [
+			{
+				intent: "reporting_intent",
+				band: "investigate",
+				risk: 0.42,
+				drivers: [
+					{
+						node: "dimension_coverage",
+						dimension_path: "semantic.coverage.dimension_coverage",
+						label: "Dimension Coverage",
+						state: "high",
+						impact_delta: 0.3,
+					},
+				],
+			},
+		],
+		...overrides,
+	};
+}
+
+function evidenceRow(
+	overrides: Partial<WhyTableEvidenceRow> = {},
+): WhyTableEvidenceRow {
+	return {
+		layer: "semantic",
+		dimension: "coverage",
+		subDimension: "dimension_coverage",
+		score: 0.22,
+		detectorId: "dimension_coverage",
+		evidence: { uncovered_dimensions: 2, covered: 7 },
+		...overrides,
+	};
+}
+
+describe("projectWhyTable (DAT-415)", () => {
+	it("assembles table identity, per-intent drivers, and correlated evidence", () => {
+		const out = projectWhyTable(
+			TABLE_ID,
+			TABLE_NAME,
+			readiness(),
+			[evidenceRow()],
+			0,
+		);
+		expect(out.table_id).toBe(TABLE_ID);
+		expect(out.table_name).toBe(TABLE_NAME);
+		expect(out.found).toBe(true);
+		expect(out.band).toBe("investigate");
+		expect(out.analyzed).toBe(true);
+		// why_table KEEPS the full per-intent drivers (look_table drops them).
+		expect(out.intents[0].drivers).toHaveLength(1);
+		expect(out.intents[0].drivers[0].label).toBe("Dimension Coverage");
+		// Evidence: dimension_path composed layer.dimension.subDimension; detail = JSON.
+		expect(out.evidence[0].dimension_path).toBe(
+			"semantic.coverage.dimension_coverage",
+		);
+		expect(out.evidence[0].detector_id).toBe("dimension_coverage");
+		expect(out.evidence[0].detail).toContain("uncovered_dimensions");
+		expect(out.signal_count).toBe(1);
+	});
+
+	it("treats a missing readiness row with evidence as found-but-unanalyzed", () => {
+		const out = projectWhyTable(TABLE_ID, TABLE_NAME, null, [evidenceRow()], 0);
+		expect(out.found).toBe(true); // evidence exists
+		expect(out.analyzed).toBe(false); // but no band
+		expect(out.band).toBeNull();
+		expect(out.intents).toEqual([]);
+		expect(out.signal_count).toBe(1);
+	});
+
+	it("treats no readiness and no evidence as not-found", () => {
+		const out = projectWhyTable(TABLE_ID, TABLE_NAME, null, [], 0);
+		expect(out.found).toBe(false);
+		expect(out.analyzed).toBe(false);
+		expect(out.evidence).toEqual([]);
+	});
+
+	it("carries a null table_name (stale id) through without throwing", () => {
+		const out = projectWhyTable(TABLE_ID, null, null, [], 3);
+		expect(out.table_name).toBeNull();
+		expect(out.found).toBe(false);
+		expect(out.pending_teaches).toBe(3);
+	});
+
+	it("degrades a malformed intents blob to empty rather than throwing", () => {
+		const out = projectWhyTable(
+			TABLE_ID,
+			TABLE_NAME,
+			readiness({ intents: "garbage" }),
+			[],
+			2,
+		);
+		expect(out.intents).toEqual([]);
+		expect(out.band).toBe("investigate"); // scalar still comes through
+		expect(out.pending_teaches).toBe(2);
+	});
+});

--- a/packages/cockpit/src/tools/why-table.ts
+++ b/packages/cockpit/src/tools/why-table.ts
@@ -1,0 +1,306 @@
+// why_table tool (DAT-415) — explain one table's table-grain readiness.
+//
+// The per-table drill-down behind look_table's `table_readiness`, the table analog
+// of why_column / why_relationship. begin_session's session_detect writes
+// table-grain readiness + detector evidence (from `dimension_coverage`) keyed by a
+// `table:{table_name}` target (DAT-415), sealed under a `session:{id}` head. This
+// reads the PRE-COMPUTED diagnosis (per-intent drivers from `entropy_readiness`,
+// raw detector evidence from `entropy_objects`) for the promoted run, then asks
+// Anthropic for ONE grounded narrative explaining why the table lands in its band
+// per intent. It does NOT recompute readiness (the engine owns the rollup) and
+// does NOT propose teaches.
+//
+// Read-only → no approval. The pure row→shape assembly (`projectWhyTable`) is
+// unit-tested; the live DB read + the LLM synthesis are smoke-covered.
+
+import { chat, toolDefinition } from "@tanstack/ai";
+import { createAnthropicChat } from "@tanstack/ai-anthropic";
+import { and, asc, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { config } from "../config";
+import { metadataDb } from "../db/metadata/client";
+import { getPendingOverlays } from "../db/metadata/pending-overlays";
+import {
+	PersistedIntent,
+	ReadinessDriver,
+} from "../db/metadata/readiness-schemas";
+import {
+	sessionHeadTarget,
+	tableTargetKey,
+} from "../db/metadata/relationship-target";
+import {
+	entropyObjects,
+	entropyReadiness,
+	metadataSnapshotHead,
+	tables,
+} from "../db/metadata/schema";
+import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
+import { getWhyInstructions } from "../prompts";
+
+// --- Tool output (mirrors why_column / why_relationship, keyed on the table).
+
+const IntentExplanation = z.object({
+	intent: z.string(),
+	band: z.string(),
+	risk: z.number(),
+	drivers: z.array(ReadinessDriver),
+});
+
+const EvidenceSignal = z.object({
+	dimension_path: z.string(),
+	detector_id: z.string(),
+	score: z.number(),
+	detail: z.string(),
+});
+
+const WhyTableResult = z.object({
+	table_id: z.string(),
+	// Display name; null when the table id no longer resolves (a dropped table).
+	table_name: z.string().nullable(),
+	// False when the table matched no table-grain readiness row AND no evidence in
+	// the promoted run — distinct from "found but not analyzed".
+	found: z.boolean(),
+	band: z.string().nullable(),
+	worst_intent_risk: z.number().nullable(),
+	analyzed: z.boolean(),
+	intents: z.array(IntentExplanation),
+	evidence: z.array(EvidenceSignal),
+	signal_count: z.number(),
+	analysis: z.string(),
+	pending_teaches: z.number(),
+});
+export type WhyTableResult = z.infer<typeof WhyTableResult>;
+
+/** The structured non-narrative payload (everything except `analysis`). */
+export type WhyTableData = Omit<WhyTableResult, "analysis">;
+
+/** The table's readiness row from the promoted run (null fields = no row). */
+export interface WhyTableReadinessRow {
+	band: string | null;
+	worstIntentRisk: number | null;
+	intents: unknown;
+}
+
+/** One entropy_objects row for the table target. */
+export interface WhyTableEvidenceRow {
+	layer: string;
+	dimension: string;
+	subDimension: string;
+	score: number;
+	detectorId: string;
+	evidence: unknown;
+}
+
+function renderDetail(evidence: unknown): string {
+	if (evidence === null || evidence === undefined) return "";
+	return JSON.stringify(evidence);
+}
+
+/**
+ * Assemble the structured why-payload from the readiness row + evidence rows.
+ * Pure (no DB, no LLM) so the parsing + correlation is unit-testable. `found`
+ * distinguishes "no such table-grain row in this run" (null readiness, no
+ * evidence) from "found but no readiness row". A malformed intents blob degrades
+ * to empty.
+ */
+export function projectWhyTable(
+	tableId: string,
+	tableName: string | null,
+	readiness: WhyTableReadinessRow | null,
+	evidenceRows: WhyTableEvidenceRow[],
+	pendingTeaches: number,
+): WhyTableData {
+	const parsed = readiness
+		? PersistedIntent.array().safeParse(readiness.intents)
+		: null;
+	const intents: z.infer<typeof IntentExplanation>[] = parsed?.success
+		? parsed.data.map((i) => ({
+				intent: i.intent,
+				band: i.band,
+				risk: i.risk,
+				drivers: i.drivers,
+			}))
+		: [];
+
+	const evidence: z.infer<typeof EvidenceSignal>[] = evidenceRows.map((e) => ({
+		dimension_path: `${e.layer}.${e.dimension}.${e.subDimension}`,
+		detector_id: e.detectorId,
+		score: e.score,
+		detail: renderDetail(e.evidence),
+	}));
+
+	return {
+		table_id: tableId,
+		table_name: tableName,
+		// Found = there's either a readiness row or at least one evidence signal for
+		// the table in the promoted run.
+		found: readiness !== null || evidence.length > 0,
+		band: readiness?.band ?? null,
+		worst_intent_risk: readiness?.worstIntentRisk ?? null,
+		analyzed: (readiness?.band ?? null) !== null,
+		intents,
+		evidence,
+		signal_count: evidence.length,
+		pending_teaches: pendingTeaches,
+	};
+}
+
+/** Synthesize the grounded narrative via one forced Anthropic call (split out so
+ * the assembly is testable apart from the LLM). The model sees only the band +
+ * drivers + evidence we pass — and the same why instructions as why_column. */
+export async function synthesizeAnalysis(data: WhyTableData): Promise<string> {
+	const label = data.table_name ?? data.table_id;
+	const result = await chat({
+		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
+		maxTokens: MAX_OUTPUT_TOKENS,
+		systemPrompts: [getWhyInstructions()],
+		messages: [
+			{
+				role: "user",
+				content: `Explain the readiness for the table "${label}", grounded only in these signals:\n\n${JSON.stringify(
+					{
+						band: data.band,
+						intents: data.intents,
+						evidence: data.evidence,
+						signal_count: data.signal_count,
+					},
+					null,
+					2,
+				)}`,
+			},
+		],
+		outputSchema: z.object({
+			analysis: z
+				.string()
+				.describe(
+					"The grounded narrative explaining why the table lands in its band per intent — drawn ONLY from the provided drivers + evidence, no outside facts.",
+				),
+		}),
+	});
+	return result.analysis;
+}
+
+export interface WhyTableInput {
+	session_id: string;
+	table_id: string;
+}
+
+/** Explain one table's table-grain readiness: pre-computed drivers + evidence + narrative. */
+export async function whyTable(input: WhyTableInput): Promise<WhyTableResult> {
+	// Resolve the table name up front — it's the target key AND the display label,
+	// and even an unanalyzed table has a name. Null only when the id is stale.
+	const [table] = await metadataDb
+		.select({ tableName: tables.tableName })
+		.from(tables)
+		.where(eq(tables.tableId, input.table_id))
+		.limit(1);
+	const tableName = table?.tableName ?? null;
+
+	const pending = await getPendingOverlays();
+
+	// A stale table id has no name → no target to read; return a not-found shell.
+	if (tableName === null) {
+		return {
+			...projectWhyTable(input.table_id, null, null, [], pending.length),
+			analysis: "",
+		};
+	}
+
+	const target = tableTargetKey(tableName);
+
+	// Table-grain readiness/evidence is sealed at session grain (DAT-415): pick the
+	// PROMOTED begin_session detect run via the per-session head, then read only
+	// that run's rows. No promoted run → unanalyzed.
+	const [head] = await metadataDb
+		.select({ runId: metadataSnapshotHead.runId })
+		.from(metadataSnapshotHead)
+		.where(
+			and(
+				eq(metadataSnapshotHead.target, sessionHeadTarget(input.session_id)),
+				eq(metadataSnapshotHead.stage, "detect"),
+			),
+		)
+		.limit(1);
+	const headRunId = head?.runId ?? null;
+
+	const [readinessRow] = headRunId
+		? await metadataDb
+				.select({
+					band: entropyReadiness.band,
+					worstIntentRisk: entropyReadiness.worstIntentRisk,
+					intents: entropyReadiness.intents,
+				})
+				.from(entropyReadiness)
+				.where(
+					and(
+						eq(entropyReadiness.sessionId, input.session_id),
+						eq(entropyReadiness.target, target),
+						eq(entropyReadiness.runId, headRunId),
+					),
+				)
+				.limit(1)
+		: [];
+
+	// Evidence is keyed by the table target (table-grain rows have no column_id),
+	// scoped to the SAME promoted run so stale runs don't inflate signal_count.
+	const evidenceRows = headRunId
+		? await metadataDb
+				.select({
+					layer: entropyObjects.layer,
+					dimension: entropyObjects.dimension,
+					subDimension: entropyObjects.subDimension,
+					score: entropyObjects.score,
+					detectorId: entropyObjects.detectorId,
+					evidence: entropyObjects.evidence,
+				})
+				.from(entropyObjects)
+				.where(
+					and(
+						eq(entropyObjects.sessionId, input.session_id),
+						eq(entropyObjects.target, target),
+						eq(entropyObjects.runId, headRunId),
+					),
+				)
+				.orderBy(asc(entropyObjects.dimension))
+		: [];
+
+	const data = projectWhyTable(
+		input.table_id,
+		tableName,
+		readinessRow ?? null,
+		evidenceRows,
+		pending.length,
+	);
+
+	// Nothing to explain when there's no readiness row — skip the LLM call.
+	const analysis = data.analyzed ? await synthesizeAnalysis(data) : "";
+
+	return { ...data, analysis };
+}
+
+export const whyTableTool = toolDefinition({
+	name: "why_table",
+	description:
+		"Explain ONE table's whole-table readiness — why it lands in its band for the " +
+		"query, aggregation, and reporting intents — grounded in the persisted " +
+		"drivers (ranked by how much fixing each would help) and the underlying " +
+		"detector evidence, with a short synthesized explanation. Read-only. Use " +
+		"after look_table (with a session_id) to drill into the table-grain band; " +
+		"identify it by its table_id and the begin_session session_id. signal_count " +
+		"shows how many detector signals back the explanation — a low count means the " +
+		"picture is partial.",
+	inputSchema: z.object({
+		session_id: z
+			.string()
+			.describe(
+				"The begin_session session the table-grain readiness belongs to.",
+			),
+		table_id: z
+			.string()
+			.describe(
+				"The table to explain (a table_id from list_tables / look_table).",
+			),
+	}),
+	outputSchema: WhyTableResult,
+}).server((input) => whyTable(input));

--- a/packages/cockpit/src/tools/why-table.ts
+++ b/packages/cockpit/src/tools/why-table.ts
@@ -197,12 +197,11 @@ export async function whyTable(input: WhyTableInput): Promise<WhyTableResult> {
 		.limit(1);
 	const tableName = table?.tableName ?? null;
 
-	const pending = await getPendingOverlays();
-
 	// A stale table id has no name → no target to read; return a not-found shell.
+	// No table ⇒ no pending teaches to attribute to it, so skip the workspace query.
 	if (tableName === null) {
 		return {
-			...projectWhyTable(input.table_id, null, null, [], pending.length),
+			...projectWhyTable(input.table_id, null, null, [], 0),
 			analysis: "",
 		};
 	}
@@ -265,6 +264,7 @@ export async function whyTable(input: WhyTableInput): Promise<WhyTableResult> {
 				.orderBy(asc(entropyObjects.dimension))
 		: [];
 
+	const pending = await getPendingOverlays();
 	const data = projectWhyTable(
 		input.table_id,
 		tableName,

--- a/packages/cockpit/src/ui/cockpit/widgets/table-readiness.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-readiness.test.tsx
@@ -68,6 +68,9 @@ const analyzed: LookTableResult = {
 			top_drivers: [],
 		},
 	],
+	// The begin_session whole-table band (DAT-415) — null here: this widget renders
+	// the add_source per-column grid; surfacing the table-grain band is a follow-up.
+	table_readiness: null,
 };
 
 describe("TableReadinessWidget (DAT-350)", () => {

--- a/packages/cockpit/src/ui/cockpit/widgets/table-readiness.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-readiness.test.tsx
@@ -96,6 +96,39 @@ describe("TableReadinessWidget (DAT-350)", () => {
 		expect(amountRow.getAllByText("investigate")).toHaveLength(2);
 	});
 
+	it("renders the whole-table band summary when table_readiness is present (DAT-415)", () => {
+		renderWidget({
+			...analyzed,
+			table_readiness: {
+				band: "investigate",
+				worst_intent_risk: 0.42,
+				intents: [
+					{ intent: "query_intent", band: "ready", risk: 0.1 },
+					{ intent: "reporting_intent", band: "investigate", risk: 0.42 },
+				],
+				top_drivers: [
+					{ label: "Dimension Coverage", state: "high", impact_delta: 0.3 },
+				],
+			},
+		});
+		const overall = within(
+			screen.getByTestId("canvas-table-readiness-overall"),
+		);
+		expect(
+			overall.getByText("Whole-table readiness (this session)"),
+		).toBeTruthy();
+		expect(overall.getByText("Dimension Coverage")).toBeTruthy();
+		// Overall band + the populated per-intent badges (query=ready,
+		// reporting=investigate) — "investigate" twice (overall + reporting).
+		expect(overall.getAllByText("investigate")).toHaveLength(2);
+		expect(overall.getAllByText("ready")).toHaveLength(1);
+	});
+
+	it("omits the whole-table summary for a plain add_source view (no session)", () => {
+		renderWidget(analyzed); // table_readiness: null
+		expect(screen.queryByTestId("canvas-table-readiness-overall")).toBeNull();
+	});
+
 	it("shows the not-analyzed note when no column has a band", () => {
 		renderWidget({
 			...analyzed,

--- a/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
@@ -9,6 +9,7 @@
 
 import { Alert, Anchor, Badge, Group, Stack, Table, Text } from "@mantine/core";
 import { displayTableName } from "#/lib/display-names";
+import type { TableReadiness } from "#/tools/look-table";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
 import { useCockpitActions } from "#/ui/cockpit/cockpit-state";
 
@@ -54,6 +55,47 @@ function BandBadge({ band }: { band: string | null | undefined }) {
 	);
 }
 
+// The begin_session whole-table band (DAT-415): the `dimension_coverage` rollup
+// for the table, sealed at the session head — distinct from, and shown above, the
+// add_source per-column grid below. Only rendered when look_table was called with
+// a session_id (else `table_readiness` is null and this is skipped). Per-intent
+// badges appear only when the rollup populated them (a clean table carries an
+// empty intents list — show just the overall band rather than a row of dashes).
+function TableBandSummary({ band }: { band: TableReadiness }) {
+	const bandByIntent = new Map(band.intents.map((i) => [i.intent, i.band]));
+	return (
+		<Group
+			gap="sm"
+			align="center"
+			wrap="wrap"
+			data-testid="canvas-table-readiness-overall"
+		>
+			<Text size="sm" fw={500}>
+				Whole-table readiness (this session)
+			</Text>
+			<BandBadge band={band.band} />
+			{band.intents.length > 0 &&
+				INTENTS.map((intent) => (
+					<Group key={intent} gap={4} align="center">
+						<Text span size="xs" c="dimmed">
+							{INTENT_LABEL[intent]}
+						</Text>
+						<BandBadge band={bandByIntent.get(intent)} />
+					</Group>
+				))}
+			{band.top_drivers.length > 0 && (
+				<Group gap={4} wrap="wrap">
+					{band.top_drivers.map((d) => (
+						<Text key={d.label} span size="xs" c="dimmed">
+							{d.label}
+						</Text>
+					))}
+				</Group>
+			)}
+		</Group>
+	);
+}
+
 export function TableReadinessWidget({
 	state,
 }: {
@@ -96,6 +138,10 @@ export function TableReadinessWidget({
 			<Text size="sm" fw={600}>
 				{tableLabel} — readiness
 			</Text>
+
+			{readiness.table_readiness && (
+				<TableBandSummary band={readiness.table_readiness} />
+			)}
 
 			{!readiness.analyzed && (
 				<Alert color="gray" data-testid="canvas-table-readiness-unanalyzed">

--- a/packages/engine/src/dataraum/analysis/typing/recipe.py
+++ b/packages/engine/src/dataraum/analysis/typing/recipe.py
@@ -88,7 +88,9 @@ def store_recipe(
     )
 
 
-def _order_by_dependency(recipes: list[MaterializationRecipe]) -> list[MaterializationRecipe]:
+def order_recipes_by_dependency(
+    recipes: list[MaterializationRecipe],
+) -> list[MaterializationRecipe]:
     """Order recipes so a DDL runs after the artifacts it reads from.
 
     Each recipe's ``target_fqn`` is matched against the ``depends_on`` of the
@@ -159,7 +161,7 @@ def _replay(
     rebuilt: list[str] = []
     duckdb_conn.execute("BEGIN TRANSACTION")
     try:
-        for recipe in _order_by_dependency(recipes):
+        for recipe in order_recipes_by_dependency(recipes):
             duckdb_conn.execute(recipe.ddl)
             rebuilt.append(recipe.target_fqn)
     except Exception:

--- a/packages/engine/src/dataraum/analysis/views/builder.py
+++ b/packages/engine/src/dataraum/analysis/views/builder.py
@@ -23,33 +23,38 @@ class DimensionJoin:
 
 
 def build_enriched_view_sql(
-    fact_table_name: str,
-    fact_duckdb_path: str,
+    view_fqn: str,
+    fact_fqn: str,
     dimension_joins: list[DimensionJoin],
-) -> tuple[str, str, list[str]]:
-    """Build SQL for an enriched view joining fact + dimension tables.
+) -> tuple[str, list[str]]:
+    """Build the ``CREATE OR REPLACE VIEW`` SQL for an enriched view.
 
-    Creates a DuckDB CREATE OR REPLACE VIEW statement that LEFT JOINs
-    the fact table with qualifying dimension tables.
+    Every table identity is a fully-qualified DuckDB name
+    (``catalog.schema."name"``) **composed by the caller** — the view target and
+    each source — so the view is collision-free across sources (the bare
+    ``enriched_{table}`` name would clash for two sources that each have an
+    ``orders`` fact). The caller derives ``view_fqn`` from the fact's
+    collision-safe ``duckdb_path`` (``enriched_{source}__{table}``), so a
+    ``CREATE OR REPLACE`` only ever replaces *this* view on a re-run.
 
     Column naming:
-    - Fact columns: f.* (all columns from fact table)
-    - Dimension columns: {dim_table}__{column} (excluding PK/FK columns)
+    - Fact columns: ``f.*`` (all columns from the fact table)
+    - Dimension columns: ``{fact_fk_column}__{column}`` (FK-prefixed so repeated
+      joins of the same dimension table stay distinct)
 
     Args:
-        fact_table_name: Name of the fact table
-        fact_duckdb_path: DuckDB path to the fact table
-        dimension_joins: List of dimension joins to include
+        view_fqn: Fully-qualified create target, e.g. ``lake.typed."enriched_csv__orders"``.
+        fact_fqn: Fully-qualified fact-table source.
+        dimension_joins: Joins to include; each ``dim_duckdb_path`` is the
+            dimension's FQN.
 
     Returns:
-        Tuple of (view_name, create_view_sql, dimension_column_names)
+        Tuple of ``(create_view_sql, dimension_column_names)``.
     """
-    view_name = f"enriched_{fact_table_name}"
-
     if not dimension_joins:
-        # No joins — view is just the fact table
-        sql = f'CREATE OR REPLACE VIEW "{view_name}" AS SELECT * FROM "{fact_duckdb_path}"'
-        return view_name, sql, []
+        # No joins — view is just the fact table.
+        sql = f"CREATE OR REPLACE VIEW {view_fqn} AS SELECT * FROM {fact_fqn}"
+        return sql, []
 
     # Build SELECT clause
     select_parts = ["f.*"]
@@ -86,20 +91,20 @@ def build_enriched_view_sql(
     join_clauses = []
     for join, alias in zip(dimension_joins, join_aliases, strict=True):
         join_clauses.append(
-            f'LEFT JOIN "{join.dim_duckdb_path}" AS {alias} '
+            f"LEFT JOIN {join.dim_duckdb_path} AS {alias} "
             f'ON f."{join.fact_fk_column}" = {alias}."{join.dim_pk_column}"'
         )
 
     joins_sql = "\n".join(join_clauses)
 
     sql = (
-        f'CREATE OR REPLACE VIEW "{view_name}" AS\n'
+        f"CREATE OR REPLACE VIEW {view_fqn} AS\n"
         f"SELECT\n    {select_clause}\n"
-        f'FROM "{fact_duckdb_path}" AS f\n'
+        f"FROM {fact_fqn} AS f\n"
         f"{joins_sql}"
     )
 
-    return view_name, sql, dimension_column_names
+    return sql, dimension_column_names
 
 
 def _table_alias(table_name: str) -> str:

--- a/packages/engine/src/dataraum/analysis/views/db_models.py
+++ b/packages/engine/src/dataraum/analysis/views/db_models.py
@@ -27,12 +27,13 @@ class EnrichedView(Base):
     """Record of an enriched DuckDB view.
 
     Tracks views created by joining fact tables with their confirmed
-    dimension tables. The view *definition* is run-versioned (``run_id``,
-    DAT-415): a begin_session run stamps its rows and prior runs' rows coexist,
-    so a reset/diff can resolve a target run. The view's ``CREATE VIEW`` DDL is
-    NOT stored here — it lives in the versioned
-    :class:`~dataraum.analysis.typing.db_models.MaterializationRecipe`
-    (``layer="enriched"``), the single rebuild source (DAT-414 substrate).
+    dimension tables. **Latest-only** (DAT-415): one row per ``fact_table_id``,
+    reconciled in place each run — ``run_id`` is a provenance stamp (the run that
+    last materialized it), NOT a version axis. The version history + reset live in
+    the :class:`~dataraum.analysis.typing.db_models.MaterializationRecipe`
+    (``layer="enriched"``) — the view's ``CREATE VIEW`` DDL is stored there
+    (sqlglot-gated, the single rebuild source), never here. ``view_sql`` was
+    removed (it was write-only).
     """
 
     __tablename__ = "enriched_views"

--- a/packages/engine/src/dataraum/analysis/views/db_models.py
+++ b/packages/engine/src/dataraum/analysis/views/db_models.py
@@ -27,8 +27,12 @@ class EnrichedView(Base):
     """Record of an enriched DuckDB view.
 
     Tracks views created by joining fact tables with their confirmed
-    dimension tables. The view SQL and metadata are stored for
-    reproducibility and downstream consumption.
+    dimension tables. The view *definition* is run-versioned (``run_id``,
+    DAT-415): a begin_session run stamps its rows and prior runs' rows coexist,
+    so a reset/diff can resolve a target run. The view's ``CREATE VIEW`` DDL is
+    NOT stored here — it lives in the versioned
+    :class:`~dataraum.analysis.typing.db_models.MaterializationRecipe`
+    (``layer="enriched"``), the single rebuild source (DAT-414 substrate).
     """
 
     __tablename__ = "enriched_views"
@@ -50,7 +54,10 @@ class EnrichedView(Base):
     view_table = relationship("Table", foreign_keys=[view_table_id])
 
     view_name: Mapped[str] = mapped_column(String, nullable=False)
-    view_sql: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Snapshot version axis (DAT-413/DAT-415): the begin_session run that
+    # materialized this view definition. None for non-run callers (tests).
+    run_id: Mapped[str | None] = mapped_column(String, index=True)
 
     # Which relationships were used to build this view
     relationship_ids: Mapped[list[str] | None] = mapped_column(JSON)

--- a/packages/engine/src/dataraum/analysis/views/recipe.py
+++ b/packages/engine/src/dataraum/analysis/views/recipe.py
@@ -37,8 +37,16 @@ logger = get_logger(__name__)
 
 
 def _bare_name(target_fqn: str) -> str:
-    """``lake.typed."enriched_x"`` → ``enriched_x`` (the last quoted segment)."""
-    return target_fqn.split('"')[-2]
+    """``lake.typed."enriched_x"`` → ``enriched_x`` (the last quoted segment).
+
+    Every enriched recipe ``target_fqn`` is composed via ``_lake_fqn`` and so
+    always quotes the bare segment; a target without quotes is a corrupt recipe
+    row — fail loud rather than silently mis-derive a name during a reset.
+    """
+    parts = target_fqn.split('"')
+    if len(parts) < 3:
+        raise ValueError(f"enriched recipe target_fqn is not a quoted FQN: {target_fqn!r}")
+    return parts[-2]
 
 
 def _enriched_fqn(bare: str) -> str:

--- a/packages/engine/src/dataraum/analysis/views/recipe.py
+++ b/packages/engine/src/dataraum/analysis/views/recipe.py
@@ -1,0 +1,113 @@
+"""Session-scoped rebuild/reset of enriched views from their versioned recipes (DAT-415).
+
+begin_session seals at one head (``session:{id}``/``detect``); there is no
+per-view head, so the *current* enriched view definitions are the latest stored
+:class:`~dataraum.analysis.typing.db_models.MaterializationRecipe` (``layer=
+"enriched"``) per fact for the session — sqlglot-gated storage (the
+``enriched_views`` phase) re-stamps a fact's recipe only when its DDL changes, so
+the most recent row per fact IS that fact's live definition.
+
+:func:`rebuild_enriched_views` re-materializes the lake to that set —
+re-executing each recipe transactionally in dependency order (the lake is
+latest-only, so a reset is a re-materialization from the versioned DDL, not a
+re-derivation of the phase) — and drops any physical enriched view this session
+produced in an earlier run that the current set no longer contains. Scoped to the
+session's own recipes throughout, so a reset never touches another session's
+views in the shared ``lake.typed`` schema. Forward-orphan GC of views with no
+recipe at all is deferred to Slice C (DAT-416).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from dataraum.analysis.typing.db_models import MaterializationRecipe
+from dataraum.analysis.typing.recipe import order_recipes_by_dependency
+from dataraum.core.duckdb_naming import schema_for_layer
+from dataraum.core.logging import get_logger
+from dataraum.server.storage import LAKE_CATALOG_ALIAS
+
+if TYPE_CHECKING:
+    import duckdb
+    from sqlalchemy.orm import Session
+
+logger = get_logger(__name__)
+
+
+def _bare_name(target_fqn: str) -> str:
+    """``lake.typed."enriched_x"`` → ``enriched_x`` (the last quoted segment)."""
+    return target_fqn.split('"')[-2]
+
+
+def _enriched_fqn(bare: str) -> str:
+    """Compose the fully-qualified enriched-view name from its bare name."""
+    return f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("enriched")}."{bare}"'
+
+
+def rebuild_enriched_views(
+    session: Session,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    *,
+    session_id: str,
+) -> list[str]:
+    """Re-materialize the session's enriched views from their recipes + drop strays.
+
+    Re-executes the current (latest-per-fact) enriched recipes transactionally in
+    dependency order, then drops any physical enriched view this session produced
+    in an earlier run that the current set no longer contains. Atomic: a
+    mid-rebuild failure rolls the whole reset back rather than leaving the lake
+    half-materialized.
+
+    Args:
+        session: Active SQLAlchemy session.
+        duckdb_conn: DuckDB connection (USE-scoped to ``lake.typed``) to execute against.
+        session_id: The investigation session whose enriched views to rebuild.
+
+    Returns:
+        The ``target_fqn``s rebuilt, in execution order.
+    """
+    # All of the session's enriched recipes, newest first. The first row seen per
+    # fact (``table_id``) is its live definition; the full set is the universe of
+    # view names this session has ever produced (for safe, session-scoped strays).
+    rows = list(
+        session.execute(
+            select(MaterializationRecipe)
+            .where(
+                MaterializationRecipe.session_id == session_id,
+                MaterializationRecipe.layer == "enriched",
+            )
+            .order_by(MaterializationRecipe.created_at.desc())
+        ).scalars()
+    )
+    latest: dict[str, MaterializationRecipe] = {}
+    session_bares: set[str] = set()
+    for recipe in rows:
+        latest.setdefault(recipe.table_id, recipe)
+        session_bares.add(_bare_name(recipe.target_fqn))
+
+    target = list(latest.values())
+    target_bares = {_bare_name(r.target_fqn) for r in target}
+    stray_bares = session_bares - target_bares
+
+    rebuilt: list[str] = []
+    duckdb_conn.execute("BEGIN TRANSACTION")
+    try:
+        for recipe in order_recipes_by_dependency(target):
+            duckdb_conn.execute(recipe.ddl)
+            rebuilt.append(recipe.target_fqn)
+        for bare in stray_bares:
+            duckdb_conn.execute(f"DROP VIEW IF EXISTS {_enriched_fqn(bare)}")
+    except Exception:
+        duckdb_conn.execute("ROLLBACK")
+        raise
+    duckdb_conn.execute("COMMIT")
+
+    logger.info(
+        "enriched_views_rebuilt",
+        session_id=session_id,
+        rebuilt=len(rebuilt),
+        dropped=len(stray_bares),
+    )
+    return rebuilt

--- a/packages/engine/src/dataraum/core/sql_normalize.py
+++ b/packages/engine/src/dataraum/core/sql_normalize.py
@@ -1,0 +1,49 @@
+"""Canonical SQL comparison for recipe-equality checks (DAT-415).
+
+A view's ``CREATE VIEW`` DDL is re-derived on each begin_session run — the LLM
+selects which dimension joins to include. To decide whether a re-run produced a
+*genuinely* different view (rather than the same view with cosmetic syntax
+differences), we compare the two DDL strings in sqlglot's canonical form
+(parse -> re-render). Whitespace, keyword casing, and optional-token noise
+collapse, so a noise-only re-run does not mint a spurious new recipe version;
+identifiers (table and column names) are preserved, so a real join change still
+registers as different.
+
+sqlglot cannot canonicalize every dialect quirk; on a parse/tokenize failure the
+helper falls back to the stripped raw string, so the check degrades to
+byte-equality rather than raising. (Same duckdb-dialect idiom the retired MCP
+``cte_parser`` used — reimplemented here, not imported.)
+"""
+
+from __future__ import annotations
+
+import sqlglot
+from sqlglot.errors import SqlglotError
+
+_DIALECT = "duckdb"
+
+
+def canonical_sql(sql: str) -> str:
+    """Return ``sql`` in sqlglot's canonical duckdb rendering.
+
+    Falls back to the stripped input when sqlglot cannot parse it, so callers
+    can treat the result as a stable comparison key without guarding for
+    malformed SQL.
+    """
+    try:
+        parsed = sqlglot.parse_one(sql, dialect=_DIALECT)
+    except SqlglotError:
+        return sql.strip()
+    if parsed is None:
+        return sql.strip()
+    return parsed.sql(dialect=_DIALECT)
+
+
+def sql_equivalent(left: str, right: str) -> bool:
+    """True if two SQL statements are equal modulo syntax noise.
+
+    Compares the canonical form (:func:`canonical_sql`) of each side, so casing,
+    whitespace, and formatting differences are ignored while identifier and
+    structural changes are not.
+    """
+    return canonical_sql(left) == canonical_sql(right)

--- a/packages/engine/src/dataraum/entropy/detectors/semantic/dimension_coverage.py
+++ b/packages/engine/src/dataraum/entropy/detectors/semantic/dimension_coverage.py
@@ -1,9 +1,16 @@
 """Dimension coverage entropy detector.
 
-Measures NULL rate per dimension column on enriched views.
+Measures NULL rate per dimension column on a fact table's enriched view.
 A column with 80% NULLs provides unreliable slicing — this detector
-quantifies that uncertainty so contracts and the Bayesian network
-can factor it in.
+quantifies that uncertainty so contracts and the readiness rollup can
+factor it in.
+
+Table-scoped (DAT-415): the signal is emitted at ``table:{fact}`` granularity —
+the enriched view IS the fact table's enrichment, so its coverage rolls into the
+fact table's readiness (one band per table, not a separate ``view:`` target the
+network never rolled up). A typed table with no enriched view (a dimension table,
+or a fact whose enrichment was declined) loads no view → ``can_run`` is False →
+the detector is skipped for it.
 
 Source: EnrichedView + StatisticalProfile (persisted during enriched_views phase)
 Score = sqrt-boosted mean NULL rate across dimension columns
@@ -28,10 +35,12 @@ logger = get_logger(__name__)
 
 
 class DimensionCoverageDetector(EntropyDetector):
-    """Detector for dimension column coverage on enriched views.
+    """Detector for dimension column coverage on a fact table's enriched view.
 
     Measures how well dimension columns (added via LEFT JOIN) are populated.
-    High NULL rates in dimension columns mean unreliable slicing/grouping.
+    High NULL rates in dimension columns mean unreliable slicing/grouping. The
+    signal is scoped to the fact ``table:`` (DAT-415) so it rolls into that
+    table's readiness band.
 
     Source: EnrichedView metadata + StatisticalProfile records
     Score = mean NULL rate across all dimension columns.
@@ -41,19 +50,19 @@ class DimensionCoverageDetector(EntropyDetector):
     layer = Layer.SEMANTIC
     dimension = Dimension.COVERAGE
     sub_dimension = SubDimension.DIMENSION_COVERAGE
-    scope = "view"
+    scope = "table"
     required_analyses = [AnalysisKey.ENRICHED_VIEW]
-    description = "Measures NULL rate per dimension column on enriched views"
+    description = "Measures NULL rate per dimension column on a fact table's enriched view"
 
     def load_data(self, context: DetectorContext) -> None:
-        """Load EnrichedView metadata for the target view."""
-        if context.session is None or not context.view_name:
+        """Load the fact table's enriched view (None for non-fact tables → skipped)."""
+        if context.session is None or not context.table_id:
             return
 
         from dataraum.analysis.views.db_models import EnrichedView
 
         view = context.session.execute(
-            select(EnrichedView).where(EnrichedView.view_name == context.view_name)
+            select(EnrichedView).where(EnrichedView.fact_table_id == context.table_id)
         ).scalar_one_or_none()
 
         if view is not None:
@@ -94,7 +103,7 @@ class DimensionCoverageDetector(EntropyDetector):
             null_rate = null_rate_by_name.get(col)
             if null_rate is None:
                 # Fallback: query DuckDB directly (profile missing)
-                null_rate = self._query_null_rate(context, col)
+                null_rate = self._query_null_rate(context, col, view.view_name)
             null_rates.append(null_rate)
             evidence.append(
                 {
@@ -149,11 +158,13 @@ class DimensionCoverageDetector(EntropyDetector):
         }
 
     @staticmethod
-    def _query_null_rate(context: DetectorContext, column: str) -> float:
+    def _query_null_rate(context: DetectorContext, column: str, view_name: str) -> float:
         """Fallback: query DuckDB for the NULL rate of a column.
 
-        Used when StatisticalProfile records are not available.
-        Returns 1.0 if the query fails (assume worst case).
+        Used when StatisticalProfile records are not available. ``view_name`` is
+        the enriched view's bare name (table-scoped detection no longer carries it
+        on the context); the cursor is USE-scoped to ``lake.typed`` so the bare
+        name resolves. Returns 1.0 if the query fails (assume worst case).
         """
         if context.duckdb_conn is None:
             return 1.0
@@ -161,13 +172,13 @@ class DimensionCoverageDetector(EntropyDetector):
         try:
             result = context.duckdb_conn.execute(
                 f'SELECT COUNT(*) FILTER (WHERE "{column}" IS NULL) * 1.0 '
-                f'/ NULLIF(COUNT(*), 0) FROM "{context.view_name}"'
+                f'/ NULLIF(COUNT(*), 0) FROM "{view_name}"'
             ).fetchone()
             return float(result[0]) if result and result[0] is not None else 0.0
         except Exception:
             logger.warning(
                 "dimension_coverage_query_failed",
-                view=context.view_name,
+                view=view_name,
                 column=column,
                 exc_info=True,
             )

--- a/packages/engine/src/dataraum/entropy/readiness.py
+++ b/packages/engine/src/dataraum/entropy/readiness.py
@@ -73,6 +73,7 @@ def persist_readiness(
         return 0
 
     target_to_ids = _column_id_map(session, table_ids)
+    table_id_by_name = _table_id_by_name(session, table_ids)
 
     rows: list[EntropyReadinessRecord] = []
     for target, col in ctx.columns.items():
@@ -81,6 +82,15 @@ def persist_readiness(
             # spans two columns so it carries no single column FK.
             table_id: str | None = None
             column_id: str | None = None
+        elif target.startswith("table:"):
+            # Table-grain readiness (DAT-415): the fact table's dimension_coverage
+            # rolled up. Carries the table FK (so it deletes with the table set on
+            # replay) but no column FK — the identity is the table.
+            table_id = table_id_by_name.get(target.split(":", 1)[1])
+            column_id = None
+            if table_id is None:
+                logger.debug("readiness_table_target_unresolved", target=target)
+                continue
         else:
             ids = target_to_ids.get(target)
             if ids is None:
@@ -129,6 +139,20 @@ def _column_id_map(session: Session, table_ids: list[str]) -> dict[str, tuple[st
             continue
         out[f"column:{table_name}.{column_name}"] = (table_id, column_id)
     return out
+
+
+def _table_id_by_name(session: Session, table_ids: list[str]) -> dict[str, str]:
+    """Map ``table_name`` -> ``table_id`` for the session's tables.
+
+    Inverse of the ``table:{table_name}`` target the table-scoped detectors write
+    (``engine.py`` builds it as ``f"table:{table.table_name}"``).
+    """
+    return {
+        table_name: table_id
+        for table_id, table_name in session.execute(
+            select(Table.table_id, Table.table_name).where(Table.table_id.in_(table_ids))
+        )
+    }
 
 
 def _intents_payload(col: ColumnReadinessResult) -> list[dict[str, object]]:

--- a/packages/engine/src/dataraum/entropy/views/query_context.py
+++ b/packages/engine/src/dataraum/entropy/views/query_context.py
@@ -220,6 +220,13 @@ def network_to_column_summaries(
     """
     summaries: dict[str, ColumnSummary] = {}
     for target, col_result in readiness_ctx.columns.items():
+        # ``readiness_ctx.columns`` is keyed by target and now holds non-column
+        # grains too — ``relationship:`` (DAT-408) and ``table:`` (DAT-415) roll up
+        # the same network. The contract gate is per-column, so skip those: a
+        # ``table:orders`` target would otherwise surface as a junk column named
+        # ``table:orders`` and pollute the contract's dimension averages.
+        if not target.startswith("column:"):
+            continue
         col_key = target.removeprefix("column:")
         parts = col_key.split(".", 1)
         table_name = parts[0] if len(parts) > 1 else ""

--- a/packages/engine/src/dataraum/entropy/views/readiness_context.py
+++ b/packages/engine/src/dataraum/entropy/views/readiness_context.py
@@ -359,14 +359,20 @@ def assemble_readiness_context(
     for obj in objects:
         by_target.setdefault(obj.target, []).append(obj)
 
-    # Step 3: Targets that roll up the network — column AND relationship
-    # granularity (DAT-408) — vs the rest (table:/view:), which stay raw
+    # Step 3: Targets that roll up the network — column, relationship (DAT-408)
+    # AND table (DAT-415) granularity — vs the rest (view:), which stay raw
     # DirectSignals. The rollup (``_build_column_result``) is target-agnostic, so
-    # a relationship's objects roll up the same intents as a column's.
+    # a relationship's or a table's objects roll up the same intents as a
+    # column's. ``table:`` carries the fact table's dimension_coverage, which maps
+    # to the ``dimension_coverage`` network node → query/reporting intent bands.
     rollup_targets: dict[str, list[EntropyObject]] = {}
     other_targets: dict[str, list[EntropyObject]] = {}
     for target, target_objects in by_target.items():
-        if target.startswith("column:") or target.startswith("relationship:"):
+        if (
+            target.startswith("column:")
+            or target.startswith("relationship:")
+            or target.startswith("table:")
+        ):
             rollup_targets[target] = target_objects
         else:
             other_targets[target] = target_objects
@@ -643,6 +649,35 @@ def load_relationship_readiness(session: Session, session_id: str) -> list[Entro
             continue
         gated.append(rec)
     return gated
+
+
+def load_table_readiness(session: Session, session_id: str) -> list[EntropyReadinessRecord]:
+    """Current table-grain readiness for a begin_session (DAT-415).
+
+    Resolves the session's **current run** via the per-session head
+    (``session:{id}``, "detect") — begin_session seals per session, not per table,
+    and its terminal promote flips only that head — then returns that run's
+    ``table:`` readiness rows (one per fact table whose enriched view the
+    ``dimension_coverage`` detector measured). Returns ``[]`` until the session has
+    a promoted run. Unlike relationships, tables are never user-suppressed, so
+    there is no liveness gate. The cockpit reads these via Drizzle; this is the
+    engine-side reader (tests, agent context).
+    """
+    from dataraum.storage import session_head_target
+
+    current_run = head_run_id(session, session_head_target(session_id), "detect")
+    if current_run is None:
+        return []
+
+    return list(
+        session.execute(
+            select(EntropyReadinessRecord).where(
+                EntropyReadinessRecord.session_id == session_id,
+                EntropyReadinessRecord.run_id == current_run,
+                EntropyReadinessRecord.target.like("table:%"),
+            )
+        ).scalars()
+    )
 
 
 def _target_by_ids(session: Session, table_ids: list[str]) -> dict[tuple[str, str], str]:

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -16,6 +16,7 @@ Post-creation: verifies row count matches fact table. Drops view if grain violat
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import replace
 from datetime import UTC, datetime
 from types import ModuleType
 from typing import TYPE_CHECKING, Any
@@ -32,11 +33,13 @@ from dataraum.analysis.views.builder import DimensionJoin, build_enriched_view_s
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.analysis.views.enrichment_agent import EnrichmentAgent
 from dataraum.analysis.views.enrichment_models import EnrichmentAnalysisResult
+from dataraum.core.duckdb_naming import schema_for_layer
 from dataraum.core.logging import get_logger
 from dataraum.llm import PromptRenderer, create_provider, load_llm_config
 from dataraum.pipeline.base import PhaseContext, PhaseResult
 from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.registry import analysis_phase
+from dataraum.server.storage import LAKE_CATALOG_ALIAS
 from dataraum.storage import Column, Table
 
 if TYPE_CHECKING:
@@ -45,6 +48,15 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _MIN_CONFIDENCE = 0.7
+
+
+def _lake_fqn(layer: str, bare: str) -> str:
+    """Fully-qualified DuckDB name ``catalog.schema."bare"`` for a lake-layer artifact.
+
+    Enriched views resolve to the ``typed`` schema (``schema_for_layer`` default),
+    so the view, its fact, and its dimensions all qualify through one helper.
+    """
+    return f'{LAKE_CATALOG_ALIAS}.{schema_for_layer(layer)}."{bare}"'
 
 
 @analysis_phase
@@ -192,28 +204,34 @@ class EnrichedViewsPhase(BasePhase):
                     reason="no qualifying dimension joins",
                 )
 
+            # Collision-free identities: name the view off the fact's
+            # source-qualified duckdb_path (``enriched_{source}__{table}``), so two
+            # sources that each have an ``orders`` fact don't clash on
+            # ``enriched_orders``. Every source is fully-qualified, so CREATE OR
+            # REPLACE only ever replaces THIS view on a re-run, never a sibling.
+            view_name = f"enriched_{fact_table.duckdb_path}"
+            view_fqn = _lake_fqn("enriched", view_name)
+            fact_fqn = _lake_fqn("typed", fact_table.duckdb_path)
+            fqn_joins = [
+                replace(join, dim_duckdb_path=_lake_fqn("typed", dim.duckdb_path))
+                for join in dimension_joins
+                if (dim := tables_by_name.get(join.dim_table_name)) is not None and dim.duckdb_path
+            ]
+
             # Build view SQL
-            view_name, view_sql, dim_columns = build_enriched_view_sql(
-                fact_table_name=fact_table.table_name,
-                fact_duckdb_path=fact_table.duckdb_path,
-                dimension_joins=dimension_joins,
-            )
+            view_sql, dim_columns = build_enriched_view_sql(view_fqn, fact_fqn, fqn_joins)
 
             # Create view in DuckDB
             try:
                 ctx.duckdb_conn.execute(view_sql)
             except Exception as e:
-                logger.warning(
-                    "view_creation_failed",
-                    view_name=view_name,
-                    error=str(e),
-                )
+                logger.warning("view_creation_failed", view_name=view_name, error=str(e))
                 continue
 
             # Verify grain preservation
             is_grain_verified = self._verify_grain(
                 ctx.duckdb_conn,
-                view_name=view_name,
+                view_target=view_fqn,
                 expected_count=fact_table.row_count,
             )
 
@@ -225,7 +243,7 @@ class EnrichedViewsPhase(BasePhase):
                     expected_count=fact_table.row_count,
                 )
                 try:
-                    ctx.duckdb_conn.execute(f'DROP VIEW IF EXISTS "{view_name}"')
+                    ctx.duckdb_conn.execute(f"DROP VIEW IF EXISTS {view_fqn}")
                 except Exception:
                     pass
                 views_dropped += 1
@@ -255,6 +273,7 @@ class EnrichedViewsPhase(BasePhase):
                 ctx,
                 fact_table,
                 view_name,
+                view_fqn,
                 dim_columns,
             )
 
@@ -328,6 +347,7 @@ class EnrichedViewsPhase(BasePhase):
         ctx: PhaseContext,
         fact_table: Table,
         view_name: str,
+        view_fqn: str,
         dim_columns: list[str],
     ) -> Table | None:
         """Register enriched-layer Table + Column records for dimension columns and profile them.
@@ -335,7 +355,8 @@ class EnrichedViewsPhase(BasePhase):
         Args:
             ctx: Phase context.
             fact_table: The fact table this view is based on.
-            view_name: Name of the enriched DuckDB view.
+            view_name: Bare name of the enriched DuckDB view (stored as duckdb_path).
+            view_fqn: Fully-qualified view name, used to query the view (DESCRIBE / profile).
             dim_columns: List of dimension column names in the view.
 
         Returns:
@@ -356,7 +377,7 @@ class EnrichedViewsPhase(BasePhase):
             ctx.session.add(view_table)
 
             # Get DuckDB types for dimension columns
-            duckdb_cols = ctx.duckdb_conn.execute(f'DESCRIBE "{view_name}"').fetchall()
+            duckdb_cols = ctx.duckdb_conn.execute(f"DESCRIBE {view_fqn}").fetchall()
             type_by_name = {row[0]: row[1] for row in duckdb_cols}
 
             registered_columns: list[Column] = []
@@ -380,7 +401,7 @@ class EnrichedViewsPhase(BasePhase):
                 profile = _profile_column_stats_parallel(
                     duckdb_conn=ctx.duckdb_conn,
                     table_name=view_name,
-                    table_duckdb_path=view_name,
+                    table_duckdb_path=view_fqn,
                     column_id=col.column_id,
                     column_name=col.column_name,
                     resolved_type=col.resolved_type or "VARCHAR",
@@ -626,18 +647,19 @@ class EnrichedViewsPhase(BasePhase):
     @staticmethod
     def _verify_grain(
         duckdb_conn: Any,
-        view_name: str,
+        view_target: str,
         expected_count: int | None,
     ) -> bool:
         """Verify that the view preserves the fact table grain.
 
-        Returns True if COUNT(*) of view matches expected row count.
+        ``view_target`` is the fully-qualified view name. Returns True if
+        COUNT(*) of the view matches the expected fact row count.
         """
         if expected_count is None:
             return True  # Can't verify without expected count
 
         try:
-            result = duckdb_conn.execute(f'SELECT COUNT(*) FROM "{view_name}"').fetchone()
+            result = duckdb_conn.execute(f"SELECT COUNT(*) FROM {view_target}").fetchone()
             actual_count = result[0] if result else 0
             return actual_count == expected_count
         except Exception:

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -29,6 +29,7 @@ from dataraum.analysis.relationships.utils import load_defined_relationships
 from dataraum.analysis.semantic.db_models import SemanticAnnotation, TableEntity
 from dataraum.analysis.statistics.db_models import StatisticalProfile
 from dataraum.analysis.statistics.profiler import _profile_column_stats_parallel
+from dataraum.analysis.typing.db_models import MaterializationRecipe
 from dataraum.analysis.typing.recipe import store_recipe
 from dataraum.analysis.views.builder import DimensionJoin, build_enriched_view_sql
 from dataraum.analysis.views.db_models import EnrichedView
@@ -36,6 +37,7 @@ from dataraum.analysis.views.enrichment_agent import EnrichmentAgent
 from dataraum.analysis.views.enrichment_models import EnrichmentAnalysisResult
 from dataraum.core.duckdb_naming import schema_for_layer
 from dataraum.core.logging import get_logger
+from dataraum.core.sql_normalize import sql_equivalent
 from dataraum.llm import PromptRenderer, create_provider, load_llm_config
 from dataraum.pipeline.base import PhaseContext, PhaseResult
 from dataraum.pipeline.phases.base import BasePhase
@@ -172,24 +174,6 @@ class EnrichedViewsPhase(BasePhase):
                 summary="skipped (LLM unavailable)",
             )
 
-        # Retry-only cleanup (DAT-415): a Temporal at-least-once retry re-enters
-        # with the SAME run_id; drop this run's prior EnrichedView rows for the
-        # in-scope facts so the re-run re-inserts cleanly. Prior runs' rows (a
-        # different run_id) coexist — the definition is run-versioned. A NULL
-        # run_id (non-run callers/tests) matches the IS NULL branch.
-        fact_table_ids = [fe.table_id for fe in fact_entities]
-        run_filter = (
-            EnrichedView.run_id.is_(None)
-            if ctx.run_id is None
-            else EnrichedView.run_id == ctx.run_id
-        )
-        ctx.session.execute(
-            delete(EnrichedView).where(
-                EnrichedView.fact_table_id.in_(fact_table_ids),
-                run_filter,
-            )
-        )
-
         views_created = 0
         views_dropped = 0
 
@@ -282,44 +266,64 @@ class EnrichedViewsPhase(BasePhase):
             )
 
             # Version the view DDL on the DAT-414 recipe substrate (emit → store →
-            # execute; the view was executed above). Keyed on the stable fact id +
-            # ``layer="enriched"`` (collision-free vs typing's typed/quarantine
-            # recipes), stamped with the run. ``depends_on`` is the typed
-            # fact/dimension FQNs the view reads — the recipe topo-sort uses it to
-            # rebuild views after their inputs (DAT-415 view chains).
-            store_recipe(
-                ctx.session,
-                session_id=ctx.require_session_id(),
-                table_id=fact_table.table_id,
-                layer="enriched",
-                run_id=ctx.run_id,
-                target_fqn=view_fqn,
-                ddl=view_sql,
-                depends_on=[fact_fqn, *(j.dim_duckdb_path for j in fqn_joins)],
-            )
+            # execute; the view was executed above), sqlglot-gated (DAT-415):
+            # only stamp a NEW run-versioned recipe when the canonical SQL differs
+            # from the fact's latest stored enriched recipe — an unchanged re-run
+            # (temp-0 LLM → same joins) adds no redundant version, and a
+            # same-run retry sees its own just-stored recipe as equivalent and
+            # no-ops. Keyed on the stable fact id + ``layer="enriched"``
+            # (collision-free vs typing's typed/quarantine recipes); ``depends_on``
+            # is the typed fact/dim FQNs the recipe topo-sort rebuilds after.
+            dim_fqns = [j.dim_duckdb_path for j in fqn_joins]
+            latest_recipe = ctx.session.execute(
+                select(MaterializationRecipe)
+                .where(
+                    MaterializationRecipe.table_id == fact_table.table_id,
+                    MaterializationRecipe.layer == "enriched",
+                )
+                .order_by(MaterializationRecipe.created_at.desc())
+                .limit(1)
+            ).scalar_one_or_none()
+            if latest_recipe is None or not sql_equivalent(latest_recipe.ddl, view_sql):
+                store_recipe(
+                    ctx.session,
+                    session_id=ctx.require_session_id(),
+                    table_id=fact_table.table_id,
+                    layer="enriched",
+                    run_id=ctx.run_id,
+                    target_fqn=view_fqn,
+                    ddl=view_sql,
+                    depends_on=[fact_fqn, *dim_fqns],
+                )
 
-            # Insert the run-versioned view definition. Prior runs' rows coexist
-            # (this run's were cleared above), so readers resolve a run via the
-            # promoted session head (DAT-408).
-            view_record = EnrichedView(
-                session_id=ctx.require_session_id(),
-                fact_table_id=fact_table.table_id,
-                run_id=ctx.run_id,
-                view_name=view_name,
-                relationship_ids=[j.relationship_id for j in dimension_joins],
-                dimension_table_ids=list(
-                    {
-                        tables_by_name[j.dim_table_name].table_id
-                        for j in dimension_joins
-                        if j.dim_table_name in tables_by_name
-                    }
-                ),
-                dimension_columns=dim_columns,
-                is_grain_verified=is_grain_verified,
-                evidence=evidence if evidence else None,
-                view_table_id=view_table.table_id if view_table else None,
+            # The view definition is latest-only substrate (one row per fact,
+            # DAT-415): reconcile-in-place, stamping the run that materialized it.
+            # The recipe (above) carries the version history; readers resolve the
+            # current view here without run-scoping.
+            view_record = ctx.session.execute(
+                select(EnrichedView).where(EnrichedView.fact_table_id == fact_table.table_id)
+            ).scalar_one_or_none()
+            if view_record is None:
+                view_record = EnrichedView(
+                    session_id=ctx.require_session_id(),
+                    fact_table_id=fact_table.table_id,
+                )
+                ctx.session.add(view_record)
+            view_record.session_id = ctx.require_session_id()
+            view_record.run_id = ctx.run_id
+            view_record.view_name = view_name
+            view_record.relationship_ids = [j.relationship_id for j in dimension_joins]
+            view_record.dimension_table_ids = list(
+                {
+                    tables_by_name[j.dim_table_name].table_id
+                    for j in dimension_joins
+                    if j.dim_table_name in tables_by_name
+                }
             )
-            ctx.session.add(view_record)
+            view_record.dimension_columns = dim_columns
+            view_record.is_grain_verified = is_grain_verified
+            view_record.evidence = evidence if evidence else None
+            view_record.view_table_id = view_table.table_id if view_table else None
 
             views_created += 1
 

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -19,7 +19,7 @@ from collections.abc import Sequence
 from dataclasses import replace
 from datetime import UTC, datetime
 from types import ModuleType
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from uuid import uuid4
 
 from sqlalchemy import delete, select
@@ -44,9 +44,6 @@ from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.registry import analysis_phase
 from dataraum.server.storage import LAKE_CATALOG_ALIAS
 from dataraum.storage import Column, Table
-
-if TYPE_CHECKING:
-    pass
 
 logger = get_logger(__name__)
 
@@ -299,7 +296,11 @@ class EnrichedViewsPhase(BasePhase):
             # The view definition is latest-only substrate (one row per fact,
             # DAT-415): reconcile-in-place, stamping the run that materialized it.
             # The recipe (above) carries the version history; readers resolve the
-            # current view here without run-scoping.
+            # current view here without run-scoping. Keyed on fact_table_id alone
+            # (no session filter) — the physical view is shared in lake.typed, so
+            # the metadata is last-writer-wins per fact, which under single-user
+            # sequential begin_session is exactly one writer. (Concurrent sessions
+            # enriching the same fact is a multi-session concern, not this slice.)
             view_record = ctx.session.execute(
                 select(EnrichedView).where(EnrichedView.fact_table_id == fact_table.table_id)
             ).scalar_one_or_none()

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -22,13 +22,14 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from dataraum.analysis.relationships.db_models import Relationship
 from dataraum.analysis.relationships.utils import load_defined_relationships
 from dataraum.analysis.semantic.db_models import SemanticAnnotation, TableEntity
 from dataraum.analysis.statistics.db_models import StatisticalProfile
 from dataraum.analysis.statistics.profiler import _profile_column_stats_parallel
+from dataraum.analysis.typing.recipe import store_recipe
 from dataraum.analysis.views.builder import DimensionJoin, build_enriched_view_sql
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.analysis.views.enrichment_agent import EnrichmentAgent
@@ -82,43 +83,33 @@ class EnrichedViewsPhase(BasePhase):
         return [db_models]
 
     def should_skip(self, ctx: PhaseContext) -> str | None:
-        """Skip if enriched views already exist for this source's fact tables."""
-        stmt = select(Table).where(Table.layer == "typed", Table.source_id == ctx.source_id)
-        typed_tables = ctx.session.execute(stmt).scalars().all()
+        """Skip only when the session's selection has no fact table to enrich.
 
-        if not typed_tables:
-            return "No typed tables found"
+        Source-free (feedback-source-dies-at-addsource): begin_session scopes by
+        ``ctx.table_ids`` — the session's selected typed tables, which may span
+        sources — never ``source_id``. Structural early-out only (mirrors typing's
+        DAT-413 re-seam): there is NO "views already exist → skip" bail — a re-run
+        mints a fresh ``run_id`` and re-derives the view definitions under it, and
+        ``_run`` is idempotent on the ``run_id`` grain.
+        """
+        if not ctx.table_ids:
+            return "No tables in session selection"
 
-        table_ids = [t.table_id for t in typed_tables]
-
-        # Check for fact tables
-        fact_stmt = select(TableEntity).where(
-            TableEntity.table_id.in_(table_ids),
+        fact_stmt = select(TableEntity.table_id).where(
+            TableEntity.table_id.in_(ctx.table_ids),
             TableEntity.is_fact_table.is_(True),
         )
-        fact_entities = ctx.session.execute(fact_stmt).scalars().all()
-
-        if not fact_entities:
+        if ctx.session.execute(fact_stmt).first() is None:
             return "No fact tables identified"
-
-        # Skip if enriched views already exist for this source's fact tables.
-        # (Was a PhaseLog "completed" check, retired with the monitoring tables
-        # in DAT-369. Existence-based now: a prior run that produced zero views —
-        # the LLM declining all enrichment — would re-run, harmless for this
-        # dormant slice-2 phase; slice-2 gives it proper activity idempotency.)
-        fact_table_ids = [fe.table_id for fe in fact_entities]
-        existing = ctx.session.execute(
-            select(EnrichedView.view_id).where(EnrichedView.fact_table_id.in_(fact_table_ids))
-        ).first()
-        if existing:
-            return "Enriched views already built"
 
         return None
 
     def _run(self, ctx: PhaseContext) -> PhaseResult:
-        """Create enriched views for fact tables using LLM recommendations."""
-        # Get typed tables
-        stmt = select(Table).where(Table.layer == "typed", Table.source_id == ctx.source_id)
+        """Create enriched views for the session's fact tables using LLM recommendations."""
+        # Source-free: scope to the session's selected typed tables (DAT-415).
+        if not ctx.table_ids:
+            return PhaseResult.failed("No tables in session selection")
+        stmt = select(Table).where(Table.table_id.in_(ctx.table_ids), Table.layer == "typed")
         typed_tables = ctx.session.execute(stmt).scalars().all()
 
         if not typed_tables:
@@ -180,6 +171,24 @@ class EnrichedViewsPhase(BasePhase):
                 records_created=0,
                 summary="skipped (LLM unavailable)",
             )
+
+        # Retry-only cleanup (DAT-415): a Temporal at-least-once retry re-enters
+        # with the SAME run_id; drop this run's prior EnrichedView rows for the
+        # in-scope facts so the re-run re-inserts cleanly. Prior runs' rows (a
+        # different run_id) coexist — the definition is run-versioned. A NULL
+        # run_id (non-run callers/tests) matches the IS NULL branch.
+        fact_table_ids = [fe.table_id for fe in fact_entities]
+        run_filter = (
+            EnrichedView.run_id.is_(None)
+            if ctx.run_id is None
+            else EnrichedView.run_id == ctx.run_id
+        )
+        ctx.session.execute(
+            delete(EnrichedView).where(
+                EnrichedView.fact_table_id.in_(fact_table_ids),
+                run_filter,
+            )
+        )
 
         views_created = 0
         views_dropped = 0
@@ -262,13 +271,8 @@ class EnrichedViewsPhase(BasePhase):
                         }
                         break
 
-            # Check if view already exists - update or create
-            existing_view_stmt = select(EnrichedView).where(
-                EnrichedView.fact_table_id == fact_table.table_id
-            )
-            existing_view = ctx.session.execute(existing_view_stmt).scalar_one_or_none()
-
-            # Register and profile dimension columns
+            # Register and profile dimension columns (latest-only substrate:
+            # reconciled by view_name, prior columns/profiles replaced).
             view_table = self._register_and_profile_dim_columns(
                 ctx,
                 fact_table,
@@ -277,49 +281,45 @@ class EnrichedViewsPhase(BasePhase):
                 dim_columns,
             )
 
-            if existing_view:
-                # Update existing view record
-                existing_view.view_name = view_name
-                existing_view.view_sql = view_sql
-                existing_view.relationship_ids = [j.relationship_id for j in dimension_joins]
-                existing_view.dimension_table_ids = list(
+            # Version the view DDL on the DAT-414 recipe substrate (emit → store →
+            # execute; the view was executed above). Keyed on the stable fact id +
+            # ``layer="enriched"`` (collision-free vs typing's typed/quarantine
+            # recipes), stamped with the run. ``depends_on`` is the typed
+            # fact/dimension FQNs the view reads — the recipe topo-sort uses it to
+            # rebuild views after their inputs (DAT-415 view chains).
+            store_recipe(
+                ctx.session,
+                session_id=ctx.require_session_id(),
+                table_id=fact_table.table_id,
+                layer="enriched",
+                run_id=ctx.run_id,
+                target_fqn=view_fqn,
+                ddl=view_sql,
+                depends_on=[fact_fqn, *(j.dim_duckdb_path for j in fqn_joins)],
+            )
+
+            # Insert the run-versioned view definition. Prior runs' rows coexist
+            # (this run's were cleared above), so readers resolve a run via the
+            # promoted session head (DAT-408).
+            view_record = EnrichedView(
+                session_id=ctx.require_session_id(),
+                fact_table_id=fact_table.table_id,
+                run_id=ctx.run_id,
+                view_name=view_name,
+                relationship_ids=[j.relationship_id for j in dimension_joins],
+                dimension_table_ids=list(
                     {
                         tables_by_name[j.dim_table_name].table_id
                         for j in dimension_joins
                         if j.dim_table_name in tables_by_name
                     }
-                )
-                existing_view.dimension_columns = dim_columns
-                existing_view.is_grain_verified = is_grain_verified
-                existing_view.evidence = evidence if evidence else None
-                if view_table:
-                    existing_view.view_table_id = view_table.table_id
-                logger.info(
-                    "enriched_view_updated",
-                    view_name=view_name,
-                    fact_table=fact_table.table_name,
-                )
-            else:
-                # Create new view record
-                view_record = EnrichedView(
-                    session_id=ctx.require_session_id(),
-                    fact_table_id=fact_table.table_id,
-                    view_name=view_name,
-                    view_sql=view_sql,
-                    relationship_ids=[j.relationship_id for j in dimension_joins],
-                    dimension_table_ids=list(
-                        {
-                            tables_by_name[j.dim_table_name].table_id
-                            for j in dimension_joins
-                            if j.dim_table_name in tables_by_name
-                        }
-                    ),
-                    dimension_columns=dim_columns,
-                    is_grain_verified=is_grain_verified,
-                    evidence=evidence if evidence else None,
-                    view_table_id=view_table.table_id if view_table else None,
-                )
-                ctx.session.add(view_record)
+                ),
+                dimension_columns=dim_columns,
+                is_grain_verified=is_grain_verified,
+                evidence=evidence if evidence else None,
+                view_table_id=view_table.table_id if view_table else None,
+            )
+            ctx.session.add(view_record)
 
             views_created += 1
 
@@ -352,6 +352,13 @@ class EnrichedViewsPhase(BasePhase):
     ) -> Table | None:
         """Register enriched-layer Table + Column records for dimension columns and profile them.
 
+        Latest-only substrate (DAT-415): the enriched ``Table`` is reconciled on
+        its ``(source, view_name, "enriched")`` unique key — reused across runs,
+        with its prior ``Column``s (and cascaded ``StatisticalProfile``s) replaced
+        — rather than minting a fresh row each run. The view *definition* is what
+        is run-versioned (``EnrichedView`` + recipe DDL); the lake substrate stays
+        latest-only and is re-materialized from the versioned recipe on a reset.
+
         Args:
             ctx: Phase context.
             fact_table: The fact table this view is based on.
@@ -366,15 +373,31 @@ class EnrichedViewsPhase(BasePhase):
             return None
 
         try:
-            view_table = Table(
-                table_id=str(uuid4()),
-                source_id=fact_table.source_id,
-                table_name=view_name,
-                layer="enriched",
-                duckdb_path=view_name,
-                row_count=fact_table.row_count,
-            )
-            ctx.session.add(view_table)
+            view_table = ctx.session.execute(
+                select(Table).where(
+                    Table.source_id == fact_table.source_id,
+                    Table.table_name == view_name,
+                    Table.layer == "enriched",
+                )
+            ).scalar_one_or_none()
+            if view_table is None:
+                view_table = Table(
+                    table_id=str(uuid4()),
+                    source_id=fact_table.source_id,
+                    table_name=view_name,
+                    layer="enriched",
+                    duckdb_path=view_name,
+                    row_count=fact_table.row_count,
+                )
+                ctx.session.add(view_table)
+                ctx.session.flush()
+            else:
+                # Reuse the row, drop its prior columns (profiles cascade) so the
+                # latest run's dimension set replaces the last one's.
+                view_table.duckdb_path = view_name
+                view_table.row_count = fact_table.row_count
+                ctx.session.execute(delete(Column).where(Column.table_id == view_table.table_id))
+                ctx.session.flush()
 
             # Get DuckDB types for dimension columns
             duckdb_cols = ctx.duckdb_conn.execute(f"DESCRIBE {view_fqn}").fetchall()

--- a/packages/engine/src/dataraum/pipeline/phases/slicing_view_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/slicing_view_phase.py
@@ -359,9 +359,12 @@ class SlicingViewPhase(BasePhase):
         fact_col_names = [col.column_name for col in fact_columns]
 
         if enriched_view and (fact_col_names or slice_dim_cols):
-            # Project from enriched view: fact cols + slice dim cols only
+            # Project from enriched view: fact cols + slice dim cols only.
+            # Read the view's stored name rather than reconstructing it — the
+            # enriched view is now collision-named off the fact's duckdb_path
+            # (``enriched_{source}__{table}``, DAT-415), not ``enriched_{table_name}``.
             select_parts = [f'"{c}"' for c in fact_col_names] + [f'"{c}"' for c in slice_dim_cols]
-            source = f'"enriched_{fact_table.table_name}"'
+            source = f'"{enriched_view.view_name}"'
             sql = (
                 f'CREATE OR REPLACE VIEW "{view_name}" AS\n'
                 f"SELECT {', '.join(select_parts)}\n"

--- a/packages/engine/src/dataraum/worker/activities.py
+++ b/packages/engine/src/dataraum/worker/activities.py
@@ -192,6 +192,22 @@ class PhaseActivities:
         )
         return self._outcome_or_raise(run, "semantic_per_table")
 
+    @activity.defn(name="enriched_views")
+    def run_enriched_views(self, payload: SessionScopedInput) -> PhaseOutcome:
+        """Enriched-views activity — grain-preserving fact×dimension views (DAT-415).
+
+        Source-free: builds one ``CREATE OR REPLACE VIEW`` per session fact table
+        over its LLM-confirmed dimension joins, versioning each view's DDL on the
+        materialization-recipe substrate (run-stamped) and registering the enriched
+        lake substrate latest-only. Runs after ``session_materialize_overlays`` so
+        the user's durable relationship teaches are folded in. Makes real Anthropic
+        calls (the enrichment agent); needs ``ANTHROPIC_API_KEY``.
+        """
+        run = run_session_phase(
+            self._manager, "enriched_views", payload.identity, payload.table_ids
+        )
+        return self._outcome_or_raise(run, "enriched_views")
+
     @activity.defn(name="session_materialize_overlays")
     def run_session_materialize_overlays(self, identity: SessionIdentity) -> PhaseOutcome:
         """Materialize durable relationship overlays into this run (DAT-409).

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -102,13 +102,14 @@ _PROMOTE_STAGES = (
 )
 
 # The begin_session chain phases whose declared detectors the terminal session
-# ``detect`` runs (DAT-408): ``semantic_per_table`` declares the relationship
-# detectors (join_path_determinism + relationship_entropy). Distinct from the
-# source-scoped ``_DETECTOR_PHASES`` so add_source never runs the relationship
-# detectors and begin_session never runs the column ones.
-# Public (imported by ``activities.py`` + tests) — unlike ``_DETECTOR_PHASES`` /
-# ``_PROMOTE_STAGES``, which are used only within this module.
-SESSION_DETECTOR_PHASES = ("relationships", "semantic_per_table")
+# ``detect`` runs: ``semantic_per_table`` declares the relationship detectors
+# (join_path_determinism + relationship_entropy, DAT-408); ``enriched_views``
+# declares ``dimension_coverage`` (table-grain fact-table enrichment coverage,
+# DAT-415). Distinct from the source-scoped ``_DETECTOR_PHASES`` so add_source
+# never runs the relationship/coverage detectors and begin_session never runs the
+# column ones. Public (imported by ``activities.py`` + tests) — unlike
+# ``_DETECTOR_PHASES`` / ``_PROMOTE_STAGES``, used only within this module.
+SESSION_DETECTOR_PHASES = ("relationships", "semantic_per_table", "enriched_views")
 
 
 @dataclass

--- a/packages/engine/src/dataraum/worker/main.py
+++ b/packages/engine/src/dataraum/worker/main.py
@@ -95,6 +95,7 @@ async def run_worker() -> None:
                     phase_activities.run_begin_session_select,
                     phase_activities.run_relationships,
                     phase_activities.run_semantic_per_table,
+                    phase_activities.run_enriched_views,
                     # DAT-408/409 begin_session: materialize durable overlays →
                     # terminal detect → silent-accept keepers → promote.
                     phase_activities.run_session_materialize_overlays,
@@ -140,6 +141,7 @@ async def run_worker() -> None:
                     "begin_session_select",
                     "relationships",
                     "semantic_per_table",
+                    "enriched_views",
                     "session_materialize_overlays",
                     "session_detect",
                     "session_write_keepers",

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -363,10 +363,12 @@ class BeginSessionWorkflow:
     (``session_tables``), then ``relationships`` (structural candidates) →
     ``semantic_per_table`` (LLM classification + confirms a subset) run over the
     whole selection, then ``session_materialize_overlays`` (fold the user's durable
-    add/keep relationship teaches into this run, DAT-409) → ``session_detect``
-    (relationship-granularity readiness) → ``session_write_keepers`` (silent-accept
-    lift-up, DAT-409) → ``session_promote_to_latest`` (flip the readiness heads). NO
-    fan-out — the work is cross-table.
+    add/keep relationship teaches into this run, DAT-409) → ``enriched_views``
+    (grain-preserving fact×dimension views over the defined catalog, DDL versioned
+    on the recipe substrate, DAT-415) → ``session_detect`` (relationship-granularity
+    readiness) → ``session_write_keepers`` (silent-accept lift-up, DAT-409) →
+    ``session_promote_to_latest`` (flip the readiness heads). NO fan-out — the work
+    is cross-table.
 
     The run mints a ``run_id`` (DAT-408) threaded through every activity; a teach
     re-run is a full re-run under a fresh ``run_id`` (candidates re-derive,
@@ -412,6 +414,19 @@ class BeginSessionWorkflow:
         await workflow.execute_activity(
             "session_materialize_overlays",
             identity,
+            result_type=PhaseOutcome,
+            start_to_close_timeout=_TIMEOUT,
+            retry_policy=_RETRY,
+        )
+
+        # Enriched views (DAT-415): build grain-preserving fact×dimension views over
+        # the now-complete defined relationship catalog (llm + the just-materialized
+        # manual/keeper teaches), versioning each view's DDL on the recipe substrate.
+        # Scoped (needs the selection's table_ids); runs before detect so the
+        # table-grain readiness it feeds (DAT-402) measures the enriched substrate.
+        await workflow.execute_activity(
+            "enriched_views",
+            scoped,
             result_type=PhaseOutcome,
             start_to_close_timeout=_TIMEOUT,
             retry_policy=_RETRY,

--- a/packages/engine/tests/integration/analysis/views/test_ducklake_view_support.py
+++ b/packages/engine/tests/integration/analysis/views/test_ducklake_view_support.py
@@ -15,7 +15,9 @@ import duckdb
 
 
 def test_ducklake_supports_enriched_views(duckdb_conn: duckdb.DuckDBPyConnection) -> None:
-    duckdb_conn.execute('CREATE OR REPLACE TABLE lake.typed."probe_fact" AS SELECT 1 AS id, 100 AS amount')
+    duckdb_conn.execute(
+        'CREATE OR REPLACE TABLE lake.typed."probe_fact" AS SELECT 1 AS id, 100 AS amount'
+    )
     duckdb_conn.execute(
         'CREATE OR REPLACE VIEW lake.typed."probe_enriched" AS '
         'SELECT * FROM lake.typed."probe_fact"'

--- a/packages/engine/tests/integration/analysis/views/test_ducklake_view_support.py
+++ b/packages/engine/tests/integration/analysis/views/test_ducklake_view_support.py
@@ -1,0 +1,27 @@
+"""Does DuckLake support CREATE VIEW in the lake catalog? (DAT-415 de-risk).
+
+The enriched_views revival materializes views with ``CREATE OR REPLACE VIEW`` in
+the lake catalog. That phase has been dormant, and the existing
+``test_enriched_views`` suite exercises only an in-memory DuckDB — so view
+support against the real DuckLake-anchored connection (catalog in Postgres, data
+on the lake DATA_PATH) is unproven. This pins it down: a view over a lake.typed
+table must create, query, and drop. If DuckLake ever stops supporting views, this
+fails loudly here rather than deep in begin_session.
+"""
+
+from __future__ import annotations
+
+import duckdb
+
+
+def test_ducklake_supports_enriched_views(duckdb_conn: duckdb.DuckDBPyConnection) -> None:
+    duckdb_conn.execute('CREATE OR REPLACE TABLE lake.typed."probe_fact" AS SELECT 1 AS id, 100 AS amount')
+    duckdb_conn.execute(
+        'CREATE OR REPLACE VIEW lake.typed."probe_enriched" AS '
+        'SELECT * FROM lake.typed."probe_fact"'
+    )
+    rows = duckdb_conn.execute('SELECT id, amount FROM lake.typed."probe_enriched"').fetchall()
+    assert rows == [(1, 100)]
+
+    duckdb_conn.execute('DROP VIEW IF EXISTS lake.typed."probe_enriched"')
+    duckdb_conn.execute('DROP TABLE IF EXISTS lake.typed."probe_fact"')

--- a/packages/engine/tests/integration/analysis/views/test_enriched_views.py
+++ b/packages/engine/tests/integration/analysis/views/test_enriched_views.py
@@ -293,8 +293,9 @@ class TestEnrichedViewsPhaseDuckLake:
         from tests.conftest import baseline_session_id
 
         fact_id, dim_id, canned = self._seed(session, duckdb_conn)
+        rec = {"current": canned}
         monkeypatch.setattr(
-            EnrichedViewsPhase, "_get_llm_recommendations", lambda self, **kw: canned
+            EnrichedViewsPhase, "_get_llm_recommendations", lambda self, **kw: rec["current"]
         )
 
         def run(run_id: str) -> None:
@@ -309,6 +310,25 @@ class TestEnrichedViewsPhaseDuckLake:
             assert result.status == PhaseStatus.COMPLETED, result.error
             session.flush()
 
+        def enriched_views():
+            return (
+                session.execute(select(EnrichedView).where(EnrichedView.fact_table_id == fact_id))
+                .scalars()
+                .all()
+            )
+
+        def enriched_recipes():
+            return (
+                session.execute(
+                    select(MaterializationRecipe).where(
+                        MaterializationRecipe.table_id == fact_id,
+                        MaterializationRecipe.layer == "enriched",
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
         # --- Run 1: the view materializes + is versioned -------------------
         run("run-1")
 
@@ -319,16 +339,12 @@ class TestEnrichedViewsPhaseDuckLake:
         ).fetchall()
         assert rows == [(1, "Alice", "US"), (2, "Bob", "UK"), (3, "Alice", "US")]
 
-        views = (
-            session.execute(select(EnrichedView).where(EnrichedView.fact_table_id == fact_id))
-            .scalars()
-            .all()
-        )
+        views = enriched_views()
         assert len(views) == 1
         assert views[0].run_id == "run-1"
         assert views[0].is_grain_verified is True
         assert views[0].view_table_id is not None
-        assert not hasattr(views[0], "view_sql") or "view_sql" not in EnrichedView.__table__.columns
+        assert "view_sql" not in EnrichedView.__table__.columns
 
         recipe = session.execute(
             select(MaterializationRecipe).where(
@@ -349,45 +365,133 @@ class TestEnrichedViewsPhaseDuckLake:
 
         # --- Run 1 retry: same run_id is idempotent (no duplicate rows) ----
         run("run-1")
-        views = (
-            session.execute(select(EnrichedView).where(EnrichedView.fact_table_id == fact_id))
-            .scalars()
-            .all()
-        )
-        assert len(views) == 1, "a same-run retry must not duplicate the view definition"
-        recipes = (
-            session.execute(
-                select(MaterializationRecipe).where(
-                    MaterializationRecipe.table_id == fact_id,
-                    MaterializationRecipe.layer == "enriched",
-                )
-            )
-            .scalars()
-            .all()
-        )
-        assert len(recipes) == 1
+        assert len(enriched_views()) == 1, "a same-run retry must not duplicate the view definition"
+        assert {r.run_id for r in enriched_recipes()} == {"run-1"}
 
-        # --- Run 2: a new run coexists; substrate stays latest-only --------
+        # --- Run 2 (identical SQL): definition is latest-only, recipe gated -
         run("run-2")
-        views = (
-            session.execute(select(EnrichedView).where(EnrichedView.fact_table_id == fact_id))
-            .scalars()
-            .all()
+        views = enriched_views()
+        assert len(views) == 1, "EnrichedView is latest-only — one row per fact"
+        assert views[0].run_id == "run-2", "the latest run stamps the (reconciled) definition"
+        assert {r.run_id for r in enriched_recipes()} == {"run-1"}, (
+            "unchanged canonical SQL adds no new recipe version (sqlglot-gated)"
         )
-        assert {v.run_id for v in views} == {"run-1", "run-2"}
-        recipes = (
-            session.execute(
-                select(MaterializationRecipe).where(
-                    MaterializationRecipe.table_id == fact_id,
-                    MaterializationRecipe.layer == "enriched",
+
+        # --- Run 3 (changed joins): a new recipe version is stamped --------
+        from dataraum.analysis.views.builder import DimensionJoin
+        from dataraum.analysis.views.enrichment_models import (
+            EnrichmentAnalysisResult,
+            EnrichmentRecommendation,
+        )
+
+        rec["current"] = EnrichmentAnalysisResult(
+            recommendations=[
+                EnrichmentRecommendation(
+                    fact_table_id=fact_id,
+                    fact_table_name="orders",
+                    dimension_joins=[
+                        DimensionJoin(
+                            dim_table_name="customers",
+                            dim_duckdb_path="(rewritten)",
+                            fact_fk_column="customer_id",
+                            dim_pk_column="id",
+                            include_columns=["name"],  # dropped "country" → DDL changes
+                            relationship_id="rel-1",
+                        )
+                    ],
+                    dimension_type="reference",
+                    confidence=0.9,
+                    reasoning="narrower enrichment",
+                    enrichment_columns=["name"],
                 )
-            )
-            .scalars()
-            .all()
+            ],
+            summary="stub",
+            model_name="stub-model",
         )
-        assert {r.run_id for r in recipes} == {"run-1", "run-2"}
-        # The enriched lake Table is reconciled latest-only — not duplicated per run.
-        enriched_tables = (
-            session.execute(select(Table).where(Table.layer == "enriched")).scalars().all()
+        run("run-3")
+        views = enriched_views()
+        assert len(views) == 1 and views[0].run_id == "run-3"
+        assert {r.run_id for r in enriched_recipes()} == {"run-1", "run-3"}, (
+            "a changed view definition stamps a new recipe version"
         )
-        assert len(enriched_tables) == 1
+        # Substrate stays latest-only across every run.
+        assert (
+            len(session.execute(select(Table).where(Table.layer == "enriched")).scalars().all())
+            == 1
+        )
+
+    def test_rebuild_rematerializes_current_and_drops_strays(self, session, duckdb_conn):
+        """rebuild_enriched_views re-execs the latest recipe per fact + drops strays.
+
+        Two recipes for one fact (an older ``enriched_legacy``, a newer
+        ``enriched_csv__orders``) model a view whose name changed between runs.
+        A reset rebuilds the current target and drops the session's stale view —
+        proving the transactional, dependency-ordered re-materialization + the
+        session-scoped drop-views-not-in-run.
+        """
+        from datetime import UTC, datetime, timedelta
+        from uuid import uuid4
+
+        from dataraum.analysis.typing.db_models import MaterializationRecipe
+        from dataraum.analysis.views.recipe import rebuild_enriched_views
+        from dataraum.storage import Source, Table
+        from tests.conftest import baseline_session_id
+
+        duckdb_conn.execute(
+            'CREATE OR REPLACE TABLE lake.typed."csv__orders" AS '
+            "SELECT * FROM (VALUES (1, 100.0), (2, 200.0), (3, 150.0)) AS t(order_id, amount)"
+        )
+        source = Source(source_id=str(uuid4()), name="csv", source_type="csv")
+        session.add(source)
+        session.flush()
+        fact = Table(
+            table_id=str(uuid4()),
+            source_id=source.source_id,
+            table_name="orders",
+            layer="typed",
+            duckdb_path="csv__orders",
+            row_count=3,
+        )
+        session.add(fact)
+        session.flush()
+
+        fact_fqn = 'lake.typed."csv__orders"'
+        legacy_fqn = 'lake.typed."enriched_legacy"'
+        current_fqn = 'lake.typed."enriched_csv__orders"'
+        base = datetime(2026, 6, 4, tzinfo=UTC)
+        session.add_all(
+            [
+                MaterializationRecipe(
+                    session_id=baseline_session_id(),
+                    table_id=fact.table_id,
+                    layer="enriched",
+                    run_id="r0",
+                    target_fqn=legacy_fqn,
+                    ddl=f"CREATE OR REPLACE VIEW {legacy_fqn} AS SELECT * FROM {fact_fqn}",
+                    depends_on=[fact_fqn],
+                    created_at=base,
+                ),
+                MaterializationRecipe(
+                    session_id=baseline_session_id(),
+                    table_id=fact.table_id,
+                    layer="enriched",
+                    run_id="r1",
+                    target_fqn=current_fqn,
+                    ddl=f"CREATE OR REPLACE VIEW {current_fqn} AS SELECT * FROM {fact_fqn}",
+                    depends_on=[fact_fqn],
+                    created_at=base + timedelta(hours=1),
+                ),
+            ]
+        )
+        session.flush()
+
+        # The stale view physically exists; the current one does not (a lost rebuild).
+        duckdb_conn.execute(f"CREATE OR REPLACE VIEW {legacy_fqn} AS SELECT * FROM {fact_fqn}")
+
+        rebuilt = rebuild_enriched_views(session, duckdb_conn, session_id=baseline_session_id())
+
+        assert rebuilt == [current_fqn], "only the latest recipe per fact is re-materialized"
+        assert duckdb_conn.execute(f"SELECT COUNT(*) FROM {current_fqn}").fetchone()[0] == 3
+        remaining = {row[0] for row in duckdb_conn.execute("SHOW TABLES").fetchall()}
+        assert "enriched_csv__orders" in remaining
+        assert "enriched_legacy" not in remaining, "the session's stray view is dropped"

--- a/packages/engine/tests/integration/analysis/views/test_enriched_views.py
+++ b/packages/engine/tests/integration/analysis/views/test_enriched_views.py
@@ -126,23 +126,268 @@ class TestEnrichedViewsIntegration:
 
 
 class TestEnrichedViewsPhaseProperties:
-    """Tests for EnrichedViewsPhase static properties."""
+    """Tests for EnrichedViewsPhase static properties.
 
-    def test_skip_when_no_typed_tables(self, session):
-        """Test skipping when no typed tables exist."""
+    The phase is source-free (DAT-415): ``should_skip`` scopes by the session's
+    ``ctx.table_ids``, never ``source_id``.
+    """
+
+    def test_skip_when_selection_empty(self, session):
+        """Skip when the session selection carries no tables."""
         from dataraum.pipeline.base import PhaseContext
-        from dataraum.storage import Source
+
+        ctx = PhaseContext(session=session, duckdb_conn=None, table_ids=[])
+
+        reason = EnrichedViewsPhase().should_skip(ctx)
+        assert reason == "No tables in session selection"
+
+    def test_skip_when_no_fact_tables(self, session):
+        """Skip when the selection has typed tables but none classified as a fact."""
+        from uuid import uuid4
+
+        from dataraum.pipeline.base import PhaseContext
+        from dataraum.storage import Source, Table
 
         source = Source(name="test", source_type="csv")
         session.add(source)
         session.flush()
-
-        ctx = PhaseContext(
-            session=session,
-            duckdb_conn=None,
+        table = Table(
+            table_id=str(uuid4()),
             source_id=source.source_id,
+            table_name="orders",
+            layer="typed",
+            duckdb_path="test__orders",
+        )
+        session.add(table)
+        session.flush()
+
+        ctx = PhaseContext(session=session, duckdb_conn=None, table_ids=[table.table_id])
+
+        # No TableEntity marked is_fact_table → nothing to enrich.
+        reason = EnrichedViewsPhase().should_skip(ctx)
+        assert reason == "No fact tables identified"
+
+
+class TestEnrichedViewsPhaseDuckLake:
+    """Drive the phase end-to-end against the real DuckLake (DAT-415).
+
+    Proves the source-free phase composes the right FQNs, materializes a real
+    ``lake.typed`` view, versions its ``CREATE VIEW`` DDL on the recipe
+    substrate, and writes a run-versioned ``EnrichedView`` — idempotent on a
+    same-run retry, coexisting across runs. The enrichment LLM is stubbed (a
+    real call would be e2e); everything below the recommendation is exercised.
+    """
+
+    @staticmethod
+    def _seed(session, duckdb_conn):
+        """Materialize a typed fact + dimension in lake.typed + their metadata.
+
+        Returns ``(fact_table_id, dim_table_id, canned_recommendations)``.
+        """
+        from uuid import uuid4
+
+        from dataraum.analysis.semantic.db_models import TableEntity
+        from dataraum.analysis.views.builder import DimensionJoin
+        from dataraum.analysis.views.enrichment_models import (
+            EnrichmentAnalysisResult,
+            EnrichmentRecommendation,
+        )
+        from dataraum.storage import Column, Source, Table
+        from tests.conftest import baseline_session_id
+
+        # Physical typed tables in the lake (the phase joins these into a view).
+        duckdb_conn.execute(
+            'CREATE OR REPLACE TABLE lake.typed."csv__orders" AS '
+            "SELECT * FROM (VALUES (1, 10, 100.0), (2, 20, 200.0), (3, 10, 150.0)) "
+            "AS t(order_id, customer_id, amount)"
+        )
+        duckdb_conn.execute(
+            'CREATE OR REPLACE TABLE lake.typed."csv__customers" AS '
+            "SELECT * FROM (VALUES (10, 'Alice', 'US'), (20, 'Bob', 'UK')) "
+            "AS t(id, name, country)"
         )
 
-        phase = EnrichedViewsPhase()
-        reason = phase.should_skip(ctx)
-        assert reason == "No typed tables found"
+        source = Source(source_id=str(uuid4()), name="csv", source_type="csv")
+        session.add(source)
+        session.flush()
+
+        fact = Table(
+            table_id=str(uuid4()),
+            source_id=source.source_id,
+            table_name="orders",
+            layer="typed",
+            duckdb_path="csv__orders",
+            row_count=3,
+        )
+        dim = Table(
+            table_id=str(uuid4()),
+            source_id=source.source_id,
+            table_name="customers",
+            layer="typed",
+            duckdb_path="csv__customers",
+            row_count=2,
+        )
+        session.add_all([fact, dim])
+        session.flush()
+
+        for tbl, names in (
+            (fact, ("order_id", "customer_id", "amount")),
+            (dim, ("id", "name", "country")),
+        ):
+            for pos, name in enumerate(names):
+                session.add(
+                    Column(
+                        column_id=str(uuid4()),
+                        table_id=tbl.table_id,
+                        column_name=name,
+                        column_position=pos,
+                        raw_type="VARCHAR",
+                        resolved_type="VARCHAR",
+                    )
+                )
+
+        session.add(
+            TableEntity(
+                entity_id=str(uuid4()),
+                session_id=baseline_session_id(),
+                table_id=fact.table_id,
+                detected_entity_type="fact",
+                is_fact_table=True,
+            )
+        )
+        session.flush()
+
+        canned = EnrichmentAnalysisResult(
+            recommendations=[
+                EnrichmentRecommendation(
+                    fact_table_id=fact.table_id,
+                    fact_table_name="orders",
+                    dimension_joins=[
+                        DimensionJoin(
+                            dim_table_name="customers",
+                            dim_duckdb_path="(rewritten by the phase to the dim FQN)",
+                            fact_fk_column="customer_id",
+                            dim_pk_column="id",
+                            include_columns=["name", "country"],
+                            relationship_id="rel-1",
+                        )
+                    ],
+                    dimension_type="reference",
+                    confidence=0.9,
+                    reasoning="customers names/regions enrich orders",
+                    enrichment_columns=["name", "country"],
+                )
+            ],
+            summary="stub",
+            model_name="stub-model",
+        )
+        return fact.table_id, dim.table_id, canned
+
+    def test_phase_materializes_versioned_view(self, session, duckdb_conn, monkeypatch):
+        from sqlalchemy import select
+
+        from dataraum.analysis.typing.db_models import MaterializationRecipe
+        from dataraum.analysis.views.db_models import EnrichedView
+        from dataraum.pipeline.base import PhaseContext, PhaseStatus
+        from dataraum.storage import Table
+        from tests.conftest import baseline_session_id
+
+        fact_id, dim_id, canned = self._seed(session, duckdb_conn)
+        monkeypatch.setattr(
+            EnrichedViewsPhase, "_get_llm_recommendations", lambda self, **kw: canned
+        )
+
+        def run(run_id: str) -> None:
+            ctx = PhaseContext(
+                session=session,
+                duckdb_conn=duckdb_conn,
+                table_ids=[fact_id, dim_id],
+                session_id=baseline_session_id(),
+                run_id=run_id,
+            )
+            result = EnrichedViewsPhase().run(ctx)
+            assert result.status == PhaseStatus.COMPLETED, result.error
+            session.flush()
+
+        # --- Run 1: the view materializes + is versioned -------------------
+        run("run-1")
+
+        # Physical view exists in lake.typed, grain-preserved, dim columns present.
+        rows = duckdb_conn.execute(
+            'SELECT order_id, "customer_id__name", "customer_id__country" '
+            'FROM lake.typed."enriched_csv__orders" ORDER BY order_id'
+        ).fetchall()
+        assert rows == [(1, "Alice", "US"), (2, "Bob", "UK"), (3, "Alice", "US")]
+
+        views = (
+            session.execute(select(EnrichedView).where(EnrichedView.fact_table_id == fact_id))
+            .scalars()
+            .all()
+        )
+        assert len(views) == 1
+        assert views[0].run_id == "run-1"
+        assert views[0].is_grain_verified is True
+        assert views[0].view_table_id is not None
+        assert not hasattr(views[0], "view_sql") or "view_sql" not in EnrichedView.__table__.columns
+
+        recipe = session.execute(
+            select(MaterializationRecipe).where(
+                MaterializationRecipe.table_id == fact_id,
+                MaterializationRecipe.layer == "enriched",
+                MaterializationRecipe.run_id == "run-1",
+            )
+        ).scalar_one()
+        assert recipe.target_fqn == 'lake.typed."enriched_csv__orders"'
+        assert "CREATE OR REPLACE VIEW" in recipe.ddl
+        assert 'lake.typed."csv__orders"' in (recipe.depends_on or [])
+        assert 'lake.typed."csv__customers"' in (recipe.depends_on or [])
+
+        enriched_tables = (
+            session.execute(select(Table).where(Table.layer == "enriched")).scalars().all()
+        )
+        assert len(enriched_tables) == 1
+
+        # --- Run 1 retry: same run_id is idempotent (no duplicate rows) ----
+        run("run-1")
+        views = (
+            session.execute(select(EnrichedView).where(EnrichedView.fact_table_id == fact_id))
+            .scalars()
+            .all()
+        )
+        assert len(views) == 1, "a same-run retry must not duplicate the view definition"
+        recipes = (
+            session.execute(
+                select(MaterializationRecipe).where(
+                    MaterializationRecipe.table_id == fact_id,
+                    MaterializationRecipe.layer == "enriched",
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(recipes) == 1
+
+        # --- Run 2: a new run coexists; substrate stays latest-only --------
+        run("run-2")
+        views = (
+            session.execute(select(EnrichedView).where(EnrichedView.fact_table_id == fact_id))
+            .scalars()
+            .all()
+        )
+        assert {v.run_id for v in views} == {"run-1", "run-2"}
+        recipes = (
+            session.execute(
+                select(MaterializationRecipe).where(
+                    MaterializationRecipe.table_id == fact_id,
+                    MaterializationRecipe.layer == "enriched",
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert {r.run_id for r in recipes} == {"run-1", "run-2"}
+        # The enriched lake Table is reconciled latest-only — not duplicated per run.
+        enriched_tables = (
+            session.execute(select(Table).where(Table.layer == "enriched")).scalars().all()
+        )
+        assert len(enriched_tables) == 1

--- a/packages/engine/tests/integration/analysis/views/test_enriched_views.py
+++ b/packages/engine/tests/integration/analysis/views/test_enriched_views.py
@@ -62,20 +62,17 @@ class TestEnrichedViewsIntegration:
             )
         ]
 
-        view_name, sql, dim_cols = build_enriched_view_sql(
-            fact_table_name="orders",
-            fact_duckdb_path="typed_orders",
-            dimension_joins=joins,
-        )
+        view = '"enriched_orders"'
+        sql, dim_cols = build_enriched_view_sql(view, "typed_orders", joins)
 
         duckdb_conn.execute(sql)
 
         # Verify grain preserved (3 fact rows)
-        result = duckdb_conn.execute(f'SELECT COUNT(*) FROM "{view_name}"').fetchone()
+        result = duckdb_conn.execute(f"SELECT COUNT(*) FROM {view}").fetchone()
         assert result[0] == 3
 
         # Verify dimension columns present
-        result = duckdb_conn.execute(f'SELECT * FROM "{view_name}" ORDER BY order_id').fetchall()
+        result = duckdb_conn.execute(f"SELECT * FROM {view} ORDER BY order_id").fetchall()
         assert result[0][4] == "Alice"  # customers__name
         assert result[0][5] == "US"  # customers__country
         assert result[1][4] == "Bob"  # customers__name
@@ -113,11 +110,7 @@ class TestEnrichedViewsIntegration:
             )
         ]
 
-        _, sql, _ = build_enriched_view_sql(
-            fact_table_name="orders",
-            fact_duckdb_path="typed_orders",
-            dimension_joins=joins,
-        )
+        sql, _ = build_enriched_view_sql('"enriched_orders"', "typed_orders", joins)
 
         duckdb_conn.execute(sql)
 

--- a/packages/engine/tests/integration/pipeline/test_slicing_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_slicing_phase.py
@@ -82,7 +82,6 @@ class TestSlicingPhase:
                 view_id=str(uuid4()),
                 fact_table_id=table.table_id,
                 view_name="slicing_test_table",
-                view_sql="SELECT * FROM typed_test_table",
                 is_grain_verified=True,
                 dimension_columns=[],
             )
@@ -166,7 +165,6 @@ class TestSlicingPhase:
                 view_id=str(uuid4()),
                 fact_table_id=table_id,
                 view_name="slicing_test_table",
-                view_sql="SELECT * FROM typed_test_table",
                 is_grain_verified=True,
                 dimension_columns=[],
             )

--- a/packages/engine/tests/unit/analysis/correlation/test_enriched_derived.py
+++ b/packages/engine/tests/unit/analysis/correlation/test_enriched_derived.py
@@ -134,7 +134,6 @@ def _make_enriched_view(
         view_id=str(uuid4()),
         fact_table_id=fact_table.table_id,
         view_name=view_name,
-        view_sql=f"CREATE VIEW {view_name} AS ...",
         dimension_columns=dimension_columns,
         view_table_id=view_table.table_id if view_table else None,
     )

--- a/packages/engine/tests/unit/analysis/typing/test_recipe.py
+++ b/packages/engine/tests/unit/analysis/typing/test_recipe.py
@@ -5,7 +5,7 @@ real-DuckDB round-trip/reset integration tests:
 
 - ``store_recipe`` upserts on ``(table_id, layer, run_id)`` — a same-run re-store
   overwrites (Temporal at-least-once idempotency); a new run COEXISTS.
-- ``_order_by_dependency`` runs a recipe AFTER the recipes it reads from, keyed
+- ``order_recipes_by_dependency`` runs a recipe AFTER the recipes it reads from, keyed
   on the fully-qualified target (layer-aware), and tolerates deps that are not
   themselves recipes (e.g. the raw table).
 """
@@ -18,7 +18,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from dataraum.analysis.typing.db_models import MaterializationRecipe
-from dataraum.analysis.typing.recipe import _order_by_dependency, store_recipe
+from dataraum.analysis.typing.recipe import order_recipes_by_dependency, store_recipe
 from dataraum.storage import init_database
 
 
@@ -140,20 +140,20 @@ class TestOrderByDependency:
     def test_dependency_runs_before_dependent(self):
         base = _recipe('lake.raw."x"')  # produced by an upstream recipe in-set
         dependent = _recipe('lake.typed."x"', depends_on=['lake.raw."x"'])
-        ordered = _order_by_dependency([dependent, base])
+        ordered = order_recipes_by_dependency([dependent, base])
         assert ordered.index(base) < ordered.index(dependent)
 
     def test_unknown_dependency_is_tolerated(self):
         """A dep that is not itself a recipe (e.g. the raw table) is 'already present'."""
         only = _recipe('lake.typed."x"', depends_on=['lake.raw."x"'])
-        ordered = _order_by_dependency([only])
+        ordered = order_recipes_by_dependency([only])
         assert ordered == [only]
 
     def test_same_bare_different_layer_does_not_self_depend(self):
         """typed + quarantine share the bare name; FQN keying keeps them independent."""
         typed = _recipe('lake.typed."x"', depends_on=['lake.raw."x"'])
         quarantine = _recipe('lake.quarantine."x"', depends_on=['lake.raw."x"'])
-        ordered = _order_by_dependency([typed, quarantine])
+        ordered = order_recipes_by_dependency([typed, quarantine])
         # Both placed exactly once, neither depends on the other.
         assert set(ordered) == {typed, quarantine}
         assert len(ordered) == 2

--- a/packages/engine/tests/unit/analysis/views/test_builder.py
+++ b/packages/engine/tests/unit/analysis/views/test_builder.py
@@ -4,27 +4,32 @@ from dataraum.analysis.views.builder import DimensionJoin, build_enriched_view_s
 
 
 class TestBuildEnrichedViewSql:
-    """Tests for build_enriched_view_sql."""
+    """Tests for build_enriched_view_sql.
+
+    The builder takes caller-composed fully-qualified DuckDB names (DAT-415):
+    the view target and every source are FQNs, so the view is collision-free
+    across sources. These tests pass the FQNs the phase composes
+    (``lake.typed."enriched_<source>__<table>"``) and assert on the emitted SQL.
+    """
 
     def test_no_joins(self):
         """View with no dimension joins is just the fact table."""
-        view_name, sql, dim_cols = build_enriched_view_sql(
-            fact_table_name="orders",
-            fact_duckdb_path="typed_orders",
+        sql, dim_cols = build_enriched_view_sql(
+            view_fqn='lake.typed."enriched_csv__orders"',
+            fact_fqn='lake.typed."csv__orders"',
             dimension_joins=[],
         )
 
-        assert view_name == "enriched_orders"
-        assert "typed_orders" in sql
+        assert 'CREATE OR REPLACE VIEW lake.typed."enriched_csv__orders"' in sql
+        assert 'lake.typed."csv__orders"' in sql
         assert dim_cols == []
-        assert "CREATE OR REPLACE VIEW" in sql
 
     def test_single_dimension_join(self):
         """View with one dimension join."""
         joins = [
             DimensionJoin(
                 dim_table_name="customers",
-                dim_duckdb_path="typed_customers",
+                dim_duckdb_path='lake.typed."csv__customers"',
                 fact_fk_column="customer_id",
                 dim_pk_column="id",
                 include_columns=["name", "country"],
@@ -32,17 +37,16 @@ class TestBuildEnrichedViewSql:
             )
         ]
 
-        view_name, sql, dim_cols = build_enriched_view_sql(
-            fact_table_name="orders",
-            fact_duckdb_path="typed_orders",
+        sql, dim_cols = build_enriched_view_sql(
+            view_fqn='lake.typed."enriched_csv__orders"',
+            fact_fqn='lake.typed."csv__orders"',
             dimension_joins=joins,
         )
 
-        assert view_name == "enriched_orders"
         assert "f.*" in sql
         assert 'AS "customer_id__name"' in sql
         assert 'AS "customer_id__country"' in sql
-        assert "LEFT JOIN" in sql
+        assert 'LEFT JOIN lake.typed."csv__customers"' in sql
         assert 'ON f."customer_id"' in sql
         assert dim_cols == ["customer_id__name", "customer_id__country"]
 
@@ -51,7 +55,7 @@ class TestBuildEnrichedViewSql:
         joins = [
             DimensionJoin(
                 dim_table_name="customers",
-                dim_duckdb_path="typed_customers",
+                dim_duckdb_path='lake.typed."csv__customers"',
                 fact_fk_column="customer_id",
                 dim_pk_column="id",
                 include_columns=["name"],
@@ -59,7 +63,7 @@ class TestBuildEnrichedViewSql:
             ),
             DimensionJoin(
                 dim_table_name="products",
-                dim_duckdb_path="typed_products",
+                dim_duckdb_path='lake.typed."csv__products"',
                 fact_fk_column="product_id",
                 dim_pk_column="id",
                 include_columns=["product_name", "category"],
@@ -67,13 +71,12 @@ class TestBuildEnrichedViewSql:
             ),
         ]
 
-        view_name, sql, dim_cols = build_enriched_view_sql(
-            fact_table_name="order_lines",
-            fact_duckdb_path="typed_order_lines",
+        sql, dim_cols = build_enriched_view_sql(
+            view_fqn='lake.typed."enriched_csv__order_lines"',
+            fact_fqn='lake.typed."csv__order_lines"',
             dimension_joins=joins,
         )
 
-        assert view_name == "enriched_order_lines"
         assert sql.count("LEFT JOIN") == 2
         assert "customer_id__name" in dim_cols
         assert "product_id__product_name" in dim_cols
@@ -84,16 +87,16 @@ class TestBuildEnrichedViewSql:
         """Same dimension table joined via two different FK columns gets distinct column names."""
         joins = [
             DimensionJoin(
-                dim_table_name="typed_sachkontenstamm",
-                dim_duckdb_path="typed_sachkontenstamm",
+                dim_table_name="sachkontenstamm",
+                dim_duckdb_path='lake.typed."csv__sachkontenstamm"',
                 fact_fk_column="kontonummer_des_gegenkontos",
                 dim_pk_column="kontonummer_des_kontos",
                 include_columns=["beschriftung", "zusfkt"],
                 relationship_id="rel-1",
             ),
             DimensionJoin(
-                dim_table_name="typed_sachkontenstamm",
-                dim_duckdb_path="typed_sachkontenstamm",
+                dim_table_name="sachkontenstamm",
+                dim_duckdb_path='lake.typed."csv__sachkontenstamm"',
                 fact_fk_column="kontonummer_des_kontos",
                 dim_pk_column="kontonummer_des_kontos",
                 include_columns=["beschriftung", "zusfkt"],
@@ -101,9 +104,9 @@ class TestBuildEnrichedViewSql:
             ),
         ]
 
-        view_name, sql, dim_cols = build_enriched_view_sql(
-            fact_table_name="kontobuchungen",
-            fact_duckdb_path="typed_kontobuchungen",
+        sql, dim_cols = build_enriched_view_sql(
+            view_fqn='lake.typed."enriched_csv__kontobuchungen"',
+            fact_fqn='lake.typed."csv__kontobuchungen"',
             dimension_joins=joins,
         )
 

--- a/packages/engine/tests/unit/core/test_sql_normalize.py
+++ b/packages/engine/tests/unit/core/test_sql_normalize.py
@@ -1,0 +1,29 @@
+"""Unit tests for SQL canonicalization used by view-recipe version gating (DAT-415)."""
+
+from __future__ import annotations
+
+from dataraum.core.sql_normalize import canonical_sql, sql_equivalent
+
+
+class TestSqlEquivalent:
+    def test_whitespace_and_case_noise_is_equal(self) -> None:
+        a = 'CREATE OR REPLACE VIEW "enriched_orders" AS SELECT * FROM "typed"."orders"'
+        b = 'create or replace view "enriched_orders" as\n    select   *\n    from "typed"."orders"'
+        assert sql_equivalent(a, b)
+
+    def test_different_joined_table_is_not_equal(self) -> None:
+        a = 'SELECT f.* FROM "orders" AS f LEFT JOIN "customers" AS c ON f."cid" = c."id"'
+        b = 'SELECT f.* FROM "orders" AS f LEFT JOIN "suppliers" AS c ON f."cid" = c."id"'
+        assert not sql_equivalent(a, b)
+
+    def test_added_join_is_not_equal(self) -> None:
+        a = 'SELECT f.* FROM "orders" AS f'
+        b = 'SELECT f.* FROM "orders" AS f LEFT JOIN "customers" AS c ON f."cid" = c."id"'
+        assert not sql_equivalent(a, b)
+
+    def test_arbitrary_input_does_not_raise_and_is_reflexive(self) -> None:
+        # Unparseable input must fall back to byte-comparison, not raise.
+        garbage = "}{ not valid sql at all ;;;"
+        assert canonical_sql(garbage) == garbage.strip()
+        assert sql_equivalent(garbage, garbage)
+        assert not sql_equivalent(garbage, garbage + " extra")

--- a/packages/engine/tests/unit/core/test_sql_normalize.py
+++ b/packages/engine/tests/unit/core/test_sql_normalize.py
@@ -21,6 +21,25 @@ class TestSqlEquivalent:
         b = 'SELECT f.* FROM "orders" AS f LEFT JOIN "customers" AS c ON f."cid" = c."id"'
         assert not sql_equivalent(a, b)
 
+    def test_three_part_fqn_view_ddl_round_trips(self) -> None:
+        # The real recipe DDL is a three-part ``catalog.schema."quoted"`` FQN — pin
+        # that sqlglot canonicalizes it stably (case/whitespace noise → equal, a real
+        # join change → not equal), so the gate never spuriously re-versions.
+        a = (
+            'CREATE OR REPLACE VIEW lake.typed."enriched_csv__orders" AS '
+            'SELECT f.* FROM lake.typed."csv__orders" AS f '
+            'LEFT JOIN lake.typed."csv__customers" AS c ON f."cid" = c."id"'
+        )
+        b = (
+            'create or replace view lake.typed."enriched_csv__orders" as\n'
+            '  select f.*\n  from lake.typed."csv__orders" as f\n'
+            '  left join lake.typed."csv__customers" as c on f."cid" = c."id"'
+        )
+        assert sql_equivalent(a, b)
+        # A different joined dimension is a genuine change → a new version.
+        c = a.replace("csv__customers", "csv__suppliers")
+        assert not sql_equivalent(a, c)
+
     def test_arbitrary_input_does_not_raise_and_is_reflexive(self) -> None:
         # Unparseable input must fall back to byte-comparison, not raise.
         garbage = "}{ not valid sql at all ;;;"

--- a/packages/engine/tests/unit/entropy/test_dimension_coverage.py
+++ b/packages/engine/tests/unit/entropy/test_dimension_coverage.py
@@ -150,24 +150,24 @@ class TestTargetRef:
 
 class TestLoadData:
     def test_load_data_populates_enriched_view(self, detector: DimensionCoverageDetector):
-        """load_data queries EnrichedView by view_name."""
+        """load_data queries the fact table's EnrichedView by table_id (DAT-415)."""
         mock_view = _make_enriched_view(["col1"])
         session = MagicMock()
         session.execute.return_value.scalar_one_or_none.return_value = mock_view
 
-        ctx = DetectorContext(view_name="enriched_orders", session=session)
+        ctx = DetectorContext(table_id="fact-1", session=session)
         detector.load_data(ctx)
 
         assert ctx.analysis_results["enriched_view"] is mock_view
 
     def test_load_data_no_session(self, detector: DimensionCoverageDetector):
         """load_data is no-op without session."""
-        ctx = DetectorContext(view_name="enriched_orders")
+        ctx = DetectorContext(table_id="fact-1")
         detector.load_data(ctx)
         assert "enriched_view" not in ctx.analysis_results
 
-    def test_load_data_no_view_name(self, detector: DimensionCoverageDetector):
-        """load_data is no-op without view_name."""
+    def test_load_data_no_table_id(self, detector: DimensionCoverageDetector):
+        """load_data is no-op without table_id (a non-fact context → skipped)."""
         ctx = DetectorContext(session=MagicMock())
         detector.load_data(ctx)
         assert "enriched_view" not in ctx.analysis_results

--- a/packages/engine/tests/unit/entropy/test_persist_readiness_scope.py
+++ b/packages/engine/tests/unit/entropy/test_persist_readiness_scope.py
@@ -104,3 +104,63 @@ def test_empty_table_set_is_a_noop(session: Session) -> None:
 
     assert persist_readiness(session, baseline_session_id(), []) == 0
     assert session.query(EntropyReadinessRecord).filter_by(table_id="tbl_c").count() == 1
+
+
+def test_table_grain_readiness_round_trip(session: Session) -> None:
+    """A table-scoped dimension_coverage object rolls up to a banded ``table:`` row (DAT-415).
+
+    Proves the P4 round-trip: a ``table:`` entropy object rolls up the network
+    (dimension_coverage → query/reporting intents), persists with the table FK and
+    NO column FK, and ``load_table_readiness`` reads it back via the session head.
+    """
+    from datetime import UTC, datetime
+
+    from dataraum.entropy.db_models import EntropyObjectRecord
+    from dataraum.entropy.views.readiness_context import load_table_readiness
+    from dataraum.storage import MetadataSnapshotHead, session_head_target
+
+    session.add(Source(source_id="src_t", name="src_t", source_type="csv"))
+    session.add(Table(table_id="fact_t", source_id="src_t", table_name="orders", layer="typed"))
+    session.flush()
+    # A high coverage-gap measurement at table grain (semantic.coverage.dimension_coverage
+    # maps to the dimension_coverage network node → query/reporting intent risk).
+    session.add(
+        EntropyObjectRecord(
+            session_id=baseline_session_id(),
+            layer="semantic",
+            dimension="coverage",
+            sub_dimension="dimension_coverage",
+            target="table:orders",
+            table_id="fact_t",
+            column_id=None,
+            run_id="run-1",
+            score=0.8,
+            detector_id="dimension_coverage",
+        )
+    )
+    session.flush()
+
+    written = persist_readiness(session, baseline_session_id(), ["fact_t"], run_id="run-1")
+    session.flush()
+    assert written >= 1
+
+    rows = [r for r in session.query(EntropyReadinessRecord).all() if r.target == "table:orders"]
+    assert len(rows) == 1
+    row = rows[0]
+    assert (row.table_id, row.column_id, row.run_id) == ("fact_t", None, "run-1")
+    assert row.band in ("investigate", "blocked"), "a 0.8 coverage gap is not 'ready'"
+
+    # Reader resolves the current run via the session head (begin_session seals there).
+    session.add(
+        MetadataSnapshotHead(
+            target=session_head_target(baseline_session_id()),
+            stage="detect",
+            run_id="run-1",
+            promoted_at=datetime.now(UTC),
+            version=0,
+        )
+    )
+    session.flush()
+    assert [r.target for r in load_table_readiness(session, baseline_session_id())] == [
+        "table:orders"
+    ]

--- a/packages/engine/tests/unit/entropy/views/test_query_context.py
+++ b/packages/engine/tests/unit/entropy/views/test_query_context.py
@@ -1,0 +1,46 @@
+"""Unit tests for the query-time contract-gate column summaries."""
+
+from __future__ import annotations
+
+from dataraum.entropy.views.query_context import network_to_column_summaries
+from dataraum.entropy.views.readiness_context import (
+    ColumnNodeEvidence,
+    ColumnReadinessResult,
+    EntropyForReadiness,
+)
+
+
+def test_network_to_column_summaries_skips_non_column_targets() -> None:
+    """Only ``column:`` targets feed the per-column contract gate (DAT-415).
+
+    ``EntropyForReadiness.columns`` now also holds ``relationship:`` (DAT-408) and
+    ``table:`` (DAT-415) grains that roll up the same network. The contract gate is
+    per-column, so those must be skipped — otherwise a ``table:orders`` target
+    surfaces as a junk column named ``table:orders`` and pollutes the dimension
+    averages.
+    """
+    ne = ColumnNodeEvidence(
+        node_name="dimension_coverage",
+        dimension_path="semantic.coverage.dimension_coverage",
+        score=0.8,
+        state="high",
+    )
+    ctx = EntropyForReadiness(
+        columns={
+            "column:orders.amount": ColumnReadinessResult(
+                target="column:orders.amount", node_evidence=[ne], readiness="ready"
+            ),
+            "table:orders": ColumnReadinessResult(
+                target="table:orders", node_evidence=[ne], readiness="ready"
+            ),
+            "relationship:fk-a::pk-b": ColumnReadinessResult(
+                target="relationship:fk-a::pk-b", node_evidence=[ne], readiness="ready"
+            ),
+        }
+    )
+
+    summaries = network_to_column_summaries(ctx)
+
+    assert set(summaries) == {"orders.amount"}, "non-column grains must not become columns"
+    assert summaries["orders.amount"].table_name == "orders"
+    assert summaries["orders.amount"].column_name == "amount"

--- a/packages/engine/tests/unit/entropy/views/test_readiness_context.py
+++ b/packages/engine/tests/unit/entropy/views/test_readiness_context.py
@@ -365,8 +365,12 @@ class TestPerColumnAssembly:
         deltas = [d.impact_delta for d in intent.drivers]
         assert deltas == sorted(deltas, reverse=True)
 
-    def test_table_target_becomes_direct_signal(self, small_network):
-        """Table-level objects always become direct signals."""
+    def test_table_target_rolls_up(self, small_network):
+        """A table: target rolls up the network like a column (DAT-415).
+
+        Table-grain readiness (the fact table's dimension_coverage) rolls into a
+        banded result keyed by the ``table:`` target, not a raw DirectSignal.
+        """
         objects = [
             make_entropy_object(
                 layer="structural",
@@ -377,9 +381,9 @@ class TestPerColumnAssembly:
             ),
         ]
         result = assemble_readiness_context(objects, small_network)
-        assert result.total_columns == 0
-        assert len(result.direct_signals) == 1
-        assert result.direct_signals[0].target == "table:sales"
+        assert result.total_columns == 1
+        assert "table:sales" in result.columns
+        assert all(ds.target != "table:sales" for ds in result.direct_signals)
 
     def test_node_evidence_carries_raw_data(self, small_network):
         """ColumnNodeEvidence has score, evidence from source object."""

--- a/packages/engine/tests/unit/pipeline/test_slicing_view_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_slicing_view_phase.py
@@ -31,6 +31,9 @@ def _make_enriched_view(
     ev = MagicMock(spec=EnrichedView)
     ev.fact_table_id = fact_table_id
     ev.dimension_columns = dim_cols
+    # Slicing now sources from the view's stored name (collision-named off the
+    # fact's duckdb_path, DAT-415), not a reconstructed ``enriched_{table_name}``.
+    ev.view_name = f"enriched_{fact_table_name}"
     return ev
 
 


### PR DESCRIPTION
Bundled slice spanning **DAT-415** (view-DDL versioning, epic DAT-412) and **DAT-402** (begin_session Slice 2.1 — enriched views + table readiness, epic DAT-356), built on the DAT-414 `MaterializationRecipe` substrate. Plan: Confluence DD/30867458.

Revives the dormant `enriched_views` phase as the **carrier** for view-DDL versioning, and adds **table-grain readiness** to begin_session — then surfaces both in the cockpit agent tier.

## What changed

**Engine**
- `enriched_views` revived as a **source-free, run-versioned session phase** (scopes by `ctx.table_ids`), wired into `BeginSessionWorkflow` after `session_materialize_overlays`, before `session_detect`.
- The `CREATE VIEW` DDL is versioned on the **DAT-414 recipe substrate** (`MaterializationRecipe(layer="enriched")`, `depends_on` = typed fact/dim FQNs). `EnrichedView.view_sql` **removed** (was write-only); `run_id` added; the enriched lake `Table`/`Column`/profile stay **latest-only**, re-materialized from the versioned DDL.
- LLM join selection **kept** (temperature 0); run-to-run "same SQL?" handled by a new **sqlglot canonicalizer** (`core/sql_normalize.py`) — a recipe is re-stamped only when the canonical DDL changes, never on whitespace/case noise.
- `analysis/views/recipe.py::rebuild_enriched_views` — session-scoped, transactional, dependency-ordered re-exec + drop-stray (substrate; reset-to-past + GC deferred to DAT-416).
- `dimension_coverage` re-keyed `view:` → **`table:`** scope; **table-grain readiness** rolls up the noisy-OR network → per-intent bands, persisted as `table:{name}` rows, sealed at the `session:{id}` head.

**Cockpit**
- `look_table` gains an optional `session_id` → also returns a `table_readiness` band resolved at the session head (two heads: `table:{id}` per-column add_source grid + `session:{id}` table-grain band).
- New `why_table` tool (table analog of `why_relationship`): persisted drivers + detector evidence + one grounded narrative.
- `tableTargetKey` added to the target-grammar mirror; registry + chat-route wired; Drizzle metadata re-pulled.
- `table-readiness` widget renders the whole-table band above the per-column grid.

## Testing

- **Engine:** 881 unit + integration green; ruff/mypy clean. DuckLake view support pinned by a real-DuckLake integration test; rebuild round-trip + latest-only + sqlglot gating covered.
- **Cockpit:** 517 unit tests green; tsc + biome clean.
- **Bundled live smoke (full stack):** `add_source → begin_session` end-to-end on the finance fixtures — enriched view materializes in DuckLake (`ducklake_view`), recipe DDL versioned, `table:payments` band = `ready`, and `look_table`/`why_table` surface it (live-verified: band with `session_id`, null without).
- Two review gates (engine + cockpit): **senior APPROVED + spec COMPLIANT**, should-fixes folded in.

## Eval handoff

`dimension_coverage` recall + the table-readiness rollup + view-DDL change are flagged in `.claude/handoff.md` for dataraum-eval calibration (recall is proven there, post-merge, not by unit tests).

## Deferred (non-blocking, logged)

- **DAT-416**: reset-to-a-*past* run must also roll the latest-only `EnrichedView`/`Table` metadata, else the physical view and its Postgres metadata diverge silently. Rebuild-to-current (this PR) is consistent; only past-reset risks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)