### PR TITLE
fix(cockpit): server-owned reload broke needsApproval continuations (prefill 400)

### DIFF
--- a/packages/cockpit/src/routes/api/chat.ts
+++ b/packages/cockpit/src/routes/api/chat.ts
@@ -208,8 +208,10 @@ export const Route = createFileRoute("/api/chat")({
 
 				// Reconstruct the model's view from cockpit_db (server-owned): persist
 				// the new user turn (+ any model-only refs), reload the full transcript,
-				// and bound it for the model. Degradable: if cockpit_db is unavailable,
-				// serve the client-sent messages unpersisted rather than a dead chat.
+				// and bound it for the model — EXCEPT on a tool-approval continuation,
+				// which has no trailing user turn (see below). Degradable: if cockpit_db
+				// is unavailable, serve the client-sent messages unpersisted rather than
+				// a dead chat.
 				let modelMessages: ChatMessages = messages;
 				let persistTo: string | null = null;
 				try {
@@ -227,9 +229,20 @@ export const Route = createFileRoute("/api/chat")({
 						entries.push({ message: refsRow(refs), modelOnly: true });
 					}
 					if (entries.length > 0) await appendMessages(threadId, entries);
-					modelMessages = buildModelMessages(
-						await loadModelTranscript(threadId),
-					);
+					// A fresh user turn → feed the model the BOUNDED server-owned
+					// transcript (DAT-462). A needsApproval CONTINUATION (the user
+					// approved a teach/select/replay/… gate) has NO trailing user turn:
+					// the client re-sends the assistant tool-call now carrying the
+					// approval. The server reload would end on that persisted assistant
+					// tool-call (teed BEFORE approval, so without the decision), which a
+					// no-prefill model (sonnet-4-6 et al.) rejects with "the conversation
+					// must end with a user message". So on a continuation, feed the model
+					// the CLIENT list — it carries the in-flight approval and ends on a
+					// tool-result/user turn. The bounding loss is one leg only (the next
+					// real user turn reloads + re-bounds); the result still tees+persists.
+					modelMessages = turn
+						? buildModelMessages(await loadModelTranscript(threadId))
+						: messages;
 					persistTo = threadId;
 				} catch (err) {
 					console.error(


### PR DESCRIPTION
## Problem

Approving a `needsApproval` tool (teach was the report; generic to select/frame/replay/operating_model) failed with:

> 400 `invalid_request_error` — "This model does not support assistant message prefill. The conversation must end with a user message."

## Root cause

Interaction between DAT-462's server-owned reload and the SDK's approval-continuation, on `packages/cockpit/src/routes/api/chat.ts`:

1. The assistant tool-call is teed+persisted **before** approval, so cockpit_db holds it at `state: "approval-requested"`.
2. On approve, the client re-POSTs a continuation whose trailing message is that assistant tool-call now at `state: "approval-responded"` — **not** a user turn → `newUserTurn()` returns `null`.
3. The handler unconditionally replaced the model view with `buildModelMessages(loadModelTranscript())`, discarding the client's approval-bearing messages.
4. `@tanstack/ai`'s `isToolCallIncluded()` excludes the pre-approval `approval-requested` state, so the reloaded transcript ends on an assistant message → `claude-sonnet-4-6` (no last-assistant-turn prefill) 400s.

## Fix

On a continuation (`newUserTurn` is `null`) feed the model the **client list** — it carries the in-flight approval and ends on a tool-result/user turn — while still teeing+persisting the result. The bounded server reload stays for fresh user turns; bounding loss is one leg only (the next user turn reloads + re-bounds). One file, +18/−5.

## Validation (real LLM + engine, Playwright on fresh `down -v` stack + current main)

- Approve `select` → `/api/chat` **200**; full add_source workflow ran to "Done — 1 table imported and analyzed".
- Hard reload → transcript fully restored (incl. the approval turn + result).
- Follow-up after reload → **200**, correct answer — no unpaired-tool-call 400 (the theoretical same-id persistence collision does not bite).
- Gates green: `check` · `typecheck` · `test` (867) · `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)