### PR TITLE
DAT-426 Phase 1: test-identity sweep — tests feed the production source-free shape

### DIFF
--- a/packages/engine/tests/integration/conftest.py
+++ b/packages/engine/tests/integration/conftest.py
@@ -116,10 +116,16 @@ class PipelineTestHarness:
                         )
                     )
                 ]
+            # Source-FREE ctx — the production shape for every post-import phase
+            # (DAT-422/426): AddSourceWorkflow threads source_id=None past the
+            # import loop, so the harness must feed exactly that. The harness's
+            # ``source_id`` stays the DB seed/scope key above (a Table column),
+            # never the ctx identity. ``import`` runs through ``run_import``,
+            # which builds the source-bearing ctx import legitimately needs.
             ctx = PhaseContext(
                 session=session,
                 duckdb_conn=self.duckdb_conn,
-                source_id=self.source_id,
+                source_id=None,
                 table_ids=scoped_table_ids,
                 config=config or {},
                 session_id=baseline_session_id(),

--- a/packages/engine/tests/integration/pipeline/test_materialization_recipe.py
+++ b/packages/engine/tests/integration/pipeline/test_materialization_recipe.py
@@ -318,10 +318,12 @@ class TestStronglyTypedRecipe:
         raw_table.columns[0].raw_type = "BIGINT"
         session.flush()
 
+        # Source-free ctx — typing runs in the source-free fan-out children
+        # (DAT-422/426); the Table row's source_id is a DB field, not ctx identity.
         ctx = PhaseContext(
             session=session,
             duckdb_conn=duckdb_conn,
-            source_id=raw_table.source_id,
+            source_id=None,
             table_ids=[raw_id],
             session_id=baseline_session_id(),
             run_id="run-strong",

--- a/packages/engine/tests/integration/pipeline/test_statistical_quality_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_statistical_quality_phase.py
@@ -23,12 +23,12 @@ class TestStatisticalQualityPhase:
     ):
         """Test skip when no typed tables exist."""
         phase = StatisticalQualityPhase()
-        source_id = str(uuid4())
 
+        # Source-free ctx — the production post-import shape (DAT-422/426).
         ctx = PhaseContext(
             session=session,
             duckdb_conn=duckdb_conn,
-            source_id=source_id,
+            source_id=None,
             config={},
         )
 
@@ -76,7 +76,7 @@ class TestStatisticalQualityPhase:
         ctx = PhaseContext(
             session=session,
             duckdb_conn=duckdb_conn,
-            source_id=source_id,
+            source_id=None,
             table_ids=[table.table_id],
             config={},
         )
@@ -90,12 +90,11 @@ class TestStatisticalQualityPhase:
     ):
         """Test failure when run without typed tables."""
         phase = StatisticalQualityPhase()
-        source_id = str(uuid4())
 
         ctx = PhaseContext(
             session=session,
             duckdb_conn=duckdb_conn,
-            source_id=source_id,
+            source_id=None,
             config={},
         )
 
@@ -144,7 +143,7 @@ class TestStatisticalQualityPhase:
         ctx = PhaseContext(
             session=session,
             duckdb_conn=duckdb_conn,
-            source_id=source_id,
+            source_id=None,
             table_ids=[table.table_id],
             config={},
         )

--- a/packages/engine/tests/integration/pipeline/test_temporal_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_temporal_phase.py
@@ -24,12 +24,12 @@ class TestTemporalPhase:
     ):
         """Test skip when no typed tables exist."""
         phase = TemporalPhase()
-        source_id = str(uuid4())
 
+        # Source-free ctx — the production post-import shape (DAT-422/426).
         ctx = PhaseContext(
             session=session,
             duckdb_conn=duckdb_conn,
-            source_id=source_id,
+            source_id=None,
             config={},
         )
 
@@ -75,7 +75,7 @@ class TestTemporalPhase:
         ctx = PhaseContext(
             session=session,
             duckdb_conn=duckdb_conn,
-            source_id=source_id,
+            source_id=None,
             table_ids=[table.table_id],
             config={},
         )
@@ -95,12 +95,11 @@ class TestTemporalPhase:
     ):
         """Test failure when run without typed tables."""
         phase = TemporalPhase()
-        source_id = str(uuid4())
 
         ctx = PhaseContext(
             session=session,
             duckdb_conn=duckdb_conn,
-            source_id=source_id,
+            source_id=None,
             config={},
         )
 
