### PR TITLE
docs(adr): ADR-0009 — entropy measures disagreement between witnesses

### DIFF
--- a/docs/adr/0009-entropy-as-disagreement.md
+++ b/docs/adr/0009-entropy-as-disagreement.md
@@ -1,0 +1,69 @@
+# ADR-0009 — Entropy measures disagreement between witnesses; no deterministic semantic overrides
+
+- **Status:** Accepted
+- **Date:** 2026-06-08
+- **Ticket:** DAT-442 (epic)
+- **Design doc:** Confluence DD — "Entropy as Disagreement" (page 32145409)
+
+## Context
+
+Calibration kept "fixing" wrong LLM judgments with deterministic patches: an
+exact-indicator override, a naming-quality floor, network edge weights moved
+until bands flipped, per-detector boost curves fitted until scores crossed
+0.3. Each patch made a metric pass without making the system understand more —
+Goodhart's law eating the calibration loop. Root defect: a single LLM
+judgment treated as truth, overruled by code when wrong. Rejected outright
+(Philipp, 2026-06-07): "it is 2026; LLMs are here; this is a multi-agent
+system."
+
+## Decision
+
+**Entropy is measured disagreement between witnesses over canonical claims.**
+
+1. **Claims are canonical.** Semantic verdicts live in closed claim spaces
+   (enums, ontology IDs, a unit lattice), forced by structured output at
+   write time. Comparison is identity or graph distance — never string or
+   embedding matching. Free text is explanation; it never gates behavior.
+2. **Claims are witnessed, never overridden.** Each modeled measurement pools
+   witnesses (semantic claims, statistic signatures, ontology priors
+   conditional on grounding, human teaches) with **measured** reliabilities,
+   and emits two numbers: **conflict** `C` (witnesses contradict) and
+   **ignorance** `U` (evidence is thin). No code path replaces a claim;
+   resolution is a new witness entering — a teach is an overlay row that
+   becomes the dominant witness. Even a teach leaves residual *documented
+   conflict* if the data still contradicts it.
+3. **Severity lives in per-intent loss tables**, not in scores:
+   `risk(intent) = E_q[loss_intent]`. Boost curves are dead for new work. The
+   noisy-OR rollup mechanics stay (deterministic plumbing) but consume
+   `risk(intent)`; hand-set `network.yaml` edge weights retire into loss
+   tables.
+4. **Reliabilities are calibrated artifacts with provenance** — shipped from
+   the eval corpus, Beta-updated by teach adjudications, cross-checked by
+   independent-witness agreement, ceiling-bounded by cross-run flicker. Never
+   inline constants; never updated by a witness's agreement with a posterior
+   it dominates.
+5. **The resolved layer delivers semantics**: `SemanticAnnotation` becomes the
+   resolved view (value + posterior + conflict flag + provenance), promoted
+   and read via the ADR-0008 surface; the Column Semantic Profile is the
+   per-column contract (teach vocabulary = write schema, entropy =
+   adjudication state, ContextDocument = read view).
+6. **The eval is Goodhart-resistant**: orderings, monotonicity, teach-deltas,
+   and calibration on **generative** fixture families — never point
+   thresholds on fixed fixtures. Terminal metric: bands vs ground-truth task
+   outcomes, and teach closure.
+
+## Consequences
+
+- **Forbidden:** deterministic semantic overrides/floors/gates; new boost
+  curves or severity-bent scores; point-threshold eval assertions for new
+  measurements; string/embedding comparison of verdicts in production;
+  reliability constants in code.
+- Retires as pattern: `network.yaml` edge tuning, per-detector severity
+  formulas, fixed memorizable fixtures. Existing instances are tolerated debt
+  until migrated, not precedent.
+- DAT-445's override framing and DAT-446's deterministic floor are dead; the
+  design doc's disagreement matrix is the build list (proving slice: null
+  semantics; then unit; then temporal_behavior after the stock/flow spike).
+- Follow-ups: pooling-engine substrate (one generic implementation; all
+  per-measurement specifics are config-with-provenance), loss-table
+  authorship in verticals, Dawid–Skene independence mapping.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,4 @@ record). When code and an ADR disagree, the code wins and the ADR needs a supers
 - [0006 — Team-lead operating model: parallel lanes, gates at the intent layer](./0006-team-lead-operating-model.md)
 - [0007 — Frame frozen-artifact contract: concept overlay rows as the engine↔cockpit grounding input](./0007-frame-frozen-artifact-contract.md)
 - [0008 — Promoted reads are enforced by the database (head-joined views + grants), not by reader convention](./0008-promoted-read-views.md)
+- [0009 — Entropy measures disagreement between witnesses; no deterministic semantic overrides](./0009-entropy-as-disagreement.md)


### PR DESCRIPTION
## Summary

The one-screen kernel of the **Entropy as Disagreement** design ([Confluence DD](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/32145409), reviewed + accepted 2026-06-07/08, linked from epic DAT-442):

- **Claims are canonical** — closed claim spaces (enums / ontology IDs / unit lattice), comparison by identity or graph distance, never string matching; free text never gates behavior.
- **Claims are witnessed, never overridden** — pooled witnesses with *measured* reliabilities emit (conflict, ignorance); resolution is a new witness (teach) entering, and even teaches leave documented conflict if data still contradicts.
- **Severity lives in per-intent loss tables** — boost curves dead for new work; noisy-OR mechanics stay, edge weights retire into loss tables.
- **Reliabilities are calibrated artifacts** with provenance (eval corpus → teach adjudications → independent agreement; flicker as ceiling) — never inline constants, never self-confirming.
- **Resolved layer** delivers semantics via the ADR-0008 promoted-read surface; the Column Semantic Profile unifies teach vocabulary (write), entropy (adjudication), ContextDocument (read).
- **Goodhart-resistant eval**: orderings/deltas/calibration on generative families; terminal metric = bands vs ground-truth outcomes + teach closure.

Forbidden henceforth: deterministic semantic overrides/floors, new boost curves, point-threshold assertions for new measurements, string/embedding verdict comparison in production.

Execution: /decompose pass over DAT-442 follows (proving slice: null semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)