### PR TITLE
fix(engine): framed-metric overlay rows steer semantic grounding (DAT-471 AC3)

### DIFF
--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -243,16 +243,31 @@ def ground_columns(
     """
     from dataraum.analysis.semantic.column_agent import ColumnAnnotationAgent
     from dataraum.analysis.semantic.ontology import OntologyLoader
-    from dataraum.graphs.loader import GraphLoader
+    from dataraum.graphs.config import get_metric_definitions
+    from dataraum.graphs.loader import GraphLoader, GraphLoadError
 
     col_config = config.features.column_annotation
     if not col_config or not col_config.enabled:
         return Result.fail("Column annotation is disabled in config.")
 
     # Standard-field concepts required by active metric graphs, so the model
-    # prioritizes mapping those concepts to actual columns.
+    # prioritizes mapping those concepts to actual columns. OVERLAY-AWARE: the
+    # declared set is the vertical's shipped graphs ⊕ `metric` overlay teach rows
+    # (get_metric_definitions), so a FRAMED vertical's metrics — declared at frame
+    # time, no on-disk directory — steer grounding too. load_all() is file-only and
+    # returns nothing for a framed/_adhoc vertical (DAT-471 AC3). The worker
+    # bootstrap installs the overlay resolver process-wide, so it resolves here in
+    # the add_source semantic phase exactly as it does in the operating_model
+    # metrics phase.
     metric_loader = GraphLoader(vertical=ontology)
-    metric_loader.load_all()
+    for graph_id, defn in get_metric_definitions(ontology).items():
+        # A declared metric that won't parse is skipped for this grounding HINT —
+        # its born-loud handling (declared-with-reason) is the metrics phase's job
+        # at operating_model; here a malformed graph must not sink column grounding.
+        try:
+            metric_loader.graphs.update(metric_loader.graphs_from_definitions({graph_id: defn}))
+        except GraphLoadError as exc:
+            logger.warning("metric_grounding_hint_skip", graph_id=graph_id, error=str(exc))
     required_standard_fields = sorted(metric_loader.get_all_abstract_fields())
 
     agent = ColumnAnnotationAgent(config=config, provider=provider, prompt_renderer=renderer)

--- a/packages/engine/src/dataraum/graphs/loader.py
+++ b/packages/engine/src/dataraum/graphs/loader.py
@@ -101,12 +101,13 @@ class GraphLoader:
     ) -> dict[str, TransformationGraph]:
         """Parse already-merged graph definition dicts into graphs.
 
-        The overlay-aware counterpart of :meth:`load_all`: the metrics phase
-        loads its declared set via
+        The overlay-aware counterpart of :meth:`load_all`: BOTH the
+        operating_model metrics phase AND the add_source semantic grounding-hint
+        path (``ground_columns``) load their declared set via
         :func:`dataraum.graphs.config.get_metric_definitions` (shipped graphs ⊕
-        ``metric`` overlay teach rows) and parses them here, so a taught metric
-        is executable exactly like a shipped one. ``load_all`` stays file-only —
-        the add_source semantic phase's field-discovery path is unchanged.
+        ``metric`` overlay teach rows) and parse them here, so a taught/framed
+        metric is groundable + executable exactly like a shipped one. ``load_all``
+        stays file-only, retained for callers that need the shipped-only set.
 
         Raises:
             GraphLoadError: a definition is malformed (missing ``graph_id`` /

--- a/packages/engine/tests/unit/analysis/semantic/test_grounding_step.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_grounding_step.py
@@ -174,7 +174,10 @@ class TestGroundColumns:
         # standard_fields must steer column grounding. load_all() (file-only) would
         # return nothing for a framed vertical — this is the DAT-471 AC3 fix. Real
         # GraphLoader (NOT mocked) so the overlay def actually parses and
-        # get_all_abstract_fields walks its steps.
+        # get_all_abstract_fields walks its steps. A malformed sibling def (missing
+        # metadata.name) must be SKIPPED for this grounding hint — logged, not
+        # raised — without dropping the parseable one (covers the GraphLoadError
+        # branch: if the except didn't fire, ground_columns would error here).
         table = _table_with_columns(session, "ledger", ["amount"])
         mock_get_defs.return_value = {
             "framed_margin": {
@@ -191,6 +194,8 @@ class TestGroundColumns:
                     },
                 },
             },
