### PR TITLE
DAT-461: cockpit_db control-plane substrate — tables + migrate-on-boot + registry resolver + tool writes

### DIFF
--- a/packages/cockpit/README.md
+++ b/packages/cockpit/README.md
@@ -47,6 +47,7 @@ The dev server runs **outside Docker** (for hot reload) against the compose back
 docker compose -f ../infra/docker-compose.yml up -d --wait postgres seaweedfs   # backend deps
 cp .env.example .env        # host-dev defaults (localhost URLs); fill ANTHROPIC_API_KEY
 bun install
+bun run db:migrate:cockpit  # apply cockpit_db migrations (control plane: workspaces/sessions/…)
 bun --bun run dev           # → http://localhost:3000  (the --bun flag is required)
 ```
 
@@ -69,15 +70,16 @@ bun run check             # biome check (lint + format)
 bun run lint              # biome lint
 bun run format            # biome format
 bun run db:pull:metadata  # introspect engine's ws_<id> schema → src/db/metadata/
-bun run db:generate:cockpit  # cockpit_db migration SQL from src/db/cockpit/schema.ts
-bun run db:push:cockpit   # push schema directly to cockpit_db
+bun run db:generate:cockpit  # generate a cockpit_db migration from src/db/cockpit/schema.ts
+bun run db:migrate:cockpit   # apply committed cockpit_db migrations (drizzle/cockpit/)
+bun run db:push:cockpit   # push schema directly (quick local iteration; no migration file)
 ```
 
 ## Drizzle layout
 
 Two clients in one package:
 
-- `src/db/cockpit/{schema,client}.ts` — hand-written cockpit_db (push/generate target)
+- `src/db/cockpit/{schema,client,registry,runs}.ts` — hand-written cockpit_db (generate/migrate target); committed migrations in `drizzle/cockpit/`
 - `src/db/metadata/{schema,relations,client}.ts` — generated from the engine substrate by `bun run db:pull:metadata`; the cockpit reads, never pushes
 
-Cockpit_db tables land as they're needed (conversations + conversation_messages are the next addition).
+cockpit_db is the cockpit's control plane (DAT-461): `workspaces` / `sessions` / `session_runs` / `actors` — additive to the engine's `investigation_sessions` run anchor. Migrations apply on the compose stack via the `cockpit-migrate` one-shot service; registry/actor rows seed lazily on first resolve. More tables land as needed (conversations + conversation_messages are the next addition, DAT-462).

