### PR TITLE
chore: enforce the TanStack Intent skill check in reviewer agents + lane skills

### DIFF
--- a/.claude/agents/senior-code-reviewer.md
+++ b/.claude/agents/senior-code-reviewer.md
@@ -91,7 +91,7 @@ Be specific. Quote code. Show the problematic line and what it should look like.
 
 ## Severity Calibration
 
-- **Critical**: Data corruption, race condition, security issue, silent failure, broken MCP contract
+- **Critical**: Data corruption, race condition, security issue, silent failure, broken cross-package contract (Temporal workflow shapes, agent-tool schemas)
 - **Improvement**: Missing edge case handling, suboptimal UX, inconsistent patterns, missing types
 - **Nit**: Naming, formatting, comment quality
 
@@ -99,11 +99,19 @@ Be specific. Quote code. Show the problematic line and what it should look like.
 
 - This project uses `Result` types, not exceptions, for expected errors
 - Database access uses context managers (`session_scope()`, `duckdb_cursor()`)
-- Python 3.14t with free-threading — the GIL is OFF, treat all shared mutable state as unsafe
-- Pipeline has 19 active phases managed by a scheduler — state transitions matter
-- MCP server exposes 6 tools (4 core + 2 source management)
+- Python 3.14, standard GIL-on CPython — but the Temporal activity worker runs phases concurrently on a `ThreadPoolExecutor`, so shared worker state (e.g. the one `ConnectionManager`) is still concurrent; review it as such
+- The engine is a **Temporal activity worker** (no HTTP): workflows AND activities are Python, bundled in `worker/` — workflow code runs in the determinism sandbox, review for replay safety
+- The legacy MCP surface is dead (`reference/mcp/`, kept as copy-reference only) — flag any new dependence on it
 - VARCHAR-first staging pattern — type inference happens in profiling, not load
 - Tests use pytest-testmon; never suggest running the full suite without testmon
+
+## TanStack code (packages/cockpit) — MANDATORY
+
+Before judging ANY code that imports `@tanstack/*`:
+
+1. From `packages/cockpit` run `bunx @tanstack/intent@latest list`, then `bunx @tanstack/intent@latest load <pkg>#<skill>` for the packages the diff touches (`@tanstack/ai#ai-core` + relevant sub-skills for AI/agent code; router/start skills for routing code). Follow the returned SKILL.md.
+2. These are the OFFICIAL skills, version-pinned to the INSTALLED packages — the only authority for TanStack API claims. Never assert SDK behavior from training data; verify claims against the loaded skill AND the installed dist.
+3. Dependency convention: `@tanstack/*` deps are declared `latest` BY DESIGN and **nothing freezes** — bun.lock owns resolution. Never flag unpinned/floating deps, never propose version pins; contract tests + tsc are the update guards.
 
 ## Workflow Context
 
@@ -113,7 +121,7 @@ When your findings include issues that suggest the implementation approach was w
 
 When you find tests that only test mocks, dead code kept for tests, or assertions that can never fail — flag these as **Critical**, not Nits. These patterns erode the project's ability to catch real bugs and are a recurring problem.
 
-When you find MCP tool changes, note that the developer should run `/smoke` to UX-test the tools before handoff.
+When you find cockpit agent-tool changes (the TanStack AI tool surface), note that the developer should run `/smoke` to UX-test the tools before handoff.
 
 **Update your agent memory** as you discover code patterns, recurring issues, architectural conventions, concurrency patterns, and state machine designs in this codebase. This builds institutional knowledge across reviews. Write concise notes about what you found and where.
 

--- a/.claude/agents/spec-compliance-reviewer.md
+++ b/.claude/agents/spec-compliance-reviewer.md
@@ -83,6 +83,7 @@ Structure your output as:
 - **Check test coverage for each requirement**: A requirement without a test is incomplete per the project's Definition of Done.
 - **Don't review code quality in general**: Stay focused on spec compliance. Style, performance, and general code quality are out of scope unless the spec explicitly addresses them.
 - **Flag implicit assumptions**: If the implementation makes assumptions not stated in the spec, note them.
+- **TanStack code (packages/cockpit) — MANDATORY**: before judging any code that imports `@tanstack/*`, run `bunx @tanstack/intent@latest list` from `packages/cockpit` and `load` the matching skills (e.g. `@tanstack/ai#ai-core` + sub-skills). They are the OFFICIAL, version-pinned-to-installed authority for TanStack API claims — never assert SDK behavior from training data. Deps are `latest` by design and nothing freezes (bun.lock owns resolution) — never flag unpinned deps or propose pins.
 
 ## Workflow Context
 

