### PR TITLE
refactor(cockpit): one agent path per teach (consistency pass 1/2)

### DIFF
--- a/packages/cockpit/src/tools/teach.test.ts
+++ b/packages/cockpit/src/tools/teach.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	AGENT_TEACH_TYPES,
 	TEACH_TYPES,
 	TeachValidationError,
 	validateTeach,
@@ -279,12 +280,14 @@ describe("validateTeach", () => {
 		});
 	});
 
-	describe("deferred types (generic passthrough)", () => {
+	// validation/cycle/metric are internal-only dispatch targets (the typed
+	// teach_validation/teach_cycle/teach_metric tools write through them with an
+	// already-validated payload), so the primitive still passthrough-accepts them.
+	describe("internal delegated types (generic passthrough)", () => {
 		it.each([
 			"validation",
 			"cycle",
 			"metric",
-			"explanation",
 		] as const)("%s accepts an arbitrary object", (type) => {
 			const out = validateTeach({
 				type,
@@ -295,7 +298,7 @@ describe("validateTeach", () => {
 	});
 
 	describe("dispatch", () => {
-		it("TEACH_TYPES exposes every wired type", () => {
+		it("TEACH_TYPES exposes every wired type (incl. internal-only delegated types)", () => {
 			expect(new Set(TEACH_TYPES)).toEqual(
 				new Set([
 					"type_pattern",
@@ -306,9 +309,26 @@ describe("validateTeach", () => {
 					"validation",
 					"cycle",
 					"metric",
-					"explanation",
 				]),
 			);
+		});
+
+		it("AGENT_TEACH_TYPES advertises only the grounding-layer corrections", () => {
+			// The agent-facing teach surface excludes the operating-model
+			// declarations (validation/cycle/metric — owned by the typed teach_*
+			// tools) and the removed `explanation` stub. One way to teach each thing.
+			expect(new Set(AGENT_TEACH_TYPES)).toEqual(
+				new Set([
+					"type_pattern",
+					"null_value",
+					"concept",
+					"concept_property",
+					"relationship",
+				]),
+			);
+			for (const t of ["validation", "cycle", "metric", "explanation"]) {
+				expect(AGENT_TEACH_TYPES as readonly string[]).not.toContain(t);
+			}
 		});
 
 		it("rejects an unknown type", () => {

--- a/packages/cockpit/src/tools/teach.ts
+++ b/packages/cockpit/src/tools/teach.ts
@@ -20,7 +20,7 @@ import { z } from "zod";
 import { metadataDb } from "../db/metadata/client";
 import { configOverlayWrite } from "../db/metadata/write-surface";
 import {
-	TEACH_TYPES,
+	AGENT_TEACH_TYPES,
 	type TeachInput,
 	TeachPayloadSchema,
 	type TeachType,
@@ -96,12 +96,16 @@ export async function undoTeach(overlayId: string): Promise<void> {
 export const teachTool = toolDefinition({
 	name: "teach",
 	description:
-		"Record a correction or declaration about the data (a type pattern, null value, concept, etc.). Writes a config_overlay row; requires user approval. Follow with `replay` to apply it to the source.",
+		"Record a grounding-layer correction about the data — a typing pattern, " +
+		"null token, ontology concept/property, or a column relationship. Writes a " +
+		"config_overlay row (requires user approval); follow with `replay` to apply " +
+		"it to the source. For operating-model declarations use the dedicated tools " +
+		"instead: teach_validation, teach_cycle, teach_metric.",
 	inputSchema: z.object({
 		type: z
-			.enum(TEACH_TYPES as readonly [TeachType, ...TeachType[]])
+			.enum(AGENT_TEACH_TYPES as readonly [TeachType, ...TeachType[]])
 			.describe(
-				"The kind of correction/declaration to record; it determines which payload fields are required (see payload).",
+				"The kind of grounding-layer correction to record; it determines which payload fields are required (see payload).",
 			),
 		payload: TeachPayloadSchema,
 		session_id: z.string().nullish(),

--- a/packages/cockpit/src/tools/teach.validation.ts
+++ b/packages/cockpit/src/tools/teach.validation.ts
@@ -210,23 +210,42 @@ const TYPE_SCHEMAS = {
 	concept: ConceptPayload,
 	concept_property: ConceptPropertyPayload,
 	relationship: RelationshipPayload,
+	// validation/cycle/metric are NOT advertised to the agent (see
+	// AGENT_TEACH_TYPES). The typed teach_validation/teach_cycle/teach_metric
+	// tools own that surface — they validate the rich spec at the SDK boundary,
+	// then write THROUGH this primitive via teach({type}). They stay here as the
+	// internal dispatch target only; their payload is already validated upstream,
+	// so GenericPayload is a passthrough. (`explanation` removed — DAT-343 stub
+	// with no typed tool, no engine applier, and no caller.)
 	validation: GenericPayload,
 	cycle: GenericPayload,
 	metric: GenericPayload,
-	explanation: GenericPayload,
 } as const;
 
 export type TeachType = keyof typeof TYPE_SCHEMAS;
 
 export const TEACH_TYPES = Object.keys(TYPE_SCHEMAS) as readonly TeachType[];
 
-// The payload shape surfaced in the teach TOOL's input schema. A union of the
-// per-type payloads above, so `toJSONSchema` dumps each type's exact fields (+
-// their descriptions) into the tool schema the model sees — the missing context
-// that made the agent guess wrong params. Anthropic's tool input_schema must be
-// a top-level object, so this rides inside the `payload` property (not as a
-// top-level discriminated union). The GenericPayload branch keeps the deferred
-// types callable; `validateTeach` still enforces the right shape per `type`.
+// What the generic `teach` TOOL advertises to the agent: ONLY the grounding-layer
+// corrections (applied by `replay`). validation/cycle/metric are deliberately
+// excluded — a second, loose agent path alongside the typed teach_* tools would
+// let the model write an unvalidated payload the operating_model grounder can't
+// consume. One way to teach each thing.
+export const AGENT_TEACH_TYPES = [
+	"type_pattern",
+	"null_value",
+	"concept",
+	"concept_property",
+	"relationship",
+] as const satisfies readonly TeachType[];
+
+// The payload shape surfaced in the teach TOOL's input schema — a union of ONLY
+// the agent-advertised (AGENT_TEACH_TYPES) payloads, so `toJSONSchema` dumps each
+// type's exact fields into the schema the model sees. Anthropic's tool
+// input_schema must be a top-level object, so this rides inside the `payload`
+// property (not a top-level discriminated union). No GenericPayload branch: the
+// agent only sends the five typed shapes; validation/cycle/metric reach the
+// write primitive via their typed tools, never through this schema.
 export const TeachPayloadSchema = z
 	.union([
 		TypePatternPayload,
@@ -234,7 +253,6 @@ export const TeachPayloadSchema = z
 		ConceptPayload,
 		ConceptPropertyPayload,
 		RelationshipPayload,
-		GenericPayload,
 	])
 	.describe(
 		"The teach payload; required fields depend on `type` — " +
@@ -243,8 +261,7 @@ export const TeachPayloadSchema = z
 			"concept: {vertical, name, indicators?, …}; " +
 			"concept_property: {vertical, concept, property, value}; " +
 			"relationship: {action: confirm|reject|add, from_column_id, to_column_id} " +
-			"(keep is engine-internal, not a user action). " +
-			"(validation/cycle/metric/explanation take a free-form object — recorded, not yet applied.)",
+			"(keep is engine-internal, not a user action).",
 	);
 
 export interface TeachInput {


### PR DESCRIPTION
First cut of a tool-API **consistency** pass (not lazy-loading — that hides count, it doesn't fix coherence).

## What was inconsistent
Generic `teach` advertised `validation`/`cycle`/`metric` to the agent as loose `GenericPayload` types **and** `explanation` (a dead DAT-343 stub: no typed tool, no engine applier, no caller) — *alongside* the typed `teach_validation`/`teach_cycle`/`teach_metric` tools. Two ways to teach the same thing; the loose one can write a payload the `operating_model` grounder can't consume.

## Why it's layered (not vestigial)
The typed tools **delegate** to generic `teach({type})` — the shared overlay-write primitive (`teach-validation.ts:116`, etc.). So the fix isn't deletion; it's splitting the agent-advertised surface from the internal dispatch:

- **`AGENT_TEACH_TYPES`** (the tool's enum + payload union) = the 5 grounding-layer corrections only: `type_pattern`, `null_value`, `concept`, `concept_property`, `relationship` (applied by `replay`).
- `validation`/`cycle`/`metric` stay in `TYPE_SCHEMAS` as **internal-only** dispatch targets (typed tools write through them, payload already validated upstream).
- `explanation` removed entirely.

Now there's exactly **one agent path** to teach each thing.

## Safety
Purely subtractive on the agent schema — no output or rendering contract changes, and the delegation seam the typed-tool tests assert (`teach({type})`) is unchanged. Gate-verified: typecheck + 881 unit tests (incl. a new `AGENT_TEACH_TYPES` contract test). No LLM smoke needed — this removes redundant/dead schema options and is fully covered by tsc + units (unlike the next pass, which changes outputs).

## Next (pass 2/2, separate PR, will be smoked)
Unify the **error envelope**: today only `teach` returns `{error}`; the other 27 tools throw, which the SDK flattens to an opaque string that `tool-chip-state.ts` hand-parses across two shapes. Standardize on agent-actionable failures → `{error}`, infra → throw. That one changes outputs + rendering, so it gets the real-LLM Playwright smoke before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)