--- a/packages/cockpit/drizzle/cockpit/20260608065208_strong_frank_castle/migration.sql
+++ b/packages/cockpit/drizzle/cockpit/20260608065208_strong_frank_castle/migration.sql
@@ -1,0 +1,42 @@
+CREATE TABLE "actors" (
+	"id" varchar PRIMARY KEY,
+	"display_name" varchar NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "session_runs" (
+	"id" varchar PRIMARY KEY,
+	"session_id" varchar NOT NULL,
+	"stage" varchar NOT NULL,
+	"workflow_id" varchar NOT NULL,
+	"run_id" varchar NOT NULL,
+	"status" varchar DEFAULT 'running' NOT NULL,
+	"started_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sessions" (
+	"id" varchar PRIMARY KEY,
+	"workspace_id" varchar NOT NULL,
+	"engine_session_id" varchar NOT NULL,
+	"kind" varchar NOT NULL,
+	"status" varchar DEFAULT 'active' NOT NULL,
+	"created_by" varchar NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"ended_at" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "workspaces" (
+	"id" varchar PRIMARY KEY,
+	"name" varchar NOT NULL,
+	"engine_schema" varchar NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"archived_at" timestamp
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "session_runs_workflow_run_uq" ON "session_runs" ("workflow_id","run_id");--> statement-breakpoint
+CREATE INDEX "session_runs_session_idx" ON "session_runs" ("session_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "sessions_engine_session_uq" ON "sessions" ("engine_session_id");--> statement-breakpoint
+CREATE INDEX "sessions_workspace_idx" ON "sessions" ("workspace_id");--> statement-breakpoint
+ALTER TABLE "session_runs" ADD CONSTRAINT "session_runs_session_id_sessions_id_fkey" FOREIGN KEY ("session_id") REFERENCES "sessions"("id");--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_workspace_id_workspaces_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id");--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_created_by_actors_id_fkey" FOREIGN KEY ("created_by") REFERENCES "actors"("id");

--- a/packages/cockpit/drizzle/cockpit/20260608065208_strong_frank_castle/snapshot.json
+++ b/packages/cockpit/drizzle/cockpit/20260608065208_strong_frank_castle/snapshot.json
@@ -1,0 +1,516 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "fc514b76-a76d-460b-9ce8-35023fc85370",
+  "prevIds": [
+    "00000000-0000-0000-0000-000000000000"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "actors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "session_runs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "workspaces",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "actors"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "actors"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "actors"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stage",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workflow_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "run_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'running'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "engine_session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "engine_schema",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workflow_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "run_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "session_runs_workflow_run_uq",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "session_runs_session_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "engine_session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_engine_session_uq",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_workspace_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "session_runs_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "workspace_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "workspaces",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sessions_workspace_id_workspaces_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "created_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "actors",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sessions_created_by_actors_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "actors_pkey",
+      "schema": "public",
+      "table": "actors",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "session_runs_pkey",
+      "schema": "public",
+      "table": "session_runs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "workspaces_pkey",
+      "schema": "public",
+      "table": "workspaces",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/cockpit/package.json
+++ b/packages/cockpit/package.json
@@ -22,7 +22,8 @@
     "check": "bun --bun biome check",
     "db:pull:metadata": "bash scripts/pull-metadata.sh",
     "db:push:cockpit": "bun --bun drizzle-kit push --config drizzle.config.cockpit.ts",
-    "db:generate:cockpit": "bun --bun drizzle-kit generate --config drizzle.config.cockpit.ts"
+    "db:generate:cockpit": "bun --bun drizzle-kit generate --config drizzle.config.cockpit.ts",
+    "db:migrate:cockpit": "bun --bun drizzle-kit migrate --config drizzle.config.cockpit.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.97.1",

--- a/packages/cockpit/scripts/smoke-dat-461.ts
+++ b/packages/cockpit/scripts/smoke-dat-461.ts
@@ -1,0 +1,114 @@
+// Lane smoke for DAT-461 — the cockpit_db control plane against a REAL Postgres.
+//
+// The cockpit client uses Bun's `SQL` (bun:sql), so this is a `bun run` script,
+// NOT a vitest test (vitest runs under Node, which can't import `bun`). The unit
+// tests cover the writer LOGIC with a mocked Drizzle client; this exercises the
+// actual SQL — registry seed, the session upsert + run append, idempotency, and
+// the terminal-status update — end to end.
+//
+// Prereqs: compose postgres up + the migration applied:
+//   docker compose -f packages/infra/docker-compose.yml up -d --wait postgres
+//   COCKPIT_DATABASE_URL=… bun run db:migrate:cockpit
+// Env (from .env or the shell): COCKPIT_DATABASE_URL + the cockpit config vars.
+//
+// Run from packages/cockpit:  bun run scripts/smoke-dat-461.ts
+
+import assert from "node:assert/strict";
+import { and, eq } from "drizzle-orm";
+import { cockpitDb } from "#/db/cockpit/client";
+import { DEFAULT_ACTOR_ID, resolveActiveWorkspace } from "#/db/cockpit/registry";
+import { markRunStatus, recordRun } from "#/db/cockpit/runs";
+import {
+	actors,
+	sessionRuns,
+	sessions,
+	workspaces,
+} from "#/db/cockpit/schema";
+
+const ENGINE_SESSION = `smoke-461-${crypto.randomUUID()}`;
+const WF = `addsource-smoke-${ENGINE_SESSION}`;
+const RUN_1 = `${ENGINE_SESSION}-run-1`;
+const RUN_2 = `${ENGINE_SESSION}-run-2`;
+
+async function main(): Promise<void> {
+	// 1. Registry seed + resolve.
+	const wsId = await resolveActiveWorkspace();
+	const [ws] = await cockpitDb
+		.select({ id: workspaces.id, engineSchema: workspaces.engineSchema })
+		.from(workspaces)
+		.where(eq(workspaces.id, wsId))
+		.limit(1);
+	assert.equal(ws?.id, wsId, "workspace seeded + resolved");
+	assert.equal(
+		ws?.engineSchema,
+		`ws_${wsId.replaceAll("-", "_")}`,
+		"engine schema derived",
+	);
+	const [actor] = await cockpitDb
+		.select({ id: actors.id })
+		.from(actors)
+		.where(eq(actors.id, DEFAULT_ACTOR_ID))
+		.limit(1);
+	assert.equal(actor?.id, DEFAULT_ACTOR_ID, "default actor seeded");
+
+	// 2. recordRun: creates a session + run; idempotent per (workflowId, runId);
+	//    a 2nd run on the same engine session appends + reuses the one session.
+	const base = {
+		workspaceId: wsId,
+		engineSessionId: ENGINE_SESSION,
+		kind: "begin_session",
+		stage: "begin_session",
+		workflowId: WF,
+		runId: RUN_1,
+	} as const;
+	await recordRun(base);
+	await recordRun(base); // re-record same run → UNIQUE no-op
+	const sess = await cockpitDb
+		.select({ id: sessions.id, kind: sessions.kind })
+		.from(sessions)
+		.where(eq(sessions.engineSessionId, ENGINE_SESSION));
+	assert.equal(sess.length, 1, "exactly one session row");
+	assert.equal(sess[0].kind, "begin_session", "session kind recorded");
+	const runsBefore = await cockpitDb
+		.select({ runId: sessionRuns.runId, status: sessionRuns.status })
+		.from(sessionRuns)
+		.where(eq(sessionRuns.sessionId, sess[0].id));
+	assert.equal(runsBefore.length, 1, "one run after idempotent re-record");
+	assert.equal(runsBefore[0].status, "running", "run starts running");
+
+	await recordRun({ ...base, stage: "operating_model", runId: RUN_2 });
+	const sessAfter = await cockpitDb
+		.select({ id: sessions.id })
+		.from(sessions)
+		.where(eq(sessions.engineSessionId, ENGINE_SESSION));
+	assert.equal(sessAfter.length, 1, "second run reuses the session");
+	const runsAfter = await cockpitDb
+		.select({ runId: sessionRuns.runId })
+		.from(sessionRuns)
+		.where(eq(sessionRuns.sessionId, sess[0].id));
+	assert.equal(runsAfter.length, 2, "second run appended");
+
+	// 3. markRunStatus: terminal transition.
+	await markRunStatus(WF, RUN_1, "completed");
+	const [r] = await cockpitDb
+		.select({ status: sessionRuns.status })
+		.from(sessionRuns)
+		.where(and(eq(sessionRuns.workflowId, WF), eq(sessionRuns.runId, RUN_1)))
+		.limit(1);
+	assert.equal(r?.status, "completed", "run marked completed");
+
+	// Cleanup — leave the shared registry rows (workspace, default actor) intact.
+	await cockpitDb
+		.delete(sessionRuns)
+		.where(eq(sessionRuns.sessionId, sess[0].id));
+	await cockpitDb.delete(sessions).where(eq(sessions.id, sess[0].id));
+
+	console.log("✓ DAT-461 lane smoke passed");
+}
+
+main()
+	.then(() => process.exit(0))
+	.catch((err) => {
+		console.error("✗ DAT-461 lane smoke FAILED:", err);
+		process.exit(1);
+	});

--- a/packages/cockpit/src/db/cockpit/client.ts
+++ b/packages/cockpit/src/db/cockpit/client.ts
@@ -10,6 +10,9 @@ import { config } from "../../config";
 
 const client = new SQL(config.cockpitDatabaseUrl);
 
-// schema is intentionally not passed yet — ./schema.ts is a placeholder. Once
-// real tables land (e.g. workspaces registry), pass `{ client, schema }`.
+// The control-plane tables (DAT-461) live in ./schema.ts; callers import the
+// table objects directly and use `cockpitDb.insert(...)` / `.select(...)`. We do
+// NOT pass `schema` to drizzle() — that only enables the relational query API
+// (`db.query.*`), which nothing here uses, and the drizzle 1.0 relations rewrite
+// makes the bun-sql `{ client, schema }` overload awkward to type.
 export const cockpitDb = drizzle({ client });

--- a/packages/cockpit/src/db/cockpit/registry.test.ts
+++ b/packages/cockpit/src/db/cockpit/registry.test.ts
@@ -1,0 +1,83 @@
+// Unit tests for the workspace registry resolver (DAT-461). Mocks the cockpit_db
+// client at the `#/` boundary (no DB) + the schema table objects (sentinels so
+// the insert mock can tell which table it targeted). Asserts the warm path
+// (workspace row exists → returned, no seed) and the cold path (no row → seed
+// the default actor + workspace, then return). The real SQL is covered by the
+// Bun lane smoke (scripts/smoke-dat-461.ts).
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const WS = "00000000-0000-0000-0000-000000000001";
+
+const h = vi.hoisted(() => ({
+	// Literal (NOT `WS`): vi.hoisted runs before the module-level `const WS` → TDZ.
+	config: {
+		dataraumWorkspaceId: "00000000-0000-0000-0000-000000000001",
+	} as Record<string, unknown>,
+	// Rows the workspace SELECT returns (empty = cold path → seed).
+	workspaceRows: [] as Array<{ id: string }>,
+	// Every onConflictDoNothing insert, tagged by table.
+	inserts: [] as Array<{ table: string; row: Record<string, unknown> }>,
+}));
+
+vi.mock("#/config", () => ({
+	get config() {
+		return h.config;
+	},
+}));
+
+vi.mock("#/db/cockpit/schema", () => ({
+	actors: { _t: "actors", id: "id" },
+	workspaces: { _t: "workspaces", id: "id" },
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: (...a: unknown[]) => a }));
+
+const limitMock = vi.fn(async () => h.workspaceRows);
+vi.mock("#/db/cockpit/client", () => ({
+	cockpitDb: {
+		insert: (table: { _t: string }) => ({
+			values: (row: Record<string, unknown>) => ({
+				onConflictDoNothing: async () => {
+					h.inserts.push({ table: table._t, row });
+				},
+			}),
+		}),
+		select: () => ({
+			from: () => ({ where: () => ({ limit: limitMock }) }),
+		}),
+	},
+}));
+
+import { DEFAULT_ACTOR_ID, resolveActiveWorkspace } from "./registry";
+
+beforeEach(() => {
+	h.config = { dataraumWorkspaceId: WS };
+	h.workspaceRows = [];
+	h.inserts = [];
+	limitMock.mockClear();
+});
+
+describe("resolveActiveWorkspace (DAT-461)", () => {
+	it("returns the existing workspace WITHOUT seeding (warm path)", async () => {
+		h.workspaceRows = [{ id: WS }];
+		const id = await resolveActiveWorkspace();
+		expect(id).toBe(WS);
+		expect(h.inserts).toEqual([]); // no seed when the row already exists
+	});
+
+	it("seeds the default actor + workspace then returns it (cold path)", async () => {
+		h.workspaceRows = []; // nothing yet
+		const id = await resolveActiveWorkspace();
+		expect(id).toBe(WS);
+
+		const actor = h.inserts.find((i) => i.table === "actors");
+		expect(actor?.row.id).toBe(DEFAULT_ACTOR_ID);
+
+		const ws = h.inserts.find((i) => i.table === "workspaces");
+		expect(ws?.row.id).toBe(WS);
+		// engine schema derives from the id (underscores, not dashes) — matches the
+		// metadata write-surface.
+		expect(ws?.row.engineSchema).toBe(`ws_${WS.replaceAll("-", "_")}`);
+	});
+});

--- a/packages/cockpit/src/db/cockpit/registry.ts
+++ b/packages/cockpit/src/db/cockpit/registry.ts
@@ -1,0 +1,66 @@
+// Workspace registry resolver (DAT-461) — the source of truth for "which
+// workspace", replacing scattered `config.dataraumWorkspaceId` env reads.
+//
+// Phase 1 is single-active-workspace: the registry holds ONE row, seeded from
+// `DATARAUM_WORKSPACE_ID`, and `resolveActiveWorkspace()` returns it. The value
+// is still the env-designated workspace — what changes is that the cockpit_db
+// `workspaces` table is now the system of record (its row backs the FK on
+// `sessions.workspaceId`, and reads go through here). Per-request workspace
+// SELECTION (a switcher) is Phase 3 (DAT-357); tools have no per-request context
+// channel today (TanStack AI `.server((input)=>…)` passes only input), so a
+// single resolver is the correct seam now.
+//
+// Seeding is LAZY here rather than a boot step: the compose `cockpit-migrate`
+// init service applies the SCHEMA only, and host dev (cockpit run outside docker)
+// has no init step at all — so the registry self-populates on first resolve,
+// idempotently, working identically everywhere.
+
+import { eq } from "drizzle-orm";
+import { config } from "../../config";
+import { cockpitDb } from "./client";
+import { actors, workspaces } from "./schema";
+
+// The single coarse actor (DAT-460): no auth, no multi-user yet. `sessions`
+// stamp `createdBy` with this so attribution exists without engine-side actor_id
+// plumbing (the retired DAT-365). Real actors/auth are Phase 3 (DAT-357).
+export const DEFAULT_ACTOR_ID = "default";
+
+/** The engine's `ws_<id>` Postgres schema for a workspace id — mirrors the
+ * metadata write-surface's derivation (underscores, not dashes). */
+function engineSchemaFor(workspaceId: string): string {
+	return `ws_${workspaceId.replaceAll("-", "_")}`;
+}
+
+/** Idempotently seed the default actor + the env-designated workspace row.
+ * Runs only on the cold path (first resolve after a fresh boot). */
+async function ensureRegistry(workspaceId: string): Promise<void> {
+	await cockpitDb
+		.insert(actors)
+		.values({ id: DEFAULT_ACTOR_ID, displayName: "Default user" })
+		.onConflictDoNothing({ target: actors.id });
+	await cockpitDb
+		.insert(workspaces)
+		.values({
+			id: workspaceId,
+			name: `Workspace ${workspaceId}`,
+			engineSchema: engineSchemaFor(workspaceId),
+		})
+		.onConflictDoNothing({ target: workspaces.id });
+}
+
+/**
+ * The active workspace id, read from the registry (seeding it on the cold path).
+ * Returns the `DATARAUM_WORKSPACE_ID` value in Phase 1 — but proven to exist as
+ * a `workspaces` row, so `sessions.workspaceId` FKs resolve.
+ */
+export async function resolveActiveWorkspace(): Promise<string> {
+	const workspaceId = config.dataraumWorkspaceId;
+	const [row] = await cockpitDb
+		.select({ id: workspaces.id })
+		.from(workspaces)
+		.where(eq(workspaces.id, workspaceId))
+		.limit(1);
+	if (row) return row.id;
+	await ensureRegistry(workspaceId);
+	return workspaceId;
+}

--- a/packages/cockpit/src/db/cockpit/runs.test.ts
+++ b/packages/cockpit/src/db/cockpit/runs.test.ts
@@ -1,0 +1,136 @@
+// Unit tests for control-plane run recording (DAT-461). Mocks the cockpit_db
+// client at the `#/` boundary (no DB). Asserts recordRun upserts the session
+// (conflict target = engine session id), looks up its id, and appends the run
+// (conflict target = workflow+run); that it's BEST-EFFORT (a db error is
+// swallowed + logged, never thrown — a control-plane write must not fail the
+// started workflow); and that markRunStatus issues the terminal update. The real
+// SQL + idempotency/append are covered by the Bun lane smoke.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+	inserts: [] as Array<{ table: string; row: Record<string, unknown> }>,
+	conflicts: [] as unknown[],
+	updates: [] as Array<{ table: string; set: Record<string, unknown> }>,
+	sessionRows: [{ id: "sess-row-1" }] as Array<{ id: string }>,
+	throwOnInsert: false,
+}));
+
+vi.mock("#/db/cockpit/registry", () => ({ DEFAULT_ACTOR_ID: "default" }));
+vi.mock("#/db/cockpit/schema", () => ({
+	sessions: { _t: "sessions", id: "id", engineSessionId: "engine_session_id" },
+	sessionRuns: {
+		_t: "session_runs",
+		sessionId: "session_id",
+		workflowId: "workflow_id",
+		runId: "run_id",
+	},
+}));
+vi.mock("drizzle-orm", () => ({
+	eq: (...a: unknown[]) => a,
+	and: (...a: unknown[]) => a,
+}));
+
+const limitMock = vi.fn(async () => h.sessionRows);
+vi.mock("#/db/cockpit/client", () => ({
+	cockpitDb: {
+		insert: (table: { _t: string }) => ({
+			values: (row: Record<string, unknown>) => {
+				if (h.throwOnInsert) throw new Error("db down");
+				h.inserts.push({ table: table._t, row });
+				return {
+					onConflictDoNothing: async (cfg: unknown) => {
+						h.conflicts.push(cfg);
+					},
+				};
+			},
+		}),
+		select: () => ({
+			from: () => ({ where: () => ({ limit: limitMock }) }),
+		}),
+		update: (table: { _t: string }) => ({
+			set: (s: Record<string, unknown>) => ({
+				where: async () => {
+					h.updates.push({ table: table._t, set: s });
+				},
+			}),
+		}),
+	},
+}));
+
+import { markRunStatus, recordRun } from "./runs";
+
+const BASE = {
+	workspaceId: "ws-1",
+	engineSessionId: "eng-sess-1",
+	kind: "begin_session" as const,
+	stage: "begin_session" as const,
+	workflowId: "wf-1",
+	runId: "run-1",
+};
+
+beforeEach(() => {
+	h.inserts = [];
+	h.conflicts = [];
+	h.updates = [];
+	h.sessionRows = [{ id: "sess-row-1" }];
+	h.throwOnInsert = false;
+	limitMock.mockClear();
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("recordRun (DAT-461)", () => {
+	it("upserts the session then appends the run against the looked-up session id", async () => {
+		await recordRun(BASE);
+
+		const sess = h.inserts.find((i) => i.table === "sessions");
+		expect(sess?.row.engineSessionId).toBe("eng-sess-1");
+		expect(sess?.row.workspaceId).toBe("ws-1");
+		expect(sess?.row.kind).toBe("begin_session");
+		expect(sess?.row.status).toBe("active");
+		expect(sess?.row.createdBy).toBe("default");
+
+		const run = h.inserts.find((i) => i.table === "session_runs");
+		// The run FKs to the looked-up session row id, NOT the engine session id.
+		expect(run?.row.sessionId).toBe("sess-row-1");
+		expect(run?.row.stage).toBe("begin_session");
+		expect(run?.row.workflowId).toBe("wf-1");
+		expect(run?.row.runId).toBe("run-1");
+		expect(run?.row.status).toBe("running");
+	});
+
+	it("is best-effort: a db error is swallowed + logged, never thrown", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		h.throwOnInsert = true;
+		await expect(recordRun(BASE)).resolves.toBeUndefined();
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(h.inserts).toEqual([]);
+	});
+
+	it("skips the run insert when the session lookup returns nothing", async () => {
+		h.sessionRows = []; // unreachable after the upsert, but the guard must hold
+		await recordRun(BASE);
+		expect(h.inserts.find((i) => i.table === "session_runs")).toBeUndefined();
+	});
+});
+
+describe("markRunStatus (DAT-461)", () => {
+	it("issues a terminal status update for the run", async () => {
+		await markRunStatus("wf-1", "run-1", "completed");
+		expect(h.updates).toHaveLength(1);
+		expect(h.updates[0].table).toBe("session_runs");
+		expect(h.updates[0].set).toEqual({ status: "completed" });
+	});
+
+	it("is best-effort: swallows a db error", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const boom = await import("./client");
+		vi.spyOn(boom.cockpitDb, "update").mockImplementation(() => {
+			throw new Error("db down");
+		});
+		await expect(
+			markRunStatus("wf-1", "run-1", "failed"),
+		).resolves.toBeUndefined();
+		expect(warn).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/cockpit/src/db/cockpit/runs.ts
+++ b/packages/cockpit/src/db/cockpit/runs.ts
@@ -1,0 +1,108 @@
+// Control-plane run recording (DAT-461) — the driver tools call this AFTER a
+// Temporal workflow starts to record the session + its run in cockpit_db.
+//
+// Additive to the engine: the tools still seed `investigation_sessions` (the
+// engine's FK anchor) exactly as before; this records the COCKPIT's view —
+// which workspace, who, and the in-flight `(workflowId, runId)` the reload-
+// recovery substrate (DAT-462) reads to re-attach progress.
+//
+// Best-effort by design: a control-plane breadcrumb must NEVER fail the user's
+// workflow (which has already started by the time this runs), so any error is
+// logged and swallowed. Idempotent: the `sessions` upsert is conflict-safe (one
+// row per engine session — operating_model reuses begin_session's, re-runs
+// reuse too), and `(workflowId, runId)` is UNIQUE so a repeated record is a
+// no-op.
+
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { cockpitDb } from "./client";
+import { DEFAULT_ACTOR_ID } from "./registry";
+import { sessionRuns, sessions } from "./schema";
+
+/** How a cockpit session originated — mirrors the engine seed `intent`. */
+export type SessionKind = "onboarding" | "begin_session" | "replay";
+/** Which workflow a run executed. */
+export type RunStage = "add_source" | "begin_session" | "operating_model";
+
+export interface RecordRunInput {
+	workspaceId: string;
+	// The engine's session id (the join into `investigation_sessions`).
+	engineSessionId: string;
+	// The session's origin — used only when the session row is first created;
+	// ignored (onConflictDoNothing) when it already exists (operating_model /
+	// re-runs reuse the row).
+	kind: SessionKind;
+	stage: RunStage;
+	workflowId: string;
+	runId: string;
+}
+
+export async function recordRun(input: RecordRunInput): Promise<void> {
+	try {
+		await cockpitDb
+			.insert(sessions)
+			.values({
+				id: randomUUID(),
+				workspaceId: input.workspaceId,
+				engineSessionId: input.engineSessionId,
+				kind: input.kind,
+				status: "active",
+				createdBy: DEFAULT_ACTOR_ID,
+			})
+			.onConflictDoNothing({ target: sessions.engineSessionId });
+
+		const [session] = await cockpitDb
+			.select({ id: sessions.id })
+			.from(sessions)
+			.where(eq(sessions.engineSessionId, input.engineSessionId))
+			.limit(1);
+		if (!session) return;
+
+		await cockpitDb
+			.insert(sessionRuns)
+			.values({
+				id: randomUUID(),
+				sessionId: session.id,
+				stage: input.stage,
+				workflowId: input.workflowId,
+				runId: input.runId,
+				status: "running",
+			})
+			.onConflictDoNothing({
+				target: [sessionRuns.workflowId, sessionRuns.runId],
+			});
+	} catch (err) {
+		console.warn(
+			`[cockpit] recordRun failed for ${input.stage} session ` +
+				`${input.engineSessionId} (run ${input.runId}): ${err}`,
+		);
+	}
+}
+
+/**
+ * Mark a recorded run terminal (completed | failed) — called best-effort when a
+ * run's completion is observed (the workflow-progress poll, DAT-461). The
+ * reload-recovery reconcile (DAT-462) is the other writer. No-op if the run
+ * isn't recorded (a run started before this feature shipped).
+ */
+export async function markRunStatus(
+	workflowId: string,
+	runId: string,
+	status: "completed" | "failed",
+): Promise<void> {
+	try {
+		await cockpitDb
+			.update(sessionRuns)
+			.set({ status })
+			.where(
+				and(
+					eq(sessionRuns.workflowId, workflowId),
+					eq(sessionRuns.runId, runId),
+				),
+			);
+	} catch (err) {
+		console.warn(
+			`[cockpit] markRunStatus failed for run ${runId} (${workflowId}): ${err}`,
+		);
+	}
+}

--- a/packages/cockpit/src/db/cockpit/schema.ts
+++ b/packages/cockpit/src/db/cockpit/schema.ts
@@ -1,16 +1,118 @@
-// cockpit_db schema — placeholder.
+// cockpit_db schema — the cockpit's control plane (DAT-461).
 //
 // Owned by TanStack Start via Drizzle ORM. Lives in its own Postgres database
-// inside the shared Postgres instance (separate from the engine's `dataraum`
-// and `dataraum_lake_catalog` databases).
+// (`cockpit_db`) inside the shared Postgres instance, separate from the engine's
+// `dataraum` / `dataraum_lake_catalog` databases and from the engine-owned
+// `ws_<id>` analytical schema (which the cockpit reads through ../metadata/).
 //
-// Tables land here when they're actually needed:
-//   - workspaces                              (DAT-339 pivot, slice 1)
-//   - conversations / conversation_messages   (chat persistence)
-//   - ui_state / ui_preferences               (future)
-//   - admin_*                                 (future)
+// Control plane vs data plane (DD/32538626): the engine owns analytical data +
+// its `investigation_sessions` run anchor; cockpit_db owns *who / which-workspace
+// / which-session / which-runs*. These tables are PURELY ADDITIVE — `sessions`
+// references the engine's session id (`engineSessionId`), it does not replace it;
+// the driver tools keep seeding `investigation_sessions` unchanged.
 //
-// Source of truth: this file. Migrations land in ../../../drizzle/cockpit/
-// via `drizzle-kit generate --config drizzle.config.cockpit.ts`.
+// Source of truth: this file. Migrations land in ../../../drizzle/cockpit/ via
+// `bun run db:generate:cockpit`, applied by `bun run db:migrate:cockpit` (the
+// compose `cockpit-migrate` init service on the stack; manual for host dev).
+//
+// Still to land here (later phases of DAT-460): conversations /
+// conversation_messages (chat persistence, DAT-462) · ui_state (DAT-462).
 
-export {};
+import {
+	index,
+	pgTable,
+	timestamp,
+	uniqueIndex,
+	varchar,
+} from "drizzle-orm/pg-core";
+
+/**
+ * Who triggered control-plane work. A coarse identity seam (DAT-460): a single
+ * seeded `default` row for now — NO auth, NO multi-user. Real actors/auth are
+ * Phase 3 (DAT-357). `sessions.createdBy` references this so attribution exists
+ * from day one without threading `actor_id` through the engine (the retired
+ * DAT-365 approach — identity is a control-plane concern, kept out of the data
+ * plane).
+ */
+export const actors = pgTable("actors", {
+	id: varchar("id").primaryKey(),
+	displayName: varchar("display_name").notNull(),
+	createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+});
+
+/**
+ * The workspace registry — the source of truth for "which workspace", replacing
+ * the bare `DATARAUM_WORKSPACE_ID` env read. Seeded from that env var on first
+ * resolve (registry.ts). `id` is the workspace key (the same value the engine is
+ * bootstrapped with, e.g. `00000000-…-001`); `engineSchema` is the derived
+ * `ws_<id>` Postgres schema the metadata client reads. Phase 1 is single-active-
+ * workspace; the switcher + lifecycle are Phase 3 (DAT-357 — hence `archivedAt`).
+ */
+export const workspaces = pgTable("workspaces", {
+	id: varchar("id").primaryKey(),
+	name: varchar("name").notNull(),
+	engineSchema: varchar("engine_schema").notNull(),
+	createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+	archivedAt: timestamp("archived_at", { mode: "date" }),
+});
+
+/**
+ * A control-plane session — the cockpit's own record of an analytical session,
+ * keyed to the engine's session by `engineSessionId` (UNIQUE, the join into the
+ * engine's `investigation_sessions`). Additive: begin_session/add_source/replay
+ * each create one; operating_model REUSES begin_session's (looked up by
+ * `engineSessionId`). `kind` mirrors the engine seed intent
+ * (onboarding | begin_session | replay); `status` carries the lifecycle
+ * (active | ended | archived) that DAT-404 will drive.
+ */
+export const sessions = pgTable(
+	"sessions",
+	{
+		id: varchar("id").primaryKey(),
+		workspaceId: varchar("workspace_id")
+			.notNull()
+			.references(() => workspaces.id),
+		engineSessionId: varchar("engine_session_id").notNull(),
+		kind: varchar("kind").notNull(),
+		status: varchar("status").notNull().default("active"),
+		createdBy: varchar("created_by")
+			.notNull()
+			.references(() => actors.id),
+		createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+		endedAt: timestamp("ended_at", { mode: "date" }),
+	},
+	(t) => [
+		// One cockpit session per engine session — the upsert key the tools use so
+		// operating_model's append (and any re-run) reuses the row instead of
+		// duplicating it.
+		uniqueIndex("sessions_engine_session_uq").on(t.engineSessionId),
+		index("sessions_workspace_idx").on(t.workspaceId),
+	],
+);
+
+/**
+ * One Temporal run under a session — the reload-recovery substrate (DAT-462
+ * reads non-terminal rows to re-attach progress). A session has 1:N runs:
+ * re-runs / teach-replays append a new row. `stage` is the workflow that ran
+ * (add_source | begin_session | operating_model); `(workflowId, runId)` is the
+ * Temporal identity the progress widget polls, UNIQUE so an idempotent record
+ * call can't double-insert.
+ */
+export const sessionRuns = pgTable(
+	"session_runs",
+	{
+		id: varchar("id").primaryKey(),
+		sessionId: varchar("session_id")
+			.notNull()
+			.references(() => sessions.id),
+		stage: varchar("stage").notNull(),
+		workflowId: varchar("workflow_id").notNull(),
+		runId: varchar("run_id").notNull(),
+		status: varchar("status").notNull().default("running"),
+		startedAt: timestamp("started_at", { mode: "date" }).notNull().defaultNow(),
+	},
+	(t) => [
+		uniqueIndex("session_runs_workflow_run_uq").on(t.workflowId, t.runId),
+		index("session_runs_session_idx").on(t.sessionId),
+	],
+);

--- a/packages/cockpit/src/routes/(app)/route.tsx
+++ b/packages/cockpit/src/routes/(app)/route.tsx
@@ -1,17 +1,18 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
-import { config } from "#/config";
+import { resolveActiveWorkspace } from "#/db/cockpit/registry";
 import { CockpitShell } from "#/ui/app-shell";
 
 // Pathless layout (`(app)` is a route group — it adds no URL segment). Every
 // section page nests under this so the AppShell chrome (rail + top bar +
 // ⌘K palette) renders once and the section fills <Outlet/>.
 
-// Active workspace id (server config). The shell needs it so the rail's
-// workspace links resolve on global routes like /settings, which carry no
-// wsId param. Read server-side so server-only config never reaches the client.
-const getActiveWorkspaceId = createServerFn({ method: "GET" }).handler(
-	() => config.dataraumWorkspaceId,
+// Active workspace id from the cockpit_db registry (DAT-461). The shell needs it
+// so the rail's workspace links resolve on global routes like /settings, which
+// carry no wsId param. Resolved server-side — the registry read never reaches
+// the client bundle.
+const getActiveWorkspaceId = createServerFn({ method: "GET" }).handler(() =>
+	resolveActiveWorkspace(),
 );
 
 export const Route = createFileRoute("/(app)")({

--- a/packages/cockpit/src/routes/api/chat.test.ts
+++ b/packages/cockpit/src/routes/api/chat.test.ts
@@ -12,6 +12,12 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("#/config", () => ({ config: { anthropicApiKey: "sk-ant-test" } }));
 vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
+// The driver tools (via the registry) import the cockpit control plane
+// (DAT-461); mock the seam so the route import never loads the cockpit_db client.
+vi.mock("#/db/cockpit/registry", () => ({
+	resolveActiveWorkspace: async () => "ws-test",
+}));
+vi.mock("#/db/cockpit/runs", () => ({ recordRun: async () => {} }));
 
 import { AGENT_LOOP_MAX_ITERATIONS, MAX_OUTPUT_TOKENS } from "../../llm";
 import { buildChatOptions } from "./chat";

--- a/packages/cockpit/src/routes/api/workflow-progress.ts
+++ b/packages/cockpit/src/routes/api/workflow-progress.ts
@@ -48,9 +48,15 @@ export const Route = createFileRoute("/api/workflow-progress")({
 					// (markRunStatus swallows): a control-plane write never affects the
 					// progress the widget renders.
 					if (result.done) {
+						// "completed" covers the clean exits: phase=="done" (the
+						// workflow finished even if describe() hasn't flipped to
+						// COMPLETED yet), an actual COMPLETED, and CONTINUED_AS_NEW (a
+						// handoff, not a failure). Everything else terminal — FAILED /
+						// TERMINATED / CANCELED / TIMED_OUT — is "failed".
 						const status =
 							result.phase === PROGRESS_DONE_PHASE ||
-							result.status === "COMPLETED"
+							result.status === "COMPLETED" ||
+							result.status === "CONTINUED_AS_NEW"
 								? "completed"
 								: "failed";
 						await markRunStatus(

--- a/packages/cockpit/src/routes/api/workflow-progress.ts
+++ b/packages/cockpit/src/routes/api/workflow-progress.ts
@@ -9,10 +9,12 @@
 // the client bundle, same as `/api/run-sql`.
 
 import { createFileRoute } from "@tanstack/react-router";
+import { markRunStatus } from "../../db/cockpit/runs";
 import {
 	getWorkflowProgress,
 	WorkflowProgressInputSchema,
 } from "../../temporal/progress";
+import { PROGRESS_DONE_PHASE } from "../../temporal/types";
 
 function badRequest(message: string): Response {
 	return new Response(JSON.stringify({ error: message }), {
@@ -40,6 +42,23 @@ export const Route = createFileRoute("/api/workflow-progress")({
 
 				try {
 					const result = await getWorkflowProgress(parsed.data);
+					// The poll is the observation point for run completion — mark the
+					// recorded session_run terminal so the reload-recovery substrate
+					// (DAT-461 / DAT-462) stops treating it as in-flight. Best-effort
+					// (markRunStatus swallows): a control-plane write never affects the
+					// progress the widget renders.
+					if (result.done) {
+						const status =
+							result.phase === PROGRESS_DONE_PHASE ||
+							result.status === "COMPLETED"
+								? "completed"
+								: "failed";
+						await markRunStatus(
+							parsed.data.workflow_id,
+							parsed.data.run_id,
+							status,
+						);
+					}
 					return Response.json(result);
 				} catch (err) {
 					console.error("workflow-progress query failed", err);

--- a/packages/cockpit/src/routes/index.tsx
+++ b/packages/cockpit/src/routes/index.tsx
@@ -1,13 +1,14 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
-import { config } from "#/config";
+import { resolveActiveWorkspace } from "#/db/cockpit/registry";
 
 // `/` resolves the active workspace and sends the user straight to its
-// cockpit. The active workspace id is server config (DATARAUM_WORKSPACE_ID);
-// once multi-workspace lands this becomes a real picker. Read server-side so
-// the server-only config never reaches the client bundle.
-const getActiveWorkspaceId = createServerFn({ method: "GET" }).handler(
-	() => config.dataraumWorkspaceId,
+// cockpit. The id comes from the cockpit_db workspace registry (DAT-461),
+// seeded from DATARAUM_WORKSPACE_ID; once multi-workspace lands (DAT-357) this
+// becomes a real picker. Resolved server-side — the registry read (and the
+// server-only config it seeds from) never reaches the client bundle.
+const getActiveWorkspaceId = createServerFn({ method: "GET" }).handler(() =>
+	resolveActiveWorkspace(),
 );
 
 export const Route = createFileRoute("/")({

--- a/packages/cockpit/src/temporal/trigger-add-source.test.ts
+++ b/packages/cockpit/src/temporal/trigger-add-source.test.ts
@@ -28,6 +28,7 @@ const h = vi.hoisted(() => ({
 	calls: [] as string[],
 	startArgs: null as unknown,
 	seededRow: null as Record<string, unknown> | null,
+	recordRun: vi.fn(async () => {}),
 }));
 
 // A live getter, not a snapshot: the unconfigured-guard test reassigns
@@ -37,6 +38,13 @@ vi.mock("#/config", () => ({
 		return h.config;
 	},
 }));
+
+// cockpit_db control plane (DAT-461): workspace via the registry, run recorded
+// after start — both mocked at the seam (no DB in units).
+vi.mock("#/db/cockpit/registry", () => ({
+	resolveActiveWorkspace: vi.fn(async () => h.config.dataraumWorkspaceId),
+}));
+vi.mock("#/db/cockpit/runs", () => ({ recordRun: h.recordRun }));
 
 // Metadata client: record the seeded row + that the insert ran (and when).
 const valuesMock = vi.fn((row: Record<string, unknown>) => {
@@ -83,6 +91,7 @@ beforeEach(() => {
 	valuesMock.mockClear();
 	startMock.mockClear();
 	closeMock.mockClear();
+	h.recordRun.mockClear();
 });
 
 describe("triggerAddSource (DAT-352, one-gate DAT-436)", () => {
@@ -160,6 +169,21 @@ describe("triggerAddSource (DAT-352, one-gate DAT-436)", () => {
 		// The guard runs first — no orphan session row, no workflow start.
 		expect(valuesMock).not.toHaveBeenCalled();
 		expect(startMock).not.toHaveBeenCalled();
+		expect(h.recordRun).not.toHaveBeenCalled();
+	});
+
+	it("records the cockpit session + run after starting (DAT-461)", async () => {
+		await triggerAddSource({ source_ids: ["src-1"] });
+		const sessionId = h.seededRow?.sessionId as string;
+		expect(h.recordRun).toHaveBeenCalledTimes(1);
+		expect(h.recordRun).toHaveBeenCalledWith({
+			workspaceId: WS,
+			engineSessionId: sessionId,
+			kind: "onboarding",
+			stage: "add_source",
+			workflowId: `addsource-${WS}-${sessionId}`,
+			runId: "run-abc",
+		});
 	});
 });
 

--- a/packages/cockpit/src/temporal/trigger-add-source.ts
+++ b/packages/cockpit/src/temporal/trigger-add-source.ts
@@ -31,6 +31,8 @@ import { Client, Connection } from "@temporalio/client";
 import { WorkflowIdReusePolicy } from "@temporalio/common";
 
 import { config } from "../config";
+import { resolveActiveWorkspace } from "../db/cockpit/registry";
+import { recordRun } from "../db/cockpit/runs";
 import { metadataDb } from "../db/metadata/client";
 import { investigationSessionsWrite } from "../db/metadata/write-surface";
 import type { AddSourceInput, AddSourceResult, SourceIdentity } from "./types";
@@ -154,17 +156,21 @@ export async function triggerAddSource(
 			"if no run follows, this row is an orphan from a failed approval",
 	);
 
+	// The active workspace, from the cockpit_db registry (DAT-461) rather than the
+	// raw env var — same value in Phase 1, source of truth for the recorded run.
+	const workspaceId = await resolveActiveWorkspace();
+
 	// Source-free identity (DAT-422): the per-source ids ride in `source_ids`; the
 	// engine scopes each `import` to one of them and the run-level reduce/detect are
 	// session-scoped. The run is keyed by `session_id`, not a source.
 	const identity: SourceIdentity = {
-		workspace_id: config.dataraumWorkspaceId,
+		workspace_id: workspaceId,
 		session_id: sessionId,
 		vertical,
 	};
 	const payload: AddSourceInput = { identity, source_ids: input.source_ids };
 
-	const workflowId = addSourceWorkflowId(config.dataraumWorkspaceId, sessionId);
+	const workflowId = addSourceWorkflowId(workspaceId, sessionId);
 
 	const connection = await Connection.connect({ address: host });
 	try {
@@ -187,6 +193,16 @@ export async function triggerAddSource(
 			// approval the user can deny. Deliberately NO idempotency key and NO
 			// in-flight check here.
 			workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
+		});
+
+		// Record the cockpit-side session + run (DAT-461) — best-effort.
+		await recordRun({
+			workspaceId,
+			engineSessionId: sessionId,
+			kind: "onboarding",
+			stage: "add_source",
+			workflowId,
+			runId: handle.firstExecutionRunId,
 		});
 
 		return {

--- a/packages/cockpit/src/tools/begin-session.test.ts
+++ b/packages/cockpit/src/tools/begin-session.test.ts
@@ -21,6 +21,7 @@ const h = vi.hoisted(() => ({
 	calls: [] as string[],
 	seededRow: null as Record<string, unknown> | null,
 	verticalRows: [] as Array<{ vertical: string }>,
+	recordRun: vi.fn(async () => {}),
 }));
 
 vi.mock("#/config", () => ({
@@ -28,6 +29,13 @@ vi.mock("#/config", () => ({
 		return h.config;
 	},
 }));
+
+// cockpit_db control plane (DAT-461): workspace via the registry, run recorded
+// after start — both mocked at the seam (no DB in units).
+vi.mock("#/db/cockpit/registry", () => ({
+	resolveActiveWorkspace: vi.fn(async () => h.config.dataraumWorkspaceId),
+}));
+vi.mock("#/db/cockpit/runs", () => ({ recordRun: h.recordRun }));
 
 const onConflictMock = vi.fn(async () => {});
 const valuesMock = vi.fn((row: Record<string, unknown>) => {
@@ -99,6 +107,7 @@ beforeEach(() => {
 	onConflictMock.mockClear();
 	startMock.mockClear();
 	closeMock.mockClear();
+	h.recordRun.mockClear();
 });
 
 describe("beginSession (DAT-409)", () => {
@@ -157,6 +166,21 @@ describe("beginSession (DAT-409)", () => {
 		);
 		expect(valuesMock).not.toHaveBeenCalled();
 		expect(startMock).not.toHaveBeenCalled();
+		expect(h.recordRun).not.toHaveBeenCalled();
+	});
+
+	it("records the cockpit session + run after starting (DAT-461)", async () => {
+		await beginSession({ table_ids: ["t1", "t2"], vertical: "finance" });
+		const sessionId = h.seededRow?.sessionId as string;
+		expect(h.recordRun).toHaveBeenCalledTimes(1);
+		expect(h.recordRun).toHaveBeenCalledWith({
+			workspaceId: WS,
+			engineSessionId: sessionId,
+			kind: "begin_session",
+			stage: "begin_session",
+			workflowId: `beginsession-${WS}-${sessionId}`,
+			runId: "run-xyz",
+		});
 	});
 
 	it("resolves the selection's framed vertical when vertical is OMITTED", async () => {

--- a/packages/cockpit/src/tools/begin-session.ts
+++ b/packages/cockpit/src/tools/begin-session.ts
@@ -27,6 +27,8 @@ import { and, desc, eq, inArray, isNotNull, ne } from "drizzle-orm";
 import { z } from "zod";
 
 import { config } from "../config";
+import { resolveActiveWorkspace } from "../db/cockpit/registry";
+import { recordRun } from "../db/cockpit/runs";
 import { metadataDb } from "../db/metadata/client";
 import { investigationSessions, sessionTables } from "../db/metadata/schema";
 import { investigationSessionsWrite } from "../db/metadata/write-surface";
@@ -136,16 +138,18 @@ export async function beginSession(
 		})
 		.onConflictDoNothing({ target: investigationSessions.sessionId });
 
+	// The active workspace, from the cockpit_db registry (DAT-461) rather than the
+	// raw env var — same value in Phase 1, but the source of truth for the
+	// sessions.workspaceId FK recorded below.
+	const workspaceId = await resolveActiveWorkspace();
+
 	const identity: SessionIdentity = {
-		workspace_id: config.dataraumWorkspaceId,
+		workspace_id: workspaceId,
 		session_id: sessionId,
 	};
 	const payload: BeginSessionInput = { identity, tables: input.table_ids };
 
-	const workflowId = beginSessionWorkflowId(
-		config.dataraumWorkspaceId,
-		sessionId,
-	);
+	const workflowId = beginSessionWorkflowId(workspaceId, sessionId);
 
 	const connection = await Connection.connect({ address: config.temporalHost });
 	try {
@@ -160,6 +164,17 @@ export async function beginSession(
 			workflowId,
 			args: [payload],
 			workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
+		});
+
+		// Record the cockpit-side session + run (DAT-461) — best-effort, never
+		// fails the started workflow.
+		await recordRun({
+			workspaceId,
+			engineSessionId: sessionId,
+			kind: "begin_session",
+			stage: "begin_session",
+			workflowId,
+			runId: handle.firstExecutionRunId,
 		});
 
 		return {

--- a/packages/cockpit/src/tools/operating-model.test.ts
+++ b/packages/cockpit/src/tools/operating-model.test.ts
@@ -18,6 +18,7 @@ const h = vi.hoisted(() => ({
 		temporalNamespace: "default",
 		temporalTaskQueue: "dataraum-pipeline",
 	} as Record<string, unknown>,
+	recordRun: vi.fn(async () => {}),
 }));
 
 vi.mock("#/config", () => ({
@@ -25,6 +26,13 @@ vi.mock("#/config", () => ({
 		return h.config;
 	},
 }));
+
+// cockpit_db control plane (DAT-461): the active workspace resolves through the
+// registry, and the run is recorded after start. Both mocked at the seam.
+vi.mock("#/db/cockpit/registry", () => ({
+	resolveActiveWorkspace: vi.fn(async () => h.config.dataraumWorkspaceId),
+}));
+vi.mock("#/db/cockpit/runs", () => ({ recordRun: h.recordRun }));
 
 const startMock = vi.fn(async (_name: string, _opts: unknown) => ({
 	firstExecutionRunId: "run-xyz",
@@ -51,6 +59,7 @@ beforeEach(() => {
 	};
 	startMock.mockClear();
 	closeMock.mockClear();
+	h.recordRun.mockClear();
 });
 
 describe("operatingModel (DAT-440)", () => {
@@ -89,5 +98,20 @@ describe("operatingModel (DAT-440)", () => {
 			/Temporal client is not configured/,
 		);
 		expect(startMock).not.toHaveBeenCalled();
+		// The guard runs before any cockpit write.
+		expect(h.recordRun).not.toHaveBeenCalled();
+	});
+
+	it("records an operating_model run on the begin_session session (DAT-461)", async () => {
+		await operatingModel({ session_id: "sess-1" });
+		expect(h.recordRun).toHaveBeenCalledTimes(1);
+		expect(h.recordRun).toHaveBeenCalledWith({
+			workspaceId: WS,
+			engineSessionId: "sess-1",
+			kind: "begin_session",
+			stage: "operating_model",
+			workflowId: `operatingmodel-${WS}-sess-1`,
+			runId: "run-xyz",
+		});
 	});
 });

--- a/packages/cockpit/src/tools/operating-model.ts
+++ b/packages/cockpit/src/tools/operating-model.ts
@@ -93,6 +93,8 @@ export async function operatingModel(
 		await recordRun({
 			workspaceId,
 			engineSessionId: input.session_id,
+			// Ignored on conflict — the row already exists from begin_session, which
+			// set kind. Passed only for the (unreachable) first-write case.
 			kind: "begin_session",
 			stage: "operating_model",
 			workflowId,

--- a/packages/cockpit/src/tools/operating-model.ts
+++ b/packages/cockpit/src/tools/operating-model.ts
@@ -23,6 +23,8 @@ import { WorkflowIdReusePolicy } from "@temporalio/common";
 import { z } from "zod";
 
 import { config } from "../config";
+import { resolveActiveWorkspace } from "../db/cockpit/registry";
+import { recordRun } from "../db/cockpit/runs";
 import type {
 	OperatingModelInput,
 	OperatingModelResult,
@@ -61,16 +63,15 @@ export async function operatingModel(
 		);
 	}
 
+	const workspaceId = await resolveActiveWorkspace();
+
 	const identity: SessionIdentity = {
-		workspace_id: config.dataraumWorkspaceId,
+		workspace_id: workspaceId,
 		session_id: input.session_id,
 	};
 	const payload: OperatingModelInput = { identity };
 
-	const workflowId = operatingModelWorkflowId(
-		config.dataraumWorkspaceId,
-		input.session_id,
-	);
+	const workflowId = operatingModelWorkflowId(workspaceId, input.session_id);
 
 	const connection = await Connection.connect({ address: config.temporalHost });
 	try {
@@ -85,6 +86,17 @@ export async function operatingModel(
 			workflowId,
 			args: [payload],
 			workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
+		});
+
+		// Append an operating_model run to the session begin_session created
+		// (DAT-461) — best-effort; the session row is reused by engine session id.
+		await recordRun({
+			workspaceId,
+			engineSessionId: input.session_id,
+			kind: "begin_session",
+			stage: "operating_model",
+			workflowId,
+			runId: handle.firstExecutionRunId,
 		});
 
 		return {

--- a/packages/cockpit/src/tools/registry.test.ts
+++ b/packages/cockpit/src/tools/registry.test.ts
@@ -13,6 +13,12 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("#/config", () => ({ config: {} }));
 vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
+// The driver tools import the cockpit control plane (DAT-461); mock the seam so
+// the registry import never loads the live cockpit_db client.
+vi.mock("#/db/cockpit/registry", () => ({
+	resolveActiveWorkspace: async () => "ws-test",
+}));
+vi.mock("#/db/cockpit/runs", () => ({ recordRun: async () => {} }));
 
 import { tools } from "./registry";
 

--- a/packages/cockpit/src/tools/replay.test.ts
+++ b/packages/cockpit/src/tools/replay.test.ts
@@ -29,6 +29,7 @@ const h = vi.hoisted(() => ({
 	verticalRows: [] as Array<{ vertical: string | null }>,
 	// The current session currentSessionId() resolves (null = none — replay rejects).
 	currentSession: null as string | null,
+	recordRun: vi.fn(async () => {}),
 }));
 
 // Live getter (the unconfigured-guard test reassigns h.config).
@@ -37,6 +38,13 @@ vi.mock("#/config", () => ({
 		return h.config;
 	},
 }));
+
+// cockpit_db control plane (DAT-461): workspace via the registry, run recorded
+// after start — both mocked at the seam (no DB in units).
+vi.mock("#/db/cockpit/registry", () => ({
+	resolveActiveWorkspace: vi.fn(async () => h.config.dataraumWorkspaceId),
+}));
+vi.mock("#/db/cockpit/runs", () => ({ recordRun: h.recordRun }));
 
 // Metadata client. The NEW session is seeded via insert(...).values(row) — a fresh
 // id, so no onConflict handling. `sourcesForSession` reads via
@@ -120,6 +128,7 @@ beforeEach(() => {
 	valuesMock.mockClear();
 	startMock.mockClear();
 	closeMock.mockClear();
+	h.recordRun.mockClear();
 });
 
 describe("replay (DAT-422)", () => {
@@ -205,6 +214,21 @@ describe("replay (DAT-422)", () => {
 		expect(h.calls).toEqual([]); // the guard is first — nothing ran
 		expect(valuesMock).not.toHaveBeenCalled();
 		expect(startMock).not.toHaveBeenCalled();
+		expect(h.recordRun).not.toHaveBeenCalled();
+	});
+
+	it("records the new replay session + run after starting (DAT-461)", async () => {
+		await replay({ session_id: "old-sess", vertical: "finance" });
+		const newSessionId = h.seededRow?.sessionId as string;
+		expect(h.recordRun).toHaveBeenCalledTimes(1);
+		expect(h.recordRun).toHaveBeenCalledWith({
+			workspaceId: WS,
+			engineSessionId: newSessionId,
+			kind: "replay",
+			stage: "add_source",
+			workflowId: `addsource-${WS}-${newSessionId}`,
+			runId: "run-xyz",
+		});
 	});
 
 	it("resolves the session's framed vertical when vertical is OMITTED", async () => {

--- a/packages/cockpit/src/tools/replay.ts
+++ b/packages/cockpit/src/tools/replay.ts
@@ -33,6 +33,8 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { config } from "../config";
+import { resolveActiveWorkspace } from "../db/cockpit/registry";
+import { recordRun } from "../db/cockpit/runs";
 import { metadataDb } from "../db/metadata/client";
 import {
 	investigationSessions,
@@ -159,19 +161,18 @@ export async function replay(input: ReplayInput): Promise<ReplayResult> {
 		vertical,
 	});
 
+	const workspaceId = await resolveActiveWorkspace();
+
 	// Source-free identity (DAT-422): the sources ride in `source_ids`; the engine
 	// scopes each `import` to one and the run-level reduce/detect are session-scoped.
 	const identity: SourceIdentity = {
-		workspace_id: config.dataraumWorkspaceId,
+		workspace_id: workspaceId,
 		session_id: newSessionId,
 		vertical,
 	};
 	const payload: AddSourceInput = { identity, source_ids: sourceIds };
 
-	const workflowId = addSourceWorkflowId(
-		config.dataraumWorkspaceId,
-		newSessionId,
-	);
+	const workflowId = addSourceWorkflowId(workspaceId, newSessionId);
 
 	const connection = await Connection.connect({ address: config.temporalHost });
 	try {
@@ -186,6 +187,16 @@ export async function replay(input: ReplayInput): Promise<ReplayResult> {
 			workflowId,
 			args: [payload],
 			workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
+		});
+
+		// Record the new replay session + its run (DAT-461) — best-effort.
+		await recordRun({
+			workspaceId,
+			engineSessionId: newSessionId,
+			kind: "replay",
+			stage: "add_source",
+			workflowId,
+			runId: handle.firstExecutionRunId,
 		});
 
 		return {

--- a/packages/cockpit/src/tools/select.test.ts
+++ b/packages/cockpit/src/tools/select.test.ts
@@ -24,6 +24,13 @@ import type { ConnectSchema } from "#/duckdb/connect";
 
 vi.mock("#/config", () => ({ config: { s3Bucket: "dataraum-lake" } }));
 
+// select → triggerAddSource imports the cockpit control plane (DAT-461); mock
+// the seam so importing select.ts never loads the live cockpit_db client.
+vi.mock("#/db/cockpit/registry", () => ({
+	resolveActiveWorkspace: async () => "ws-test",
+}));
+vi.mock("#/db/cockpit/runs", () => ({ recordRun: async () => {} }));
+
 // Pre-flight effective-concept count (relocated into select by DAT-436).
 // Default >0 so the gate's happy path passes; the refusal test flips it to 0.
 const preflight = vi.hoisted(() => ({

--- a/packages/infra/docker-compose.yml
+++ b/packages/infra/docker-compose.yml
@@ -238,12 +238,31 @@ services:
       # only mount left is the read-only config tree.
       - ${HOST_CONFIG_DIR:-../dataraum-config}:/opt/dataraum/config:ro
 
+  # One-shot: apply the cockpit_db migrations (DAT-461) before the cockpit
+  # serves. Uses the cockpit image's `build` stage — it carries drizzle-kit + the
+  # source + the committed migrations under drizzle/cockpit/ (the slim runner
+  # does not). The cockpit waits on its successful completion. Registry/actor
+  # seeding is lazy in the app (resolveActiveWorkspace), so this is schema-only.
+  cockpit-migrate:
+    build:
+      context: ../cockpit
+      target: build
+    restart: on-failure:5
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      COCKPIT_DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${COCKPIT_DB}
+    command: ["bun", "run", "db:migrate:cockpit"]
+
   cockpit:
     build:
       context: ../cockpit
     depends_on:
       postgres:
         condition: service_healthy
+      cockpit-migrate:
+        condition: service_completed_successfully
       # engine-worker bootstraps the ws_<id> metadata schema the cockpit reads
       # via Drizzle. No healthcheck on the worker (its health is the Temporal
       # heartbeat), so gate on service_started; the smoke additionally waits for

--- a/packages/infra/docker-compose.yml
+++ b/packages/infra/docker-compose.yml
@@ -243,6 +243,8 @@ services:
   # source + the committed migrations under drizzle/cockpit/ (the slim runner
   # does not). The cockpit waits on its successful completion. Registry/actor
   # seeding is lazy in the app (resolveActiveWorkspace), so this is schema-only.
+  # If this fails (after 5 retries), the cockpit blocks on
+  # service_completed_successfully — check COCKPIT_DATABASE_URL / COCKPIT_DB.
   cockpit-migrate:
     build:
       context: ../cockpit


### PR DESCRIPTION
## Task

[DAT-461](https://real-dataraum.atlassian.net/browse/DAT-461) — Phase 1 of epic [DAT-460](https://real-dataraum.atlassian.net/browse/DAT-460) (Cockpit control plane). Design: [DD/32538626](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/32538626).

Stands up the first real `cockpit_db` tables (it was an empty placeholder), records control-plane sessions + runs as the driver tools fire, and moves workspace resolution off the bare env var onto a registry. **Purely additive — zero engine change**: the tools still seed the engine's `investigation_sessions` exactly as before; `cockpit_db.sessions` references it via `engineSessionId`.

## Contract consumed

None — no locked contract. Cockpit-only; Temporal contracts (`SessionIdentity`/`SourceIdentity`) and the generated `db/metadata/` mirror are untouched.

## Acceptance criteria

- [x] `cockpit_db` defines `actors`/`workspaces`/`sessions`/`session_runs`; first migration under `drizzle/cockpit/`; `db:migrate:cockpit` applies it; cockpit_db reachable in compose; local `db:push:cockpit` documented.
- [x] `actors` seeds one `default` row; `workspaces` seeds from `DATARAUM_WORKSPACE_ID` (idempotent, lazy in `resolveActiveWorkspace`).
- [x] `resolveActiveWorkspace()` reads the registry; both `getActiveWorkspaceId()` route copies + the 4 driver tools resolve through it (no raw env read in the tool hot path).
- [x] add_source/begin_session/replay write `sessions` + `session_runs` with `created_by` + the started `(workflow_id, run_id)`; operating_model appends a run; the engine `investigation_sessions` seed is unchanged.
- [x] `session_runs` normalized with `UNIQUE(workflow_id, run_id)`; multi-run-per-session coexistence tested.
- [x] `session_runs.status` reaches terminal via the progress poll (`markRunStatus`).
- [x] Vitest units for the resolver + writers (mocked boundary); CI gates green; TanStack Intent skills loaded.

**Out of scope (deferred):** reload-recovery UI + chat persistence → Phase 2 (DAT-462); workspace switcher + auth → Phase 3 (DAT-357).

## Migrate-on-boot

The slim runner image lacks drizzle-kit, so a one-shot `cockpit-migrate` compose service (cockpit image `build` target) applies the committed migrations before the cockpit serves; the cockpit gates on its `service_completed_successfully`. Registry/actor seeding stays lazy in the app so host-dev (cockpit outside docker) works identically.

## Lane smoke

`scripts/smoke-dat-461.ts` — Bun-runtime smoke (the client uses `bun:sql`, so vitest/Node can't import it) against a live `cockpit_db`:

\`\`\`
$ bun run db:migrate:cockpit          # → migrations applied; 4 tables created
$ bun run scripts/smoke-dat-461.ts    # registry seed + recordRun idempotency/append + markRunStatus
✓ DAT-461 lane smoke passed
\`\`\`

Gates: biome ✓ · tsc ✓ · vitest 735/735 ✓ · vite build ✓. Reviewers: senior-code APPROVE, spec-compliance COMPLIANT (converged finding — CONTINUED_AS_NEW classification — fixed).

## Other lanes in flight

- #247 DAT-455 (engine — cycles lifecycle) — no overlap.
- #245 ADR-0009 (docs) — no overlap.
- (#246 DAT-441 teach_validation merged during this lane; #244 DAT-440 already on main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)