### PR TITLE
fix(engine): born-loud resolve_vertical — shipped|framed|placeholder|unknown (DAT-480)

### DIFF
--- a/packages/engine/src/dataraum/analysis/semantic/ontology.py
+++ b/packages/engine/src/dataraum/analysis/semantic/ontology.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 
 from dataraum.core.config import get_config_dir, load_yaml_config
 from dataraum.core.overlay import apply_overlay
+from dataraum.core.vertical import VerticalKind, resolve_vertical
 
 
 class OntologyConcept(BaseModel):
@@ -82,19 +83,18 @@ class OntologyLoader:
             the test path when the YAML doesn't exist.
         """
         if self.verticals_dir is None:
+            # The shipped/framed/placeholder/unknown discrimination lives in
+            # one place (DAT-480): an UNKNOWN name (typo, or never framed) is
+            # the only `None` case. Everything else resolves — shipped /
+            # placeholder read their on-disk baseline (⊕ overlay); a framed
+            # vertical has no file, so it materializes from overlay rows alone.
             relative = f"verticals/{vertical}/ontology.yaml"
+            if resolve_vertical(vertical) is VerticalKind.UNKNOWN:
+                return None
             try:
                 data = load_yaml_config(relative)
             except FileNotFoundError:
-                # No on-disk vertical → try a framed (overlay-only) vertical:
-                # layer its active `concept`/`concept_property` rows over an
-                # empty base. If that yields concepts it's a real framed
-                # vertical; if nothing resolves (no file AND no rows) the
-                # vertical is unknown → keep the `None` contract.
-                merged = apply_overlay(relative, {"name": vertical, "concepts": []})
-                if not merged.get("concepts"):
-                    return None
-                data = merged
+                data = apply_overlay(relative, {"name": vertical, "concepts": []})
             return OntologyDefinition(**data)
 
         ontology_path = self.verticals_dir / vertical / "ontology.yaml"

--- a/packages/engine/src/dataraum/core/overlay.py
+++ b/packages/engine/src/dataraum/core/overlay.py
@@ -104,6 +104,20 @@ def reset_overlay_resolver_for_tests() -> None:
     _overlay_resolver = None
 
 
+def get_overlay_rows() -> list[OverlayRow]:
+    """Return the workspace's active overlay rows, or ``[]`` if no resolver.
+
+    The single read path for code that needs to *enumerate* overlay rows
+    (vertical resolution, DAT-480) rather than merge them onto a base via
+    :func:`apply_overlay`. Inert (``[]``) when no resolver is registered —
+    CLI / tests that never bootstrap a workspace — mirroring
+    :func:`apply_overlay`'s short-circuit.
+    """
+    if _overlay_resolver is None:
+        return []
+    return _overlay_resolver()
+
+
 # ---------------------------------------------------------------------------
 # Per-type appliers.
 # ---------------------------------------------------------------------------

--- a/packages/engine/src/dataraum/core/vertical.py
+++ b/packages/engine/src/dataraum/core/vertical.py
@@ -1,80 +1,151 @@
-"""Vertical configuration resolver.
+"""Vertical resolution — classify a vertical name (DAT-480).
 
-Resolves paths for a specific vertical (e.g. 'finance') within the
-config/verticals/ directory. Follows the same pattern as OntologyLoader:
-accept optional verticals_dir, default from get_config_dir("verticals").
+A vertical name resolves to one of four kinds:
 
-Fails loudly if the vertical directory does not exist.
+* ``shipped`` — a curated builtin with an on-disk
+  ``config/verticals/<name>/ontology.yaml`` (e.g. ``finance``).
+* ``framed`` — declared at runtime through the cockpit ``frame`` stage: no
+  on-disk directory (the config tree is read-only), but the workspace's
+  overlay carries vertical-scoped rows (``concept`` / ``validation`` /
+  ``cycle`` / ``metric``) for the name.
+* ``placeholder`` — the no-vertical default ``_adhoc`` (and any leading-
+  underscore name): always valid, never an error, the fallback when the user
+  declared no domain. Mirrors the cockpit ``DEFAULT_VERTICAL``. ``_adhoc``
+  ships an on-disk dir but is classified by the underscore convention, never
+  as a domain vertical.
+* ``unknown`` — a name matching none of the above: a typo (``finanace``) or a
+  vertical that was never framed. Both previously resolved to ``{}`` / ``None``
+  at every executable-knowledge loader and every phase turned that into a
+  benign ``no_declared_*`` "success". The engine now fails LOUD on it at run
+  entry instead (see :func:`require_known_vertical`).
+
+This module replaces the dead ``VerticalConfig`` path-resolver: the engine
+reads vertical config through ``load_yaml_config`` (overlay-aware), never by
+constructing per-file paths, so a path-resolver had no remaining caller.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
+from enum import StrEnum
+
+from dataraum.core.config import get_config_dir
+from dataraum.core.overlay import get_overlay_rows
+
+# Overlay row types that DECLARE a *vertical's* model (concepts + the
+# validation/cycle/metric families, DAT-371/438/455/456) — the presence of any
+# one for a name is what makes it a framed vertical. ``concept_property`` is
+# deliberately excluded: it patches a field on an existing concept, so it can
+# never establish a vertical on its own (it always rides alongside a ``concept``
+# row for the same vertical).
+_VERTICAL_SCOPED_TYPES: frozenset[str] = frozenset({"concept", "validation", "cycle", "metric"})
 
 
-class VerticalConfig:
-    """Resolved paths for a specific vertical (e.g. 'finance').
+class VerticalKind(StrEnum):
+    """Classification of a vertical name (DAT-480)."""
 
