### PR TITLE
refactor(cockpit): uniform agent-actionable error envelope — run_sql/probe (consistency 2a)

### DIFF
--- a/packages/cockpit/src/duckdb/probe.ts
+++ b/packages/cockpit/src/duckdb/probe.ts
@@ -141,10 +141,16 @@ export async function probe(input: ProbeInput): Promise<QueryResult> {
 			}
 		}
 	} catch (err) {
+		// SECURITY: a failed ATTACH can echo the connection DSN (which carries the
+		// credential) in the driver message. Redact the resolved URL before the
+		// message leaves this function — it reaches the agent (now as a `{ error }`
+		// result) and the persisted transcript.
+		const raw = err instanceof Error ? err.message : String(err);
+		const safe = credential.url
+			? raw.split(credential.url).join("<source url redacted>")
+			: raw;
 		throw new Error(
-			`Probe of source '${input.source_name}' (${backend}) failed: ${
-				err instanceof Error ? err.message : String(err)
-			}`,
+			`Probe of source '${input.source_name}' (${backend}) failed: ${safe}`,
 		);
 	} finally {
 		conn.closeSync();

--- a/packages/cockpit/src/tools/agent-error.test.ts
+++ b/packages/cockpit/src/tools/agent-error.test.ts
@@ -1,0 +1,63 @@
+// Tests for the shared agent-actionable error envelope (consistency pass 2).
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+	AgentActionableError,
+	asAgentError,
+	catchActionable,
+	isAgentError,
+	withAgentError,
+} from "./agent-error";
+
+describe("isAgentError", () => {
+	it("narrows the { error: string } shape only", () => {
+		expect(isAgentError({ error: "bad SQL" })).toBe(true);
+		expect(isAgentError({ error: 42 })).toBe(false);
+		expect(isAgentError({ columns: [], rows: [] })).toBe(false);
+		expect(isAgentError(null)).toBe(false);
+		expect(isAgentError("nope")).toBe(false);
+	});
+});
+
+describe("withAgentError", () => {
+	it("accepts the success shape OR the error branch", () => {
+		const schema = withAgentError(z.object({ ok: z.boolean() }));
+		expect(schema.safeParse({ ok: true }).success).toBe(true);
+		expect(schema.safeParse({ error: "stale id" }).success).toBe(true);
+		expect(schema.safeParse({ nope: 1 }).success).toBe(false);
+	});
+});
+
+describe("asAgentError (read/query tools — catch-all)", () => {
+	it("passes a success through unchanged", async () => {
+		await expect(asAgentError(async () => ({ rows: 3 }))).resolves.toEqual({
+			rows: 3,
+		});
+	});
+
+	it("converts ANY throw into { error } (turn survives a bad query)", async () => {
+		const out = await asAgentError(async () => {
+			throw new Error('Parser Error: syntax error at "FROM"');
+		});
+		expect(out).toEqual({ error: 'Parser Error: syntax error at "FROM"' });
+	});
+});
+
+describe("catchActionable (write/compute tools — selective)", () => {
+	it("converts AgentActionableError into { error }", async () => {
+		const out = await catchActionable(async () => {
+			throw new AgentActionableError("validation_id already declared");
+		});
+		expect(out).toEqual({ error: "validation_id already declared" });
+	});
+
+	it("lets infra errors propagate (throws)", async () => {
+		await expect(
+			catchActionable(async () => {
+				throw new Error("ECONNREFUSED postgres");
+			}),
+		).rejects.toThrow("ECONNREFUSED postgres");
+	});
+});

