### PR TITLE
DAT-439: validation agent-tier honesty pass — inconclusive ≠ failed, no silent rescues

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,35 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-07: validation agent-tier honesty pass — `status=failed` semantics changed (DAT-439)
+
+Branch `feat/dat-439-fail-loud-sweep`. **DAT-442's cross_table_consistency
+calibration must land AFTER this** — what `status=failed` MEANS in
+`validation_results` changed:
+
+- **`failed` now means a JUDGED data failure only.** An evaluation that could
+  not judge the data (no recognizable result columns, zero rows from a
+  balance/comparison/aggregate summary query, unrecognized `check_type`) is
+  now `status=error` — previously these surfaced as `failed` (live-proven:
+  `three_way_match` "Comparison check inconclusive" was reported FAILED).
+  The artifact stays `grounded` with the reason in
+  `lifecycle_artifacts.state_reason`; the result row is `error`, never
+  `failed`. Any eval assertion counting failures must not expect
+  inconclusives among them.
+- **`_score_validation_result` branches** (`entropy/detectors/computational/
+  cross_table_consistency.py`): `skipped` now scores 0.0 explicitly
+  (previously fell into check-type scoring and a skip carrying table_ids
+  could score 1.0); `error` keeps 0.5 (covers execution errors AND
+  inconclusive evaluations). Calibration of these constants = DAT-442.
+- **No-tool-call LLM responses are no longer rescued** by JSON-parsing the
+  text content — they are bind ERRORs (artifact stays `declared` + reason
+  "no structured output"). A mocked-LLM eval scenario that emitted plain-text
+  JSON instead of a tool call now yields an ungroundable validation.
+- `can_validate=true` with no SQL is a bind ERROR now, not `skipped`.
+- Unrecognized `check_type` (e.g. `referential`) no longer passes on
+  row_count>0 — it is `error` (inconclusive). Only `balance` / `comparison` /
+  `constraint` / `aggregate` are judgeable.
+
 ## 2026-06-07: operating_model stage — validation lifecycle revival (DAT-438)
 
 Branch `feat/dat-438-operating-model`. The validation family moved from a

--- a/.claude/platform-status.md
+++ b/.claude/platform-status.md
@@ -1,17 +1,12 @@
-# DAT-294 Platform Lanes — Status
+# Platform Lanes — Status
 
 At-a-glance view of all parallel platform lanes. Maintained by `/take`.
 Row is added when a lane opens its PR; removed when the PR merges.
 
 | Task | Worktree | Branch | PR | Contract | Status |
 |---|---|---|---|---|---|
-| DAT-354 | .worktrees/DAT-354 | feat/DAT-354-chat-tool-result-chips | (pending — lead opens) | none (cockpit-only: chat tool-result chips + canvas-rehydration mechanism) | pushed, awaiting PR |
-| DAT-352 | .worktrees/DAT-352 | feat/DAT-352-measure-progress-rehydration | (pending — lead opens) | mirrors engine ProgressSnapshot (DAT-406) into temporal/types.ts | pushed, awaiting PR — SALVAGED: impl agent looped on result-emit (context exhaustion); work was committed + gates-green; verified independently (biome/tsc/345 unit tests + 3/3 review) then pushed |
-| DAT-414 | .worktrees/DAT-414 | feat/DAT-414-versioned-typing-ddl | #213 | none (engine-internal: typed/quarantine materialization DDL; "Cross-repo: None expected") | lane smoke green (4 real-DuckLake tests), 62 affected tests green, gates clean, awaiting review — reviewer subagents not spawnable from background lane (no Agent tool); self-reviewed |
-| DAT-433 | .claude/worktrees/agent-af06c3be03c932571 | feat/dat-433-agent-name-leaks | #225 | none (cockpit-only; engine evidence shape read-only-mirrored in fixtures) | gates green (check ✓, tsc ✓, 590 unit tests ✓), lane smoke = agent-name-leaks property suite green, PR open — self-reviewed (no Agent tool in background lane); lead runs independent 3-reviewer pass |
-| DAT-436 | .claude/worktrees/agent-add416cb8ba92c479 | fix/dat-436-onboarding-flow | #231 | none (cockpit-only; engine untouched) | gates green (check ✓, tsc ✓, 643 unit tests ✓), chip root cause empirically pinned, Intent re-review applied (M1 modelOptions.max_tokens root-cause fix + S1 stop-then-idle orphan), PR open — self-reviewed (no Agent tool in background lane); lead runs independent review. Stays clear of DAT-437's chat-rail text filtering + tool-chip-summary.ts |
-| DAT-437 | .claude/worktrees/agent-ab1f432a11317f4a4 | feat/dat-437-presentation-polish | #230 | none (cockpit-only: shared agent-refs marker, logical chip count, shared evidence-detail renderer) | gates green (check ✓, tsc ✓, 614 unit tests ✓), lane smoke = 10 targeted suites/123 tests + leak grep sweep, PR open — chat-rail edit scoped to the text-part filter (DAT-436 owns the chip spinner region); lead runs independent review |
+| DAT-439 | .claude/worktrees/agent-a047eb664f12448a4 | feat/dat-439-fail-loud-sweep | #243 | none (engine-only: validation agent-tier honesty pass; `status=failed` semantics change handed off to dataraum-eval for DAT-442) | gates green (ruff ✓, mypy ✓, 1325 unit + 260 integration ✓), lane smoke = 82 targeted validation/scorer tests, 2/2 reviewers APPROVE (senior + spec-compliance), PR open — awaiting lead merge |
 