-    Raises FileNotFoundError on construction if the vertical directory
-    does not exist. This ensures misconfiguration is caught early.
+    SHIPPED = "shipped"
+    FRAMED = "framed"
+    PLACEHOLDER = "placeholder"
+    UNKNOWN = "unknown"
 
-    Usage:
-        vc = VerticalConfig("finance")
-        vc.cycles_path       # -> config/verticals/finance/cycles.yaml
-        vc.validations_dir   # -> config/verticals/finance/validations/
-        vc.metrics_dir       # -> config/verticals/finance/metrics/
-        vc.ontology_path     # -> config/verticals/finance/ontology.yaml
+
+def _is_placeholder(name: str | None) -> bool:
+    """``_adhoc`` and any leading-underscore name are the no-vertical default.
+
+    A missing name (``None`` / empty) is the same "no domain declared" state —
+    phases coalesce it to ``_adhoc`` — so it classifies as a placeholder too.
     """
-
-    def __init__(self, name: str, verticals_dir: Path | None = None):
-        """Initialize vertical config.
-
-        Args:
-            name: Vertical name (e.g. 'finance')
-            verticals_dir: Root verticals directory.
-                          If None, uses config/verticals/
-
-        Raises:
-            FileNotFoundError: If the vertical directory does not exist.
-        """
-        if verticals_dir is None:
-            from dataraum.core.config import get_config_dir
-
-            verticals_dir = get_config_dir("verticals")
-
-        self.name = name
-        self.base_dir = verticals_dir / name
-
-        if not self.base_dir.is_dir():
-            raise FileNotFoundError(
-                f"Vertical '{name}' not found: {self.base_dir} does not exist. "
-                f"Available verticals: {_list_verticals(verticals_dir)}"
-            )
-
-    @property
-    def ontology_path(self) -> Path:
-        """Path to the ontology YAML file."""
-        return self.base_dir / "ontology.yaml"
-
-    @property
-    def cycles_path(self) -> Path:
-        """Path to the cycles YAML file."""
-        return self.base_dir / "cycles.yaml"
-
-    @property
-    def validations_dir(self) -> Path:
-        """Path to the validations directory."""
-        return self.base_dir / "validations"
-
-    @property
-    def metrics_dir(self) -> Path:
-        """Path to the metrics directory."""
-        return self.base_dir / "metrics"
+    return not name or name.startswith("_")
 
 
-def _list_verticals(verticals_dir: Path) -> str:
-    """List available vertical names for error messages."""
-    if not verticals_dir.is_dir():
-        return "(verticals directory not found)"
-    names = sorted(d.name for d in verticals_dir.iterdir() if d.is_dir())
-    return ", ".join(names) if names else "(none)"
+def _shipped_verticals() -> set[str]:
+    """On-disk builtin verticals (a ``<name>/ontology.yaml`` exists).
+
+    Excludes leading-underscore placeholders (``_adhoc`` ships a dir but is the
+    no-vertical default, not a domain vertical). Returns ``set()`` if the
+    verticals root is absent.
+    """
+    try:
+        root = get_config_dir("verticals")
+    except FileNotFoundError:
+        return set()
+    return {
+        p.parent.name for p in root.glob("*/ontology.yaml") if not p.parent.name.startswith("_")
+    }
+
+
+def _framed_verticals() -> set[str]:
+    """Vertical names that exist purely as overlay rows (declared via frame).
+
+    Distinct ``payload.vertical`` over the workspace's active vertical-scoped
+    overlay rows. Workspace scope is implicit in the resolver (its rows already
+    come from the ``ws_<id>`` schema); multi-workspace defers to DAT-357.
+    """
+    names: set[str] = set()
+    for row in get_overlay_rows():
+        if row.type in _VERTICAL_SCOPED_TYPES:
+            vertical = row.payload.get("vertical")
+            if vertical:
+                names.add(vertical)
+    return names
+
+
+def resolve_vertical(name: str | None) -> VerticalKind:
+    """Classify a vertical name into shipped / framed / placeholder / unknown.
+
+    Existence is INFERRED, no registry: placeholder by the underscore
+    convention, shipped from the on-disk verticals tree, framed from the
+    workspace's overlay rows. Placeholder is checked FIRST — ``_adhoc`` ships an
+    on-disk dir but must never read as a domain (``shipped``) vertical.
+    """
+    if _is_placeholder(name):
+        return VerticalKind.PLACEHOLDER
+    if name in _shipped_verticals():
+        return VerticalKind.SHIPPED
+    if name in _framed_verticals():
+        return VerticalKind.FRAMED
+    return VerticalKind.UNKNOWN
+
+
+def available_verticals() -> list[str]:
+    """Sorted names a user can legitimately select — shipped ∪ framed.
+
+    Never includes the ``_adhoc`` placeholder; for the "available verticals"
+    half of a born-loud unknown-vertical error.
+    """
+    return sorted(_shipped_verticals() | _framed_verticals())
+
+
+def require_known_vertical(name: str | None) -> VerticalKind:
+    """Resolve ``name``, raising a born-loud error if it is ``unknown``.
+
+    Run-entry guard (DAT-480): the engine grounds, validates, and computes
+    against a vertical's declared model. An unknown name would silently resolve
+    to zero concepts/specs and every phase would emit a benign ``no_declared_*``
+    — the failure mode this closes. Raise here, naming the verticals that DO
+    exist (shipped + framed; never the ``_adhoc`` placeholder).
+
+    Returns the resolved :class:`VerticalKind` for the known cases (shipped /
+    framed / placeholder), so a caller can branch without re-resolving.
+
+    Raises ``RuntimeError`` (not ``ValueError``) to match the sibling fail-loud
+    raises at the operating_model resolve seam — and because the failure is
+    permanent (a typo doesn't fix itself on retry), keeping it the same
+    deterministic-failure shape Temporal's retry policy already handles there.
+    """
+    kind = resolve_vertical(name)
+    if kind is VerticalKind.UNKNOWN:
+        available = available_verticals()
+        raise RuntimeError(
+            f"Unknown vertical {name!r}. Available verticals: "
+            f"{', '.join(available) if available else '(none — frame one first)'}."
+        )
+    return kind
+
+
+__all__ = [
+    "VerticalKind",
+    "available_verticals",
+    "require_known_vertical",
+    "resolve_vertical",
+]

