### PR TITLE
DAT-449: AI-surface Intent fixes — explicit agent-loop budget, abort propagation, type-source cleanup

### DIFF
--- a/packages/cockpit/src/lib/abort.test.ts
+++ b/packages/cockpit/src/lib/abort.test.ts
@@ -1,0 +1,48 @@
+// Unit tests for the abort bridge (DAT-449) — the seam that makes a user
+// stop() reach the nested synthesis chat() calls (frame induction, why_*
+// narratives) instead of letting them run — and bill — to completion.
+
+import { describe, expect, it } from "vitest";
+
+import { linkedAbortController } from "#/lib/abort";
+
+describe("linkedAbortController (DAT-449)", () => {
+	it("returns undefined for no signal — absent context changes nothing", () => {
+		expect(linkedAbortController(undefined)).toBeUndefined();
+	});
+
+	it("returns a live controller for a live signal", () => {
+		const source = new AbortController();
+		const linked = linkedAbortController(source.signal);
+		expect(linked).toBeDefined();
+		expect(linked?.signal.aborted).toBe(false);
+	});
+
+	it("aborting the source aborts the linked controller, reason propagated", () => {
+		const source = new AbortController();
+		const linked = linkedAbortController(source.signal);
+		const reason = new Error("user stopped the run");
+		source.abort(reason);
+		expect(linked?.signal.aborted).toBe(true);
+		expect(linked?.signal.reason).toBe(reason);
+	});
+
+	it("a signal that ALREADY aborted yields an already-aborted controller", () => {
+		// The tool can be invoked after the run was stopped (the loop drains
+		// in-flight work) — the nested call must see the abort immediately, not
+		// only on a future event.
+		const source = new AbortController();
+		const reason = new Error("aborted before the tool ran");
+		source.abort(reason);
+		const linked = linkedAbortController(source.signal);
+		expect(linked?.signal.aborted).toBe(true);
+		expect(linked?.signal.reason).toBe(reason);
+	});
+
+	it("the link is one-way: aborting the linked controller leaves the source alone", () => {
+		const source = new AbortController();
+		const linked = linkedAbortController(source.signal);
+		linked?.abort();
+		expect(source.signal.aborted).toBe(false);
+	});
+});

--- a/packages/cockpit/src/lib/abort.ts
+++ b/packages/cockpit/src/lib/abort.ts
@@ -1,0 +1,31 @@
+// Abort bridging for nested LLM calls (DAT-449).
+//
+// chat()'s agentic loop hands every server tool a `ToolExecutionContext` whose
+// `abortSignal` fires when the run aborts (user stop(), client disconnect).
+// A tool that makes its OWN nested chat() synthesis call must forward that
+// signal, or the nested call — and its Anthropic bill — runs to completion
+// after the user already stopped the turn. chat() takes an `AbortController`
+// (it only ever reads `.signal`), so the bridge wraps the inbound signal in a
+// fresh, linked controller.
+
+/**
+ * Wrap an inbound AbortSignal in a linked AbortController: aborting the signal
+ * aborts the controller (reason propagated), including a signal that already
+ * aborted before the call. `undefined` in → `undefined` out, so call sites stay
+ * a one-liner (`abortController: linkedAbortController(signal)`) and an
+ * absent signal changes nothing.
+ */
+export function linkedAbortController(
+	signal?: AbortSignal,
+): AbortController | undefined {
+	if (!signal) return undefined;
+	const controller = new AbortController();
+	if (signal.aborted) {
+		controller.abort(signal.reason);
+	} else {
+		signal.addEventListener("abort", () => controller.abort(signal.reason), {
+			once: true,
+		});
+	}
+	return controller;
+}

--- a/packages/cockpit/src/lib/agent-refs.ts
+++ b/packages/cockpit/src/lib/agent-refs.ts
@@ -13,6 +13,19 @@
 // transcript export, copy-to-clipboard, debug panel) MUST apply the same skip,
 // or the internals leak.
 
