### PR TITLE
fix(engine): right-size the DuckLake catalog pool — 64 → 16 (small static singleton)

### DIFF
--- a/packages/engine/src/dataraum/core/settings.py
+++ b/packages/engine/src/dataraum/core/settings.py
@@ -81,7 +81,16 @@ class Settings(BaseSettings):
     s3_bucket: str
 
     # --- DuckLake tuning (defaulted; see server/storage.py) ---
-    ducklake_pg_pool_max: int = 64
+    # Postgres connection-pool ceiling for the (singleton, process-wide) DuckLake
+    # catalog ATTACH. Small + static on purpose: with thread-local caching
+    # DISABLED (storage.py) connections recycle to the pool promptly, so the pool
+    # only needs to cover peak concurrent catalog ops (~_MAX_CONCURRENT_METRICS),
+    # NOT total churn. 16 covers the operating_model concurrency with headroom and
+    # stays well under Postgres max_connections — which the engine ORM pool,
+    # temporal, and cockpit share. (Was 64: an over-correction stacked on top of
+    # the thread-local-cache disable that actually fixed DuckLake's exhaustion,
+    # and 64 alone tipped a 100-connection Postgres over once metrics ran.)
+    ducklake_pg_pool_max: int = 16
     ducklake_skip_install: bool = False
     duckdb_extension_directory: Path | None = None
 

--- a/packages/engine/src/dataraum/server/storage.py
+++ b/packages/engine/src/dataraum/server/storage.py
@@ -255,8 +255,13 @@ def bootstrap_lake(catalog_url: str, data_path: str) -> None:
             keeps the runtime ``LOAD`` aligned with that path so it does
             not fall back to ``$HOME/.duckdb/`` (which the system user has
             no access to).
-        DUCKLAKE_PG_POOL_MAX: Postgres extension pool ceiling (default 64).
-            DuckDB's default is 8, which exhausts under multi-session churn.
+        DUCKLAKE_PG_POOL_MAX: Postgres extension pool ceiling for the shared
+            catalog ATTACH (default 16). Kept small + static: the real fix for
+            DuckLake's pool exhaustion is disabling thread-local caching (below),
+            which lets connections recycle — so the pool only needs to cover peak
+            concurrent catalog ops, not total churn, and must stay well under
+            Postgres ``max_connections`` (shared with the ORM pool / temporal /
+            cockpit). DuckDB's own default (8) is too small under that concurrency.
         DUCKLAKE_SKIP_INSTALL: Set to ``1`` to skip the network ``INSTALL
             ducklake`` step. Container builds should pre-install the extension
             at image build time and set this to avoid the cold-start round
@@ -287,13 +292,17 @@ def bootstrap_lake(catalog_url: str, data_path: str) -> None:
             if not settings.ducklake_skip_install:
                 conn.execute("INSTALL ducklake")
             conn.execute("LOAD ducklake")
-            # Raise the Postgres pool ceiling and unpin connections from
-            # threads — DuckLake routes every catalog op through the postgres
-            # extension's pool, and the defaults (max=8, thread-local pinning
-            # ON) exhaust under multi-session churn. Must be ``SET GLOBAL`` and
+            # Unpin catalog connections from threads, then bound the pool. The
+            # REAL fix is disabling thread-local caching: DuckLake routes every
+            # catalog op through the postgres extension's pool, and with the
+            # default thread-local pinning ON those connections stay "in use"
+            # while idle and exhaust the pool (duckdb/ducklake#1031). With it OFF
+            # connections recycle, so the pool stays SMALL + static
+            # (``pool_max``) — just enough for peak concurrent catalog ops, well
+            # under Postgres ``max_connections``. Must be ``SET GLOBAL`` and
             # ``BEFORE`` the ATTACH for the lake's pool to inherit the values.
-            conn.execute(f"SET GLOBAL pg_pool_max_connections = {pool_max}")
             conn.execute("SET GLOBAL pg_pool_enable_thread_local_cache = false")
+            conn.execute(f"SET GLOBAL pg_pool_max_connections = {pool_max}")
             # The lake DATA_PATH is an ``s3://`` URI: register the object-store
             # secret + httpfs before the ATTACH (DuckLake resolves DATA_PATH
             # eagerly).

--- a/packages/engine/tests/unit/core/test_settings.py
+++ b/packages/engine/tests/unit/core/test_settings.py
@@ -142,7 +142,7 @@ def test_ducklake_tuning_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_required(monkeypatch)
     settings = get_settings()
 
-    assert settings.ducklake_pg_pool_max == 64
+    assert settings.ducklake_pg_pool_max == 16
     assert settings.ducklake_skip_install is False
     assert settings.duckdb_extension_directory is None
 


### PR DESCRIPTION
## Why

The gate-fix smoke (#254) — once metrics actually **execute** — hit Postgres `FATAL: sorry, too many clients already`. With the operating_model concurrency now real, the shared DuckLake catalog pool climbs toward its ceiling, and **64** + the engine ORM pool + temporal + cockpit tips a **100-connection** Postgres over (87/100 were in use even at rest). The cycle family was affected too (`cycle_health_failed: too many clients`).

## The architecture (it's sound — the number was wrong)

The DuckLake catalog ATTACH is a **process-wide singleton** (`server/storage.py`: one anchor connection, one GLOBAL pool, shared by all worker cursors) — not a per-worker explosion. The only mis-sizing was the pool ceiling:

`DUCKLAKE_PG_POOL_MAX = 64` was an **over-correction**. It was raised 8→64 to dodge DuckLake's thread-local-cache pool exhaustion ([duckdb/ducklake#1031](https://github.com/duckdb/ducklake/issues/1031)) — but `pg_pool_enable_thread_local_cache = false` was *also* set, and **that is the real fix** (connections recycle to the pool instead of sitting idle "in use"). With recycling on, the pool only needs to cover **peak concurrent catalog ops** (~`_MAX_CONCURRENT_METRICS`), not total churn.

## The fix

`ducklake_pg_pool_max` default **64 → 16** — a small, static, singleton catalog pool (the classic DB-layer pattern), well under `max_connections`. No `max_connections` bump needed; raising it would just mask the over-allocation. Comments in `settings.py` / `storage.py` corrected to reflect that thread-local-cache-off is the real fix and the pool stays small on purpose.

## Verification

`ruff` / `mypy` / `vulture` clean; `test_settings.py` updated (the default assertion follows the design) — 8 pass.

**Live smoke deferred** — the cluster is in use by another agent. The #254 smoke already showed the 8 non-executing metrics **compose** fine and die *only* on the connection error, so the smaller pool should let them execute. I'll re-run the operating_model smoke to confirm all-12-execute once the cluster frees.

Follows #254 (the gate fix that unmasked this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)