+            # Unparseable (no metadata.name) → GraphLoadError, skipped for the hint.
+            "broken_metric": {"graph_id": "broken_metric", "dependencies": {}},
         }
         mock_ontology_cls.return_value.load.return_value = None
 

--- a/packages/engine/tests/unit/analysis/semantic/test_grounding_step.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_grounding_step.py
@@ -61,6 +61,7 @@ def _enabled_config() -> MagicMock:
 
 
 class TestGroundColumns:
+    @patch("dataraum.graphs.config.get_metric_definitions")
     @patch("dataraum.analysis.semantic.ontology.OntologyLoader")
     @patch("dataraum.graphs.loader.GraphLoader")
     @patch("dataraum.analysis.semantic.column_agent.ColumnAnnotationAgent")
@@ -69,10 +70,12 @@ class TestGroundColumns:
         mock_agent_cls: MagicMock,
         mock_graph_cls: MagicMock,
         mock_ontology_cls: MagicMock,
+        mock_get_defs: MagicMock,
         session,
     ) -> None:
         table = _table_with_columns(session, "customers", ["customer_id", "revenue"])
 
+        mock_get_defs.return_value = {}
         mock_graph_cls.return_value.get_all_abstract_fields.return_value = set()
         mock_ontology_cls.return_value.load.return_value = None
         mock_agent_cls.return_value.annotate.return_value = Result.ok(
@@ -127,6 +130,7 @@ class TestGroundColumns:
         assert "disabled" in (result.error or "").lower()
         assert session.execute(select(AnnotationDB)).scalars().all() == []
 
+    @patch("dataraum.graphs.config.get_metric_definitions")
     @patch("dataraum.analysis.semantic.ontology.OntologyLoader")
     @patch("dataraum.graphs.loader.GraphLoader")
     @patch("dataraum.analysis.semantic.column_agent.ColumnAnnotationAgent")
@@ -135,8 +139,10 @@ class TestGroundColumns:
         mock_agent_cls: MagicMock,
         mock_graph_cls: MagicMock,
         mock_ontology_cls: MagicMock,
+        mock_get_defs: MagicMock,
         session,
     ) -> None:
+        mock_get_defs.return_value = {}
         mock_graph_cls.return_value.get_all_abstract_fields.return_value = set()
         mock_agent_cls.return_value.annotate.return_value = Result.fail("annotation LLM down")
 
@@ -152,3 +158,73 @@ class TestGroundColumns:
 
         assert not result.success
         assert "annotation LLM down" in (result.error or "")