+// Both halves of `RefsTurn` are PUBLIC SDK exports (DAT-449): the message
+// shape from @tanstack/ai-client, the content-part shape from the
+// @tanstack/ai/client subpath — no hand-mirrored field shapes to drift.
+import type { TextPart } from "@tanstack/ai/client";
+import type { MultimodalContent } from "@tanstack/ai-client";
+
+/** A refs turn IS the SDK's `MultimodalContent` (what `sendMessage` accepts),
+ * narrowed to the text-part array this module actually emits — consumers keep
+ * `turn.content[i].content` precision without re-narrowing the SDK union. */
+export type RefsTurn = Omit<MultimodalContent, "content"> & {
+	content: Array<TextPart>;
+};
+
 /** Sentinel prefix marking a model-only refs part. Renderers skip any user text
  * part that starts with it; nothing a human types begins this way.
  * Replaced DAT-423's `[[dataraum:uploaded-objects]]` outright — chat is
@@ -31,14 +44,6 @@ export function isAgentRefsPart(content: string): boolean {
  * tool calls, never echo them). */
 export function agentRefsBlock(body: string): string {
 	return `${AGENT_REFS_MARKER} ${body}`;
-}
-
-/** A two-part turn: the clean bubble + the marked refs part. Structurally the
- * multimodal content shape the SDK's `sendMessage` accepts (mirrored as
- * `TurnContent` in cockpit-state — kept structural here so lib/ doesn't import
- * from ui/). */
-export interface RefsTurn {
-	content: Array<{ type: "text"; content: string }>;
 }
 
 /** Compose a turn whose bubble is clean and whose internals ride in a marked,

--- a/packages/cockpit/src/llm.ts
+++ b/packages/cockpit/src/llm.ts
@@ -18,3 +18,13 @@
 export const MODEL = "claude-sonnet-4-6";
 
 export const MAX_OUTPUT_TOKENS = 24576;
+
+// The agent-loop iteration ceiling for /api/chat. chat() defaults to
+// maxIterations(5) when no agentLoopStrategy is given — a SILENT governor from
+// the same defect class as the 1024-token default above: a 17-tool orchestrator
+// turn (poll → poll → look → why → narrate) just STOPS mid-task at iteration 5,
+// no error, no signal (DAT-449). 20 follows the @tanstack/ai tool-calling
+// skill's multi-tool example; it is a runaway-loop ceiling, not an expected
+// budget — normal turns finish well under it, and a turn that genuinely needs
+// more is a prompt/tool-design problem, not a reason to raise this.
+export const AGENT_LOOP_MAX_ITERATIONS = 20;

--- a/packages/cockpit/src/routes/api/chat.test.ts
+++ b/packages/cockpit/src/routes/api/chat.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("#/config", () => ({ config: { anthropicApiKey: "sk-ant-test" } }));
 vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 
-import { MAX_OUTPUT_TOKENS } from "../../llm";
+import { AGENT_LOOP_MAX_ITERATIONS, MAX_OUTPUT_TOKENS } from "../../llm";
 import { buildChatOptions } from "./chat";
 
 /** Narrow the SDK's `SystemPrompt` union (string | {content, metadata?}) to the
@@ -71,6 +71,23 @@ describe("chat route wiring (DAT-353)", () => {
 		const opts = buildChatOptions([{ role: "user", content: "hi" }]);
 		expect(opts.modelOptions).toEqual({ max_tokens: MAX_OUTPUT_TOKENS });
 		expect(opts).not.toHaveProperty("maxTokens");
+	});
+
+	it("sets an explicit agent-loop budget — no silent maxIterations(5) default", () => {
+		// THE DAT-449 pin, sibling of the max_tokens pin above: chat() defaults
+		// agentLoopStrategy to maxIterations(5) when omitted, silently stopping a
+		// multi-tool turn at iteration 5 with no error. The strategy is a pure
+		// predicate over the loop state, so pin the exact budget behaviorally.
+		const strategy = buildChatOptions([
+			{ role: "user", content: "hi" },
+		]).agentLoopStrategy;
+		expect(strategy).toBeDefined();
+		const continues = (iterationCount: number) =>
+			strategy?.({ iterationCount, messages: [], finishReason: null });
+		expect(continues(AGENT_LOOP_MAX_ITERATIONS - 1)).toBe(true);
+		expect(continues(AGENT_LOOP_MAX_ITERATIONS)).toBe(false);
+		// And the budget itself is deliberately ABOVE the SDK default.
+		expect(AGENT_LOOP_MAX_ITERATIONS).toBeGreaterThan(5);
 	});
 
 	it("attaches the full tool registry to the loop", () => {

--- a/packages/cockpit/src/routes/api/chat.ts
+++ b/packages/cockpit/src/routes/api/chat.ts
@@ -10,13 +10,14 @@
 import {
 	chat,
 	chatParamsFromRequest,
+	maxIterations,
 	toServerSentEventsResponse,
 } from "@tanstack/ai";
 import { createAnthropicChat } from "@tanstack/ai-anthropic";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { config } from "../../config";
-import { MAX_OUTPUT_TOKENS, MODEL } from "../../llm";
+import { AGENT_LOOP_MAX_ITERATIONS, MAX_OUTPUT_TOKENS, MODEL } from "../../llm";
 import { getOrchestratorInstructions } from "../../prompts";
 import { buildWorkspaceContext } from "../../prompts/workspace-context";
 import { tools } from "../../tools/registry";
@@ -113,6 +114,9 @@ export function buildChatOptions(
 		// A truncated stream severs the client's background result drain, which
 		// is what parked tool chips on an eternal spinner (DAT-436).
 		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
+		// Explicit loop budget — the SDK's silent default is maxIterations(5),
+		// which stops a multi-tool turn mid-task with no error (see src/llm.ts).
+		agentLoopStrategy: maxIterations(AGENT_LOOP_MAX_ITERATIONS),
 		systemPrompts,
 		messages,
 		tools: [...tools],

--- a/packages/cockpit/src/tools/frame.test.ts
+++ b/packages/cockpit/src/tools/frame.test.ts
@@ -168,4 +168,32 @@ describe("frame (DAT-382)", () => {
 		expect(concepts).toEqual([{ name: "customer_id", typical_role: "key" }]);
 		expect(insertedRows).toHaveLength(0);
 	});
+
+	it("forwards the tool-context abort into the nested induction chat() (DAT-449)", async () => {
+		// The pattern shared by all four nested-synthesis sites (frame induction +
+		// the three why_* narratives): the .server() context's abortSignal is
+		// bridged into the abortController chat() expects, so a user stop()
+		// cancels the in-flight nested Anthropic call instead of billing it out.
+		chatMock.mockResolvedValue({ concepts: [] });
+		const source = new AbortController();
+		await induceConcepts(SCHEMA, source.signal);
+
+		const options = chatMock.mock.calls[0]?.[0] as {
+			abortController?: AbortController;
+		};
+		expect(options.abortController).toBeDefined();
+		expect(options.abortController?.signal.aborted).toBe(false);
+		// Stopping the run (the tool context's signal) aborts the nested call.
+		source.abort();
+		expect(options.abortController?.signal.aborted).toBe(true);
+	});
+
+	it("passes NO abortController when the tool context carries no signal", async () => {
+		chatMock.mockResolvedValue({ concepts: [] });
+		await induceConcepts(SCHEMA);
+		const options = chatMock.mock.calls[0]?.[0] as {
+			abortController?: AbortController;
+		};
+		expect(options.abortController).toBeUndefined();
+	});
 });

--- a/packages/cockpit/src/tools/frame.ts
+++ b/packages/cockpit/src/tools/frame.ts
@@ -26,6 +26,7 @@ import { z } from "zod";
 
 import { config } from "../config";
 import { ConnectSchema } from "../duckdb/connect";
+import { linkedAbortController } from "../lib/abort";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { getFrameInstructions } from "../prompts";
 import { teach } from "./teach";
@@ -131,13 +132,16 @@ export interface FrameInput {
  * Induce a business vocabulary from a `ConnectSchema` via one forced
  * structured-output Anthropic call. Returns the proposed concepts; does NOT
  * write anything. Split out so the induction step is testable apart from the
- * DB write.
+ * DB write. `signal` is the tool-context abort (DAT-449): a stopped run aborts
+ * this nested call instead of billing it to completion.
  */
 export async function induceConcepts(
 	schema: ConnectSchema,
+	signal?: AbortSignal,
 ): Promise<ProposedConcept[]> {
 	const result = await chat({
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
+		abortController: linkedAbortController(signal),
 		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
 		systemPrompts: [getFrameInstructions()],
 		messages: [
@@ -160,13 +164,16 @@ export async function induceConcepts(
  * the shared teach seam. Returns the written concepts + their overlay ids for
  * the ConceptFrame widget.
  */
-export async function frame(input: FrameInput): Promise<FrameResult> {
+export async function frame(
+	input: FrameInput,
+	signal?: AbortSignal,
+): Promise<FrameResult> {
 	const schema = ConnectSchema.parse(input.schema);
 	const vertical = resolveVertical(input.vertical_name);
 	const concepts =
 		input.concepts && input.concepts.length > 0
 			? input.concepts.map((c) => ProposedConcept.parse(c))
-			: await induceConcepts(schema);
+			: await induceConcepts(schema, signal);
 
 	if (concepts.length === 0) {
 		throw new Error(
@@ -239,4 +246,4 @@ export const frameTool = toolDefinition({
 	}),
 	outputSchema: FrameResult,
 	needsApproval: true,
-}).server((input) => frame(input));
+}).server((input, ctx) => frame(input, ctx?.abortSignal));

--- a/packages/cockpit/src/tools/run_sql.ts
+++ b/packages/cockpit/src/tools/run_sql.ts
@@ -69,4 +69,10 @@ export const runSqlTool = toolDefinition({
 			.describe("Max rows to return (default 1000, capped at 200000)."),
 	}),
 	outputSchema: QueryResultSchema,
+	// ctx.abortSignal deliberately NOT forwarded (DAT-449): duckdb-neo has no
+	// per-query cancellation — its only primitive is connection-level
+	// `interrupt()`, and the lake connection is process-wide memoized
+	// (duckdb/lake.ts), so interrupting would kill CONCURRENT queries (the
+	// grid's /api/run-sql, other tool calls), not just this one. Revisit only
+	// with a per-query connection or a driver-level signal API.
 }).server((input) => runSql(input));

--- a/packages/cockpit/src/tools/select.ts
+++ b/packages/cockpit/src/tools/select.ts
@@ -542,4 +542,9 @@ export const selectTool = toolDefinition({
 	// The lambda is load-bearing: .server() calls its handler as (input, context)
 	// — passing `select` bare would shove the SDK's context object into select's
 	// injectable `enumerate` test-seam parameter, clobbering its default.
+	// ctx.abortSignal deliberately NOT forwarded (DAT-449): the trigger's
+	// `workflow.start` is a short, non-blocking gRPC call — an abort mid-start
+	// can't un-start the Temporal workflow and would only orphan the seeded
+	// investigation_sessions row (the exact failure seam trigger-add-source.ts
+	// guards against).
 }).server((input) => select(input));

--- a/packages/cockpit/src/tools/why-column.ts
+++ b/packages/cockpit/src/tools/why-column.ts
@@ -31,6 +31,7 @@ import {
 	metadataSnapshotHead,
 	tables,
 } from "../db/metadata/schema";
+import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { getWhyInstructions } from "../prompts";
@@ -159,10 +160,16 @@ export function projectWhyData(
  * Synthesize the grounded narrative from the structured data via one forced
  * Anthropic call. Split out so the assembly is testable apart from the LLM. The
  * model sees only the band + drivers + evidence we pass — never the whole DB.
+ * `signal` is the tool-context abort (DAT-449): a stopped run aborts this
+ * nested call instead of billing it to completion.
  */
-export async function synthesizeAnalysis(data: WhyColumnData): Promise<string> {
+export async function synthesizeAnalysis(
+	data: WhyColumnData,
+	signal?: AbortSignal,
+): Promise<string> {
 	const result = await chat({
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
+		abortController: linkedAbortController(signal),
 		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
 		systemPrompts: [getWhyInstructions()],
 		messages: [
@@ -198,6 +205,7 @@ export interface WhyColumnInput {
 /** Explain one column's readiness: pre-computed drivers + evidence + narrative. */
 export async function whyColumn(
 	input: WhyColumnInput,
+	signal?: AbortSignal,
 ): Promise<WhyColumnResult> {
 	// Resolve the column + its table first — even an unanalyzed column has a name.
 	const [col] = await metadataDb
@@ -301,7 +309,7 @@ export async function whyColumn(
 
 	// Nothing to explain when the column has no readiness row — skip the LLM call
 	// (no cost, no risk of fabricating an explanation for absent data).
-	const analysis = data.analyzed ? await synthesizeAnalysis(data) : "";
+	const analysis = data.analyzed ? await synthesizeAnalysis(data, signal) : "";
 
 	return { ...data, analysis };
 }
@@ -322,4 +330,4 @@ export const whyColumnTool = toolDefinition({
 			.describe("The column to explain (a column_id from look_table)."),
 	}),
 	outputSchema: WhyColumnResult,
-}).server((input) => whyColumn(input));
+}).server((input, ctx) => whyColumn(input, ctx?.abortSignal));

--- a/packages/cockpit/src/tools/why-relationship.ts
+++ b/packages/cockpit/src/tools/why-relationship.ts
@@ -35,6 +35,7 @@ import {
 	metadataSnapshotHead,
 	tables,
 } from "../db/metadata/schema";
+import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { getWhyInstructions } from "../prompts";
@@ -176,14 +177,17 @@ export function projectWhyRelationship(
 
 /** Synthesize the grounded narrative via one forced Anthropic call (split out so
  * the assembly is testable apart from the LLM). The model sees only the band +
- * drivers + evidence we pass. */
+ * drivers + evidence we pass. `signal` is the tool-context abort (DAT-449): a
+ * stopped run aborts this nested call instead of billing it to completion. */
 export async function synthesizeAnalysis(
 	data: WhyRelationshipData,
+	signal?: AbortSignal,
 ): Promise<string> {
 	const fromLabel = `${data.from_table_name ?? "?"}.${data.from_column_name ?? data.from_column_id}`;
 	const toLabel = `${data.to_table_name ?? "?"}.${data.to_column_name ?? data.to_column_id}`;
 	const result = await chat({
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
+		abortController: linkedAbortController(signal),
 		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
 		systemPrompts: [getWhyInstructions()],
 		messages: [
@@ -221,6 +225,7 @@ export interface WhyRelationshipInput {
 /** Explain one relationship's readiness: pre-computed drivers + evidence + narrative. */
 export async function whyRelationship(
 	input: WhyRelationshipInput,
+	signal?: AbortSignal,
 ): Promise<WhyRelationshipResult> {
 	const target = relationshipTargetKey(
 		input.from_column_id,
@@ -301,7 +306,7 @@ export async function whyRelationship(
 	);
 
 	// Nothing to explain when there's no readiness row — skip the LLM call.
-	const analysis = data.analyzed ? await synthesizeAnalysis(data) : "";
+	const analysis = data.analyzed ? await synthesizeAnalysis(data, signal) : "";
 
 	return { ...data, analysis };
 }
@@ -364,4 +369,4 @@ export const whyRelationshipTool = toolDefinition({
 			),
 	}),
 	outputSchema: WhyRelationshipResult,
-}).server((input) => whyRelationship(input));
+}).server((input, ctx) => whyRelationship(input, ctx?.abortSignal));

--- a/packages/cockpit/src/tools/why-table.ts
+++ b/packages/cockpit/src/tools/why-table.ts
@@ -35,6 +35,7 @@ import {
 	metadataSnapshotHead,
 	tables,
 } from "../db/metadata/schema";
+import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { getWhyInstructions } from "../prompts";
@@ -152,11 +153,17 @@ export function projectWhyTable(
 
 /** Synthesize the grounded narrative via one forced Anthropic call (split out so
  * the assembly is testable apart from the LLM). The model sees only the band +
- * drivers + evidence we pass — and the same why instructions as why_column. */
-export async function synthesizeAnalysis(data: WhyTableData): Promise<string> {
+ * drivers + evidence we pass — and the same why instructions as why_column.
+ * `signal` is the tool-context abort (DAT-449): a stopped run aborts this
+ * nested call instead of billing it to completion. */
+export async function synthesizeAnalysis(
+	data: WhyTableData,
+	signal?: AbortSignal,
+): Promise<string> {
 	const label = data.table_name ?? data.table_id;
 	const result = await chat({
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
+		abortController: linkedAbortController(signal),
 		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
 		systemPrompts: [getWhyInstructions()],
 		messages: [
@@ -191,7 +198,10 @@ export interface WhyTableInput {
 }
 
 /** Explain one table's table-grain readiness: pre-computed drivers + evidence + narrative. */
-export async function whyTable(input: WhyTableInput): Promise<WhyTableResult> {
+export async function whyTable(
+	input: WhyTableInput,
+	signal?: AbortSignal,
+): Promise<WhyTableResult> {
 	// Resolve the table name up front — it's the target key AND the display label,
 	// and even an unanalyzed table has a name. Null only when the id is stale.
 	const [table] = await metadataDb
@@ -278,7 +288,7 @@ export async function whyTable(input: WhyTableInput): Promise<WhyTableResult> {
 	);
 
 	// Nothing to explain when there's no readiness row — skip the LLM call.
-	const analysis = data.analyzed ? await synthesizeAnalysis(data) : "";
+	const analysis = data.analyzed ? await synthesizeAnalysis(data, signal) : "";
 
 	return { ...data, analysis };
 }
@@ -307,4 +317,4 @@ export const whyTableTool = toolDefinition({
 			),
 	}),
 	outputSchema: WhyTableResult,
-}).server((input) => whyTable(input));
+}).server((input, ctx) => whyTable(input, ctx?.abortSignal));

--- a/packages/cockpit/src/ui/cockpit/cockpit-state.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-state.tsx
@@ -48,8 +48,8 @@ export interface SendOptions {
 
 /** The content a turn carries: a plain string, or multimodal content parts — the
  * upload handoff (DAT-423) sends a clean text part + a model-only refs part.
- * EXACTLY `sendMessage`'s param type (the SDK exports `MultimodalContent` —
- * re-exported by @tanstack/ai-react — so no hand-mirrored shape, DAT-449). */
+ * EXACTLY `sendMessage`'s param type, built on the public `MultimodalContent`
+ * export (see the import note above) — no hand-mirrored shape (DAT-449). */
 export type TurnContent = string | MultimodalContent;
 
 // The context is SPLIT in two so that consumers reading only stable callbacks

--- a/packages/cockpit/src/ui/cockpit/cockpit-state.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-state.tsx
@@ -17,6 +17,9 @@
 // Chat lives HERE (not trapped in a leaf) so any canvas widget can drive a turn
 // through the real `sendMessage` — no registration bridge.
 
+// MultimodalContent comes from @tanstack/ai-client (the package that defines
+// it) — @tanstack/ai-react's root index does not re-export it.
+import type { MultimodalContent } from "@tanstack/ai-client";
 import {
 	fetchServerSentEvents,
 	type UIMessage,
@@ -45,10 +48,9 @@ export interface SendOptions {
 
 /** The content a turn carries: a plain string, or multimodal content parts — the
  * upload handoff (DAT-423) sends a clean text part + a model-only refs part.
- * Mirrors the shape the SDK's `sendMessage` accepts; we only use text parts. */
-export type TurnContent =
-	| string
-	| { content: Array<{ type: "text"; content: string }> };
+ * EXACTLY `sendMessage`'s param type (the SDK exports `MultimodalContent` —
+ * re-exported by @tanstack/ai-react — so no hand-mirrored shape, DAT-449). */
+export type TurnContent = string | MultimodalContent;
 
 // The context is SPLIT in two so that consumers reading only stable callbacks
 // don't re-render on every streaming token. React context subscription ignores
@@ -130,11 +132,9 @@ export function CockpitProvider({ children }: { children: ReactNode }) {
 	const sendTurn = useCallback(
 		(content: TurnContent, opts?: SendOptions) => {
 			setPendingLabel(opts?.label);
-			// This call is the compile-time guard that `TurnContent` stays assignable
-			// to the SDK's `sendMessage` param: if a future SDK bump narrows it, this
-			// line stops type-checking. (We can't assert against the SDK's
-			// `MultimodalContent` directly — @tanstack/ai-react doesn't export it,
-			// which is why `TurnContent` mirrors the shape locally.)
+			// `TurnContent` IS the SDK's `string | MultimodalContent` (type-only
+			// import), so this call is assignable by construction — an SDK bump
+			// that reshapes the param surfaces at the import, not here.
 			void sendMessage(content);
 		},
 		[sendMessage],

--- a/packages/cockpit/src/ui/cockpit/tool-chip-state.contract.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-state.contract.test.ts
@@ -1,11 +1,14 @@
 // SDK contract test for the tool-chip terminal-state mapping (DAT-436).
 //
-// tool-chip-state.ts encodes UNDOCUMENTED @tanstack/ai internals: the SDK has
-// no error-terminal ToolCallState, so an errored server-tool execution parks at
+// tool-chip-state.ts encodes the SDK's errored-tool-call behavior: there is no
+// error-terminal ToolCallState, so an errored server-tool execution parks at
 // `state: "input-complete"` with the error riding in `output` + a sibling
-// `tool-result` part `state: "error"`. That shape is an implementation detail
-// of the SDK's stream pipeline — nothing type-checks it, so an SDK bump can
-// silently change it and resurrect the eternal chip spinner.
+// `tool-result` part `state: "error"`. The tool-CALL half (error-in-output at
+// "input-complete") is an UNDOCUMENTED implementation detail of the SDK's
+// stream pipeline — nothing type-checks it, so an SDK bump can silently change
+// it and resurrect the eternal chip spinner. The tool-RESULT half is the
+// public `ToolResultPart` export of @tanstack/ai-client (typed), but WHEN the
+// SDK emits it with `state: "error"` is still behavior only this test pins.
 //
 // This test is the contract-catcher: it drives the REAL installed SDK end to
 // end (bun.lock owns the version; deps stay "latest" by project convention) —

--- a/packages/cockpit/src/ui/cockpit/tool-chip-state.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-state.ts
@@ -1,12 +1,18 @@
 // Tool-call chip state (DAT-436) — the terminal-state mapping the chat rail's
 // chips render from. Pure, no React.
 //
-// SDK CONTRACT: the shapes below are UNDOCUMENTED internals of @tanstack/ai.
+// SDK CONTRACT (two halves, DAT-449):
+//   - The tool-CALL part behavior — an errored execution parking at
+//     "input-complete" with the error riding in `output` — is an UNDOCUMENTED
+//     internal of @tanstack/ai (no error-terminal ToolCallState exists).
+//   - The tool-RESULT part shape (`state: "error"` + `error?: string`) is the
+//     PUBLIC `ToolResultPart` export of @tanstack/ai-client —
+//     `toolResultErrorsById` consumes a documented contract, not an internal.
 // Deps stay "latest" by project convention — bun.lock owns the installed
-// version, which only moves on an explicit `bun update`. The shapes are pinned
-// empirically by tool-chip-state.contract.test.ts, which drives the real
-// chat() → SSE → ChatClient pipeline on every suite run — an update that
-// changes the contract fails the suite loudly; re-verify this mapping then.
+// version, which only moves on an explicit `bun update`. BOTH halves are
+// pinned empirically by tool-chip-state.contract.test.ts, which drives the
+// real chat() → SSE → ChatClient pipeline on every suite run — an update that
+// changes either fails the suite loudly; re-verify this mapping then.
 //
 // WHY THIS EXISTS — the SDK's tool-call part state machine has NO error-terminal
 // state (verified against the installed @tanstack/ai — bun.lock owns the
@@ -186,7 +192,8 @@ export interface MessageLike {
  * Collect every errored `tool-result` part's error text by toolCallId. The SDK
  * emits these alongside the (state-less) error on the tool-call part itself;
  * the rail prefers this text when present (it survives even when the call
- * part's output was clobbered).
+ * part's output was clobbered). The part shape read here is the PUBLIC
+ * `ToolResultPart` export of @tanstack/ai-client (a documented contract).
  */
 export function toolResultErrorsById(
 	messages: ReadonlyArray<MessageLike>,

--- a/packages/cockpit/src/ui/cockpit/tool-chip-state.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-state.ts
@@ -5,9 +5,11 @@
 //   - The tool-CALL part behavior — an errored execution parking at
 //     "input-complete" with the error riding in `output` — is an UNDOCUMENTED
 //     internal of @tanstack/ai (no error-terminal ToolCallState exists).
-//   - The tool-RESULT part shape (`state: "error"` + `error?: string`) is the
-//     PUBLIC `ToolResultPart` export of @tanstack/ai-client —
-//     `toolResultErrorsById` consumes a documented contract, not an internal.
+//   - The tool-RESULT part shape (`state: "error"` + `error?: string`) MATCHES
+//     the PUBLIC `ToolResultPart` export of @tanstack/ai-client — a documented
+//     contract, not an internal. (`MessageLike` below still reads it through a
+//     loose structural type: the rail iterates heterogeneous parts, so only
+//     the contract test — not tsc — ties the field names to the export.)
 // Deps stay "latest" by project convention — bun.lock owns the installed
 // version, which only moves on an explicit `bun update`. BOTH halves are
 // pinned empirically by tool-chip-state.contract.test.ts, which drives the
@@ -192,8 +194,9 @@ export interface MessageLike {
  * Collect every errored `tool-result` part's error text by toolCallId. The SDK
  * emits these alongside the (state-less) error on the tool-call part itself;
  * the rail prefers this text when present (it survives even when the call
- * part's output was clobbered). The part shape read here is the PUBLIC
- * `ToolResultPart` export of @tanstack/ai-client (a documented contract).
+ * part's output was clobbered). The fields read here match the PUBLIC
+ * `ToolResultPart` export of @tanstack/ai-client (a documented contract; the
+ * tie is pinned by the contract test, not tsc — see the header).
  */
 export function toolResultErrorsById(
 	messages: ReadonlyArray<MessageLike>,


### PR DESCRIPTION
## Task

DAT-449 — https://real-dataraum.atlassian.net/browse/DAT-449 (epic DAT-356; sequenced after #231, merged)

The remaining members of the silent-SDK-default defect class from the 2026-06-05 Intent-conformance audit (sibling of #231's `max_tokens`/1024 fix). All SDK claims re-verified against the installed `@tanstack/ai` 0.28.0 dist; the `@tanstack/ai#ai-core/tool-calling` Intent skill was loaded before implementation and by all three reviewers.

## What changed

1. **Explicit agent-loop budget** — `/api/chat` now sets `agentLoopStrategy: maxIterations(AGENT_LOOP_MAX_ITERATIONS)` (20, per the Intent tool-calling skill example; constant + rationale in `src/llm.ts`). The SDK's silent default `maxIterations(5)` stopped multi-tool orchestrator turns mid-task with no error. Pinned behaviorally in `chat.test.ts` (19 continues / 20 stops / budget > 5).
2. **Abort propagation** — new `src/lib/abort.ts` `linkedAbortController` bridges `ToolExecutionContext.abortSignal` into the `AbortController` `chat()` expects. All four nested-synthesis sites (frame induction, why_column/why_table/why_relationship narratives) forward it: a user stop() now cancels the in-flight nested Anthropic call instead of billing it to completion. End-to-end chain dist-verified by strict review (route controller → ctx signal → linked controller → anthropic adapter `signal`, both plain + structured paths).
3. **Type-source cleanup** — `TurnContent` = `string | MultimodalContent` (public `@tanstack/ai-client` export; ai-react's root does NOT re-export it); `RefsTurn` re-derived entirely from public exports (`Omit<MultimodalContent,"content"> & {content: Array<TextPart>}`, `TextPart` from `@tanstack/ai/client`) — zero hand-mirrored field shapes, consumer narrowing kept; `tool-chip-state` headers split the contract honestly (tool-RESULT shape matches the public `ToolResultPart`; tool-CALL error-in-output stays empirical, contract-test-pinned). `src/llm.ts`'s stale comment was already fixed by #231's fix round (verified).

**Deliberately NOT wired** (documented at the `.server()` sites): `run_sql` — duckdb-neo's only cancellation is connection-level `interrupt()` and the lake connection is process-wide memoized, so interrupting kills concurrent queries; `select` — `workflow.start` is non-blocking, an abort can't un-start the workflow and would orphan the session seed. The other 11 tools make no LLM calls (nothing billing-relevant).

## Acceptance criteria

- [x] Explicit, commented agent-loop budget on /api/chat, pinned in chat.test.ts; no silent SDK default governs the loop.
- [x] User stop aborts nested synthesis chat() calls (no post-stop billing); the four sites forward the context signal.
- [x] The three misdirecting comments/mirrors corrected; type-only imports replace the hand-mirrored shapes.
- [x] `bun run check` + `bun run test` + `bunx tsc --noEmit` green. Deps untouched — nothing freezes, no pins.

## Review

Independent 3-reviewer pass with the TanStack Intent mandate (all loaded `ai-core/tool-calling`, verified against the installed dist):
- spec-compliance: **APPROVE** (one low note: abort-forwarding chat-level test covers frame only; helper fully unit-tested, the three why_* sites are the identical one-liner)
- senior-code: **APPROVE** (asked for the skip rationale in code — done in the fix round)
- strict: **NEEDS WORK → resolved** (stale "re-exported by ai-react" comment fixed; tool-chip-state claim softened to match what tsc actually enforces; run_sql's REAL constraint — memoized shared connection vs `interrupt()` — now on disk)

## Lane smoke

```
bun run check          # biome: 193 files clean
bunx tsc --noEmit      # clean
bun run test           # 651/651 (69 files) — includes the SDK contract test
```

## Other lanes in flight

#233 (DAT-405, engine-side) — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)