### PR TITLE
DAT-435: begin_session progress — engine get_progress query + cockpit session-progress widget

### DIFF
--- a/packages/cockpit/src/routeTree.gen.ts
+++ b/packages/cockpit/src/routeTree.gen.ts
@@ -11,10 +11,10 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as appRouteRouteImport } from './routes/(app)/route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ApiWorkflowProgressRouteImport } from './routes/api/workflow-progress'
 import { Route as ApiUploadRouteImport } from './routes/api/upload'
 import { Route as ApiRunSqlRouteImport } from './routes/api/run-sql'
 import { Route as ApiChatRouteImport } from './routes/api/chat'
-import { Route as ApiAddSourceProgressRouteImport } from './routes/api/add-source-progress'
 import { Route as appSettingsRouteImport } from './routes/(app)/settings'
 import { Route as appWorkspaceWsIdRouteRouteImport } from './routes/(app)/workspace/$wsId/route'
 import { Route as appWorkspaceWsIdWorkflowsRouteImport } from './routes/(app)/workspace/$wsId/workflows'
@@ -32,6 +32,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiWorkflowProgressRoute = ApiWorkflowProgressRouteImport.update({
+  id: '/api/workflow-progress',
+  path: '/api/workflow-progress',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiUploadRoute = ApiUploadRouteImport.update({
   id: '/api/upload',
   path: '/api/upload',
@@ -45,11 +50,6 @@ const ApiRunSqlRoute = ApiRunSqlRouteImport.update({
 const ApiChatRoute = ApiChatRouteImport.update({
   id: '/api/chat',
   path: '/api/chat',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiAddSourceProgressRoute = ApiAddSourceProgressRouteImport.update({
-  id: '/api/add-source-progress',
-  path: '/api/add-source-progress',
   getParentRoute: () => rootRouteImport,
 } as any)
 const appSettingsRoute = appSettingsRouteImport.update({
@@ -94,10 +94,10 @@ const appWorkspaceWsIdCockpitRoute = appWorkspaceWsIdCockpitRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/settings': typeof appSettingsRoute
-  '/api/add-source-progress': typeof ApiAddSourceProgressRoute
   '/api/chat': typeof ApiChatRoute
   '/api/run-sql': typeof ApiRunSqlRoute
   '/api/upload': typeof ApiUploadRoute
+  '/api/workflow-progress': typeof ApiWorkflowProgressRoute
   '/workspace/$wsId': typeof appWorkspaceWsIdRouteRouteWithChildren
   '/workspace/$wsId/cockpit': typeof appWorkspaceWsIdCockpitRoute
   '/workspace/$wsId/governance': typeof appWorkspaceWsIdGovernanceRoute
@@ -108,10 +108,10 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/settings': typeof appSettingsRoute
-  '/api/add-source-progress': typeof ApiAddSourceProgressRoute
   '/api/chat': typeof ApiChatRoute
   '/api/run-sql': typeof ApiRunSqlRoute
   '/api/upload': typeof ApiUploadRoute
+  '/api/workflow-progress': typeof ApiWorkflowProgressRoute
   '/workspace/$wsId': typeof appWorkspaceWsIdRouteRouteWithChildren
   '/workspace/$wsId/cockpit': typeof appWorkspaceWsIdCockpitRoute
   '/workspace/$wsId/governance': typeof appWorkspaceWsIdGovernanceRoute
@@ -124,10 +124,10 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/(app)': typeof appRouteRouteWithChildren
   '/(app)/settings': typeof appSettingsRoute
-  '/api/add-source-progress': typeof ApiAddSourceProgressRoute
   '/api/chat': typeof ApiChatRoute
   '/api/run-sql': typeof ApiRunSqlRoute
   '/api/upload': typeof ApiUploadRoute
+  '/api/workflow-progress': typeof ApiWorkflowProgressRoute
   '/(app)/workspace/$wsId': typeof appWorkspaceWsIdRouteRouteWithChildren
   '/(app)/workspace/$wsId/cockpit': typeof appWorkspaceWsIdCockpitRoute
   '/(app)/workspace/$wsId/governance': typeof appWorkspaceWsIdGovernanceRoute
@@ -140,10 +140,10 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/settings'
-    | '/api/add-source-progress'
     | '/api/chat'
     | '/api/run-sql'
     | '/api/upload'
+    | '/api/workflow-progress'
     | '/workspace/$wsId'
     | '/workspace/$wsId/cockpit'
     | '/workspace/$wsId/governance'
@@ -154,10 +154,10 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/settings'
-    | '/api/add-source-progress'
     | '/api/chat'
     | '/api/run-sql'
     | '/api/upload'
+    | '/api/workflow-progress'
     | '/workspace/$wsId'
     | '/workspace/$wsId/cockpit'
     | '/workspace/$wsId/governance'
@@ -169,10 +169,10 @@ export interface FileRouteTypes {
     | '/'
     | '/(app)'
     | '/(app)/settings'
-    | '/api/add-source-progress'
     | '/api/chat'
     | '/api/run-sql'
     | '/api/upload'
+    | '/api/workflow-progress'
     | '/(app)/workspace/$wsId'
     | '/(app)/workspace/$wsId/cockpit'
     | '/(app)/workspace/$wsId/governance'
@@ -184,10 +184,10 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   appRouteRoute: typeof appRouteRouteWithChildren
-  ApiAddSourceProgressRoute: typeof ApiAddSourceProgressRoute
   ApiChatRoute: typeof ApiChatRoute
   ApiRunSqlRoute: typeof ApiRunSqlRoute
   ApiUploadRoute: typeof ApiUploadRoute
+  ApiWorkflowProgressRoute: typeof ApiWorkflowProgressRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -204,6 +204,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/workflow-progress': {
+      id: '/api/workflow-progress'
+      path: '/api/workflow-progress'
+      fullPath: '/api/workflow-progress'
+      preLoaderRoute: typeof ApiWorkflowProgressRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/upload': {
@@ -225,13 +232,6 @@ declare module '@tanstack/react-router' {
       path: '/api/chat'
       fullPath: '/api/chat'
       preLoaderRoute: typeof ApiChatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/add-source-progress': {
-      id: '/api/add-source-progress'
-      path: '/api/add-source-progress'
-      fullPath: '/api/add-source-progress'
-      preLoaderRoute: typeof ApiAddSourceProgressRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/(app)/settings': {
@@ -324,10 +324,10 @@ const appRouteRouteWithChildren = appRouteRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   appRouteRoute: appRouteRouteWithChildren,
-  ApiAddSourceProgressRoute: ApiAddSourceProgressRoute,
   ApiChatRoute: ApiChatRoute,
   ApiRunSqlRoute: ApiRunSqlRoute,
   ApiUploadRoute: ApiUploadRoute,
+  ApiWorkflowProgressRoute: ApiWorkflowProgressRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/packages/cockpit/src/routes/api/workflow-progress.ts
+++ b/packages/cockpit/src/routes/api/workflow-progress.ts
@@ -1,17 +1,17 @@
-// add_source progress endpoint (DAT-352) — the read side the MeasureProgress
-// widget polls.
+// Workflow progress endpoint (DAT-352 add_source; DAT-435 begin_session) —
+// the read side the progress widgets poll.
 //
-// A thin I/O shell over `getAddSourceProgress` (temporal/progress.ts): parse +
+// A thin I/O shell over `getWorkflowProgress` (temporal/progress.ts): parse +
 // validate `{workflow_id, run_id}`, query the run's `get_progress` + describe(),
 // return the snapshot + `done`. POST (not GET) so the run identity rides in the
-// body, not the URL. The widget posts here on a TanStack Query `refetchInterval`
+// body, not the URL. The widgets post here on a TanStack Query `refetchInterval`
 // rather than importing the server module — keeping config/Temporal deps out of
 // the client bundle, same as `/api/run-sql`.
 
 import { createFileRoute } from "@tanstack/react-router";
 import {
-	AddSourceProgressInputSchema,
-	getAddSourceProgress,
+	getWorkflowProgress,
+	WorkflowProgressInputSchema,
 } from "../../temporal/progress";
 
 function badRequest(message: string): Response {
@@ -21,7 +21,7 @@ function badRequest(message: string): Response {
 	});
 }
 
-export const Route = createFileRoute("/api/add-source-progress")({
+export const Route = createFileRoute("/api/workflow-progress")({
 	server: {
 		handlers: {
 			POST: async ({ request }) => {
@@ -31,7 +31,7 @@ export const Route = createFileRoute("/api/add-source-progress")({
 				} catch {
 					return badRequest("Request body must be JSON.");
 				}
-				const parsed = AddSourceProgressInputSchema.safeParse(raw);
+				const parsed = WorkflowProgressInputSchema.safeParse(raw);
 				if (!parsed.success) {
 					return badRequest(
 						parsed.error.issues[0]?.message ?? "Invalid input.",
@@ -39,10 +39,10 @@ export const Route = createFileRoute("/api/add-source-progress")({
 				}
 
 				try {
-					const result = await getAddSourceProgress(parsed.data);
+					const result = await getWorkflowProgress(parsed.data);
 					return Response.json(result);
 				} catch (err) {
-					console.error("add-source-progress query failed", err);
+					console.error("workflow-progress query failed", err);
 					return new Response(
 						JSON.stringify({ error: "Internal server error." }),
 						{

--- a/packages/cockpit/src/temporal/progress.test.ts
+++ b/packages/cockpit/src/temporal/progress.test.ts
@@ -1,7 +1,7 @@
 // Unit tests for the add_source progress poll (DAT-352).
 //
 // Mocked seams: `#/config` (Temporal config) + `@temporalio/client` (a handle
-// whose query/describe the test scripts). We assert: getAddSourceProgress queries
+// whose query/describe the test scripts). We assert: getWorkflowProgress queries
 // `get_progress` on getHandle(id, runId) and maps to the mirrored snake_case
 // shape; `done` is true on phase==="done" OR a terminal describe() status; and
 // the unconfigured guard throws like replay.ts.
@@ -24,7 +24,7 @@ const h = vi.hoisted(() => ({
 		tables_total: number;
 		tables_completed: number;
 		// Optional so the done/terminal-status tests can omit them and exercise
-		// the `?? []` / `?? null` defaults in getAddSourceProgress.
+		// the `?? []` / `?? null` defaults in getWorkflowProgress.
 		tables?: { raw_table_id: string; status: string }[];
 		failure?: {
 			message: string;
@@ -89,7 +89,7 @@ vi.mock("@temporalio/client", () => ({
 	}),
 }));
 
-import { getAddSourceProgress, isProgressDone } from "./progress";
+import { getWorkflowProgress, isProgressDone } from "./progress";
 
 beforeEach(() => {
 	h.config = { temporalHost: "localhost:7233", temporalNamespace: "default" };
@@ -112,14 +112,14 @@ beforeEach(() => {
 	whereMock.mockClear();
 });
 
-describe("getAddSourceProgress (DAT-352)", () => {
+describe("getWorkflowProgress (DAT-352)", () => {
 	it("queries get_progress on the precise (workflowId, runId) and maps the shape", async () => {
 		h.snapshot = {
 			phase: "processing_tables",
 			tables_total: 4,
 			tables_completed: 2,
 		};
-		const result = await getAddSourceProgress({
+		const result = await getWorkflowProgress({
 			workflow_id: "addsource-ws-src",
 			run_id: "run-1",
 		});
@@ -157,7 +157,7 @@ describe("getAddSourceProgress (DAT-352)", () => {
 			{ tableId: "r1", tableName: "orders" },
 			{ tableId: "r2", tableName: "customers" },
 		];
-		const result = await getAddSourceProgress({
+		const result = await getWorkflowProgress({
 			workflow_id: "w",
 			run_id: "r",
 		});
@@ -183,7 +183,7 @@ describe("getAddSourceProgress (DAT-352)", () => {
 			failure: null,
 		};
 		h.tableNameRows = [];
-		const result = await getAddSourceProgress({
+		const result = await getWorkflowProgress({
 			workflow_id: "w",
 			run_id: "r",
 		});
@@ -199,7 +199,7 @@ describe("getAddSourceProgress (DAT-352)", () => {
 	it("reports done when phase reaches the terminal 'done'", async () => {
 		h.snapshot = { phase: "done", tables_total: 4, tables_completed: 4 };
 		h.status = "COMPLETED";
-		const result = await getAddSourceProgress({
+		const result = await getWorkflowProgress({
 			workflow_id: "w",
 			run_id: "r",
 		});
@@ -215,7 +215,7 @@ describe("getAddSourceProgress (DAT-352)", () => {
 			tables_completed: 1,
 		};
 		h.status = "FAILED";
-		const result = await getAddSourceProgress({
+		const result = await getWorkflowProgress({
 			workflow_id: "w",
 			run_id: "r",
 		});
@@ -224,16 +224,17 @@ describe("getAddSourceProgress (DAT-352)", () => {
 		expect(result.phase).toBe("processing_tables");
 	});
 
-	it("falls back to describe()-only when the workflow has no get_progress query (begin_session)", async () => {
-		// beginSessionWorkflow registers no get_progress — the query raises
-		// WorkflowQueryFailedError; the poll degrades to status + done, no phase detail.
+	it("falls back to describe()-only when the workflow has no get_progress query (operating_model)", async () => {
+		// operatingModelWorkflow registers no get_progress (begin_session does
+		// since DAT-435) — the query raises WorkflowQueryFailedError; the poll
+		// degrades to status + done, no phase detail.
 		const err = new Error("query not registered: get_progress");
 		err.name = "WorkflowQueryFailedError";
 		h.queryError = err;
 		h.status = "RUNNING";
 
-		const result = await getAddSourceProgress({
-			workflow_id: "beginsession-ws-sess",
+		const result = await getWorkflowProgress({
+			workflow_id: "operatingmodel-ws-sess",
 			run_id: "run-1",
 		});
 		expect(result).toEqual({
@@ -253,7 +254,7 @@ describe("getAddSourceProgress (DAT-352)", () => {
 		h.queryError = err;
 		h.status = "COMPLETED";
 
-		const result = await getAddSourceProgress({
+		const result = await getWorkflowProgress({
 			workflow_id: "w",
 			run_id: "r",
 		});
@@ -265,14 +266,14 @@ describe("getAddSourceProgress (DAT-352)", () => {
 	it("rethrows a non-query-handler query failure (a real error is not swallowed)", async () => {
 		h.queryError = new Error("connection reset"); // name !== WorkflowQueryFailedError
 		await expect(
-			getAddSourceProgress({ workflow_id: "w", run_id: "r" }),
+			getWorkflowProgress({ workflow_id: "w", run_id: "r" }),
 		).rejects.toThrow(/connection reset/);
 	});
 
 	it("throws when Temporal is unconfigured (like replay.ts)", async () => {
 		h.config = {};
 		await expect(
-			getAddSourceProgress({ workflow_id: "w", run_id: "r" }),
+			getWorkflowProgress({ workflow_id: "w", run_id: "r" }),
 		).rejects.toThrow(/Temporal client is not configured/);
 		expect(getHandleMock).not.toHaveBeenCalled();
 	});

--- a/packages/cockpit/src/temporal/progress.ts
+++ b/packages/cockpit/src/temporal/progress.ts
@@ -1,12 +1,16 @@
-// add_source progress poll (DAT-352) — the read side of the TRIGGER.
+// Workflow progress poll (DAT-352 add_source; DAT-435 begin_session) — the
+// read side of the TRIGGER.
 //
-// Queries the running addSourceWorkflow's `get_progress` @workflow.query (DAT-406)
-// for the parent-level ProgressSnapshot {phase, tables_total, tables_completed},
-// plus its describe() status so the poll can stop on a terminal run (a workflow
-// that FAILED/TERMINATED never reaches phase==="done", so phase alone can't tell
-// a stuck run from a finished one).
+// Queries a running workflow's `get_progress` @workflow.query (DAT-406) for the
+// ProgressSnapshot {phase, tables_total, tables_completed}, plus its describe()
+// status so the poll can stop on a terminal run (a workflow that
+// FAILED/TERMINATED never reaches phase==="done", so phase alone can't tell a
+// stuck run from a finished one). `addSourceWorkflow` and `beginSessionWorkflow`
+// both serve the SAME query name + snapshot shape (one seam, no per-workflow
+// branch); a workflow without the query (operatingModelWorkflow) degrades to
+// describe()-only.
 //
-// Targets the PRECISE run_id: the workflow id is reused per source under
+// Targets the PRECISE run_id: the workflow id is reused per session under
 // ALLOW_DUPLICATE across replays, so getHandle(id, runId) pins the iteration the
 // TRIGGER returned. NON-mutating (query + describe) → safe to poll on an interval.
 
@@ -37,7 +41,7 @@ const TERMINAL_STATUSES = new Set([
 	"CONTINUED_AS_NEW",
 ]);
 
-export interface AddSourceProgressInput {
+export interface WorkflowProgressInput {
 	workflow_id: string;
 	run_id: string;
 }
@@ -49,8 +53,8 @@ export interface TableStep {
 	status: "running" | "done" | "failed";
 }
 
-/** The progress snapshot plus the run's terminal-ness — what the widget polls. */
-export interface AddSourceProgress {
+/** The progress snapshot plus the run's terminal-ness — what the widgets poll. */
+export interface WorkflowProgress {
 	phase: string;
 	tables_total: number;
 	tables_completed: number;
@@ -111,16 +115,18 @@ export function isProgressDone(phase: string, status: string): boolean {
  * (workflowId, runId) so a replay/re-run iteration sharing the workflow id is
  * never confused for the run being watched.
  *
- * Works for any cockpit-triggered workflow. `addSourceWorkflow` registers a
- * `get_progress` @workflow.query (rich phase + per-table fan-out detail);
- * `beginSessionWorkflow` is sequential (no fan-out) and registers none, so its
- * query raises `WorkflowQueryFailedError` — caught here to fall back to a
- * `describe()`-only status (no phase detail, but the authoritative run status +
- * `done`). Any OTHER query error is a real failure and rethrows.
+ * Works for any cockpit-triggered workflow. `addSourceWorkflow` (DAT-406) and
+ * `beginSessionWorkflow` (DAT-435) both register a `get_progress`
+ * @workflow.query serving the same snapshot shape (add_source with per-table
+ * fan-out detail, begin_session sequential with empty fan-out fields). A
+ * workflow without the query (`operatingModelWorkflow`) raises
+ * `WorkflowQueryFailedError` — caught here to fall back to a `describe()`-only
+ * status (no phase detail, but the authoritative run status + `done`). Any
+ * OTHER query error is a real failure and rethrows.
  */
-export async function getAddSourceProgress(
-	input: AddSourceProgressInput,
-): Promise<AddSourceProgress> {
+export async function getWorkflowProgress(
+	input: WorkflowProgressInput,
+): Promise<WorkflowProgress> {
 	const { host, namespace } = requireTemporalConfig();
 
 	const connection = await Connection.connect({ address: host });
@@ -134,7 +140,7 @@ export async function getAddSourceProgress(
 		try {
 			snapshot = await handle.query<ProgressSnapshot, []>("get_progress");
 		} catch (err) {
-			// A workflow with no get_progress handler (begin_session) raises
+			// A workflow with no get_progress handler (operating_model) raises
 			// WorkflowQueryFailedError — degrade to describe()-only. Match on the
 			// error name to avoid coupling to the SDK's class export.
 			if (!(err instanceof Error) || err.name !== "WorkflowQueryFailedError") {
@@ -171,9 +177,9 @@ export async function getAddSourceProgress(
 	}
 }
 
-/** Request-body schema for `POST /api/add-source-progress` — the API route
+/** Request-body schema for `POST /api/workflow-progress` — the API route
  * validates the polled `{workflow_id, run_id}` against this before querying. */
-export const AddSourceProgressInputSchema = z.object({
+export const WorkflowProgressInputSchema = z.object({
 	workflow_id: z.string().min(1),
 	run_id: z.string().min(1),
 });

--- a/packages/cockpit/src/tools/agent-name-leaks.test.ts
+++ b/packages/cockpit/src/tools/agent-name-leaks.test.ts
@@ -26,7 +26,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("#/config", () => ({ config: { anthropicApiKey: "test" } }));
 vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 
-import type { AddSourceProgress } from "../temporal/progress";
+import type { WorkflowProgress } from "../temporal/progress";
 import { buildInventory, type InventoryTableRow } from "./list-tables";
 import {
 	type ColumnNameLookup,
@@ -237,7 +237,7 @@ describe("agent name-leak property (DAT-433)", () => {
 	});
 
 	it("workflow_status: full result is digest-free, failure surfaced sanitized", () => {
-		const progress: AddSourceProgress = {
+		const progress: WorkflowProgress = {
 			phase: "typing",
 			tables_total: 2,
 			tables_completed: 1,
@@ -270,7 +270,7 @@ describe("agent name-leak property (DAT-433)", () => {
 		// the digest appears BARE (`uploads/<digest>/`, no `src_` prefix), so the
 		// generic /src_<40hex>/ property regex is blind to it. Assert on the
 		// fixture's specific digest instead.
-		const progress: AddSourceProgress = {
+		const progress: WorkflowProgress = {
 			phase: "import",
 			tables_total: 0,
 			tables_completed: 0,

--- a/packages/cockpit/src/tools/workflow-status.ts
+++ b/packages/cockpit/src/tools/workflow-status.ts
@@ -5,8 +5,9 @@
 // way to query the run, the agent had no signal for "is it done?" and fell back
 // to re-calling list_tables until tables appeared — a fragile proxy that can't
 // tell RUNNING from FAILED. This tool wraps the SAME cross-language
-// `get_progress` query the progress widget polls (`getAddSourceProgress`), so
-// the agent can check completion directly.
+// `get_progress` query the progress widgets poll (`getWorkflowProgress`), so
+// the agent can check completion directly. begin_session serves the same query
+// (DAT-435), so its runs report real phases here too.
 //
 // The agent-facing result is an EXPLICIT projection of that progress object
 // (DAT-433) — never the object itself, whose extra fields used to be withheld
@@ -25,8 +26,8 @@ import { z } from "zod";
 
 import { stripSrcDigests } from "../lib/display-names";
 import {
-	type AddSourceProgress,
-	getAddSourceProgress,
+	getWorkflowProgress,
+	type WorkflowProgress,
 } from "../temporal/progress";
 
 // Why the run ended badly — projected from `ProgressFailure` (temporal/types.ts).
@@ -61,7 +62,7 @@ export type WorkflowStatusResult = z.infer<typeof WorkflowStatus>;
  * carries a content-keyed `src_<digest>` name.
  */
 export function projectWorkflowStatus(
-	progress: AddSourceProgress,
+	progress: WorkflowProgress,
 ): WorkflowStatusResult {
 	return {
 		phase: progress.phase,
@@ -87,8 +88,8 @@ export const workflowStatusTool = toolDefinition({
 		"Returns the current phase, tables_completed / tables_total, the run status, " +
 		"`done` (true once the run is closed), and — when the run ended badly — " +
 		"`failure` with the root-cause message, the phase in flight, and the failing " +
-		"table's id (look it up via list_tables to name it). begin_session is " +
-		"sequential, so it reports status + done without per-phase detail. Use this " +
+		"table's id (look it up via list_tables to name it). begin_session reports " +
+		"its real phases too (sequential — tables_total/completed stay 0). Use this " +
 		"to detect completion — do NOT poll list_tables as a proxy.",
 	inputSchema: z.object({
 		workflow_id: z
@@ -106,5 +107,5 @@ export const workflowStatusTool = toolDefinition({
 	}),
 	outputSchema: WorkflowStatus,
 }).server(async (input) =>
-	projectWorkflowStatus(await getAddSourceProgress(input)),
+	projectWorkflowStatus(await getWorkflowProgress(input)),
 );

--- a/packages/cockpit/src/ui/cockpit/canvas-registry.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-registry.ts
@@ -16,6 +16,7 @@ import { RelationshipListWidget } from "#/ui/cockpit/widgets/relationship-list";
 import { RelationshipWhyWidget } from "#/ui/cockpit/widgets/relationship-why";
 import { ResultGridWidget } from "#/ui/cockpit/widgets/result-grid";
 import { SchemaPreviewWidget } from "#/ui/cockpit/widgets/schema-preview";
+import { SessionProgressWidget } from "#/ui/cockpit/widgets/session-progress";
 import { SourceListWidget } from "#/ui/cockpit/widgets/source-list";
 import { TableReadinessWidget } from "#/ui/cockpit/widgets/table-readiness";
 import { TableWhyWidget } from "#/ui/cockpit/widgets/table-why";
@@ -40,4 +41,5 @@ export const canvasRegistry = new WidgetRegistry()
 	.register({ kind: "relationship-why", component: RelationshipWhyWidget })
 	.register({ kind: "relationship-list", component: RelationshipListWidget })
 	.register({ kind: "add-source-progress", component: MeasureProgressWidget })
+	.register({ kind: "session-progress", component: SessionProgressWidget })
 	.register({ kind: "upload-area", component: UploadAreaWidget });

--- a/packages/cockpit/src/ui/cockpit/canvas-state.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-state.ts
@@ -54,6 +54,10 @@ export type CanvasState =
 	// select STARTS the import, so its result carries the run ids. (The old
 	// trigger-button UI action that used to seed this member is retired.)
 	| { kind: "add-source-progress"; workflowId: string; runId: string }
+	// DAT-435: live begin_session workflow progress — the session analogue of
+	// add-source-progress. Same carry (the started run's ids; the widget polls
+	// `get_progress`), projected from the begin_session TOOL RESULT.
+	| { kind: "session-progress"; workflowId: string; runId: string }
 	// DAT-385 P2: the human-facing SQL grid. The P1 stream server is stateless
 	// (no queryId→SQL registry), so the grid re-issues the query — it carries the
 	// `sql` (+ optional bind `params`) the mapper lifts off the `run_sql` tool

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -31,6 +31,8 @@ describe("toolLabel", () => {
 		expect(toolLabel("connect", true)).toBe("Source schema");
 		expect(toolLabel("teach", true)).toBe("Taught");
 		expect(toolLabel("replay", true)).toBe("Re-ran");
+		expect(toolLabel("begin_session")).toBe("Starting session");
+		expect(toolLabel("begin_session", true)).toBe("Session started");
 	});
 
 	it("leaves already-settled noun titles unchanged when done", () => {
@@ -41,8 +43,8 @@ describe("toolLabel", () => {
 });
 
 describe("isCanvasTool", () => {
-	it("marks the 13 canvas-producing tools clickable", () => {
-		expect(CANVAS_TOOLS.size).toBe(13);
+	it("marks the 14 canvas-producing tools clickable", () => {
+		expect(CANVAS_TOOLS.size).toBe(14);
 		for (const name of [
 			"list_sources",
 			"list_tables",
@@ -54,6 +56,7 @@ describe("isCanvasTool", () => {
 			"connect",
 			"frame",
 			"select",
+			"begin_session",
 			"run_sql",
 			"replay",
 			"upload",
@@ -272,6 +275,27 @@ describe("toolChipSummary — completed canvas tools (no JSON, readable)", () =>
 		expect(
 			toolChipSummary("select", {}, { name: "orders", source_type: "file" }),
 		).toBe("orders (file)");
+	});
+
+	it("begin_session counts the selection and never leaks run/session ids (DAT-435)", () => {
+		const input = { table_ids: ["t-1", "t-2", "t-3"] };
+		const output = {
+			workflow_id: "beginsession-ws-abc",
+			run_id: "5f6e7d8c-0000-0000-0000-000000000000",
+			session_id: "9a8b7c6d-0000-0000-0000-000000000000",
+			table_ids: ["t-1", "t-2", "t-3"],
+		};
+		expect(toolChipSummary("begin_session", input, undefined)).toBe(
+			"starting the session…",
+		);
+		const done = toolChipSummary("begin_session", input, output);
+		expect(done).toBe("analyzing 3 tables");
+		expect(done).not.toContain("beginsession-ws-abc");
+		expect(done).not.toContain("5f6e7d8c");
+		// No input selection yet (arguments still streaming) → neutral line.
+		expect(toolChipSummary("begin_session", undefined, output)).toBe(
+			"analysis running",
+		);
 	});
 
 	it("run_sql shows the SQL from the call input (truncated, flattened)", () => {

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -63,6 +63,7 @@ const TOOL_LABELS: Record<string, string> = {
 	connect: "Reading source",
 	frame: "Concepts",
 	select: "Registering source",
+	begin_session: "Starting session",
 	run_sql: "Query",
 	probe: "Data check",
 	teach: "Teaching",
@@ -77,6 +78,7 @@ const TOOL_LABELS: Record<string, string> = {
 const TOOL_LABELS_DONE: Record<string, string> = {
 	connect: "Source schema",
 	select: "Registered source",
+	begin_session: "Session started",
 	teach: "Taught",
 	replay: "Re-ran",
 };
@@ -224,6 +226,21 @@ export function toolChipSummary(
 			const s = output as SelectResult | undefined;
 			if (!s) return "registering source…";
 			return `${s.name} (${s.source_type})`;
+		}
+		case "begin_session": {
+			// The tool returns as soon as the workflow STARTS — the run keeps going
+			// (the session-progress widget tracks it), so the settled summary still
+			// reads as in-flight analysis. Count from the INPUT selection (present
+			// from approval time); ids (workflow/run/session uuids) never reach the
+			// chip.
+			const args = input as { table_ids?: unknown } | undefined;
+			const count = Array.isArray(args?.table_ids)
+				? args.table_ids.length
+				: null;
+			if (!done) return "starting the session…";
+			return count !== null
+				? `analyzing ${plural(count, "table")}`
+				: "analysis running";
 		}
 		case "run_sql": {
 			const sql = (input as { sql?: string } | undefined)?.sql;

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
@@ -309,6 +309,27 @@ describe("toolResultToCanvas", () => {
 		expect(toolResultToCanvas("replay", {})).toBeNull();
 	});
 
+	it("maps begin_session to the session-progress canvas (DAT-435)", () => {
+		expect(
+			toolResultToCanvas("begin_session", {
+				workflow_id: "beginsession-ws-sess",
+				run_id: "run-1",
+				session_id: "sess-1",
+				table_ids: ["t1", "t2"],
+			}),
+		).toEqual({
+			kind: "session-progress",
+			workflowId: "beginsession-ws-sess",
+			runId: "run-1",
+		});
+		// A failed start (no ids — e.g. the SDK's `{error}` output) leaves the
+		// canvas unchanged; the failure surfaces in the chat rail.
+		expect(toolResultToCanvas("begin_session", null)).toBeNull();
+		expect(
+			toolResultToCanvas("begin_session", { error: "session row missing" }),
+		).toBeNull();
+	});
+
 	it("returns null for a missing or NON-array list result (no .filter/.reduce crash)", () => {
 		// A partial/streaming or errored output can be undefined or a truthy
 		// NON-array; projecting it crashed SourceList/Inventory on .filter/.reduce/

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -127,6 +127,20 @@ const PROJECTORS: Record<string, CanvasProjector> = {
 				}
 			: null;
 	},
+	// begin_session STARTS the session workflow and returns immediately
+	// (DAT-435): the result carries the started run's ids, so project the live
+	// session-progress widget — the session analogue of select/replay above. A
+	// failed start (no ids) leaves the canvas unchanged.
+	begin_session: (result) => {
+		const r = result as { workflow_id?: string; run_id?: string } | null;
+		return r?.workflow_id && r?.run_id
+			? {
+					kind: "session-progress",
+					workflowId: r.workflow_id,
+					runId: r.run_id,
+				}
+			: null;
+	},
 	// The agent's run_sql returns a small sample for the LLM; the human grid
 	// re-issues the query against the stateless streaming endpoint, so it maps
 	// from the CALL INPUT (sql + bind params), not the result. No sql → unchanged.

--- a/packages/cockpit/src/ui/cockpit/widget-registry.test.ts
+++ b/packages/cockpit/src/ui/cockpit/widget-registry.test.ts
@@ -50,6 +50,10 @@ describe("WidgetRegistry (DAT-347)", () => {
 		expect(canvasRegistry.has("add-source-progress")).toBe(true);
 	});
 
+	it("the shared canvas registry has the session-progress widget (DAT-435)", () => {
+		expect(canvasRegistry.has("session-progress")).toBe(true);
+	});
+
 	it("the shared canvas registry has the upload-area widget (redesign)", () => {
 		expect(canvasRegistry.has("upload-area")).toBe(true);
 	});

--- a/packages/cockpit/src/ui/cockpit/widgets/measure-progress.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/measure-progress.test.tsx
@@ -28,7 +28,7 @@ vi.mock("@tanstack/react-query", () => ({
 }));
 
 // The widget only `import type`s from #/temporal/progress (erased) and reaches the
-// server over `fetch("/api/add-source-progress")`, so no config mock is needed —
+// server over `fetch("/api/workflow-progress")`, so no config mock is needed —
 // `useQuery` is mocked, so the queryFn (the fetch) never runs in these units.
 
 import { MeasureProgressWidget } from "#/ui/cockpit/widgets/measure-progress";
@@ -70,7 +70,7 @@ describe("MeasureProgressWidget (DAT-352)", () => {
 		};
 		renderWidget();
 		expect(h.lastOptions?.queryKey).toEqual([
-			"add-source-progress",
+			"workflow-progress",
 			"addsource-ws-src",
 			"run-1",
 		]);

--- a/packages/cockpit/src/ui/cockpit/widgets/measure-progress.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/measure-progress.tsx
@@ -1,34 +1,19 @@
 // MeasureProgress widget (DAT-352) — live per-phase progress for an add_source
 // (or replay) run the TRIGGER started.
 //
-// Polls the engine's `get_progress` @workflow.query (DAT-406) via the
-// `/api/add-source-progress` route (→ `getAddSourceProgress`) on a TanStack Query `refetchInterval` (~1s),
-// keyed on the precise (workflowId, runId) the TRIGGER returned. It STOPS polling
-// once the snapshot reports `done` — either phase==="done" OR a terminal
-// describe() status (so a FAILED run, which never sets "done", still halts).
-//
-// Renders the phase pipeline (import → check_column_limit → processing_tables →
-// semantic_per_column → detect → promote → done) with the current step
-// highlighted, the per-table fan-out tally during processing_tables, plus done /
-// failed states. Receives ONLY {state} (canvas widgets have no sendMessage) —
-// the run identity is on the state.
+// A display config over the shared WorkflowProgressView core
+// (workflow-progress.tsx), which owns the polling (`/api/workflow-progress` on
+// a TanStack Query `refetchInterval`) and the rendering. add_source's pipeline
+// is ungrouped — every raw engine phase (workflows.py advance sequence) is its
+// own badge — and it is the one workflow with a per-table fan-out, so it
+// supplies the tally config. Receives ONLY {state} (canvas widgets have no
+// sendMessage) — the run identity is on the state.
 
-import {
-	Alert,
-	Badge,
-	Group,
-	Loader,
-	Progress,
-	ScrollArea,
-	Stack,
-	Text,
-} from "@mantine/core";
-import { useQuery } from "@tanstack/react-query";
-import { Check, X } from "lucide-react";
-import { displayTableName, stripSrcDigests } from "#/lib/display-names";
-import type { AddSourceProgress, TableStep } from "#/temporal/progress";
-import { PROGRESS_DONE_PHASE } from "#/temporal/types";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
+import {
+	type WorkflowProgressDisplay,
+	WorkflowProgressView,
+} from "#/ui/cockpit/widgets/workflow-progress";
 
 // The phase pipeline in order, with friendly labels. Mirrors the engine's
 // advance sequence (workflows.py): import → check_column_limit →
@@ -45,18 +30,6 @@ const PHASES = [
 	{ key: "done", label: "Done" },
 ] as const;
 
-// How long to count a phase as "active" before it's reached — the index of the
-// reported phase in PHASES; everything before it reads as completed.
-function phaseIndex(phase: string): number {
-	return PHASES.findIndex((p) => p.key === phase);
-}
-
-// The friendly label for a phase key (for the failure message); falls back to
-// the raw key for a forward-compat phase not in PHASES.
-function phaseLabel(phase: string): string {
-	return PHASES.find((p) => p.key === phase)?.label ?? phase;
-}
-
 // Live caption for the phases that carry NO per-table signal: `import` /
 // `check_column_limit` (before the fan-out exists) and `semantic_per_column` /
 // `detect` / `promote` (each ONE run-level activity, workflows.py). For these the
@@ -71,226 +44,33 @@ const PHASE_CAPTION: Record<string, string> = {
 	promote: "Promoting this run's results…",
 };
 
-/** The leading status glyph for one fanned-out table row. */
-function TableStatusIcon({ status }: { status: TableStep["status"] }) {
-	if (status === "done") {
-		return (
-			<Check
-				size={14}
-				color="var(--mantine-color-green-6)"
-				data-testid="table-status-done"
-			/>
-		);
-	}
-	if (status === "failed") {
-		return (
-			<X
-				size={14}
-				color="var(--mantine-color-red-6)"
-				data-testid="table-status-failed"
-			/>
-		);
-	}
-	return <Loader size={12} data-testid="table-status-running" />;
-}
-
-const POLL_INTERVAL_MS = 1000;
-
-/** Poll the progress API route for one run. Throws on a non-2xx so TanStack
- * Query surfaces it as the widget's error state. */
-async function fetchProgress(
-	workflowId: string,
-	runId: string,
-): Promise<AddSourceProgress> {
-	const res = await fetch("/api/add-source-progress", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ workflow_id: workflowId, run_id: runId }),
-	});
-	if (!res.ok) {
-		const body = (await res.json().catch(() => ({}))) as { error?: string };
-		throw new Error(body.error ?? `Progress query failed (${res.status}).`);
-	}
-	return (await res.json()) as AddSourceProgress;
-}
+const ADD_SOURCE_DISPLAY: WorkflowProgressDisplay = {
+	title: "Add source — progress",
+	testId: "measure",
+	groups: PHASES.map((p) => ({ key: p.key, label: p.label, phases: [p.key] })),
+	captions: PHASE_CAPTION,
+	tallyPhase: "processing_tables",
+	tallyLabel: "Typing tables",
+	failurePrefix: "Add source",
+	startingLabel: "Starting add source…",
+	doneMessage: (data) =>
+		data.tables.length > 0
+			? `Done — ${data.tables.length} table${
+					data.tables.length === 1 ? "" : "s"
+				} imported and analyzed. Ask about any table to see its readiness.`
+			: "Done — the source is imported and analyzed.",
+};
 
 export function MeasureProgressWidget({
 	state,
 }: {
 	state: Extract<CanvasState, { kind: "add-source-progress" }>;
 }) {
-	const { workflowId, runId } = state;
-
-	const { data, error, isLoading } = useQuery({
-		queryKey: ["add-source-progress", workflowId, runId],
-		queryFn: () => fetchProgress(workflowId, runId),
-		// Poll until the run is done; then stop (refetchInterval returns false).
-		refetchInterval: (query) =>
-			query.state.data?.done ? false : POLL_INTERVAL_MS,
-		refetchOnWindowFocus: false,
-	});
-
-	if (error) {
-		return (
-			<Stack gap="xs" data-testid="canvas-measure-progress">
-				<Text size="sm" fw={600}>
-					Add source — progress
-				</Text>
-				<Alert color="red" data-testid="canvas-measure-progress-error">
-					Couldn't read workflow progress: {(error as Error).message}
-				</Alert>
-			</Stack>
-		);
-	}
-
-	if (isLoading || !data) {
-		return (
-			<Stack
-				gap="sm"
-				align="center"
-				justify="center"
-				h="100%"
-				data-testid="canvas-measure-progress-loading"
-			>
-				<Loader size="sm" />
-				<Text c="dimmed" size="sm">
-					Starting add source…
-				</Text>
-			</Stack>
-		);
-	}
-
-	const activeIdx = phaseIndex(data.phase);
-	const failed =
-		data.done &&
-		data.phase !== PROGRESS_DONE_PHASE &&
-		data.status !== "COMPLETED";
-	const succeeded =
-		data.phase === PROGRESS_DONE_PHASE || data.status === "COMPLETED";
-
-	// During the per-table fan-out, surface the tally as a determinate bar.
-	const showTally = data.phase === "processing_tables" && data.tables_total > 0;
-	const tallyPct = showTally
-		? Math.round((data.tables_completed / data.tables_total) * 100)
-		: 0;
-
 	return (
-		<Stack gap="sm" data-testid="canvas-measure-progress">
-			{/* No corner spinner: the per-phase pipeline + captions below already
-			    show liveness; a detached top-right Loader read as "stuck". */}
-			<Text size="sm" fw={600}>
-				Add source — progress
-			</Text>
-
-			{/* Phase pipeline — current step highlighted, prior steps done. */}
-			<Group gap="xs" wrap="wrap" data-testid="measure-progress-phases">
-				{PHASES.map((p, i) => {
-					const isActive = i === activeIdx && !data.done;
-					const isPast = activeIdx > i || (succeeded && p.key === "done");
-					const color = isActive ? "blue" : isPast ? "green" : "gray";
-					const variant = isActive || isPast ? "filled" : "light";
-					return (
-						<Badge
-							key={p.key}
-							color={color}
-							variant={variant}
-							size="sm"
-							data-testid={`measure-phase-${p.key}`}
-							data-state={isActive ? "active" : isPast ? "done" : "pending"}
-						>
-							{p.label}
-						</Badge>
-					);
-				})}
-			</Group>
-
-			{showTally && (
-				<Stack gap={4} data-testid="measure-progress-tally">
-					<Text size="xs" c="dimmed">
-						Typing tables: {data.tables_completed} / {data.tables_total}
-					</Text>
-					<Progress value={tallyPct} size="sm" />
-				</Stack>
-			)}
-
-			{/* The reduce phases (semantic / detect) have no per-table signal — show
-			    an indeterminate caption so the surface isn't dead air while they run. */}
-			{!data.done && !showTally && PHASE_CAPTION[data.phase] && (
-				<Group gap="xs" wrap="nowrap" data-testid="measure-progress-caption">
-					<Loader size="xs" />
-					<Text size="xs" c="dimmed">
-						{PHASE_CAPTION[data.phase]}
-					</Text>
-				</Group>
-			)}
-
-			{/* The named steps behind the count — which tables are running / done /
-			    failed. Scrolls past a handful so a wide source can't blow out the
-			    canvas. */}
-			{data.tables.length > 0 && (
-				<ScrollArea.Autosize mah={180} data-testid="measure-progress-tables">
-					<Stack gap={2}>
-						{data.tables.map((t) => (
-							<Group key={t.raw_table_id} gap={6} wrap="nowrap">
-								<TableStatusIcon status={t.status} />
-								<Text
-									size="xs"
-									c={
-										t.status === "failed"
-											? "red"
-											: t.status === "running"
-												? "dimmed"
-												: undefined
-									}
-									truncate
-									data-testid={`measure-table-${t.raw_table_id}`}
-								>
-									{displayTableName(t.name)}
-								</Text>
-							</Group>
-						))}
-					</Stack>
-				</ScrollArea.Autosize>
-			)}
-
-			{succeeded && (
-				<Alert color="green" data-testid="measure-progress-done">
-					{data.tables.length > 0
-						? `Done — ${data.tables.length} table${
-								data.tables.length === 1 ? "" : "s"
-							} imported and analyzed. Ask about any table to see its readiness.`
-						: "Done — the source is imported and analyzed."}
-				</Alert>
-			)}
-
-			{failed && (
-				<Alert color="red" data-testid="measure-progress-failed">
-					{failureMessage(data)}
-				</Alert>
-			)}
-		</Stack>
+		<WorkflowProgressView
+			display={ADD_SOURCE_DISPLAY}
+			workflowId={state.workflowId}
+			runId={state.runId}
+		/>
 	);
-}
-
-/** The human-readable failure line: the engine's root-cause message, scoped to
- * the failed table (by name) or the failed source-level phase. Falls back to the
- * describe() status when the snapshot carried no failure detail (e.g. a run
- * TERMINATED out-of-band, which never stamps `failure`). The engine-built
- * message can embed content-keyed `src_<digest>` names or the staged-upload s3
- * URI — `stripSrcDigests` neutralizes them, the same treatment the agent-facing
- * workflow_status projection applies (DAT-433). */
-function failureMessage(data: AddSourceProgress): string {
-	const f = data.failure;
-	if (!f) {
-		return `The add source run ended in ${data.status.toLowerCase()} at the ${data.phase} phase.`;
-	}
-	if (f.table_id) {
-		// Same name-display rule as the live list — strip the `<source>__` prefix so
-		// a FAILED run reads `trial_balance`, not `finance_data__trial_balance`.
-		const name =
-			data.tables.find((t) => t.raw_table_id === f.table_id)?.name ??
-			`table ${f.table_id.slice(0, 8)}`;
-		return `Add source failed on ${displayTableName(name)}: ${stripSrcDigests(f.message)}`;
-	}
-	return `Add source failed during ${phaseLabel(f.phase)}: ${stripSrcDigests(f.message)}`;
 }

--- a/packages/cockpit/src/ui/cockpit/widgets/session-progress.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/session-progress.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+
+// Unit tests for the SessionProgress widget (DAT-435). Mocks `useQuery` at the
+// TanStack Query boundary (the test controls the polled snapshot), like the
+// measure-progress tests. Asserts the GROUPED pipeline (13 raw engine phases →
+// 6 badges), the per-raw-phase caption, the group+stage failure copy, and that
+// no per-table surface ever renders (sequential workflow). The real poll loop +
+// server fn are exercised by the compose smoke.
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+	queryResult: {
+		data: undefined as unknown,
+		error: undefined as unknown,
+		isLoading: false,
+	},
+	lastOptions: null as Record<string, unknown> | null,
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+	useQuery: (opts: Record<string, unknown>) => {
+		h.lastOptions = opts;
+		return h.queryResult;
+	},
+}));
+
+import { SessionProgressWidget } from "#/ui/cockpit/widgets/session-progress";
+
+const STATE = {
+	kind: "session-progress" as const,
+	workflowId: "beginsession-ws-sess",
+	runId: "run-1",
+};
+
+/** A begin_session snapshot: the fan-out fields are ALWAYS empty (sequential). */
+function snapshot(overrides: Record<string, unknown>) {
+	return {
+		phase: "begin_session_select",
+		tables_total: 0,
+		tables_completed: 0,
+		tables: [],
+		failure: null,
+		status: "RUNNING",
+		done: false,
+		...overrides,
+	};
+}
+
+function renderWidget() {
+	render(
+		<MantineProvider env="test">
+			<SessionProgressWidget state={STATE} />
+		</MantineProvider>,
+	);
+}
+
+beforeEach(() => {
+	h.queryResult = { data: undefined, error: undefined, isLoading: false };
+	h.lastOptions = null;
+});
+afterEach(() => cleanup());
+
+describe("SessionProgressWidget (DAT-435)", () => {
+	it("keys the poll on the precise (workflowId, runId) and stops on done", () => {
+		h.queryResult = {
+			data: snapshot({}),
+			error: undefined,
+			isLoading: false,
+		};
+		renderWidget();
+		expect(h.lastOptions?.queryKey).toEqual([
+			"workflow-progress",
+			"beginsession-ws-sess",
+			"run-1",
+		]);
+		const refetch = h.lastOptions?.refetchInterval as (q: {
+			state: { data?: { done: boolean } };
+		}) => number | false;
+		expect(refetch({ state: { data: { done: false } } })).toBeGreaterThan(0);
+		expect(refetch({ state: { data: { done: true } } })).toBe(false);
+	});
+
+	it("shows a starting state before the first snapshot lands", () => {
+		h.queryResult = { data: undefined, error: undefined, isLoading: true };
+		renderWidget();
+		const loading = screen.getByTestId("canvas-session-progress-loading");
+		expect(loading.textContent).toContain("Starting the session…");
+	});
+
+	it("highlights the GROUP of the running raw phase and marks prior groups done", () => {
+		// `slice_analysis` is the 3rd of 5 raw phases under the "Slice analysis"
+		// badge — the grouping, not the raw phase, drives the pipeline.
+		h.queryResult = {
+			data: snapshot({ phase: "slice_analysis" }),
+			error: undefined,
+			isLoading: false,
+		};
+		renderWidget();
+		expect(
+			screen
+				.getByTestId("session-phase-slice-analysis")
+				.getAttribute("data-state"),
+		).toBe("active");
+		expect(
+			screen
+				.getByTestId("session-phase-relationships")
+				.getAttribute("data-state"),
+		).toBe("done");
+		expect(
+			screen
+				.getByTestId("session-phase-enriched-views")
+				.getAttribute("data-state"),
+		).toBe("done");
+		expect(
+			screen.getByTestId("session-phase-finalize").getAttribute("data-state"),
+		).toBe("pending");
+		// The caption names the PRECISE raw stage the badge hides.
+		expect(
+			screen.getByTestId("session-progress-caption").textContent,
+		).toContain("Profiling each slice");
+	});
+
+	it("captions every no-tally stage and never renders a tally or table list", () => {
+		h.queryResult = {
+			data: snapshot({ phase: "semantic_per_table" }),
+			error: undefined,
+			isLoading: false,
+		};
+		renderWidget();
+		expect(
+			screen.getByTestId("session-progress-caption").textContent,
+		).toContain("Classifying tables and confirming relationships");
+		// Sequential workflow: no fan-out tally, no named per-table steps.
+		expect(screen.queryByTestId("session-progress-tally")).toBeNull();
+		expect(screen.queryByTestId("session-progress-tables")).toBeNull();
+	});
+
+	it("renders the done state on completion", () => {
+		h.queryResult = {
+			data: snapshot({ phase: "done", status: "COMPLETED", done: true }),
+			error: undefined,
+			isLoading: false,
+		};
+		renderWidget();
+		expect(screen.getByTestId("session-progress-done").textContent).toContain(
+			"the session is ready",
+		);
+		expect(
+			screen.getByTestId("session-phase-done").getAttribute("data-state"),
+		).toBe("done");
+	});
+
+	it("names the group AND the precise stage when a grouped phase fails", () => {
+		h.queryResult = {
+			data: snapshot({
+				phase: "slice_analysis",
+				failure: {
+					message: "slice profiling failed: out of memory",
+					phase: "slice_analysis",
+					table_id: null,
+				},
+				status: "FAILED",
+				done: true,
+			}),
+			error: undefined,
+			isLoading: false,
+		};
+		renderWidget();
+		const alert = screen.getByTestId("session-progress-failed");
+		// Group label for orientation, raw-stage caption for precision.
+		expect(alert.textContent).toContain(
+			"Session analysis failed during Slice analysis (profiling each slice):",
+		);
+		expect(alert.textContent).toContain(
+			"slice profiling failed: out of memory",
+		);
+	});
+
+	it("names just the group when a single-phase group fails (already precise)", () => {
+		h.queryResult = {
+			data: snapshot({
+				phase: "enriched_views",
+				failure: {
+					message: "view DDL rejected",
+					phase: "enriched_views",
+					table_id: null,
+				},
+				status: "FAILED",
+				done: true,
+			}),
+			error: undefined,
+			isLoading: false,
+		};
+		renderWidget();
+		const alert = screen.getByTestId("session-progress-failed");
+		expect(alert.textContent).toContain(
+			"Session analysis failed during Enriched views:",
+		);
+		expect(alert.textContent).not.toContain("(");
+	});
+
+	it("renders an unknown forward-compat phase without crashing (no highlight)", () => {
+		h.queryResult = {
+			data: snapshot({ phase: "some_future_phase" }),
+			error: undefined,
+			isLoading: false,
+		};
+		renderWidget();
+		// No badge active, no caption — but the pipeline + title still render.
+		expect(screen.getByTestId("canvas-session-progress")).toBeTruthy();
+		expect(screen.queryByTestId("session-progress-caption")).toBeNull();
+		for (const key of [
+			"set-up",
+			"relationships",
+			"enriched-views",
+			"slice-analysis",
+			"finalize",
+		]) {
+			expect(
+				screen.getByTestId(`session-phase-${key}`).getAttribute("data-state"),
+			).not.toBe("active");
+		}
+	});
+
+	it("surfaces a query error", () => {
+		h.queryResult = {
+			data: undefined,
+			error: new Error("temporal unreachable"),
+			isLoading: false,
+		};
+		renderWidget();
+		expect(
+			screen.getByTestId("canvas-session-progress-error").textContent,
+		).toContain("temporal unreachable");
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/widgets/session-progress.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/session-progress.tsx
@@ -1,0 +1,113 @@
+// SessionProgress widget (DAT-435) — live phase progress for a begin_session
+// run the `begin_session` tool started.
+//
+// A display config over the shared WorkflowProgressView core
+// (workflow-progress.tsx). begin_session is sequential (13 raw engine phases,
+// no fan-out — the snapshot's table fields stay empty), so the pipeline GROUPS
+// the raw phases into six user-meaningful badges: not all phases are equally
+// informative, and 14 badges read as noise where 6 read as a journey. The live
+// caption below the badges still names the precise running stage, and a
+// failure names the group plus the precise stage ("Slice analysis (profiling
+// each slice)") — grouping de-emphasizes, it never hides. Receives ONLY
+// {state}; the run identity is on the state.
+
+import type { CanvasState } from "#/ui/cockpit/canvas-state";
+import {
+	type WorkflowProgressDisplay,
+	WorkflowProgressView,
+} from "#/ui/cockpit/widgets/workflow-progress";
+
+// The six display groups over the engine's 13-phase session chain
+// (workflows.py: select → relationships/semantic/overlays → enriched_views →
+// the DAT-403 value layer → detect/keepers/promote → done). Cut lines: the
+// user's question per badge — "checking my selection", "how do my tables
+// connect?", "building the views I'll query", "deep in analysis", "wrapping
+// up". A phase the engine reports that isn't covered (forward-compat) renders
+// no highlight rather than crashing.
+const SESSION_GROUPS = [
+	{ key: "set-up", label: "Set up", phases: ["begin_session_select"] },
+	{
+		key: "relationships",
+		label: "Relationships",
+		// The LLM confirm + the teach-overlay fold are mechanics of answering
+		// "how do my tables connect?" — one badge.
+		phases: [
+			"relationships",
+			"semantic_per_table",
+			"session_materialize_overlays",
+		],
+	},
+	{
+		key: "enriched-views",
+		label: "Enriched views",
+		phases: ["enriched_views"],
+	},
+	{
+		key: "slice-analysis",
+		label: "Slice analysis",
+		// The whole DAT-403 value layer: one arc (find slices → build → profile →
+		// trend → correlate); the captions carry the differentiation.
+		phases: [
+			"slicing",
+			"slicing_view",
+			"slice_analysis",
+			"temporal_slice_analysis",
+			"correlations",
+		],
+	},
+	{
+		key: "finalize",
+		label: "Finalize",
+		// Readiness scoring + run-versioning bookkeeping a user never parses.
+		phases: [
+			"session_detect",
+			"session_write_keepers",
+			"session_promote_to_latest",
+		],
+	},
+	{ key: "done", label: "Done", phases: ["done"] },
+] as const;
+
+// Live caption per raw engine phase — the precise stage behind the badge. No
+// tally phase exists (sequential workflow), so every running phase captions.
+const SESSION_CAPTIONS: Record<string, string> = {
+	begin_session_select: "Checking the selected tables…",
+	relationships: "Detecting relationship candidates…",
+	semantic_per_table: "Classifying tables and confirming relationships…",
+	session_materialize_overlays: "Applying your saved teachings…",
+	enriched_views: "Building combined views across related tables…",
+	slicing: "Identifying meaningful data slices…",
+	slicing_view: "Building slice views…",
+	slice_analysis: "Profiling each slice…",
+	temporal_slice_analysis: "Analyzing trends over time…",
+	correlations: "Finding correlated columns…",
+	session_detect: "Scoring relationship readiness…",
+	session_write_keepers: "Saving accepted relationships…",
+	session_promote_to_latest: "Publishing results…",
+};
+
+const SESSION_DISPLAY: WorkflowProgressDisplay = {
+	title: "Session analysis — progress",
+	testId: "session",
+	groups: SESSION_GROUPS,
+	captions: SESSION_CAPTIONS,
+	// No tallyPhase: begin_session has no per-table fan-out.
+	failurePrefix: "Session analysis",
+	startingLabel: "Starting the session…",
+	doneMessage: () =>
+		"Done — the session is ready. Ask about the tables' relationships or readiness.",
+};
+
+export function SessionProgressWidget({
+	state,
+}: {
+	state: Extract<CanvasState, { kind: "session-progress" }>;
+}) {
+	return (
+		<WorkflowProgressView
+			display={SESSION_DISPLAY}
+			workflowId={state.workflowId}
+			runId={state.runId}
+		/>
+	);
+}

--- a/packages/cockpit/src/ui/cockpit/widgets/workflow-progress.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/workflow-progress.tsx
@@ -93,7 +93,13 @@ function phaseDescriptor(
 	const caption = display.captions[phase];
 	if (!caption) return group.label;
 	const detail = caption.replace(/…+$/u, "");
-	return `${group.label} (${detail.charAt(0).toLowerCase()}${detail.slice(1)})`;
+	// Sentence-case → lowercase for the parenthetical, but leave an
+	// acronym-leading caption ("LLM …") alone — only a [A-Z][a-z] start is a
+	// sentence capital.
+	const decapped = /^[A-Z][a-z]/.test(detail)
+		? detail.charAt(0).toLowerCase() + detail.slice(1)
+		: detail;
+	return `${group.label} (${decapped})`;
 }
 
 /** The leading status glyph for one fanned-out table row. */

--- a/packages/cockpit/src/ui/cockpit/widgets/workflow-progress.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/workflow-progress.tsx
@@ -1,0 +1,330 @@
+// Shared workflow-progress core (DAT-352 add_source; DAT-435 begin_session).
+//
+// One polling + rendering surface for every workflow-progress widget: a grouped
+// phase pipeline with the current step highlighted, a live caption naming the
+// running stage, the per-table fan-out detail when the snapshot carries it, and
+// terminal success/failure alerts. The per-workflow widgets (measure-progress,
+// session-progress) supply ONLY a `WorkflowProgressDisplay` config — shared
+// visual vocabulary is shared code (React idiom rule 13, the why-detail
+// precedent).
+//
+// Polls the engine's `get_progress` @workflow.query via the
+// `/api/workflow-progress` route (→ `getWorkflowProgress`) on a TanStack Query
+// `refetchInterval` (~1s), keyed on the precise (workflowId, runId). It STOPS
+// polling once the snapshot reports `done` — either phase==="done" OR a
+// terminal describe() status (so a FAILED run, which never sets "done", still
+// halts). This is the polling template of React idiom rule 3.
+
+import {
+	Alert,
+	Badge,
+	Group,
+	Loader,
+	Progress,
+	ScrollArea,
+	Stack,
+	Text,
+} from "@mantine/core";
+import { useQuery } from "@tanstack/react-query";
+import { Check, X } from "lucide-react";
+import { displayTableName, stripSrcDigests } from "#/lib/display-names";
+import type { TableStep, WorkflowProgress } from "#/temporal/progress";
+import { PROGRESS_DONE_PHASE } from "#/temporal/types";
+
+/** One badge in the pipeline, covering 1–N raw engine phases. A single-phase
+ * group renders exactly like the ungrouped add_source pipeline; a multi-phase
+ * group (the begin_session value layer) collapses noisy stages into one badge
+ * while the caption below still names the precise running stage. */
+export interface PhaseGroup {
+	// Stable badge identity — the testid suffix (`${testId}-phase-${key}`).
+	key: string;
+	label: string;
+	// The raw snapshot phases this badge covers, in execution order.
+	phases: readonly string[];
+}
+
+/** The per-workflow display config — everything the shared view can't derive
+ * from the polled snapshot. */
+export interface WorkflowProgressDisplay {
+	title: string;
+	// testid prefix: root `canvas-${testId}-progress`, badges
+	// `${testId}-phase-${key}`, … — keeps each widget's tests targetable.
+	testId: string;
+	// The display pipeline in order, INCLUDING the terminal done group. A phase
+	// the engine reports that maps to no group (forward-compat) renders no
+	// highlight rather than crashing.
+	groups: readonly PhaseGroup[];
+	// Live caption per raw phase, for phases that carry no per-table signal.
+	// The tally phase (if any) is intentionally absent — it has its own bar.
+	captions: Record<string, string>;
+	// The raw phase whose per-table fan-out tally owns the surface (add_source's
+	// "processing_tables"); omit for sequential workflows with no fan-out.
+	tallyPhase?: string;
+	// Label over the tally bar, e.g. "Typing tables".
+	tallyLabel?: string;
+	// Sentence prefix for failure copy: `${failurePrefix} failed during …`.
+	failurePrefix: string;
+	// Caption under the loader before the first snapshot lands.
+	startingLabel: string;
+	// The success-alert line, derived from the terminal snapshot.
+	doneMessage: (data: WorkflowProgress) => string;
+}
+
+/** The group a raw phase renders under, or undefined for a forward-compat
+ * phase the config doesn't know. */
+function groupIndex(display: WorkflowProgressDisplay, phase: string): number {
+	return display.groups.findIndex((g) => g.phases.includes(phase));
+}
+
+/**
+ * The human descriptor for a failed phase: the group label, plus — when the
+ * group collapses several raw stages — the stage's caption (lowercased,
+ * ellipsis stripped) so the failure still names the precise stage the badge
+ * hides: "Slice analysis (profiling each slice)". A single-phase group is
+ * already precise; an unmapped phase falls back to the raw key.
+ */
+function phaseDescriptor(
+	display: WorkflowProgressDisplay,
+	phase: string,
+): string {
+	const group = display.groups.find((g) => g.phases.includes(phase));
+	if (!group) return phase;
+	if (group.phases.length === 1) return group.label;
+	const caption = display.captions[phase];
+	if (!caption) return group.label;
+	const detail = caption.replace(/…+$/u, "");
+	return `${group.label} (${detail.charAt(0).toLowerCase()}${detail.slice(1)})`;
+}
+
+/** The leading status glyph for one fanned-out table row. */
+function TableStatusIcon({ status }: { status: TableStep["status"] }) {
+	if (status === "done") {
+		return (
+			<Check
+				size={14}
+				color="var(--mantine-color-green-6)"
+				data-testid="table-status-done"
+			/>
+		);
+	}
+	if (status === "failed") {
+		return (
+			<X
+				size={14}
+				color="var(--mantine-color-red-6)"
+				data-testid="table-status-failed"
+			/>
+		);
+	}
+	return <Loader size={12} data-testid="table-status-running" />;
+}
+
+const POLL_INTERVAL_MS = 1000;
+
+/** Poll the progress API route for one run. Throws on a non-2xx so TanStack
+ * Query surfaces it as the widget's error state. */
+async function fetchProgress(
+	workflowId: string,
+	runId: string,
+): Promise<WorkflowProgress> {
+	const res = await fetch("/api/workflow-progress", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ workflow_id: workflowId, run_id: runId }),
+	});
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `Progress query failed (${res.status}).`);
+	}
+	return (await res.json()) as WorkflowProgress;
+}
+
+export function WorkflowProgressView({
+	display,
+	workflowId,
+	runId,
+}: {
+	display: WorkflowProgressDisplay;
+	workflowId: string;
+	runId: string;
+}) {
+	const { data, error, isLoading } = useQuery({
+		// One key namespace for both widgets — they poll the same endpoint for
+		// the same run, so the cached snapshot is interchangeable.
+		queryKey: ["workflow-progress", workflowId, runId],
+		queryFn: () => fetchProgress(workflowId, runId),
+		// Poll until the run is done; then stop (refetchInterval returns false).
+		refetchInterval: (query) =>
+			query.state.data?.done ? false : POLL_INTERVAL_MS,
+		refetchOnWindowFocus: false,
+	});
+
+	const p = display.testId;
+
+	if (error) {
+		return (
+			<Stack gap="xs" data-testid={`canvas-${p}-progress`}>
+				<Text size="sm" fw={600}>
+					{display.title}
+				</Text>
+				<Alert color="red" data-testid={`canvas-${p}-progress-error`}>
+					Couldn't read workflow progress: {(error as Error).message}
+				</Alert>
+			</Stack>
+		);
+	}
+
+	if (isLoading || !data) {
+		return (
+			<Stack
+				gap="sm"
+				align="center"
+				justify="center"
+				h="100%"
+				data-testid={`canvas-${p}-progress-loading`}
+			>
+				<Loader size="sm" />
+				<Text c="dimmed" size="sm">
+					{display.startingLabel}
+				</Text>
+			</Stack>
+		);
+	}
+
+	const activeIdx = groupIndex(display, data.phase);
+	const failed =
+		data.done &&
+		data.phase !== PROGRESS_DONE_PHASE &&
+		data.status !== "COMPLETED";
+	const succeeded =
+		data.phase === PROGRESS_DONE_PHASE || data.status === "COMPLETED";
+
+	// During a per-table fan-out, surface the tally as a determinate bar.
+	const showTally =
+		display.tallyPhase !== undefined &&
+		data.phase === display.tallyPhase &&
+		data.tables_total > 0;
+	const tallyPct = showTally
+		? Math.round((data.tables_completed / data.tables_total) * 100)
+		: 0;
+
+	return (
+		<Stack gap="sm" data-testid={`canvas-${p}-progress`}>
+			{/* No corner spinner: the per-phase pipeline + captions below already
+			    show liveness; a detached top-right Loader read as "stuck". */}
+			<Text size="sm" fw={600}>
+				{display.title}
+			</Text>
+
+			{/* Phase pipeline — current group highlighted, prior groups done. */}
+			<Group gap="xs" wrap="wrap" data-testid={`${p}-progress-phases`}>
+				{display.groups.map((g, i) => {
+					const isActive = i === activeIdx && !data.done;
+					const isPast =
+						activeIdx > i || (succeeded && g.phases.includes("done"));
+					const color = isActive ? "blue" : isPast ? "green" : "gray";
+					const variant = isActive || isPast ? "filled" : "light";
+					return (
+						<Badge
+							key={g.key}
+							color={color}
+							variant={variant}
+							size="sm"
+							data-testid={`${p}-phase-${g.key}`}
+							data-state={isActive ? "active" : isPast ? "done" : "pending"}
+						>
+							{g.label}
+						</Badge>
+					);
+				})}
+			</Group>
+
+			{showTally && (
+				<Stack gap={4} data-testid={`${p}-progress-tally`}>
+					<Text size="xs" c="dimmed">
+						{display.tallyLabel}: {data.tables_completed} / {data.tables_total}
+					</Text>
+					<Progress value={tallyPct} size="sm" />
+				</Stack>
+			)}
+
+			{/* The no-tally phases have no per-table signal — show an indeterminate
+			    caption so the surface isn't dead air while they run. */}
+			{!data.done && !showTally && display.captions[data.phase] && (
+				<Group gap="xs" wrap="nowrap" data-testid={`${p}-progress-caption`}>
+					<Loader size="xs" />
+					<Text size="xs" c="dimmed">
+						{display.captions[data.phase]}
+					</Text>
+				</Group>
+			)}
+
+			{/* The named steps behind the count — which tables are running / done /
+			    failed. Scrolls past a handful so a wide source can't blow out the
+			    canvas. Renders only when the snapshot carries steps (add_source). */}
+			{data.tables.length > 0 && (
+				<ScrollArea.Autosize mah={180} data-testid={`${p}-progress-tables`}>
+					<Stack gap={2}>
+						{data.tables.map((t) => (
+							<Group key={t.raw_table_id} gap={6} wrap="nowrap">
+								<TableStatusIcon status={t.status} />
+								<Text
+									size="xs"
+									c={
+										t.status === "failed"
+											? "red"
+											: t.status === "running"
+												? "dimmed"
+												: undefined
+									}
+									truncate
+									data-testid={`${p}-table-${t.raw_table_id}`}
+								>
+									{displayTableName(t.name)}
+								</Text>
+							</Group>
+						))}
+					</Stack>
+				</ScrollArea.Autosize>
+			)}
+
+			{succeeded && (
+				<Alert color="green" data-testid={`${p}-progress-done`}>
+					{display.doneMessage(data)}
+				</Alert>
+			)}
+
+			{failed && (
+				<Alert color="red" data-testid={`${p}-progress-failed`}>
+					{failureMessage(display, data)}
+				</Alert>
+			)}
+		</Stack>
+	);
+}
+
+/** The human-readable failure line: the engine's root-cause message, scoped to
+ * the failed table (by name) or the failed run-level phase. Falls back to the
+ * describe() status when the snapshot carried no failure detail (e.g. a run
+ * TERMINATED out-of-band, which never stamps `failure`). The engine-built
+ * message can embed content-keyed `src_<digest>` names or the staged-upload s3
+ * URI — `stripSrcDigests` neutralizes them, the same treatment the agent-facing
+ * workflow_status projection applies (DAT-433). */
+function failureMessage(
+	display: WorkflowProgressDisplay,
+	data: WorkflowProgress,
+): string {
+	const f = data.failure;
+	if (!f) {
+		return `The ${display.failurePrefix.toLowerCase()} run ended in ${data.status.toLowerCase()} at the ${data.phase} phase.`;
+	}
+	if (f.table_id) {
+		// Same name-display rule as the live list — strip the `<source>__` prefix so
+		// a FAILED run reads `trial_balance`, not `finance_data__trial_balance`.
+		const name =
+			data.tables.find((t) => t.raw_table_id === f.table_id)?.name ??
+			`table ${f.table_id.slice(0, 8)}`;
+		return `${display.failurePrefix} failed on ${displayTableName(name)}: ${stripSrcDigests(f.message)}`;
+	}
+	return `${display.failurePrefix} failed during ${phaseDescriptor(display, f.phase)}: ${stripSrcDigests(f.message)}`;
+}

--- a/packages/engine/src/dataraum/worker/contracts.py
+++ b/packages/engine/src/dataraum/worker/contracts.py
@@ -65,14 +65,19 @@ class ProgressFailure:
 
 @dataclass
 class ProgressSnapshot:
-    """Parent-level progress for ``addSourceWorkflow``, served by ``get_progress`` (DAT-406).
+    """Workflow progress served by a ``get_progress`` query (DAT-406, DAT-435).
 
+    One shape for every cockpit-polled workflow — ``addSourceWorkflow`` (the
+    original, DAT-406) and ``beginSessionWorkflow`` (DAT-435) serve it from the
+    same query name, so the cockpit's poll/types need no per-workflow branch.
     Read-only snapshot the cockpit polls via the Temporal Client's
-    ``query`` API while the parent runs (queries answer against current
-    state even while ``@workflow.run`` is blocked awaiting the fan-out).
-    The workflow body advances ``phase`` before each stage, seeds the
-    per-table ``tables`` list once the fan-out set is known, and flips each
-    entry (plus ``tables_completed``) as its child resolves.
+    ``query`` API while the workflow runs (queries answer against current
+    state even while ``@workflow.run`` is blocked awaiting a stage).
+    The workflow body advances ``phase`` before each stage; add_source
+    additionally seeds the per-table ``tables`` list once the fan-out set is
+    known and flips each entry (plus ``tables_completed``) as its child
+    resolves — a sequential workflow (begin_session) leaves the fan-out
+    fields at their empty defaults.
 
     Deliberately a plain stdlib ``@dataclass`` (NOT a Pydantic engine
     type): it carries only primitives + nested dataclasses, and the worker's
@@ -83,14 +88,18 @@ class ProgressSnapshot:
     (a field rename/retype here is a cross-PACKAGE change).
 
     Attributes:
-        phase: The stage the parent is currently in. Advances
+        phase: The stage the workflow is currently in. add_source advances
             ``"import"`` → ``"check_column_limit"`` → ``"processing_tables"``
             → ``"semantic_per_column"`` → ``"detect"`` → ``"promote"`` →
-            ``"done"``. A plain string (not an enum) so the wire value stays a
-            bare JSON string for the cockpit.
+            ``"done"``; begin_session walks its sequential chain
+            (``"begin_session_select"`` → … → ``"session_promote_to_latest"``
+            → ``"done"`` — the authoritative order is the workflow body). A
+            plain string (not an enum) so the wire value stays a bare JSON
+            string for the cockpit and a new phase is not a contract change.
         tables_total: The number of child ``ProcessTableWorkflow``s fanned
             out. ``0`` until ``import`` enumerates the raw tables (or a
             replay narrows the set); set once before the fan-out awaits.
+            Stays ``0`` for begin_session (sequential, no children).
         tables_completed: How many children have resolved so far —
             monotonically increasing toward ``tables_total`` during the
             ``"processing_tables"`` phase.

--- a/packages/engine/src/dataraum/worker/contracts.py
+++ b/packages/engine/src/dataraum/worker/contracts.py
@@ -43,19 +43,21 @@ class TableProgress:
 
 @dataclass
 class ProgressFailure:
-    """Why an add_source run ended badly — surfaced in the cockpit, not buried.
+    """Why a workflow run ended badly — surfaced in the cockpit, not buried.
 
     A polling cockpit reads this off the snapshot instead of opening the Temporal
-    UI for the failure detail.
+    UI for the failure detail. Served by both progress-bearing workflows
+    (add_source DAT-406, begin_session DAT-435).
 
     Attributes:
         message: The root-cause message — Temporal's Activity/ChildWorkflow
             error chain unwrapped to the phase's own non-retryable failure text.
         phase: The stage in flight when it failed (the snapshot's ``phase``).
         table_id: The raw table whose child failed, when the failure is
-            table-scoped; ``None`` for run-level stages (``import`` /
-            ``check_column_limit`` / ``semantic_per_column`` / ``detect`` /
-            ``promote``).
+            table-scoped; ``None`` for add_source's run-level stages (``import``
+            / ``check_column_limit`` / ``semantic_per_column`` / ``detect`` /
+            ``promote``) and ALWAYS ``None`` for begin_session (sequential, no
+            table-scoped stages).
     """
 
     message: str

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -434,7 +434,7 @@ class BeginSessionWorkflow:
     :class:`ProgressSnapshot` in ``self._progress`` and advances ``phase``
     before each stage; the read-only :meth:`get_progress` query serves it under
     the SAME query name and snapshot shape as ``AddSourceWorkflow``, so the
-    cockpit's existing poll (``getAddSourceProgress``) and ``workflow_status``
+    cockpit's existing poll (``getWorkflowProgress``) and ``workflow_status``
     tool report real phases with no contract change. Sequential chain, no
     fan-out → the per-table fields stay at their empty defaults. Every mutation
     sits between awaited, history-recorded activity completions, so a replay

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -429,10 +429,60 @@ class BeginSessionWorkflow:
     The run mints a ``run_id`` (DAT-408) threaded through every activity; a teach
     re-run is a full re-run under a fresh ``run_id`` (candidates re-derive,
     llm/manual/keeper survive, readiness is non-destructive + promoted to the new run).
+
+    Progress (DAT-435): mirrors add_source's DAT-406 pattern — the body keeps a
+    :class:`ProgressSnapshot` in ``self._progress`` and advances ``phase``
+    before each stage; the read-only :meth:`get_progress` query serves it under
+    the SAME query name and snapshot shape as ``AddSourceWorkflow``, so the
+    cockpit's existing poll (``getAddSourceProgress``) and ``workflow_status``
+    tool report real phases with no contract change. Sequential chain, no
+    fan-out → the per-table fields stay at their empty defaults. Every mutation
+    sits between awaited, history-recorded activity completions, so a replay
+    reconstructs the identical snapshot — determinism is preserved.
     """
+
+    def __init__(self) -> None:
+        # Initialized to the pre-flight stage so a query that lands before the
+        # first activity still returns a well-formed snapshot (never None). The
+        # fan-out fields keep their empty defaults — begin_session has no
+        # children, which the cockpit widget reads as "no per-table tally".
+        self._progress = ProgressSnapshot(phase="begin_session_select")
+
+    @workflow.query
+    def get_progress(self) -> ProgressSnapshot:
+        """Return the current progress snapshot (DAT-435).
+
+        Read-only, non-mutating → determinism-safe; Temporal answers it against
+        current state even while :meth:`run` is blocked awaiting a stage (and on
+        a CLOSED run by replaying history, so the cockpit can read the final
+        snapshot — including ``failure`` — off a failed run). Same query name +
+        shape as :meth:`AddSourceWorkflow.get_progress`, so the cockpit polls
+        both workflows through one seam.
+        """
+        return self._progress
 
     @workflow.run
     async def run(self, payload: BeginSessionInput) -> BeginSessionResult:
+        """Run the begin_session spine, recording any failure into the snapshot.
+
+        Thin wrapper over :meth:`_run_inner`: on any stage failure it stamps
+        ``self._progress.failure`` (root-cause message + the phase in flight)
+        before re-raising, so a polling cockpit sees WHY the run ended, not
+        just a FAILED status. Unconditional stamp — unlike add_source there is
+        no fanned-out child that could have stamped a table-scoped failure
+        first. ``except Exception`` deliberately misses ``CancelledError`` (a
+        ``BaseException``) so cancellation still propagates clean.
+        """
+        try:
+            return await self._run_inner(payload)
+        except Exception as err:
+            self._progress.failure = ProgressFailure(
+                message=_failure_message(err),
+                phase=self._progress.phase,
+            )
+            raise
+
+    async def _run_inner(self, payload: BeginSessionInput) -> BeginSessionResult:
         # Mint the run's ``run_id`` once (DAT-408), mirroring AddSourceWorkflow, and
         # thread it through every activity so all of this run's metadata shares it
         # and the terminal promote can flip the relationship-readiness heads.
@@ -454,7 +504,10 @@ class BeginSessionWorkflow:
             retry_policy=_RETRY,
         )
 
+        # Advance the snapshot before each stage (DAT-435) so a failure is
+        # attributed to the stage in flight and a poll names what is running now.
         for phase in _SESSION_PHASE_ORDER:
+            self._progress.phase = phase
             await workflow.execute_activity(
                 phase,
                 scoped,
@@ -467,6 +520,7 @@ class BeginSessionWorkflow:
         # the user's add/keep overlays into this run as manual/keeper rows (skipping
         # pairs already produced as llm) so the defined catalog detect measures next
         # carries them.
+        self._progress.phase = "session_materialize_overlays"
         await workflow.execute_activity(
             "session_materialize_overlays",
             identity,
@@ -480,6 +534,7 @@ class BeginSessionWorkflow:
         # manual/keeper teaches), versioning each view's DDL on the recipe substrate.
         # Scoped (needs the selection's table_ids); runs before detect so the
         # table-grain readiness it feeds (DAT-402) measures the enriched substrate.
+        self._progress.phase = "enriched_views"
         await workflow.execute_activity(
             "enriched_views",
             scoped,
@@ -494,6 +549,7 @@ class BeginSessionWorkflow:
         # the terminal ``session_detect`` measures. Each is idempotent on its
         # CREATE-OR-REPLACE / reconcile, so a re-run under a fresh run_id re-derives.
         for phase in _SESSION_VALUE_PHASE_ORDER:
+            self._progress.phase = phase
             await workflow.execute_activity(
                 phase,
                 scoped,
@@ -505,6 +561,7 @@ class BeginSessionWorkflow:
         # Terminal relationship detect (DAT-408): runs the relationship detectors
         # over the session's tables, persisting relationship-granularity readiness
         # stamped with ``run_id`` — then promote flips the heads to this run.
+        self._progress.phase = "session_detect"
         await workflow.execute_activity(
             "session_detect",
             identity,
@@ -516,6 +573,7 @@ class BeginSessionWorkflow:
         # Silent-accept keepers (DAT-409): BEFORE promote, while the head still names
         # the prior run — lift each promoted llm this run didn't reproduce (and the
         # user didn't reject) into a keep overlay for the next run to materialize.
+        self._progress.phase = "session_write_keepers"
         await workflow.execute_activity(
             "session_write_keepers",
             identity,
@@ -524,6 +582,7 @@ class BeginSessionWorkflow:
             retry_policy=_RETRY,
         )
 
+        self._progress.phase = "session_promote_to_latest"
         await workflow.execute_activity(
             "session_promote_to_latest",
             identity,
@@ -532,6 +591,7 @@ class BeginSessionWorkflow:
             retry_policy=_RETRY,
         )
 
+        self._progress.phase = "done"
         return BeginSessionResult(session_id=identity.session_id, table_ids=payload.tables)
 
 

--- a/packages/engine/tests/integration/worker/conftest.py
+++ b/packages/engine/tests/integration/worker/conftest.py
@@ -3,7 +3,7 @@
 A single-container Temporal CLI dev server (``server start-dev``) + a client
 bound to it with the worker's pydantic data converter. Used by the workflow
 exec + offline-``Replayer`` determinism tests (``test_progress_query`` for
-add_source, ``test_begin_session_workflow_replay`` for begin_session).
+add_source, ``test_begin_session_progress_query`` for begin_session).
 
 We use the CLI dev server (in-memory SQLite, one container) instead of
 ``WorkflowEnvironment.start_time_skipping()`` — that downloads a test-server

--- a/packages/engine/tests/integration/worker/test_begin_session_progress_query.py
+++ b/packages/engine/tests/integration/worker/test_begin_session_progress_query.py
@@ -1,0 +1,216 @@
+"""Progress query + replay-determinism for ``beginSessionWorkflow`` (DAT-435).
+
+The session workflow serves the SAME read-only ``get_progress`` query and
+:class:`ProgressSnapshot` shape as ``addSourceWorkflow`` (DAT-406), so the
+cockpit polls both through one seam. Three things have to hold:
+
+* **The snapshot advances.** ``phase`` walks the sequential session chain
+  (``begin_session_select`` → … → ``session_promote_to_latest`` → ``done``)
+  in order, and the fan-out fields stay at their empty defaults (no children).
+  Driven on a real Temporal **dev-server testcontainer** (NOT
+  ``WorkflowEnvironment`` — project convention) with every activity mocked to
+  a trivial deterministic stub, so no engine/DB is dragged in.
+
+* **A failure is stamped.** A stage that raises lands in
+  ``snapshot.failure`` with the root-cause message + the phase in flight
+  (the same ``_failure_message`` unwrap as add_source), readable off the
+  CLOSED run — that is what the cockpit's failure alert renders.
+
+* **It replays clean.** The ``self._progress`` mutations only change state
+  between awaited, history-recorded activity completions, so the offline
+  :class:`Replayer` reconstructs both the clean and the failed run with no
+  non-determinism error.
+
+Real end-to-end values (live worker, real activities) are covered by
+compose-smoke, not here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Coroutine
+
+import pytest
+from temporalio import activity
+from temporalio.client import Client, WorkflowFailureError
+from temporalio.contrib.pydantic import pydantic_data_converter
+from temporalio.exceptions import ApplicationError
+from temporalio.worker import Replayer, Worker
+
+from dataraum.worker.contracts import (
+    BeginSessionInput,
+    PhaseOutcome,
+    ProgressSnapshot,
+    SessionIdentity,
+    begin_session_workflow_id,
+)
+from dataraum.worker.workflows import BeginSessionWorkflow
+from tests.integration.worker.conftest import make_sandboxed_runner
+
+_TASK_QUEUE = "dat435-progress-test"
+_TABLE_IDS = ["typed-a", "typed-b"]
+
+# The sequential session chain in execution order — must match the workflow
+# body (workflows.py: select, _SESSION_PHASE_ORDER, the overlay/views stages,
+# _SESSION_VALUE_PHASE_ORDER, then the detect/keepers/promote tail). The
+# ordering assertion below walks exactly this list.
+_PHASE_ORDER = [
+    "begin_session_select",
+    "relationships",
+    "semantic_per_table",
+    "session_materialize_overlays",
+    "enriched_views",
+    "slicing",
+    "slicing_view",
+    "slice_analysis",
+    "temporal_slice_analysis",
+    "correlations",
+    "session_detect",
+    "session_write_keepers",
+    "session_promote_to_latest",
+]
+
+_StubFn = Callable[[object], Coroutine[object, object, PhaseOutcome]]
+
+
+def _phase_stub(name: str) -> _StubFn:
+    """A trivial deterministic stub registered under one production activity name.
+
+    Returns the right contract shape and touches no engine/DB, so the test
+    exercises ONLY the orchestration + progress bookkeeping. The short sleep
+    staggers stage completions so the polling loop genuinely observes
+    intermediate phases (rather than the whole chain landing in one tick).
+    """
+
+    @activity.defn(name=name)
+    async def _stub(_payload: object) -> PhaseOutcome:
+        await asyncio.sleep(0.01)
+        return PhaseOutcome(status="completed")
+
+    return _stub
+
+
+def _failing_stub(name: str, message: str) -> _StubFn:
+    """A stub that fails its stage with a non-retryable phase failure."""
+
+    @activity.defn(name=name)
+    async def _stub(_payload: object) -> PhaseOutcome:
+        raise ApplicationError(message, type="PhaseFailed", non_retryable=True)
+
+    return _stub
+
+
+def _worker(client: Client, activities: list[_StubFn]) -> Worker:
+    """A worker serving the session workflow + the given activity stubs."""
+    return Worker(
+        client,
+        task_queue=_TASK_QUEUE,
+        workflows=[BeginSessionWorkflow],
+        activities=activities,
+        workflow_runner=make_sandboxed_runner(),
+    )
+
+
+async def _replay(handle_history: object) -> None:
+    """Offline determinism: replay a captured history, no server."""
+    replayer = Replayer(
+        workflows=[BeginSessionWorkflow],
+        data_converter=pydantic_data_converter,
+        workflow_runner=make_sandboxed_runner(),
+    )
+    await replayer.replay_workflow(handle_history)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_get_progress_advances_and_replays_clean(temporal_client: Client) -> None:
+    """``get_progress`` walks the session chain in order, then replays clean.
+
+    Drives a real run on the dev server, polling the query while it runs. We
+    don't try to catch every phase (timing is racy) — we record every snapshot
+    we observe and assert the ordering invariants over the trace plus the
+    terminal state. The query answering at all while a stage is awaited is
+    itself part of what's under test.
+    """
+    identity = SessionIdentity(workspace_id="test", session_id="sess-dat435-ok")
+    workflow_id = begin_session_workflow_id(identity.workspace_id, identity.session_id)
+    stubs = [_phase_stub(name) for name in _PHASE_ORDER]
+
+    async with _worker(temporal_client, stubs):
+        handle = await temporal_client.start_workflow(
+            BeginSessionWorkflow.run,
+            BeginSessionInput(identity=identity, tables=_TABLE_IDS),
+            id=workflow_id,
+            task_queue=_TASK_QUEUE,
+        )
+
+        observed: list[ProgressSnapshot] = []
+        for _ in range(400):
+            observed.append(await handle.query(BeginSessionWorkflow.get_progress))
+            if observed[-1].phase == "done":
+                break
+            await asyncio.sleep(0.02)
+
+        result = await handle.result()
+
+    assert result.session_id == identity.session_id
+    assert result.table_ids == _TABLE_IDS
+
+    # Terminal snapshot: chain finished, healthy, and the fan-out fields stayed
+    # at their empty defaults (sequential workflow, no children).
+    final = observed[-1]
+    assert final.phase == "done"
+    assert final.failure is None
+    assert all(s.tables_total == 0 and s.tables_completed == 0 and s.tables == [] for s in observed)
+
+    # Phase only ever moves forward through the declared session order.
+    order = [*_PHASE_ORDER, "done"]
+    seen_indices = [order.index(s.phase) for s in observed]
+    assert seen_indices == sorted(seen_indices), f"phase regressed: {[s.phase for s in observed]}"
+
+    history = await handle.fetch_history()
+    await _replay(history)
+
+
+@pytest.mark.asyncio
+async def test_failure_is_stamped_with_phase_and_replays_clean(
+    temporal_client: Client,
+) -> None:
+    """A failing stage stamps ``failure`` (message + phase), readable off the closed run.
+
+    ``enriched_views`` fails mid-chain; the run ends FAILED and the final
+    snapshot — queried AFTER the run closed, which Temporal answers by
+    replaying history on the worker — carries the root-cause message and the
+    phase in flight. ``table_id`` stays ``None`` (no table-scoped stages in the
+    session chain). The failed history must also replay clean: the failure
+    stamping in the ``run`` wrapper is a workflow-state mutation like any other.
+    """
+    identity = SessionIdentity(workspace_id="test", session_id="sess-dat435-fail")
+    workflow_id = begin_session_workflow_id(identity.workspace_id, identity.session_id)
+    stubs = [
+        _failing_stub(name, "enriched views exploded")
+        if name == "enriched_views"
+        else _phase_stub(name)
+        for name in _PHASE_ORDER
+    ]
+
+    async with _worker(temporal_client, stubs):
+        handle = await temporal_client.start_workflow(
+            BeginSessionWorkflow.run,
+            BeginSessionInput(identity=identity, tables=_TABLE_IDS),
+            id=workflow_id,
+            task_queue=_TASK_QUEUE,
+        )
+
+        with pytest.raises(WorkflowFailureError):
+            await handle.result()
+
+        final = await handle.query(BeginSessionWorkflow.get_progress)
+        history = await handle.fetch_history()
+
+    assert final.phase == "enriched_views"
+    assert final.failure is not None
+    assert final.failure.phase == "enriched_views"
+    assert "enriched views exploded" in final.failure.message
+    assert final.failure.table_id is None
+
+    await _replay(history)


### PR DESCRIPTION
## Task

[DAT-435](https://real-dataraum.atlassian.net/browse/DAT-435) — begin_session progress (epic DAT-356). A begin_session run (~10 min) had **no progress surface**: no `get_progress` query, no canvas member, `workflow_status` degraded to describe()-only.

## Approach (refined with Philipp)

- **Engine**: `BeginSessionWorkflow` mirrors add_source's DAT-406 pattern — `ProgressSnapshot` in workflow state, **same query name + same dataclass** (reuse = zero cross-package contract change; `types.ts` untouched), phase advanced before each of the 13 sequential stages, failure stamped with root-cause + phase, terminal `done`. All mutations sit between awaited history events — both clean and failed histories replay clean offline.
- **Cockpit**: the polling seam goes officially two-workflow, so the names follow — `getWorkflowProgress`, `POST /api/workflow-progress` (canvas kind `add-source-progress` stays; describe()-only fallback stays for the query-less `operatingModelWorkflow`). The widget core is extracted to a shared `WorkflowProgressView` (idiom rule 13); measure-progress becomes its add_source config (behavior byte-identical, verified line-by-line by the reviewer); the new **session-progress** widget renders the 13 raw phases as **6 user-approved badges** (Set up / Relationships / Enriched views / Slice analysis / Finalize / Done) with live captions naming the precise raw stage, and failure copy = group + precise stage ("Slice analysis (profiling each slice)").
- **Rejected in refine**: `emitCustomEvent` live streaming — the tool returns immediately (non-blocking `workflow.start`); holding a turn open ~10 min inverts the durable-workflow design. SSE revisit deferred until cockpit_db holds recoverable UI state (Philipp's call).

## Acceptance criteria

- [x] A running begin_session shows live phase progress on the canvas; failure surfaces with the phase + reason (grouped badge + precise stage + root cause)
- [x] `workflow_status` against a begin_session run returns real phase data (no describe-only degradation) — zero tool-code change, it wraps the same poll
- [x] Engine gates green incl. the real-Temporal progress integration test pattern (`test_begin_session_progress_query.py`: phase ordering + failure stamping + offline Replayer determinism, both histories); cockpit check + typecheck + test (690/690) + build green

## Lane smoke

```
engine:  uv run pytest tests/integration/worker -q          → 52 passed (incl. 2 new, real Temporal testcontainer)
cockpit: bun run check ✓ · tsc --noEmit ✓ · vitest 690/690 ✓ · vite build ✓
```

Full live smoke (real begin_session run watching the widget) needs the stack + LLM calls — flagging for the post-merge `/smoke` pass.

## Review

Single strict reviewer (spec + code), independent gate re-run: **APPROVE** — 3 comment-level findings (rename pointer, docstring generalization, latent acronym-mangling in the failure parenthetical), all fixed in the follow-up commit.

## Other lanes in flight

None (`platform-status.md`: no lanes in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)