### PR TITLE
DAT-434: Wire the missing readiness surfaces — why_table, why_relationship, look_relationships widgets

### DIFF
--- a/packages/cockpit/src/ui/cockpit/canvas-registry.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-registry.ts
@@ -12,10 +12,13 @@ import { EmptyWidget } from "#/ui/cockpit/widgets/empty";
 import { ErrorWidget } from "#/ui/cockpit/widgets/error";
 import { LoadingWidget } from "#/ui/cockpit/widgets/loading";
 import { MeasureProgressWidget } from "#/ui/cockpit/widgets/measure-progress";
+import { RelationshipListWidget } from "#/ui/cockpit/widgets/relationship-list";
+import { RelationshipWhyWidget } from "#/ui/cockpit/widgets/relationship-why";
 import { ResultGridWidget } from "#/ui/cockpit/widgets/result-grid";
 import { SchemaPreviewWidget } from "#/ui/cockpit/widgets/schema-preview";
 import { SourceListWidget } from "#/ui/cockpit/widgets/source-list";
 import { TableReadinessWidget } from "#/ui/cockpit/widgets/table-readiness";
+import { TableWhyWidget } from "#/ui/cockpit/widgets/table-why";
 import { UploadAreaWidget } from "#/ui/cockpit/widgets/upload-area";
 import { WorkspaceInventoryWidget } from "#/ui/cockpit/widgets/workspace-inventory";
 
@@ -33,5 +36,8 @@ export const canvasRegistry = new WidgetRegistry()
 	.register({ kind: "result-grid", component: ResultGridWidget })
 	.register({ kind: "table-readiness", component: TableReadinessWidget })
 	.register({ kind: "column-why", component: ColumnWhyWidget })
+	.register({ kind: "table-why", component: TableWhyWidget })
+	.register({ kind: "relationship-why", component: RelationshipWhyWidget })
+	.register({ kind: "relationship-list", component: RelationshipListWidget })
 	.register({ kind: "add-source-progress", component: MeasureProgressWidget })
 	.register({ kind: "upload-area", component: UploadAreaWidget });

--- a/packages/cockpit/src/ui/cockpit/canvas-state.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-state.ts
@@ -9,8 +9,11 @@ import type { ConnectSchema } from "#/duckdb/connect";
 import type { FrameResult } from "#/tools/frame";
 import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
+import type { LookRelationshipsResult } from "#/tools/look-relationships";
 import type { LookTableResult } from "#/tools/look-table";
 import type { WhyColumnResult } from "#/tools/why-column";
+import type { WhyRelationshipResult } from "#/tools/why-relationship";
+import type { WhyTableResult } from "#/tools/why-table";
 
 export type CanvasState =
 	| { kind: "empty" }
@@ -34,6 +37,15 @@ export type CanvasState =
 	// DAT-351: per-column readiness explanation. Carries the why_column result —
 	// per-intent drivers + detector evidence + the synthesized narrative.
 	| { kind: "column-why"; why: WhyColumnResult }