--- a/packages/cockpit/src/tools/agent-error.ts
+++ b/packages/cockpit/src/tools/agent-error.ts
@@ -1,0 +1,83 @@
+// The uniform agent-actionable error envelope (tool-API consistency pass 2).
+//
+// Three things could go wrong in a tool; they map to TWO signals, not three:
+//   1. "Looked, didn't find / partial" — a legitimate RESULT, carried by a
+//      discriminant on the success shape (the `why_*` `found: boolean` pattern,
+//      or an empty array from `list_*`). NOT an error.
+//   2. "Couldn't act, but you can fix it" — an AGENT-ACTIONABLE failure (a bad
+//      query, a stale id, an unmet precondition). Returned as `{ error }` so the
+//      model reads the message and retries IN-LOOP instead of the turn dying on
+//      an opaque "Error executing tool: …" string. This is the `teach` precedent,
+//      generalized.
+//   3. Infra (DB down, engine unreachable) — NOT the agent's to fix. Still throws.
+//
+// Read/query tools whose failures are dominantly agent-fixable (run_sql, probe —
+// bad SQL) wrap their call in `asAgentError`: a thrown driver error becomes
+// `{ error }` rather than killing the turn. Write/compute tools that need to
+// separate actionable from infra throw `AgentActionableError` for the former and
+// let infra propagate; `catchActionable` converts only the former.
+
+import { z } from "zod";
+
+/** The agent-actionable error branch. Unioned onto a tool's success schema via
+ * `withAgentError` so the model sees `{ error }` as a valid (recoverable) output. */
+export const AgentErrorSchema = z.object({
+	error: z
+		.string()
+		.describe(
+			"The call could not complete, but the cause is yours to fix — correct " +
+				"the query, the id, or an unmet precondition and retry. Surfaced as " +
+				"data (not a thrown error) so the turn continues.",
+		),
+});
+export type AgentError = z.infer<typeof AgentErrorSchema>;
+
+/** Narrow an unknown tool output to the error branch. */
+export function isAgentError(value: unknown): value is AgentError {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as { error?: unknown }).error === "string"
+	);
+}
+
+/** Wrap a success schema with the agent-error branch: `Success | { error }`. */
+export function withAgentError<T extends z.ZodTypeAny>(success: T) {
+	return z.union([success, AgentErrorSchema]);
+}
+
+/** An agent-fixable failure raised from deep in a tool's logic. Write/compute
+ * tools throw this for actionable failures; `catchActionable` turns it into the
+ * `{ error }` envelope while letting infra errors propagate (throw). */
+export class AgentActionableError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "AgentActionableError";
+	}
+}
+
+/** Run a fn, converting ANY throw into `{ error }`. For read/query tools whose
+ * failures are dominantly agent-fixable (bad SQL) — a degraded infra error
+ * returned as data still beats an opaque turn-killing string. */
+export async function asAgentError<T>(
+	fn: () => Promise<T>,
+): Promise<T | AgentError> {
+	try {
+		return await fn();
+	} catch (err) {
+		return { error: err instanceof Error ? err.message : String(err) };
+	}
+}
+
+/** Run a fn, converting ONLY `AgentActionableError` into `{ error }`; everything
+ * else (infra) propagates. For write/compute tools that must keep that line. */
+export async function catchActionable<T>(
+	fn: () => Promise<T>,
+): Promise<T | AgentError> {
+	try {
+		return await fn();
+	} catch (err) {
+		if (err instanceof AgentActionableError) return { error: err.message };
+		throw err;
+	}
+}

--- a/packages/cockpit/src/tools/probe.ts
+++ b/packages/cockpit/src/tools/probe.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 
 import { HARD_ROW_CEILING } from "../duckdb/limit";
 import { probe, SUPPORTED_BACKENDS } from "../duckdb/probe";
+import { asAgentError, withAgentError } from "./agent-error";
 
 // QueryResult shape ({columns, rows, rowCount}). `rows` is intentionally
 // permissive — `probe` returns `Record<string, Json>[]` (arbitrary JSON-safe
@@ -49,5 +50,9 @@ export const probeTool = toolDefinition({
 			.optional()
 			.describe("Max rows to return (default 1000, capped at 200000)."),
 	}),
-	outputSchema: QueryResultSchema,
-}).server((input) => probe(input));
+	// Success OR `{ error }`: a bad query or unreachable-by-the-agent issue (bad
+	// SQL, wrong source_name, unsupported shape) comes back as data so the model
+	// can correct and retry in-loop, not as an opaque turn-killing string
+	// (consistency pass 2). Credentials never appear in the message.
+	outputSchema: withAgentError(QueryResultSchema),
+}).server((input) => asAgentError(() => probe(input)));

--- a/packages/cockpit/src/tools/run_sql.test.ts
+++ b/packages/cockpit/src/tools/run_sql.test.ts
@@ -43,7 +43,9 @@ describe("run_sql tool outputSchema (DAT-400)", () => {
 		});
 		expect(ok.success).toBe(true);
 		if (ok.success) {
-			expect(ok.data.truncated).toBe(true);
+			// outputSchema is now `QueryResult | { error }` (pass 2) — assert via a
+			// matcher rather than dot-access so the error branch doesn't break tsc.
+			expect(ok.data).toHaveProperty("truncated", true);
 		}
 	});
 });

--- a/packages/cockpit/src/tools/run_sql.ts
+++ b/packages/cockpit/src/tools/run_sql.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import { AGENT_SAMPLE_ROWS } from "../duckdb/agent-sample";
 import { HARD_ROW_CEILING } from "../duckdb/limit";
 import { runSql } from "../duckdb/run-sql";
