### PR TITLE
fix(cockpit): unbreak client render + reload-recovery chat render

### DIFF
--- a/packages/cockpit/src/select/mappers.ts
+++ b/packages/cockpit/src/select/mappers.ts
@@ -29,11 +29,7 @@
 import { createHash } from "node:crypto";
 
 import type { ConnectSchema } from "../duckdb/connect";
-import {
-	ALLOWED_EXTENSIONS,
-	fileExtension,
-	UPLOAD_PREFIX,
-} from "../upload/policy";
+import { UPLOAD_PREFIX } from "../upload/policy";
 
 // THE source-name rule — this pattern is the authority (DAT-430 deleted the
 // engine's legacy `SourceManager` and its `_NAME_PATTERN`; `select` is the only
@@ -75,43 +71,11 @@ export function reservedSourceNamePrefix(name: string): string | null {
 
 // --- source_type from a file URI suffix -------------------------------------
 
-// Suffix → engine `source_type`. MIRRORS the engine's import-dispatch suffix map
-// (`pipeline/phases/import_phase.py` `_PARQUET_EXTENSIONS`/`_JSON_EXTENSIONS` +
-// CSV default) + the cockpit connect/upload contract: csv/tsv/txt → csv,
-// parquet/pq → parquet, json/jsonl/ndjson → json. A file source's `source_type`
-// is this derived value, NEVER the literal "file" — the engine import dispatch
-// keys off it.
-const EXTENSION_TO_SOURCE_TYPE: Record<string, "csv" | "parquet" | "json"> = {
-	csv: "csv",
-	tsv: "csv",
-	txt: "csv",
-	parquet: "parquet",
-	pq: "parquet",
-	json: "json",
-	jsonl: "json",
-	ndjson: "json",
-};
-
-/**
- * The engine `source_type` for a single file URI, derived from its suffix.
- *
- * Throws on an unsupported / extensionless URI — a select that can't name the
- * source_type is a loud error, not a silently-mislabelled row the engine import
- * would reject. Each content-keyed file source carries one file, so this single
- * value is its declared `source_type` (the loader still dispatches per-URI by
- * suffix at import time).
- */
-export function sourceTypeForUri(uri: string): "csv" | "parquet" | "json" {
-	const ext = fileExtension(uri);
-	const type = ext ? EXTENSION_TO_SOURCE_TYPE[ext] : undefined;
-	if (!type) {
-		throw new Error(
-			`Cannot derive source_type for '${uri}' — unsupported or missing extension ` +
-				`(supported: ${ALLOWED_EXTENSIONS.join(", ")}).`,
-		);
-	}
-	return type;
-}
+// `sourceTypeForUri` (suffix → engine `source_type`) moved to the crypto-free
+// upload/policy so the CLIENT upload dropzone can import it (via upload/batch)
+// without dragging this module's `node:crypto` into the browser bundle. Re-
+// exported here so select-stage callers keep importing it from `select/mappers`.
+export { sourceTypeForUri } from "../upload/policy";
 
 // --- content-keyed file sources (DAT-422) ------------------------------------
 

--- a/packages/cockpit/src/ui/cockpit/markdown.tsx
+++ b/packages/cockpit/src/ui/cockpit/markdown.tsx
@@ -18,7 +18,7 @@ import sql from "highlight.js/lib/languages/sql";
 import typescript from "highlight.js/lib/languages/typescript";
 import { Marked } from "marked";
 import { markedHighlight } from "marked-highlight";
-import { memo, useMemo } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import "highlight.js/styles/github.css";
 import "./markdown.css";
 
@@ -76,12 +76,21 @@ export const MarkdownMessage = memo(function MarkdownMessage({
 }: {
 	content: string;
 }) {
+	// Sanitized markdown is CLIENT-ONLY (DOMPurify needs a DOM). The server and the
+	// FIRST client render must agree, or React leaves the server's empty HTML in
+	// place — which silently blanked RESTORED messages once reload hydration began
+	// SSR-ing the transcript (DAT-462; only a real-browser smoke catches it). So
+	// gate the HTML behind a mount flag: SSR + first paint render nothing (they
+	// match → no hydration mismatch), then the client fills it post-mount. This
+	// effect is justified — it synchronizes with a browser-only external system
+	// (DOMPurify), the sanctioned reason for an effect.
+	const [mounted, setMounted] = useState(false);
+	useEffect(() => setMounted(true), []);
+
 	const html = useMemo(() => {
-		// Client-only: no purifier on the server (no DOM). Returning "" guarantees
-		// raw LLM HTML can never exit the server even if the chat ever SSRs content.
-		if (!purifier) return "";
+		if (!mounted || !purifier) return "";
 		return purifier.sanitize(marked.parse(content, { async: false }));
-	}, [content]);
+	}, [content, mounted]);
 
 	return (
 		<div

--- a/packages/cockpit/src/upload/batch.ts
+++ b/packages/cockpit/src/upload/batch.ts
@@ -8,14 +8,15 @@
 //   2. every file an extension `connect` can sniff,
 //   3. HOMOGENEOUS source_type — a `file_uris` source is one `source_type`, so a
 //      batch must be all-csv / all-parquet / all-json (csv+tsv+txt all map to
-//      csv, etc.). We reuse the select stage's `sourceTypeForUri` so this gate
-//      and the eventual `select` write agree on the ext→type mapping (no drift).
+//      csv, etc.). We reuse the shared `sourceTypeForUri` (upload/policy, also
+//      re-exported by select/mappers) so this gate and the eventual `select`
+//      write agree on the ext→type mapping (no drift).
 
-import { sourceTypeForUri } from "../select/mappers";
 import {
 	ALLOWED_EXTENSIONS,
 	isAllowedExtension,
 	MAX_UPLOAD_FILES,
+	sourceTypeForUri,
 } from "./policy";
 
 /**

--- a/packages/cockpit/src/upload/policy.ts
+++ b/packages/cockpit/src/upload/policy.ts
@@ -57,6 +57,44 @@ export function isAllowedExtension(filename: string): boolean {
 	);
 }
 
+// Extension → `file_uris` source_type (csv/tsv/txt → csv, parquet/pq → parquet,
+// json/jsonl/ndjson → json). A file source's `source_type` is this derived value,
+// NEVER the literal "file" — the engine import dispatch keys off it. THE single
+// authority both the upload batch gate (upload/batch.ts) and the select write
+// (select/mappers.ts re-exports `sourceTypeForUri`) key off, so the two can't
+// drift. Lives HERE (the pure, crypto-free upload policy) rather than in
+// select/mappers so the CLIENT dropzone can import it without dragging
+// select/mappers' `node:crypto` into the browser bundle.
+const EXTENSION_TO_SOURCE_TYPE: Record<string, "csv" | "parquet" | "json"> = {
+	csv: "csv",
+	tsv: "csv",
+	txt: "csv",
+	parquet: "parquet",
+	pq: "parquet",
+	json: "json",
+	jsonl: "json",
+	ndjson: "json",
+};
+
+/**
+ * The engine `source_type` for a single file URI, derived from its suffix.
+ *
+ * Throws on an unsupported / extensionless URI — a select that can't name the
+ * source_type is a loud error, not a silently-mislabelled row the engine import
+ * would reject.
+ */
+export function sourceTypeForUri(uri: string): "csv" | "parquet" | "json" {
+	const ext = fileExtension(uri);
+	const type = ext ? EXTENSION_TO_SOURCE_TYPE[ext] : undefined;
+	if (!type) {
+		throw new Error(
+			`Cannot derive source_type for '${uri}' — unsupported or missing extension ` +
+				`(supported: ${ALLOWED_EXTENSIONS.join(", ")}).`,
+		);
+	}
+	return type;
+}
+
 // A filename can carry path separators or control bytes (a malicious or sloppy
 // client); the object key must be a single safe leaf so it can't escape the
 // `uploads/<uuid>/` directory or break the S3 path. Strip directory parts, then


### PR DESCRIPTION
Two version-independent cockpit fixes found while running the first real-browser smoke of DAT-462 reload recovery in a while.

## Commits

1. **`node:crypto` leaked into the client bundle** — `upload-dropzone` (client) → `upload/batch` → `select/mappers` → `node:crypto.createHash`, which Vite externalizes for the browser → the whole cockpit error-boundaried on load. Moved the pure `sourceTypeForUri` to the crypto-free `upload/policy` (re-exported from `select/mappers` so server callers are untouched). *Pre-existing.*
2. **Markdown SSR hydration mismatch blanked restored chat messages** — `MarkdownMessage` is client-only (DOMPurify needs a DOM) so SSR emitted `__html=""`; React keeps the empty server HTML on mismatch. Harmless until DAT-462 reload hydration began SSR-ing the transcript → restored assistant replies rendered blank. Mount-gated so SSR + first paint agree, then fill. *DAT-462-exposed.*

## Verification

- `bun install --frozen-lockfile` (ai 0.28.0 / ai-anthropic 0.15.1, matching the committed lock) → `typecheck` ✓ · `check` (231 files) ✓ · `test` (787) ✓ · `build` ✓
- Real-browser smoke ✓: DAT-462 reload recovery (full conversation restores across a refresh, markdown renders, no console errors) + live multi-turn chat.

## Note — dropped commits

An earlier revision of this branch also "migrated" `modelOptions.max_tokens` → top-level `maxTokens` and dropped `ctx.abortSignal`, against a **stale local `node_modules` (0.26.1)** that didn't match the committed lock. The locked/CI version (0.28.0 / 0.15.1) keeps `modelOptions.max_tokens` + `ctx.abortSignal` — the original DAT-462 code is correct — so those commits were dropped. Lesson: `bun install --frozen-lockfile` before trusting a local typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)