+	// DAT-434: per-table readiness explanation (the begin_session table-grain
+	// analog of column-why). Carries the why_table result.
+	| { kind: "table-why"; why: WhyTableResult }
+	// DAT-434: per-relationship readiness explanation. Carries the
+	// why_relationship result.
+	| { kind: "relationship-why"; why: WhyRelationshipResult }
+	// DAT-434: the begin_session relationship-readiness list — one row per
+	// relationship pair with its band; rows drill down to relationship-why.
+	| { kind: "relationship-list"; look: LookRelationshipsResult }
 	// DAT-352/DAT-436: live add_source workflow progress. Carries ONLY the
 	// (workflowId, runId) of the started run — the widget polls `get_progress`
 	// for the snapshot; the run id pins the precise iteration (the id is reused

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -41,13 +41,16 @@ describe("toolLabel", () => {
 });
 
 describe("isCanvasTool", () => {
-	it("marks the 10 canvas-producing tools clickable", () => {
-		expect(CANVAS_TOOLS.size).toBe(10);
+	it("marks the 13 canvas-producing tools clickable", () => {
+		expect(CANVAS_TOOLS.size).toBe(13);
 		for (const name of [
 			"list_sources",
 			"list_tables",
 			"look_table",
 			"why_column",
+			"why_table",
+			"why_relationship",
+			"look_relationships",
 			"connect",
 			"frame",
 			"select",
@@ -177,6 +180,62 @@ describe("toolChipSummary — completed canvas tools (no JSON, readable)", () =>
 		expect(toolChipSummary("why_column", {}, { found: false })).toBe(
 			"column not found",
 		);
+	});
+
+	it("why_table names the table + band (DAT-434)", () => {
+		expect(
+			toolChipSummary(
+				"why_table",
+				{},
+				{ table_name: "orders", found: true, band: "ready" },
+			),
+		).toBe("orders — ready");
+		expect(toolChipSummary("why_table", {}, { found: false })).toBe(
+			"table not found",
+		);
+		// A null display name degrades to a placeholder, never the table_id.
+		expect(
+			toolChipSummary(
+				"why_table",
+				{},
+				{ table_id: "t_1", table_name: null, found: true, band: "ready" },
+			),
+		).toBe("table — ready");
+	});
+
+	it("why_relationship names the endpoints + band (DAT-434)", () => {
+		expect(
+			toolChipSummary(
+				"why_relationship",
+				{},
+				{
+					from_table_name: "orders",
+					to_table_name: "customers",
+					found: true,
+					band: "ready",
+				},
+			),
+		).toBe("orders → customers — ready");
+		expect(toolChipSummary("why_relationship", {}, { found: false })).toBe(
+			"relationship not found",
+		);
+	});
+
+	it("look_relationships counts the relationships (DAT-434)", () => {
+		expect(
+			toolChipSummary(
+				"look_relationships",
+				{},
+				{ analyzed: true, relationships: [{}, {}] },
+			),
+		).toBe("2 relationships");
+		expect(
+			toolChipSummary(
+				"look_relationships",
+				{},
+				{ analyzed: false, relationships: [] },
+			),
+		).toBe("not yet analyzed");
 	});
 
 	it("connect names the source + table count", () => {

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -23,10 +23,13 @@ import type { FrameResult } from "#/tools/frame";
 import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
 import type { Vertical } from "#/tools/list-verticals";
+import type { LookRelationshipsResult } from "#/tools/look-relationships";
 import type { LookTableResult } from "#/tools/look-table";
 import type { SelectResult } from "#/tools/select";
 import type { TeachResult } from "#/tools/teach";
 import type { WhyColumnResult } from "#/tools/why-column";
+import type { WhyRelationshipResult } from "#/tools/why-relationship";
+import type { WhyTableResult } from "#/tools/why-table";
 import { groupLogicalTables } from "#/ui/cockpit/widgets/inventory-grouping";
 
 // Re-exported from the canvas bridge: defined ONCE there (derived from the
@@ -54,6 +57,9 @@ const TOOL_LABELS: Record<string, string> = {
 	list_tables: "Workspace tables",
 	look_table: "Table readiness",
 	why_column: "Column detail",
+	why_table: "Table detail",
+	why_relationship: "Relationship detail",
+	look_relationships: "Relationships",
 	connect: "Reading source",
 	frame: "Concepts",
 	select: "Registering source",
@@ -169,6 +175,33 @@ export function toolChipSummary(
 			const band = r.band ?? "not analyzed";
 			// `table_name` arrives in display form (projected in the tool, DAT-431).
 			return `${r.column_name} (${r.table_name}) — ${band}`;
+		}
+		case "why_table": {
+			const r = output as WhyTableResult | undefined;
+			if (!r) return "explaining table…";
+			if (!r.found) return "table not found";
+			const band = r.band ?? "not analyzed";
+			// `table_name` arrives in display form (DAT-431); null → no id fallback.
+			return `${r.table_name ?? "table"} — ${band}`;
+		}
+		case "why_relationship": {
+			const r = output as WhyRelationshipResult | undefined;
+			if (!r) return "explaining relationship…";
+			if (!r.found) return "relationship not found";
+			const band = r.band ?? "not analyzed";
+			// Endpoint names arrive in display form (DAT-431); nulls degrade to the
+			// bare arrow — never a column id.
+			const from = r.from_table_name ?? "";
+			const to = r.to_table_name ?? "";
+			return `${from} → ${to} — ${band}`.trim();
+		}
+		case "look_relationships": {
+			const r = output as LookRelationshipsResult | undefined;
+			if (!r || !Array.isArray(r.relationships))
+				return "reading relationships…";
+			return r.analyzed
+				? plural(r.relationships.length, "relationship")
+				: "not yet analyzed";
 		}
 		case "connect": {
 			const s = output as ConnectSchema | undefined;

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -189,11 +189,11 @@ export function toolChipSummary(
 			if (!r) return "explaining relationship…";
 			if (!r.found) return "relationship not found";
 			const band = r.band ?? "not analyzed";
-			// Endpoint names arrive in display form (DAT-431); nulls degrade to the
-			// bare arrow — never a column id.
-			const from = r.from_table_name ?? "";
-			const to = r.to_table_name ?? "";
-			return `${from} → ${to} — ${band}`.trim();
+			// Endpoint names arrive in display form (DAT-431); nulls degrade to a
+			// placeholder word (matching why_table) — never a column id.
+			const from = r.from_table_name ?? "table";
+			const to = r.to_table_name ?? "table";
+			return `${from} → ${to} — ${band}`;
 		}
 		case "look_relationships": {
 			const r = output as LookRelationshipsResult | undefined;

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
@@ -85,6 +85,17 @@ describe("toolResultToCanvas", () => {
 		expect(toolResultToCanvas("why_column", null)).toBeNull();
 	});
 
+	it("the why_* projectors reject the SDK's errored-call output shape (DAT-434)", () => {
+		// An errored server tool's output is the truthy `{ error }` object — it
+		// must NOT project (it would render as a not-found state, masking the
+		// failure); the error surfaces in the chat rail instead.
+		for (const tool of ["why_column", "why_table", "why_relationship"]) {
+			expect(
+				toolResultToCanvas(tool, { error: "Temporal query failed" }),
+			).toBeNull();
+		}
+	});
+
 	it("maps why_table to a table-why canvas (DAT-434)", () => {
 		const state = toolResultToCanvas("why_table", {
 			table_id: "t1",

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
@@ -85,6 +85,71 @@ describe("toolResultToCanvas", () => {
 		expect(toolResultToCanvas("why_column", null)).toBeNull();
 	});
 
+	it("maps why_table to a table-why canvas (DAT-434)", () => {
+		const state = toolResultToCanvas("why_table", {
+			table_id: "t1",
+			table_name: "orders",
+			found: true,
+			band: "ready",
+			worst_intent_risk: 0.1,
+			analyzed: true,
+			intents: [],
+			evidence: [],
+			signal_count: 0,
+			analysis: "…",
+			pending_teaches: 0,
+		});
+		expect(state?.kind).toBe("table-why");
+	});
+
+	it("leaves the canvas unchanged when why_table has no result", () => {
+		expect(toolResultToCanvas("why_table", null)).toBeNull();
+	});
+
+	it("maps why_relationship to a relationship-why canvas (DAT-434)", () => {
+		const state = toolResultToCanvas("why_relationship", {
+			from_column_id: "c1",
+			to_column_id: "c2",
+			from_table_name: "orders",
+			from_column_name: "customer_id",
+			to_table_name: "customers",
+			to_column_name: "id",
+			found: true,
+			band: "ready",
+			worst_intent_risk: 0.1,
+			analyzed: true,
+			intents: [],
+			evidence: [],
+			signal_count: 0,
+			analysis: "…",
+			pending_teaches: 0,
+		});
+		expect(state?.kind).toBe("relationship-why");
+	});
+
+	it("leaves the canvas unchanged when why_relationship has no result", () => {
+		expect(toolResultToCanvas("why_relationship", null)).toBeNull();
+	});
+
+	it("maps look_relationships to a relationship-list canvas (DAT-434)", () => {
+		const state = toolResultToCanvas("look_relationships", {
+			session_id: "s1",
+			analyzed: true,
+			pending_teaches: 0,
+			relationships: [],
+		});
+		expect(state?.kind).toBe("relationship-list");
+	});
+
+	it("leaves the canvas unchanged for a partial look_relationships output (no relationships array)", () => {
+		// Same partial/streaming guard as connect/frame: a truthy object without
+		// the array must not project (the list widget maps over it).
+		expect(
+			toolResultToCanvas("look_relationships", { analyzed: true }),
+		).toBeNull();
+		expect(toolResultToCanvas("look_relationships", null)).toBeNull();
+	});
+
 	it("maps connect to a schema-preview canvas", () => {
 		const schema = {
 			sourceKind: "file" as const,

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -27,6 +27,12 @@ import type { CanvasState } from "#/ui/cockpit/canvas-state";
  * the canvas unchanged. */
 type CanvasProjector = (result: unknown, input: unknown) => CanvasState | null;
 
+/** A complete why_* result carries the boolean `found` discriminant — the SDK's
+ * errored-call output (`{ error: string }`) does not, and must not project. */
+function isWhyResult(result: unknown): boolean {
+	return typeof (result as { found?: unknown } | null)?.found === "boolean";
+}
+
 /**
  * The canonical tool → canvas projector map — the SINGLE source of truth for
  * which tools produce a canvas member. A new canvas tool adds ONE entry here
@@ -53,15 +59,23 @@ const PROJECTORS: Record<string, CanvasProjector> = {
 		result
 			? { kind: "table-readiness", readiness: result as LookTableResult }
 			: null,
-	// The per-column explanation; a missing result leaves the canvas as-is.
+	// The per-column explanation. Guard on the `found` discriminant, not mere
+	// truthiness (DAT-434 review): an ERRORED tool call's output is the SDK's
+	// truthy `{ error }` object, which would project and render as "No such
+	// column" — a failure masquerading as not-found. Error shape → leave the
+	// canvas unchanged; the failure surfaces in the chat rail (connect behavior).
 	why_column: (result) =>
-		result ? { kind: "column-why", why: result as WhyColumnResult } : null,
-	// The per-table explanation (DAT-434) — same guard as why_column.
+		isWhyResult(result)
+			? { kind: "column-why", why: result as WhyColumnResult }
+			: null,
+	// The per-table explanation (DAT-434) — same `found` guard.
 	why_table: (result) =>
-		result ? { kind: "table-why", why: result as WhyTableResult } : null,
-	// The per-relationship explanation (DAT-434) — same guard.
+		isWhyResult(result)
+			? { kind: "table-why", why: result as WhyTableResult }
+			: null,
+	// The per-relationship explanation (DAT-434) — same `found` guard.
 	why_relationship: (result) =>
-		result
+		isWhyResult(result)
 			? { kind: "relationship-why", why: result as WhyRelationshipResult }
 			: null,
 	// The begin_session relationship-readiness list (DAT-434). Project only a

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -16,8 +16,11 @@ import type { ConnectSchema } from "#/duckdb/connect";
 import type { FrameResult } from "#/tools/frame";
 import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
+import type { LookRelationshipsResult } from "#/tools/look-relationships";
 import type { LookTableResult } from "#/tools/look-table";
 import type { WhyColumnResult } from "#/tools/why-column";
+import type { WhyRelationshipResult } from "#/tools/why-relationship";
+import type { WhyTableResult } from "#/tools/why-table";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
 
 /** Projects one tool's result (+ call input) to a CanvasState, or null to leave
@@ -53,6 +56,21 @@ const PROJECTORS: Record<string, CanvasProjector> = {
 	// The per-column explanation; a missing result leaves the canvas as-is.
 	why_column: (result) =>
 		result ? { kind: "column-why", why: result as WhyColumnResult } : null,
+	// The per-table explanation (DAT-434) — same guard as why_column.
+	why_table: (result) =>
+		result ? { kind: "table-why", why: result as WhyTableResult } : null,
+	// The per-relationship explanation (DAT-434) — same guard.
+	why_relationship: (result) =>
+		result
+			? { kind: "relationship-why", why: result as WhyRelationshipResult }
+			: null,
+	// The begin_session relationship-readiness list (DAT-434). Project only a
+	// complete result (a `relationships` array) — a partial/streaming or errored
+	// output would crash the list widget's .map (same guard as connect/frame).
+	look_relationships: (result) =>
+		Array.isArray((result as { relationships?: unknown } | null)?.relationships)
+			? { kind: "relationship-list", look: result as LookRelationshipsResult }
+			: null,
 	// Only project once the result is a COMPLETE schema (a `tables` array): a
 	// partial/streaming or errored connect output is truthy-but-tables-less, and
 	// projecting it crashes SchemaPreview on `schema.tables.length` (the multi-file

--- a/packages/cockpit/src/ui/cockpit/widgets/column-why.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/column-why.tsx
@@ -1,15 +1,21 @@
 // Column-why widget (DAT-351) — renders the `why_column` result: the synthesized
 // narrative, the per-intent drivers (the pre-computed diagnosis, ranked by
-// impact), and the underlying detector evidence. The bands/drivers are the
-// engine's persisted values; this widget only displays them.
+// impact), and the underlying detector evidence. The shared blocks live in
+// why-detail.tsx (rule 13, DAT-434 — this widget was the template the table/
+// relationship analogs cloned; the clones are now one module). The bands/
+// drivers are the engine's persisted values; this widget only displays them.
 //
 // Reads theme/tokens only; the row type is a type-only import (erased).
 
-import { Alert, Group, Stack, Table, Text } from "@mantine/core";
-import { humanizeIdentifier } from "#/lib/display-names";
+import { Alert, Group, Stack, Text } from "@mantine/core";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
-import { BandBadge, INTENT_LABEL } from "#/ui/cockpit/widgets/band-badge";
-import { EvidenceDetail } from "#/ui/cockpit/widgets/evidence-detail";
+import { BandBadge } from "#/ui/cockpit/widgets/band-badge";
+import {
+	EvidenceTable,
+	IntentDriversBlock,
+	PendingTeachAlert,
+	SignalsCaption,
+} from "#/ui/cockpit/widgets/why-detail";
 
 export function ColumnWhyWidget({
 	state,
@@ -58,10 +64,10 @@ export function ColumnWhyWidget({
 				<BandBadge band={why.band} />
 			</Group>
 
-			<Text size="xs" c="dimmed" data-testid="canvas-column-why-signals">
-				Based on {why.signal_count} signal{why.signal_count === 1 ? "" : "s"}
-				{why.signal_count === 0 ? " — not yet characterised" : ""}.
-			</Text>
+			<SignalsCaption
+				count={why.signal_count}
+				testId="canvas-column-why-signals"
+			/>
 
 			{why.analysis && (
 				<Text size="sm" data-testid="canvas-column-why-analysis">
@@ -76,85 +82,17 @@ export function ColumnWhyWidget({
 				</Alert>
 			)}
 
-			{why.pending_teaches > 0 && (
-				<Alert color="blue" data-testid="canvas-column-why-pending">
-					{why.pending_teaches} pending teach
-					{why.pending_teaches === 1 ? "" : "es"} may affect this view —
-					consider a replay before trusting it.
-				</Alert>
-			)}
+			<PendingTeachAlert
+				count={why.pending_teaches}
+				testId="canvas-column-why-pending"
+			/>
 
-			{/* Per-intent drivers — the pre-computed diagnosis, ranked by impact. */}
-			<Stack gap={4}>
-				{why.intents.map((i) => (
-					<Group key={i.intent} gap="xs" wrap="wrap" align="center">
-						<Text size="xs" fw={500} w={92}>
-							{INTENT_LABEL[i.intent] ?? i.intent}
-						</Text>
-						<BandBadge band={i.band} />
-						{i.drivers.length === 0 ? (
-							<Text span size="xs" c="dimmed">
-								no drivers
-							</Text>
-						) : (
-							i.drivers.map((d) => (
-								<Text key={d.node} span size="xs" c="dimmed">
-									{d.label} ({d.state})
-								</Text>
-							))
-						)}
-					</Group>
-				))}
-			</Stack>
+			<IntentDriversBlock intents={why.intents} />
 
-			{/* Underlying detector evidence. */}
-			{why.evidence.length > 0 && (
-				<Table.ScrollContainer minWidth={360}>
-					<Table striped data-testid="canvas-column-why-evidence">
-						<Table.Thead>
-							<Table.Tr>
-								<Table.Th>Dimension</Table.Th>
-								<Table.Th>Detector</Table.Th>
-								<Table.Th>Score</Table.Th>
-								<Table.Th>Detail</Table.Th>
-							</Table.Tr>
-						</Table.Thead>
-						<Table.Tbody>
-							{why.evidence.map((e) => {
-								// The readable dimension: the last path segment, humanized
-								// ("Naming clarity"). The dotted `dimension_path` is internal
-								// taxonomy (DAT-437) — never shown, kept only as a hover
-								// tooltip on the label.
-								const dimLeaf = e.dimension_path.split(".").at(-1) ?? "";
-								return (
-									<Table.Tr key={`${e.dimension_path}-${e.detector_id}`}>
-										<Table.Td>
-											<Text
-												span
-												size="xs"
-												title={e.dimension_path || undefined}
-											>
-												{humanizeIdentifier(dimLeaf) || "—"}
-											</Text>
-										</Table.Td>
-										<Table.Td>
-											<Text span size="xs" c="dimmed">
-												{humanizeIdentifier(e.detector_id) || e.detector_id}
-											</Text>
-										</Table.Td>
-										<Table.Td>{e.score.toFixed(2)}</Table.Td>
-										<Table.Td>
-											{/* Key→value hierarchy, shared with the upcoming
-											    why_table / why_relationship widgets (DAT-434). */}
-											<EvidenceDetail detail={e.detail} />
-										</Table.Td>
-									</Table.Tr>
-								);
-							})}
-						</Table.Tbody>
-					</Table>
-				</Table.ScrollContainer>
-			)}
+			<EvidenceTable
+				evidence={why.evidence}
+				testId="canvas-column-why-evidence"
+			/>
 		</Stack>
 	);
 }

--- a/packages/cockpit/src/ui/cockpit/widgets/relationship-list.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/relationship-list.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+//
+// Render tests for the RelationshipListWidget (DAT-434): rows with endpoint
+// labels + band badges, the not-analyzed / empty states, the overflow cap
+// (rule 15), and the why_relationship click-through — ids in the model-only
+// refs part, never the bubble (the table-readiness precedent).
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isAgentRefsPart } from "#/lib/agent-refs";
+import type { LookRelationshipsResult } from "#/tools/look-relationships";
+import { RelationshipListWidget } from "#/ui/cockpit/widgets/relationship-list";
+import { theme } from "#/ui/theme";
+
+// The widget reads the chat-loop hook from the cockpit context. Mock it so the
+// render tests don't need a CockpitProvider and the click test can observe the
+// dispatched request.
+const sendMessage = vi.fn();
+vi.mock("#/ui/cockpit/cockpit-state", () => ({
+	useCockpitActions: () => ({ sendMessage }),
+}));
+
+function renderWidget(look: LookRelationshipsResult) {
+	render(
+		<MantineProvider theme={theme} env="test">
+			<RelationshipListWidget state={{ kind: "relationship-list", look }} />
+		</MantineProvider>,
+	);
+}
+
+const REL = {
+	from_column_id: "c_orders_customer",
+	to_column_id: "c_customers_id",
+	from_table_name: "orders",
+	from_column_name: "customer_id",
+	to_table_name: "customers",
+	to_column_name: "id",
+	band: "ready",
+	worst_intent_risk: 0.1,
+	intents: [{ intent: "query_intent", band: "ready", risk: 0.1 }],
+	top_drivers: [
+		{ label: "Referential Integrity", state: "low", impact_delta: 0.05 },
+	],
+};
+
+const analyzed: LookRelationshipsResult = {
+	session_id: "sess-1",
+	analyzed: true,
+	pending_teaches: 0,
+	relationships: [REL],
+};
+
+beforeEach(() => {
+	sendMessage.mockClear();
+});
+afterEach(cleanup);
+
+describe("RelationshipListWidget (DAT-434)", () => {
+	it("renders a row per relationship with endpoint labels + band — no id leaks", () => {
+		renderWidget(analyzed);
+		expect(screen.getByTestId("canvas-relationship-list")).toBeTruthy();
+		expect(screen.getByText("orders.customer_id")).toBeTruthy();
+		expect(screen.getByText("customers.id")).toBeTruthy();
+		expect(screen.getByText("Ready")).toBeTruthy();
+		expect(screen.getByText("Referential Integrity")).toBeTruthy();
+		expect(document.body.textContent).not.toContain("c_orders_customer");
+		expect(document.body.textContent).not.toContain("sess-1");
+	});
+
+	it("renders the not-analyzed state pointing at begin_session", () => {
+		renderWidget({ ...analyzed, analyzed: false, relationships: [] });
+		expect(
+			screen.getByTestId("canvas-relationship-list-unanalyzed"),
+		).toBeTruthy();
+	});
+
+	it("renders the empty state for an analyzed session with no relationships", () => {
+		renderWidget({ ...analyzed, relationships: [] });
+		expect(screen.getByTestId("canvas-relationship-list-empty")).toBeTruthy();
+	});
+
+	it("caps rendered rows and shows the overflow tail (rule 15)", () => {
+		const many = Array.from({ length: 120 }, (_, i) => ({
+			...REL,
+			from_column_id: `c_from_${i}`,
+			to_column_id: `c_to_${i}`,
+			from_column_name: `col_${i}`,
+		}));
+		renderWidget({ ...analyzed, relationships: many });
+		// 100 rendered + the tail; never all 120.
+		expect(screen.getAllByText(/customers\.id/)).toHaveLength(100);
+		expect(
+			screen.getByTestId("relationship-list-overflow").textContent,
+		).toContain("…and 20 more");
+	});
+
+	it("surfaces the pending-teach note", () => {
+		renderWidget({ ...analyzed, pending_teaches: 1 });
+		expect(
+			screen.getByTestId("canvas-relationship-list-pending").textContent,
+		).toContain("1 pending teach");
+	});
+
+	it("click-through dispatches a why_relationship request — ids in the refs part, never the bubble", () => {
+		renderWidget(analyzed);
+		fireEvent.click(
+			screen.getByTestId("relationship-why-c_orders_customer->c_customers_id"),
+		);
+		expect(sendMessage).toHaveBeenCalledTimes(1);
+		const turn = sendMessage.mock.calls[0][0] as {
+			content: Array<{ type: "text"; content: string }>;
+		};
+		expect(turn.content).toHaveLength(2);
+		const [bubble, refs] = turn.content;
+		// The bubble: display names + the tool name, NO internal ids.
+		expect(bubble?.content).toContain("orders.customer_id");
+		expect(bubble?.content).toContain("customers.id");
+		expect(bubble?.content).toContain("why_relationship");
+		expect(bubble?.content).not.toContain("c_orders_customer");
+		expect(bubble?.content).not.toContain("sess-1");
+		// The refs part: marked model-only, key=value imperative form.
+		expect(refs && isAgentRefsPart(refs.content)).toBe(true);
+		expect(refs?.content).toContain("session_id=sess-1");
+		expect(refs?.content).toContain("from_column_id=c_orders_customer");
+		expect(refs?.content).toContain("to_column_id=c_customers_id");
+		expect(refs?.content).toContain("Internal only");
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/widgets/relationship-list.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/relationship-list.tsx
@@ -13,7 +13,10 @@ import type { RelationshipReadiness } from "#/tools/look-relationships";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
 import { useCockpitActions } from "#/ui/cockpit/cockpit-state";
 import { BandBadge } from "#/ui/cockpit/widgets/band-badge";
-import { relationshipEndpointLabel } from "#/ui/cockpit/widgets/relationship-why";
+import {
+	PendingTeachAlert,
+	relationshipEndpointLabel,
+} from "#/ui/cockpit/widgets/why-detail";
 
 // Cap the rows rendered into the DOM (rule 15: a wide workspace can carry
 // hundreds of candidate relationships). Navigation surface, not a result set —
@@ -89,13 +92,10 @@ export function RelationshipListWidget({
 				</Text>
 			</Text>
 
-			{look.pending_teaches > 0 && (
-				<Alert color="blue" data-testid="canvas-relationship-list-pending">
-					{look.pending_teaches} pending teach
-					{look.pending_teaches === 1 ? "" : "es"} may affect this view —
-					consider a replay before trusting it.
-				</Alert>
-			)}
+			<PendingTeachAlert
+				count={look.pending_teaches}
+				testId="canvas-relationship-list-pending"
+			/>
 
 			<Table.ScrollContainer minWidth={420}>
 				<Table striped highlightOnHover data-testid="relationship-rows">
@@ -161,8 +161,12 @@ export function RelationshipListWidget({
 			</Table.ScrollContainer>
 
 			{overflow > 0 && (
+				// look_relationships has NO narrowing input (session-wide by design),
+				// so don't promise a filtered re-render — the agent can only answer
+				// about specific tables in prose from the result already in context.
 				<Text size="xs" c="dimmed" data-testid="relationship-list-overflow">
-					…and {overflow} more — ask the agent to narrow down (e.g. by table).
+					…and {overflow} more — ask the agent about a specific table's
+					relationships.
 				</Text>
 			)}
 		</Stack>

--- a/packages/cockpit/src/ui/cockpit/widgets/relationship-list.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/relationship-list.tsx
@@ -1,0 +1,170 @@
+// Relationship-list widget (DAT-434) — renders the `look_relationships` result
+// as one row per relationship pair: endpoints (display names), readiness band,
+// top drivers. A row click drives the why_relationship drill-down through the
+// chat loop — the column ids ride in a model-only refs part (lib/agent-refs),
+// never in the visible bubble (the table-readiness → why_column precedent).
+//
+// Endpoint names arrive in DISPLAY form (`src_<digest>__` stripped, DAT-431);
+// the band is the engine's persisted value — never recomputed here.
+
+import { Alert, Anchor, Stack, Table, Text } from "@mantine/core";
+import { turnWithRefs } from "#/lib/agent-refs";
+import type { RelationshipReadiness } from "#/tools/look-relationships";
+import type { CanvasState } from "#/ui/cockpit/canvas-state";
+import { useCockpitActions } from "#/ui/cockpit/cockpit-state";
+import { BandBadge } from "#/ui/cockpit/widgets/band-badge";
+import { relationshipEndpointLabel } from "#/ui/cockpit/widgets/relationship-why";
+
+// Cap the rows rendered into the DOM (rule 15: a wide workspace can carry
+// hundreds of candidate relationships). Navigation surface, not a result set —
+// past the cap we show an "…and N more" tail (the workspace-inventory pattern).
+const MAX_VISIBLE_ROWS = 100;
+
+const TOP_DRIVERS_SHOWN = 2;
+
+export function RelationshipListWidget({
+	state,
+}: {
+	state: Extract<CanvasState, { kind: "relationship-list" }>;
+}) {
+	const { look } = state;
+	const { sendMessage } = useCockpitActions();
+
+	const explainRelationship = (rel: RelationshipReadiness) => {
+		const fromLabel = relationshipEndpointLabel(
+			rel.from_table_name,
+			rel.from_column_name,
+		);
+		const toLabel = relationshipEndpointLabel(
+			rel.to_table_name,
+			rel.to_column_name,
+		);
+		sendMessage(
+			turnWithRefs(
+				`Explain the readiness for the relationship "${fromLabel}" → "${toLabel}" using the why_relationship tool.`,
+				`Internal only — do not quote in prose: session_id=${look.session_id} ` +
+					`from_column_id=${rel.from_column_id} to_column_id=${rel.to_column_id} ` +
+					`(use as the arguments to the why_relationship tool).`,
+			),
+			{ label: "Explaining the relationship…" },
+		);
+	};
+
+	if (!look.analyzed) {
+		return (
+			<Stack gap="xs" data-testid="canvas-relationship-list">
+				<Text size="sm" fw={600}>
+					Relationships
+				</Text>
+				<Alert color="gray" data-testid="canvas-relationship-list-unanalyzed">
+					This session has no relationship readiness yet — run begin_session to
+					compute it.
+				</Alert>
+			</Stack>
+		);
+	}
+
+	if (look.relationships.length === 0) {
+		return (
+			<Stack gap="xs" data-testid="canvas-relationship-list">
+				<Text size="sm" fw={600}>
+					Relationships
+				</Text>
+				<Alert color="gray" data-testid="canvas-relationship-list-empty">
+					No relationships in this session's readiness run.
+				</Alert>
+			</Stack>
+		);
+	}
+
+	const visible = look.relationships.slice(0, MAX_VISIBLE_ROWS);
+	const overflow = look.relationships.length - visible.length;
+
+	return (
+		<Stack gap="sm" data-testid="canvas-relationship-list">
+			<Text size="sm" fw={600}>
+				Relationships{" "}
+				<Text span c="dimmed" size="xs">
+					{look.relationships.length} in this session
+				</Text>
+			</Text>
+
+			{look.pending_teaches > 0 && (
+				<Alert color="blue" data-testid="canvas-relationship-list-pending">
+					{look.pending_teaches} pending teach
+					{look.pending_teaches === 1 ? "" : "es"} may affect this view —
+					consider a replay before trusting it.
+				</Alert>
+			)}
+
+			<Table.ScrollContainer minWidth={420}>
+				<Table striped highlightOnHover data-testid="relationship-rows">
+					<Table.Thead>
+						<Table.Tr>
+							<Table.Th>From</Table.Th>
+							<Table.Th>To</Table.Th>
+							<Table.Th>Band</Table.Th>
+							<Table.Th>Top drivers</Table.Th>
+						</Table.Tr>
+					</Table.Thead>
+					<Table.Tbody>
+						{visible.map((rel) => {
+							const key = `${rel.from_column_id}->${rel.to_column_id}`;
+							return (
+								<Table.Tr key={key} data-testid={`relationship-row-${key}`}>
+									<Table.Td>
+										{/* The name is the drill-down — same affordance as the
+										    inventory's table links; ids ride in the refs part. */}
+										<Anchor
+											component="button"
+											type="button"
+											size="sm"
+											onClick={() => explainRelationship(rel)}
+											data-testid={`relationship-why-${key}`}
+										>
+											{relationshipEndpointLabel(
+												rel.from_table_name,
+												rel.from_column_name,
+											)}
+										</Anchor>
+									</Table.Td>
+									<Table.Td>
+										<Text span size="sm">
+											{relationshipEndpointLabel(
+												rel.to_table_name,
+												rel.to_column_name,
+											)}
+										</Text>
+									</Table.Td>
+									<Table.Td>
+										<BandBadge band={rel.band} />
+									</Table.Td>
+									<Table.Td>
+										{rel.top_drivers.length === 0 ? (
+											<Text span size="xs" c="dimmed">
+												—
+											</Text>
+										) : (
+											<Text span size="xs" c="dimmed">
+												{rel.top_drivers
+													.slice(0, TOP_DRIVERS_SHOWN)
+													.map((d) => d.label)
+													.join(" · ")}
+											</Text>
+										)}
+									</Table.Td>
+								</Table.Tr>
+							);
+						})}
+					</Table.Tbody>
+				</Table>
+			</Table.ScrollContainer>
+
+			{overflow > 0 && (
+				<Text size="xs" c="dimmed" data-testid="relationship-list-overflow">
+					…and {overflow} more — ask the agent to narrow down (e.g. by table).
+				</Text>
+			)}
+		</Stack>
+	);
+}

--- a/packages/cockpit/src/ui/cockpit/widgets/relationship-why.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/relationship-why.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+//
+// Render tests for the RelationshipWhyWidget (DAT-434) — the relationship
+// analog of column-why.test.tsx: endpoint labels (display names, NEVER ids),
+// narrative, drivers, evidence, and the not-found / not-analyzed states.
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { WhyRelationshipResult } from "#/tools/why-relationship";
+import { RelationshipWhyWidget } from "#/ui/cockpit/widgets/relationship-why";
+import { theme } from "#/ui/theme";
+
+function renderWidget(why: WhyRelationshipResult) {
+	render(
+		<MantineProvider theme={theme} env="test">
+			<RelationshipWhyWidget state={{ kind: "relationship-why", why }} />
+		</MantineProvider>,
+	);
+}
+
+const analyzed: WhyRelationshipResult = {
+	from_column_id: "c_from",
+	to_column_id: "c_to",
+	from_table_name: "orders",
+	from_column_name: "customer_id",
+	to_table_name: "customers",
+	to_column_name: "id",
+	found: true,
+	band: "ready",
+	worst_intent_risk: 0.1,
+	analyzed: true,
+	intents: [
+		{
+			intent: "query_intent",
+			band: "ready",
+			risk: 0.1,
+			drivers: [],
+		},
+	],
+	evidence: [
+		{
+			dimension_path: "structural.relationships.referential_integrity",
+			detector_id: "fk_orphan_ratio",
+			score: 0.05,
+			detail: '[{"metric":"orphan_ratio","value":0.001}]',
+		},
+	],
+	signal_count: 1,
+	analysis: "The join key is clean: orphan ratio is negligible.",
+	pending_teaches: 0,
+};
+
+afterEach(cleanup);
+
+describe("RelationshipWhyWidget (DAT-434)", () => {
+	it("renders endpoint labels, band, narrative, and evidence", () => {
+		renderWidget(analyzed);
+		expect(screen.getByTestId("canvas-relationship-why")).toBeTruthy();
+		expect(screen.getByText(/orders\.customer_id/)).toBeTruthy();
+		expect(screen.getByText(/customers\.id/)).toBeTruthy();
+		expect(screen.getAllByText("Ready").length).toBeGreaterThan(0);
+		expect(
+			screen.getByTestId("canvas-relationship-why-analysis").textContent,
+		).toBe(analyzed.analysis);
+		expect(screen.getByTestId("canvas-relationship-why-evidence")).toBeTruthy();
+		// Column ids never render.
+		expect(document.body.textContent).not.toContain("c_from");
+		expect(document.body.textContent).not.toContain("c_to");
+	});
+
+	it("renders the not-found state — no id leaks", () => {
+		renderWidget({ ...analyzed, found: false, analyzed: false });
+		expect(screen.getByTestId("canvas-relationship-why-notfound")).toBeTruthy();
+		expect(document.body.textContent).not.toContain("c_from");
+	});
+
+	it("renders the not-analyzed state pointing at begin_session", () => {
+		renderWidget({
+			...analyzed,
+			analyzed: false,
+			band: null,
+			intents: [],
+			evidence: [],
+			signal_count: 0,
+			analysis: "",
+		});
+		expect(
+			screen.getByTestId("canvas-relationship-why-unanalyzed"),
+		).toBeTruthy();
+	});
+
+	it("null endpoint names render placeholders, never the column ids", () => {
+		renderWidget({
+			...analyzed,
+			from_table_name: null,
+			from_column_name: null,
+		});
+		expect(
+			screen.getByText(/\(unknown table\)\.\(unknown column\)/),
+		).toBeTruthy();
+		expect(document.body.textContent).not.toContain("c_from");
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/widgets/relationship-why.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/relationship-why.tsx
@@ -1,0 +1,174 @@
+// Relationship-why widget (DAT-434) — renders the `why_relationship` result:
+// the synthesized narrative, per-intent drivers, and detector evidence for ONE
+// relationship pair (mirrors column-why/table-why). The bands/drivers are the
+// engine's persisted values; this widget only displays them.
+//
+// Endpoint names arrive in DISPLAY form (`src_<digest>__` stripped, DAT-431);
+// a null name (stale id) renders a dimmed placeholder — never the raw id.
+
+import { Alert, Group, Stack, Table, Text } from "@mantine/core";
+import { humanizeIdentifier } from "#/lib/display-names";
+import type { CanvasState } from "#/ui/cockpit/canvas-state";
+import { BandBadge, INTENT_LABEL } from "#/ui/cockpit/widgets/band-badge";
+import { EvidenceDetail } from "#/ui/cockpit/widgets/evidence-detail";
+
+/** "table.column" endpoint label from nullable display names — NEVER an id. */
+export function relationshipEndpointLabel(
+	tableName: string | null,
+	columnName: string | null,
+): string {
+	const table = tableName ?? "(unknown table)";
+	const column = columnName ?? "(unknown column)";
+	return `${table}.${column}`;
+}
+
+export function RelationshipWhyWidget({
+	state,
+}: {
+	state: Extract<CanvasState, { kind: "relationship-why" }>;
+}) {
+	const { why } = state;
+
+	if (!why.found) {
+		return (
+			<Stack gap="xs" data-testid="canvas-relationship-why">
+				<Text size="sm" fw={600}>
+					why_relationship
+				</Text>
+				<Alert color="gray" data-testid="canvas-relationship-why-notfound">
+					No such relationship in this session.
+				</Alert>
+			</Stack>
+		);
+	}
+
+	const fromLabel = relationshipEndpointLabel(
+		why.from_table_name,
+		why.from_column_name,
+	);
+	const toLabel = relationshipEndpointLabel(
+		why.to_table_name,
+		why.to_column_name,
+	);
+
+	if (!why.analyzed) {
+		return (
+			<Stack gap="xs" data-testid="canvas-relationship-why">
+				<Text size="sm" fw={600}>
+					{fromLabel} → {toLabel} — why
+				</Text>
+				<Alert color="gray" data-testid="canvas-relationship-why-unanalyzed">
+					This relationship has no session readiness yet — run begin_session to
+					compute it.
+				</Alert>
+			</Stack>
+		);
+	}
+
+	return (
+		<Stack gap="sm" data-testid="canvas-relationship-why">
+			<Group justify="space-between" wrap="nowrap">
+				<Text size="sm" fw={600}>
+					{fromLabel}{" "}
+					<Text span c="dimmed">
+						→
+					</Text>{" "}
+					{toLabel}
+				</Text>
+				<BandBadge band={why.band} />
+			</Group>
+
+			<Text size="xs" c="dimmed" data-testid="canvas-relationship-why-signals">
+				Based on {why.signal_count} signal{why.signal_count === 1 ? "" : "s"}
+				{why.signal_count === 0 ? " — not yet characterised" : ""}.
+			</Text>
+
+			{why.analysis && (
+				<Text size="sm" data-testid="canvas-relationship-why-analysis">
+					{why.analysis}
+				</Text>
+			)}
+
+			{why.signal_count === 0 && (
+				<Alert color="gray" data-testid="canvas-relationship-why-nosignals">
+					No detector signals for this relationship yet — its band reflects
+					structural metadata only. More detectors will sharpen this.
+				</Alert>
+			)}
+
+			{why.pending_teaches > 0 && (
+				<Alert color="blue" data-testid="canvas-relationship-why-pending">
+					{why.pending_teaches} pending teach
+					{why.pending_teaches === 1 ? "" : "es"} may affect this view —
+					consider a replay before trusting it.
+				</Alert>
+			)}
+
+			{/* Per-intent drivers — the pre-computed diagnosis, ranked by impact. */}
+			<Stack gap={4}>
+				{why.intents.map((i) => (
+					<Group key={i.intent} gap="xs" wrap="wrap" align="center">
+						<Text size="xs" fw={500} w={92}>
+							{INTENT_LABEL[i.intent] ?? i.intent}
+						</Text>
+						<BandBadge band={i.band} />
+						{i.drivers.length === 0 ? (
+							<Text span size="xs" c="dimmed">
+								no drivers
+							</Text>
+						) : (
+							i.drivers.map((d) => (
+								<Text key={d.node} span size="xs" c="dimmed">
+									{d.label} ({d.state})
+								</Text>
+							))
+						)}
+					</Group>
+				))}
+			</Stack>
+
+			{/* Underlying detector evidence. */}
+			{why.evidence.length > 0 && (
+				<Table.ScrollContainer minWidth={360}>
+					<Table striped data-testid="canvas-relationship-why-evidence">
+						<Table.Thead>
+							<Table.Tr>
+								<Table.Th>Dimension</Table.Th>
+								<Table.Th>Detector</Table.Th>
+								<Table.Th>Score</Table.Th>
+								<Table.Th>Detail</Table.Th>
+							</Table.Tr>
+						</Table.Thead>
+						<Table.Tbody>
+							{why.evidence.map((e) => {
+								const dimLeaf = e.dimension_path.split(".").at(-1) ?? "";
+								return (
+									<Table.Tr key={`${e.dimension_path}-${e.detector_id}`}>
+										<Table.Td>
+											<Text
+												span
+												size="xs"
+												title={e.dimension_path || undefined}
+											>
+												{humanizeIdentifier(dimLeaf) || "—"}
+											</Text>
+										</Table.Td>
+										<Table.Td>
+											<Text span size="xs" c="dimmed">
+												{humanizeIdentifier(e.detector_id) || e.detector_id}
+											</Text>
+										</Table.Td>
+										<Table.Td>{e.score.toFixed(2)}</Table.Td>
+										<Table.Td>
+											<EvidenceDetail detail={e.detail} />
+										</Table.Td>
+									</Table.Tr>
+								);
+							})}
+						</Table.Tbody>
+					</Table>
+				</Table.ScrollContainer>
+			)}
+		</Stack>
+	);
+}

--- a/packages/cockpit/src/ui/cockpit/widgets/relationship-why.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/relationship-why.tsx
@@ -1,26 +1,21 @@
 // Relationship-why widget (DAT-434) — renders the `why_relationship` result:
 // the synthesized narrative, per-intent drivers, and detector evidence for ONE
-// relationship pair (mirrors column-why/table-why). The bands/drivers are the
-// engine's persisted values; this widget only displays them.
+// relationship pair. The shared blocks live in why-detail.tsx (rule 13); the
+// bands/drivers are the engine's persisted values — this widget only displays.
 //
 // Endpoint names arrive in DISPLAY form (`src_<digest>__` stripped, DAT-431);
 // a null name (stale id) renders a dimmed placeholder — never the raw id.
 
-import { Alert, Group, Stack, Table, Text } from "@mantine/core";
-import { humanizeIdentifier } from "#/lib/display-names";
+import { Alert, Group, Stack, Text } from "@mantine/core";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
-import { BandBadge, INTENT_LABEL } from "#/ui/cockpit/widgets/band-badge";
-import { EvidenceDetail } from "#/ui/cockpit/widgets/evidence-detail";
-
-/** "table.column" endpoint label from nullable display names — NEVER an id. */
-export function relationshipEndpointLabel(
-	tableName: string | null,
-	columnName: string | null,
-): string {
-	const table = tableName ?? "(unknown table)";
-	const column = columnName ?? "(unknown column)";
-	return `${table}.${column}`;
-}
+import { BandBadge } from "#/ui/cockpit/widgets/band-badge";
+import {
+	EvidenceTable,
+	IntentDriversBlock,
+	PendingTeachAlert,
+	relationshipEndpointLabel,
+	SignalsCaption,
+} from "#/ui/cockpit/widgets/why-detail";
 
 export function RelationshipWhyWidget({
 	state,
@@ -78,10 +73,10 @@ export function RelationshipWhyWidget({
 				<BandBadge band={why.band} />
 			</Group>
 
-			<Text size="xs" c="dimmed" data-testid="canvas-relationship-why-signals">
-				Based on {why.signal_count} signal{why.signal_count === 1 ? "" : "s"}
-				{why.signal_count === 0 ? " — not yet characterised" : ""}.
-			</Text>
+			<SignalsCaption
+				count={why.signal_count}
+				testId="canvas-relationship-why-signals"
+			/>
 
 			{why.analysis && (
 				<Text size="sm" data-testid="canvas-relationship-why-analysis">
@@ -96,79 +91,17 @@ export function RelationshipWhyWidget({
 				</Alert>
 			)}
 
-			{why.pending_teaches > 0 && (
-				<Alert color="blue" data-testid="canvas-relationship-why-pending">
-					{why.pending_teaches} pending teach
-					{why.pending_teaches === 1 ? "" : "es"} may affect this view —
-					consider a replay before trusting it.
-				</Alert>
-			)}
+			<PendingTeachAlert
+				count={why.pending_teaches}
+				testId="canvas-relationship-why-pending"
+			/>
 
-			{/* Per-intent drivers — the pre-computed diagnosis, ranked by impact. */}
-			<Stack gap={4}>
-				{why.intents.map((i) => (
-					<Group key={i.intent} gap="xs" wrap="wrap" align="center">
-						<Text size="xs" fw={500} w={92}>
-							{INTENT_LABEL[i.intent] ?? i.intent}
-						</Text>
-						<BandBadge band={i.band} />
-						{i.drivers.length === 0 ? (
-							<Text span size="xs" c="dimmed">
-								no drivers
-							</Text>
-						) : (
-							i.drivers.map((d) => (
-								<Text key={d.node} span size="xs" c="dimmed">
-									{d.label} ({d.state})
-								</Text>
-							))
-						)}
-					</Group>
-				))}
-			</Stack>
+			<IntentDriversBlock intents={why.intents} />
 
-			{/* Underlying detector evidence. */}
-			{why.evidence.length > 0 && (
-				<Table.ScrollContainer minWidth={360}>
-					<Table striped data-testid="canvas-relationship-why-evidence">
-						<Table.Thead>
-							<Table.Tr>
-								<Table.Th>Dimension</Table.Th>
-								<Table.Th>Detector</Table.Th>
-								<Table.Th>Score</Table.Th>
-								<Table.Th>Detail</Table.Th>
-							</Table.Tr>
-						</Table.Thead>
-						<Table.Tbody>
-							{why.evidence.map((e) => {
-								const dimLeaf = e.dimension_path.split(".").at(-1) ?? "";
-								return (
-									<Table.Tr key={`${e.dimension_path}-${e.detector_id}`}>
-										<Table.Td>
-											<Text
-												span
-												size="xs"
-												title={e.dimension_path || undefined}
-											>
-												{humanizeIdentifier(dimLeaf) || "—"}
-											</Text>
-										</Table.Td>
-										<Table.Td>
-											<Text span size="xs" c="dimmed">
-												{humanizeIdentifier(e.detector_id) || e.detector_id}
-											</Text>
-										</Table.Td>
-										<Table.Td>{e.score.toFixed(2)}</Table.Td>
-										<Table.Td>
-											<EvidenceDetail detail={e.detail} />
-										</Table.Td>
-									</Table.Tr>
-								);
-							})}
-						</Table.Tbody>
-					</Table>
-				</Table.ScrollContainer>
-			)}
+			<EvidenceTable
+				evidence={why.evidence}
+				testId="canvas-relationship-why-evidence"
+			/>
 		</Stack>
 	);
 }

--- a/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
@@ -17,6 +17,7 @@ import {
 	INTENT_LABEL,
 	INTENTS,
 } from "#/ui/cockpit/widgets/band-badge";
+import { PendingTeachAlert } from "#/ui/cockpit/widgets/why-detail";
 
 // The begin_session whole-table band (DAT-415): the `dimension_coverage` rollup
 // for the table, sealed at the session head — distinct from, and shown above, the
@@ -119,13 +120,10 @@ export function TableReadinessWidget({
 				</Alert>
 			)}
 
-			{readiness.pending_teaches > 0 && (
-				<Alert color="blue" data-testid="canvas-table-readiness-pending">
-					{readiness.pending_teaches} pending teach
-					{readiness.pending_teaches === 1 ? "" : "es"} may affect this view —
-					consider a replay before trusting it.
-				</Alert>
-			)}
+			<PendingTeachAlert
+				count={readiness.pending_teaches}
+				testId="canvas-table-readiness-pending"
+			/>
 
 			<Table.ScrollContainer minWidth={480}>
 				<Table striped highlightOnHover>

--- a/packages/cockpit/src/ui/cockpit/widgets/table-why.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-why.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+//
+// Render tests for the TableWhyWidget (DAT-434) — mirrors column-why.test.tsx:
+// the narrative, per-intent drivers, signal caption, evidence table, and the
+// not-found / not-analyzed states. The live read + LLM synthesis are
+// smoke-covered.
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { WhyTableResult } from "#/tools/why-table";
+import { TableWhyWidget } from "#/ui/cockpit/widgets/table-why";
+import { theme } from "#/ui/theme";
+
+function renderWidget(why: WhyTableResult) {
+	render(
+		<MantineProvider theme={theme} env="test">
+			<TableWhyWidget state={{ kind: "table-why", why }} />
+		</MantineProvider>,
+	);
+}
+
+const analyzed: WhyTableResult = {
+	table_id: "t_orders",
+	table_name: "orders",
+	found: true,
+	band: "investigate",
+	worst_intent_risk: 0.42,
+	analyzed: true,
+	intents: [
+		{
+			intent: "aggregation_intent",
+			band: "investigate",
+			risk: 0.42,
+			drivers: [
+				{
+					node: "dimension_coverage",
+					dimension_path: "structural.coverage.dimension_coverage",
+					label: "Dimension Coverage",
+					state: "high",
+					impact_delta: 0.3,
+				},
+			],
+		},
+	],
+	evidence: [
+		{
+			dimension_path: "structural.coverage.dimension_coverage",
+			detector_id: "dimension_coverage",
+			score: 0.7,
+			detail: '[{"metric":"covered_ratio","value":0.55}]',
+		},
+	],
+	signal_count: 1,
+	analysis: "orders lacks dimensional coverage for reliable aggregation.",
+	pending_teaches: 0,
+};
+
+afterEach(cleanup);
+
+describe("TableWhyWidget (DAT-434)", () => {
+	it("renders the narrative, band, drivers, and evidence for an analyzed table", () => {
+		renderWidget(analyzed);
+		expect(screen.getByTestId("canvas-table-why")).toBeTruthy();
+		expect(screen.getByText("orders")).toBeTruthy();
+		// Shared BandBadge humanizes the band (DAT-451).
+		expect(screen.getAllByText("Investigate").length).toBeGreaterThan(0);
+		expect(screen.getByTestId("canvas-table-why-analysis").textContent).toBe(
+			analyzed.analysis,
+		);
+		expect(screen.getByText("Aggregation")).toBeTruthy();
+		expect(screen.getByText("Dimension Coverage (high)")).toBeTruthy();
+		expect(screen.getByTestId("canvas-table-why-evidence")).toBeTruthy();
+		expect(
+			screen.getByTestId("canvas-table-why-signals").textContent,
+		).toContain("Based on 1 signal");
+	});
+
+	it("renders the not-found state — no id leaks", () => {
+		renderWidget({
+			...analyzed,
+			found: false,
+			table_name: null,
+			analyzed: false,
+		});
+		expect(screen.getByTestId("canvas-table-why-notfound")).toBeTruthy();
+		expect(document.body.textContent).not.toContain("t_orders");
+	});
+
+	it("renders the not-analyzed state pointing at begin_session", () => {
+		renderWidget({
+			...analyzed,
+			analyzed: false,
+			band: null,
+			intents: [],
+			evidence: [],
+			signal_count: 0,
+			analysis: "",
+		});
+		expect(screen.getByTestId("canvas-table-why-unanalyzed")).toBeTruthy();
+	});
+
+	it("a null table_name renders a placeholder, never the table_id", () => {
+		renderWidget({ ...analyzed, table_name: null });
+		expect(screen.getByText(/unknown table/)).toBeTruthy();
+		expect(document.body.textContent).not.toContain("t_orders");
+	});
+
+	it("surfaces the pending-teach note", () => {
+		renderWidget({ ...analyzed, pending_teaches: 2 });
+		expect(
+			screen.getByTestId("canvas-table-why-pending").textContent,
+		).toContain("2 pending teaches");
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/widgets/table-why.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-why.tsx
@@ -1,0 +1,159 @@
+// Table-why widget (DAT-434) — renders the `why_table` result: the synthesized
+// narrative, the per-intent drivers, and the underlying detector evidence for
+// ONE table's session-grain readiness (the begin_session table analog of
+// column-why, which this mirrors). The bands/drivers are the engine's
+// persisted values; this widget only displays them.
+//
+// `table_name` arrives in DISPLAY form (`src_<digest>__` stripped, DAT-431);
+// a null name (stale id) renders a dimmed placeholder — never the raw id.
+
+import { Alert, Group, Stack, Table, Text } from "@mantine/core";
+import { humanizeIdentifier } from "#/lib/display-names";
+import type { CanvasState } from "#/ui/cockpit/canvas-state";
+import { BandBadge, INTENT_LABEL } from "#/ui/cockpit/widgets/band-badge";
+import { EvidenceDetail } from "#/ui/cockpit/widgets/evidence-detail";
+
+export function TableWhyWidget({
+	state,
+}: {
+	state: Extract<CanvasState, { kind: "table-why" }>;
+}) {
+	const { why } = state;
+
+	if (!why.found) {
+		return (
+			<Stack gap="xs" data-testid="canvas-table-why">
+				<Text size="sm" fw={600}>
+					why_table
+				</Text>
+				<Alert color="gray" data-testid="canvas-table-why-notfound">
+					No such table in this session.
+				</Alert>
+			</Stack>
+		);
+	}
+
+	const label = why.table_name ?? "(unknown table)";
+
+	if (!why.analyzed) {
+		return (
+			<Stack gap="xs" data-testid="canvas-table-why">
+				<Text size="sm" fw={600}>
+					{label} — why
+				</Text>
+				<Alert color="gray" data-testid="canvas-table-why-unanalyzed">
+					This table has no session readiness yet — run begin_session over it to
+					compute the table-grain rollup.
+				</Alert>
+			</Stack>
+		);
+	}
+
+	return (
+		<Stack gap="sm" data-testid="canvas-table-why">
+			<Group justify="space-between" wrap="nowrap">
+				<Text size="sm" fw={600}>
+					{label}{" "}
+					<Text span c="dimmed">
+						· whole-table readiness
+					</Text>
+				</Text>
+				<BandBadge band={why.band} />
+			</Group>
+
+			<Text size="xs" c="dimmed" data-testid="canvas-table-why-signals">
+				Based on {why.signal_count} signal{why.signal_count === 1 ? "" : "s"}
+				{why.signal_count === 0 ? " — not yet characterised" : ""}.
+			</Text>
+
+			{why.analysis && (
+				<Text size="sm" data-testid="canvas-table-why-analysis">
+					{why.analysis}
+				</Text>
+			)}
+
+			{why.signal_count === 0 && (
+				<Alert color="gray" data-testid="canvas-table-why-nosignals">
+					No detector signals for this table yet — its band reflects structural
+					metadata only. More detectors will sharpen this.
+				</Alert>
+			)}
+
+			{why.pending_teaches > 0 && (
+				<Alert color="blue" data-testid="canvas-table-why-pending">
+					{why.pending_teaches} pending teach
+					{why.pending_teaches === 1 ? "" : "es"} may affect this view —
+					consider a replay before trusting it.
+				</Alert>
+			)}
+
+			{/* Per-intent drivers — the pre-computed diagnosis, ranked by impact. */}
+			<Stack gap={4}>
+				{why.intents.map((i) => (
+					<Group key={i.intent} gap="xs" wrap="wrap" align="center">
+						<Text size="xs" fw={500} w={92}>
+							{INTENT_LABEL[i.intent] ?? i.intent}
+						</Text>
+						<BandBadge band={i.band} />
+						{i.drivers.length === 0 ? (
+							<Text span size="xs" c="dimmed">
+								no drivers
+							</Text>
+						) : (
+							i.drivers.map((d) => (
+								<Text key={d.node} span size="xs" c="dimmed">
+									{d.label} ({d.state})
+								</Text>
+							))
+						)}
+					</Group>
+				))}
+			</Stack>
+
+			{/* Underlying detector evidence. */}
+			{why.evidence.length > 0 && (
+				<Table.ScrollContainer minWidth={360}>
+					<Table striped data-testid="canvas-table-why-evidence">
+						<Table.Thead>
+							<Table.Tr>
+								<Table.Th>Dimension</Table.Th>
+								<Table.Th>Detector</Table.Th>
+								<Table.Th>Score</Table.Th>
+								<Table.Th>Detail</Table.Th>
+							</Table.Tr>
+						</Table.Thead>
+						<Table.Tbody>
+							{why.evidence.map((e) => {
+								// The readable dimension: the last path segment, humanized.
+								// The dotted `dimension_path` stays a hover tooltip only.
+								const dimLeaf = e.dimension_path.split(".").at(-1) ?? "";
+								return (
+									<Table.Tr key={`${e.dimension_path}-${e.detector_id}`}>
+										<Table.Td>
+											<Text
+												span
+												size="xs"
+												title={e.dimension_path || undefined}
+											>
+												{humanizeIdentifier(dimLeaf) || "—"}
+											</Text>
+										</Table.Td>
+										<Table.Td>
+											<Text span size="xs" c="dimmed">
+												{humanizeIdentifier(e.detector_id) || e.detector_id}
+											</Text>
+										</Table.Td>
+										<Table.Td>{e.score.toFixed(2)}</Table.Td>
+										<Table.Td>
+											<EvidenceDetail detail={e.detail} />
+										</Table.Td>
+									</Table.Tr>
+								);
+							})}
+						</Table.Tbody>
+					</Table>
+				</Table.ScrollContainer>
+			)}
+		</Stack>
+	);
+}

--- a/packages/cockpit/src/ui/cockpit/widgets/table-why.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-why.tsx
@@ -1,17 +1,21 @@
 // Table-why widget (DAT-434) — renders the `why_table` result: the synthesized
 // narrative, the per-intent drivers, and the underlying detector evidence for
 // ONE table's session-grain readiness (the begin_session table analog of
-// column-why, which this mirrors). The bands/drivers are the engine's
-// persisted values; this widget only displays them.
+// column-why). The shared blocks live in why-detail.tsx (rule 13); the
+// bands/drivers are the engine's persisted values — this widget only displays.
 //
 // `table_name` arrives in DISPLAY form (`src_<digest>__` stripped, DAT-431);
 // a null name (stale id) renders a dimmed placeholder — never the raw id.
 
-import { Alert, Group, Stack, Table, Text } from "@mantine/core";
-import { humanizeIdentifier } from "#/lib/display-names";
+import { Alert, Group, Stack, Text } from "@mantine/core";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
-import { BandBadge, INTENT_LABEL } from "#/ui/cockpit/widgets/band-badge";
-import { EvidenceDetail } from "#/ui/cockpit/widgets/evidence-detail";
+import { BandBadge } from "#/ui/cockpit/widgets/band-badge";
+import {
+	EvidenceTable,
+	IntentDriversBlock,
+	PendingTeachAlert,
+	SignalsCaption,
+} from "#/ui/cockpit/widgets/why-detail";
 
 export function TableWhyWidget({
 	state,
@@ -61,10 +65,10 @@ export function TableWhyWidget({
 				<BandBadge band={why.band} />
 			</Group>
 
-			<Text size="xs" c="dimmed" data-testid="canvas-table-why-signals">
-				Based on {why.signal_count} signal{why.signal_count === 1 ? "" : "s"}
-				{why.signal_count === 0 ? " — not yet characterised" : ""}.
-			</Text>
+			<SignalsCaption
+				count={why.signal_count}
+				testId="canvas-table-why-signals"
+			/>
 
 			{why.analysis && (
 				<Text size="sm" data-testid="canvas-table-why-analysis">
@@ -79,81 +83,17 @@ export function TableWhyWidget({
 				</Alert>
 			)}
 
-			{why.pending_teaches > 0 && (
-				<Alert color="blue" data-testid="canvas-table-why-pending">
-					{why.pending_teaches} pending teach
-					{why.pending_teaches === 1 ? "" : "es"} may affect this view —
-					consider a replay before trusting it.
-				</Alert>
-			)}
+			<PendingTeachAlert
+				count={why.pending_teaches}
+				testId="canvas-table-why-pending"
+			/>
 
-			{/* Per-intent drivers — the pre-computed diagnosis, ranked by impact. */}
-			<Stack gap={4}>
-				{why.intents.map((i) => (
-					<Group key={i.intent} gap="xs" wrap="wrap" align="center">
-						<Text size="xs" fw={500} w={92}>
-							{INTENT_LABEL[i.intent] ?? i.intent}
-						</Text>
-						<BandBadge band={i.band} />
-						{i.drivers.length === 0 ? (
-							<Text span size="xs" c="dimmed">
-								no drivers
-							</Text>
-						) : (
-							i.drivers.map((d) => (
-								<Text key={d.node} span size="xs" c="dimmed">
-									{d.label} ({d.state})
-								</Text>
-							))
-						)}
-					</Group>
-				))}
-			</Stack>
+			<IntentDriversBlock intents={why.intents} />
 
-			{/* Underlying detector evidence. */}
-			{why.evidence.length > 0 && (
-				<Table.ScrollContainer minWidth={360}>
-					<Table striped data-testid="canvas-table-why-evidence">
-						<Table.Thead>
-							<Table.Tr>
-								<Table.Th>Dimension</Table.Th>
-								<Table.Th>Detector</Table.Th>
-								<Table.Th>Score</Table.Th>
-								<Table.Th>Detail</Table.Th>
-							</Table.Tr>
-						</Table.Thead>
-						<Table.Tbody>
-							{why.evidence.map((e) => {
-								// The readable dimension: the last path segment, humanized.
-								// The dotted `dimension_path` stays a hover tooltip only.
-								const dimLeaf = e.dimension_path.split(".").at(-1) ?? "";
-								return (
-									<Table.Tr key={`${e.dimension_path}-${e.detector_id}`}>
-										<Table.Td>
-											<Text
-												span
-												size="xs"
-												title={e.dimension_path || undefined}
-											>
-												{humanizeIdentifier(dimLeaf) || "—"}
-											</Text>
-										</Table.Td>
-										<Table.Td>
-											<Text span size="xs" c="dimmed">
-												{humanizeIdentifier(e.detector_id) || e.detector_id}
-											</Text>
-										</Table.Td>
-										<Table.Td>{e.score.toFixed(2)}</Table.Td>
-										<Table.Td>
-											<EvidenceDetail detail={e.detail} />
-										</Table.Td>
-									</Table.Tr>
-								);
-							})}
-						</Table.Tbody>
-					</Table>
-				</Table.ScrollContainer>
-			)}
+			<EvidenceTable
+				evidence={why.evidence}
+				testId="canvas-table-why-evidence"
+			/>
 		</Stack>
 	);
 }

--- a/packages/cockpit/src/ui/cockpit/widgets/why-detail.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/why-detail.tsx
@@ -1,0 +1,153 @@
+// Shared why-detail vocabulary (DAT-434) — the blocks every readiness
+// explanation surface renders from: per-intent drivers, the detector-evidence
+// table, the signals caption, and the pending-teach note. Extracted from the
+// column-why / table-why / relationship-why triplication before it drifts
+// (rule 13; the BandBadge lesson — per-widget copies diverged until DAT-451
+// pulled them into band-badge.tsx).
+//
+// Prop types are STRUCTURAL: the three why_* tool results share these shapes
+// field-for-field, so each widget's own result type satisfies them without a
+// cast — and a tool whose shape diverges fails tsc here, loudly.
+
+import { Alert, Group, Stack, Table, Text } from "@mantine/core";
+import { humanizeIdentifier } from "#/lib/display-names";
+import { BandBadge, INTENT_LABEL } from "#/ui/cockpit/widgets/band-badge";
+import { EvidenceDetail } from "#/ui/cockpit/widgets/evidence-detail";
+
+/** "table.column" endpoint label from nullable display names — NEVER an id. */
+export function relationshipEndpointLabel(
+	tableName: string | null,
+	columnName: string | null,
+): string {
+	const table = tableName ?? "(unknown table)";
+	const column = columnName ?? "(unknown column)";
+	return `${table}.${column}`;
+}
+
+interface IntentExplanationLike {
+	intent: string;
+	band: string;
+	drivers: ReadonlyArray<{ node: string; label: string; state: string }>;
+}
+
+interface EvidenceSignalLike {
+	dimension_path: string;
+	detector_id: string;
+	score: number;
+	detail: string;
+}
+
+/** "Based on N signals" caption; zero reads as not-yet-characterised. */
+export function SignalsCaption({
+	count,
+	testId,
+}: {
+	count: number;
+	testId: string;
+}) {
+	return (
+		<Text size="xs" c="dimmed" data-testid={testId}>
+			Based on {count} signal{count === 1 ? "" : "s"}
+			{count === 0 ? " — not yet characterised" : ""}.
+		</Text>
+	);
+}
+
+/** The pending-teach advisory — identical wording on every readiness surface. */
+export function PendingTeachAlert({
+	count,
+	testId,
+}: {
+	count: number;
+	testId: string;
+}) {
+	if (count <= 0) return null;
+	return (
+		<Alert color="blue" data-testid={testId}>
+			{count} pending teach
+			{count === 1 ? "" : "es"} may affect this view — consider a replay before
+			trusting it.
+		</Alert>
+	);
+}
+
+/** Per-intent drivers — the pre-computed diagnosis, ranked by impact. */
+export function IntentDriversBlock({
+	intents,
+}: {
+	intents: ReadonlyArray<IntentExplanationLike>;
+}) {
+	return (
+		<Stack gap={4}>
+			{intents.map((i) => (
+				<Group key={i.intent} gap="xs" wrap="wrap" align="center">
+					<Text size="xs" fw={500} w={92}>
+						{INTENT_LABEL[i.intent] ?? i.intent}
+					</Text>
+					<BandBadge band={i.band} />
+					{i.drivers.length === 0 ? (
+						<Text span size="xs" c="dimmed">
+							no drivers
+						</Text>
+					) : (
+						i.drivers.map((d) => (
+							<Text key={d.node} span size="xs" c="dimmed">
+								{d.label} ({d.state})
+							</Text>
+						))
+					)}
+				</Group>
+			))}
+		</Stack>
+	);
+}
+
+/** The detector-evidence table: readable dimension leaf (dotted path stays a
+ * hover tooltip), detector, score, and the sanitized key→value detail through
+ * the shared EvidenceDetail renderer. Renders nothing for empty evidence. */
+export function EvidenceTable({
+	evidence,
+	testId,
+}: {
+	evidence: ReadonlyArray<EvidenceSignalLike>;
+	testId: string;
+}) {
+	if (evidence.length === 0) return null;
+	return (
+		<Table.ScrollContainer minWidth={360}>
+			<Table striped data-testid={testId}>
+				<Table.Thead>
+					<Table.Tr>
+						<Table.Th>Dimension</Table.Th>
+						<Table.Th>Detector</Table.Th>
+						<Table.Th>Score</Table.Th>
+						<Table.Th>Detail</Table.Th>
+					</Table.Tr>
+				</Table.Thead>
+				<Table.Tbody>
+					{evidence.map((e) => {
+						const dimLeaf = e.dimension_path.split(".").at(-1) ?? "";
+						return (
+							<Table.Tr key={`${e.dimension_path}-${e.detector_id}`}>
+								<Table.Td>
+									<Text span size="xs" title={e.dimension_path || undefined}>
+										{humanizeIdentifier(dimLeaf) || "—"}
+									</Text>
+								</Table.Td>
+								<Table.Td>
+									<Text span size="xs" c="dimmed">
+										{humanizeIdentifier(e.detector_id) || e.detector_id}
+									</Text>
+								</Table.Td>
+								<Table.Td>{e.score.toFixed(2)}</Table.Td>
+								<Table.Td>
+									<EvidenceDetail detail={e.detail} />
+								</Table.Td>
+							</Table.Tr>
+						);
+					})}
+				</Table.Tbody>
+			</Table>
+		</Table.ScrollContainer>
+	);
+}


### PR DESCRIPTION
## Task

DAT-434 — https://real-dataraum.atlassian.net/browse/DAT-434 (epic DAT-356; cockpit-only; from the 2026-06-05 live-smoke triage)

Three readiness tools returned rich structured results but rendered as bare chips — no projector, no canvas kind, no widget.

## What changed

Each tool lands the full canvas seam (the established extension contract: one projector case + one canvas member + one `register()` line):

- **table-why / relationship-why** mirror column-why: narrative, per-intent drivers, detector evidence (shared `EvidenceDetail` key→value renderer), explicit not-found / not-analyzed / no-signals / pending-teach states.
- **relationship-list**: one row per pair (display names, band, top drivers), 100-row cap + overflow tail (rule 15); row click drives the `why_relationship` drill-down through the chat loop with session/column ids in the **model-only refs part** — never the visible bubble.
- Chips become clickable + rehydrate automatically (`isCanvasTool` derives from the projector map) and get readable titles + summaries.
- **New shared `widgets/why-detail.tsx`** (review-driven, rule 13): the intents/evidence/signals/pending-teach blocks were byte-identical ×3 (pending-teach ×5) — extracted, and **all five** readiness widgets (incl. column-why + table-readiness) now consume it. The BandBadge drift lesson, applied before the drift this time.
- **`found`-guard on the why_* projectors** (review-driven): the SDK's errored-call output is a truthy `{error}` object that previously projected and rendered as "No such table/column" — a failure masquerading as not-found. Error shape now leaves the canvas unchanged (the failure surfaces in the rail). Fixes the same latent flaw in the pre-existing `why_column` projector.

## Acceptance criteria

- [x] All three tools project a canvas member; chips are clickable and rehydrate.
- [x] No `src_<digest>` or raw id appears in any of the new widgets or click-composed messages (null display names render placeholders, never ids; pinned in tests; the agent-name-leaks property suite already covers all three tool projections).
- [x] Loading/empty/error states per the UI quality bar; `bun run check` + `bun run test` green.

## Review

Single strict-reviewer pass (per lead's call): **NEEDS WORK → resolved** — all three findings fixed (why-detail extraction; the `{error}`-shape projector guard, dist-verified; the misleading overflow advice) plus the summary-degradation nit. Reviewer confirmed: display names dist-verified clean through the tool projections, no duplicate-key path (run-scoped reads), orchestrator prompt consistent as-is, agent-name-leaks coverage present.

## Lane smoke

```
bun run check      # 202 files clean
bun run typecheck  # clean
bun run test       # 676/676 (72 files) — 25 new tests
bun run build      # green
```

## Other lanes in flight

#239 (DAT-448/453, engine-side) — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)