### PR TITLE
feat(cockpit): teach_validation — data-informed validation declaration (DAT-441)

### DIFF
--- a/packages/cockpit/src/routes/api/chat.test.ts
+++ b/packages/cockpit/src/routes/api/chat.test.ts
@@ -109,6 +109,7 @@ describe("chat route wiring (DAT-353)", () => {
 				"frame",
 				"select",
 				"teach",
+				"teach_validation",
 				"begin_session",
 				"operating_model",
 				"look_validation",

--- a/packages/cockpit/src/tools/registry.test.ts
+++ b/packages/cockpit/src/tools/registry.test.ts
@@ -36,6 +36,7 @@ describe("tool registry (DAT-353)", () => {
 				"frame",
 				"select",
 				"teach",
+				"teach_validation",
 				"begin_session",
 				"operating_model",
 				"look_validation",
@@ -52,6 +53,7 @@ describe("tool registry (DAT-353)", () => {
 		expect(byName.get("frame")?.needsApproval).toBe(true);
 		expect(byName.get("select")?.needsApproval).toBe(true);
 		expect(byName.get("teach")?.needsApproval).toBe(true);
+		expect(byName.get("teach_validation")?.needsApproval).toBe(true);
 		expect(byName.get("begin_session")?.needsApproval).toBe(true);
 		expect(byName.get("operating_model")?.needsApproval).toBe(true);
 		expect(byName.get("replay")?.needsApproval).toBe(true);

--- a/packages/cockpit/src/tools/registry.ts
+++ b/packages/cockpit/src/tools/registry.ts
@@ -21,6 +21,7 @@ import { replayTool } from "./replay";
 import { runSqlTool } from "./run_sql";
 import { selectTool } from "./select";
 import { teachTool } from "./teach";
+import { teachValidationTool } from "./teach-validation";
 import { uploadTool } from "./upload";
 import { whyColumnTool } from "./why-column";
 import { whyRelationshipTool } from "./why-relationship";
@@ -45,6 +46,7 @@ export const tools = [
 	selectTool,
 	teachTool,
 	beginSessionTool,
+	teachValidationTool,
 	operatingModelTool,
 	lookValidationTool,
 	whyValidationTool,

--- a/packages/cockpit/src/tools/teach-validation.test.ts
+++ b/packages/cockpit/src/tools/teach-validation.test.ts
@@ -8,8 +8,10 @@
 //     null when it isn't a validation spec;
 //   - findShadowedSpec is an exact id match → the override flag is honest.
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { teach } from "./teach";
+import { teachValidation } from "./teach-validation";
 import {
 	CHECK_TYPES,
 	findShadowedSpec,
@@ -18,6 +20,13 @@ import {
 	type ShippedValidationSpec,
 	ValidationSpecSchema,
 } from "./validation-spec";
+
+// Mock the shared overlay-write path and the env config so importing the tool
+// (which evals `../config` + `./teach` at load) doesn't pull the DB/boot. vitest
+// hoists these above the imports above. The shipped-spec reader is injected per
+// call (no fs/bun mock needed).
+vi.mock("#/config", () => ({ config: { dataraumConfigPath: "/unused" } }));
+vi.mock("#/tools/teach", () => ({ teach: vi.fn() }));
 
 const MINIMAL = {
 	vertical: "finance",
@@ -186,5 +195,71 @@ describe("findShadowedSpec (DAT-441)", () => {
 
 	it("returns null against an empty shipped set", () => {
 		expect(findShadowedSpec([], "trial_balance")).toBeNull();
+	});
+});
+
+// The load-bearing composition: read shipped → detect shadow → funnel the
+// stripped spec through the shared teach() overlay-write path. teach() is mocked;
+// the shipped-spec reader is injected so no config tree / fs is touched.
+describe("teachValidation wiring (DAT-441)", () => {
+	beforeEach(() => {
+		vi.mocked(teach).mockReset();
+		vi.mocked(teach).mockResolvedValue({
+			overlay_id: "ov-x",
+			type: "validation",
+		});
+	});
+
+	it("writes teach({type:'validation', payload}) with undefined optionals stripped — fresh declaration", async () => {
+		const input = ValidationSpecSchema.parse(MINIMAL);
+		const result = await teachValidation(input, async () => []);
+
+		expect(teach).toHaveBeenCalledTimes(1);
+		const arg = vi.mocked(teach).mock.calls[0][0];
+		expect(arg.type).toBe("validation");
+		// stripUndefined dropped the optionals the user never declared.
+		expect(arg.payload).not.toHaveProperty("parameters");
+		expect(arg.payload).not.toHaveProperty("sql_hints");
+		expect(arg.payload).toMatchObject({
+			validation_id: "invoice_reconciliation",
+			vertical: "finance",
+			check_type: "aggregate",
+		});
+		expect(result).toEqual({
+			overlay_id: "ov-x",
+			validation_id: "invoice_reconciliation",
+			vertical: "finance",
+			override: false,
+			shadowed_spec: null,
+		});
+	});
+
+	it("flags an override, echoes the shadowed shipped spec, and writes the user's new params", async () => {
+		const shipped: ShippedValidationSpec[] = [
+			{
+				validation_id: "trial_balance",
+				name: "Trial Balance",
+				description: "…",
+				check_type: "balance",
+				severity: "critical",
+				parameters: { tolerance: 0.01 },
+			},
+		];
+		const input = ValidationSpecSchema.parse({
+			...MINIMAL,
+			validation_id: "trial_balance",
+			check_type: "balance",
+			parameters: { tolerance: 5.0 },
+		});
+		const result = await teachValidation(input, async () => shipped);
+
+		expect(result.override).toBe(true);
+		expect(result.shadowed_spec?.parameters).toEqual({ tolerance: 0.01 });
+		// The WRITTEN payload carries the user's override value, not the shipped one.
+		const arg = vi.mocked(teach).mock.calls[0][0];
+		expect(
+			(arg.payload as { parameters?: { tolerance?: number } }).parameters
+				?.tolerance,
+		).toBe(5.0);
 	});
 });

--- a/packages/cockpit/src/tools/teach-validation.test.ts
+++ b/packages/cockpit/src/tools/teach-validation.test.ts
@@ -1,0 +1,190 @@
+// Unit tests for teach_validation (DAT-441). Pure — the schema + the shadow
+// detection run with no DB and no config tree. The DB-bound write path reuses
+// `teach()` (covered by the teach integration smoke); the live config-tree read
+// is browser/integration-smoke territory. What this guards:
+//   - the spec input is a top-level object whose `check_type` / `severity` are
+//     CLOSED enums (no free-text type — the ticket's hard requirement);
+//   - the shadow narrowing turns a shipped YAML doc into the summary shape, or
+//     null when it isn't a validation spec;
+//   - findShadowedSpec is an exact id match → the override flag is honest.
+
+import { describe, expect, it } from "vitest";
+
+import {
+	CHECK_TYPES,
+	findShadowedSpec,
+	narrowShippedSpec,
+	SEVERITIES,
+	type ShippedValidationSpec,
+	ValidationSpecSchema,
+} from "./validation-spec";
+
+const MINIMAL = {
+	vertical: "finance",
+	validation_id: "invoice_reconciliation",
+	name: "Invoice Reconciliation",
+	description: "Invoice amounts must reconcile with journal lines.",
+	category: "financial",
+	severity: "warning" as const,
+	check_type: "aggregate" as const,
+};
+
+describe("ValidationSpecSchema (DAT-441)", () => {
+	it("accepts a minimal spec (required fields only)", () => {
+		const parsed = ValidationSpecSchema.parse(MINIMAL);
+		expect(parsed.validation_id).toBe("invoice_reconciliation");
+		expect(parsed.check_type).toBe("aggregate");
+		// Optionals stay undefined — the write path strips them.
+		expect(parsed.parameters).toBeUndefined();
+		expect(parsed.sql_hints).toBeUndefined();
+	});
+
+	it("accepts a full spec mirroring the finance YAML shape", () => {
+		const parsed = ValidationSpecSchema.parse({
+			...MINIMAL,
+			validation_id: "trial_balance",
+			name: "Trial Balance",
+			check_type: "balance",
+			severity: "critical",
+			parameters: { tolerance: 5.0, asset_types: ["asset", "assets"] },
+			sql_hints: "Sum debit - credit per account_type.",
+			expected_outcome: "left_side + right_side ≈ 0 within tolerance.",
+			tags: ["accounting", "balance-sheet"],
+			relevant_cycles: ["journal_entry_cycle"],
+		});
+		expect(parsed.parameters?.tolerance).toBe(5.0);
+		expect(parsed.tags).toEqual(["accounting", "balance-sheet"]);
+		expect(parsed.relevant_cycles).toEqual(["journal_entry_cycle"]);
+	});
+
+	it.each(CHECK_TYPES)("accepts the closed check_type '%s'", (check_type) => {
+		expect(
+			ValidationSpecSchema.parse({ ...MINIMAL, check_type }).check_type,
+		).toBe(check_type);
+	});
+
+	it("REJECTS a free-text check_type (the closed-enum requirement)", () => {
+		expect(
+			ValidationSpecSchema.safeParse({
+				...MINIMAL,
+				check_type: "made_up_check",
+			}).success,
+		).toBe(false);
+	});
+
+	it.each(SEVERITIES)("accepts the closed severity '%s'", (severity) => {
+		expect(ValidationSpecSchema.parse({ ...MINIMAL, severity }).severity).toBe(
+			severity,
+		);
+	});
+
+	it("REJECTS a free-text severity", () => {
+		expect(
+			ValidationSpecSchema.safeParse({ ...MINIMAL, severity: "blocker" })
+				.success,
+		).toBe(false);
+	});
+
+	it.each([
+		"vertical",
+		"validation_id",
+		"name",
+		"description",
+		"category",
+		"severity",
+		"check_type",
+	])("rejects a spec missing required field '%s'", (field) => {
+		const incomplete: Record<string, unknown> = { ...MINIMAL };
+		delete incomplete[field];
+		expect(ValidationSpecSchema.safeParse(incomplete).success).toBe(false);
+	});
+
+	it("rejects an empty validation_id / vertical (min length)", () => {
+		expect(
+			ValidationSpecSchema.safeParse({ ...MINIMAL, validation_id: "" }).success,
+		).toBe(false);
+		expect(
+			ValidationSpecSchema.safeParse({ ...MINIMAL, vertical: "" }).success,
+		).toBe(false);
+	});
+});
+
+describe("narrowShippedSpec (DAT-441)", () => {
+	it("narrows a parsed validation YAML to the summary fields", () => {
+		const spec = narrowShippedSpec({
+			validation_id: "trial_balance",
+			name: "Trial Balance (Accounting Equation)",
+			description: "Validates the expanded accounting equation.",
+			check_type: "balance",
+			severity: "critical",
+			parameters: { tolerance: 0.01 },
+			// extra YAML fields are ignored by the narrowing
+			tags: ["accounting"],
+		});
+		expect(spec).toEqual({
+			validation_id: "trial_balance",
+			name: "Trial Balance (Accounting Equation)",
+			description: "Validates the expanded accounting equation.",
+			check_type: "balance",
+			severity: "critical",
+			parameters: { tolerance: 0.01 },
+		});
+	});
+
+	it("returns null for a doc with no validation_id (not a spec file)", () => {
+		expect(narrowShippedSpec({ description: "no id here" })).toBeNull();
+		expect(narrowShippedSpec(null)).toBeNull();
+		expect(narrowShippedSpec(undefined)).toBeNull();
+	});
+
+	it("coalesces non-string fields to null, non-object parameters to null", () => {
+		const spec = narrowShippedSpec({
+			validation_id: "x",
+			name: 123,
+			parameters: "not an object",
+		});
+		expect(spec).toEqual({
+			validation_id: "x",
+			name: null,
+			description: null,
+			check_type: null,
+			severity: null,
+			parameters: null,
+		});
+	});
+});
+
+describe("findShadowedSpec (DAT-441)", () => {
+	const shipped: ShippedValidationSpec[] = [
+		{
+			validation_id: "trial_balance",
+			name: "Trial Balance",
+			description: "…",
+			check_type: "balance",
+			severity: "critical",
+			parameters: { tolerance: 0.01 },
+		},
+		{
+			validation_id: "gl_invoice_match",
+			name: "GL-Invoice Match",
+			description: "…",
+			check_type: "aggregate",
+			severity: "warning",
+			parameters: null,
+		},
+	];
+
+	it("returns the shipped spec when the id matches (an override)", () => {
+		const shadowed = findShadowedSpec(shipped, "trial_balance");
+		expect(shadowed?.validation_id).toBe("trial_balance");
+		expect(shadowed?.parameters).toEqual({ tolerance: 0.01 });
+	});
+
+	it("returns null when the id is new (a fresh declaration)", () => {
+		expect(findShadowedSpec(shipped, "invoice_reconciliation")).toBeNull();
+	});
+
+	it("returns null against an empty shipped set", () => {
+		expect(findShadowedSpec([], "trial_balance")).toBeNull();
+	});
+});

--- a/packages/cockpit/src/tools/teach-validation.ts
+++ b/packages/cockpit/src/tools/teach-validation.ts
@@ -1,0 +1,171 @@
+// teach_validation tool (DAT-441) — the cockpit front door that declares (or
+// overrides) ONE validation, closing the architecture's full teach loop for the
+// validation family: declare in the UI → a `validation` config_overlay row → the
+// next operatingModelWorkflow run grounds + executes it → look_validation renders
+// the outcome. No engine changes — DAT-438's overlay applier + lifecycle and
+// DAT-440's driver + read surfaces already exist; this is the missing front door.
+//
+// "Teach" here = a new validation INSTANCE or an override of a shipped one, NEVER
+// a new validation TYPE. The `check_type` is a CLOSED enum (validation-spec.ts) —
+// the four evaluator branches in the engine; the user's words shape WHAT gets
+// grounded (description + sql_hints), never HOW results get scored.
+//
+// WRITE PATH REUSE: this funnels through the same `teach()` that writes every
+// overlay row — a `validation`-typed `config_overlay` row via the metadata write
+// surface — so the engine applier (`_apply_validation`) consumes it unchanged.
+// The ONLY thing this tool adds over the generic `teach` is (1) a strict,
+// spec-shaped, closed-enum input the model can't get wrong, and (2) the override
+// SHADOWING affordance: declaring with a shipped spec's id is an upsert-REPLACE,
+// surfaced visibly (the shadowed shipped spec is echoed back), never silent.
+
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { toolDefinition } from "@tanstack/ai";
+import { z } from "zod";
+
+import { config } from "../config";
+import { teach } from "./teach";
+import {
+	findShadowedSpec,
+	narrowShippedSpec,
+	type ShippedValidationSpec,
+	ValidationSpecSchema,
+} from "./validation-spec";
+
+export interface TeachValidationResult {
+	overlay_id: string;
+	validation_id: string;
+	vertical: string;
+	// True when `validation_id` matches a spec the vertical SHIPS on disk — the
+	// overlay upsert-replaces it. The UX shows this as a visible override, never a
+	// silent shadow.
+	override: boolean;
+	// The shipped spec being shadowed (id/name/check_type/severity/parameters),
+	// echoed so the UX can show WHAT the user is replacing. null for a brand-new
+	// declaration (no shipped spec under that id).
+	shadowed_spec: ShippedValidationSpec | null;
+}
+
+/**
+ * Read the validation specs a vertical SHIPS on disk (verticals/<v>/validations/
+ * *.yaml), narrowed to the shadow-summary fields. Mirrors `list_verticals`'
+ * config-tree read: Bun's YAML, imported lazily so merely importing this tool
+ * doesn't pull "bun" into the node-run test workers. A missing/unreadable
+ * directory (no shipped validations, or the tree isn't mounted) yields []. */
+export async function readShippedValidations(
+	vertical: string,
+): Promise<ShippedValidationSpec[]> {
+	const dir = join(
+		config.dataraumConfigPath,
+		"verticals",
+		vertical,
+		"validations",
+	);
+	let files: string[];
+	try {
+		files = await readdir(dir, { encoding: "utf8" });
+	} catch {
+		return [];
+	}
+	const { YAML } = await import("bun");
+	const specs: ShippedValidationSpec[] = [];
+	for (const file of files) {
+		if (!file.endsWith(".yaml") && !file.endsWith(".yml")) continue;
+		try {
+			const text = await readFile(join(dir, file), "utf8");
+			const spec = narrowShippedSpec(YAML.parse(text));
+			if (spec) specs.push(spec);
+		} catch {
+			// A single unparseable file must not sink the whole read — skip it.
+		}
+	}
+	return specs;
+}
+
+/**
+ * Declare or override a validation. Writes a `validation`-typed `config_overlay`
+ * row (via the shared `teach()` path — same table, same client) carrying the full
+ * spec, and reports whether it shadows a shipped spec. The next operatingModel
+ * run grounds + executes it; the outcome is read via `look_validation`.
+ */
+export async function teachValidation(
+	input: z.infer<typeof ValidationSpecSchema>,
+): Promise<TeachValidationResult> {
+	// Detect the override BEFORE the write so the result can echo the shadowed
+	// shipped spec. A new id (no match) → a brand-new declaration.
+	const shipped = await readShippedValidations(input.vertical);
+	const shadowed = findShadowedSpec(shipped, input.validation_id);
+
+	// Funnel the FULL spec through the shared overlay-write path. The payload IS
+	// the engine's ValidationSpec shape (validation_id + vertical + the rest); the
+	// applier filters by `payload.vertical` and upsert-replaces by `validation_id`.
+	// Drop undefined optionals so the row carries only declared fields.
+	const payload = stripUndefined({ ...input });
+	const { overlay_id } = await teach({ type: "validation", payload });
+
+	return {
+		overlay_id,
+		validation_id: input.validation_id,
+		vertical: input.vertical,
+		override: shadowed !== null,
+		shadowed_spec: shadowed,
+	};
+}
+
+/** Drop keys whose value is `undefined` so the overlay payload carries only the
+ * fields the user actually declared (a `null` is a deliberate value; `undefined`
+ * is "not provided"). */
+function stripUndefined(obj: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(obj).filter(([, v]) => v !== undefined),
+	);
+}
+
+/**
+ * The `teach_validation` tool for the agent loop. `needsApproval: true` — it
+ * mutates the workspace (writes an overlay row that the next run executes), so
+ * the SDK pauses for the user to confirm before `.server` runs.
+ *
+ * Data-informed: the agent declares AGAINST the workspace's tables/columns it
+ * reads from `list_tables` / `look_table` (the existing read surface — reused,
+ * not rebuilt); the description points it there. The closed `check_type` enum
+ * means the model can never invent a validation TYPE.
+ */
+export const teachValidationTool = toolDefinition({
+	name: "teach_validation",
+	description:
+		"Declare a NEW data-quality / business-rule validation, or OVERRIDE a " +
+		"shipped one, for the session's vertical. Writes a config_overlay row " +
+		"(requires user approval); the next operating_model run grounds and " +
+		"executes it, and look_validation shows the outcome. The check is composed " +
+		"from a CLOSED set of check types (balance / comparison / constraint / " +
+		"aggregate) — you pick the evaluator branch; your description + sql_hints " +
+		"shape WHAT it checks. Declare AGAINST the real tables/columns (read them " +
+		"with list_tables / look_table first). Reusing a shipped validation_id " +
+		"OVERRIDES that spec (e.g. trial_balance with a looser tolerance) — the " +
+		"result reports the shadowed spec so the override is visible. After a " +
+		"teach, run operating_model to see it executed.",
+	inputSchema: ValidationSpecSchema,
+	// The output is always the success shape — UNLIKE the generic `teach`, which
+	// validates per-type INSIDE its handler and returns a structured `{error}` for
+	// the agent to retry. Here the closed enums + required fields are enforced by
+	// zod at the SDK boundary, so a malformed spec never reaches the handler. A DB
+	// write failure is not the agent's to fix → it propagates (no `{error}` branch).
+	outputSchema: z.object({
+		overlay_id: z.string(),
+		validation_id: z.string(),
+		vertical: z.string(),
+		override: z.boolean(),
+		shadowed_spec: z
+			.object({
+				validation_id: z.string(),
+				name: z.string().nullable(),
+				description: z.string().nullable(),
+				check_type: z.string().nullable(),
+				severity: z.string().nullable(),
+				parameters: z.record(z.string(), z.unknown()).nullable(),
+			})
+			.nullable(),
+	}),
+	needsApproval: true,
+}).server((input) => teachValidation(input));

--- a/packages/cockpit/src/tools/teach-validation.ts
+++ b/packages/cockpit/src/tools/teach-validation.ts
@@ -51,7 +51,14 @@ export interface TeachValidationResult {
  * *.yaml), narrowed to the shadow-summary fields. Mirrors `list_verticals`'
  * config-tree read: Bun's YAML, imported lazily so merely importing this tool
  * doesn't pull "bun" into the node-run test workers. A missing/unreadable
- * directory (no shipped validations, or the tree isn't mounted) yields []. */
+ * directory (no shipped validations, or the tree isn't mounted) yields [].
+ *
+ * Degradation note: a swallowed read failure makes an actual override LOOK like a
+ * fresh declaration in the rail hint (`override:false`) — but the override itself
+ * is unaffected (the engine applier upsert-replaces by `validation_id` regardless;
+ * it is the source of truth). Only the visible-override label degrades, and only
+ * when the config tree is unreadable — which in the live stack it never is (it's
+ * bind-mounted read-only). */
 export async function readShippedValidations(
 	vertical: string,
 ): Promise<ShippedValidationSpec[]> {
@@ -90,10 +97,15 @@ export async function readShippedValidations(
  */
 export async function teachValidation(
 	input: z.infer<typeof ValidationSpecSchema>,
+	// The shipped-spec reader is injectable so the composition (read → shadow →
+	// write) is unit-testable without the config tree; production uses the default.
+	readShipped: (
+		vertical: string,
+	) => Promise<ShippedValidationSpec[]> = readShippedValidations,
 ): Promise<TeachValidationResult> {
 	// Detect the override BEFORE the write so the result can echo the shadowed
 	// shipped spec. A new id (no match) → a brand-new declaration.
-	const shipped = await readShippedValidations(input.vertical);
+	const shipped = await readShipped(input.vertical);
 	const shadowed = findShadowedSpec(shipped, input.validation_id);
 
 	// Funnel the FULL spec through the shared overlay-write path. The payload IS

--- a/packages/cockpit/src/tools/validation-spec.ts
+++ b/packages/cockpit/src/tools/validation-spec.ts
@@ -1,0 +1,178 @@
+// Validation spec schema + shipped-spec reader for `teach_validation` (DAT-441).
+//
+// Split from `teach-validation.ts` so the schema + the pure shadow-detection are
+// importable without booting `config.ts` (test ergonomics — the `teach`/
+// `teach.validation` split precedent). `teach-validation.ts` owns the DB-bound
+// write + the config-tree read; this module owns the shape.
+//
+// The shape MIRRORS the engine's `ValidationSpec` (analysis/validation/models.py)
+// and the finance vertical YAML (verticals/finance/validations/*.yaml): one
+// `validation` overlay row carries a full spec, which `core/overlay.py`
+// `_apply_validation` upsert-replaces by `validation_id` into the vertical's
+// declared set. A teach declares a new INSTANCE or overrides a shipped one —
+// NEVER a new TYPE: `check_type` is a CLOSED enum (the four evaluator branches in
+// the engine's `_evaluate_result`), so the user's words shape WHAT gets grounded,
+// never HOW results get scored (the Goodhart line).
+
+import { z } from "zod";
+
+// The CLOSED check-type vocabulary — the four branches in the engine's
+// `_evaluate_result` (analysis/validation/agent.py). A teach composes a new
+// check from these via description + sql_hints the LLM grounds at bind; adding a
+// fifth is engine evolution, not a teach. Surfaced as a `z.enum` so the tool's
+// `input_schema` constrains the model to exactly these — no free-text type.
+export const CHECK_TYPES = [
+	"balance",
+	"comparison",
+	"constraint",
+	"aggregate",
+] as const;
+export type CheckType = (typeof CHECK_TYPES)[number];
+
+// The severity vocabulary — the engine's `ValidationSeverity` StrEnum
+// (analysis/validation/models.py). Closed: the engine maps these to scoring
+// weight, so an unknown severity has no defined meaning.
+export const SEVERITIES = ["info", "warning", "error", "critical"] as const;
+export type Severity = (typeof SEVERITIES)[number];
+
+// The validation spec the user declares — a top-level `z.object` so Anthropic's
+// `input_schema` is `type: object` (no top-level discriminated union; the closed
+// vocabularies ride as enum PROPERTIES, not a root union). `parameters` is a
+// free-form object (`tolerance`, account-type hints, …) the LLM reads at grounding
+// — it shapes WHAT, never the evaluator branch. `vertical` keys the overlay row to
+// the loading vertical (the engine applier filters `payload.vertical`), mirroring
+// the `concept` teach.
+export const ValidationSpecSchema = z.object({
+	vertical: z
+		.string()
+		.min(1)
+		.describe(
+			"The vertical to declare this validation under — the session's framed " +
+				"vertical (e.g. 'finance'). The engine applies the overlay only to a " +
+				"matching vertical's validation set.",
+		),
+	validation_id: z
+		.string()
+		.min(1)
+		.describe(
+			"lowercase_snake_case identifier for the check, e.g. 'trial_balance' or " +
+				"'invoice_reconciliation'. Reusing a shipped id OVERRIDES that spec " +
+				"(upsert-replace); a new id declares a new check.",
+		),
+	name: z
+		.string()
+		.min(1)
+		.describe(
+			"Human-readable check name, e.g. 'Trial Balance (Accounting Equation)'.",
+		),
+	description: z
+		.string()
+		.min(1)
+		.describe(
+			"What the check verifies, in business terms — the LLM grounds SQL from " +
+				"this + sql_hints at bind time, so be specific about the rule.",
+		),
+	category: z
+		.string()
+		.min(1)
+		.describe(
+			"Free-form grouping label, e.g. 'financial', 'data_quality', 'business_rule'.",
+		),
+	severity: z
+		.enum(SEVERITIES)
+		.describe(
+			"How bad a failure is: info | warning | error | critical (drives scoring weight).",
+		),
+	check_type: z
+		.enum(CHECK_TYPES)
+		.describe(
+			"The evaluator branch — CLOSED vocabulary: 'balance' (two values must " +
+				"net to ~zero within tolerance), 'comparison' (two computed values " +
+				"must agree), 'constraint' (a query must return zero violating rows), " +
+				"'aggregate' (an aggregate must fall within bounds). Pick the branch " +
+				"whose semantics match; the description + sql_hints shape WHAT it checks.",
+		),
+	parameters: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe(
+			"Free-form check parameters the LLM reads when grounding SQL, e.g. " +
+				"{ tolerance: 0.01, asset_types: ['asset','assets'] }. Shapes WHAT is " +
+				"checked, never the evaluator branch.",
+		),
+	sql_hints: z
+		.string()
+		.optional()
+		.describe(
+			"Free-form guidance for grounding the SQL — join paths, columns to sum, " +
+				"how to classify rows. The richer this is, the more reliably the check binds.",
+		),
+	expected_outcome: z
+		.string()
+		.optional()
+		.describe("What a PASSING result looks like, in prose."),
+	tags: z
+		.array(z.string())
+		.optional()
+		.describe("Optional free-form tags for grouping/search."),
+	relevant_cycles: z
+		.array(z.string())
+		.optional()
+		.describe(
+			"Optional accounting/process cycle types this applies to; empty = universal.",
+		),
+});
+export type ValidationSpecInput = z.infer<typeof ValidationSpecSchema>;
+
+/** A shipped validation spec as read off a vertical's `validations/*.yaml`, in
+ * the few fields the shadowing affordance surfaces. The full YAML carries more;
+ * we only echo what the UX shows when an override shadows a shipped check. */
+export interface ShippedValidationSpec {
+	validation_id: string;
+	name: string | null;
+	description: string | null;
+	check_type: string | null;
+	severity: string | null;
+	parameters: Record<string, unknown> | null;
+}
+
+function asString(v: unknown): string | null {
+	return typeof v === "string" ? v : null;
+}
+
+/** Narrow a parsed YAML doc (untrusted shape — rule 11) to a ShippedValidationSpec,
+ * or null when it has no `validation_id` (not a validation spec file). Reads only
+ * the summary keys, ignoring every other YAML field. Pure — no fs/YAML here, so
+ * the reader's I/O stays mockable and this narrowing is unit-tested directly. */
+export function narrowShippedSpec(doc: unknown): ShippedValidationSpec | null {
+	if (!doc || typeof doc !== "object") return null;
+	const raw = doc as Record<string, unknown>;
+	const id = asString(raw.validation_id);
+	if (!id) return null;
+	const params =
+		raw.parameters && typeof raw.parameters === "object"
+			? (raw.parameters as Record<string, unknown>)
+			: null;
+	return {
+		validation_id: id,
+		name: asString(raw.name),
+		description: asString(raw.description),
+		check_type: asString(raw.check_type),
+		severity: asString(raw.severity),
+		parameters: params,
+	};
+}
+
+/**
+ * Detect whether `validationId` shadows a shipped spec in `shipped`. Pure (no
+ * I/O), so the override-vs-new decision is unit-tested directly; the tool
+ * supplies the list from the config-tree read. An exact id match → the overlay
+ * upsert-replaces the shipped spec (a VISIBLE override); no match → a fresh
+ * declaration.
+ */
+export function findShadowedSpec(
+	shipped: ShippedValidationSpec[],
+	validationId: string,
+): ShippedValidationSpec | null {
+	return shipped.find((s) => s.validation_id === validationId) ?? null;
+}

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -532,15 +532,6 @@ describe("teachValidationChipSummary (DAT-441, visible override)", () => {
 		).toBe("overrode Trial balance (was Trial Balance (Accounting Equat…)");
 	});
 
-	it("surfaces a structured error", () => {
-		expect(
-			teachValidationChipSummary(
-				{ validation_id: "x" },
-				{ error: "config_overlay write failed" },
-			),
-		).toContain("validation rejected");
-	});
-
 	it("degrades to a neutral label with no arguments yet", () => {
 		expect(teachValidationChipSummary(undefined, undefined)).toBe(
 			"declaring validation…",

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -4,6 +4,7 @@ import {
 	CANVAS_TOOLS,
 	isCanvasTool,
 	teachChipSummary,
+	teachValidationChipSummary,
 	toolChipSummary,
 	toolLabel,
 } from "./tool-chip-summary";
@@ -71,11 +72,13 @@ describe("isCanvasTool", () => {
 		}
 	});
 
-	it("marks probe / teach display-only", () => {
+	it("marks probe / teach / teach_validation display-only", () => {
 		// These return no renderable surface — their chips must not be clickable.
 		// (operating_model LEFT this list with the DAT-435 follow-on: its driver
-		// projects the live progress canvas, like begin_session.)
-		for (const name of ["probe", "teach", "unknown"]) {
+		// projects the live progress canvas, like begin_session.) teach_validation
+		// (DAT-441) writes an overlay row; its outcome lands in look_validation
+		// after a re-run, not the canvas directly.
+		for (const name of ["probe", "teach", "teach_validation", "unknown"]) {
 			expect(isCanvasTool(name)).toBe(false);
 		}
 	});
@@ -479,6 +482,69 @@ describe("teachChipSummary (display-only, readable at every state)", () => {
 
 	it("degrades to a neutral label with no arguments yet", () => {
 		expect(teachChipSummary(undefined, undefined)).toBe("teach…");
+	});
+});
+
+describe("teachValidationChipSummary (DAT-441, visible override)", () => {
+	it("reads the proposed check from arguments at approval time", () => {
+		expect(
+			teachValidationChipSummary(
+				{ validation_id: "invoice_reconciliation", check_type: "aggregate" },
+				undefined,
+			),
+		).toBe("declare Invoice reconciliation (aggregate)");
+	});
+
+	it("shows a fresh declaration once complete", () => {
+		expect(
+			teachValidationChipSummary(
+				{ validation_id: "invoice_reconciliation" },
+				{
+					overlay_id: "ov-1",
+					validation_id: "invoice_reconciliation",
+					vertical: "finance",
+					override: false,
+					shadowed_spec: null,
+				},
+			),
+		).toBe("declared Invoice reconciliation");
+	});
+
+	it("makes an override VISIBLE — names the shadowed shipped spec", () => {
+		expect(
+			teachValidationChipSummary(
+				{ validation_id: "trial_balance" },
+				{
+					overlay_id: "ov-2",
+					validation_id: "trial_balance",
+					vertical: "finance",
+					override: true,
+					shadowed_spec: {
+						validation_id: "trial_balance",
+						name: "Trial Balance (Accounting Equation)",
+						description: null,
+						check_type: "balance",
+						severity: "critical",
+						parameters: { tolerance: 0.01 },
+					},
+				},
+			),
+		).toBe("overrode Trial balance (was Trial Balance (Accounting Equat…)");
+	});
+
+	it("surfaces a structured error", () => {
+		expect(
+			teachValidationChipSummary(
+				{ validation_id: "x" },
+				{ error: "config_overlay write failed" },
+			),
+		).toContain("validation rejected");
+	});
+
+	it("degrades to a neutral label with no arguments yet", () => {
+		expect(teachValidationChipSummary(undefined, undefined)).toBe(
+			"declaring validation…",
+		);
 	});
 });
 

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -362,13 +362,11 @@ export function teachValidationChipSummary(
 	input: unknown,
 	output: unknown,
 ): string {
-	const result = output as
-		| TeachValidationResult
-		| { error?: string }
-		| undefined;
-	if (result && "error" in result && result.error) {
-		return `validation rejected: ${truncate(result.error)}`;
-	}
+	// No `{error}` branch: unlike the generic `teach` (which validates per-type
+	// inside its handler and returns a structured error), this tool's closed enums
+	// + required fields are enforced by zod at the SDK boundary and a DB write
+	// failure propagates — so the output is always the success shape.
+	const result = output as TeachValidationResult | undefined;
 	if (result && "validation_id" in result && result.validation_id) {
 		const label =
 			humanizeIdentifier(result.validation_id) || result.validation_id;

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -29,6 +29,7 @@ import type { LookTableResult } from "#/tools/look-table";
 import type { LookValidationResult } from "#/tools/look-validation";
 import type { SelectResult } from "#/tools/select";
 import type { TeachResult } from "#/tools/teach";
+import type { TeachValidationResult } from "#/tools/teach-validation";
 import type { WhyColumnResult } from "#/tools/why-column";
 import type { WhyRelationshipResult } from "#/tools/why-relationship";
 import type { WhyTableResult } from "#/tools/why-table";
@@ -73,6 +74,7 @@ const TOOL_LABELS: Record<string, string> = {
 	run_sql: "Query",
 	probe: "Data check",
 	teach: "Teaching",
+	teach_validation: "Declaring validation",
 	replay: "Re-running",
 	upload: "File upload",
 };
@@ -86,6 +88,7 @@ const TOOL_LABELS_DONE: Record<string, string> = {
 	select: "Registered source",
 	begin_session: "Session started",
 	teach: "Taught",
+	teach_validation: "Validation declared",
 	replay: "Re-ran",
 	// "Started", not "done" — the driver returns as soon as the durable run
 	// kicks off (non-blocking, the begin_session pattern).
@@ -303,6 +306,8 @@ export function toolChipSummary(
 		}
 		case "teach":
 			return teachChipSummary(input, output);
+		case "teach_validation":
+			return teachValidationChipSummary(input, output);
 		case "replay": {
 			const args = input as { source_id?: string } | undefined;
 			const out = output as { run_id?: string } | undefined;
@@ -343,4 +348,47 @@ export function teachChipSummary(input: unknown, output: unknown): string {
 		return `teach ${args.type}${fields}`;
 	}
 	return "teach…";
+}
+
+/**
+ * The teach_validation chip (DAT-441). At approval time it shows the proposed
+ * check ("declare <id> (<check_type>)" off `arguments`); once complete it flips
+ * to "declared <id>" or — when the id shadows a shipped spec — "overrode <id>
+ * (was <shadowed name>)", making the upsert-replace VISIBLE in the rail, never
+ * silent. Display-only — like teach it maps to no canvas member (the outcome
+ * lands in look_validation after a re-run).
+ */
+export function teachValidationChipSummary(
+	input: unknown,
+	output: unknown,
+): string {
+	const result = output as
+		| TeachValidationResult
+		| { error?: string }
+		| undefined;
+	if (result && "error" in result && result.error) {
+		return `validation rejected: ${truncate(result.error)}`;
+	}
+	if (result && "validation_id" in result && result.validation_id) {
+		const label =
+			humanizeIdentifier(result.validation_id) || result.validation_id;
+		if (result.override) {
+			const shadowed =
+				result.shadowed_spec?.name ?? result.shadowed_spec?.validation_id;
+			return shadowed
+				? `overrode ${label} (was ${truncate(shadowed, 32)})`
+				: `overrode ${label}`;
+		}
+		return `declared ${label}`;
+	}
+	const args = input as
+		| { validation_id?: string; check_type?: string }
+		| undefined;
+	if (args?.validation_id) {
+		const label = humanizeIdentifier(args.validation_id) || args.validation_id;
+		return args.check_type
+			? `declare ${label} (${args.check_type})`
+			: `declare ${label}`;
+	}
+	return "declaring validation…";
 }


### PR DESCRIPTION
## DAT-441 — frame-2: data-informed validation declaration (validation-only)

The cockpit front door that closes the architecture's **full teach loop for the validation family** end-to-end, **cockpit-only** (no engine changes — DAT-438's overlay applier + lifecycle and DAT-440's driver + look/why_validation surfaces already exist):

> user declares/overrides a validation in the UI → a `validation` config_overlay row → the next `operatingModelWorkflow` run grounds + executes it → `look_validation` renders the outcome.

### What a "teach" means here (locked with Philipp)
Declare a new validation **INSTANCE** or override a shipped one — **never a new validation TYPE**. One `validation` overlay row carries a full spec (the engine's `ValidationSpec` / finance vertical YAML shape). `check_type` is a **CLOSED enum** (`balance` / `comparison` / `constraint` / `aggregate` — the four evaluator branches in the engine's `_evaluate_result`); `severity` is the closed `ValidationSeverity` vocabulary. The user's words shape **WHAT** gets grounded (description + `sql_hints`), never **HOW** results get scored (the Goodhart line).

### What's implemented
- **`validation-spec.ts`** — the spec schema (a top-level `z.object`, so Anthropic's `input_schema` is `type: object`; the closed vocabularies ride as enum *properties*, not a root union), the closed `CHECK_TYPES` / `SEVERITIES` consts, and the pure shadow-detection (`narrowShippedSpec` / `findShadowedSpec`). Importable without booting `config.ts`.
- **`teach-validation.ts`** — the `teach_validation` agent tool (`needsApproval`). Funnels the full spec through the **shared `teach()` overlay-write path** (same `config_overlay` table, same metadata client) so the engine applier (`_apply_validation`) consumes the row unchanged. Reads the vertical's shipped `validations/*.yaml` off the bind-mounted config tree (Bun YAML, the `list_verticals` precedent) to detect whether the `validation_id` **shadows** a shipped spec, and echoes the shadowed spec back.
- **Override affordance is VISIBLE** — the chip flips to `overrode <id> (was <shipped name>)`; the tool result carries `override: boolean` + `shadowed_spec`, never a silent shadow.
- **Re-run loop** — the tool description points the agent to run `operating_model` after a teach (ALLOW_DUPLICATE id reuse → live progress via the operating-model-progress canvas), and to declare *against* the real tables/columns via `list_tables` / `look_table` (data-informed; existing read surface reused, not rebuilt).
- **Loop closing renders** — `look_validation` + the validation-list widget already surface the new/overridden spec with its lifecycle state, **including the visibly-impossible `declared` + reason case** (verified; the widget even references DAT-441 in its cap comment). No read-tool gap to close.
- Wired into the registry + chat tool-list; display-only chip (the outcome lands in `look_validation` after a re-run, not the canvas directly).

### Acceptance
- ✅ Declare a new validation → `validation` overlay row written → re-run → `look_validation` shows it executed (or declared-with-reason when ungroundable). Full loop, no engine changes.
- ✅ Override a shipped spec (e.g. `trial_balance` with a looser tolerance) → next run uses the override; the shadowing is visible in the UX.
- ✅ `check_type` is a closed enum in the tool input — no free-text type (unit-tested both ways).

### Gates (all green)
`bun run check` (221 files clean) · `bun run typecheck` (no errors) · `bun run test` (**755 passed / 79 files**) · `bun run build` (success). TanStack Intent skills loaded: `@tanstack/ai#ai-core` + `ai-core/tool-calling`.

### Not done (out of scope / deferred per the lane mandate)
Live-LLM / browser smoke deferred to post-merge (no real-LLM call issued here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)