### PR TITLE
fix(typing/eligibility): replay-poison TypeDecisions, STRPTIME-throw, key-name run abort

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,43 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-05: typing replay-poison + STRPTIME-throw + eligibility key-abort fixes
+
+Three add_source typing/eligibility bug fixes from a user report (German DD.MM.YYYY
+data; branch `fix/typing-replay-poison`). **Typing outcomes change — re-run the
+add_source recall suite.** Expected movement: date-typed coverage UP.
+
+### dataraum-eval
+- **Changed:** `analysis/typing/{patterns.py, inference.py, resolution.py}`,
+  `analysis/eligibility/{evaluator.py, config.py}`, `pipeline/phases/column_eligibility_phase.py`,
+  `storage/models.py` (`Column.type_decision` → `type_decisions` list), `graphs/context.py`,
+  `dataraum-config/phases/column_eligibility.yaml` (`key_patterns` removed).
+- **Behavior changes:**
+  1. **One malformed value no longer zeroes a date pattern.** Standardization exprs are
+     TRY_-normalized (`STRPTIME`→`TRY_STRPTIME`, inner `CAST`→`TRY_CAST`) at Pattern load.
+     A 99%-clean DD.MM.YYYY column now types DATE with the bad rows quarantined instead of
+     falling back to VARCHAR with `success_rate=0.0` and no failed examples. Columns that
+     previously stayed VARCHAR because of a single dirty value will now be DATE — ground
+     truths that encoded the buggy VARCHAR outcome need updating.
+  2. **Re-runs/replays re-decide types.** Resolution honors only `decision_source='manual'`
+     TypeDecisions (latest), and a manual pin keeps the standardization expr; candidates are
+     run-scoped. Previously ANY second run froze the first run's outcome (taught patterns
+     never applied) or re-applied DATE without its parse expr (100%-NULL column → all rows
+     quarantined → eligibility dropped it). Any calibration that re-runs typing on the same
+     workspace exercises this path.
+  3. **Eligibility no longer aborts on all-null key-named columns.** `is_likely_key` /
+     `key_patterns` deleted; an all-null `*_id` column drops + records INELIGIBLE like any
+     other and the run continues. Scenarios that asserted a pipeline FAILURE for null key
+     columns now expect a completed run with `dropped >= 1`.
+- **Calibrate:** add_source recall suite + any teach/replay strategy. No new response
+  fields; no workflow contract change.
+
+### dataraum-testdata
+- Injection hints: (a) a date column with exactly one unparseable-but-regex-matching value
+  (e.g. `29.02.2023`) — should type DATE, quarantine 1 row; (b) a 100%-null `*_id` column —
+  should drop, not abort; (c) a DD.MM.YYYY column re-typed across two runs — second run must
+  still parse (the replay-poison regression).
+
 ## 2026-06-04: DAT-421 — add_source `semantic_per_column` scopes by session, not source
 
 Epic DAT-420 (source model). The add_source source-level reduce was the last spine

--- a/packages/dataraum-config/phases/column_eligibility.yaml
+++ b/packages/dataraum-config/phases/column_eligibility.yaml
@@ -45,10 +45,3 @@ rules:
 
 # Default status if no rules match
 default_status: "ELIGIBLE"
-
-# Patterns to identify likely key columns (regex)
-# Pipeline fails if a column matching these patterns is INELIGIBLE
-key_patterns:
-  - "_id$"      # Columns ending in _id
-  - "^id$"      # Column named exactly 'id'
-  - "_key$"     # Columns ending in _key

--- a/packages/engine/src/dataraum/analysis/eligibility/__init__.py
+++ b/packages/engine/src/dataraum/analysis/eligibility/__init__.py
@@ -15,7 +15,6 @@ from dataraum.analysis.eligibility.evaluator import (
     evaluate_rules,
     extract_metrics,
     format_reason,
-    is_likely_key,
     quarantine_and_drop_columns,
 )
 
@@ -27,7 +26,6 @@ __all__ = [
     "evaluate_rules",
     "extract_metrics",
     "format_reason",
-    "is_likely_key",
     "load_eligibility_config",
     "quarantine_and_drop_columns",
 ]

--- a/packages/engine/src/dataraum/analysis/eligibility/config.py
+++ b/packages/engine/src/dataraum/analysis/eligibility/config.py
@@ -5,7 +5,7 @@ Loads and validates the column eligibility configuration from YAML.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 
@@ -36,7 +36,6 @@ class EligibilityConfig:
     thresholds: EligibilityThresholds
     rules: list[EligibilityRule]
     default_status: str
-    key_patterns: list[str] = field(default_factory=lambda: ["_id$", "^id$", "_key$"])
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> EligibilityConfig:
@@ -66,7 +65,6 @@ class EligibilityConfig:
             thresholds=thresholds,
             rules=rules,
             default_status=data["default_status"],
-            key_patterns=data.get("key_patterns", ["_id$", "^id$", "_key$"]),
         )
 
 

--- a/packages/engine/src/dataraum/analysis/eligibility/evaluator.py
+++ b/packages/engine/src/dataraum/analysis/eligibility/evaluator.py
@@ -6,7 +6,6 @@ Pure logic — no pipeline/phase dependencies.
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from dataraum.analysis.eligibility.config import EligibilityConfig
@@ -110,14 +109,6 @@ def format_reason(template: str, metrics: dict[str, Any]) -> str:
         return template.format(**metrics)
     except KeyError, ValueError:
         return template