--- a/packages/engine/src/dataraum/graphs/loader.py
+++ b/packages/engine/src/dataraum/graphs/loader.py
@@ -64,15 +64,16 @@ class GraphLoader:
                 raise ValueError("vertical is required when graphs_dir is not provided")
             from dataraum.core.config import get_config_dir
 
-            # Resolve the vertical's dir WITHOUT VerticalConfig's fail-loud
-            # existence check. A framed vertical (declared via the cockpit `frame`
-            # stage — its concepts live in config_overlay, with no on-disk
-            # directory) legitimately ships no metric graphs. `load_all` already
-            # returns {} for a missing dir, so resolving the path here and letting
-            # load_all handle absence is what lets grounding run for a framed
-            # vertical instead of crashing in the constructor (the `add_source`
-            # semantic phase grounds against framed concepts via the overlay-aware
-            # OntologyLoader, then asks GraphLoader for metric standard-fields).
+            # Resolve the vertical's dir WITHOUT a fail-loud existence check
+            # (the unknown-vertical guard lives once at run entry, DAT-480). A
+            # framed vertical (declared via the cockpit `frame` stage — its
+            # concepts live in config_overlay, with no on-disk directory)
+            # legitimately ships no metric graphs. `load_all` already returns {}
+            # for a missing dir, so resolving the path here and letting load_all
+            # handle absence is what lets grounding run for a framed vertical
+            # (the `add_source` semantic phase grounds against framed concepts
+            # via the overlay-aware OntologyLoader, then asks GraphLoader for
+            # metric standard-fields).
             graphs_dir = get_config_dir("verticals") / vertical
         self.graphs_dir = graphs_dir
         self.graphs: dict[str, TransformationGraph] = {}