@@ -149,7 +148,7 @@ class TestTemporalPhase:
         ctx = PhaseContext(
             session=session,
             duckdb_conn=duckdb_conn,
-            source_id=source_id,
+            source_id=None,
             table_ids=[table.table_id],
             config={},
         )
@@ -197,7 +196,7 @@ class TestTemporalPhase:
         ctx = PhaseContext(
             session=session,
             duckdb_conn=duckdb_conn,
-            source_id=source_id,
+            source_id=None,
             table_ids=[table.table_id],
             config={},
         )

--- a/packages/engine/tests/integration/worker/test_begin_session_activity.py
+++ b/packages/engine/tests/integration/worker/test_begin_session_activity.py
@@ -225,11 +225,15 @@ def _build_typed_tables(manager: ConnectionManager, small_finance_path: Path) ->
                 started_at=datetime.now(UTC),
             )
         )
-    identity = SourceIdentity(workspace_id="test", source_id=source_id, session_id=add_session_id)
-    assert run_phase(manager, "import", identity, []).status == "completed"
+    import_identity = SourceIdentity(
+        workspace_id="test", source_id=source_id, session_id=add_session_id
+    )
+    assert run_phase(manager, "import", import_identity, []).status == "completed"
+    # Past import the chain runs source-free (DAT-422), as AddSourceWorkflow threads it.
+    child_identity = SourceIdentity(workspace_id="test", session_id=add_session_id)
     typed: list[str] = []
     for raw_id in raw_table_ids(manager, source_id):
-        assert run_phase(manager, "typing", identity, [raw_id]).status == "completed"
+        assert run_phase(manager, "typing", child_identity, [raw_id]).status == "completed"
         typed_id = typed_table_id_for_raw(manager, raw_id)
         assert typed_id is not None
         typed.append(typed_id)

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -93,7 +93,16 @@ def worker_manager(pg_url_clean: str, lake_anchor, lake_clean):  # noqa: ANN001
     manager.close()
 
 
-def _identity(source_id: str, session_id: str, run_id: str | None = None) -> SourceIdentity:
+def _identity(
+    session_id: str, *, source_id: str | None = None, run_id: str | None = None
+) -> SourceIdentity:
+    """Source-FREE by default — the production shape past ``import`` (DAT-422/426).
+
+    ``AddSourceWorkflow`` drops ``source_id`` after the import loop, so every
+    post-import phase runs source-free. Pass ``source_id`` ONLY for the
+    per-source ``import`` activity; feeding it anywhere else would mask a
+    regression that reintroduces a ``ctx.source_id`` read.
+    """
     return SourceIdentity(
         workspace_id="test", source_id=source_id, session_id=session_id, run_id=run_id
     )
