### PR TITLE
DAT-429: fail-closed session isolation on the remaining cycles + validation readers

### DIFF
--- a/packages/engine/src/dataraum/analysis/cycles/context.py
+++ b/packages/engine/src/dataraum/analysis/cycles/context.py
@@ -117,13 +117,32 @@ def build_cycle_detection_context(
 
     context["tables"] = table_info
 
-    # 2. Entity classifications (fact vs dimension)
-    entities_stmt = (
-        select(TableEntity, Table.table_name)
-        .join(Table, TableEntity.table_id == Table.table_id)
-        .where(Table.table_id.in_(table_ids))
-    )
-    entities = session.execute(entities_stmt).all()
+    # Resolve the session's current (promoted) run ONCE via the per-session head
+    # (DAT-409). Both run-versioned reads below — entity classifications AND the
+    # defined relationships (DAT-408/413: they coexist across runs) — scope to the
+    # SAME run. **Fail-closed (DAT-429, session isolation):** with no resolved run
+    # (no session_id, or the session hasn't promoted one yet) we MUST NOT fall back
+    # to a cross-run read — that would mix OTHER sessions' entities/relationships
+    # into this context. Leave both empty instead. The remaining reads (slices,
+    # temporal, enriched views) are keyed by table_id and are unaffected.
+    run_id = head_run_id(session, session_head_target(session_id), "detect") if session_id else None
+    if session_id and run_id is None:
+        logger.warning(
+            "session_run_unresolved",
+            session_id=session_id,
+            detail="no promoted run for this session; entity/relationship context is empty",
+        )
+
+    # 2. Entity classifications (fact vs dimension) — run-scoped (fail-closed above).
+    entities: list[Any] = []
+    if run_id is not None:
+        entities = list(
+            session.execute(
+                select(TableEntity, Table.table_name)
+                .join(Table, TableEntity.table_id == Table.table_id)
+                .where(Table.table_id.in_(table_ids), TableEntity.run_id == run_id)
+            ).all()
+        )
 
     context["entity_classifications"] = [
         {
@@ -137,12 +156,11 @@ def build_cycle_detection_context(
         for ent, table_name in entities
     ]
 
-    # 3. The defined relationships (not candidate) within the selection, scoped to
-    # the session's current (promoted) run via the per-session head (DAT-409). With
-    # no session_id (legacy/un-sealed callers) the head is unresolved and the read
-    # falls back to the cross-run catalog.
-    run_id = head_run_id(session, session_head_target(session_id), "detect") if session_id else None
-    relationships = load_defined_relationships(session, table_ids, run_id=run_id)
+    # 3. The defined relationships (not candidate) within the selection — run-scoped,
+    # fail-closed above (empty when the session's run is unresolved).
+    relationships = (
+        load_defined_relationships(session, table_ids, run_id=run_id) if run_id is not None else []
+    )
 
     rel_list = []
     for rel in relationships:

--- a/packages/engine/src/dataraum/analysis/validation/resolver.py
+++ b/packages/engine/src/dataraum/analysis/validation/resolver.py
@@ -101,11 +101,22 @@ def get_multi_table_schema_for_llm(
         return {"error": "No tables with DuckDB paths found"}
 
     # The defined relationships (not candidate) between these tables, scoped to the
-    # session's current (promoted) run via the per-session head (DAT-409). With no
-    # session_id the head is unresolved and the read falls back to the cross-run
-    # catalog.
+    # session's current (promoted) run via the per-session head (DAT-409).
+    # **Fail-closed (DAT-429, session isolation):** with no resolved run — no
+    # session_id, or the session hasn't promoted one yet — we MUST NOT fall back to
+    # a cross-run read (``run_id=None`` reads ALL runs), which would surface OTHER
+    # sessions' relationships into this schema. Leave relationships empty instead;
+    # the table schemas above are keyed by table_id and are unaffected.
     run_id = head_run_id(session, session_head_target(session_id), "detect") if session_id else None
-    relationships = load_defined_relationships(session, table_ids, run_id=run_id)
+    if session_id and run_id is None:
+        logger.warning(
+            "session_run_unresolved",
+            session_id=session_id,
+            detail="no promoted run for this session; relationship context is empty",
+        )
+    relationships = (
+        load_defined_relationships(session, table_ids, run_id=run_id) if run_id is not None else []
+    )
 
     # Format relationships
     formatted_rels = []

--- a/packages/engine/tests/unit/analysis/cycles/test_context.py
+++ b/packages/engine/tests/unit/analysis/cycles/test_context.py
@@ -1,0 +1,162 @@
+"""Fail-closed session isolation for the cycle-detection context (DAT-429).
+
+``build_cycle_detection_context`` assembles two run-versioned reads — entity
+classifications and the defined relationships — both of which coexist across runs
+(DAT-408/413). With no resolved run (no ``session_id``, or a session whose head was
+never promoted) the builder must surface NEITHER: a cross-run read here would mix
+other sessions' entities/relationships into this context. These pin that contract,
+mirroring ``graphs/test_context_builder`` for the cycles reader.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import duckdb
+import pytest
+
+from dataraum.analysis.cycles.context import build_cycle_detection_context
+from dataraum.analysis.relationships.db_models import Relationship
+from dataraum.analysis.semantic.db_models import TableEntity
+from dataraum.investigation.db_models import InvestigationSession
+from dataraum.storage import Column, Source, Table
+from dataraum.storage.snapshot_head import MetadataSnapshotHead, session_head_target
+
+
+def _id() -> str:
+    return str(uuid4())
+
+
+@pytest.fixture
+def two_tables_two_runs(session):
+    """Two related tables with entity + relationship rows under two coexisting runs.
+
+    ``run-current`` and ``run-stale`` each carry a fact classification for the
+    transactions table and the same directional relationship (distinguishable by
+    confidence). No head is promoted here — each test promotes the one it needs.
+
+    Returns ``(table_ids, session_id)``.
+    """
+    source = Source(name="test_source", source_type="csv")
+    session.add(source)
+    session.flush()
+
+    txn = Table(
+        source_id=source.source_id,
+        table_name="transactions",
+        layer="typed",
+        row_count=1000,
+        duckdb_path="typed_transactions",
+    )
+    acct = Table(
+        source_id=source.source_id,
+        table_name="accounts",
+        layer="typed",
+        row_count=50,
+        duckdb_path="typed_accounts",
+    )
+    session.add_all([txn, acct])
+    session.flush()
+
+    txn_account_col = Column(
+        table_id=txn.table_id,
+        column_name="account_id",
+        column_position=0,
+        raw_type="VARCHAR",
+        resolved_type="VARCHAR",
+    )
+    acct_id_col = Column(
+        table_id=acct.table_id,
+        column_name="account_id",
+        column_position=0,
+        raw_type="VARCHAR",
+        resolved_type="VARCHAR",
+    )
+    session.add_all([txn_account_col, acct_id_col])
+    session.flush()
+
+    session_id = "sess-cycles"
+    session.add(InvestigationSession(session_id=session_id, intent="test"))
+    session.flush()
+    for run_id, conf, is_fact, desc in (
+        ("run-current", 0.95, True, "CURRENT classification"),
+        ("run-stale", 0.10, False, "STALE classification"),
+    ):
+        session.add(
+            Relationship(
+                session_id=session_id,
+                run_id=run_id,
+                from_table_id=txn.table_id,
+                from_column_id=txn_account_col.column_id,
+                to_table_id=acct.table_id,
+                to_column_id=acct_id_col.column_id,
+                relationship_type="foreign_key",
+                cardinality="many-to-one",
+                confidence=conf,
+                detection_method="llm",
+            )
+        )
+        session.add(
+            TableEntity(
+                entity_id=_id(),
+                session_id=session_id,
+                table_id=txn.table_id,
+                run_id=run_id,
+                detected_entity_type="fact" if is_fact else "dimension",
+                description=desc,
+                is_fact_table=is_fact,
+            )
+        )
+    session.commit()
+
+    return [txn.table_id, acct.table_id], session_id
+
+
+def _build(session, table_ids, **kwargs):
+    """Build the cycle context against an ephemeral DuckDB (row counts → None)."""
+    return build_cycle_detection_context(
+        session,
+        duckdb.connect(),
+        table_ids,
+        vertical="finance",
+        **kwargs,
+    )
+
+
+def test_unresolved_session_reads_no_run_versioned_data(session, two_tables_two_runs) -> None:
+    """No resolved run ⇒ no entities, no relationships — never the cross-run union."""
+    table_ids, session_id = two_tables_two_runs
+
+    # No session_id ⇒ unresolved run.
+    ctx_none = _build(session, table_ids)
+    assert ctx_none["entity_classifications"] == []
+    assert ctx_none["relationships"] == []
+
+    # A recognized session whose head was never promoted is equally unresolved
+    # (``session_id`` is seeded as an InvestigationSession by the fixture, but no
+    # detect head was ever promoted for it).
+    ctx_unpromoted = _build(session, table_ids, session_id=session_id)
+    assert ctx_unpromoted["entity_classifications"] == []
+    assert ctx_unpromoted["relationships"] == []
+
+
+def test_scopes_to_promoted_head(session, two_tables_two_runs) -> None:
+    """With a promoted head, only that run's entity + relationship surface."""
+    table_ids, session_id = two_tables_two_runs
+    session.add(
+        MetadataSnapshotHead(
+            target=session_head_target(session_id), stage="detect", run_id="run-current"
+        )
+    )
+    session.commit()
+
+    ctx = _build(session, table_ids, session_id=session_id)
+
+    rels = ctx["relationships"]
+    assert len(rels) == 1
+    assert rels[0]["confidence"] == 0.95
+
+    entities = ctx["entity_classifications"]
+    assert len(entities) == 1
+    assert entities[0]["is_fact_table"] is True
+    assert entities[0]["description"] == "CURRENT classification"

--- a/packages/engine/tests/unit/analysis/validation/test_resolver.py
+++ b/packages/engine/tests/unit/analysis/validation/test_resolver.py
@@ -167,10 +167,31 @@ def two_tables_with_relationship(session):
 
 
 def test_get_multi_table_schema_for_llm(session, two_tables_with_relationship):
-    """Test fetching multi-table schema with relationships."""
+    """Multi-table schema formats tables + the session's run-scoped relationships.
+
+    Fail-closed (DAT-429): relationships surface only for the session's promoted
+    run, so resolve the fixture relationship under one and pass the ``session_id``.
+    """
+    from dataraum.analysis.relationships.db_models import Relationship
+    from dataraum.investigation.db_models import InvestigationSession
+    from dataraum.storage.snapshot_head import MetadataSnapshotHead, session_head_target
+
     txn_table, acct_table = two_tables_with_relationship
 
-    schema = get_multi_table_schema_for_llm(session, [txn_table.table_id, acct_table.table_id])
+    session_id = "sess-fmt"
+    session.add(InvestigationSession(session_id=session_id, intent="test"))
+    session.flush()
+    rel = session.query(Relationship).one()
+    rel.session_id = session_id
+    rel.run_id = "run-1"
+    session.add(
+        MetadataSnapshotHead(target=session_head_target(session_id), stage="detect", run_id="run-1")
+    )
+    session.commit()
+
+    schema = get_multi_table_schema_for_llm(
+        session, [txn_table.table_id, acct_table.table_id], session_id=session_id
+    )
 
     assert "error" not in schema
     assert "tables" in schema
@@ -246,10 +267,15 @@ def test_get_multi_table_schema_for_llm_scopes_to_current_run(
     assert len(scoped["relationships"]) == 1
     assert scoped["relationships"][0]["confidence"] == 0.95
 
-    # Without session_id: the read is unscoped and both runs leak through (the bug
-    # this fix closes for the agent tier).
+    # Fail-closed (DAT-429): with no session_id the run is unresolved, so the read
+    # surfaces NOTHING — never the cross-run union that would leak other sessions'
+    # relationships into this schema.
     unscoped = get_multi_table_schema_for_llm(session, table_ids)
-    assert len(unscoped["relationships"]) == 2
+    assert unscoped["relationships"] == []
+
+    # A session_id whose head was never promoted is equally unresolved → still empty.
+    unpromoted = get_multi_table_schema_for_llm(session, table_ids, session_id="sess-no-head")
+    assert unpromoted["relationships"] == []
 
 
 def test_get_multi_table_schema_for_llm_single_table(session, table_with_columns):


### PR DESCRIPTION
## What

Extends the **fail-closed session-isolation contract** — already shipped for `graphs/context.py::build_execution_context` (PR #220) — to the two remaining query/agent-tier readers that still fell back to a cross-run read when the session was unscoped (`session_id is None`) or unresolved (no promoted snapshot head).

Run-versioned metadata (DAT-408/413) coexists across runs keyed by `run_id`; the session's current run is resolved via the per-session head (`head_run_id(session, session_head_target(session_id), "detect")`). A head-resolved reader that falls back to a cross-run read on an unresolved session **leaks other sessions' entities/relationships** into the current context.

| Reader | Leak closed |
|---|---|
| `analysis/validation/resolver.py::get_multi_table_schema_for_llm` | relationships read passed `run_id=None` (= **all runs**) → now empty unless the run resolves |
| `analysis/cycles/context.py::build_cycle_detection_context` | **two** leaks — same relationship fallback **plus a fully unscoped `TableEntity` read** that mixed every coexisting run's classifications → both gated on a single up-front `run_id` resolution |

Both mirror the `graphs/context.py` reference exactly: empty context (not error), `session_run_unresolved` warning only when `session_id` is set but unresolved (a bare `session_id=None` is the legitimate session-less case), and non-run-versioned table-keyed reads (schemas, slices, temporal, enriched views) left untouched.

## Scope

The remaining query/agent-tier leak set is exactly these **two dormant readers**. Independently confirmed (spec-compliance reviewer swept every `head_run_id(` / `load_defined_relationships(` call site):

- `entropy/views/readiness_context.py` readers (live) were **already fail-closed** (DAT-408 P6 / DAT-415 P4) — `if current_run is None: return []`.
- `cycles/induction.py` is run-agnostic **by design** (vertical-rule authoring, no session run) — out of scope.
- `enriched_views_phase.py` is phase-tier, already scoped to `ctx.run_id`.

## Tests

- New `tests/unit/analysis/cycles/test_context.py` — regression: unresolved session (no `session_id`, and a recognized-but-unpromoted session) → empty entities + relationships; promoted head → that run only.
- `tests/unit/analysis/validation/test_resolver.py` — flipped from asserting the cross-run leak (`== 2`) to the fail-closed contract; basic formatting test reseeded under a resolved session.

192 affected-area unit tests pass (cycles/validation/graphs/entropy); ruff + mypy clean. Reviewers: senior-code APPROVE, spec-compliance COMPLIANT.

## Notes

No `handoff.md` entry — this gates context assembly for two dormant agents, not detector behavior or response shapes, so there is no eval-calibration impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)