+import { asAgentError, withAgentError } from "./agent-error";
 
 // Agent-result shape ({columns, rows, rowCount, truncated}). `rows` is
 // intentionally permissive — `runSql` returns `Record<string, Json>[]`
@@ -68,11 +69,15 @@ export const runSqlTool = toolDefinition({
 			.optional()
 			.describe("Max rows to return (default 1000, capped at 200000)."),
 	}),
-	outputSchema: QueryResultSchema,
+	// Success OR `{ error }`: a bad query (syntax, unknown table/column) is the
+	// agent's to fix, so a thrown driver error is returned as data — the model
+	// reads it and rewrites the SQL in-loop instead of the turn dying on an
+	// opaque "Error executing tool: …" string (consistency pass 2).
+	outputSchema: withAgentError(QueryResultSchema),
 	// ctx.abortSignal deliberately NOT forwarded (DAT-449): duckdb-neo has no
 	// per-query cancellation — its only primitive is connection-level
 	// `interrupt()`, and the lake connection is process-wide memoized
 	// (duckdb/lake.ts), so interrupting would kill CONCURRENT queries (the
 	// grid's /api/run-sql, other tool calls), not just this one. Revisit only
 	// with a per-query connection or a driver-level signal API.
-}).server((input) => runSql(input));
+}).server((input) => asAgentError(() => runSql(input)));

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -13,6 +13,7 @@
 
 import type { UIMessage } from "@tanstack/ai-react";
 import type { ConnectSchema } from "#/duckdb/connect";
+import { isAgentError } from "#/tools/agent-error";
 import type { FrameResult } from "#/tools/frame";
 import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
@@ -203,7 +204,10 @@ const PROJECTORS: Record<string, CanvasProjector> = {
 	// The agent's run_sql returns a small sample for the LLM; the human grid
 	// re-issues the query against the stateless streaming endpoint, so it maps
 	// from the CALL INPUT (sql + bind params), not the result. No sql → unchanged.
-	run_sql: (_result, input) => {
+	run_sql: (result, input) => {
+		// A query the agent couldn't run came back as `{ error }` (pass 2) — don't
+		// drive the human grid with SQL we already know fails.
+		if (isAgentError(result)) return null;
 		const args = (input ?? {}) as { sql?: unknown; params?: unknown };
 		if (typeof args.sql !== "string" || args.sql.length === 0) return null;
 		// Carry params ONLY when there are bind values: an empty array and


### PR DESCRIPTION
Consistency pass 2 (first slice). Follows #259.

## The inconsistency
The tool surface had **three** signals for "couldn't do it": `teach` returned `{ error }`, `why_*` used a `found` discriminant, and **everyone else threw** — which the SDK flattens to an opaque `"Error executing tool: …"` string the agent can't act on (`tool-chip-state.ts` hand-parses two shapes as a result).

## The standard (two signals, not three)
- **"Looked, didn't find / partial"** → structured result (`why_*` `found`, `list_*` empty array). Data, not an error. **Unchanged** — this is correct.
- **"Couldn't act, you can fix it"** → `{ error }` so the model self-corrects in-loop.
- **Infra** → still throws (not the agent's to fix).

## This slice
- Shared envelope `src/tools/agent-error.ts`: `AgentErrorSchema`, `withAgentError`, `isAgentError`, `asAgentError` (catch-all, for query tools), `AgentActionableError` + `catchActionable` (selective, for the write/compute tools in 2b).
- Applied `{ error }` to the **highest-value actionable-throw sites**: `run_sql` and `probe`. A bad query is the agent's to fix — it now rewrites the SQL in-loop instead of the turn dying. The `run_sql` canvas projector skips an `{ error }` result.
- **SECURITY:** `probe` re-threw the raw driver message, which on a failed Postgres ATTACH can echo the credentialed DSN — now redacted in `duckdb/probe` before it leaves (it reaches the agent as data + the persisted transcript).

## Scope note (honest)
After reading the handlers, the read family (`why_*`/`look_*`) already returns structured not-found/empty — it does **not** throw opaque errors — so this is **not** a 27-tool rewrite. The remaining `{ error }` candidates are the write/compute tools' actionable failures (`select`/`frame`/`replay`/`operating_model`), which need per-handler actionable-vs-infra judgement → **pass 2b**, which gets the real-LLM Playwright smoke (the actionable/infra split is novel there).

This slice's `{ error }`-union pattern is identical to `teach`'s shipped pattern, so it's covered by typecheck + 887 unit tests (incl. `agent-error.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)