@@ -205,11 +214,12 @@ def test_import_then_typing_share_one_manager(
     source_id = str(uuid4())
     session_id = str(uuid4())
     _seed_source_and_session(worker_manager, source_id, session_id, "orders", csv)
-    identity = _identity(source_id, session_id)
 
-    # import (no LLM, no prereq) — raw tables land; the source's raw ids are the
-    # fan-out source the parent reads.
-    import_result = run_phase(worker_manager, "import", identity, [])
+    # import (no LLM, no prereq) — the one source-bearing activity; raw tables
+    # land and the source's raw ids are the fan-out source the parent reads.
+    import_result = run_phase(
+        worker_manager, "import", _identity(session_id, source_id=source_id), []
+    )
     assert import_result.status == "completed", import_result.error
     raw_ids = raw_table_ids(worker_manager, source_id)
     assert raw_ids, "import produced no raw tables"
@@ -220,8 +230,8 @@ def test_import_then_typing_share_one_manager(
     duckdb_conn_after_import = worker_manager._duckdb_conn  # noqa: SLF001
 
     # typing scoped to the single raw table (DuckDB-heavy; runs on the SAME
-    # long-lived manager).
-    typing_result = run_phase(worker_manager, "typing", identity, [raw_ids[0]])
+    # long-lived manager), source-free as the workflow threads it (DAT-422).
+    typing_result = run_phase(worker_manager, "typing", _identity(session_id), [raw_ids[0]])
     assert typing_result.status == "completed", typing_result.error
     assert _lake_tables(worker_manager, "typed"), "no tables in lake.typed after typing"
     assert typed_table_id_for_raw(worker_manager, raw_ids[0]) is not None
@@ -234,8 +244,7 @@ def test_import_then_typing_share_one_manager(
 
 def test_unknown_phase_returns_failed(worker_manager: ConnectionManager) -> None:
     """A phase name not in the registry fails cleanly rather than raising."""
-    identity = _identity(str(uuid4()), str(uuid4()))
-    result = run_phase(worker_manager, "does_not_exist", identity, [])
+    result = run_phase(worker_manager, "does_not_exist", _identity(str(uuid4())), [])
     assert result.status == "failed"
     assert "does_not_exist" in (result.error or "")
 
@@ -297,17 +306,19 @@ def test_addsource_runs_under_nondefault_workspace(
         session_id = str(uuid4())
         files = _enumerate_fixture_files(small_finance_path)
         _seed_source_and_session(manager, source_id, session_id, "small_finance", files)
-        identity = SourceIdentity(
+        import_identity = SourceIdentity(
             workspace_id=nondefault_workspace,
             source_id=source_id,
             session_id=session_id,
         )
 
-        assert run_phase(manager, "import", identity, []).status == "completed"
+        assert run_phase(manager, "import", import_identity, []).status == "completed"
         raw_ids = raw_table_ids(manager, source_id)
         assert raw_ids, "import produced no raw tables under the non-default workspace"
 
-        typed_ids = [_process_one_table(manager, identity, raw_id) for raw_id in raw_ids]
+        # Past import the chain runs source-free (DAT-422), as the workflow threads it.
+        child_identity = SourceIdentity(workspace_id=nondefault_workspace, session_id=session_id)
+        typed_ids = [_process_one_table(manager, child_identity, raw_id) for raw_id in raw_ids]
         assert len(typed_ids) == len(raw_ids)
         assert _lake_tables(manager, "typed"), "no typed tables after the chain"
     finally:
@@ -340,10 +351,10 @@ def test_per_table_chain_runs(worker_manager: ConnectionManager, small_finance_p
     session_id = str(uuid4())
     files = _enumerate_fixture_files(small_finance_path)
     _seed_source_and_session(worker_manager, source_id, session_id, "small_finance", files)
-    identity = _identity(source_id, session_id)
 
-    # ONE import activity over the multi-URI list yields N raw tables.
-    assert run_phase(worker_manager, "import", identity, []).status == "completed"
+    # ONE import activity (source-bearing) over the multi-URI list yields N raw tables.
+    import_identity = _identity(session_id, source_id=source_id)
+    assert run_phase(worker_manager, "import", import_identity, []).status == "completed"
     raw_ids = raw_table_ids(worker_manager, source_id)
     assert len(raw_ids) > 1, "one import over a multi-URI source must yield >1 raw tables"
     assert len(raw_ids) == len(files), "each enumerated URI maps to one raw table"
@@ -365,6 +376,8 @@ def test_per_table_chain_runs(worker_manager: ConnectionManager, small_finance_p
         "per-URI loop changed the raw-table set — dataraum-eval baselines would move"
     )
 
+    # Past import the chain + terminal detect run source-free (DAT-422).
+    identity = _identity(session_id)
     typed_ids = [_process_one_table(worker_manager, identity, raw_id) for raw_id in raw_ids]
     assert len(typed_ids) == len(raw_ids)
     assert _lake_tables(worker_manager, "typed"), "no typed tables after the chain"
@@ -392,10 +405,12 @@ def test_terminal_detect_persists_per_column_readiness_and_replay_overwrites(
     session_id = str(uuid4())
     files = _enumerate_fixture_files(small_finance_path)
     _seed_source_and_session(worker_manager, source_id, session_id, "small_finance", files)
-    identity = _identity(source_id, session_id)
 
-    assert run_phase(worker_manager, "import", identity, []).status == "completed"
+    import_identity = _identity(session_id, source_id=source_id)
+    assert run_phase(worker_manager, "import", import_identity, []).status == "completed"
     raw_ids = raw_table_ids(worker_manager, source_id)
+    # Past import: source-free, as the workflow threads it (DAT-422).
+    identity = _identity(session_id)
     typed_ids = {_process_one_table(worker_manager, identity, raw_id) for raw_id in raw_ids}
 
     # Terminal detect: writes entropy_objects AND persists readiness in one pass.
@@ -473,10 +488,13 @@ def test_persisted_readiness_is_single_source_of_truth(
     run_id = str(uuid4())
     files = _enumerate_fixture_files(small_finance_path)
     _seed_source_and_session(worker_manager, source_id, session_id, "small_finance", files)
-    identity = _identity(source_id, session_id, run_id=run_id)
 
-    assert run_phase(worker_manager, "import", identity, []).status == "completed"
+    import_identity = _identity(session_id, source_id=source_id, run_id=run_id)
+    assert run_phase(worker_manager, "import", import_identity, []).status == "completed"
     raw_ids = raw_table_ids(worker_manager, source_id)
+    # Past import: source-free (DAT-422) — the chain, detect AND promote all run
+    # under the source-free identity, exactly as AddSourceWorkflow threads it.
+    identity = _identity(session_id, run_id=run_id)
     typed_ids = sorted({_process_one_table(worker_manager, identity, raw_id) for raw_id in raw_ids})
     assert run_detectors(worker_manager, session_id=identity.session_id, run_id=identity.run_id) > 0
     # Promote this run so the head names it — the query-time read is head-resolved.
@@ -525,7 +543,9 @@ def test_source_free_children_run_the_full_per_table_chain(
     whole ProcessTableWorkflow body (typing → statistics → … → temporal) under a
     source-free identity. It guards the regression where the table-local phases
     scoped via ``Table.source_id == require_source_id()`` and raised on the
-    source-free child — a break the source-bearing test identities masked.
+    source-free child — a break the source-bearing test identities masked. Since
+    DAT-426 the whole suite defaults to the source-free shape; this test stays as
+    the explicit, named statement of the invariant.
     """
     source_id = str(uuid4())
     session_id = str(uuid4())
@@ -533,8 +553,8 @@ def test_source_free_children_run_the_full_per_table_chain(
     _seed_source_and_session(worker_manager, source_id, session_id, "small_finance", files)
 
     # import is the one per-source activity — it needs the source.
-    import_status = run_phase(worker_manager, "import", _identity(source_id, session_id), []).status
-    assert import_status == "completed"
+    import_identity = _identity(session_id, source_id=source_id)
+    assert run_phase(worker_manager, "import", import_identity, []).status == "completed"
     raw_ids = raw_table_ids(worker_manager, source_id)
     assert raw_ids, "import produced no raw tables"
 
@@ -568,13 +588,16 @@ def test_parallel_tables_do_not_conflict_and_terminal_detect_covers_all(
     session_id = str(uuid4())
     files = _enumerate_fixture_files(small_finance_path)
     _seed_source_and_session(worker_manager, source_id, session_id, "small_finance", files)
-    identity = _identity(source_id, session_id)
 
-    # ONE import activity over the multi-URI list yields N raw tables.
-    assert run_phase(worker_manager, "import", identity, []).status == "completed"
+    # ONE import activity (source-bearing) over the multi-URI list yields N raw tables.
+    import_identity = _identity(session_id, source_id=source_id)
+    assert run_phase(worker_manager, "import", import_identity, []).status == "completed"
     raw_ids = raw_table_ids(worker_manager, source_id)
     assert len(raw_ids) > 1, "one import over a multi-URI source must yield >1 raw tables"
     assert len(raw_ids) == len(files), "each enumerated URI maps to one raw table"
+
+    # Past import: source-free, as the workflow threads it into the children (DAT-422).
+    identity = _identity(session_id)
 
     # Fan the per-table analytics chains out across threads — concurrent typing +
     # analytics against the shared lake from independent cursors.
@@ -639,9 +662,11 @@ def test_semantic_per_column_reduce_runs_live(
     session_id = str(uuid4())
     files = _enumerate_fixture_files(small_finance_path)
     _seed_source_and_session(worker_manager, source_id, session_id, "small_finance", files)
-    identity = _identity(source_id, session_id)
 
-    assert run_phase(worker_manager, "import", identity, []).status == "completed"
+    import_identity = _identity(session_id, source_id=source_id)
+    assert run_phase(worker_manager, "import", import_identity, []).status == "completed"
+    # Past import: source-free (DAT-422) — typing, statistics AND the reduce.
+    identity = _identity(session_id)
     for raw_id in raw_table_ids(worker_manager, source_id):
         assert run_phase(worker_manager, "typing", identity, [raw_id]).status == "completed"
         typed_id = typed_table_id_for_raw(worker_manager, raw_id)

--- a/packages/engine/tests/unit/pipeline/test_semantic_split_phases.py
+++ b/packages/engine/tests/unit/pipeline/test_semantic_split_phases.py
@@ -63,14 +63,16 @@ def _annotate(session: Session, table: Table, run_id: str | None = None) -> None
     session.flush()
 
 
-def _ctx(session: Session, duckdb_conn: duckdb.DuckDBPyConnection, source_id: str) -> PhaseContext:
+def _ctx(session: Session, duckdb_conn: duckdb.DuckDBPyConnection) -> PhaseContext:
     # semantic_per_column is session-scoped now (DAT-421): it derives its tables
     # from the run's ``session_tables``, so the ctx must carry the session id the
-    # typed tables above are linked under (``baseline_session_id()``).
+    # typed tables above are linked under (``baseline_session_id()``). Source-FREE
+    # (DAT-422/426): the reduce runs past the add_source boundary, where the
+    # workflow threads source_id=None.
     return PhaseContext(
         session=session,
         duckdb_conn=duckdb_conn,
-        source_id=source_id,
+        source_id=None,
         session_id=baseline_session_id(),
     )
 
@@ -96,8 +98,8 @@ class TestPerColumnShouldSkip:
     def test_no_typed_tables(
         self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection
     ) -> None:
-        src = _source(session)
-        assert SemanticPerColumnPhase().should_skip(_ctx(session, duckdb_conn, src.source_id)) == (
+        _source(session)  # a Source exists, but no typed tables
+        assert SemanticPerColumnPhase().should_skip(_ctx(session, duckdb_conn)) == (
             "No typed tables found"
         )
 
@@ -106,9 +108,7 @@ class TestPerColumnShouldSkip:
     ) -> None:
         src = _source(session)
         _typed_table(session, src.source_id, "t1", ["a", "b"])
-        assert (
-            SemanticPerColumnPhase().should_skip(_ctx(session, duckdb_conn, src.source_id)) is None
-        )
+        assert SemanticPerColumnPhase().should_skip(_ctx(session, duckdb_conn)) is None
 
     def test_re_runs_when_only_a_prior_runs_annotations_exist(
         self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection
@@ -125,9 +125,7 @@ class TestPerColumnShouldSkip:
         src = _source(session)
         t1 = _typed_table(session, src.source_id, "t1", ["a", "b"])
         _annotate(session, t1, run_id="run-A")
-        assert (
-            SemanticPerColumnPhase().should_skip(_ctx(session, duckdb_conn, src.source_id)) is None
-        )
+        assert SemanticPerColumnPhase().should_skip(_ctx(session, duckdb_conn)) is None
 
     def test_scopes_by_session_anchor_not_source(
         self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection
@@ -151,9 +149,7 @@ class TestPerColumnShouldSkip:
         session.add(orphan)
         session.flush()
 
-        scoped = set(
-            SemanticPerColumnPhase()._typed_table_ids(_ctx(session, duckdb_conn, src_a.source_id))
-        )
+        scoped = set(SemanticPerColumnPhase()._typed_table_ids(_ctx(session, duckdb_conn)))
         assert scoped == {a.table_id, b.table_id}  # across sources, session-anchored
         assert orphan.table_id not in scoped  # same source, but not session-linked
 
@@ -168,9 +164,7 @@ class TestPerColumnShouldSkip:
         t1 = _typed_table(session, src.source_id, "t1", ["a"])
         t2 = _typed_table(session, src.source_id, "t2", ["b"])
 
-        scoped = set(
-            SemanticPerColumnPhase()._typed_table_ids(_ctx(session, duckdb_conn, src.source_id))
-        )
+        scoped = set(SemanticPerColumnPhase()._typed_table_ids(_ctx(session, duckdb_conn)))
         # The pre-DAT-421 key: every typed table under this source.
         old_key = {
             tid
@@ -189,13 +183,11 @@ class TestPerColumnAdhocFailLoud:
     the cockpit ``frame`` stage must write ``concept`` overlay rows first.
     """
 
-    def _adhoc_ctx(
-        self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection, source_id: str
-    ) -> PhaseContext:
+    def _adhoc_ctx(self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection) -> PhaseContext:
         return PhaseContext(
             session=session,
             duckdb_conn=duckdb_conn,
-            source_id=source_id,
+            source_id=None,
             config={"vertical": "_adhoc"},
             session_id=baseline_session_id(),
         )
@@ -223,7 +215,7 @@ class TestPerColumnAdhocFailLoud:
         src = _source(session)
         _typed_table(session, src.source_id, "t1", ["a"])
 
-        result = SemanticPerColumnPhase()._run(self._adhoc_ctx(session, duckdb_conn, src.source_id))
+        result = SemanticPerColumnPhase()._run(self._adhoc_ctx(session, duckdb_conn))
 
         assert result.status == PhaseStatus.FAILED
         assert "No concepts found for vertical '_adhoc'" in (result.error or "")

--- a/packages/engine/tests/unit/pipeline/test_typing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_typing_phase.py
@@ -75,13 +75,15 @@ def _make_typed_table(session: Session, source_id: str, name: str) -> Table:
 def _ctx(
     session: Session,
     duckdb_conn: duckdb.DuckDBPyConnection,
-    source_id: str,
     table_ids: list[str] | None = None,
 ) -> PhaseContext:
+    # Source-FREE — the production shape (DAT-422/426): typing runs in the
+    # per-table fan-out children, which AddSourceWorkflow threads source_id=None
+    # into. ``source_id`` above is a Table DB column (seeding), never ctx identity.
     return PhaseContext(
         session=session,
         duckdb_conn=duckdb_conn,
-        source_id=source_id,
+        source_id=None,
         table_ids=table_ids or [],
     )
 
@@ -103,9 +105,7 @@ class TestResolveTargetTableIds:
         _make_table(session, src.source_id, "t1")
         _make_table(session, src.source_id, "t2")
 
-        resolved = TypingPhase()._resolve_target_table_ids(
-            _ctx(session, duckdb_conn, src.source_id)
-        )
+        resolved = TypingPhase()._resolve_target_table_ids(_ctx(session, duckdb_conn))
 
         assert resolved == []
 
@@ -118,7 +118,7 @@ class TestResolveTargetTableIds:
         t3 = _make_table(session, src.source_id, "t3")
 
         resolved = TypingPhase()._resolve_target_table_ids(
-            _ctx(session, duckdb_conn, src.source_id, table_ids=[t1.table_id])
+            _ctx(session, duckdb_conn, table_ids=[t1.table_id])
         )
 
         # Only the targeted table is resolved; siblings are excluded so _run
@@ -145,7 +145,6 @@ class TestResolveTargetTableIds:
             _ctx(
                 session,
                 duckdb_conn,
-                src.source_id,
                 table_ids=[t1.table_id, typed.table_id, foreign.table_id],
             )
         )
@@ -163,11 +162,11 @@ class TestResolveTargetTableIds:
         verbatim when the source has no raw rows" fallback is gone; the per-table
         fan-out always hands real raw ids.
         """
-        src = _make_source(session)
+        _make_source(session)  # a Source exists, but the carried ids are not its tables
         carried = [str(uuid4()), str(uuid4())]  # not real tables
 
         resolved = TypingPhase()._resolve_target_table_ids(
-            _ctx(session, duckdb_conn, src.source_id, table_ids=carried)
+            _ctx(session, duckdb_conn, table_ids=carried)
         )
 
         assert resolved == []
@@ -182,8 +181,8 @@ class TestShouldSkip:
     def test_no_raw_tables_skips(
         self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection
     ) -> None:
-        src = _make_source(session)
-        reason = TypingPhase().should_skip(_ctx(session, duckdb_conn, src.source_id))
+        _make_source(session)  # a Source exists, but it has no raw tables
+        reason = TypingPhase().should_skip(_ctx(session, duckdb_conn))
         assert reason == "No raw tables to process"
 
     def test_targeted_untyped_runs_even_when_siblings_typed(
@@ -197,9 +196,7 @@ class TestShouldSkip:
         _make_typed_table(session, src.source_id, "t2")
         t3 = _make_table(session, src.source_id, "t3")
 
-        reason = TypingPhase().should_skip(
-            _ctx(session, duckdb_conn, src.source_id, table_ids=[t3.table_id])
-        )
+        reason = TypingPhase().should_skip(_ctx(session, duckdb_conn, table_ids=[t3.table_id]))
         assert reason is None
 
     def test_targeted_already_typed_re_runs(
@@ -216,9 +213,7 @@ class TestShouldSkip:
         _make_typed_table(session, src.source_id, "t1")
         _make_table(session, src.source_id, "t2")  # untyped sibling, but not targeted
 
-        reason = TypingPhase().should_skip(
-            _ctx(session, duckdb_conn, src.source_id, table_ids=[t1.table_id])
-        )
+        reason = TypingPhase().should_skip(_ctx(session, duckdb_conn, table_ids=[t1.table_id]))
         assert reason is None
 
     def test_filter_matches_no_raw_tables_skips(
@@ -227,7 +222,5 @@ class TestShouldSkip:
         src = _make_source(session)
         _make_table(session, src.source_id, "t1")
 
-        reason = TypingPhase().should_skip(
-            _ctx(session, duckdb_conn, src.source_id, table_ids=[str(uuid4())])
-        )
+        reason = TypingPhase().should_skip(_ctx(session, duckdb_conn, table_ids=[str(uuid4())]))
         assert reason == "No raw tables match the requested table_ids filter"

--- a/packages/engine/tests/unit/worker/test_import_requires_source.py
+++ b/packages/engine/tests/unit/worker/test_import_requires_source.py
@@ -1,0 +1,35 @@
+"""``import`` is the ONE source-bound activity (DAT-422/426) — pin its guard.
+
+Past the import loop the whole spine runs source-free (the suite now feeds that
+shape everywhere), so this is the counterpart assertion: the per-source
+``import`` activity must REFUSE a source-free identity loudly — a ``None``
+``source_id`` is a caller bug, and silently loading nothing would be worse than
+failing the run.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+from dataraum.worker.activities import PhaseActivities
+from dataraum.worker.contracts import SourceIdentity
+
+
+def test_import_refuses_a_source_free_identity() -> None:
+    """A source-free identity fails the import activity loud + non-retryable.
+
+    The guard sits before any substrate work, so a bare MagicMock manager
+    proves it raises without touching connections.
+    """
+    activities = PhaseActivities(MagicMock())
+    identity = SourceIdentity(workspace_id="ws-1", session_id="sess-1", run_id="run-A")
+
+    with pytest.raises(ApplicationError) as excinfo:
+        activities.run_import(identity)
+
+    assert excinfo.value.type == "PhaseFailed"
+    assert excinfo.value.non_retryable
+    assert "source_id" in str(excinfo.value)

--- a/packages/engine/tests/unit/worker/test_promote_run.py
+++ b/packages/engine/tests/unit/worker/test_promote_run.py
@@ -70,9 +70,10 @@ def _heads(session_factory: Any) -> list[MetadataSnapshotHead]:
 
 def test_promote_run_upserts_one_head_per_table_stage(monkeypatch, session_factory):
     """First promote inserts a v0 head per (table_id, stage); a re-run bumps + re-points."""
+    # Source-free: AddSourceWorkflow threads source_id=None into the terminal
+    # promote (DAT-422/426) — the test feeds exactly what production feeds.
     identity = SourceIdentity(
         workspace_id="ws-1",
-        source_id="src-1",
         session_id="sess-1",
         run_id="run-A",
     )
@@ -110,7 +111,6 @@ def test_promote_run_no_tables_is_noop(monkeypatch, session_factory):
     """An empty session-table set promotes nothing (logged warning, no rows)."""
     identity = SourceIdentity(
         workspace_id="ws-1",
-        source_id="src-1",
         session_id="sess-1",
         run_id="run-A",
     )
@@ -123,7 +123,7 @@ def test_promote_run_no_tables_is_noop(monkeypatch, session_factory):
 
 def test_promote_run_requires_run_id(monkeypatch, session_factory):
     """A missing run_id is a caller bug — fail loud rather than write a NULL head."""
-    identity = SourceIdentity(workspace_id="ws-1", source_id="src-1", session_id="sess-1")
+    identity = SourceIdentity(workspace_id="ws-1", session_id="sess-1")
     monkeypatch.setattr(activity_mod, "get_active_workspace_id", lambda: "ws-1")
 
     with pytest.raises(RuntimeError, match="requires a stamped identity.run_id"):

--- a/packages/engine/tests/unit/worker/test_snapshot_run_id.py
+++ b/packages/engine/tests/unit/worker/test_snapshot_run_id.py
@@ -81,8 +81,9 @@ def _run_phase_capturing(
         lambda source, phase_name, ident: {},
     )
 
+    # Source-free identity (the production post-import shape, DAT-422/426):
+    # run_phase never resolves a Source row, so no session.get stub is needed.
     session = MagicMock()
-    session.get.return_value = MagicMock()  # the Source row exists
 
     @contextmanager
     def _session_scope():  # noqa: ANN202
@@ -106,7 +107,6 @@ def test_run_phase_threads_run_id_from_identity(monkeypatch: Any) -> None:
     """A stamped ``SourceIdentity.run_id`` lands on ``PhaseContext.run_id``."""
     identity = SourceIdentity(
         workspace_id="ws-1",
-        source_id="src-1",
         session_id="sess-1",
         run_id="run-xyz",
     )
@@ -118,7 +118,6 @@ def test_run_phase_run_id_defaults_none(monkeypatch: Any) -> None:
     """An identity with no ``run_id`` (cockpit initial-run shape) stays ``None``."""
     identity = SourceIdentity(
         workspace_id="ws-1",
-        source_id="src-1",
         session_id="sess-1",
     )
     ctx = _run_phase_capturing(monkeypatch, identity)


### PR DESCRIPTION
## Task

DAT-426 (Phase 1 ONLY) — https://real-dataraum.atlassian.net/browse/DAT-426 (epic DAT-420)

Phase 2 (deleting `PhaseContext.source_id` + `require_source_id()`) is the gated capstone and is deliberately NOT in this PR.

## The risk this closes

Production runs every post-import phase source-free — `AddSourceWorkflow` drops `source_id` after the import loop (`worker/workflows.py:256`) — but the suite's default identity shape was source-bearing (40 of 73 `PhaseContext(` constructions; the worker `_identity` fixture took `source_id` as a required positional). A regression reintroducing a `ctx.source_id` read on the active spine would have stayed green because tests fed a value production never supplies. This flips the suite default to the production shape.

## What flipped (engine tests only, no production code)

- **`tests/integration/worker/test_phase_activity.py`** — `_identity(session_id, *, source_id=None, run_id=None)`: source-free primary; source-bearing only for the per-source `import` calls. Every post-import call site (per-table chains, terminal detect, promote, the live-LLM reduce) threads the source-free identity.
- **`tests/integration/worker/test_begin_session_activity.py`** — `_build_typed_tables`: `import` keeps its source; the typing loop runs source-free.
- **`tests/unit/worker/test_promote_run.py`, `test_snapshot_run_id.py`** — identities source-free (both exercise post-import plumbing); the now-dead Source-row stub removed.
- **`tests/integration/conftest.py`** — `PipelineTestHarness.run_phase` builds a source-free ctx for every phase; `run_import` keeps the source-bearing ctx `import` legitimately needs. The harness `source_id` remains the DB seed/scope key only.
- **`tests/integration/pipeline/test_statistical_quality_phase.py`** (4 ctx), **`test_temporal_phase.py`** (5 ctx), **`test_materialization_recipe.py`** (1 ctx — typing is active spine) — `PhaseContext(source_id=None)`; `Source`/`Table` row seeding (a DB field) untouched.
- **`tests/unit/pipeline/test_typing_phase.py`, `test_semantic_split_phases.py`** — `_ctx`/`_adhoc_ctx` helpers no longer take a `source_id`.
- **NEW `tests/unit/worker/test_import_requires_source.py`** — the counterpart pin: the `import` activity refuses a source-free identity loud + non-retryable (`ApplicationError`/`PhaseFailed`); the guard had no test.

## Finding (ticket item 4)

**No production read surfaced.** Every flipped test passes with `source_id=None`. Static sweep agrees: on the active spine all `ctx.source_id` grep hits are comments; the only real readers are the dormant phases (`graph_execution`, `validation`, `business_cycles`) that the begin_session slices re-seam — exactly why their test files are skipped here and why Phase 2 stays gated.

## Skipped (deliberate, per ticket)

Dormant-phase test files: `test_business_cycles_phase.py`, `test_validation_phase.py`, `integration/analysis/validation/*`, graph_execution-related, `test_replay_cross_stage.py`. The DAT-403 value-layer files (`slicing`, `slicing_view`, `slice_analysis`, `temporal_slice_analysis`, `correlations`, `enriched_views`, `test_value_phase_scoping.py`) and `test_typed_tables_scope.py`/`test_progress_query.py`/`test_check_column_limit.py` were verified **already source-free** — no change needed. `import` tests (`test_import_phase.py` unit+integration) stay source-bearing: import is the one source-bound activity.

## Acceptance criteria (Phase 1)

- [x] Worker fixture + active-spine tests feed source-free identities/contexts past import
- [x] Source-bearing identities remain only for `import` and row seeding
- [x] Engine type-check + unit + worker integration green
- [x] A reintroduced `ctx.source_id` read on the active spine now sees `None` and fails loud

## Gates

```
uv run ruff format                          -> clean
uv run ruff check                           -> All checks passed!
uv run mypy src                             -> Success: no issues in 235 files
uv run pytest --testmon tests -q            -> 1519 passed, 8 skipped
tests/integration/worker/ + touched pipeline integration files -> 34 passed, 1 skipped (env-gated live-LLM)
```

(`test_progress_query.py` errored once on a transient `temporalio/temporal:latest` testcontainer image pull; passes after the image cached.)

## Other lanes in flight

`gh pr list` → none open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)