--- a/packages/engine/src/dataraum/pipeline/phases/semantic_per_column_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/semantic_per_column_phase.py
@@ -19,6 +19,7 @@ from sqlalchemy import func, select
 from dataraum.analysis.semantic.ontology import OntologyLoader
 from dataraum.analysis.semantic.processor import ground_columns
 from dataraum.core.logging import get_logger
+from dataraum.core.vertical import VerticalKind, available_verticals, resolve_vertical
 from dataraum.investigation.queries import tables_for_session
 from dataraum.llm import PromptRenderer, create_provider, load_llm_config
 from dataraum.pipeline.base import PhaseContext, PhaseResult
@@ -134,6 +135,18 @@ class SemanticPerColumnPhase(BasePhase):
         if not ontology:
             return PhaseResult.failed(
                 "No vertical configured. Set 'vertical' in config/phases/semantic.yaml."
+            )
+
+        # Born-loud on an UNKNOWN vertical (DAT-480): a typo'd or never-framed
+        # name would otherwise resolve to zero concepts and look identical to a
+        # legitimately-empty framed vertical below. Distinguish it up front and
+        # name what DOES exist, so the user fixes the name rather than the data.
+        if resolve_vertical(ontology) is VerticalKind.UNKNOWN:
+            available = available_verticals()
+            return PhaseResult.failed(
+                f"Unknown vertical '{ontology}'. Available verticals: "
+                f"{', '.join(available) if available else '(none — frame one first)'}. "
+                "Frame this vertical (cockpit `frame`) or pick an existing one."
             )
 
         # Cold-start fail-loud (DAT-382, generalized for framed verticals): a

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -26,6 +26,7 @@ from sqlalchemy import func, select
 
 from dataraum.core.config import load_phase_config, load_pipeline_config
 from dataraum.core.logging import get_logger
+from dataraum.core.vertical import require_known_vertical
 from dataraum.entropy.engine import run_detector_post_step
 from dataraum.entropy.readiness import persist_readiness
 from dataraum.investigation.db_models import InvestigationSession