-
-
-def is_likely_key(column_name: str, patterns: list[str]) -> bool:
-    """Check if column name matches key patterns."""
-    for pattern in patterns:
-        if re.search(pattern, column_name, re.IGNORECASE):
-            return True
-    return False
 
 
 def quarantine_and_drop_columns(

--- a/packages/engine/src/dataraum/analysis/typing/db_models.py
+++ b/packages/engine/src/dataraum/analysis/typing/db_models.py
@@ -133,7 +133,7 @@ class TypeDecision(Base):
     decision_reason: Mapped[str | None] = mapped_column(String)
 
     # Relationships
-    column: Mapped[Column] = relationship(back_populates="type_decision")
+    column: Mapped[Column] = relationship(back_populates="type_decisions")
 
 
 class MaterializationRecipe(Base):

--- a/packages/engine/src/dataraum/analysis/typing/inference.py
+++ b/packages/engine/src/dataraum/analysis/typing/inference.py
@@ -299,14 +299,11 @@ def _infer_column_types(
                 continue  # Need multiple patterns to COALESCE
 
             # Build COALESCE(TRY_STRPTIME(col, fmt1), TRY_STRPTIME(col, fmt2), ...)
-            # Replace error-throwing functions with TRY_ variants so mismatches
+            # Exprs are TRY_-normalized at Pattern construction, so mismatches
             # return NULL instead of failing the entire COALESCE expression.
             parts = []
             for p in type_patterns:
-                expr = p.standardization_expr.format(col=col_name)  # type: ignore[union-attr]
-                expr = expr.replace("STRPTIME(", "TRY_STRPTIME(")
-                expr = expr.replace("CAST(", "TRY_CAST(")
-                parts.append(expr)
+                parts.append(p.standardization_expr.format(col=col_name))  # type: ignore[union-attr]
             coalesce_expr = f"COALESCE({', '.join(parts)})"
 
             parse_result = _test_type_cast(
@@ -466,5 +463,9 @@ def _test_type_cast(
         )
 
     except Exception as e:
-        logger.debug("type_cast_test_error", table=table_name, column=col_name, error=str(e))
+        # With TRY_-normalized exprs this should not fire for malformed VALUES
+        # (those return NULL and count as failures with examples). An exception
+        # here means the expression itself is broken — surface it loudly, since
+        # the caller will score the pattern 0.0 with no failed examples.
+        logger.warning("type_cast_test_error", table=table_name, column=col_name, error=str(e))
         return ParseResult(success_rate=0.0, failed_examples=[])

--- a/packages/engine/src/dataraum/analysis/typing/patterns.py
+++ b/packages/engine/src/dataraum/analysis/typing/patterns.py
@@ -19,12 +19,37 @@ from dataraum.core.models.base import DataType
 
 logger = get_logger(__name__)
 
+# Error-throwing DuckDB functions and their NULL-returning TRY_ variants.
+# ``\b`` keeps already-prefixed calls (TRY_STRPTIME, TRY_CAST) untouched:
+# the underscore is a word character, so there is no boundary before the
+# bare function name inside them — normalization is idempotent.
+_TRY_FUNC_RE = re.compile(r"\b(STRPTIME|CAST)\(")
+
+
+def normalize_standardization_expr(expr: str) -> str:
+    """Rewrite error-throwing functions to their ``TRY_`` variants.
+
+    DuckDB's ``STRPTIME``/``CAST`` raise on non-conforming input, and a
+    surrounding ``TRY_CAST`` does NOT catch errors thrown by inner function
+    calls — so a single malformed value would fail an entire inference query
+    (scoring the pattern 0.0) or the typed-table ``CREATE`` itself.
+    ``TRY_STRPTIME``/``TRY_CAST`` return NULL instead, which the quarantine
+    flow is designed around: the bad rows quarantine, the column still types.
+
+    Applied once at :class:`Pattern` construction so builtin YAML patterns,
+    overlay-taught patterns, and synthetic combined patterns all carry the
+    safe form.
+    """
+    return _TRY_FUNC_RE.sub(lambda m: f"TRY_{m.group(1)}(", expr)
+
 
 @dataclass
 class Pattern:
     """A single pattern definition for value matching.
 
     Patterns match against actual cell values (not column names).
+    ``standardization_expr`` is normalized to TRY_ function variants on
+    construction (see :func:`normalize_standardization_expr`).
     """
 
     name: str
@@ -43,9 +68,11 @@ class Pattern:
     _regex: re.Pattern[str] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
-        """Compile regex pattern."""
+        """Compile regex pattern and normalize the standardization expr."""
         flags = 0 if self.case_sensitive else re.IGNORECASE
         self._regex = re.compile(self.pattern, flags)
+        if self.standardization_expr:
+            self.standardization_expr = normalize_standardization_expr(self.standardization_expr)
 
     def matches(self, value: str) -> bool:
         """Check if value matches this pattern.

--- a/packages/engine/src/dataraum/analysis/typing/resolution.py
+++ b/packages/engine/src/dataraum/analysis/typing/resolution.py
@@ -70,13 +70,12 @@ def _resolve_pattern(
         return parts[0]
 
     # Build COALESCE(TRY_STRPTIME("{col}", fmt1), TRY_STRPTIME("{col}", fmt2), ...)
-    # Each part's standardization_expr is e.g. STRPTIME("{col}", '%m/%d/%Y')
-    # We replace STRPTIME → TRY_STRPTIME so mismatches return NULL not error
+    # Exprs are TRY_-normalized at Pattern construction, so each part returns
+    # NULL on mismatch instead of erroring.
     coalesce_parts = []
     for p in parts:
         if p.standardization_expr:
-            expr = p.standardization_expr.replace("STRPTIME(", "TRY_STRPTIME(")
-            coalesce_parts.append(expr)
+            coalesce_parts.append(p.standardization_expr)
 
     if not coalesce_parts:
         return parts[0]  # No standardization exprs, fallback to first

--- a/packages/engine/src/dataraum/analysis/typing/resolution.py
+++ b/packages/engine/src/dataraum/analysis/typing/resolution.py
@@ -203,7 +203,6 @@ def _select_best_candidates(
     columns: list[Column],
     min_confidence: float,
     run_id: str | None,
-    table_name: str = "",
 ) -> list[ColumnTypeSpec]:
     """Select best type candidate per column for THIS run.
 
@@ -245,12 +244,25 @@ def _select_best_candidates(
             default=None,
         )
         if manual is not None:
+            # The pattern search deliberately ignores min_confidence — a human
+            # pinned the type, so even a weak same-type candidate's expr beats
+            # a plain cast.
             pattern = None
             for cand in candidates:
                 if cand.data_type == manual.decided_type and cand.detected_pattern:
                     pattern = _resolve_pattern(cand.detected_pattern, patterns_by_name)
                     if pattern is not None:
                         break
+            if pattern is None:
+                # No same-type candidate this run → the DDL plain-TRY_CASTs to
+                # the decided type. For string-parsed types (dates) that can
+                # NULL every value — surface it instead of failing silently.
+                logger.warning(
+                    "manual_override_no_matching_candidate",
+                    column=col.column_name,
+                    decided_type=manual.decided_type,
+                    run_id=run_id,
+                )
             specs.append(
                 ColumnTypeSpec(
                     column_id=col.column_id,
@@ -412,12 +424,7 @@ def resolve_types(
     quarantine_target = f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("quarantine")}."{bare}"'
 
     # Select best candidates
-    specs = _select_best_candidates(
-        table.columns,
-        min_confidence,
-        run_id,
-        table_name=table.table_name,
-    )
+    specs = _select_best_candidates(table.columns, min_confidence, run_id)
 
     # Persist THIS run's TypeDecision for every column — upsert on
     # ``(column_id, run_id)`` (idempotent under a Temporal at-least-once

--- a/packages/engine/src/dataraum/analysis/typing/resolution.py
+++ b/packages/engine/src/dataraum/analysis/typing/resolution.py
@@ -196,19 +196,32 @@ class ColumnTypeSpec:
     decision_source: str = "automatic"  # 'automatic', 'manual', 'override', 'fallback'
     decision_reason: str | None = None
     candidate_confidence: float | None = None  # Confidence from best TypeCandidate
+    decided_by: str | None = None  # Provenance carried from an honored manual decision
 
 
 def _select_best_candidates(
     columns: list[Column],
     min_confidence: float,
+    run_id: str | None,
     table_name: str = "",
 ) -> list[ColumnTypeSpec]:
-    """Select best type candidate per column.
+    """Select best type candidate per column for THIS run.
 
     Priority:
-    1. TypeDecision (human override) if exists
-    2. Highest confidence TypeCandidate >= threshold
-    3. Fallback to VARCHAR
+    1. Manual TypeDecision (human override) — pins the TYPE; the best
+       same-type candidate still supplies the standardization expr.
+    2. Highest confidence TypeCandidate >= threshold (this run's candidates).
+    3. Fallback to VARCHAR.
+
+    Only ``decision_source == "manual"`` rows are honored as overrides:
+    resolution persists its own ``automatic``/``fallback`` decisions every
+    run, and honoring those froze the first run's outcome forever — a prior
+    fallback-VARCHAR row blocked taught patterns from ever applying, and a
+    prior automatic DATE row re-applied WITHOUT its standardization expr,
+    plain-TRY_CASTing e.g. DD.MM.YYYY to an all-NULL column. Candidates are
+    likewise scoped to ``run_id`` (DAT-413: runs coexist): a prior run's
+    VARCHAR fallback at confidence 1.0 must not outcompete this run's real
+    candidates.
 
     Returns ColumnTypeSpec with decision metadata for persisting TypeDecision records.
     """
@@ -217,21 +230,41 @@ def _select_best_candidates(
     specs = []
 
     for col in sorted(columns, key=lambda c: c.column_position):
-        # Check for human override (pre-existing TypeDecision)
-        if col.type_decision:
+        candidates = sorted(
+            (c for c in col.type_candidates if c.run_id == run_id),
+            key=lambda c: c.confidence,
+            reverse=True,
+        )
+
+        # Human override: the latest manual decision pins the TYPE. Keep the
+        # best same-type candidate's pattern — honoring the type while
+        # dropping its standardization expr is the destruction path.
+        manual = max(
+            (td for td in col.type_decisions if td.decision_source == "manual"),
+            key=lambda td: td.decided_at,
+            default=None,
+        )
+        if manual is not None:
+            pattern = None
+            for cand in candidates:
+                if cand.data_type == manual.decided_type and cand.detected_pattern:
+                    pattern = _resolve_pattern(cand.detected_pattern, patterns_by_name)
+                    if pattern is not None:
+                        break
             specs.append(
                 ColumnTypeSpec(
                     column_id=col.column_id,
                     column_name=col.column_name,
-                    data_type=DataType[col.type_decision.decided_type],
-                    decision_source="manual",  # Already decided by human
-                    decision_reason=col.type_decision.decision_reason,
+                    data_type=DataType[manual.decided_type],
+                    pattern=pattern,
+                    decision_source="manual",
+                    decision_reason=manual.decision_reason,
+                    decided_by=manual.decided_by,
                 )
             )
             continue
 
         # Find best candidate
-        candidates = sorted(col.type_candidates, key=lambda c: c.confidence, reverse=True)
         if candidates and candidates[0].confidence >= min_confidence:
             best = candidates[0]
             pattern = (
@@ -354,7 +387,7 @@ def resolve_types(
         .where(Table.table_id == table_id)
         .options(
             selectinload(Table.columns).selectinload(Column.type_candidates),
-            selectinload(Table.columns).selectinload(Column.type_decision),
+            selectinload(Table.columns).selectinload(Column.type_decisions),
         )
     )
     result = session.execute(stmt)
@@ -382,30 +415,31 @@ def resolve_types(
     specs = _select_best_candidates(
         table.columns,
         min_confidence,
+        run_id,
         table_name=table.table_name,
     )
 
-    # Persist TypeDecision records for columns that don't already have one
-    # (columns with pre-existing TypeDecision are human overrides, don't overwrite).
-    # Use relationship assignment (column=raw_col) instead of FK assignment
-    # (column_id=...) so that back_populates fires and raw_col.type_decision
-    # is populated for the copy step below.
+    # Persist THIS run's TypeDecision for every column — upsert on
+    # ``(column_id, run_id)`` (idempotent under a Temporal at-least-once
+    # retry; prior runs' rows coexist untouched, DAT-413). Each run records
+    # what it actually executed, including ``manual`` when it honored a
+    # human override.
     raw_col_by_id = {col.column_id: col for col in table.columns}
-    columns_with_decision = {col.column_id for col in table.columns if col.type_decision}
-    for spec in specs:
-        if spec.column_id not in columns_with_decision:
-            raw_col = raw_col_by_id[spec.column_id]
-            type_decision = TypeDecision(
-                decision_id=str(uuid4()),
-                session_id=session_id,
-                column=raw_col,
-                run_id=run_id,
-                decided_type=spec.data_type.value,
-                decision_source=spec.decision_source,
-                decided_at=datetime.now(UTC),
-                decision_reason=spec.decision_reason,
-            )
-            session.add(type_decision)
+    decided_at = datetime.now(UTC)
+    raw_decision_rows: list[dict[str, Any]] = [
+        {
+            "session_id": session_id,
+            "column_id": spec.column_id,
+            "run_id": run_id,
+            "decided_type": spec.data_type.value,
+            "decision_source": spec.decision_source,
+            "decided_at": decided_at,
+            "decided_by": spec.decided_by,
+            "decision_reason": spec.decision_reason,
+        }
+        for spec in specs
+    ]
+    upsert(session, TypeDecision, raw_decision_rows, index_elements=["column_id", "run_id"])
 
     # Emit → store → execute (DAT-414): build the materialization DDL strings
     # first, persist them as versioned recipes stamped with ``run_id`` (so a
@@ -529,11 +563,13 @@ def resolve_types(
             )
         )
 
-        # Set quarantine metrics on raw TypeCandidate records
+        # Set quarantine metrics on THIS run's raw TypeCandidate records
+        # (prior runs' candidates coexist and keep their own metrics).
         raw_col = raw_col_by_id[spec.column_id]
         for tc in raw_col.type_candidates:
-            tc.quarantine_count = failures
-            tc.quarantine_rate = q_rate
+            if tc.run_id == run_id:
+                tc.quarantine_count = failures
+                tc.quarantine_rate = q_rate
 
     # Copy TypeDecision and TypeCandidate from raw columns to typed columns.
     # Raw columns keep originals (audit trail); typed columns get copies so
@@ -557,30 +593,34 @@ def resolve_types(
         )
         session.flush()
 
+    spec_by_column_id = {spec.column_id: spec for spec in specs}
     type_decision_rows: list[dict[str, Any]] = []
     for raw_col in table.columns:
         target_col_id = typed_column_map.get(raw_col.column_name)
         if target_col_id is None:
             continue
 
-        if raw_col.type_decision:
-            td = raw_col.type_decision
+        # The typed copy mirrors THIS run's executed decision (the spec) —
+        # never a prior run's row off the multi-run relationship.
+        col_spec = spec_by_column_id.get(raw_col.column_id)
+        if col_spec is not None:
             # PK omitted so the model's Python-side default applies.
             type_decision_rows.append(
                 {
                     "session_id": session_id,
                     "column_id": target_col_id,
                     "run_id": run_id,
-                    "decided_type": td.decided_type,
-                    "decision_source": td.decision_source,
-                    "decided_at": td.decided_at,
-                    "decided_by": td.decided_by,
-                    "previous_type": td.previous_type,
-                    "decision_reason": td.decision_reason,
+                    "decided_type": col_spec.data_type.value,
+                    "decision_source": col_spec.decision_source,
+                    "decided_at": decided_at,
+                    "decided_by": col_spec.decided_by,
+                    "decision_reason": col_spec.decision_reason,
                 }
             )
 
         for tc in raw_col.type_candidates:
+            if tc.run_id != run_id:
+                continue  # copy only THIS run's candidates (DAT-413 coexistence)
             session.add(
                 TypeCandidate(
                     candidate_id=str(uuid4()),

--- a/packages/engine/src/dataraum/pipeline/phases/column_eligibility_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/column_eligibility_phase.py
@@ -16,7 +16,6 @@ from dataraum.analysis.eligibility.db_models import ColumnEligibilityRecord
 from dataraum.analysis.eligibility.evaluator import (
     evaluate_rules,
     extract_metrics,
-    is_likely_key,
     quarantine_and_drop_columns,
 )
 from dataraum.analysis.statistics.db_models import StatisticalProfile
@@ -127,13 +126,6 @@ class ColumnEligibilityPhase(BasePhase):
             profile = profile_map.get(column.column_id)
             metrics = extract_metrics(profile)
             status, rule_id, reason = evaluate_rules(config, metrics, column.column_name)
-
-            # Check if critical column (likely key)
-            if status == "INELIGIBLE" and is_likely_key(column.column_name, config.key_patterns):
-                return PhaseResult.failed(
-                    f"Critical column '{column.column_name}' in table '{table.table_name}' "
-                    f"is ineligible: {reason}. Cannot proceed with unusable key column."
-                )
 
             # PK omitted so the model's Python-side default applies.
             rows.append(

--- a/packages/engine/src/dataraum/storage/models.py
+++ b/packages/engine/src/dataraum/storage/models.py
@@ -165,9 +165,11 @@ class Column(Base):
     type_candidates: Mapped[list[TypeCandidate]] = relationship(
         back_populates="column", cascade="all, delete-orphan", passive_deletes=True
     )
-    type_decision: Mapped[TypeDecision | None] = relationship(
+    # One TypeDecision per column PER RUN (DAT-413) — runs coexist, so this is
+    # a list; readers pick the relevant run's row (or the latest manual), never
+    # "the" decision.
+    type_decisions: Mapped[list[TypeDecision]] = relationship(
         back_populates="column",
-        uselist=False,
         cascade="all, delete-orphan",
         passive_deletes=True,
     )

--- a/packages/engine/tests/integration/conftest.py
+++ b/packages/engine/tests/integration/conftest.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from dataraum.entropy.engine import run_detector_post_step
 from dataraum.pipeline.base import Phase, PhaseContext, PhaseResult, PhaseStatus
+from dataraum.pipeline.phases.column_eligibility_phase import ColumnEligibilityPhase
 from dataraum.pipeline.phases.correlations_phase import CorrelationsPhase
 from dataraum.pipeline.phases.import_phase import ImportPhase
 from dataraum.pipeline.phases.relationships_phase import RelationshipsPhase
@@ -467,6 +468,7 @@ def integration_phases() -> dict[str, Phase]:
         ImportPhase(),
         TypingPhase(),
         StatisticsPhase(),
+        ColumnEligibilityPhase(),
         StatisticalQualityPhase(),
         RelationshipsPhase(),
         CorrelationsPhase(),

--- a/packages/engine/tests/integration/pipeline/test_column_eligibility_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_column_eligibility_phase.py
@@ -1,0 +1,67 @@
+"""Column eligibility phase against a real substrate.
+
+Pins the deletion of the key-name hard abort (German-dates user report,
+2026-06-05): the phase used to ``PhaseResult.failed`` the ENTIRE run when an
+INELIGIBLE (100%-null) column's NAME matched ``_id$``/``^id$``/``_key$`` —
+name-only key inference with no structural evidence and no teach escape
+hatch. An all-null key-named column is now dropped + recorded INELIGIBLE
+like any other, and the run continues; key-ness claims live downstream where
+relationship evidence exists.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from dataraum.analysis.eligibility.db_models import ColumnEligibilityRecord
+from dataraum.pipeline.base import PhaseStatus
+from dataraum.storage import Column, Table
+
+
+@pytest.fixture
+def csv_with_all_null_id_column(tmp_path):
+    """An optional FK column (``logikal30_id``) that is 100% empty in this extract."""
+    csv_file = tmp_path / "positions.csv"
+    csv_file.write_text(
+        "id,logikal30_id,amount\n1,,10.5\n2,,20.0\n3,,30.25\n4,,40.0\n",
+    )
+    return csv_file
+
+
+def test_all_null_key_named_column_drops_without_failing_the_run(
+    harness, csv_with_all_null_id_column
+) -> None:
+    result = harness.run_import(source_path=csv_with_all_null_id_column, source_name="positions")
+    assert result.status == PhaseStatus.COMPLETED, result.error
+    result = harness.run_phase("typing")
+    assert result.status == PhaseStatus.COMPLETED, result.error
+    result = harness.run_phase("statistics")
+    assert result.status == PhaseStatus.COMPLETED, result.error
+
+    # The old behavior: PhaseResult.failed("Critical column 'logikal30_id' …
+    # Cannot proceed with unusable key column.") — the whole run died.
+    result = harness.run_phase("column_eligibility")
+    assert result.status == PhaseStatus.COMPLETED, result.error
+    assert result.outputs is not None
+    assert result.outputs["dropped"] == 1
+
+    with harness.session_factory() as session:
+        # Recorded INELIGIBLE like any other all-null column…
+        record = session.execute(
+            select(ColumnEligibilityRecord).where(
+                ColumnEligibilityRecord.column_name == "logikal30_id"
+            )
+        ).scalar_one()
+        assert record.status == "INELIGIBLE"
+        assert record.triggered_rule == "all_null"
+
+        # …dropped from the typed table; the usable columns survive.
+        typed_table = session.execute(select(Table).where(Table.layer == "typed")).scalar_one()
+        typed_names = set(
+            session.execute(
+                select(Column.column_name).where(Column.table_id == typed_table.table_id)
+            ).scalars()
+        )
+        assert "logikal30_id" not in typed_names
+        assert {"id", "amount"} <= typed_names

--- a/packages/engine/tests/integration/pipeline/test_replay_cross_stage.py
+++ b/packages/engine/tests/integration/pipeline/test_replay_cross_stage.py
@@ -89,11 +89,14 @@ def _resolve_once(
     staged_table_id: str,
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
+    run_id: str | None = None,
 ) -> str:
     """Infer + resolve types for a raw table, returning the typed table id."""
     raw_table = session.get(Table, staged_table_id)
     assert raw_table is not None
-    infer = infer_type_candidates(raw_table, duckdb_conn, session, session_id=baseline_session_id())
+    infer = infer_type_candidates(
+        raw_table, duckdb_conn, session, session_id=baseline_session_id(), run_id=run_id
+    )
     assert infer.success, infer.error
     session.flush()
     resolve = resolve_types(
@@ -102,6 +105,7 @@ def _resolve_once(
         session,
         min_confidence=0.85,
         session_id=baseline_session_id(),
+        run_id=run_id,
     )
     assert resolve.success, resolve.error
     return resolve.unwrap().typed_table_id
@@ -136,6 +140,67 @@ class TestStableTypedIdentity:
         # The typed Table id and every typed Column id are UNCHANGED.
         assert second_typed_id == first_typed_id
         assert second_cols == first_cols
+
+
+class TestRetypeDoesNotFreezeOrDestroyDateColumns:
+    """The replay-poison regression (German-dates user report, 2026-06-05).
+
+    Run A persists an ``automatic`` TypeDecision for every column. The old
+    selection honored that row as a human override on run B — re-applying the
+    DATE type WITHOUT its standardization expr, so DD.MM.YYYY values plain-
+    TRY_CAST to NULL: a 100%-NULL typed column whose rows all quarantine, which
+    eligibility then drops as all_null. Run B must instead re-decide from its
+    own candidates and keep parsing.
+    """
+
+    def test_second_run_still_parses_ddmmyyyy_dates(self, duckdb_conn, session, tmp_path) -> None:
+        from dataraum.analysis.typing.db_models import TypeDecision
+        from dataraum.core.duckdb_naming import schema_for_layer
+        from dataraum.server.storage import LAKE_CATALOG_ALIAS
+
+        # 5 parseable DD.MM.YYYY dates + 1 regex-matching but unparseable value
+        # (no leap day): parse success 5/6 ≈ 0.83 clears the 0.8 gate, the bad
+        # row quarantines instead of zeroing the pattern (TRY_STRPTIME).
+        csv_file = tmp_path / "bookings.csv"
+        csv_file.write_text(
+            "id,tag_datum\n"
+            "1,15.01.2024\n2,31.12.2023\n3,29.02.2023\n4,01.06.2026\n5,07.04.2025\n6,24.12.2024\n"
+        )
+        _source_id, staged_table_id = _seed_source(duckdb_conn, session, csv_file)
+
+        _resolve_once(staged_table_id, duckdb_conn, session, run_id="run-A")
+        typed_id = _resolve_once(staged_table_id, duckdb_conn, session, run_id="run-B")
+
+        # Run B's decision is its own automatic DATE — not run A's row replayed
+        # as a frozen "manual" override.
+        raw_date_col = session.execute(
+            select(Column).where(
+                Column.table_id == staged_table_id, Column.column_name == "tag_datum"
+            )
+        ).scalar_one()
+        run_b_decision = session.execute(
+            select(TypeDecision).where(
+                TypeDecision.column_id == raw_date_col.column_id,
+                TypeDecision.run_id == "run-B",
+            )
+        ).scalar_one()
+        assert run_b_decision.decided_type == "DATE"
+        assert run_b_decision.decision_source == "automatic"
+
+        # The typed column still resolves DATE and still PARSES: 5 real dates,
+        # only the unparseable row NULL. (The destruction path produced 0.)
+        typed_col = session.execute(
+            select(Column).where(Column.table_id == typed_id, Column.column_name == "tag_datum")
+        ).scalar_one()
+        assert typed_col.resolved_type == "DATE"
+
+        typed_table = session.get(Table, typed_id)
+        assert typed_table is not None
+        fqn = f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("typed")}."{typed_table.duckdb_path}"'
+        (parsed,) = duckdb_conn.execute(
+            f"SELECT COUNT(*) FROM {fqn} WHERE tag_datum IS NOT NULL"
+        ).fetchone()
+        assert parsed == 5
 
 
 class TestCrossStageSurvival:

--- a/packages/engine/tests/unit/analysis/eligibility/test_eligibility.py
+++ b/packages/engine/tests/unit/analysis/eligibility/test_eligibility.py
@@ -10,7 +10,6 @@ from dataraum.analysis.eligibility.evaluator import (
     evaluate_rules,
     extract_metrics,
     format_reason,
-    is_likely_key,
 )
 
 
@@ -48,7 +47,6 @@ def _make_config(
             ),
         ],
         default_status="ELIGIBLE",
-        key_patterns=["_id$", "^id$", "_key$"],
     )
 
 
@@ -153,25 +151,6 @@ class TestEvaluateRules:
         status, rule_id, _ = evaluate_rules(config, metrics, "col")
         assert status == "INELIGIBLE"
         assert rule_id == "all_null"
-
-
-class TestIsLikelyKey:
-    """Tests for is_likely_key."""
-
-    def test_matches_id_suffix(self):
-        assert is_likely_key("customer_id", ["_id$", "^id$", "_key$"])
-
-    def test_matches_exact_id(self):
-        assert is_likely_key("id", ["_id$", "^id$", "_key$"])
-
-    def test_matches_key_suffix(self):
-        assert is_likely_key("order_key", ["_id$", "^id$", "_key$"])
-
-    def test_no_match(self):
-        assert not is_likely_key("amount", ["_id$", "^id$", "_key$"])
-
-    def test_case_insensitive(self):
-        assert is_likely_key("Customer_ID", ["_id$", "^id$", "_key$"])
 
 
 class TestExtractMetrics:

--- a/packages/engine/tests/unit/analysis/typing/test_inference.py
+++ b/packages/engine/tests/unit/analysis/typing/test_inference.py
@@ -1,0 +1,71 @@
+"""Tests for type-inference cast testing against real DuckDB.
+
+Pins the TRY_-normalization behavior end-to-end: one malformed value among
+clean DD.MM.YYYY dates must reduce the success rate and surface a failed
+example — NOT score the pattern 0.0 via a thrown STRPTIME (the bug that
+froze such columns to VARCHAR with zero diagnostics).
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from dataraum.analysis.typing.inference import _test_type_cast
+from dataraum.analysis.typing.patterns import Pattern
+from dataraum.core.models.base import DataType
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    yield c
+    c.close()
+
+
+def _eu_date_pattern() -> Pattern:
+    """The builtin eu_date pattern as loaded from YAML (pre-normalization form)."""
+    return Pattern(
+        name="eu_date",
+        pattern=r"^\d{1,2}\.\d{1,2}\.\d{2,4}$",
+        inferred_type=DataType.DATE,
+        standardization_expr="STRPTIME(\"{col}\", '%d.%m.%Y')",
+    )
+
+
+def test_one_malformed_value_does_not_zero_the_pattern(conn: duckdb.DuckDBPyConnection) -> None:
+    """29.02.2023 (no leap day) matches the regex but fails the parse.
+
+    Old behavior: STRPTIME threw on it, the whole COUNT query errored, and the
+    pattern scored success_rate=0.0 with no failed examples — VARCHAR fallback
+    for a 75%-clean date column. New behavior: the bad value returns NULL,
+    success_rate reflects reality, and the failed example is captured.
+    """
+    conn.execute(
+        "CREATE TABLE t AS SELECT * FROM (VALUES "
+        "('15.01.2024'), ('31.12.2023'), ('29.02.2023'), ('01.06.2026')) v(tag_datum)"
+    )
+    result = _test_type_cast(
+        table_name="t",
+        col_name="tag_datum",
+        target_type=DataType.DATE,
+        duckdb_conn=conn,
+        standardization_expr=_eu_date_pattern().standardization_expr,
+    )
+    assert result.success_rate == pytest.approx(0.75)
+    assert result.failed_examples == ["29.02.2023"]
+
+
+def test_clean_column_parses_fully(conn: duckdb.DuckDBPyConnection) -> None:
+    conn.execute(
+        "CREATE TABLE t AS SELECT * FROM (VALUES ('15.01.2024'), ('01.06.2026')) v(tag_datum)"
+    )
+    result = _test_type_cast(
+        table_name="t",
+        col_name="tag_datum",
+        target_type=DataType.DATE,
+        duckdb_conn=conn,
+        standardization_expr=_eu_date_pattern().standardization_expr,
+    )
+    assert result.success_rate == 1.0
+    assert result.failed_examples == []

--- a/packages/engine/tests/unit/analysis/typing/test_patterns.py
+++ b/packages/engine/tests/unit/analysis/typing/test_patterns.py
@@ -126,11 +126,11 @@ class TestNormalizeStandardizationExpr:
         )
 
     def test_idempotent_on_try_variants(self):
-        expr = "COALESCE(TRY_STRPTIME(\"{col}\", '%d.%m.%Y'), TRY_CAST(\"{col}\" AS DATE))"
+        expr = 'COALESCE(TRY_STRPTIME("{col}", \'%d.%m.%Y\'), TRY_CAST("{col}" AS DATE))'
         assert normalize_standardization_expr(expr) == expr
 
     def test_other_functions_untouched(self):
-        expr = "MAKE_DATE(TRY_CAST(LEFT(\"{col}\", 4) AS INT), 1, 1)"
+        expr = 'MAKE_DATE(TRY_CAST(LEFT("{col}", 4) AS INT), 1, 1)'
         assert normalize_standardization_expr(expr) == expr
 
     def test_pattern_normalizes_on_construction(self):

--- a/packages/engine/tests/unit/analysis/typing/test_patterns.py
+++ b/packages/engine/tests/unit/analysis/typing/test_patterns.py
@@ -4,7 +4,11 @@ Tests the value-based pattern matching used for type inference.
 Column name patterns are intentionally NOT supported.
 """
 
-from dataraum.analysis.typing.patterns import Pattern, PatternConfig
+from dataraum.analysis.typing.patterns import (
+    Pattern,
+    PatternConfig,
+    normalize_standardization_expr,
+)
 from dataraum.core.models.base import DataType
 
 
@@ -98,6 +102,64 @@ class TestPattern:
         assert pattern.matches("$1,234.56")
         assert pattern.matches("$100")
         assert pattern.detected_unit == "USD"
+
+
+class TestNormalizeStandardizationExpr:
+    """TRY_-normalization of standardization expressions.
+
+    DuckDB's STRPTIME/CAST throw on non-conforming input, and TRY_CAST does
+    NOT catch inner-function errors — one malformed value would score a
+    pattern 0.0 in inference or fail the typed-table CREATE outright.
+    """
+
+    def test_strptime_rewritten(self):
+        assert (
+            normalize_standardization_expr("STRPTIME(\"{col}\", '%d.%m.%Y')")
+            == "TRY_STRPTIME(\"{col}\", '%d.%m.%Y')"
+        )
+
+    def test_inner_cast_rewritten(self):
+        expr = "CAST(REPLACE(\"{col}\", '%', '') AS DOUBLE) / 100"
+        assert (
+            normalize_standardization_expr(expr)
+            == "TRY_CAST(REPLACE(\"{col}\", '%', '') AS DOUBLE) / 100"
+        )
+
+    def test_idempotent_on_try_variants(self):
+        expr = "COALESCE(TRY_STRPTIME(\"{col}\", '%d.%m.%Y'), TRY_CAST(\"{col}\" AS DATE))"
+        assert normalize_standardization_expr(expr) == expr
+
+    def test_other_functions_untouched(self):
+        expr = "MAKE_DATE(TRY_CAST(LEFT(\"{col}\", 4) AS INT), 1, 1)"
+        assert normalize_standardization_expr(expr) == expr
+
+    def test_pattern_normalizes_on_construction(self):
+        pattern = Pattern(
+            name="eu_date",
+            pattern=r"^\d{1,2}\.\d{1,2}\.\d{2,4}$",
+            inferred_type=DataType.DATE,
+            standardization_expr="STRPTIME(\"{col}\", '%d.%m.%Y')",
+        )
+        assert pattern.standardization_expr == "TRY_STRPTIME(\"{col}\", '%d.%m.%Y')"
+
+    def test_taught_override_pattern_normalized(self):
+        """Overlay-taught patterns get the same normalization as builtins."""
+        config = PatternConfig(
+            {
+                "overrides": {
+                    "patterns": {
+                        "de_date_ddmmyyyy": {
+                            "pattern": r"^\d{1,2}\.\d{1,2}\.\d{4}$",
+                            "standardization_expr": "STRPTIME(\"{col}\", '%d.%m.%Y')",
+                        }
+                    }
+                }
+            }
+        )
+        (p,) = config.get_patterns()
+        assert p.standardization_expr == "TRY_STRPTIME(\"{col}\", '%d.%m.%Y')"
+        # inferred_type defaults to DATE for override patterns with an expr
+        assert p.inferred_type == DataType.DATE
 
 
 class TestPatternConfig:

--- a/packages/engine/tests/unit/analysis/typing/test_resolution_selection.py
+++ b/packages/engine/tests/unit/analysis/typing/test_resolution_selection.py
@@ -1,0 +1,120 @@
+"""Tests for run-aware best-candidate selection in type resolution.
+
+Pins the fix for the replay-poison bug: resolution persists its own
+``automatic``/``fallback`` TypeDecision every run, and the old selection
+honored ANY pre-existing decision as a human override — freezing the first
+run's outcome forever (a fallback-VARCHAR row blocked taught patterns; an
+automatic DATE row re-applied WITHOUT its standardization expr, plain-
+TRY_CASTing DD.MM.YYYY columns to all-NULL). Selection now scopes candidates
+to the current run and honors only ``manual`` decisions — keeping the
+standardization expr for the decided type.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from dataraum.analysis.typing.db_models import TypeCandidate, TypeDecision
+from dataraum.analysis.typing.resolution import _select_best_candidates
+from dataraum.core.models.base import DataType
+from dataraum.pipeline.registry import import_all_phase_models
+from dataraum.storage import Column
+
+# Constructing detached ORM objects triggers mapper configuration, which needs
+# every string-annotated relationship target (TableEntity, ...) imported.
+import_all_phase_models()
+
+MIN_CONFIDENCE = 0.85
+
+
+def _column(name: str = "tag_datum") -> Column:
+    return Column(column_id="col-1", table_id="tbl-1", column_name=name, column_position=0)
+
+
+def _candidate(
+    run_id: str,
+    data_type: str,
+    confidence: float,
+    pattern: str | None = None,
+) -> TypeCandidate:
+    return TypeCandidate(
+        session_id="sess-1",
+        column_id="col-1",
+        run_id=run_id,
+        data_type=data_type,
+        confidence=confidence,
+        detected_pattern=pattern,
+    )
+
+
+def _decision(run_id: str, source: str, decided_type: str) -> TypeDecision:
+    return TypeDecision(
+        session_id="sess-1",
+        column_id="col-1",
+        run_id=run_id,
+        decided_type=decided_type,
+        decision_source=source,
+        decided_at=datetime.now(UTC),
+    )
+
+
+def test_prior_automatic_decision_does_not_freeze_the_column() -> None:
+    """Run B re-decides from its own candidates despite run A's automatic row.
+
+    The user-visible failure: run A fell back to VARCHAR, the taught date
+    pattern produced a DATE candidate on run B — and the old code returned
+    VARCHAR/"manual" off run A's decision, so teaching could never work.
+    """
+    col = _column()
+    col.type_decisions.append(_decision("run-A", "fallback", "VARCHAR"))
+    col.type_candidates.append(_candidate("run-A", "VARCHAR", 1.0))
+    col.type_candidates.append(_candidate("run-B", "DATE", 0.95, pattern="eu_date"))
+
+    (spec,) = _select_best_candidates([col], MIN_CONFIDENCE, run_id="run-B")
+
+    assert spec.data_type == DataType.DATE
+    assert spec.decision_source == "automatic"
+    assert spec.pattern is not None
+    assert spec.pattern.standardization_expr is not None
+    assert "TRY_STRPTIME" in spec.pattern.standardization_expr
+
+
+def test_prior_run_candidates_do_not_compete() -> None:
+    """Run A's confidence-1.0 VARCHAR fallback must not outcompete run B's DATE."""
+    col = _column()
+    col.type_candidates.append(_candidate("run-A", "VARCHAR", 1.0))
+    col.type_candidates.append(_candidate("run-B", "DATE", 0.9, pattern="eu_date"))
+
+    (spec,) = _select_best_candidates([col], MIN_CONFIDENCE, run_id="run-B")
+
+    assert spec.data_type == DataType.DATE
+
+
+def test_manual_decision_pins_type_and_keeps_standardization_expr() -> None:
+    """A human override pins the TYPE but the same-type candidate's pattern
+    still supplies the standardization expr — honoring the type while dropping
+    the expr would plain-TRY_CAST DD.MM.YYYY to an all-NULL column."""
+    col = _column()
+    col.type_decisions.append(_decision("run-A", "manual", "DATE"))
+    col.type_candidates.append(_candidate("run-B", "DATE", 0.7, pattern="eu_date"))
+    col.type_candidates.append(_candidate("run-B", "VARCHAR", 1.0))
+
+    (spec,) = _select_best_candidates([col], MIN_CONFIDENCE, run_id="run-B")
+
+    assert spec.decision_source == "manual"
+    assert spec.data_type == DataType.DATE
+    assert spec.pattern is not None
+    assert spec.pattern.standardization_expr is not None
+    assert "TRY_STRPTIME" in spec.pattern.standardization_expr
+
+
+def test_no_run_candidates_falls_back_to_varchar() -> None:
+    """A run with no candidates of its own falls back — it never borrows a
+    prior run's."""
+    col = _column()
+    col.type_candidates.append(_candidate("run-A", "DATE", 0.95, pattern="eu_date"))
+
+    (spec,) = _select_best_candidates([col], MIN_CONFIDENCE, run_id="run-B")
+
+    assert spec.data_type == DataType.VARCHAR
+    assert spec.decision_source == "fallback"

--- a/packages/engine/tests/unit/analysis/typing/test_resolution_selection.py
+++ b/packages/engine/tests/unit/analysis/typing/test_resolution_selection.py
@@ -93,7 +93,12 @@ def test_prior_run_candidates_do_not_compete() -> None:
 def test_manual_decision_pins_type_and_keeps_standardization_expr() -> None:
     """A human override pins the TYPE but the same-type candidate's pattern
     still supplies the standardization expr — honoring the type while dropping
-    the expr would plain-TRY_CAST DD.MM.YYYY to an all-NULL column."""
+    the expr would plain-TRY_CAST DD.MM.YYYY to an all-NULL column.
+
+    The DATE candidate sits BELOW min_confidence (0.7 < 0.85) on purpose: a
+    manual pin bypasses the threshold — even a weak same-type candidate's expr
+    beats a plain cast.
+    """
     col = _column()
     col.type_decisions.append(_decision("run-A", "manual", "DATE"))
     col.type_candidates.append(_candidate("run-B", "DATE", 0.7, pattern="eu_date"))
@@ -106,6 +111,26 @@ def test_manual_decision_pins_type_and_keeps_standardization_expr() -> None:
     assert spec.pattern is not None
     assert spec.pattern.standardization_expr is not None
     assert "TRY_STRPTIME" in spec.pattern.standardization_expr
+
+
+def test_manual_decision_without_matching_candidate_plain_casts_and_warns() -> None:
+    """No same-type candidate this run → the manual type is honored with a
+    plain TRY_CAST (pattern None) and the degradation is logged loudly — for
+    string-parsed types that cast can NULL every value, and silence here was
+    part of the original destruction path."""
+    from structlog.testing import capture_logs
+
+    col = _column()
+    col.type_decisions.append(_decision("run-A", "manual", "DATE"))
+    col.type_candidates.append(_candidate("run-B", "VARCHAR", 1.0))
+
+    with capture_logs() as logs:
+        (spec,) = _select_best_candidates([col], MIN_CONFIDENCE, run_id="run-B")
+
+    assert spec.decision_source == "manual"
+    assert spec.data_type == DataType.DATE
+    assert spec.pattern is None
+    assert any(e["event"] == "manual_override_no_matching_candidate" for e in logs)
 
 
 def test_no_run_candidates_falls_back_to_varchar() -> None:


### PR DESCRIPTION
Three pipeline bugs from a user report (German DD.MM.YYYY data): date columns destroyed or frozen VARCHAR on replay, taught patterns never applying, and the whole run aborting on an empty optional FK column.

## Bug A — stale automatic TypeDecisions honored as human overrides (the decisive one)
Resolution persists an `automatic`/`fallback` TypeDecision for every column on every run, and the table is run-versioned (DAT-413) — rows coexist. Selection honored ANY pre-existing decision via the `uselist=False` `Column.type_decision` relationship (an arbitrary run's row) as a "manual" override with `pattern=None`. On any re-run: a prior fallback-VARCHAR froze the column so taught patterns were never consulted, and a prior automatic DATE re-applied **without** its standardization expr — plain `TRY_CAST` NULLs every DD.MM.YYYY value → all rows quarantined → eligibility drops the column as `all_null`. Exactly the reported layer state (`abgerufen_am` in raw+quarantine, no typed column).

**Fix:** selection is run-scoped (candidates filtered to this run — a prior run's confidence-1.0 VARCHAR fallback no longer outcompetes) and honors only `decision_source='manual'` (latest); a manual pin keeps the best same-type candidate's standardization expr (pinning the type while dropping the expr IS the destruction path) and warns when none exists. `Column.type_decision` → `type_decisions` list; per-run decisions always upsert on `(column_id, run_id)`; typed copies mirror the executed specs. (`graphs/context.py` needed no change — rebased onto main, where DAT-429 already run-scopes its TypeDecision read via `_is_current`.)

## Bug B — STRPTIME throws; one bad value zeroes a pattern
DuckDB `STRPTIME` throws on non-matching input and `TRY_CAST` doesn't catch inner-function errors: one malformed value (`29.02.2023`) made the whole parse-test query throw → pattern scored 0.0 with no failed examples → 99.9%-clean date column fell back to VARCHAR; at resolution the same throw could fail the typed-table CREATE outright.

**Fix:** standardization exprs are TRY_-normalized (`STRPTIME`→`TRY_STRPTIME`, inner `CAST`→`TRY_CAST`) once at `Pattern` construction — covering builtin YAML, overlay-taught, and synthetic combined patterns; the ad-hoc `str.replace` calls in Strategy 1b / `_resolve_pattern` (which would now double-wrap) removed. A 99%-clean date column types DATE with the bad rows quarantined — the designed behavior.

## Bug D — key-name hard abort deleted
`column_eligibility` aborted the ENTIRE run when a 100%-null column's NAME matched `_id$`/`^id$`/`_key$` — name-only key inference contradicting the engine's own principle (types from values, never names), with no structural evidence and no teach escape hatch. A 100%-null column can't be functioning as a key, so the abort protected nothing while making datasets with empty optional FK columns (`logikal30_id`) unprocessable. `is_likely_key`, `key_patterns`, and the abort branch are deleted; all-null columns drop + record INELIGIBLE and the run continues.

## Verification
- Integration regression re-types a DD.MM.YYYY CSV across two runs — **verified to fail on the old code** (run 2 plain-cast all values to NULL) and pass with the fix.
- DuckDB-backed unit tests pin the parse-test behavior (one bad value → 0.83 success + captured example, not 0.0).
- Run-aware selection unit tests (freeze, cross-run candidate competition, manual pin keeps expr, manual-without-candidate warns).
- Eligibility integration test: all-null `logikal30_id` → dropped + INELIGIBLE record, phase COMPLETED (`ColumnEligibilityPhase` is now registered in the integration harness — it never was, which is why no phase-level test existed).
- 1334 unit + 61 pipeline-integration tests green; ruff/format, mypy, vulture clean.
- Reviews: spec-compliance APPROVED; senior reviewer's blocker (silent plain-cast degradation under a manual override) fixed in the last commit.

`.claude/handoff.md` updated for dataraum-eval (typing outcomes change — re-run the add_source recall suite; date-typed coverage expected UP) and dataraum-testdata (injection hints). Off-branch follow-up: unit-teach disconnect → DAT-428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
