### PR TITLE
DAT-454: CI cockpit quality gates — biome, tsc, vitest, build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,11 @@ jobs:
             - name: Biome check
               run: bun run check
 
+            # `bun run typecheck` (NOT bare `bunx tsc`): the script resolves the
+            # locked devDep and fails loudly if typescript ever leaves the
+            # lockfile — bare bunx would silently fetch latest instead.
             - name: Type check
-              run: bunx tsc --noEmit
+              run: bun run typecheck
 
             - name: Unit tests
               run: bun run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,16 +98,54 @@ jobs:
                       exit 1
                   fi
 
+    # Cockpit quality gates (DAT-454). Deps are declared `latest` with bun.lock
+    # owning resolution (NOTHING freezes — no version pins); the guards against
+    # an SDK move are exactly these: tsc + the unit suite, which includes the
+    # @tanstack/ai contract test (tool-chip-state.contract.test.ts) driving the
+    # real chat()→SSE→ChatClient pipeline. `bun run build` catches the Nitro/
+    # preset/externalization breakage class (duckdb-neo bindings, bun preset).
+    # Integration tests need a real stack and stay out of this fast PR gate.
+    # NOT path-filtered: engine PRs touching worker/contracts.py are
+    # cross-package (the cockpit hand-mirrors the Temporal contracts).
+    cockpit:
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        defaults:
+            run:
+                working-directory: packages/cockpit
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Set up Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: "1.3.14"
+
+            - name: Install deps
+              run: bun install --frozen-lockfile
+
+            - name: Biome check
+              run: bun run check
+
+            - name: Type check
+              run: bunx tsc --noEmit
+
+            - name: Unit tests
+              run: bun run test
+
+            - name: Build
+              run: bun run build
+
     # Single status for branch protection (matrix jobs report as "check (3.x)")
     check:
         if: always()
-        needs: [test, docs, schema-drift]
+        needs: [test, docs, schema-drift, cockpit]
         runs-on: ubuntu-latest
         steps:
             - name: All checks passed
               run: |
-                  if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ] || [ "${{ needs.schema-drift.result }}" != "success" ]; then
-                    echo "test=${{ needs.test.result }} docs=${{ needs.docs.result }} schema-drift=${{ needs.schema-drift.result }}"
+                  if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ] || [ "${{ needs.schema-drift.result }}" != "success" ] || [ "${{ needs.cockpit.result }}" != "success" ]; then
+                    echo "test=${{ needs.test.result }} docs=${{ needs.docs.result }} schema-drift=${{ needs.schema-drift.result }} cockpit=${{ needs.cockpit.result }}"
                     exit 1
                   fi
 

--- a/packages/cockpit/package.json
+++ b/packages/cockpit/package.json
@@ -16,6 +16,7 @@
     "preview": "bun --bun vite preview",
     "test": "vitest run --project unit",
     "test:integration": "vitest run --project integration",
+    "typecheck": "tsc --noEmit",
     "format": "bun --bun biome format",
     "lint": "bun --bun biome lint",
     "check": "bun --bun biome check",


### PR DESCRIPTION
## Task

DAT-454 — https://real-dataraum.atlassian.net/browse/DAT-454 (epic DAT-356; surfaced by strict review on #236)

ci.yml ran ZERO cockpit checks — every cockpit PR to date (#225/#230/#231/#234/#236) shipped guarded only by local gates + the reviewer pass. With deps declared `latest` (bun.lock owns resolution, nothing freezes), CI is exactly where the drift guards must run unskippably.

## What changed

New `cockpit` job (mirrors the engine job's shape, `working-directory: packages/cockpit`):

1. setup-bun **1.3.14** (matches the `engines` pin + the schema-drift job)
2. `bun install --frozen-lockfile`
3. `bun run check` (biome)
4. `bun run typecheck` (new script; NOT bare `bunx tsc`, which would silently fetch latest if typescript ever left the lockfile — strict-review hardening)
5. `bun run test` (vitest unit project — includes `tool-chip-state.contract.test.ts`, the @tanstack/ai drift catcher)
6. `bun run build` (catches the Nitro/preset/externalization breakage class; preset is `bun` since #236)

Wired into the `check` aggregator (needs + result condition — `!= "success"` also catches skipped/cancelled). Deliberately **not path-filtered**: engine PRs touching `worker/contracts.py` are cross-package (cockpit hand-mirrors the Temporal contracts). Integration tests stay out (need a real stack; this is the fast PR gate). No version pins anywhere.

## Lane smoke

The job's exact steps executed verbatim **cold** in a fresh worktree (no prior node_modules), independently re-verified by the strict reviewer under CI-equivalent env (no `.env`, no cockpit env vars):

```
bun install --frozen-lockfile   # clean, lockfile untouched
bun run check                   # 195 files clean
bun run typecheck               # clean (local typescript 6.0.3)
bun run test                    # 651/651 (69 files)
bun run build                   # green; .output/nitro.json preset "bun"
```

YAML parse-validated (js-yaml). Aggregator wiring + linux-cold-build risk (duckdb bindings in bun.lock for linux-x64; Dockerfile precedent) verified in review.

## Review

strict-reviewer: **APPROVED** (S change, single reviewer; both its hardening notes assessed — `typecheck` script adopted; vitest-under-system-node noted as inherent to the script, matches local dev).

## Other lanes in flight

#233 (DAT-405, engine-side) — no file overlap. NOTE: this PR's own CI run is the first with the new job — it gates itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)