@@ -739,11 +740,17 @@ def resolve_operating_model_scope(
         )
 
     with manager.session_scope() as session:
-        if session.get(InvestigationSession, identity.session_id) is None:
+        inv_session = session.get(InvestigationSession, identity.session_id)
+        if inv_session is None:
             raise RuntimeError(
                 f"InvestigationSession '{identity.session_id}' not found — "
                 "operating_model runs over an existing journey session."
             )
+        # Born-loud on a typo'd / never-framed vertical (DAT-480): an unknown
+        # name would silently resolve to no declared validations/cycles/metrics
+        # and every phase would emit a benign no_declared_*. A placeholder
+        # (_adhoc), shipped, or framed name passes through unchanged.
+        require_known_vertical(inv_session.vertical)
         table_ids = tables_for_session(session, identity.session_id)
         if not table_ids:
             raise RuntimeError(

--- a/packages/engine/tests/unit/core/test_vertical.py
+++ b/packages/engine/tests/unit/core/test_vertical.py
@@ -1,45 +1,118 @@
-"""Tests for core/vertical.py - VerticalConfig."""
+"""Tests for core/vertical.py — resolve_vertical born-loud discriminator (DAT-480)."""
 
 from __future__ import annotations
 
-from pathlib import Path
+from collections.abc import Iterator
 
 import pytest
 
-from dataraum.core.vertical import VerticalConfig
+from dataraum.core.overlay import (
+    OverlayRow,
+    reset_overlay_resolver_for_tests,
+    set_overlay_resolver,
+)
+from dataraum.core.vertical import (
+    VerticalKind,
+    available_verticals,
+    require_known_vertical,
+    resolve_vertical,
+)
 
 
-class TestVerticalConfig:
-    """Tests for VerticalConfig path resolution."""
+@pytest.fixture(autouse=True)
+def _clean_resolver() -> Iterator[None]:
+    """Every test starts (and ends) with no overlay resolver registered."""
+    reset_overlay_resolver_for_tests()
+    yield
+    reset_overlay_resolver_for_tests()
 
-    def test_resolves_paths_for_finance(self) -> None:
-        """Check all properties resolve to correct paths for 'finance'."""
-        vc = VerticalConfig("finance")
-        assert vc.name == "finance"
-        assert vc.base_dir.name == "finance"
-        assert vc.base_dir.parent.name == "verticals"
-        assert vc.ontology_path == vc.base_dir / "ontology.yaml"
-        assert vc.cycles_path == vc.base_dir / "cycles.yaml"
-        assert vc.validations_dir == vc.base_dir / "validations"
-        assert vc.metrics_dir == vc.base_dir / "metrics"
 
-    def test_nonexistent_vertical_raises(self) -> None:
-        """Non-existent vertical raises FileNotFoundError on construction."""
-        with pytest.raises(FileNotFoundError, match="not found"):
-            VerticalConfig("nonexistent_vertical_xyz")
+def _frame(vertical: str, *, row_type: str = "concept") -> None:
+    """Register a resolver exposing one vertical-scoped overlay row."""
+    set_overlay_resolver(
+        lambda: [OverlayRow(type=row_type, payload={"vertical": vertical, "name": "x"})]
+    )
 
-    def test_error_message_lists_available(self) -> None:
-        """Error message lists available verticals."""
-        with pytest.raises(FileNotFoundError, match="finance"):
-            VerticalConfig("bad_name")
 
-    def test_custom_verticals_dir(self, tmp_path: Path) -> None:
-        """Custom verticals_dir is respected."""
-        (tmp_path / "custom_vert").mkdir()
-        vc = VerticalConfig("custom_vert", verticals_dir=tmp_path)
-        assert vc.base_dir == tmp_path / "custom_vert"
+class TestResolveVertical:
+    def test_shipped_builtin(self) -> None:
+        """An on-disk builtin (finance) is shipped."""
+        assert resolve_vertical("finance") is VerticalKind.SHIPPED
 
-    def test_custom_dir_nonexistent_raises(self, tmp_path: Path) -> None:
-        """Custom verticals_dir with nonexistent vertical raises."""
-        with pytest.raises(FileNotFoundError, match="missing"):
-            VerticalConfig("missing", verticals_dir=tmp_path)
+    @pytest.mark.parametrize("name", ["_adhoc", "_custom", None, ""])
+    def test_placeholder(self, name: str | None) -> None:
+        """_adhoc, any leading-underscore name, and a missing name are placeholders.
+
+        _adhoc ships an on-disk dir yet must NOT read as a shipped vertical — the
+        underscore convention wins (checked before the on-disk lookup).
+        """
+        assert resolve_vertical(name) is VerticalKind.PLACEHOLDER
+
+    def test_framed_from_overlay(self) -> None:
+        """A name with vertical-scoped overlay rows but no on-disk dir is framed."""
+        _frame("sales")
+        assert resolve_vertical("sales") is VerticalKind.FRAMED
+
+    @pytest.mark.parametrize("row_type", ["concept", "validation", "cycle", "metric"])
+    def test_framed_by_any_family_row(self, row_type: str) -> None:
+        """Any vertical-scoped family row (not just concept) makes a vertical framed."""
+        _frame("ops", row_type=row_type)
+        assert resolve_vertical("ops") is VerticalKind.FRAMED
+
+    def test_unknown_typo(self) -> None:
+        """A typo with no on-disk dir and no overlay rows is unknown."""
+        assert resolve_vertical("finanace") is VerticalKind.UNKNOWN
+
+    def test_non_vertical_overlay_row_does_not_frame(self) -> None:
+        """A non-vertical overlay type (e.g. null_value) never makes a name framed."""
+        set_overlay_resolver(lambda: [OverlayRow(type="null_value", payload={"vertical": "ghost"})])
+        assert resolve_vertical("ghost") is VerticalKind.UNKNOWN
+
+
+class TestAvailableVerticals:
+    def test_lists_shipped_excludes_placeholder(self) -> None:
+        """Available verticals lists shipped builtins but never the _adhoc placeholder."""
+        available = available_verticals()
+        assert "finance" in available
+        assert "_adhoc" not in available
+
+    def test_includes_framed(self) -> None:
+        """A framed vertical joins the available list (shipped ∪ framed)."""
+        _frame("sales")
+        available = available_verticals()
+        assert "sales" in available
+        assert "finance" in available
+
+
+class TestRequireKnownVertical:
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("finance", VerticalKind.SHIPPED),
+            ("_adhoc", VerticalKind.PLACEHOLDER),
+            (None, VerticalKind.PLACEHOLDER),
+        ],
+    )
+    def test_known_passes_through(self, name: str | None, expected: VerticalKind) -> None:
+        """Shipped / placeholder / framed names return their kind, never raise."""
+        assert require_known_vertical(name) is expected
+
+    def test_framed_passes_through(self) -> None:
+        _frame("sales")
+        assert require_known_vertical("sales") is VerticalKind.FRAMED
+
+    def test_unknown_raises_born_loud_naming_available(self) -> None:
+        """A typo'd vertical raises, naming the verticals that DO exist.
+
+        RuntimeError (not ValueError) matches the sibling fail-loud raises at the
+        operating_model resolve seam.
+        """
+        with pytest.raises(RuntimeError, match="Unknown vertical 'finanace'"):
+            require_known_vertical("finanace")
+
+    def test_unknown_error_lists_finance_not_adhoc(self) -> None:
+        """The error names shipped/framed verticals (finance), never _adhoc."""
+        with pytest.raises(RuntimeError) as exc:
+            require_known_vertical("nope")
+        assert "finance" in str(exc.value)
+        assert "_adhoc" not in str(exc.value)

