### PR TITLE
fix: pre-bake DuckDB extensions in both images — no runtime egress to extensions.duckdb.org

### DIFF
--- a/packages/cockpit/Dockerfile
+++ b/packages/cockpit/Dockerfile
@@ -49,7 +49,10 @@ ENV NODE_ENV=production \
     HOSTNAME=0.0.0.0
 
 # oven/bun:1-slim ships without wget; add it for the healthcheck.
-RUN apt-get update && apt-get install -y wget \
+# libgssapi-krb5-2: runtime dependency of the community mssql DuckDB extension
+# (probe backend) — without it LOAD mssql fails with a missing
+# libgssapi_krb5.so.2, both at the pre-bake below and at runtime.
+RUN apt-get update && apt-get install -y wget libgssapi-krb5-2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Nitro produces a self-contained server bundle at .output/server/index.mjs.
@@ -63,6 +66,28 @@ COPY --from=build /app/.output ./.output
 # The deps stage installs the binding for THIS image's platform/libc (alpine =
 # musl), which matches the runner — so the binary loads.
 COPY --from=deps /app/node_modules/@duckdb ./node_modules/@duckdb
+
+# Pre-install the DuckDB extensions at image build time (mirror of the engine's
+# worker.Dockerfile): ducklake + httpfs for the READ_ONLY lake reader / S3
+# secret, plus the connect-probe backends (postgres/mysql/sqlite + community
+# mssql). Runtime sets DUCKLAKE_SKIP_INSTALL=1 (read via config.ts by lake.ts /
+# s3-secret.ts / probe.ts) so neither cold start nor a probe ever hits
+# extensions.duckdb.org — required behind egress proxy filters and in
+# air-gapped deploys. `SET extension_directory` lands the cache at a known
+# image path; the matching env var keeps the runtime LOAD aligned with it.
+RUN bun -e "const { DuckDBInstance } = await import('@duckdb/node-api'); \
+    const inst = await DuckDBInstance.create(':memory:'); \
+    const conn = await inst.connect(); \
+    await conn.run(\"SET extension_directory = '/opt/dataraum/duckdb-extensions'\"); \
+    for (const ext of ['ducklake', 'httpfs', 'postgres', 'mysql', 'sqlite']) { \
+      await conn.run('INSTALL ' + ext); \
+      await conn.run('LOAD ' + ext); \
+    } \
+    await conn.run('INSTALL mssql FROM community'); \
+    await conn.run('LOAD mssql');"
+
+ENV DUCKDB_EXTENSION_DIRECTORY=/opt/dataraum/duckdb-extensions \
+    DUCKLAKE_SKIP_INSTALL=1
 
 EXPOSE 3000
 