--- a/.claude/agents/strict-reviewer.md
+++ b/.claude/agents/strict-reviewer.md
@@ -34,6 +34,14 @@ Before approving any code:
 - Approve code you haven't actually reviewed
 - Be satisfied with partial implementations
 
+## TanStack code (packages/cockpit) — MANDATORY
+
+Before judging ANY code that imports `@tanstack/*`:
+
+1. From `packages/cockpit` run `bunx @tanstack/intent@latest list`, then `bunx @tanstack/intent@latest load <pkg>#<skill>` for the packages the diff touches (`@tanstack/ai#ai-core` + relevant sub-skills for AI/agent code; router/start skills for routing code). Follow the returned SKILL.md.
+2. These are the OFFICIAL skills, version-pinned to the INSTALLED packages — the only authority for TanStack API claims. Never assert SDK behavior from training data; verify claims against the loaded skill AND the installed dist.
+3. Dependency convention: `@tanstack/*` deps are declared `latest` BY DESIGN and **nothing freezes** — bun.lock owns resolution. Never flag unpinned/floating deps, never propose version pins; contract tests + tsc are the update guards.
+
 ## Response Format
 
 When reviewing, structure your response as:

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -24,6 +24,7 @@ $ARGUMENTS is a Jira issue identifier, a description of the agreed approach, or 
    DO NOT change: [large/unrelated areas that must stay untouched — NOT a cage]
    ```
 4. For M+: get explicit user sign-off on the plan before writing code.
+5. **Cockpit/TanStack work — MANDATORY:** if the task touches code importing `@tanstack/*`, run the TanStack Intent skill check FIRST, from `packages/cockpit`: `bunx @tanstack/intent@latest list`, then `load <pkg>#<skill>` for the packages you'll touch (`@tanstack/ai#ai-core` + sub-skills for agent/AI code; router/start skills for routing). Follow the returned SKILL.md — it is official guidance version-pinned to the installed packages (see cockpit CLAUDE.md "Skill Loading"). Never write TanStack API usage from memory. Deps stay `latest` and nothing freezes (bun.lock owns resolution) — never add version pins.
 
 ### Scope is a fence against *unrelated* sprawl — not a cage
 

--- a/.claude/skills/take/SKILL.md
+++ b/.claude/skills/take/SKILL.md
@@ -44,6 +44,8 @@ Before touching any code:
 
    Note: most of the original Platform Contracts inventory (Mcp-Session-Id, CP↔executor gRPC, TanStack AI wire format, OpenAPI for `/api/*`) was superseded or deferred by the v1 plan. Contract #5 (config storage shape) stays locked for future multi-user work. If the task names no contract, this step is a no-op.
 
+6. **Cockpit/TanStack tasks:** if the task touches `packages/cockpit` code importing `@tanstack/*`, the TanStack Intent skill check is MANDATORY at every stage — `/implement` runs it before writing code (its "Before you start" step), and any reviewer runs it before judging (the reviewer agent definitions carry the same mandate). A lane that writes or reviews TanStack code without loading the matching Intent skills is operating on stale training-data memory — that is how bogus findings and deprecated API usage get in.
+
 If anything is wrong, STOP and report. Don't "make it work."
 
 ## Step 2: Open the worktree and switch the session into it

--- a/packages/cockpit/CLAUDE.md
+++ b/packages/cockpit/CLAUDE.md
@@ -14,6 +14,11 @@ Before substantial work:
 
 > TanStack guidance is official **[TanStack Intent](https://tanstack.com/intent/latest)** skills, version-pinned to our installed packages (`@tanstack/ai`, `react-start`, `router-core`, …) and discovered via the CLI above — not vendored into `.claude/skills/`. Run `bunx @tanstack/intent@latest list` from this package dir.
 
+Knowledge sources beyond Intent:
+- **AG-UI (the streaming protocol under TanStack AI):** the `@tanstack/ai#ai-core/ag-ui-protocol` sub-skill covers the event layer (`RUN_*`, `TOOL_CALL_*`, `STATE_SNAPSHOT`/`STATE_DELTA`, `CUSTOM`). Load it for chat-transport, tool-state, or model-only-context work; upstream protocol reference: <https://docs.ag-ui.com>. Where a skill doc and the installed dist disagree, the installed types win.
+- **React 19 has NO Intent skill** — the authority is <https://react.dev> (fetch it; never write React idioms from training-data memory). Project-distilled rules: the "UI quality bar" below, plus the cockpit-idiom conventions as the React-idiom audit lands.
+- **Dependency convention:** `@tanstack/*` deps are declared `latest` and **nothing freezes** — bun.lock owns resolution; never add version pins. Contract tests + tsc guard deliberate updates.
+
 ## Layout
 
 ```

--- a/packages/cockpit/CLAUDE.md
+++ b/packages/cockpit/CLAUDE.md
@@ -75,6 +75,26 @@ A widget that "renders" is not done. The user's real query returns big, messy da
 
 If you notice yourself thinking "this works" about a surface you only tried with toy data, that's the cue to push it to realistic scale — which is exactly what `/smoke` step 4 checks.
 
+## React idiom (React 19, no Compiler — manual memoization is load-bearing)
+
+Derived from the 2026-06-05 React-idiom audit: these rules state what the codebase already does — hold the line. React itself has no Intent skill; <https://react.dev> is the authority (fetch it, don't recall it).
+
+1. **Derive during render; never mirror into state via effects.** Anything computable from props/state/messages is computed inline (the canvas, chip status, inventory grouping are the precedents). [react.dev/learn/you-might-not-need-an-effect]
+2. **Effects are for external systems only** — DOM sync, stream subscriptions with abort/cleanup. Two exist (chat scroll-pin, NDJSON fold); a third needs the same justification in a comment. [react.dev/learn/synchronizing-with-effects]
+3. **Server data goes through TanStack Query** — polling = `refetchInterval` callback returning `false` when done (measure-progress is the template). No `setInterval`, no hand-rolled `isLoading` for queries.
+4. **Mutations fired by user events live in event handlers** (optionally `useMutation`), never in effects.
+5. **Reset child state with a remount `key`, not a reset effect** (ResultGridWidget → StreamingGrid is the template).
+6. **Memoize with a stated reason** — streaming makes the provider re-render per token, so `memo`/`useMemo` on that path is load-bearing (markdown, focus-canvas, context values); anywhere else it must earn its line. There is no React Compiler — don't assume auto-memoization, and don't blanket-memoize either.
+7. **Context splits by volatility:** reactive state and stable actions are separate contexts; action-only widgets read `useCockpitActions()` and never re-render while a turn streams. New cross-cutting state joins this split — no prop-drilling, no third merged context.
+8. **No refs read/written during render** (init excepted) — value-stabilize with `useMemo` over a serialized key instead. [react.dev/reference/react/useRef pitfall]
+9. **No legacy APIs:** no `forwardRef` (ref is a prop in 19), `defaultProps`, class components, or `UNSAFE_` lifecycles.
+10. **Extract pure logic to `.ts` modules with their own tests** (tool-chip-state, inventory-grouping); components stay render + dispatch.
+11. **Tool/LLM output is `unknown` at the boundary** and narrowed explicitly — never `any`, never trusted shapes.
+12. **Widgets are pure renders of engine-persisted values** — they color/format, never recompute analysis; new canvas kinds land via one `register()` in canvas-registry.ts.
+13. **Shared visual vocabulary is shared code** — band/intent badges and the like live in one widget module (evidence-detail is the precedent), not per-widget copies.
+14. **Chat/streaming idiom comes from the `@tanstack/ai` Intent skills** (`ai-core/chat-experience`, `ai-core/tool-calling`) — `useChat` owns optimistic append and approval flows; don't wrap it in `useActionState`/`useOptimistic`.
+15. **Bound every data surface:** virtualize (result-grid) or cap with an overflow tail (inventory, evidence arrays) — never render an unbounded set into the DOM.
+
 ## Driving the UI from a session
 
 Playwright MCP is registered per-project in `~/.claude.json` (stdio, `npx @playwright/mcp@latest`) — browser tools are available automatically when the dev server is up on `:3000`. Bring up the backend deps + `bun --bun run dev`, then point the agent at a page; edits land hot via Vite.


### PR DESCRIPTION
## Why

The cockpit CLAUDE.md has mandated the TanStack Intent skill check since it was added — and it was ignored: lanes and reviewers judged `@tanstack/*` code from training-data memory. Cost so far: a bogus "unpinned dependency" review finding (PR #231), and a live regression only caught once a reviewer actually loaded Intent + read the installed dist (`/api/chat` passing the silently-ignored top-level `maxTokens` → orchestrator capped at 1024 output tokens).

## What

Make the mandate structural — it rides in the agent definitions and skills, so no spawn prompt has to remember it:

- `.claude/agents/{strict,senior-code,spec-compliance}-reviewer.md`: mandatory Intent skill check before judging `@tanstack/*` code; the `latest`/nothing-freezes dep convention (bun.lock owns resolution — never flag unpinned deps, never propose pins).
- `.claude/skills/implement/SKILL.md`: Intent check as a "Before you start" step for TanStack-touching work.
- `.claude/skills/take/SKILL.md`: pre-check note that the mandate applies at every lane stage.
- senior-code-reviewer: retired stale project rules (free-threading/GIL-off, 19-phase scheduler, live MCP server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)