--- a/packages/engine/tests/unit/graphs/test_loader.py
+++ b/packages/engine/tests/unit/graphs/test_loader.py
@@ -29,10 +29,11 @@ class TestGraphLoaderBasics:
 
         Regression: the `add_source` semantic phase grounds a framed vertical's
         columns (concepts resolved via the overlay-aware OntologyLoader) and then
-        asks GraphLoader for metric standard-fields. The old fail-loud
-        `VerticalConfig` crashed the whole phase with
+        asks GraphLoader for metric standard-fields. An on-construction fail-loud
+        on the missing dir crashed the whole phase with
         `FileNotFoundError: .../verticals/<framed> does not exist`. The path now
-        resolves and `load_all` degrades to an empty graph set.
+        resolves and `load_all` degrades to an empty graph set (the
+        unknown-vertical guard lives once at run entry, DAT-480).
         """
         loader = GraphLoader(vertical="a_framed_vertical_with_no_on_disk_dir")
         assert loader.graphs_dir.name == "a_framed_vertical_with_no_on_disk_dir"

--- a/packages/engine/tests/unit/pipeline/test_semantic_split_phases.py
+++ b/packages/engine/tests/unit/pipeline/test_semantic_split_phases.py
@@ -222,6 +222,45 @@ class TestPerColumnAdhocFailLoud:
         # Grounded nothing — no annotations written.
         assert session.execute(select(SemanticAnnotation)).scalars().all() == []
 
+    @patch("dataraum.pipeline.phases.semantic_per_column_phase.OntologyLoader")
+    @patch("dataraum.pipeline.phases.semantic_per_column_phase.PromptRenderer")
+    @patch("dataraum.pipeline.phases.semantic_per_column_phase.create_provider")
+    @patch("dataraum.pipeline.phases.semantic_per_column_phase.load_llm_config")
+    def test_fails_loud_on_unknown_vertical(
+        self,
+        mock_load_config: MagicMock,
+        mock_create_provider: MagicMock,
+        mock_renderer_cls: MagicMock,
+        mock_loader_cls: MagicMock,
+        session: Session,
+        duckdb_conn: duckdb.DuckDBPyConnection,
+    ) -> None:
+        """A typo'd / never-framed vertical fails born-loud naming what exists
+        (DAT-480) — distinct from the _adhoc 'run frame first' message, and it
+        never reaches OntologyLoader."""
+        config = MagicMock()
+        config.active_provider = "anthropic"
+        config.providers = {"anthropic": MagicMock()}
+        mock_load_config.return_value = config
+
+        ctx = PhaseContext(
+            session=session,
+            duckdb_conn=duckdb_conn,
+            source_id=None,
+            config={"vertical": "finanace"},
+            session_id=baseline_session_id(),
+        )
+        src = _source(session)
+        _typed_table(session, src.source_id, "t1", ["a"])
+
+        result = SemanticPerColumnPhase()._run(ctx)
+
+        assert result.status == PhaseStatus.FAILED
+        assert "Unknown vertical 'finanace'" in (result.error or "")
+        assert "finance" in (result.error or "")  # names what DOES exist
+        mock_loader_cls.return_value.load.assert_not_called()
+        assert session.execute(select(SemanticAnnotation)).scalars().all() == []
+
 
 class TestPerTableShouldSkip:
     """The per-table phase scopes by the session's ``table_ids`` (DAT-401, source-free)."""