--- a/packages/cockpit/src/config.test.ts
+++ b/packages/cockpit/src/config.test.ts
@@ -20,6 +20,8 @@ const REQUIRED: Record<string, string> = {
 const OPTIONAL = [
 	"S3_REGION",
 	"S3_USE_SSL",
+	"DUCKDB_EXTENSION_DIRECTORY",
+	"DUCKLAKE_SKIP_INSTALL",
 	"TEMPORAL_HOST",
 	"TEMPORAL_NAMESPACE",
 	"TEMPORAL_TASK_QUEUE",
@@ -69,6 +71,28 @@ describe("cockpit config (DAT-363)", () => {
 		const { config } = await import("./config");
 
 		expect(config.s3UseSsl).toBe(false);
+	});
+
+	it("defaults the DuckDB extension cache to host-dev behavior when unset", async () => {
+		stubBaseline();
+		const { config } = await import("./config");
+
+		expect(config.duckdbExtensionDirectory).toBeUndefined();
+		expect(config.ducklakeSkipInstall).toBe(false);
+	});
+
+	it("parses the container's pre-baked extension cache contract", async () => {
+		// The image sets both (Dockerfile): DUCKLAKE_SKIP_INSTALL=1 is the same
+		// env contract as the engine's worker.Dockerfile.
+		stubBaseline();
+		vi.stubEnv("DUCKDB_EXTENSION_DIRECTORY", "/opt/dataraum/duckdb-extensions");
+		vi.stubEnv("DUCKLAKE_SKIP_INSTALL", "1");
+		const { config } = await import("./config");
+
+		expect(config.duckdbExtensionDirectory).toBe(
+			"/opt/dataraum/duckdb-extensions",
+		);
+		expect(config.ducklakeSkipInstall).toBe(true);
 	});
 
 	it("fails loud naming the field when a required var is missing", async () => {

--- a/packages/cockpit/src/config.ts
+++ b/packages/cockpit/src/config.ts
@@ -55,6 +55,16 @@ const ConfigSchema = z.object({
 	// cockpit needs it explicitly to address PutObject. Must match S3_BUCKET.
 	s3Bucket: z.string().min(1),
 
+	// --- DuckDB extension cache (mirror of the engine's
+	// duckdb_extension_directory / ducklake_skip_install — core/settings.py).
+	// The container image pre-installs ducklake/httpfs/probe-backend extensions
+	// at /opt/dataraum/duckdb-extensions and sets both vars (Dockerfile), so a
+	// cold start never hits extensions.duckdb.org — required behind egress proxy
+	// filters / air-gapped. Both unset in host dev: DuckDB falls back to
+	// ~/.duckdb and installs on demand. ---
+	duckdbExtensionDirectory: z.string().min(1).optional(),
+	ducklakeSkipInstall: z.boolean(),
+
 	// --- Temporal (optional for slice-1: the cockpit Temporal client lands in
 	// E4 (DAT-344), which flips these to required; no Temporal service yet) ---
 	temporalHost: z.string().optional(),
@@ -84,6 +94,10 @@ function loadConfig(): Config {
 		s3AccessKeyId: process.env.S3_ACCESS_KEY_ID,
 		s3SecretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
 		s3Bucket: process.env.S3_BUCKET,
+		duckdbExtensionDirectory: process.env.DUCKDB_EXTENSION_DIRECTORY,
+		// Same env contract as the engine ("set to 1"); anything else — including
+		// unset — keeps the on-demand INSTALL path for host dev.
+		ducklakeSkipInstall: (process.env.DUCKLAKE_SKIP_INSTALL ?? "0") === "1",
 		temporalHost: process.env.TEMPORAL_HOST,
 		temporalNamespace: process.env.TEMPORAL_NAMESPACE,
 		temporalTaskQueue: process.env.TEMPORAL_TASK_QUEUE,

--- a/packages/cockpit/src/duckdb/lake.ts
+++ b/packages/cockpit/src/duckdb/lake.ts
@@ -27,7 +27,7 @@ import { type DuckDBConnection, DuckDBInstance } from "@duckdb/node-api";
 
 import { config } from "../config";
 import { applyS3Secret } from "./s3-secret";
-import { buildDucklakeAttachSql } from "./sql-escape";
+import { buildDucklakeAttachSql, escapeSqlLiteral } from "./sql-escape";
 
 // Alias the DuckLake catalog is ATTACHed under. Matches the engine's
 // `LAKE_CATALOG_ALIAS` so fully-qualified names (`lake.typed.orders`) resolve
@@ -53,15 +53,26 @@ async function openConnection(): Promise<DuckDBConnection> {
 		config.dataraumLakePath,
 	);
 
-	// The container image pre-installs the ducklake extension; LOAD is enough
-	// there. INSTALL is attempted first and tolerated-on-failure so a local dev
-	// run without the cached extension still works (it falls through to LOAD,
-	// which errors loudly if the extension is genuinely missing).
-	try {
-		await conn.run("INSTALL ducklake");
-	} catch {
-		// Extension already present (offline/air-gapped image) — LOAD will
-		// surface a real "not found" below if it truly isn't installed.
+	// The container image pre-bakes ducklake at DUCKDB_EXTENSION_DIRECTORY and
+	// sets DUCKLAKE_SKIP_INSTALL=1 (Dockerfile — mirror of the engine's
+	// bootstrap_lake), so a cold start never hits extensions.duckdb.org. Host
+	// dev has neither set: INSTALL is attempted tolerate-fail (it needs the
+	// network once) and LOAD errors loudly if the extension is genuinely
+	// missing.
+	if (config.duckdbExtensionDirectory) {
+		// Must precede INSTALL/LOAD so DuckDB looks the extension up at the
+		// image-baked path rather than ~/.duckdb.
+		await conn.run(
+			`SET extension_directory = '${escapeSqlLiteral(config.duckdbExtensionDirectory)}'`,
+		);
+	}
+	if (!config.ducklakeSkipInstall) {
+		try {
+			await conn.run("INSTALL ducklake");
+		} catch {
+			// Extension already present (offline) — LOAD will surface a real
+			// "not found" below if it truly isn't installed.
+		}
 	}
 	await conn.run("LOAD ducklake");
 	// The lake DATA_PATH is an `s3://` URI; register httpfs + the S3 secret

--- a/packages/cockpit/src/duckdb/probe.integration.test.ts
+++ b/packages/cockpit/src/duckdb/probe.integration.test.ts
@@ -5,6 +5,10 @@
 // USE → wrapped SELECT → DETACH → JSON result. sqlite is the cheapest of the
 // supported backends to stand up hermetically (a file, no server); the ATTACH
 // machinery is shared across all four backends.
+//
+// Importing probe boots config.ts (the extension-cache contract), so we stub
+// the required env before the dynamic import — same approach as
+// connect.integration. The values are placeholders; nothing here touches them.
 
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -13,12 +17,43 @@ import { join } from "node:path";
 import { DuckDBInstance } from "@duckdb/node-api";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { probe } from "./probe";
+const REQUIRED_DEFAULTS: Record<string, string> = {
+	COCKPIT_DATABASE_URL:
+		process.env.COCKPIT_DATABASE_URL ??
+		"postgresql://dataraum:dataraum@127.0.0.1:5432/cockpit_db",
+	METADATA_DATABASE_URL:
+		process.env.METADATA_DATABASE_URL ??
+		"postgresql://dataraum:dataraum@127.0.0.1:5432/dataraum",
+	DATARAUM_WORKSPACE_ID:
+		process.env.DATARAUM_WORKSPACE_ID ?? "00000000-0000-0000-0000-000000000001",
+	DATARAUM_CONFIG_PATH:
+		process.env.DATARAUM_CONFIG_PATH ?? "/opt/dataraum/config",
+	DATARAUM_LAKE_PATH:
+		process.env.DATARAUM_LAKE_PATH ?? "s3://dataraum-lake/lake",
+	DUCKLAKE_CATALOG_URL:
+		process.env.DUCKLAKE_CATALOG_URL ??
+		"postgresql://dataraum:dataraum@127.0.0.1:5432/lake_catalog",
+	ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? "sk-ant-test-placeholder",
+	S3_ENDPOINT: process.env.S3_ENDPOINT ?? "127.0.0.1:8333",
+	S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID ?? "dataraum",
+	S3_SECRET_ACCESS_KEY:
+		process.env.S3_SECRET_ACCESS_KEY ?? "dataraum-s3-secret",
+	S3_BUCKET: process.env.S3_BUCKET ?? "dataraum-lake",
+};
+for (const [k, v] of Object.entries(REQUIRED_DEFAULTS)) {
+	if (!process.env[k]) process.env[k] = v;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic-imported module shape
+let probe: any;
 
 let dir: string;
 let dbfile: string;
 
 beforeAll(async () => {
+	// Dynamic import so the env stub above is in place before config.ts loads.
+	({ probe } = await import("./probe"));
+
 	dir = mkdtempSync(join(tmpdir(), "probe-it-"));
 	dbfile = join(dir, "src.sqlite");
 

--- a/packages/cockpit/src/duckdb/probe.ts
+++ b/packages/cockpit/src/duckdb/probe.ts
@@ -13,6 +13,7 @@
 
 import { DuckDBInstance } from "@duckdb/node-api";
 
+import { config } from "../config";
 import { resolveCredential } from "./credentials";
 import { clampRowLimit } from "./limit";
 import type { QueryResult } from "./query-result";
@@ -101,10 +102,21 @@ export async function probe(input: ProbeInput): Promise<QueryResult> {
 	const instance = await DuckDBInstance.create(":memory:");
 	const conn = await instance.connect();
 	try {
-		if (COMMUNITY_EXTENSIONS.has(extension)) {
-			await conn.run(`INSTALL ${extension} FROM community`);
-		} else {
-			await conn.run(`INSTALL ${extension}`);
+		// Same extension-cache contract as the lake reader (lake.ts): the image
+		// pre-bakes all four backend extensions and sets DUCKLAKE_SKIP_INSTALL=1,
+		// so a probe never hits extensions.duckdb.org at runtime. Host dev has
+		// neither var set and installs on demand into ~/.duckdb.
+		if (config.duckdbExtensionDirectory) {
+			await conn.run(
+				`SET extension_directory = '${escapeSqlLiteral(config.duckdbExtensionDirectory)}'`,
+			);
+		}
+		if (!config.ducklakeSkipInstall) {
+			if (COMMUNITY_EXTENSIONS.has(extension)) {
+				await conn.run(`INSTALL ${extension} FROM community`);
+			} else {
+				await conn.run(`INSTALL ${extension}`);
+			}
 		}
 		await conn.run(`LOAD ${extension}`);
 

--- a/packages/cockpit/src/duckdb/s3-secret.test.ts
+++ b/packages/cockpit/src/duckdb/s3-secret.test.ts
@@ -1,19 +1,22 @@
 import type { DuckDBConnection } from "@duckdb/node-api";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // applyS3Secret imports `#/config`, which parses process.env at module load.
 // Mock it with S3 values so the unit test needs no real env. The mock MUST use
 // the `#/` alias — a relative `./config` mock does NOT intercept (DAT-381).
-vi.mock("#/config", () => ({
-	config: {
-		s3Endpoint: "seaweedfs:8333",
-		s3Region: "us-east-1",
-		s3UseSsl: false,
-		s3AccessKeyId: "dataraum",
-		s3SecretAccessKey: "dataraum-s3-secret",
-		s3Bucket: "dataraum-lake",
-	},
+// Hoisted + mutable so tests can flip the extension-cache fields (the
+// container pre-bake contract) per case.
+const mockConfig = vi.hoisted(() => ({
+	s3Endpoint: "seaweedfs:8333",
+	s3Region: "us-east-1",
+	s3UseSsl: false,
+	s3AccessKeyId: "dataraum",
+	s3SecretAccessKey: "dataraum-s3-secret",
+	s3Bucket: "dataraum-lake",
+	duckdbExtensionDirectory: undefined as string | undefined,
+	ducklakeSkipInstall: false,
 }));
+vi.mock("#/config", () => ({ config: mockConfig }));
 
 import { applyS3Secret, buildS3SecretSql } from "./s3-secret";
 
@@ -74,6 +77,11 @@ function fakeConn(run: ReturnType<typeof vi.fn>): DuckDBConnection {
 }
 
 describe("applyS3Secret (DAT-388)", () => {
+	afterEach(() => {
+		mockConfig.duckdbExtensionDirectory = undefined;
+		mockConfig.ducklakeSkipInstall = false;
+	});
+
 	it("installs + loads httpfs, then registers the secret from config", async () => {
 		const run = vi.fn().mockResolvedValue(undefined);
 		await applyS3Secret(fakeConn(run));
@@ -98,5 +106,31 @@ describe("applyS3Secret (DAT-388)", () => {
 		const sql = run.mock.calls.map((c) => c[0] as string);
 		expect(sql).toContain("LOAD httpfs");
 		expect(sql.some((s) => s.includes("CREATE OR REPLACE SECRET"))).toBe(true);
+	});
+
+	it("pins extension_directory + skips INSTALL when the image pre-bakes", async () => {
+		// The container contract (Dockerfile): DUCKDB_EXTENSION_DIRECTORY points
+		// at the baked cache and DUCKLAKE_SKIP_INSTALL=1 — the cold start must
+		// not touch extensions.duckdb.org.
+		mockConfig.duckdbExtensionDirectory = "/opt/dataraum/duckdb-extensions";
+		mockConfig.ducklakeSkipInstall = true;
+		const run = vi.fn().mockResolvedValue(undefined);
+		await applyS3Secret(fakeConn(run));
+
+		const sql = run.mock.calls.map((c) => c[0] as string);
+		expect(sql[0]).toBe(
+			"SET extension_directory = '/opt/dataraum/duckdb-extensions'",
+		);
+		expect(sql[1]).toBe("LOAD httpfs");
+		expect(sql[2]).toContain("CREATE OR REPLACE SECRET dataraum_s3");
+		expect(sql.some((s) => s.startsWith("INSTALL"))).toBe(false);
+	});
+
+	it("escapes the extension directory as a SQL literal", async () => {
+		mockConfig.duckdbExtensionDirectory = "/odd'path";
+		const run = vi.fn().mockResolvedValue(undefined);
+		await applyS3Secret(fakeConn(run));
+
+		expect(run.mock.calls[0][0]).toBe("SET extension_directory = '/odd''path'");
 	});
 });

--- a/packages/cockpit/src/duckdb/s3-secret.ts
+++ b/packages/cockpit/src/duckdb/s3-secret.ts
@@ -54,15 +54,27 @@ export function buildS3SecretSql(params: {
  * Load `httpfs` + register the object-store S3 secret on `conn`.
  *
  * Must run before ATTACHing a DuckLake catalog whose DATA_PATH is an `s3://`
- * URI. `INSTALL` is tolerate-fail (the image may already have httpfs); `LOAD`
- * errors loud if it is genuinely missing — mirrors `lake.ts`'s ducklake load.
+ * URI. Honors the image's pre-baked extension cache (DUCKDB_EXTENSION_DIRECTORY
+ * + DUCKLAKE_SKIP_INSTALL — mirror of the engine's `apply_s3_secret`): the
+ * `SET extension_directory` must happen HERE, not just in `lake.ts`, because a
+ * fresh in-memory connection (connect.ts's upload-sniff throwaway) otherwise
+ * defaults to ~/.duckdb and the LOAD misses the baked httpfs. In host dev
+ * (neither var set) `INSTALL` is tolerate-fail; `LOAD` errors loud if the
+ * extension is genuinely missing — mirrors `lake.ts`'s ducklake load.
  */
 export async function applyS3Secret(conn: DuckDBConnection): Promise<void> {
-	try {
-		await conn.run("INSTALL httpfs");
-	} catch {
-		// Extension already present (offline/air-gapped image) — LOAD surfaces a
-		// real "not found" below if it truly isn't installed.
+	if (config.duckdbExtensionDirectory) {
+		await conn.run(
+			`SET extension_directory = '${escapeSqlLiteral(config.duckdbExtensionDirectory)}'`,
+		);
+	}
+	if (!config.ducklakeSkipInstall) {
+		try {
+			await conn.run("INSTALL httpfs");
+		} catch {
+			// Extension already present (offline) — LOAD surfaces a real
+			// "not found" below if it truly isn't installed.
+		}
 	}
 	await conn.run("LOAD httpfs");
 	await conn.run(

--- a/packages/engine/docker/worker.Dockerfile
+++ b/packages/engine/docker/worker.Dockerfile
@@ -7,8 +7,11 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 # System deps: gcc/g++ for any source builds. No curl — the engine is a Temporal
 # worker now (DAT-344), not an HTTP service; its health is the worker heartbeat
 # the Temporal server records, checked externally via `temporal worker list`.
+# libgssapi-krb5-2: runtime dependency of the community mssql DuckDB extension
+# (db-recipe backend) — without it LOAD mssql fails with a missing
+# libgssapi_krb5.so.2, both at the pre-bake below and at runtime.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc g++ && \
+    gcc g++ libgssapi-krb5-2 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install uv for fast dependency resolution
@@ -41,19 +44,21 @@ RUN groupadd -r dataraum && useradd -r -g dataraum -u 1001 dataraum && \
 
 USER dataraum
 
-# Pre-install the DuckLake + httpfs extensions at image build time. Runtime sets
-# DUCKLAKE_SKIP_INSTALL=1 (read by server/storage.bootstrap_lake AND
-# apply_s3_secret) so the cold start does not hit the network — also makes
-# air-gapped deploys work. httpfs is required to read/write the lake's parquet
-# over s3:// (DAT-388). ``SET extension_directory`` makes the cache land at the
-# known image path rather than the (missing) home directory of the system user.
+# Pre-install the DuckDB extensions at image build time. Runtime sets
+# DUCKLAKE_SKIP_INSTALL=1 (read by server/storage.bootstrap_lake,
+# apply_s3_secret AND sources/backends.extract_backend) so neither the cold
+# start nor a db-recipe extraction hits the network — also makes air-gapped
+# deploys work. httpfs is required to read/write the lake's parquet over s3://
+# (DAT-388); postgres/mysql/sqlite + community mssql are the db-recipe
+# backends. ``SET extension_directory`` makes the cache land at the known
+# image path rather than the (missing) home directory of the system user.
 RUN /app/.venv/bin/python -c "import duckdb; \
     c = duckdb.connect(); \
     c.execute(\"SET extension_directory = '/opt/dataraum/duckdb-extensions'\"); \
-    c.execute('INSTALL ducklake'); \
-    c.execute('LOAD ducklake'); \
-    c.execute('INSTALL httpfs'); \
-    c.execute('LOAD httpfs'); \
+    [ (c.execute('INSTALL ' + e), c.execute('LOAD ' + e)) \
+      for e in ['ducklake', 'httpfs', 'postgres', 'mysql', 'sqlite'] ]; \
+    c.execute('INSTALL mssql FROM community'); \
+    c.execute('LOAD mssql'); \
     c.close()"
 
 ENV DUCKDB_EXTENSION_DIRECTORY=/opt/dataraum/duckdb-extensions

--- a/packages/engine/src/dataraum/sources/backends.py
+++ b/packages/engine/src/dataraum/sources/backends.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 import duckdb
 
 from dataraum.core.models import Result
+from dataraum.core.settings import get_settings
 from dataraum.sources.db_recipe import RecipeTable
 
 _log = logging.getLogger(__name__)
@@ -120,12 +121,23 @@ def extract_backend(
     default_catalog_row = duckdb_conn.execute("SELECT current_catalog()").fetchone()
     default_catalog = default_catalog_row[0] if default_catalog_row else "memory"
 
-    # 1. Install + load extension.
+    # 1. Install + load extension. Honors the image's pre-baked extension
+    # cache, same contract as bootstrap_lake / apply_s3_secret
+    # (server/storage.py): point ``extension_directory`` at the baked path so
+    # LOAD resolves it, and skip the network INSTALL when
+    # ``DUCKLAKE_SKIP_INSTALL`` is set — a db-recipe extraction must not hit
+    # extensions.duckdb.org at runtime (egress-filtered / air-gapped deploys).
+    settings = get_settings()
     try:
-        if extension in _COMMUNITY_EXTENSIONS:
-            duckdb_conn.execute(f"INSTALL {extension} FROM community")
-        else:
-            duckdb_conn.execute(f"INSTALL {extension}")
+        ext_dir = settings.duckdb_extension_directory
+        if ext_dir:
+            safe_dir = str(ext_dir).replace("'", "''")
+            duckdb_conn.execute(f"SET extension_directory = '{safe_dir}'")
+        if not settings.ducklake_skip_install:
+            if extension in _COMMUNITY_EXTENSIONS:
+                duckdb_conn.execute(f"INSTALL {extension} FROM community")
+            else:
+                duckdb_conn.execute(f"INSTALL {extension}")
         duckdb_conn.execute(f"LOAD {extension}")
     except Exception as exc:
         return Result.fail(f"DuckDB extension '{extension}' failed to install/load: {exc}")

--- a/packages/engine/tests/unit/sources/test_extract_backend.py
+++ b/packages/engine/tests/unit/sources/test_extract_backend.py
@@ -267,6 +267,57 @@ class TestExtractBackendCleanup:
         assert result[0] == "memory"
 
 
+class TestExtensionCachePreBake:
+    """The image pre-bakes extensions (worker.Dockerfile): extract_backend must
+    honor DUCKDB_EXTENSION_DIRECTORY (cache lookup at the baked path) and
+    DUCKLAKE_SKIP_INSTALL (no network INSTALL) — the same contract as
+    bootstrap_lake / apply_s3_secret in server/storage.py.
+    """
+
+    def test_install_lands_in_configured_extension_directory(
+        self, sqlite_source, duckdb_conn, tmp_path, monkeypatch
+    ):
+        """With DUCKDB_EXTENSION_DIRECTORY set, the INSTALL writes the cache there."""
+        ext_dir = tmp_path / "ext-cache"
+        monkeypatch.setenv("DUCKDB_EXTENSION_DIRECTORY", str(ext_dir))
+        result = extract_backend(
+            backend="sqlite",
+            url=sqlite_source,
+            queries=[RecipeTable(name="customers", sql="SELECT * FROM customers")],
+            duckdb_conn=duckdb_conn,
+        )
+        assert result.success, result.error
+        assert list(ext_dir.rglob("sqlite_scanner.duckdb_extension"))
+
+    def test_skip_install_loads_from_pre_baked_cache(self, sqlite_source, tmp_path, monkeypatch):
+        """The container contract: extensions baked at build time, INSTALL skipped.
+
+        Bake sqlite into a cache dir (stand-in for the image build step), then
+        run extract_backend with DUCKLAKE_SKIP_INSTALL=1 — LOAD must resolve
+        the baked file and the extraction must work end-to-end.
+        """
+        ext_dir = tmp_path / "ext-cache"
+        bake = duckdb.connect(":memory:")
+        bake.execute(f"SET extension_directory = '{ext_dir}'")
+        bake.execute("INSTALL sqlite")
+        bake.close()
+
+        monkeypatch.setenv("DUCKDB_EXTENSION_DIRECTORY", str(ext_dir))
+        monkeypatch.setenv("DUCKLAKE_SKIP_INSTALL", "1")
+        conn = duckdb.connect(":memory:")
+        try:
+            result = extract_backend(
+                backend="sqlite",
+                url=sqlite_source,
+                queries=[RecipeTable(name="customers", sql="SELECT * FROM customers")],
+                duckdb_conn=conn,
+            )
+            assert result.success, result.error
+            assert result.unwrap().tables[0].row_count == 3
+        finally:
+            conn.close()
+
+
 class TestExtractBackendFileBackedConnection:
     """In production the DuckDB connection is file-backed (session data.duckdb),
     not :memory:. extract_backend must use the connection's actual catalog name

--- a/packages/infra/docker-compose.yml
+++ b/packages/infra/docker-compose.yml
@@ -12,6 +12,16 @@
 #   docker compose run --rm --no-deps --entrypoint temporal temporal-admin-tools \
 #     worker list --namespace default --address temporal:7233   # → Status: Running
 #   open http://127.0.0.1:3000
+#
+# Egress posture: both app images pre-bake their DuckDB extensions
+# (DUCKLAKE_SKIP_INSTALL=1 in engine + cockpit Dockerfiles), so nothing here
+# touches extensions.duckdb.org at runtime. The remaining runtime egress is
+# (1) api.anthropic.com — HTTPS from engine (httpx) and cockpit (Bun fetch),
+# both of which honor standard HTTPS_PROXY/NO_PROXY env, injectable via a
+# compose override — and (2) raw TCP to user-configured source DBs
+# (connect/probe), which no HTTP proxy can carry. That asymmetry is why this
+# stack deliberately bundles NO egress proxy or network topology: deployers
+# bring their own network policy.
 
 services:
   postgres:


### PR DESCRIPTION
## Why

In environments with runtime egress proxy filters, both containers failed at first DuckDB use: the cockpit's lake reader ran a network `INSTALL ducklake`/`INSTALL httpfs` on cold start, and the engine's db-recipe loaders (`sources/backends.py`) installed postgres/mysql/sqlite/mssql at extraction time. The engine image already pre-baked ducklake + httpfs; this PR completes the pattern on both sides.

## What

**Cockpit (`e7c4dcf4`)**
- Dockerfile runner stage bakes ducklake + httpfs + the four connect-probe backends into `/opt/dataraum/duckdb-extensions`, sets `DUCKDB_EXTENSION_DIRECTORY` + `DUCKLAKE_SKIP_INSTALL=1` (same env contract as the engine's worker.Dockerfile).
- `config.ts` grows the two settings (twin of `core/settings.py`); `lake.ts` (≙ `bootstrap_lake`), `s3-secret.ts` (≙ `apply_s3_secret` — covers connect's throwaway sniff connections) and `probe.ts` honor them. Host dev is unchanged: neither var set → on-demand install into `~/.duckdb`.

**Engine (`8c09b5e9`)**
- `extract_backend` honors `duckdb_extension_directory` + `ducklake_skip_install` instead of unconditionally hitting the network; worker.Dockerfile bakes the four db-recipe backends alongside ducklake + httpfs.

**Latent bug fixed in both images:** `LOAD mssql` (community) could never have worked in either container — `oven/bun:1-slim` and `python:3.14-slim` both lack `libgssapi_krb5.so.2` (verified). `libgssapi-krb5-2` added to both.

**Egress posture documented** in the compose header: remaining runtime egress is `api.anthropic.com` (HTTPS_PROXY/NO_PROXY honored by httpx and Bun fetch via compose override) and raw TCP to user source DBs, which no HTTP proxy can carry — hence deliberately no bundled egress proxy or network topology; that's the deployer's network policy.

## Verification

- Cockpit: 566 unit tests + hermetic probe integration green; biome + tsc clean; image builds; **all six extensions `LOAD` under `docker run --network none`**.
- Engine: 19 `extract_backend` tests (2 new for the cache contract) + 21 import-phase tests green; ruff + mypy clean; image builds; **a real `extract_backend` sqlite extraction runs under `--network none`** with the image's production settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)