-_(previously merged: DAT-320 #110, DAT-324 #111, DAT-321 #113, DAT-323 #114, DAT-325 #115, DAT-358 #128, DAT-340 #129, DAT-339 substrate #132, bun toolchain #133, DAT-400 #191, DAT-406 #192)_
+_(previously merged: DAT-320 #110, DAT-324 #111, DAT-321 #113, DAT-323 #114, DAT-325 #115, DAT-358 #128, DAT-340 #129, DAT-339 substrate #132, bun toolchain #133, DAT-400 #191, DAT-406 #192, DAT-414 #213, DAT-433 #225, DAT-437 #230, DAT-436 #231, Intent enforcement #232, DAT-449 #234, DAT-451 #236, DAT-454 CI gates #237, DAT-452 #238, DAT-434 #240; DAT-354/DAT-352 shipped via the DAT-339 lanes)_
 
 For slice-1 feature ticket state see [`dat339-pivot-status.md`](./dat339-pivot-status.md) and [`dat339-slice1-features-plan.md`](./dat339-slice1-features-plan.md).

--- a/packages/engine/src/dataraum/analysis/cycles/health.py
+++ b/packages/engine/src/dataraum/analysis/cycles/health.py
@@ -109,8 +109,14 @@ def compute_cycle_health(
             if vr.validation_id in relevant_spec_ids and set(vr.table_ids or []) & cycle_table_ids
         ]
 
-        validations_run = len(matched_results)
-        validations_passed = sum(1 for vr in matched_results if vr.passed)
+        # Pass rate counts JUDGED measurements only (DAT-439): error =
+        # inconclusive evaluation and skipped = never executed — neither is an
+        # assessment of the data, so both stay out of numerator AND
+        # denominator. Counting them (passed=False) would silently deflate
+        # cycle health for runs the system merely failed to judge.
+        assessed = [vr for vr in matched_results if vr.status not in ("error", "skipped")]
+        validations_run = len(assessed)
+        validations_passed = sum(1 for vr in assessed if vr.passed)
 
         validation_pass_rate: float | None = None
         if validations_run > 0:

--- a/packages/engine/src/dataraum/analysis/validation/agent.py
+++ b/packages/engine/src/dataraum/analysis/validation/agent.py
@@ -74,7 +74,13 @@ class ValidationAgent(LLMFeature):
             issues.append("No columns found in any table")
             return issues
 
-        # Check for semantic annotations (warning only, not blocking)
+        # DAT-439 decision: zero semantic annotations stays a WARNING, never a
+        # blocking issue. The absence is already durably visible — bind records
+        # the pinned base-run map (including its empty ``semantic_runs``) into
+        # every artifact's ``grounded_against`` provenance, and the workflow's
+        # resolve activity warns on unresolved heads. Blocking here would
+        # forbid validating legitimately annotation-free workspaces; the LLM
+        # degrades gracefully to bare column names/types.
         columns_with_semantic = sum(
             1 for t in tables for c in t.get("columns", []) if c.get("semantic")
         )
@@ -237,8 +243,11 @@ class ValidationAgent(LLMFeature):
             ]
             row_count = len(result_rows)
 
-            # Evaluate results based on check type
-            passed, message, details = self._evaluate_result(
+            # Evaluate results based on check type. ERROR = the evaluation is
+            # INCONCLUSIVE (ran, but the result shape cannot be judged) — the
+            # phase keeps the artifact at ``grounded`` with the reason, and
+            # the result never pollutes the FAILED measurements (DAT-439).
+            status, message, details = self._evaluate_result(
                 spec=spec,
                 result_rows=result_rows,
                 row_count=row_count,
@@ -247,11 +256,11 @@ class ValidationAgent(LLMFeature):
             return ValidationResult(
                 validation_id=spec.validation_id,
                 spec_name=spec.name,
-                status=ValidationStatus.PASSED if passed else ValidationStatus.FAILED,
+                status=status,
                 severity=spec.severity,
                 table_ids=scoped_table_ids,
                 table_name=combined_table_name,
-                passed=passed,
+                passed=status == ValidationStatus.PASSED,
                 message=message,
                 details=details,
                 sql_used=generated.sql_query,
@@ -354,37 +363,37 @@ class ValidationAgent(LLMFeature):
 
         response = result.value
 
-        # Extract tool call result
+        # No tool call = degraded generation. There is no rescue: under the
+        # lifecycle this is a bind ERROR — the artifact stays ``declared``
+        # with the reason. (DAT-439 deleted the JSON-parse-from-text fallback
+        # that silently rescued unstructured responses.)
         if not response.tool_calls:
-            # LLM didn't use the tool - try to parse text as fallback
             logger.warning(
                 "validation_llm_no_tool_call",
                 validation_id=spec.validation_id,
                 has_content=bool(response.content),
             )
-            if response.content:
-                try:
-                    response_data = json.loads(response.content)
-                    output = ValidationSQLOutput.model_validate(response_data)
-                except Exception as e:
-                    logger.warning(
-                        "validation_json_fallback_failed",
-                        validation_id=spec.validation_id,
-                        error=str(e),
-                    )
-                    return Result.fail(f"LLM did not use tool. Response: {response.content[:200]}")
-            else:
-                return Result.fail("LLM did not use the generate_validation_sql tool")
-        else:
-            # Parse tool response using Pydantic model
-            tool_call = response.tool_calls[0]
-            if tool_call.name != "generate_validation_sql":
-                return Result.fail(f"Unexpected tool call: {tool_call.name}")
+            return Result.fail(
+                "LLM did not use the generate_validation_sql tool — no structured output"
+            )
 
-            try:
-                output = ValidationSQLOutput.model_validate(tool_call.input)
-            except Exception as e:
-                return Result.fail(f"Failed to validate tool response: {e}")
+        # Parse tool response using Pydantic model
+        tool_call = response.tool_calls[0]
+        if tool_call.name != "generate_validation_sql":
+            return Result.fail(f"Unexpected tool call: {tool_call.name}")
+
+        try:
+            output = ValidationSQLOutput.model_validate(tool_call.input)
+        except Exception as e:
+            return Result.fail(f"Failed to validate tool response: {e}")
+
+        # can_validate without SQL is a degraded generation, not a skip —
+        # labeling it SKIPPED would mislabel the degradation as legitimate
+        # inapplicability (DAT-439 sweep). Bind ERROR instead.
+        if output.can_validate and not output.sql:
+            return Result.fail(
+                "LLM declared the validation feasible (can_validate=true) but returned no SQL"
+            )
 
         # Convert to GeneratedSQL
         generated = GeneratedSQL(
@@ -394,7 +403,7 @@ class ValidationAgent(LLMFeature):
             columns_used=output.columns_used,
             generated_at=datetime.now(UTC),
             model_used=model,
-            is_valid=output.can_validate and output.sql is not None,
+            is_valid=output.can_validate,
             validation_error=output.skip_reason,
         )
 
@@ -405,8 +414,16 @@ class ValidationAgent(LLMFeature):
         spec: ValidationSpec,
         result_rows: list[dict[str, Any]],
         row_count: int,
-    ) -> tuple[bool, str, dict[str, Any]]:
+    ) -> tuple[ValidationStatus, str, dict[str, Any]]:
         """Evaluate validation result based on check type.
+
+        PASSED/FAILED is a *judged measurement* of the data. ERROR means the
+        evaluation is INCONCLUSIVE: the SQL ran, but the result shape cannot
+        be judged (no recognizable columns, zero rows on a summary check, an
+        unrecognized check type). An inconclusive evaluation is not a data
+        failure — reporting it FAILED would pollute the failure measurements
+        ``cross_table_consistency`` scores, so it must never reach FAILED
+        (DAT-439; the artifact stays ``grounded`` with the reason).
 
         Args:
             spec: Validation spec
@@ -414,28 +431,34 @@ class ValidationAgent(LLMFeature):
             row_count: Total row count
 
         Returns:
-            Tuple of (passed, message, details)
+            Tuple of (status, message, details) with status PASSED/FAILED/ERROR
         """
         check_type = spec.check_type
         params = spec.parameters
         tolerance = params.get("tolerance", self.DEFAULT_TOLERANCE)
 
+        def measured(passed: bool) -> ValidationStatus:
+            return ValidationStatus.PASSED if passed else ValidationStatus.FAILED
+
         if check_type == "balance":
             # Balance checks compare two values
             if row_count == 0:
-                return (False, "No results returned", {"check_type": check_type})
+                return (
+                    ValidationStatus.ERROR,
+                    "Balance check inconclusive: query returned no rows",
+                    {"check_type": check_type},
+                )
 
             row = result_rows[0]
 
             # Look for difference column first (preferred: LLM computes the diff)
             if "difference" in row or "diff" in row:
                 diff = abs(float(row.get("difference", row.get("diff", 0)) or 0))
-                passed = diff <= tolerance
                 # Promote magnitude into flat details so the scorer can
                 # read it directly (it expects details["magnitude"]).
                 mag = abs(float(row.get("magnitude") or 0)) or abs(diff) or 1
                 return (
-                    passed,
+                    measured(diff <= tolerance),
                     f"Balance difference: {diff:.2f} (tolerance: {tolerance})",
                     {
                         "check_type": check_type,
@@ -452,9 +475,8 @@ class ValidationAgent(LLMFeature):
                 val1 = float(row[value_cols[0]] or 0)
                 val2 = float(row[value_cols[1]] or 0)
                 diff = abs(val1 - val2)
-                passed = diff <= tolerance
                 return (
-                    passed,
+                    measured(diff <= tolerance),
                     f"Balance check: {value_cols[0]}={val1:.2f}, {value_cols[1]}={val2:.2f}, diff={diff:.2f}",
                     {
                         "check_type": check_type,
@@ -464,18 +486,23 @@ class ValidationAgent(LLMFeature):
                     },
                 )
 
-            # No recognizable columns — fail explicitly rather than silently pass
+            # No recognizable columns — inconclusive, never FAILED
             return (
-                False,
+                ValidationStatus.ERROR,
                 f"Balance check inconclusive: could not identify balance columns in result. "
                 f"Columns returned: {list(row.keys())}",
                 {"check_type": check_type, "row": row},
             )
 
         elif check_type == "constraint":
-            # Constraint checks return violating rows.
+            # Constraint checks return violating rows; an empty result IS the
+            # judgement (no violations), unlike the summary checks above.
             if row_count == 0:
-                return (True, "No constraint violations found", {"check_type": check_type})
+                return (
+                    ValidationStatus.PASSED,
+                    "No constraint violations found",
+                    {"check_type": check_type},
+                )
             # Extract total_rows from result columns if the LLM included it
             details: dict[str, Any] = {"check_type": check_type, "violation_count": row_count}
             if result_rows:
@@ -490,7 +517,7 @@ class ValidationAgent(LLMFeature):
                     # Single row with violation_count → summary, not raw violations
                     details["violation_count"] = int(vc)
             return (
-                False,
+                ValidationStatus.FAILED,
                 f"Found {details['violation_count']} constraint violations",
                 details,
             )
@@ -498,7 +525,11 @@ class ValidationAgent(LLMFeature):
         elif check_type == "comparison":
             # Comparison checks (e.g., Assets = Liabilities + Equity)
             if row_count == 0:
-                return (False, "No results returned", {"check_type": check_type})
+                return (
+                    ValidationStatus.ERROR,
+                    "Comparison check inconclusive: query returned no rows",
+                    {"check_type": check_type},
+                )
 
             row = result_rows[0]
             tolerance = params.get("tolerance", self.DEFAULT_TOLERANCE)
@@ -507,7 +538,7 @@ class ValidationAgent(LLMFeature):
             if "equation_holds" in row:
                 passed = bool(row["equation_holds"])
                 return (
-                    passed,
+                    measured(passed),
                     f"Equation check: {'passed' if passed else 'failed'}",
                     {**row, "check_type": check_type},
                 )
@@ -515,7 +546,7 @@ class ValidationAgent(LLMFeature):
             if "is_valid" in row:
                 passed = bool(row["is_valid"])
                 return (
-                    passed,
+                    measured(passed),
                     f"Comparison check: {'passed' if passed else 'failed'}",
                     {**row, "check_type": check_type},
                 )
@@ -523,15 +554,16 @@ class ValidationAgent(LLMFeature):
             # Check for difference column
             if "difference" in row:
                 diff = abs(float(row["difference"] or 0))
-                passed = diff <= tolerance
                 return (
-                    passed,
+                    measured(diff <= tolerance),
                     f"Comparison difference: {diff:.2f}",
                     {"check_type": check_type, "difference": diff},
                 )
 
+            # No recognizable columns — inconclusive, never FAILED (the
+            # smoke-proven three_way_match shape, DAT-439).
             return (
-                False,
+                ValidationStatus.ERROR,
                 f"Comparison check inconclusive: could not identify comparison columns in result. "
                 f"Columns returned: {list(row.keys())}",
                 {"check_type": check_type, "row": row},
@@ -540,7 +572,11 @@ class ValidationAgent(LLMFeature):
         elif check_type == "aggregate":
             # Aggregate checks return summary values with a rate metric
             if row_count == 0:
-                return (False, "No results returned", {"check_type": check_type})
+                return (
+                    ValidationStatus.ERROR,
+                    "Aggregate check inconclusive: query returned no rows",
+                    {"check_type": check_type},
+                )
 
             row = result_rows[0]
             details = {**row, "check_type": check_type}
@@ -554,16 +590,21 @@ class ValidationAgent(LLMFeature):
                     break
 
             if rate is not None:
-                passed = rate <= tolerance
-                return (passed, f"Aggregate rate: {rate:.4f}", details)
+                return (measured(rate <= tolerance), f"Aggregate rate: {rate:.4f}", details)
 
-            return (True, "Aggregate check completed", details)
+            # DAT-439 decision: no rate metric stays PASSED — the prompt
+            # contract for aggregate checks is "summary values for review"
+            # (no rate required); the rate judgement above is opportunistic.
+            return (ValidationStatus.PASSED, "Aggregate check completed", details)
 
         else:
-            # Custom check - assume passing if any results
+            # Unrecognized check type: the evaluator has no semantics to
+            # judge with — inconclusive, never a row_count>0 guess (DAT-439
+            # sweep; previously "assume passing if any results").
             return (
-                row_count > 0,
-                f"Custom check returned {row_count} rows",
+                ValidationStatus.ERROR,
+                f"Cannot evaluate check_type {check_type!r}: no evaluation semantics defined "
+                f"(query returned {row_count} rows)",
                 {"check_type": check_type, "row_count": row_count},
             )
 

--- a/packages/engine/src/dataraum/analysis/validation/models.py
+++ b/packages/engine/src/dataraum/analysis/validation/models.py
@@ -184,6 +184,14 @@ class ValidationRunResult(BaseModel):
             failed_checks=failed,
             skipped_checks=skipped,
             error_checks=errors,
+            # ``overall_status`` collapses to FAILED on either a judged data
+            # failure OR an inconclusive/errored check (``errors`` now
+            # includes inconclusive evaluations, DAT-439) — it is a coarse
+            # "not all-clean" flag, NOT a pure data-failure signal. A
+            # cockpit/readiness consumer that needs to distinguish "data is
+            # wrong" from "couldn't judge" must read the per-check
+            # ``failed_checks`` vs ``error_checks`` axes, not this rollup
+            # (a DEGRADED/INCONCLUSIVE overall state is DAT-440+).
             overall_status=(
                 ValidationStatus.FAILED if (failed or errors) else ValidationStatus.PASSED
             ),

--- a/packages/engine/src/dataraum/analysis/validation/resolver.py
+++ b/packages/engine/src/dataraum/analysis/validation/resolver.py
@@ -76,6 +76,13 @@ def get_multi_table_schema_for_llm(
     if not tables:
         return {"error": "No tables found"}
 
+    # A requested table missing from metadata silently shrinks the LLM's
+    # schema — surface it loudly (DAT-439 sweep): the session-scope wiring
+    # asked for a table that does not exist.
+    if len(tables) < len(table_ids):
+        missing = sorted(set(table_ids) - {t.table_id for t in tables})
+        logger.warning("validation_schema_tables_missing", missing_table_ids=missing)
+
     annotations = _load_pinned_annotations(session, tables, base_runs.semantic_runs)
 
     # Build table schemas
@@ -85,6 +92,14 @@ def get_multi_table_schema_for_llm(
 
     for table in tables:
         if not table.duckdb_path:
+            # Excluded from the schema the LLM sees — loud, never a silent
+            # drop (DAT-439 sweep). A typed table without a lake path is a
+            # pipeline wiring bug.
+            logger.warning(
+                "validation_schema_table_without_duckdb_path",
+                table=table.table_name,
+                table_id=table.table_id,
+            )
             continue
 
         row_count = None
@@ -95,6 +110,14 @@ def get_multi_table_schema_for_llm(
                 ).fetchone()
                 row_count = result[0] if result else None
             except Exception:
+                # DAT-439 decision (item 4): KEEP this swallow. Row counts are
+                # LLM-context garnish — a failed COUNT(*) must not block
+                # schema assembly. The real failure it could mask (table
+                # missing from the lake) surfaces loudly downstream: bind
+                # proves every generated SQL with EXPLAIN, which fails →
+                # bind ERROR → the artifact stays ``declared`` with the
+                # reason. Pinned by test_bind_missing_lake_table_fails_explain
+                # and test_missing_lake_table_keeps_schema_without_row_count.
                 logger.warning(
                     "row_count_failed",
                     table=table.table_name,

--- a/packages/engine/src/dataraum/entropy/detectors/computational/cross_table_consistency.py
+++ b/packages/engine/src/dataraum/entropy/detectors/computational/cross_table_consistency.py
@@ -40,6 +40,9 @@ def _score_validation_result(result: Any) -> float:
     Returns:
         Score between 0.0 (passed) and 1.0 (critical failure).
     """
+    # PASSED is the ONLY ``passed=True`` state — SKIPPED and ERROR both carry
+    # ``passed=False`` and so fall through to the explicit status branches
+    # below (which is why there is no ``status == "passed"`` branch).
     if result.passed:
         return 0.0
 

--- a/packages/engine/src/dataraum/entropy/detectors/computational/cross_table_consistency.py
+++ b/packages/engine/src/dataraum/entropy/detectors/computational/cross_table_consistency.py
@@ -43,8 +43,18 @@ def _score_validation_result(result: Any) -> float:
     if result.passed:
         return 0.0
 
+    if result.status == "skipped":
+        # Bind-time skip: the LLM declared the validation inapplicable to
+        # this workspace. Not a data measurement — it must not contribute
+        # entropy. Without this branch a skipped row that carries table_ids
+        # falls into the check-type scoring below and can score 1.0
+        # (comparison's binary branch) — a mislabel (DAT-439).
+        return 0.0
+
     if result.status == "error":
-        # Execution error — can't assess, treat as moderate uncertainty
+        # Execution error or inconclusive evaluation (DAT-439) — the check
+        # could not assess the data; moderate uncertainty, never a failure
+        # measurement.
         return 0.5
 
     details = result.details or {}

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -1171,9 +1171,14 @@ def format_metadata_document(
         lines.append("")
         lines.append("## Validation Results")
         lines.append("")
-        failed = [v for v in context.validations if not v.passed]
+        # Bucket by STATUS, not the passed bool (DAT-439): error = the
+        # evaluation was inconclusive and skipped = never executed — labeling
+        # either as FAILED would tell the LLM the data failed a check it was
+        # never actually judged by.
         passed = [v for v in context.validations if v.passed]
-        lines.append(f"PASSED: {len(passed)} | FAILED: {len(failed)}")
+        failed = [v for v in context.validations if v.status == "failed"]
+        unjudged = [v for v in context.validations if v.status in ("error", "skipped")]
+        lines.append(f"PASSED: {len(passed)} | FAILED: {len(failed)} | UNJUDGED: {len(unjudged)}")
         if failed:
             lines.append("")
             lines.append("Failed:")
@@ -1183,6 +1188,11 @@ def format_metadata_document(
                     summary = v.details.get("summary", "")
                     if summary:
                         lines.append(f"  Details: {summary}")
+        if unjudged:
+            lines.append("")
+            lines.append("Unjudged (inconclusive or not executed — NOT data failures):")
+            for v in unjudged:
+                lines.append(f"- [{v.status}] {v.validation_id}: {v.message}")
 
     return "\n".join(lines)
 

--- a/packages/engine/src/dataraum/pipeline/phases/validation_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/validation_phase.py
@@ -245,7 +245,7 @@ class ValidationPhase(BasePhase):
             summary=(
                 f"{executed}/{len(artifacts)} validations executed "
                 f"({run_result.passed_checks} passed, {run_result.failed_checks} failed); "
-                f"{declared_stuck} ungroundable, {grounded_stuck} execution errors"
+                f"{declared_stuck} ungroundable, {grounded_stuck} unresolved (execution error or inconclusive)"
             ),
         )
 

--- a/packages/engine/src/dataraum/pipeline/phases/validation_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/validation_phase.py
@@ -11,8 +11,10 @@ lifecycle:
   reason on the row — visibly impossible, never silently absent.
 * **execute** (``validation.execute``) — the grounded SQL runs and is
   evaluated; the artifact reaches ``executed``. PASSED/FAILED is the
-  *measurement*, not the lifecycle outcome; only an execution ERROR keeps the
-  artifact at ``grounded`` (with the reason recorded).
+  *measurement*, not the lifecycle outcome; an execution ERROR **or an
+  inconclusive evaluation** (the SQL ran but its result shape cannot be
+  judged — DAT-439) keeps the artifact at ``grounded`` with the reason
+  recorded. Inconclusive is never reported as FAILED.
 
 A re-run supersedes: everything is re-declared and re-flowed under the fresh
 ``run_id`` (no skip-if-already-ran — the prior run's rows coexist untouched,
@@ -192,7 +194,9 @@ class ValidationPhase(BasePhase):
 
             result = agent.execute_validation(ctx.duckdb_conn, table_ids, spec, schema, generated)
             if result.status == ValidationStatus.ERROR:
-                # Execution didn't complete cleanly: stays grounded, with reason.
+                # Execution error OR inconclusive evaluation (the SQL ran but
+                # its result shape cannot be judged, DAT-439): stays grounded,
+                # with the reason on the row.
                 artifact.state_reason = result.message
             else:
                 transition(artifact, operation="execute", stage=_STAGE)

--- a/packages/engine/tests/integration/analysis/validation/test_agent.py
+++ b/packages/engine/tests/integration/analysis/validation/test_agent.py
@@ -141,126 +141,168 @@ def table_with_data(session, duckdb_conn):
     return table
 
 
+def _eval_spec(check_type: str, **parameters) -> ValidationSpec:
+    return ValidationSpec(
+        validation_id="test",
+        name="Test",
+        description="Test",
+        category="test",
+        check_type=check_type,
+        parameters=parameters,
+    )
+
+
 class TestValidationAgentEvaluateResult:
-    """Tests for the _evaluate_result method."""
+    """Tests for the _evaluate_result method.
+
+    Returns (status, message, details): PASSED/FAILED is a judged
+    measurement; ERROR means INCONCLUSIVE — the result shape could not be
+    judged. Inconclusive must never surface as FAILED (DAT-439).
+    """
 
     def test_evaluate_balance_check_passed(self, validation_agent):
         """Test balance check evaluation when balanced."""
-        spec = ValidationSpec(
-            validation_id="test",
-            name="Test",
-            description="Test",
-            category="test",
-            check_type="balance",
-            parameters={"tolerance": 0.01},
-        )
-
+        spec = _eval_spec("balance", tolerance=0.01)
         result_rows = [{"total_debits": 150.00, "total_credits": 150.00, "difference": 0.00}]
 
-        passed, message, details = validation_agent._evaluate_result(spec, result_rows, 1)
+        status, message, details = validation_agent._evaluate_result(spec, result_rows, 1)
 
-        assert passed is True
+        assert status == ValidationStatus.PASSED
         assert "0.00" in message
 
     def test_evaluate_balance_check_failed(self, validation_agent):
         """Test balance check evaluation when not balanced."""
-        spec = ValidationSpec(
-            validation_id="test",
-            name="Test",
-            description="Test",
-            category="test",
-            check_type="balance",
-            parameters={"tolerance": 0.01},
-        )
-
+        spec = _eval_spec("balance", tolerance=0.01)
         result_rows = [{"total_debits": 150.00, "total_credits": 100.00, "difference": 50.00}]
 
-        passed, message, details = validation_agent._evaluate_result(spec, result_rows, 1)
+        status, message, details = validation_agent._evaluate_result(spec, result_rows, 1)
 
-        assert passed is False
+        assert status == ValidationStatus.FAILED
         assert details["difference"] == 50.0
 
+    def test_evaluate_balance_unrecognizable_columns_is_error_not_failed(self, validation_agent):
+        """A balance result without judgeable columns is inconclusive → ERROR."""
+        spec = _eval_spec("balance")
+        result_rows = [{"some_col": 1, "other_col": 2}]
+
+        status, message, details = validation_agent._evaluate_result(spec, result_rows, 1)
+
+        assert status == ValidationStatus.ERROR
+        assert "inconclusive" in message
+        assert "some_col" in message
+
+    def test_evaluate_balance_zero_rows_is_error(self, validation_agent):
+        """A balance summary query returning no rows cannot be judged → ERROR."""
+        status, message, _ = validation_agent._evaluate_result(_eval_spec("balance"), [], 0)
+
+        assert status == ValidationStatus.ERROR
+        assert "inconclusive" in message
+
     def test_evaluate_constraint_check_no_violations(self, validation_agent):
-        """Test constraint check with no violations."""
-        spec = ValidationSpec(
-            validation_id="test",
-            name="Test",
-            description="Test",
-            category="test",
-            check_type="constraint",
+        """Constraint: an empty result IS the judgement (no violations) → PASSED."""
+        status, message, details = validation_agent._evaluate_result(
+            _eval_spec("constraint"), [], 0
         )
 
-        passed, message, details = validation_agent._evaluate_result(spec, [], 0)
-
-        assert passed is True
+        assert status == ValidationStatus.PASSED
         assert "No constraint violations" in message
 
     def test_evaluate_constraint_check_with_violations(self, validation_agent):
         """Test constraint check with violations."""
-        spec = ValidationSpec(
-            validation_id="test",
-            name="Test",
-            description="Test",
-            category="test",
-            check_type="constraint",
-        )
-
         result_rows = [{"id": 1, "violation": "negative amount"}]
 
-        passed, message, details = validation_agent._evaluate_result(spec, result_rows, 1)
+        status, message, details = validation_agent._evaluate_result(
+            _eval_spec("constraint"), result_rows, 1
+        )
 
-        assert passed is False
+        assert status == ValidationStatus.FAILED
         assert "1 constraint violations" in message
 
     def test_evaluate_comparison_check_equation_holds(self, validation_agent):
         """Test comparison check with equation_holds column."""
-        spec = ValidationSpec(
-            validation_id="test",
-            name="Test",
-            description="Test",
-            category="test",
-            check_type="comparison",
-        )
-
         result_rows = [{"assets": 1000, "liabilities": 600, "equity": 400, "equation_holds": True}]
 
-        passed, message, details = validation_agent._evaluate_result(spec, result_rows, 1)
+        status, message, details = validation_agent._evaluate_result(
+            _eval_spec("comparison"), result_rows, 1
+        )
 
-        assert passed is True
+        assert status == ValidationStatus.PASSED
         assert "passed" in message
 
     def test_evaluate_comparison_check_equation_fails(self, validation_agent):
         """Test comparison check when equation doesn't hold."""
-        spec = ValidationSpec(
-            validation_id="test",
-            name="Test",
-            description="Test",
-            category="test",
-            check_type="comparison",
-        )
-
         result_rows = [{"assets": 1000, "liabilities": 600, "equity": 300, "equation_holds": False}]
 
-        passed, message, details = validation_agent._evaluate_result(spec, result_rows, 1)
-
-        assert passed is False
-
-    def test_evaluate_aggregate_check(self, validation_agent):
-        """Test aggregate check evaluation."""
-        spec = ValidationSpec(
-            validation_id="test",
-            name="Test",
-            description="Test",
-            category="test",
-            check_type="aggregate",
+        status, message, details = validation_agent._evaluate_result(
+            _eval_spec("comparison"), result_rows, 1
         )
 
+        assert status == ValidationStatus.FAILED
+
+    def test_evaluate_comparison_inconclusive_is_error_not_failed(self, validation_agent):
+        """The smoke-proven three_way_match shape (DAT-439): a comparison
+        result without equation_holds/is_valid/difference columns is
+        inconclusive — it must be ERROR, never FAILED."""
+        result_rows = [{"po_count": 5, "invoice_count": 3, "receipt_count": 4}]
+
+        status, message, details = validation_agent._evaluate_result(
+            _eval_spec("comparison"), result_rows, 1
+        )
+
+        assert status == ValidationStatus.ERROR
+        assert "Comparison check inconclusive" in message
+        assert "could not identify comparison columns" in message
+        assert details["check_type"] == "comparison"
+
+    def test_evaluate_comparison_zero_rows_is_error(self, validation_agent):
+        """A comparison query returning no rows cannot be judged → ERROR."""
+        status, message, _ = validation_agent._evaluate_result(_eval_spec("comparison"), [], 0)
+
+        assert status == ValidationStatus.ERROR
+        assert "inconclusive" in message
+
+    def test_evaluate_aggregate_check(self, validation_agent):
+        """DAT-439 decision pin: aggregate without a rate metric stays PASSED —
+        the prompt contract is 'summary values for review' (no rate required);
+        the rate judgement is opportunistic."""
         result_rows = [{"min_date": "2024-01-01", "max_date": "2024-12-31", "total_records": 1000}]
 
-        passed, message, details = validation_agent._evaluate_result(spec, result_rows, 1)
+        status, message, details = validation_agent._evaluate_result(
+            _eval_spec("aggregate"), result_rows, 1
+        )
 
-        assert passed is True
+        assert status == ValidationStatus.PASSED
         assert "Aggregate check completed" in message
+
+    def test_evaluate_aggregate_rate_above_tolerance_fails(self, validation_agent):
+        """An aggregate WITH a rate metric is judged against tolerance."""
+        result_rows = [{"orphan_rate": 0.5, "total": 100}]
+
+        status, message, _ = validation_agent._evaluate_result(
+            _eval_spec("aggregate", tolerance=0.01), result_rows, 1
+        )
+
+        assert status == ValidationStatus.FAILED
+
+    def test_evaluate_aggregate_zero_rows_is_error(self, validation_agent):
+        """An aggregate summary query returning no rows cannot be judged → ERROR."""
+        status, message, _ = validation_agent._evaluate_result(_eval_spec("aggregate"), [], 0)
+
+        assert status == ValidationStatus.ERROR
+        assert "inconclusive" in message
+
+    def test_evaluate_unknown_check_type_is_error(self, validation_agent):
+        """An unrecognized check type has no evaluation semantics — ERROR,
+        never the old row_count>0 guess (DAT-439 sweep)."""
+        result_rows = [{"anything": 1}]
+
+        status, message, details = validation_agent._evaluate_result(
+            _eval_spec("referential"), result_rows, 1
+        )
+
+        assert status == ValidationStatus.ERROR
+        assert "Cannot evaluate check_type 'referential'" in message
+        assert details["row_count"] == 1
 
 
 class TestValidationAgentGenerateSQL:
@@ -386,6 +428,47 @@ class TestValidationAgentGenerateSQL:
         assert not result.success
         assert "disabled" in result.error
 
+    def test_generate_sql_no_tool_call_fails(self, validation_agent, mock_provider):
+        """No tool call = bind ERROR with reason — the JSON-parse-from-text
+        fallback is deleted (DAT-439): even parseable text content must NOT
+        be rescued into a GeneratedSQL."""
+        spec = _eval_spec("balance")
+        schema = {"table_name": "test", "duckdb_path": "test", "columns": []}
+
+        response = MagicMock()
+        response.tool_calls = []
+        # Valid JSON the old fallback would have silently rescued.
+        response.content = (
+            '{"sql": "SELECT 1", "can_validate": true, "columns_used": [], "skip_reason": null}'
+        )
+        mock_provider.converse.return_value = Result.ok(response)
+
+        result = validation_agent._generate_sql(spec, schema)
+
+        assert not result.success
+        assert "did not use the generate_validation_sql tool" in result.error
+
+    def test_generate_sql_can_validate_without_sql_fails(self, validation_agent, mock_provider):
+        """can_validate=true with no SQL is a degraded generation, not a
+        legitimate skip — it must fail the bind, never surface as SKIPPED
+        (DAT-439 sweep)."""
+        spec = _eval_spec("balance")
+        schema = {"table_name": "test", "duckdb_path": "test", "columns": []}
+
+        tool_input = {
+            "sql": None,
+            "explanation": "confused response",
+            "columns_used": [],
+            "can_validate": True,
+            "skip_reason": None,
+        }
+        mock_provider.converse.return_value = Result.ok(_make_tool_response(tool_input))
+
+        result = validation_agent._generate_sql(spec, schema)
+
+        assert not result.success
+        assert "returned no SQL" in result.error
+
 
 class TestValidationAgentBindExecute:
     """Tests for the bind/execute lifecycle operations (DAT-438).
@@ -486,3 +569,88 @@ class TestValidationAgentBindExecute:
         assert bind_failure is not None
         assert bind_failure.status == ValidationStatus.SKIPPED
         assert "Missing account_type" in bind_failure.message
+
+    def test_bind_missing_lake_table_fails_explain(
+        self, session, duckdb_conn, validation_agent, mock_provider, table_with_data
+    ):
+        """Pins the downstream catch behind the resolver's row-count swallow
+        (DAT-439 item 4): a table missing from the lake surfaces at bind —
+        EXPLAIN fails → bind ERROR with reason, never a silent half-context
+        run."""
+        table = table_with_data
+
+        spec = ValidationSpec(
+            validation_id="missing_table_check",
+            name="Missing Table Check",
+            description="References a table that is not in the lake",
+            category="test",
+            check_type="balance",
+        )
+
+        from dataraum.analysis.validation.resolver import (
+            get_multi_table_schema_for_llm,
+        )
+
+        schema = get_multi_table_schema_for_llm(session, [table.table_id], base_runs=BaseRunMap())
+
+        tool_input = {
+            "sql": "SELECT SUM(debit) AS total_debits FROM typed_table_not_in_lake",
+            "explanation": "Sums debits from a table that does not exist",
+            "columns_used": ["debit"],
+            "can_validate": True,
+            "skip_reason": None,
+        }
+        mock_provider.converse.return_value = Result.ok(_make_tool_response(tool_input))
+
+        generated, bind_failure = validation_agent.bind_validation(
+            duckdb_conn, [table.table_id], spec, schema
+        )
+
+        assert generated is None
+        assert bind_failure is not None
+        assert bind_failure.status == ValidationStatus.ERROR
+        assert "Generated SQL is invalid" in bind_failure.message
+
+    def test_execute_inconclusive_result_is_error(
+        self, session, duckdb_conn, validation_agent, mock_provider, table_with_data
+    ):
+        """End-to-end execute pin: SQL runs but returns an unjudgeable shape
+        → status ERROR (inconclusive), never FAILED (DAT-439 item 1)."""
+        table = table_with_data
+
+        spec = ValidationSpec(
+            validation_id="three_way_match",
+            name="Three Way Match",
+            description="PO = invoice = receipt",
+            category="financial",
+            check_type="comparison",
+        )
+
+        from dataraum.analysis.validation.resolver import (
+            get_multi_table_schema_for_llm,
+        )
+
+        schema = get_multi_table_schema_for_llm(session, [table.table_id], base_runs=BaseRunMap())
+
+        tool_input = {
+            "sql": "SELECT 5 AS po_count, 3 AS invoice_count FROM typed_journal_entries LIMIT 1",
+            "explanation": "Counts without a judgeable comparison column",
+            "columns_used": [],
+            "can_validate": True,
+            "skip_reason": None,
+        }
+        mock_provider.converse.return_value = Result.ok(_make_tool_response(tool_input))
+
+        generated, bind_failure = validation_agent.bind_validation(
+            duckdb_conn, [table.table_id], spec, schema
+        )
+        assert bind_failure is None
+        assert generated is not None
+
+        result = validation_agent.execute_validation(
+            duckdb_conn, [table.table_id], spec, schema, generated
+        )
+
+        assert result.status == ValidationStatus.ERROR
+        assert result.passed is False
+        assert "Comparison check inconclusive" in result.message

--- a/packages/engine/tests/integration/pipeline/test_validation_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_validation_phase.py
@@ -264,6 +264,45 @@ class TestValidationLifecycleFlow:
     @patch("dataraum.analysis.validation.agent.ValidationAgent.execute_validation")
     @patch("dataraum.analysis.validation.agent.ValidationAgent.bind_validation")
     @patch("dataraum.pipeline.phases.validation_phase.load_all_validation_specs")
+    def test_inconclusive_evaluation_stays_grounded_never_failed(
+        self,
+        mock_load: MagicMock,
+        mock_bind: MagicMock,
+        mock_execute: MagicMock,
+        session: Session,
+        duckdb_conn: duckdb.DuckDBPyConnection,
+        workspace_table: Table,
+        _mock_llm: None,
+    ) -> None:
+        """The smoke-proven three_way_match shape (DAT-439): an evaluation
+        that could not judge the data arrives as status ERROR — the artifact
+        stays grounded with the reason, and the persisted record is never
+        ``failed``."""
+        mock_load.return_value = {"three_way_match": _spec("three_way_match")}
+        mock_bind.return_value = (MagicMock(sql_query="SELECT 1"), None)
+        inconclusive_msg = (
+            "Comparison check inconclusive: could not identify comparison columns in result. "
+            "Columns returned: ['po_count', 'invoice_count']"
+        )
+        mock_execute.return_value = _result(
+            "three_way_match", ValidationStatus.ERROR, inconclusive_msg
+        )
+
+        result = ValidationPhase()._run(_make_ctx(session, duckdb_conn, [workspace_table.table_id]))
+        session.flush()
+
+        artifact = _artifacts(session, "run-om-1")["three_way_match"]
+        assert artifact.state == ArtifactState.GROUNDED.value
+        assert "inconclusive" in (artifact.state_reason or "")
+
+        records = session.execute(select(ValidationResultRecord)).scalars().all()
+        assert [(r.validation_id, r.status) for r in records] == [("three_way_match", "error")]
+        assert result.outputs["failed_checks"] == 0
+        assert result.outputs["error_checks"] == 1
+
+    @patch("dataraum.analysis.validation.agent.ValidationAgent.execute_validation")
+    @patch("dataraum.analysis.validation.agent.ValidationAgent.bind_validation")
+    @patch("dataraum.pipeline.phases.validation_phase.load_all_validation_specs")
     def test_rerun_supersedes_under_fresh_run_id(
         self,
         mock_load: MagicMock,

--- a/packages/engine/tests/unit/analysis/cycles/test_health.py
+++ b/packages/engine/tests/unit/analysis/cycles/test_health.py
@@ -32,11 +32,13 @@ def _make_validation_result(
     validation_id: str = "double_entry_balance",
     table_ids: list[str] | None = None,
     passed: bool = True,
+    status: str | None = None,
 ) -> MagicMock:
     vr = MagicMock()
     vr.validation_id = validation_id
     vr.table_ids = table_ids or ["t1"]
     vr.passed = passed
+    vr.status = status if status is not None else ("passed" if passed else "failed")
     return vr
 
 
@@ -120,6 +122,42 @@ class TestComputeCycleHealth:
         assert score.completion_rate is None
         assert score.validation_pass_rate == 1.0
         assert score.composite_score == pytest.approx(1.0)
+
+    @patch("dataraum.analysis.cycles.health.get_validation_specs_for_cycles")
+    def test_unjudged_results_stay_out_of_the_pass_rate(self, mock_get_specs: MagicMock) -> None:
+        """DAT-439: error = inconclusive and skipped = never executed.
+
+        Neither is an assessment of the data — they leave the pass-rate
+        numerator AND denominator, instead of silently deflating cycle
+        health as passed=False rows.
+        """
+        mock_get_specs.return_value = [
+            _make_validation_spec("double_entry_balance"),
+            _make_validation_spec("three_way_match"),
+            _make_validation_spec("sign_conventions"),
+        ]
+
+        cycle = _make_cycle(completion_rate=None)
+        judged = _make_validation_result("double_entry_balance", ["t1"], passed=True)
+        inconclusive = _make_validation_result(
+            "three_way_match", ["t1"], passed=False, status="error"
+        )
+        never_ran = _make_validation_result(
+            "sign_conventions", ["t1"], passed=False, status="skipped"
+        )
+
+        session = MagicMock()
+        session.scalars.side_effect = [
+            MagicMock(all=MagicMock(return_value=[cycle])),
+            MagicMock(all=MagicMock(return_value=[judged, inconclusive, never_ran])),
+        ]
+
+        report = compute_cycle_health(session, "src1", vertical="finance", run_id="run-om")
+
+        score = report.cycle_scores[0]
+        assert score.validations_run == 1  # only the judged measurement
+        assert score.validations_passed == 1
+        assert score.validation_pass_rate == 1.0  # NOT 1/3
 
     @patch("dataraum.analysis.cycles.health.get_validation_specs_for_cycles")
     def test_no_run_reads_no_validation_evidence(self, mock_get_specs: MagicMock) -> None:

--- a/packages/engine/tests/unit/analysis/validation/test_resolver.py
+++ b/packages/engine/tests/unit/analysis/validation/test_resolver.py
@@ -330,6 +330,72 @@ def test_get_multi_table_schema_for_llm_nonexistent_tables(session):
     assert "error" in schema
 
 
+def test_missing_lake_table_keeps_schema_without_row_count(
+    session, duckdb_conn, table_with_columns
+):
+    """DAT-439 item-4 pin: the row-count swallow holds.
+
+    The table's ``duckdb_path`` does not exist in the lake — COUNT(*) raises,
+    the resolver swallows it (row counts are LLM-context garnish) and still
+    assembles the schema, just without ``row_count``. The REAL failure
+    surfaces downstream at bind: EXPLAIN fails → bind ERROR → the artifact
+    stays declared with the reason (pinned by
+    test_bind_missing_lake_table_fails_explain in the agent tests).
+    """
+    table = table_with_columns  # duckdb_path="typed_transactions", not in duckdb_conn
+
+    schema = get_multi_table_schema_for_llm(
+        session, [table.table_id], duckdb_conn=duckdb_conn, base_runs=_pins(table)
+    )
+
+    assert "error" not in schema
+    assert len(schema["tables"]) == 1
+    assert "row_count" not in schema["tables"][0]
+    # The schema is otherwise complete — columns intact for the LLM prompt.
+    assert {c["column_name"] for c in schema["tables"][0]["columns"]} == {
+        "transaction_id",
+        "amount",
+        "account_type",
+    }
+
+
+def test_partially_missing_table_ids_returns_existing(session, table_with_columns):
+    """A requested-but-missing table id shrinks the schema loudly (warning),
+    never silently: the existing tables still resolve (DAT-439 sweep)."""
+    table = table_with_columns
+
+    schema = get_multi_table_schema_for_llm(
+        session, [table.table_id, "nonexistent-id"], base_runs=_pins(table)
+    )
+
+    assert "error" not in schema
+    assert [t["table_id"] for t in schema["tables"]] == [table.table_id]
+
+
+def test_table_without_duckdb_path_is_excluded(session, table_with_columns):
+    """A table with no lake path cannot be validated against — it is excluded
+    from the LLM schema (with a warning, DAT-439 sweep); the rest survive."""
+    from dataraum.storage import Source, Table
+
+    good = table_with_columns
+    source = session.query(Source).first()
+    pathless = Table(
+        source_id=source.source_id,
+        table_name="pathless",
+        layer="typed",
+        duckdb_path=None,
+    )
+    session.add(pathless)
+    session.commit()
+
+    schema = get_multi_table_schema_for_llm(
+        session, [good.table_id, pathless.table_id], base_runs=_pins(good)
+    )
+
+    assert "error" not in schema
+    assert [t["table_name"] for t in schema["tables"]] == ["transactions"]
+
+
 class TestFormatMultiTableSchemaForPrompt:
     """Tests for formatting multi-table schema as prompt text."""
 

--- a/packages/engine/tests/unit/entropy/test_cross_table_consistency.py
+++ b/packages/engine/tests/unit/entropy/test_cross_table_consistency.py
@@ -57,8 +57,18 @@ class TestScoreValidationResult:
         assert _score_validation_result(r) == 0.0
 
     def test_error_returns_moderate(self):
+        """Execution errors AND inconclusive evaluations land here (DAT-439):
+        the check could not assess the data — moderate uncertainty, never a
+        failure measurement."""
         r = _make_result(status="error")
         assert _score_validation_result(r) == 0.5
+
+    def test_skipped_returns_zero(self):
+        """A bind-time skip (LLM declared the validation inapplicable) is not
+        a data measurement — without the explicit branch it would fall into
+        check-type scoring and a comparison skip would score 1.0 (DAT-439)."""
+        r = _make_result(status="skipped", details={"check_type": "comparison"})
+        assert _score_validation_result(r) == 0.0
 
     def test_comparison_failure_returns_one(self):
         r = _make_result(details={"check_type": "comparison"})


### PR DESCRIPTION
## Task

DAT-439 — https://real-dataraum.atlassian.net/browse/DAT-439

Phase 2 of the operating_model epic (DAT-417): the evaluator/agent-tier honesty pass. DAT-438 (PR #241) built the validation lifecycle born loud; this PR makes "visibly impossible" real one tier deeper — every silent rescue/conflation in the LLM-agent internals becomes an explicit lifecycle outcome or a loud signal.

## What each scope item resolved to

1. **Inconclusive ≠ FAILED** — `_evaluate_result` now returns `(ValidationStatus, message, details)`: PASSED/FAILED is a *judged measurement*; **ERROR = inconclusive** (unjudgeable result columns, zero rows on a balance/comparison/aggregate summary query, unrecognized check_type). Home: the phase's existing ERROR route — artifact stays `grounded` + `state_reason`. The smoke-proven three_way_match shape is pinned at three levels (unit evaluate, agent execute, phase lifecycle). Aggregate-without-rate stays PASSED — documented prompt contract ("summary values for review"), decision in-code.
2. **JSON-parse-from-text fallback DELETED** — no tool call = bind ERROR → `declared` + reason ("no structured output"). No existing tests covered the fallback (grep-verified); new pinning test proves even parseable text content is NOT rescued. Bonus sweep fix: `can_validate=true` with no SQL is a bind ERROR now (was mislabeled SKIPPED).
3. **"No semantic annotations" stays a warning** — decision recorded in-code: the absence is already durably visible (bind records the pinned base-run map with its empty `semantic_runs` into every artifact's `grounded_against`), and blocking would forbid legitimately annotation-free workspaces.
4. **Row-count swallow KEPT** — verified: the real failure it could mask (table missing from the lake) surfaces at bind via EXPLAIN → `declared`-with-reason. Pinned by tests on both sides (`test_missing_lake_table_keeps_schema_without_row_count`, `test_bind_missing_lake_table_fails_explain`). Decision + pointers in-code on the except block.
5. **Audit sweep** — findings fixed: resolver silently dropped requested-but-missing table_ids and tables without `duckdb_path` (both warn loudly now); scorer `_score_validation_result` had no `skipped` branch (a skip carrying table_ids fell into check-type scoring — a comparison skip scored 1.0) → explicit `skipped → 0.0`; `error` stays 0.5 and now covers inconclusives — branches coherent for DAT-442.

### Audit note (AC: zero unrecorded drops)

Post-change grep of `validation_phase.py` + `agent.py` + `resolver.py` for `except`/`continue`/empty-return:
- agent.py: all `except` blocks produce a bind/execute ERROR result with reason (lines 159/182/199/272) or a `Result.fail` (334/387) — recorded outcomes.
- resolver.py: `continue` at 103 (pathless table) now warns; 112 (row-count swallow) = the item-4 decision, in-code; 201/257/260 are fail-closed pin semantics (documented, DAT-429) — absent pins read empty by design, recorded in `grounded_against`.
- validation_phase.py: `continue` at 191 is the bind-failure route that *records* the reason on the artifact; all early returns are loud `PhaseResult.failed`/explicit outcomes.

## Cross-repo

`.claude/handoff.md` entry tells dataraum-eval that `status=failed` semantics changed — **DAT-442's cross_table_consistency calibration must land after this.** Scorer branches checked for coherence (no new status values introduced; `error`/`skipped` both explicit now). Band wiring/network.yaml untouched.

## Acceptance criteria

- [x] An inconclusive evaluation never produces `status=FAILED`; artifact carries the reason at the correct lifecycle state (three_way_match shape pinned)
- [x] No tool call → bind failure with reason; JSON-parse fallback deleted (+ pinning tests; no legacy tests existed)
- [x] Item-3 decision recorded in-code; item-4 downstream catch pinned by tests
- [x] Audit finds zero unrecorded drops (grep + note above)

## Lane smoke

```
uv run ruff format src tests   # clean
uv run ruff check src tests    # All checks passed!
uv run mypy src                # Success: no issues in 239 files
uv run pytest tests/unit -q          # 1325 passed
uv run pytest tests/integration -q   # 260 passed, 8 skipped (pre-existing)
```

Targeted runs of the changed behavior: tests/integration/analysis/validation/test_agent.py (24), tests/unit/analysis/validation (34), tests/unit/entropy/test_cross_table_consistency.py (18), tests/integration/pipeline/test_validation_phase.py (8). No live-LLM runs (per policy).

## Reviewers

- **senior-code-reviewer**: APPROVE — no critical issues, no correctness bugs; two clarifying-comment improvements applied (commit 5154bbd6).
- **spec-compliance-reviewer**: APPROVE — all 5 spec items implemented and tested, no scope/fence violations, handoff entry accurate.

## Other lanes in flight

No other DAT-417 lane PRs open at PR-creation time (`gh pr list --state open` empty). Parallel non-PR work noted in memory: DAT-440 (cockpit, owns `packages/cockpit/**` — fenced out here) and DAT-435 (begin_session progress). No file overlap with this engine-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