--- a/packages/engine/tests/unit/worker/test_operating_model_activity.py
+++ b/packages/engine/tests/unit/worker/test_operating_model_activity.py
@@ -128,6 +128,23 @@ class TestResolveOperatingModelScope:
         with pytest.raises(RuntimeError, match="not found"):
             resolve_operating_model_scope(_manager(session_factory), _IDENTITY)
 
+    def test_typod_vertical_fails_born_loud(self, monkeypatch, session_factory):
+        """A typo'd / never-framed vertical raises at run entry (DAT-480) — before
+        any phase turns it into a benign no_declared_*."""
+        monkeypatch.setattr(activity_mod, "get_active_workspace_id", lambda: "ws-1")
+        with session_factory() as s:
+            s.add(
+                InvestigationSession(
+                    session_id=_IDENTITY.session_id, intent="test", vertical="finanace"
+                )
+            )
+            s.add(Table(table_id="tbl-1", source_id="src-1", table_name="tbl-1", layer="typed"))
+            s.add(SessionTable(session_id=_IDENTITY.session_id, table_id="tbl-1"))
+            s.commit()
+
+        with pytest.raises(RuntimeError, match="Unknown vertical 'finanace'"):
+            resolve_operating_model_scope(_manager(session_factory), _IDENTITY)
+
     def test_workspace_mismatch_refused(self, monkeypatch, session_factory):
         monkeypatch.setattr(activity_mod, "get_active_workspace_id", lambda: "ws-OTHER")
 