+
+    @patch("dataraum.graphs.config.get_metric_definitions")
+    @patch("dataraum.analysis.semantic.ontology.OntologyLoader")
+    @patch("dataraum.analysis.semantic.column_agent.ColumnAnnotationAgent")
+    def test_grounding_prioritizes_overlay_metric_fields(
+        self,
+        mock_agent_cls: MagicMock,
+        mock_ontology_cls: MagicMock,
+        mock_get_defs: MagicMock,
+        session,
+    ) -> None:
+        # A FRAMED vertical declares its metrics as `metric` overlay rows (no
+        # on-disk dir); get_metric_definitions resolves them, and their extract-leaf
+        # standard_fields must steer column grounding. load_all() (file-only) would
+        # return nothing for a framed vertical — this is the DAT-471 AC3 fix. Real
+        # GraphLoader (NOT mocked) so the overlay def actually parses and
+        # get_all_abstract_fields walks its steps.
+        table = _table_with_columns(session, "ledger", ["amount"])
+        mock_get_defs.return_value = {
+            "framed_margin": {
+                "graph_id": "framed_margin",
+                "version": "1.0",
+                "metadata": {"name": "Framed Margin", "category": "test"},
+                "output": {"type": "scalar", "metric_id": "framed_margin"},
+                "dependencies": {
+                    "extract_revenue": {
+                        "level": 1,
+                        "type": "extract",
+                        "source": {"standard_field": "revenue"},
+                        "output_step": True,
+                    },
+                },
+            },
+        }
+        mock_ontology_cls.return_value.load.return_value = None
+
+        captured: dict[str, object] = {}
+
+        def _annotate(**kwargs: object) -> Result[ColumnAnnotationOutput]:
+            captured["required_standard_fields"] = kwargs["required_standard_fields"]
+            return Result.ok(
+                ColumnAnnotationOutput(
+                    tables=[
+                        TableColumnAnnotation(
+                            table_name="ledger", columns=[_col("amount", "measure")]
+                        )
+                    ]
+                )
+            )
+
+        mock_agent_cls.return_value.annotate.side_effect = _annotate
+        provider = MagicMock()
+        provider.get_model_for_tier.return_value = "test-model"
+
+        result = ground_columns(
+            session=session,
+            config=_enabled_config(),
+            provider=provider,
+            renderer=MagicMock(),
+            table_ids=[table.table_id],
+            ontology="framed_co",
+            session_id=baseline_session_id(),
+        )
+        session.flush()
+
+        assert result.success
+        # The framed metric's extract-leaf standard_field steers grounding —
+        # sourced from the overlay-aware declared set, not file-only load_all().
+        assert captured["required_standard_fields"] == ["revenue"]
+        mock_get_defs.assert_called_once_with("framed_co")


### PR DESCRIPTION
## What

The DAT-471 review (PR #263) surfaced that the DAT-468 design assumption — *framed metrics steer semantic goal-direction with no engine change* — was **false**. `ground_columns` (`analysis/semantic/processor.py`) built `required_standard_fields` from `GraphLoader.load_all()`, which is **file-only**: a framed/`_adhoc` vertical (metrics declared at frame time as `metric` overlay rows, no on-disk `metrics/` dir) resolved to `{}`, so its metrics never prioritized concept→column mapping during grounding.

The cockpit (#263) writes the consumable `metric` overlay rows; this wires the **grounding** path to read them.

## Change

Swap `load_all()` → `get_metric_definitions(ontology)` (shipped graphs ⊕ `metric` overlay teach rows — the same overlay-aware path the operating_model metrics phase uses) + `graphs_from_definitions` per declared graph. The overlay resolver is installed **process-wide at worker bootstrap** (`worker/bootstrap.py`), so it resolves in the add_source semantic phase exactly as it does in operating_model.

- **Behavior-preserving for shipped verticals** — `finance`: shipped ⊕ no-overlay == the files `load_all()` read.
- **Additive for framed verticals** — their overlay metrics now steer grounding.
- A declared metric that won't parse is **skipped for this prioritization hint** (logged) — born-loud *declared-with-reason* stays the metrics phase's job at operating_model; a malformed graph must not sink column grounding.

## Tests

- New `test_grounding_prioritizes_overlay_metric_fields` — real `GraphLoader`, an overlay-sourced metric def parsed for real, asserts its extract-leaf `standard_field` reaches `required_standard_fields`.
- Existing grounding tests patch the new `get_metric_definitions` dependency.
- Gates: ruff ✓, `mypy -i src` ✓, `pytest --testmon tests/unit` ✓ (grounding 4/4).

## Eval impact

None for `finance` (behavior-preserving) — no `handoff.md` entry.

## Deferred

End-to-end **live operating_model smoke** (real LLM, framed vertical: frame a metric → semantic phase → assert its `standard_field` is in the annotation prompt's `required_standard_fields`) remains deferred pending an explicit go-ahead.

Relates: DAT-417 (operating_model epic) · DAT-471 AC3 · DAT-468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)