### PR TITLE
refactor(cockpit): agent-actionable {error} for write/compute tools (consistency 2b)

### DIFF
--- a/packages/cockpit/src/temporal/trigger-add-source.ts
+++ b/packages/cockpit/src/temporal/trigger-add-source.ts
@@ -35,6 +35,7 @@ import { resolveActiveWorkspace } from "../db/cockpit/registry";
 import { recordRun } from "../db/cockpit/runs";
 import { metadataDb } from "../db/metadata/client";
 import { investigationSessionsWrite } from "../db/metadata/write-surface";
+import { AgentActionableError } from "../tools/agent-error";
 import type { AddSourceInput, AddSourceResult, SourceIdentity } from "./types";
 import { addSourceWorkflowId } from "./workflow-id";
 
@@ -51,7 +52,7 @@ const SEED_STATUS = "active";
  * not a server fault: `select` raises it BEFORE any source write, so a refused
  * vertical leaves no half-state and never starts the doomed workflow.
  */
-export class NoConceptsError extends Error {
+export class NoConceptsError extends AgentActionableError {
 	constructor(public readonly vertical: string) {
 		super(
 			vertical === "_adhoc"

--- a/packages/cockpit/src/tools/frame.ts
+++ b/packages/cockpit/src/tools/frame.ts
@@ -33,6 +33,11 @@ import {
 	getFrameValidationsInstructions,
 } from "../prompts";
 import {
+	AgentActionableError,
+	catchActionable,
+	withAgentError,
+} from "./agent-error";
+import {
 	formatSeedExamples,
 	frameFamily,
 	induceStructured,
@@ -64,7 +69,7 @@ function resolveVertical(name?: string | null): string {
 	// select's resolveVertical; `_adhoc`'s leading underscore fails the pattern).
 	if (!trimmed || trimmed === DEFAULT_VERTICAL) return DEFAULT_VERTICAL;
 	if (!VERTICAL_NAME_PATTERN.test(trimmed)) {
-		throw new Error(
+		throw new AgentActionableError(
 			`Invalid vertical name '${trimmed}'. Must match ${VERTICAL_NAME_PATTERN.source} ` +
 				"(lowercase, start with a letter, 2–49 chars of [a-z0-9_]).",
 		);
@@ -258,7 +263,7 @@ export async function frame(
 	});
 
 	if (concepts.items.length === 0) {
-		throw new Error(
+		throw new AgentActionableError(
 			"Frame induction returned no concepts — nothing to declare.",
 		);
 	}
@@ -329,6 +334,11 @@ export const frameTool = toolDefinition({
 			),
 		session_id: z.string().nullish(),
 	}),
-	outputSchema: FrameResult,
+	// Success OR `{ error }`: an invalid vertical name or an induction that
+	// returned no concepts is the agent's to fix (rephrase / pick a vertical), so
+	// it's returned as data, not an opaque throw (consistency pass 2b).
+	outputSchema: withAgentError(FrameResult),
 	needsApproval: true,
-}).server((input, ctx) => frame(input, ctx?.abortSignal));
+}).server((input, ctx) =>
+	catchActionable(() => frame(input, ctx?.abortSignal)),
+);

--- a/packages/cockpit/src/tools/replay.ts
+++ b/packages/cockpit/src/tools/replay.ts
@@ -49,6 +49,11 @@ import type {
 	SourceIdentity,
 } from "../temporal/types";
 import { addSourceWorkflowId } from "../temporal/workflow-id";
+import {
+	AgentActionableError,
+	catchActionable,
+	withAgentError,
+} from "./agent-error";
 
 /**
  * The distinct sources a session was built from — its linked tables' `source_id`s.
@@ -128,7 +133,7 @@ export async function replay(input: ReplayInput): Promise<ReplayResult> {
 	// the one the user is in / has been teaching). So a bare "replay" just works.
 	const sessionId = input.session_id ?? (await currentSessionId());
 	if (!sessionId) {
-		throw new Error(
+		throw new AgentActionableError(
 			"No session to replay — add a source or begin a session first.",
 		);
 	}
@@ -136,7 +141,7 @@ export async function replay(input: ReplayInput): Promise<ReplayResult> {
 	// Resolve what to replay FROM the session — the sources it was built on.
 	const sourceIds = await sourcesForSession(sessionId);
 	if (sourceIds.length === 0) {
-		throw new Error(
+		throw new AgentActionableError(
 			`Session '${sessionId}' has no sources to replay — it has no ` +
 				"linked tables yet (nothing was added to it).",
 		);
@@ -233,11 +238,16 @@ export const replayTool = toolDefinition({
 				"Optional. Omit to re-run on the session's own framed vertical (resolved automatically); pass one only to override.",
 			),
 	}),
-	outputSchema: z.object({
-		workflow_id: z.string(),
-		run_id: z.string(),
-		source_ids: z.array(z.string()),
-		session_id: z.string(),
-	}),
+	// Success OR `{ error }`: "no session to replay" / "session has no sources"
+	// are the agent's to fix (add a source / begin a session first), so they come
+	// back as data. A missing Temporal config is infra → still throws (pass 2b).
+	outputSchema: withAgentError(
+		z.object({
+			workflow_id: z.string(),
+			run_id: z.string(),
+			source_ids: z.array(z.string()),
+			session_id: z.string(),
+		}),
+	),
 	needsApproval: true,
-}).server((input) => replay(input));
+}).server((input) => catchActionable(() => replay(input)));

--- a/packages/cockpit/src/tools/select.ts
+++ b/packages/cockpit/src/tools/select.ts
@@ -72,6 +72,11 @@ import {
 	NoConceptsError,
 	triggerAddSource,
 } from "../temporal/trigger-add-source";
+import {
+	AgentActionableError,
+	catchActionable,
+	withAgentError,
+} from "./agent-error";
 import { verticalConceptCount } from "./list-verticals";
 
 // The onboarding stage `select` leaves the source(s) at. The cockpit drives a
@@ -99,7 +104,7 @@ function resolveVertical(name?: string | null): string {
 	const trimmed = name?.trim();
 	if (!trimmed || trimmed === DEFAULT_VERTICAL) return DEFAULT_VERTICAL;
 	if (!VERTICAL_NAME_PATTERN.test(trimmed)) {
-		throw new Error(
+		throw new AgentActionableError(
 			`Invalid vertical '${trimmed}'. Must match ${VERTICAL_NAME_PATTERN.source} ` +
 				"(lowercase, start with a letter, 2–49 chars of [a-z0-9_]) or be '_adhoc'.",
 		);
@@ -348,7 +353,7 @@ export async function persistSelection(
 	// database — ONE source, named by the user (files are content-keyed instead).
 	const name = input.source_name;
 	if (!name || !SOURCE_NAME_PATTERN.test(name)) {
-		throw new Error(
+		throw new AgentActionableError(
 			`Database select requires a valid source_name (got '${name ?? ""}'). ` +
 				`Must match ${SOURCE_NAME_PATTERN.source} (lowercase, start with a ` +
 				"letter, 2–49 chars of [a-z0-9_]).",
@@ -360,7 +365,7 @@ export async function persistSelection(
 	// source rows, so this check IS the reservation.
 	const reserved = reservedSourceNamePrefix(name);
 	if (reserved !== null) {
-		throw new Error(
+		throw new AgentActionableError(
 			`Source name '${name}' starts with the reserved prefix '${reserved}' — ` +
 				`${RESERVED_SOURCE_NAME_PREFIXES.join("/")} name the derived-table ` +
 				"families (content-keyed uploads, enriched views, slice tables), and a " +
@@ -369,7 +374,7 @@ export async function persistSelection(
 		);
 	}
 	if (!input.backend || !SUPPORTED_BACKENDS.includes(input.backend)) {
-		throw new Error(
+		throw new AgentActionableError(
 			`Database select requires a supported backend (got '${input.backend ?? ""}'; ` +
 				`supported: ${SUPPORTED_BACKENDS.join(", ")}). The engine import fails ` +
 				"loud on a db_recipe source with no backend.",
@@ -380,7 +385,7 @@ export async function persistSelection(
 			? schema.tables.filter((t) => input.table_names?.includes(t.name))
 			: schema.tables;
 	if (picked.length === 0) {
-		throw new Error(
+		throw new AgentActionableError(
 			`None of the requested tables (${(input.table_names ?? []).join(", ")}) ` +
 				"are in the connected schema.",
 		);
@@ -538,7 +543,12 @@ export const selectTool = toolDefinition({
 			),
 		session_id: z.string().nullish(),
 	}),
-	outputSchema: SelectResult,
+	// Success OR `{ error }`: the actionable pre-flight failures (bad vertical /
+	// source_name / reserved prefix / unsupported backend / no matching tables /
+	// NoConceptsError) come back as data so the model fixes the input and retries.
+	// They all raise BEFORE any write, so there's no half-state. A Temporal
+	// workflow.start failure is infra → still throws (re-approval recovers).
+	outputSchema: withAgentError(SelectResult),
 	needsApproval: true,
 	// The lambda is load-bearing: .server() calls its handler as (input, context)
 	// — passing `select` bare would shove the SDK's context object into select's
@@ -548,4 +558,4 @@ export const selectTool = toolDefinition({
 	// can't un-start the Temporal workflow and would only orphan the seeded
 	// investigation_sessions row (the exact failure seam trigger-add-source.ts
 	// guards against).
-}).server((input) => select(input));
+}).server((input) => catchActionable(() => select(input)));

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -20,6 +20,7 @@
 import type { ConnectSchema } from "#/duckdb/connect";
 import { humanizeIdentifier } from "#/lib/display-names";
 import { fileName } from "#/lib/file-uri";
+import { isAgentError } from "#/tools/agent-error";
 import type { FrameResult } from "#/tools/frame";
 import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
@@ -122,6 +123,12 @@ export function toolChipSummary(
 	output: unknown,
 ): string {
 	const done = output !== undefined;
+	// A tool that returned the agent-actionable `{ error }` envelope (consistency
+	// pass 2): show the message, not the success-shape fields — `select`'s
+	// `${name} (${source_type})` on an `{ error }` object reads as
+	// "undefined (undefined)". The chip's failed STATE is set separately
+	// (tool-chip-state); this is just the readable subtitle.
+	if (done && isAgentError(output)) return truncate(output.error);
 	switch (toolName) {
 		case "list_sources": {
 			if (!done) return "listing available inputs…";


### PR DESCRIPTION
Consistency pass 2b — the write/compute (`needsApproval`) tools. Follows #259, #260.

## Change
Their **agent-actionable preconditions** threw plain Errors (SDK-flattened to opaque `"Error executing tool: …"`). They now return `{ error }` via `AgentActionableError` + `catchActionable`, so the model fixes the input and retries in-loop:
- **select** — bad vertical / source_name / reserved prefix / unsupported backend / no matching tables / `NoConceptsError` (now extends `AgentActionableError` — its cold-start pre-flight is the canonical "frame first" fixable failure).
- **frame** — invalid vertical name / induction returned no concepts.
- **replay** — no session to replay / session has no sources.

**Infra still throws:** the "Temporal client is not configured" guards in `replay`/`operating_model`/`begin_session` are env misconfig, not the agent's to fix. `operating_model`/`begin_session` have *only* that infra throw → untouched (no cargo-cult unions). All actionable throws raise BEFORE any write (no half-state); a `select` Temporal `workflow.start` failure is infra → still throws (re-approval recovers, DAT-436).

Plus a UI fix the smoke caught: `toolChipSummary` read success-shape fields off an `{ error }` object → "undefined (undefined)"; one uniform `isAgentError` guard now shows the message.

## Live smoke (real LLM + engine, Playwright) — the novel interaction
A `needsApproval` tool returning `{ error }` **on the approval continuation** (composes with the #257 prefill fix):
1. Fresh workspace → uploaded a CSV → asked to import under an **unframed** `widgets` vertical → approved `select`.
2. `select` hit `NoConceptsError` → returned `{ error }`: chip rendered **"failed"** (not a crash), all `/api/chat` POSTs **200**.
3. The agent **recovered in-loop** — read the error and offered "Frame 'widgets' now" or "Pick an existing builtin", instead of the turn dying on an opaque string. ✅

Gate-verified: typecheck + 887 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)