### PR DESCRIPTION
**DAT-480** (epic DAT-479 · vertical-loading consolidation V1) · design [DD/33161217](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/33161217) §V1

## Problem
A typo'd vertical (`finanace`) was indistinguishable from a legitimately-empty *framed* vertical — both resolved to `{}`/`None` at every executable-knowledge loader, and every phase turned that into a benign `no_declared_*` "success". No loader validated the name was known; the one fail-loud guard (`core/vertical.py::VerticalConfig`) was dead/bypassed.

## What changed
- **`core/vertical.py` (rewritten):** `VerticalKind` StrEnum + `resolve_vertical(name) → shipped | framed | placeholder | unknown` + `available_verticals()` + `require_known_vertical()`. Existence is **inferred** (on-disk verticals dir ∪ overlay rows) — no registry. `_adhoc`/leading-underscore → `placeholder` (checked first, so its on-disk dir never reads as `shipped`). Framed = any `concept`/`validation`/`cycle`/`metric` overlay row for the name (`concept_property` excluded — it only patches an existing concept).
- **`core/overlay.py`:** new `get_overlay_rows()` (enumerate active rows, vs `apply_overlay`'s merge).
- **`OntologyLoader.load`:** refactored onto `resolve_vertical` — the inline unknown-detection heuristic is removed (single home for the discrimination).
- **Born-loud at both run entries:** the `operating_model_resolve` activity (off `InvestigationSession.vertical`) and `add_source`'s `semantic_per_column` phase. `require_known_vertical` raises `RuntimeError` (matches the sibling fail-loud raises at the resolve seam).
- **Removed:** dead `VerticalConfig` + its test.

The **4 family config loaders** (validation/cycle/metric/graphs) are intentionally **untouched** — a *known* vertical with no rows for one family keeps its legit `empty → no_declared_<family>`.

## Design note for review
The `add_source` guard fires inside the `semantic_per_column` phase (after `import`/`typing`/`statistics`), not as a workflow pre-flight before `import`. This matches the LOCKED refinement, which named the semantic phase as the add_source seam. Earliest-fail would need a **new** pre-flight activity (`AddSourceWorkflow._run_inner` runs in Temporal's determinism sandbox and can't call `resolve_vertical` directly) — beyond this ticket. A typo still fails loud; only a few phases of compute run first. Clean follow-up if earliest-fail is wanted.

## Tests
- New `tests/unit/core/test_vertical.py` (all four kinds, framed-by-any-family-row, non-vertical row doesn't frame, available-verticals excludes `_adhoc`, unknown → born-loud naming `finance`).
- Adversarial typo tests at **both** seams: `test_operating_model_activity.py::test_typod_vertical_fails_born_loud` + `test_semantic_split_phases.py::test_fails_loud_on_unknown_vertical`.
- 57 unit green · ruff + mypy + vulture clean.

## Reviewers (pre-merge)
- senior-code-reviewer: **APPROVE** (its finding — `RuntimeError` not `ValueError` — applied).
- spec-compliance-reviewer: **COMPLIANT** (its `concept_property` point applied; the add_source-seam divergence noted above is the LOCKED design).

## Cross-repo
None — behaviour-preserving for known verticals; only a *wrong* name now fails loud. No detector/calibration surface, so no eval/testdata handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)