### PR TITLE
fix(engine): value-layer eval findings — profiling, stale slices, loader head-fallback, drift gate (DAT-405)

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,34 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-05: value-layer fixes from DAT-405 calibration (eval findings)
+
+Two fixes on `fix/dat-405-value-layer-eval-findings`, found by the first
+post-DAT-403 calibration runs in dataraum-eval (findings list on DAT-405):
+
+- **Enriched dim-column profiling repaired** — `enriched_views_phase` passed the
+  pre-quoted `view_fqn` as the profiler's `table_duckdb_path`, which the profiler
+  re-quotes as ONE identifier → DuckDB `zero-length delimited identifier` → every
+  enriched join-column profile failed (`dim_columns_profiled … profiles: 0` on
+  every run). Now passes the bare view name (== the persisted `Table.duckdb_path`).
+  Enriched join columns (`account_id__account_type`, …) now HAVE statistics —
+  dimension_coverage / slice detector inputs change accordingly.
+- **`slice_analysis` no longer dies on stale slice definitions** — a slice VIEW
+  whose definition references a column the current slicing view doesn't carry
+  (e.g. an enriched join column on a run whose enriched view is a passthrough)
+  binder-failed at COUNT and killed the whole begin_session run (both
+  detection-typing-v1 runs). `register_slice_tables` now probes the COUNT, warns
+  `slice_view_unbindable`, and skips that slice. The underlying replay hazard —
+  `slicing` skips itself when "all fact tables already have slice definitions",
+  freezing stale definitions across runs — is documented on DAT-405, not yet fixed.
+
+### dataraum-eval
+- Re-run value-layer calibration; detection-typing-v1 completes begin_session
+  end-to-end now (verified 2026-06-05, recall 2/2).
+- Known residue: temporal slice profiling still warns `column_profile_failed`
+  (Binder) for stale-definition columns on period slices — non-fatal, same
+  stale-definitions family.
+
 ## 2026-06-05: DAT-403 value layer revived + wired into begin_session
 
 The 5 dormant value-layer phases (`slicing` → `slicing_view` → `slice_analysis` →

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -30,6 +30,21 @@ post-DAT-403 calibration runs in dataraum-eval (findings list on DAT-405):
   per-column rows were written by the add_source run, so strict this-run reads
   silently broke `temporal_drift` (0 records ever — fail closed) and
   `slice_variance`'s role gate (1.000 on ID columns on clean data — fail open).
+- **temporal_drift gates on `temporal_behavior` (third commit)** — point-in-time
+  measures (period balances: clean trial_balance debit/credit_balance scored
+  0.45–0.54) drift by data-model design; the detector now skips them next to the
+  existing role gate. Additive measures (transaction amounts) keep drift
+  detection. Decision: DAT-405 hybrid (accept slice_variance's clean scores as
+  accurate heterogeneity; gate drift on periodic snapshots).
+- **network.yaml edge calibration (DAT-405, two edges)** —
+  `temporal_drift → query_intent` 0.3→0.45 (at 0.3 even a maximal drift score
+  rolled to ≤ the 0.3 clean-band floor — query_intent could never leave "ready"
+  on drift evidence); `relationship_quality → reporting_intent` 0.5→0.75 (at
+  relationship grain it is the only observed parent, and the sqrt-boosted
+  20%-orphan fixture scores ≈0.45 — 0.5 could never band past "ready").
+  Eval floor expectations now assert relationship problems at RELATIONSHIP grain
+  (per-endpoint), per the DAT-405 decision: the column's own band stays blind to
+  relationship problems by design.
 - **Systemic (not yet fixed): slice definitions are table-scoped + immortal**
   while enriched/slicing views are run-versioned and LLM-shaped. Third
   manifestation observed same day: `drift_analysis_failed` GROUP BY on a stale

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -24,6 +24,20 @@ post-DAT-403 calibration runs in dataraum-eval (findings list on DAT-405):
   `slice_view_unbindable`, and skips that slice. The underlying replay hazard —
   `slicing` skips itself when "all fact tables already have slice definitions",
   freezing stale definitions across runs — is documented on DAT-405, not yet fixed.
+- **Loaders head-fallback (second commit)** — `load_semantic`/`load_statistics`
+  fall back to the promoted `(table:{id}, stage)` snapshot head when the current
+  run has no row. Session detects carried the SESSION run's run_id while the
+  per-column rows were written by the add_source run, so strict this-run reads
+  silently broke `temporal_drift` (0 records ever — fail closed) and
+  `slice_variance`'s role gate (1.000 on ID columns on clean data — fail open).
+- **Systemic (not yet fixed): slice definitions are table-scoped + immortal**
+  while enriched/slicing views are run-versioned and LLM-shaped. Third
+  manifestation observed same day: `drift_analysis_failed` GROUP BY on a stale
+  dim column after a re-run's enriched view picked different dims. Content-keyed
+  sources (DAT-422) widen this to CROSS-strategy leakage in eval (same bytes →
+  same table_id). Proposed: run-version slice definitions (stamp run_id, promote
+  via MetadataSnapshotHead, re-derive instead of skip on column-set change).
+  Full mechanics on DAT-405.
 
 ### dataraum-eval
 - Re-run value-layer calibration; detection-typing-v1 completes begin_session

--- a/packages/dataraum-config/entropy/network.yaml
+++ b/packages/dataraum-config/entropy/network.yaml
@@ -135,7 +135,11 @@ edges:
   - [null_ratio, query_intent, 0.5]
   - [outlier_rate, query_intent, 0.4]
   - [naming_clarity, query_intent, 0.3]
-  - [temporal_drift, query_intent, 0.3]
+  # 0.3 → 0.45 (DAT-405 calibration): at 0.3 even a MAXIMAL drift score rolls to
+  # risk ≤ 0.3 (the clean-band floor) — query_intent could never leave "ready" on
+  # drift evidence alone. 0.45 puts the detection-v1 injected shift (score 0.93)
+  # at "investigate" while clean trial_balance period drift (≈0.53) stays "ready".
+  - [temporal_drift, query_intent, 0.45]
   # A broken time role (unparseable dates) makes time-filtering/ordering
   # unreliable — more severe than drift, hence the higher strength.
   - [time_role, query_intent, 0.5]
@@ -148,7 +152,12 @@ edges:
   - [time_role, aggregation_intent, 0.4]
   # -> reporting_intent (6+1 parents)
   - [naming_clarity, reporting_intent, 0.7]
-  - [relationship_quality, reporting_intent, 0.5]
+  # 0.5 → 0.75 (DAT-405 calibration): at relationship grain the ONLY observed
+  # parent is relationship_quality itself, so the edge alone must carry a real
+  # RI problem past the 0.3 band. The sqrt-boosted 20%-orphan fixture scores
+  # ≈0.45 → 0.75 puts it at "investigate" with margin; clean relationships
+  # score ≈0.1 (below the clean-band floor) and are unaffected.
+  - [relationship_quality, reporting_intent, 0.75]
   - [aggregation_safety, reporting_intent, 0.8]
   - [unit_declaration, reporting_intent, 0.6]
   - [time_role, reporting_intent, 0.4]

--- a/packages/dataraum-config/verticals/finance/ontology.yaml
+++ b/packages/dataraum-config/verticals/finance/ontology.yaml
@@ -212,6 +212,27 @@ concepts:
     typical_role: measure
     unit_from_concept: currency
 
+  # Trial-balance / ledger period balances (DAT-405). Without this concept,
+  # debit_balance/credit_balance keyword-match the `debit`/`credit` FLOW
+  # concepts below and inherit `additive` — but a balance column is a
+  # point-in-time stock per period. That mislabel made temporal_drift's
+  # point-in-time gate inert on trial_balance (period-over-period distribution
+  # shift is the data model there, not drift) and misgrounds query agents
+  # (a periodic TB must not be summed across periods).
+  - name: account_balance
+    description: Account balance as of a period end (trial balance, ledger balance)
+    indicators:
+      - account_balance
+      - debit_balance
+      - credit_balance
+      - opening_balance
+      - closing_balance
+      - ending_balance
+      - beginning_balance
+    temporal_behavior: point_in_time
+    typical_role: measure
+    unit_from_concept: currency
+
   - name: transaction_amount
     description: Monetary value of a transaction
     indicators:

--- a/packages/engine/src/dataraum/analysis/slicing/slice_runner.py
+++ b/packages/engine/src/dataraum/analysis/slicing/slice_runner.py
@@ -111,6 +111,26 @@ def register_slice_tables(
                 if slice_name not in slice_tables_in_duckdb:
                     continue
 
+                # Stale-definition guard (DAT-405): slice VIEWS bind lazily, so a
+                # definition whose column the CURRENT slicing view no longer
+                # carries (e.g. an enriched join column on a run whose enriched
+                # view is a passthrough) surfaces only here, as a Binder Error on
+                # COUNT. Skip that slice with a warning — one stale definition
+                # must not fail the phase and kill the whole begin_session run.
+                try:
+                    count_result = duckdb_conn.execute(
+                        f'SELECT COUNT(*) FROM "{slice_name}"'
+                    ).fetchone()
+                except duckdb.Error as e:
+                    logger.warning(
+                        "slice_view_unbindable",
+                        slice_name=slice_name,
+                        slice_column=effective_column_name,
+                        error=str(e),
+                    )
+                    continue
+                row_count = count_result[0] if count_result else 0
+
                 # Check if already registered (include source_id in query for correct uniqueness).
                 # Earlier iterations flush before they fall through, so this query sees them.
                 existing_stmt = select(Table).where(
@@ -122,10 +142,6 @@ def register_slice_tables(
 
                 if existing_table:
                     # Already registered
-                    count_result = duckdb_conn.execute(
-                        f'SELECT COUNT(*) FROM "{slice_name}"'
-                    ).fetchone()
-                    row_count = count_result[0] if count_result else 0
                     registered.append(
                         SliceTableInfo(
                             slice_table_id=existing_table.table_id,
@@ -138,12 +154,6 @@ def register_slice_tables(
                         )
                     )
                     continue
-
-                # Get row count from DuckDB
-                count_result = duckdb_conn.execute(
-                    f'SELECT COUNT(*) FROM "{slice_name}"'
-                ).fetchone()
-                row_count = count_result[0] if count_result else 0
 
                 # Create Table entry for slice
                 # Generate table_id explicitly since SQLAlchemy defaults only apply at INSERT time

--- a/packages/engine/src/dataraum/entropy/detectors/loaders.py
+++ b/packages/engine/src/dataraum/entropy/detectors/loaders.py
@@ -16,6 +16,26 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 
+def _table_head_run(session: Session, column_id: str, stage: str) -> str | None:
+    """The promoted head ``run_id`` for the column's table at ``stage`` (DAT-405).
+
+    Session-detect reads carry the begin_session run's ``run_id``, but the
+    per-column analysis rows (semantic, statistics, …) were written — and
+    promoted — by the add_source run that produced the typed table. When the
+    current run has no row, the ``(table:{id}, stage)`` head names the run whose
+    rows are current; resolving it keeps the read run-scoped instead of guessing
+    across coexisting runs. Returns ``None`` when nothing was promoted — the
+    caller keeps its no-data behaviour (fail closed, never guess).
+    """
+    from dataraum.storage import Column
+    from dataraum.storage.snapshot_head import head_run_id
+
+    col = session.get(Column, column_id)
+    if col is None:
+        return None
+    return head_run_id(session, f"table:{col.table_id}", stage)
+
+
 def load_typing(
     session: Session, column_id: str, run_id: str | None = None
 ) -> dict[str, Any] | None:
@@ -88,14 +108,28 @@ def load_statistics(
 
     ``run_id`` (DAT-413): when set, restrict to THIS run's profile + quality
     metrics. ``None`` (non-detect / test callers) adds no filter.
+
+    Head fallback (DAT-405): like :func:`load_semantic` — session detects read
+    statistics the add_source run wrote, so a this-run miss falls back to the
+    promoted head (``statistics`` for the profile, ``statistical_quality`` for
+    the quality metrics — distinct stages, distinct heads).
     """
     from dataraum.analysis.statistics.db_models import StatisticalProfile
     from dataraum.analysis.statistics.quality_db_models import StatisticalQualityMetrics
 
     sp_stmt = select(StatisticalProfile).where(StatisticalProfile.column_id == column_id)
     if run_id is not None:
-        sp_stmt = sp_stmt.where(StatisticalProfile.run_id == run_id)
-    sp = session.execute(sp_stmt).scalar_one_or_none()
+        sp = session.execute(
+            sp_stmt.where(StatisticalProfile.run_id == run_id)
+        ).scalar_one_or_none()
+        if sp is None:
+            head = _table_head_run(session, column_id, "statistics")
+            if head is not None and head != run_id:
+                sp = session.execute(
+                    sp_stmt.where(StatisticalProfile.run_id == head)
+                ).scalar_one_or_none()
+    else:
+        sp = session.execute(sp_stmt).scalar_one_or_none()
 
     if not sp:
         return None
@@ -112,8 +146,17 @@ def load_statistics(
         StatisticalQualityMetrics.column_id == column_id
     )
     if run_id is not None:
-        qm_stmt = qm_stmt.where(StatisticalQualityMetrics.run_id == run_id)
-    qm = session.execute(qm_stmt).scalar_one_or_none()
+        qm = session.execute(
+            qm_stmt.where(StatisticalQualityMetrics.run_id == run_id)
+        ).scalar_one_or_none()
+        if qm is None:
+            head = _table_head_run(session, column_id, "statistical_quality")
+            if head is not None and head != run_id:
+                qm = session.execute(
+                    qm_stmt.where(StatisticalQualityMetrics.run_id == head)
+                ).scalar_one_or_none()
+    else:
+        qm = session.execute(qm_stmt).scalar_one_or_none()
     if qm:
         qd = qm.quality_data or {}
         quality_dict: dict[str, Any] = {
@@ -151,13 +194,30 @@ def load_semantic(
 
     ``run_id`` (DAT-413): when set, restrict to THIS run's annotation. ``None``
     (non-detect / test callers) adds no filter.
+
+    Head fallback (DAT-405): a begin_session detect carries the SESSION run's
+    ``run_id``, but annotations are written by the add_source run — a strict
+    this-run read finds nothing and silently disabled every semantic-gated
+    session detector (temporal_drift scored 0 records; slice_variance lost its
+    role gate and over-fired on ID columns). When this run has no annotation,
+    read the run the ``semantic_per_column`` head promotes for the column's
+    table; no head → ``None`` as before.
     """
     from dataraum.analysis.semantic.db_models import SemanticAnnotation
 
     sa_stmt = select(SemanticAnnotation).where(SemanticAnnotation.column_id == column_id)
     if run_id is not None:
-        sa_stmt = sa_stmt.where(SemanticAnnotation.run_id == run_id)
-    sa = session.execute(sa_stmt).scalar_one_or_none()
+        sa = session.execute(
+            sa_stmt.where(SemanticAnnotation.run_id == run_id)
+        ).scalar_one_or_none()
+        if sa is None:
+            head = _table_head_run(session, column_id, "semantic_per_column")
+            if head is not None and head != run_id:
+                sa = session.execute(
+                    sa_stmt.where(SemanticAnnotation.run_id == head)
+                ).scalar_one_or_none()
+    else:
+        sa = session.execute(sa_stmt).scalar_one_or_none()
     if not sa:
         return None
 

--- a/packages/engine/src/dataraum/entropy/detectors/value/temporal_drift.py
+++ b/packages/engine/src/dataraum/entropy/detectors/value/temporal_drift.py
@@ -78,6 +78,18 @@ class TemporalDriftDetector(EntropyDetector):
         if role not in self._APPLICABLE_ROLES:
             return []
 
+        # Skip point-in-time measures (period balances, snapshot levels) — their
+        # per-period distribution shifts BY THE DATA MODEL as the business moves
+        # (DAT-405: clean trial_balance debit/credit_balance scored 0.45–0.54).
+        # Drift detection is meaningful for additive measures (transaction
+        # amounts), where the generating process should be period-stationary.
+        if hasattr(semantic, "temporal_behavior"):
+            behavior = semantic.temporal_behavior
+        else:
+            behavior = semantic.get("temporal_behavior")
+        if behavior == "point_in_time":
+            return []
+
         # Skip high-cardinality columns — near-unique values (references, codes)
         # produce max JS divergence by construction, not from real drift
         stats = context.get_analysis("statistics", {})

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -446,10 +446,16 @@ class EnrichedViewsPhase(BasePhase):
             profiled_at = datetime.now(UTC)
             profiled_count = 0
             for col in registered_columns:
+                # Bare name, NOT view_fqn: the profiler interpolates the path as
+                # ONE quoted identifier, so a pre-quoted catalog.schema."name"
+                # FQN parses as a zero-length identifier and every dim-column
+                # profile fails (eval DAT-405 finding). Bare lake-view names
+                # resolve on ctx.duckdb_conn (same as DESCRIBE in slicing_view),
+                # and match the Table.duckdb_path the row persists.
                 profile = _profile_column_stats_parallel(
                     duckdb_conn=ctx.duckdb_conn,
                     table_name=view_name,
-                    table_duckdb_path=view_fqn,
+                    table_duckdb_path=view_name,
                     column_id=col.column_id,
                     column_name=col.column_name,
                     resolved_type=col.resolved_type or "VARCHAR",

--- a/packages/engine/tests/unit/entropy/test_loaders.py
+++ b/packages/engine/tests/unit/entropy/test_loaders.py
@@ -277,3 +277,100 @@ class TestLoaderRunIdFilter:
 
         # No run_id (non-detect / legacy callers) → unfiltered → still found.
         assert load_typing(real_session, "col-1") is not None
+
+
+class TestLoaderHeadFallback:
+    """DAT-405: session-detect reads fall back to the promoted head run.
+
+    A begin_session detect carries the SESSION run's run_id, but per-column
+    analysis rows (semantic, statistics) were written by the add_source run.
+    A strict this-run read returned None and silently disabled the semantic-
+    gated session detectors. The loaders now resolve the column's
+    ``(table:{id}, stage)`` snapshot head and read that run's row; without a
+    promoted head they keep returning None (never guess a run).
+    """
+
+    def _seed_column(self, session, column_id: str, table_id: str) -> None:
+        from dataraum.storage import Column
+
+        session.add(
+            Column(
+                column_id=column_id,
+                table_id=table_id,
+                column_name="amount",
+                column_position=0,
+                raw_type="VARCHAR",
+            )
+        )
+        session.flush()
+
+    def _seed_annotation(self, session, column_id: str, run_id: str) -> None:
+        from dataraum.analysis.semantic.db_models import SemanticAnnotation
+
+        session.add(
+            SemanticAnnotation(
+                annotation_id=str(uuid4()),
+                session_id="sess-1",
+                column_id=column_id,
+                run_id=run_id,
+                semantic_role="measure",
+            )
+        )
+        session.flush()
+
+    def _promote(self, session, table_id: str, stage: str, run_id: str) -> None:
+        from datetime import UTC, datetime
+
+        from dataraum.storage.snapshot_head import MetadataSnapshotHead
+
+        session.add(
+            MetadataSnapshotHead(
+                target=f"table:{table_id}",
+                stage=stage,
+                run_id=run_id,
+                promoted_at=datetime.now(UTC),
+                version=0,
+            )
+        )
+        session.flush()
+
+    def test_semantic_falls_back_to_promoted_head(self, real_session):
+        self._seed_column(real_session, "col-h1", "tbl-h1")
+        self._seed_annotation(real_session, "col-h1", "run-addsource")
+        self._promote(real_session, "tbl-h1", "semantic_per_column", "run-addsource")
+
+        # Session run has no annotation; the head names the add_source run.
+        sem = load_semantic(real_session, "col-h1", run_id="run-session")
+        assert sem is not None
+        assert sem["semantic_role"] == "measure"
+
+    def test_semantic_without_head_stays_none(self, real_session):
+        self._seed_column(real_session, "col-h2", "tbl-h2")
+        self._seed_annotation(real_session, "col-h2", "run-addsource")
+
+        # No promoted head → no fallback → None (never guess a run).
+        assert load_semantic(real_session, "col-h2", run_id="run-session") is None
+
+    def test_statistics_falls_back_to_promoted_head(self, real_session):
+        from dataraum.analysis.statistics.db_models import StatisticalProfile
+
+        self._seed_column(real_session, "col-h3", "tbl-h3")
+        real_session.add(
+            StatisticalProfile(
+                profile_id=str(uuid4()),
+                session_id="sess-1",
+                column_id="col-h3",
+                run_id="run-addsource",
+                total_count=100,
+                null_count=0,
+                distinct_count=90,
+                cardinality_ratio=0.9,
+                profile_data={},
+            )
+        )
+        real_session.flush()
+        self._promote(real_session, "tbl-h3", "statistics", "run-addsource")
+
+        stats = load_statistics(real_session, "col-h3", run_id="run-session")
+        assert stats is not None
+        assert stats["cardinality_ratio"] == 0.9

--- a/packages/engine/tests/unit/entropy/test_value_detectors.py
+++ b/packages/engine/tests/unit/entropy/test_value_detectors.py
@@ -574,6 +574,42 @@ class TestTemporalDriftDetector:
         results = detector.detect(context)
         assert len(results) == 0
 
+    def test_skip_point_in_time_measure(self, detector: TemporalDriftDetector):
+        """Periodic snapshot measures (period balances) drift by data-model
+        design — skipped (DAT-405; clean trial_balance balances scored 0.45+)."""
+        summary = _MockDriftSummary("debit_balance", 0.6, 0.5, 12, 8)
+        context = DetectorContext(
+            table_name="trial_balance",
+            column_name="debit_balance",
+            analysis_results={
+                "drift_summaries": [summary],
+                "semantic": {
+                    "semantic_role": "measure",
+                    "temporal_behavior": "point_in_time",
+                },
+            },
+        )
+        results = detector.detect(context)
+        assert len(results) == 0
+
+    def test_additive_measure_keeps_drift_detection(self, detector: TemporalDriftDetector):
+        """Additive measures (transaction amounts) are still scored."""
+        summary = _MockDriftSummary("amount", 0.5, 0.3, 5, 2)
+        context = DetectorContext(
+            table_name="orders",
+            column_name="amount",
+            analysis_results={
+                "drift_summaries": [summary],
+                "semantic": {
+                    "semantic_role": "measure",
+                    "temporal_behavior": "additive",
+                },
+            },
+        )
+        results = detector.detect(context)
+        assert len(results) == 1
+        assert results[0].score == pytest.approx(0.7, abs=0.01)
+
     def test_skip_foreign_key_column(self, detector: TemporalDriftDetector):
         """Drift detection is skipped for foreign key columns."""
         summary = _MockDriftSummary("vendor_id", 0.693, 0.5, 5, 5)


### PR DESCRIPTION
## What

Five commits closing the hard findings from the first post-DAT-403 value-layer calibration in dataraum-eval (full report: `dataraum-eval/calibration/reports/dat-405-findings-2026-06-05.md`; follow-up epic: DAT-442).

1. **Enriched dim-column profiling repaired** — `enriched_views_phase` passed the pre-quoted FQN as the profiler's `table_duckdb_path`; the profiler re-quotes it as ONE identifier → DuckDB `zero-length delimited identifier` → **every** enriched join-column profile failed on every run (`dim_columns_profiled … profiles: 0`). Now passes the bare view name (== persisted `Table.duckdb_path`).
2. **`slice_analysis` no longer kills the run on stale slice definitions** — a slice view whose definition references a column the current slicing view doesn't carry binder-failed at `COUNT(*)` and hard-failed begin_session (both detection-typing-v1 runs). Now probes the COUNT, warns `slice_view_unbindable`, skips that slice. The underlying table-scoped-immortal-definitions hazard is ticketed (DAT-448).
3. **Session-detect loaders fall back to the promoted head run** — session detects carry the SESSION run's `run_id`, but semantic/statistics rows are written by the ADD_SOURCE run; strict this-run reads silently broke the value layer both ways: `temporal_drift` 0 records ever (fail closed), `slice_variance` role-gate disabled → 1.000 on ID columns on clean data (fail open). Loaders now resolve the column's `(table:{id}, stage)` `MetadataSnapshotHead`; no head → None (never guess a run).
4. **`temporal_drift` gates on `temporal_behavior='point_in_time'`** + two network edge calibrations (`temporal_drift→query_intent` 0.3→0.45, `relationship_quality→reporting_intent` 0.5→0.75 — at the old strengths even maximal scores could never band past "ready").
5. **`account_balance` ontology concept** — TB `debit_balance`/`credit_balance` keyword-matched the debit/credit FLOW concepts (additive). Known caveat, verified live: concept matching is LLM-judgment, an exact indicator match carries no deterministic priority — making indicators authoritative is DAT-445.

## Verification

- detection-typing-v1 completes begin_session end-to-end (hard-failed before); recall 2/2.
- detection-v1 clean-room: `temporal_drift` first-ever records, recall **0.933–1.000** on the injected 1.35× shift; `slice_variance` role-gated (41→11 records, ID columns gone); zero profiling/drift/unbindable warnings.
- Full eval sweep green: detection-v1 18 passed / 5 skipped / 5 xfailed / 1 xpassed (slack inventory → epic DAT-442); typing 5 passed.
- Engine: 1277 testmon-affected unit tests + slice/enriched integration tests green; ruff + mypy clean.

## Cross-repo

dataraum-eval `fdc060c` pins its submodule to this branch and asserts the value layer (`temporal_drift`, `dimensional_entropy`, `derived_value`, `slice_variance` in `CURRENT_SLICE_DETECTORS`); re-pin to main after merge. `.claude/handoff.md` updated with all of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)