### PR TITLE
feat(cockpit): look_profile — per-column descriptive profile + widget (DAT-475)

### DIFF
--- a/packages/cockpit/src/routes/api/chat.test.ts
+++ b/packages/cockpit/src/routes/api/chat.test.ts
@@ -112,6 +112,7 @@ describe("chat route wiring (DAT-353)", () => {
 				"list_tables",
 				"list_verticals",
 				"look_table",
+				"look_profile",
 				"why_column",
 				"why_table",
 				"look_relationships",

--- a/packages/cockpit/src/tools/look-profile.test.ts
+++ b/packages/cockpit/src/tools/look-profile.test.ts
@@ -179,6 +179,72 @@ describe("projectColumnProfile — stats JSONB parse + caps", () => {
 		]);
 	});
 
+	it("keeps the whole stats block when a percentile leaf is null", () => {
+		// The engine wraps each percentile in `_finite_or_none` (profiler.py) → a
+		// degenerate/NaN column persists `{"p01": null, "p50": 40, ...}`. A
+		// non-nullable percentile value would fail the whole ProfileData parse and
+		// SILENTLY drop numeric_stats + string_stats + histogram + top_values.
+		const out = projectColumnProfile("c_1", "amount", "orders", null, {
+			...EMPTY_ROWS,
+			stats: statsRow({
+				numeric_stats: {
+					min_value: 40,
+					max_value: 40,
+					mean: 40,
+					stddev: 0,
+					skewness: null,
+					kurtosis: null,
+					cv: null,
+					mad: 0,
+					robust_cv: null,
+					percentiles: { p01: null, p25: 40, p50: 40, p75: 40, p99: null },
+				},
+				string_stats: { min_length: 2, max_length: 2, avg_length: 2 },
+				histogram: [{ bucket_min: 0, bucket_max: 100, count: 30 }],
+				top_values: [{ value: 40, count: 100, percentage: 1 }],
+			}),
+		});
+		// numeric_stats survives with the null leaves preserved.
+		expect(out.stats?.numeric_stats?.mean).toBe(40);
+		expect(out.stats?.numeric_stats?.percentiles).toEqual({
+			p01: null,
+			p25: 40,
+			p50: 40,
+			p75: 40,
+			p99: null,
+		});
+		// The sibling sub-blocks are NOT dropped.
+		expect(out.stats?.string_stats?.avg_length).toBe(2);
+		expect(out.stats?.histogram).toEqual([
+			{ bucket_min: 0, bucket_max: 100, count: 30 },
+		]);
+		expect(out.stats?.top_values).toEqual([
+			{ value: 40, count: 100, percentage: 1 },
+		]);
+	});
+
+	it("keeps the stats block when a histogram bucket edge is categorical (string)", () => {
+		// The engine types bucket_min/bucket_max `float | str` (models.py) — a
+		// string bucket must not be rejected and nuke the whole stats block.
+		const out = projectColumnProfile("c_1", "category", "orders", null, {
+			...EMPTY_ROWS,
+			stats: statsRow({
+				histogram: [
+					{ bucket_min: "A", bucket_max: "A", count: 12 },
+					{ bucket_min: "B", bucket_max: "B", count: 8 },
+				],
+				top_values: [{ value: "A", count: 12, percentage: 0.6 }],
+			}),
+		});
+		expect(out.stats?.histogram).toEqual([
+			{ bucket_min: "A", bucket_max: "A", count: 12 },
+			{ bucket_min: "B", bucket_max: "B", count: 8 },
+		]);
+		expect(out.stats?.top_values).toEqual([
+			{ value: "A", count: 12, percentage: 0.6 },
+		]);
+	});
+
 	it("caps top_values at 10", () => {
 		const many = Array.from({ length: 25 }, (_, i) => ({
 			value: `v${i}`,
@@ -221,13 +287,16 @@ describe("projectColumnProfile — stats JSONB parse + caps", () => {
 });
 
 describe("projectColumnProfile — type candidates", () => {
-	it("sorts by confidence desc and omits failed_examples", () => {
+	it("preserves the DB confidence-desc order and omits failed_examples", () => {
+		// Rows arrive already confidence-desc ordered from the DB
+		// (loadTypeCandidates `orderBy(desc(confidence))`); the projection trusts
+		// that order and does NOT re-sort.
 		const out = projectColumnProfile("c_1", "amount", "orders", null, {
 			...EMPTY_ROWS,
 			typeCandidates: [
-				candidate({ dataType: "VARCHAR", confidence: 0.3 }),
 				candidate({ dataType: "DECIMAL", confidence: 0.9 }),
 				candidate({ dataType: "INTEGER", confidence: 0.6 }),
+				candidate({ dataType: "VARCHAR", confidence: 0.3 }),
 			],
 		});
 		expect(out.type_candidates.map((c) => c.data_type)).toEqual([
@@ -237,20 +306,6 @@ describe("projectColumnProfile — type candidates", () => {
 		]);
 		// `failed_examples` is omitted — never present on the projected shape.
 		expect(out.type_candidates[0]).not.toHaveProperty("failed_examples");
-	});
-
-	it("sinks a null-confidence candidate to the bottom", () => {
-		const out = projectColumnProfile("c_1", "amount", "orders", null, {
-			...EMPTY_ROWS,
-			typeCandidates: [
-				candidate({ dataType: "UNKNOWN", confidence: null }),
-				candidate({ dataType: "DECIMAL", confidence: 0.9 }),
-			],
-		});
-		expect(out.type_candidates.map((c) => c.data_type)).toEqual([
-			"DECIMAL",
-			"UNKNOWN",
-		]);
 	});
 });
 

--- a/packages/cockpit/src/tools/look-profile.test.ts
+++ b/packages/cockpit/src/tools/look-profile.test.ts
@@ -1,0 +1,379 @@
+// Unit tests for look_profile's pure row→shape projection (DAT-475). No DB — the
+// Drizzle joins are smoke-covered; here we pin the JSONB parsing (numeric/string
+// stats, histogram, top_values, Benford, outlier samples), the null-degradation
+// of an absent block, the not-found shell, the caps (top_values ≤10, outlier
+// samples ≤10), the confidence-desc candidate sort + `failed_examples` omission,
+// the 0/1-int → bool coercion, the timestamp ISO serialization, and the
+// display-form table_name (no `src_<digest>__`).
+
+import { describe, expect, it, vi } from "vitest";
+
+// Importing the tool transitively pulls config.ts + the Postgres metadata client.
+// Mock both so this pure-helper test needs no env and opens no connection — and,
+// per registry.test.ts, set NO process.env (which would leak across files in a
+// reused worker and un-skip the gated integration tests).
+vi.mock("#/config", () => ({ config: {} }));
+vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
+
+import {
+	type ColumnProfileRows,
+	projectColumnProfile,
+	type StatsRow,
+	type TypeCandidateRow,
+} from "./look-profile";
+
+const EMPTY_ROWS: ColumnProfileRows = {
+	semantic: null,
+	stats: null,
+	typeCandidates: [],
+	typeDecision: null,
+	quality: null,
+	temporal: null,
+	derived: [],
+};
+
+function statsRow(profileData: unknown): StatsRow {
+	return {
+		totalCount: 100,
+		nullCount: 5,
+		distinctCount: 80,
+		nullRatio: 0.05,
+		cardinalityRatio: 0.8,
+		isUnique: 0,
+		isNumeric: 1,
+		profileData,
+	};
+}
+
+function candidate(
+	overrides: Partial<TypeCandidateRow> = {},
+): TypeCandidateRow {
+	return {
+		dataType: "INTEGER",
+		confidence: 0.5,
+		parseSuccessRate: 0.99,
+		detectedPattern: null,
+		patternMatchRate: null,
+		detectedUnit: null,
+		unitConfidence: null,
+		quarantineRate: 0.01,
+		...overrides,
+	};
+}
+
+describe("projectColumnProfile — identity + not-found (DAT-475)", () => {
+	it("strips the digest prefix to a display table_name; column_id stays the round-trip key", () => {
+		const DIGEST = "204bc8e118543a6c35654c1f68c43539a2e226f2";
+		const out = projectColumnProfile(
+			"c_1",
+			"amount",
+			`src_${DIGEST}__orders`,
+			"DECIMAL(18,2)",
+			EMPTY_ROWS,
+		);
+		expect(out.found).toBe(true);
+		expect(out.column_id).toBe("c_1");
+		expect(out.column_name).toBe("amount");
+		expect(out.table_name).toBe("orders");
+		expect(out.resolved_type).toBe("DECIMAL(18,2)");
+		// The digest appears NOWHERE in the projection.
+		expect(JSON.stringify(out)).not.toMatch(/src_[0-9a-f]{40}/);
+	});
+
+	it("degrades every block to null/empty when no stage has a promoted row", () => {
+		const out = projectColumnProfile(
+			"c_1",
+			"amount",
+			"orders",
+			null,
+			EMPTY_ROWS,
+		);
+		expect(out.semantic).toBeNull();
+		expect(out.stats).toBeNull();
+		expect(out.type_candidates).toEqual([]);
+		expect(out.type_decision).toBeNull();
+		expect(out.quality).toBeNull();
+		expect(out.temporal).toBeNull();
+		expect(out.derived).toEqual([]);
+	});
+});
+
+describe("projectColumnProfile — semantic + type decision", () => {
+	it("projects the semantic annotation", () => {
+		const out = projectColumnProfile("c_1", "amount", "orders", null, {
+			...EMPTY_ROWS,
+			semantic: {
+				businessConcept: "revenue",
+				semanticRole: "measure",
+				businessName: "Order Amount",
+				entityType: null,
+				temporalBehavior: null,
+				unitSourceColumn: "currency",
+			},
+		});
+		expect(out.semantic).toEqual({
+			business_concept: "revenue",
+			semantic_role: "measure",
+			business_name: "Order Amount",
+			entity_type: null,
+			temporal_behavior: null,
+			unit_source_column: "currency",
+		});
+	});
+
+	it("projects the type decision", () => {
+		const out = projectColumnProfile("c_1", "amount", "orders", null, {
+			...EMPTY_ROWS,
+			typeDecision: {
+				decidedType: "DECIMAL(18,2)",
+				decisionSource: "detector",
+				decisionReason: "high parse rate",
+				previousType: "VARCHAR",
+			},
+		});
+		expect(out.type_decision).toEqual({
+			decided_type: "DECIMAL(18,2)",
+			decision_source: "detector",
+			decision_reason: "high parse rate",
+			previous_type: "VARCHAR",
+		});
+	});
+});
+
+describe("projectColumnProfile — stats JSONB parse + caps", () => {
+	it("parses numeric/string stats, histogram, and top_values; coerces 0/1 flags", () => {
+		const out = projectColumnProfile("c_1", "amount", "orders", null, {
+			...EMPTY_ROWS,
+			stats: statsRow({
+				numeric_stats: {
+					min_value: 0,
+					max_value: 1000,
+					mean: 42.5,
+					stddev: 10.1,
+					skewness: 0.2,
+					kurtosis: 3.1,
+					cv: 0.24,
+					mad: 8,
+					robust_cv: 0.2,
+					percentiles: { p50: 40, p90: 200 },
+				},
+				string_stats: { min_length: 1, max_length: 12, avg_length: 6.5 },
+				histogram: [{ bucket_min: 0, bucket_max: 100, count: 30 }],
+				top_values: [{ value: "USD", count: 50, percentage: 0.5 }],
+			}),
+		});
+		expect(out.stats?.total_count).toBe(100);
+		expect(out.stats?.is_unique).toBe(false);
+		expect(out.stats?.is_numeric).toBe(true);
+		expect(out.stats?.numeric_stats?.mean).toBe(42.5);
+		expect(out.stats?.numeric_stats?.percentiles).toEqual({
+			p50: 40,
+			p90: 200,
+		});
+		expect(out.stats?.string_stats?.avg_length).toBe(6.5);
+		expect(out.stats?.histogram).toEqual([
+			{ bucket_min: 0, bucket_max: 100, count: 30 },
+		]);
+		expect(out.stats?.top_values).toEqual([
+			{ value: "USD", count: 50, percentage: 0.5 },
+		]);
+	});
+
+	it("caps top_values at 10", () => {
+		const many = Array.from({ length: 25 }, (_, i) => ({
+			value: `v${i}`,
+			count: 25 - i,
+			percentage: (25 - i) / 100,
+		}));
+		const out = projectColumnProfile("c_1", "amount", "orders", null, {
+			...EMPTY_ROWS,
+			stats: statsRow({ top_values: many }),
+		});
+		expect(out.stats?.top_values).toHaveLength(10);
+		expect(out.stats?.top_values[0]?.value).toBe("v0");
+	});
+
+	it("degrades a malformed profile_data blob to scalar-only stats (no throw)", () => {
+		const out = projectColumnProfile("c_1", "amount", "orders", null, {
+			...EMPTY_ROWS,
+			stats: statsRow("garbage-not-an-object"),
+		});
+		// The scalar columns still come through; the JSONB-derived blocks degrade.
+		expect(out.stats?.total_count).toBe(100);
+		expect(out.stats?.numeric_stats).toBeNull();
+		expect(out.stats?.string_stats).toBeNull();
+		expect(out.stats?.histogram).toEqual([]);
+		expect(out.stats?.top_values).toEqual([]);
+	});
+
+	it("handles an absent numeric_stats sub-block (string-only column)", () => {
+		const out = projectColumnProfile("c_1", "name", "orders", null, {
+			...EMPTY_ROWS,
+			stats: statsRow({
+				string_stats: { min_length: 2, max_length: 40, avg_length: 12 },
+			}),
+		});
+		expect(out.stats?.numeric_stats).toBeNull();
+		expect(out.stats?.string_stats?.max_length).toBe(40);
+		expect(out.stats?.histogram).toEqual([]);
+		expect(out.stats?.top_values).toEqual([]);
+	});
+});
+
+describe("projectColumnProfile — type candidates", () => {
+	it("sorts by confidence desc and omits failed_examples", () => {
+		const out = projectColumnProfile("c_1", "amount", "orders", null, {
+			...EMPTY_ROWS,
+			typeCandidates: [
+				candidate({ dataType: "VARCHAR", confidence: 0.3 }),
+				candidate({ dataType: "DECIMAL", confidence: 0.9 }),
+				candidate({ dataType: "INTEGER", confidence: 0.6 }),
+			],
+		});
+		expect(out.type_candidates.map((c) => c.data_type)).toEqual([
+			"DECIMAL",
+			"INTEGER",
+			"VARCHAR",
+		]);
+		// `failed_examples` is omitted — never present on the projected shape.
+		expect(out.type_candidates[0]).not.toHaveProperty("failed_examples");
+	});
+
+	it("sinks a null-confidence candidate to the bottom", () => {
+		const out = projectColumnProfile("c_1", "amount", "orders", null, {
+			...EMPTY_ROWS,
+			typeCandidates: [
+				candidate({ dataType: "UNKNOWN", confidence: null }),
+				candidate({ dataType: "DECIMAL", confidence: 0.9 }),
+			],
+		});
+		expect(out.type_candidates.map((c) => c.data_type)).toEqual([
+			"DECIMAL",
+			"UNKNOWN",
+		]);
+	});
+});
+
+describe("projectColumnProfile — quality JSONB parse + caps", () => {
+	it("parses Benford + outlier samples and coerces 0/1 flags", () => {
+		const out = projectColumnProfile("c_1", "amount", "orders", null, {
+			...EMPTY_ROWS,
+			quality: {
+				hasOutliers: 1,
+				iqrOutlierRatio: 0.02,
+				zscoreOutlierRatio: 0.01,
+				benfordCompliant: 0,
+				qualityData: {
+					benford_analysis: {
+						chi_square: 12.3,
+						p_value: 0.04,
+						is_compliant: false,
+						interpretation: "non-compliant",
+					},
+					outlier_detection: { outlier_samples: [999, 1000, 1001] },
+				},
+			},
+		});
+		expect(out.quality?.has_outliers).toBe(true);
+		expect(out.quality?.benford_compliant).toBe(false);
+		expect(out.quality?.benford).toEqual({
+			chi_square: 12.3,
+			p_value: 0.04,
+			is_compliant: false,
+			interpretation: "non-compliant",
+		});
+		expect(out.quality?.outlier_samples).toEqual([999, 1000, 1001]);
+	});
+
+	it("caps outlier_samples at 10", () => {
+		const samples = Array.from({ length: 30 }, (_, i) => i);
+		const out = projectColumnProfile("c_1", "amount", "orders", null, {
+			...EMPTY_ROWS,
+			quality: {
+				hasOutliers: 1,
+				iqrOutlierRatio: null,
+				zscoreOutlierRatio: null,
+				benfordCompliant: null,
+				qualityData: { outlier_detection: { outlier_samples: samples } },
+			},
+		});
+		expect(out.quality?.outlier_samples).toHaveLength(10);
+	});
+
+	it("degrades a malformed quality_data blob to scalar-only quality (no throw)", () => {
+		const out = projectColumnProfile("c_1", "amount", "orders", null, {
+			...EMPTY_ROWS,
+			quality: {
+				hasOutliers: 0,
+				iqrOutlierRatio: 0,
+				zscoreOutlierRatio: 0,
+				benfordCompliant: 1,
+				qualityData: 42,
+			},
+		});
+		expect(out.quality?.has_outliers).toBe(false);
+		expect(out.quality?.benford).toBeNull();
+		expect(out.quality?.outlier_samples).toEqual([]);
+	});
+});
+
+describe("projectColumnProfile — temporal + derived", () => {
+	it("serializes timestamps to ISO strings", () => {
+		const min = new Date("2020-01-01T00:00:00.000Z");
+		const max = new Date("2021-12-31T00:00:00.000Z");
+		const out = projectColumnProfile("c_1", "order_date", "orders", null, {
+			...EMPTY_ROWS,
+			temporal: {
+				minTimestamp: min,
+				maxTimestamp: max,
+				detectedGranularity: "day",
+				completenessRatio: 0.97,
+				hasSeasonality: true,
+				hasTrend: false,
+				isStale: false,
+			},
+		});
+		expect(out.temporal?.min_timestamp).toBe("2020-01-01T00:00:00.000Z");
+		expect(out.temporal?.max_timestamp).toBe("2021-12-31T00:00:00.000Z");
+		expect(out.temporal?.granularity).toBe("day");
+		expect(out.temporal?.completeness).toBe(0.97);
+		expect(out.temporal?.has_seasonality).toBe(true);
+	});
+
+	it("tolerates a null timestamp", () => {
+		const out = projectColumnProfile("c_1", "order_date", "orders", null, {
+			...EMPTY_ROWS,
+			temporal: {
+				minTimestamp: null,
+				maxTimestamp: null,
+				detectedGranularity: null,
+				completenessRatio: null,
+				hasSeasonality: null,
+				hasTrend: null,
+				isStale: null,
+			},
+		});
+		expect(out.temporal?.min_timestamp).toBeNull();
+		expect(out.temporal?.max_timestamp).toBeNull();
+	});
+
+	it("projects derived columns (formula + match rate)", () => {
+		const out = projectColumnProfile("c_1", "total", "orders", null, {
+			...EMPTY_ROWS,
+			derived: [
+				{
+					derivationType: "arithmetic",
+					formula: "qty * price",
+					matchRate: 0.98,
+				},
+			],
+		});
+		expect(out.derived).toEqual([
+			{
+				derivation_type: "arithmetic",
+				formula: "qty * price",
+				match_rate: 0.98,
+			},
+		]);
+	});
+});

--- a/packages/cockpit/src/tools/look-profile.ts
+++ b/packages/cockpit/src/tools/look-profile.ts
@@ -1,0 +1,719 @@
+// look_profile tool (DAT-475) — one column's heavy descriptive profile.
+//
+// The cockpit analog of the MCP `look(target="table.column")`: the per-column
+// deep dive that aggregates every promoted per-column artifact the engine
+// persists — semantic annotation, the statistical profile (numeric / string /
+// histogram / top values), the type candidates + decision, the statistical
+// quality metrics (outliers + Benford), the temporal profile, and any derived
+// columns that point AT this column. Each block reads from a `current_*` view,
+// so it reflects the latest promoted run — the view's head-join lives in the
+// database (ADR-0008/DAT-453); no run plumbing here.
+//
+// Read-only → no approval. A column with no promoted artifact for a given stage
+// gets a null/empty block for it; an unknown column_id returns the empty shell
+// with `found:false` (the look_table not-found signal — NOT the `{error}`
+// envelope). The heavy JSONB blobs (`profileData`, `qualityData`) are parsed
+// LENIENTLY (zod `safeParse`): a malformed/absent blob degrades to null/empty,
+// never throws. The DB joins are smoke-covered; the pure `projectColumnProfile`
+// is unit-tested directly here.
+
+import { toolDefinition } from "@tanstack/ai";
+import { desc, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { metadataDb } from "../db/metadata/client";
+import {
+	columns,
+	currentDerivedColumns,
+	currentSemanticAnnotations,
+	currentStatisticalProfiles,
+	currentStatisticalQualityMetrics,
+	currentTemporalColumnProfiles,
+	currentTypeCandidates,
+	currentTypeDecisions,
+	tables,
+} from "../db/metadata/schema";
+import { displayTableName } from "../lib/display-names";
+
+// How many entries of an unbounded sample list to surface — caps keep the heavy
+// profile from dumping an arbitrarily long list into the agent's context.
+const MAX_SAMPLE = 10;
+
+// --- The lenient JSONB grammars. Each `safeParse`d at the projection so a
+// malformed/absent blob degrades to null/empty rather than throwing.
+
+const NumericStats = z.object({
+	min_value: z.number().nullable().optional(),
+	max_value: z.number().nullable().optional(),
+	mean: z.number().nullable().optional(),
+	stddev: z.number().nullable().optional(),
+	skewness: z.number().nullable().optional(),
+	kurtosis: z.number().nullable().optional(),
+	cv: z.number().nullable().optional(),
+	mad: z.number().nullable().optional(),
+	robust_cv: z.number().nullable().optional(),
+	percentiles: z.record(z.string(), z.number()).nullable().optional(),
+});
+
+const StringStats = z.object({
+	min_length: z.number().nullable().optional(),
+	max_length: z.number().nullable().optional(),
+	avg_length: z.number().nullable().optional(),
+});
+
+const HistogramBucket = z.object({
+	bucket_min: z.number().nullable().optional(),
+	bucket_max: z.number().nullable().optional(),
+	count: z.number().nullable().optional(),
+});
+
+const TopValue = z.object({
+	value: z.unknown(),
+	count: z.number().nullable().optional(),
+	percentage: z.number().nullable().optional(),
+});
+
+// The whole `statistical_profiles.profile_data` blob — every block optional so a
+// numeric-only or string-only column parses cleanly.
+const ProfileData = z.object({
+	numeric_stats: NumericStats.nullable().optional(),
+	string_stats: StringStats.nullable().optional(),
+	histogram: z.array(HistogramBucket).nullable().optional(),
+	top_values: z.array(TopValue).nullable().optional(),
+});
+
+const BenfordAnalysis = z.object({
+	chi_square: z.number().nullable().optional(),
+	p_value: z.number().nullable().optional(),
+	is_compliant: z.boolean().nullable().optional(),
+	interpretation: z.string().nullable().optional(),
+});
+
+const OutlierSample = z.unknown();
+
+// The `statistical_quality_metrics.quality_data` blob — the Benford analysis +
+// outlier samples live under their detector sub-objects.
+const QualityData = z.object({
+	benford_analysis: BenfordAnalysis.nullable().optional(),
+	outlier_detection: z
+		.object({ outlier_samples: z.array(OutlierSample).nullable().optional() })
+		.nullable()
+		.optional(),
+});
+
+// --- The tool output shape.
+
+const Semantic = z.object({
+	business_concept: z.string().nullable(),
+	semantic_role: z.string().nullable(),
+	business_name: z.string().nullable(),
+	entity_type: z.string().nullable(),
+	temporal_behavior: z.string().nullable(),
+	unit_source_column: z.string().nullable(),
+});
+
+const Stats = z.object({
+	total_count: z.number().nullable(),
+	null_count: z.number().nullable(),
+	distinct_count: z.number().nullable(),
+	null_ratio: z.number().nullable(),
+	cardinality_ratio: z.number().nullable(),
+	is_unique: z.boolean().nullable(),
+	is_numeric: z.boolean().nullable(),
+	numeric_stats: z
+		.object({
+			min_value: z.number().nullable(),
+			max_value: z.number().nullable(),
+			mean: z.number().nullable(),
+			stddev: z.number().nullable(),
+			skewness: z.number().nullable(),
+			kurtosis: z.number().nullable(),
+			cv: z.number().nullable(),
+			mad: z.number().nullable(),
+			robust_cv: z.number().nullable(),
+			percentiles: z.record(z.string(), z.number()).nullable(),
+		})
+		.nullable(),
+	string_stats: z
+		.object({
+			min_length: z.number().nullable(),
+			max_length: z.number().nullable(),
+			avg_length: z.number().nullable(),
+		})
+		.nullable(),
+	histogram: z.array(
+		z.object({
+			bucket_min: z.number().nullable(),
+			bucket_max: z.number().nullable(),
+			count: z.number().nullable(),
+		}),
+	),
+	top_values: z.array(
+		z.object({
+			value: z.unknown(),
+			count: z.number().nullable(),
+			percentage: z.number().nullable(),
+		}),
+	),
+});
+export type ProfileStats = z.infer<typeof Stats>;
+
+const TypeCandidate = z.object({
+	data_type: z.string().nullable(),
+	confidence: z.number().nullable(),
+	parse_success_rate: z.number().nullable(),
+	detected_pattern: z.string().nullable(),
+	pattern_match_rate: z.number().nullable(),
+	detected_unit: z.string().nullable(),
+	unit_confidence: z.number().nullable(),
+	quarantine_rate: z.number().nullable(),
+});
+export type ProfileTypeCandidate = z.infer<typeof TypeCandidate>;
+
+const TypeDecision = z.object({
+	decided_type: z.string().nullable(),
+	decision_source: z.string().nullable(),
+	decision_reason: z.string().nullable(),
+	previous_type: z.string().nullable(),
+});
+
+const Quality = z.object({
+	has_outliers: z.boolean().nullable(),
+	iqr_outlier_ratio: z.number().nullable(),
+	zscore_outlier_ratio: z.number().nullable(),
+	benford_compliant: z.boolean().nullable(),
+	benford: z
+		.object({
+			chi_square: z.number().nullable(),
+			p_value: z.number().nullable(),
+			is_compliant: z.boolean().nullable(),
+			interpretation: z.string().nullable(),
+		})
+		.nullable(),
+	outlier_samples: z.array(z.unknown()),
+});
+export type ProfileQuality = z.infer<typeof Quality>;
+
+const Temporal = z.object({
+	// ISO strings — the engine persists these as timestamps; serialized at the edge.
+	min_timestamp: z.string().nullable(),
+	max_timestamp: z.string().nullable(),
+	granularity: z.string().nullable(),
+	completeness: z.number().nullable(),
+	has_seasonality: z.boolean().nullable(),
+	has_trend: z.boolean().nullable(),
+	is_stale: z.boolean().nullable(),
+});
+
+const Derived = z.object({
+	derivation_type: z.string().nullable(),
+	formula: z.string().nullable(),
+	match_rate: z.number().nullable(),
+});
+export type ProfileDerived = z.infer<typeof Derived>;
+
+const LookProfileResult = z.object({
+	// False when column_id matched no column — return the empty shell (the
+	// look_table not-found signal, NOT the `{error}` envelope).
+	found: z.boolean(),
+	column_id: z.string(),
+	column_name: z.string(),
+	// Display form (`src_<digest>__` prefix stripped, DAT-433) — for prose. The
+	// round-trip key stays column_id; never surface the raw physical name here.
+	table_name: z.string(),
+	resolved_type: z.string().nullable(),
+	semantic: Semantic.nullable(),
+	stats: Stats.nullable(),
+	type_candidates: z.array(TypeCandidate),
+	type_decision: TypeDecision.nullable(),
+	quality: Quality.nullable(),
+	temporal: Temporal.nullable(),
+	derived: z.array(Derived),
+});
+export type LookProfileResult = z.infer<typeof LookProfileResult>;
+
+// --- The raw Drizzle row shapes (one per `current_*` read).
+
+export interface SemanticRow {
+	businessConcept: string | null;
+	semanticRole: string | null;
+	businessName: string | null;
+	entityType: string | null;
+	temporalBehavior: string | null;
+	unitSourceColumn: string | null;
+}
+
+export interface StatsRow {
+	totalCount: number | null;
+	nullCount: number | null;
+	distinctCount: number | null;
+	nullRatio: number | null;
+	cardinalityRatio: number | null;
+	isUnique: number | null;
+	isNumeric: number | null;
+	profileData: unknown;
+}
+
+export interface TypeCandidateRow {
+	dataType: string | null;
+	confidence: number | null;
+	parseSuccessRate: number | null;
+	detectedPattern: string | null;
+	patternMatchRate: number | null;
+	detectedUnit: string | null;
+	unitConfidence: number | null;
+	quarantineRate: number | null;
+}
+
+export interface TypeDecisionRow {
+	decidedType: string | null;
+	decisionSource: string | null;
+	decisionReason: string | null;
+	previousType: string | null;
+}
+
+export interface QualityRow {
+	hasOutliers: number | null;
+	iqrOutlierRatio: number | null;
+	zscoreOutlierRatio: number | null;
+	benfordCompliant: number | null;
+	qualityData: unknown;
+}
+
+export interface TemporalRow {
+	minTimestamp: Date | string | null;
+	maxTimestamp: Date | string | null;
+	detectedGranularity: string | null;
+	completenessRatio: number | null;
+	hasSeasonality: boolean | null;
+	hasTrend: boolean | null;
+	isStale: boolean | null;
+}
+
+export interface DerivedRow {
+	derivationType: string | null;
+	formula: string | null;
+	matchRate: number | null;
+}
+
+/** The seven per-column reads gathered for one column (any may be absent). */
+export interface ColumnProfileRows {
+	semantic: SemanticRow | null;
+	stats: StatsRow | null;
+	typeCandidates: TypeCandidateRow[];
+	typeDecision: TypeDecisionRow | null;
+	quality: QualityRow | null;
+	temporal: TemporalRow | null;
+	derived: DerivedRow[];
+}
+
+/** Coerce the engine's 0/1 integer flags (DuckDB has no bool in these views) to
+ * a tri-state boolean; null stays null. */
+function intToBool(v: number | null | undefined): boolean | null {
+	return v === null || v === undefined ? null : v !== 0;
+}
+
+/** Serialize a timestamp value (Drizzle hands back a Date for `timestamp`
+ * columns; a raw string can slip through) to an ISO string; null stays null. */
+function toIso(v: Date | string | null | undefined): string | null {
+	if (v === null || v === undefined) return null;
+	if (v instanceof Date) return v.toISOString();
+	const d = new Date(v);
+	return Number.isNaN(d.getTime()) ? String(v) : d.toISOString();
+}
+
+function projectSemantic(
+	row: SemanticRow | null,
+): z.infer<typeof Semantic> | null {
+	if (!row) return null;
+	return {
+		business_concept: row.businessConcept ?? null,
+		semantic_role: row.semanticRole ?? null,
+		business_name: row.businessName ?? null,
+		entity_type: row.entityType ?? null,
+		temporal_behavior: row.temporalBehavior ?? null,
+		unit_source_column: row.unitSourceColumn ?? null,
+	};
+}
+
+function projectStats(row: StatsRow | null): ProfileStats | null {
+	if (!row) return null;
+	const parsed = ProfileData.safeParse(row.profileData);
+	const data = parsed.success ? parsed.data : {};
+
+	const n = data.numeric_stats;
+	const s = data.string_stats;
+	const histogram = Array.isArray(data.histogram) ? data.histogram : [];
+	const top = Array.isArray(data.top_values) ? data.top_values : [];
+
+	return {
+		total_count: row.totalCount ?? null,
+		null_count: row.nullCount ?? null,
+		distinct_count: row.distinctCount ?? null,
+		null_ratio: row.nullRatio ?? null,
+		cardinality_ratio: row.cardinalityRatio ?? null,
+		is_unique: intToBool(row.isUnique),
+		is_numeric: intToBool(row.isNumeric),
+		numeric_stats: n
+			? {
+					min_value: n.min_value ?? null,
+					max_value: n.max_value ?? null,
+					mean: n.mean ?? null,
+					stddev: n.stddev ?? null,
+					skewness: n.skewness ?? null,
+					kurtosis: n.kurtosis ?? null,
+					cv: n.cv ?? null,
+					mad: n.mad ?? null,
+					robust_cv: n.robust_cv ?? null,
+					percentiles: n.percentiles ?? null,
+				}
+			: null,
+		string_stats: s
+			? {
+					min_length: s.min_length ?? null,
+					max_length: s.max_length ?? null,
+					avg_length: s.avg_length ?? null,
+				}
+			: null,
+		histogram: histogram.map((b) => ({
+			bucket_min: b.bucket_min ?? null,
+			bucket_max: b.bucket_max ?? null,
+			count: b.count ?? null,
+		})),
+		// Cap the top values at MAX_SAMPLE — an unbounded distinct-value list would
+		// flood the agent's context.
+		top_values: top.slice(0, MAX_SAMPLE).map((v) => ({
+			value: v.value ?? null,
+			count: v.count ?? null,
+			percentage: v.percentage ?? null,
+		})),
+	};
+}
+
+function projectTypeCandidates(
+	rows: TypeCandidateRow[],
+): ProfileTypeCandidate[] {
+	// Sort by confidence desc (a null confidence sinks to the bottom); `failed_examples`
+	// is deliberately omitted — it's noisy raw input the agent doesn't need.
+	return [...rows]
+		.sort((a, b) => (b.confidence ?? -1) - (a.confidence ?? -1))
+		.map((r) => ({
+			data_type: r.dataType ?? null,
+			confidence: r.confidence ?? null,
+			parse_success_rate: r.parseSuccessRate ?? null,
+			detected_pattern: r.detectedPattern ?? null,
+			pattern_match_rate: r.patternMatchRate ?? null,
+			detected_unit: r.detectedUnit ?? null,
+			unit_confidence: r.unitConfidence ?? null,
+			quarantine_rate: r.quarantineRate ?? null,
+		}));
+}
+
+function projectTypeDecision(
+	row: TypeDecisionRow | null,
+): z.infer<typeof TypeDecision> | null {
+	if (!row) return null;
+	return {
+		decided_type: row.decidedType ?? null,
+		decision_source: row.decisionSource ?? null,
+		decision_reason: row.decisionReason ?? null,
+		previous_type: row.previousType ?? null,
+	};
+}
+
+function projectQuality(row: QualityRow | null): ProfileQuality | null {
+	if (!row) return null;
+	const parsed = QualityData.safeParse(row.qualityData);
+	const data = parsed.success ? parsed.data : {};
+	const benford = data.benford_analysis;
+	const samples = Array.isArray(data.outlier_detection?.outlier_samples)
+		? data.outlier_detection.outlier_samples
+		: [];
+	return {
+		has_outliers: intToBool(row.hasOutliers),
+		iqr_outlier_ratio: row.iqrOutlierRatio ?? null,
+		zscore_outlier_ratio: row.zscoreOutlierRatio ?? null,
+		benford_compliant: intToBool(row.benfordCompliant),
+		benford: benford
+			? {
+					chi_square: benford.chi_square ?? null,
+					p_value: benford.p_value ?? null,
+					is_compliant: benford.is_compliant ?? null,
+					interpretation: benford.interpretation ?? null,
+				}
+			: null,
+		// Cap the outlier samples at MAX_SAMPLE.
+		outlier_samples: samples.slice(0, MAX_SAMPLE),
+	};
+}
+
+function projectTemporal(
+	row: TemporalRow | null,
+): z.infer<typeof Temporal> | null {
+	if (!row) return null;
+	return {
+		min_timestamp: toIso(row.minTimestamp),
+		max_timestamp: toIso(row.maxTimestamp),
+		granularity: row.detectedGranularity ?? null,
+		completeness: row.completenessRatio ?? null,
+		has_seasonality: row.hasSeasonality ?? null,
+		has_trend: row.hasTrend ?? null,
+		is_stale: row.isStale ?? null,
+	};
+}
+
+function projectDerived(rows: DerivedRow[]): ProfileDerived[] {
+	return rows.map((r) => ({
+		derivation_type: r.derivationType ?? null,
+		formula: r.formula ?? null,
+		match_rate: r.matchRate ?? null,
+	}));
+}
+
+/**
+ * Assemble the full profile from the resolved pieces. Pure (no DB) so the
+ * JSONB-parse + null-degradation + cap logic is unit-testable without a live
+ * schema. Every block degrades to null/empty when its stage has no promoted row;
+ * a malformed JSONB blob degrades to null/empty rather than throwing. `rawTableName`
+ * is the physical name — stripped to display form (DAT-433); the round-trip key
+ * stays column_id.
+ */
+export function projectColumnProfile(
+	columnId: string,
+	columnName: string,
+	rawTableName: string | null,
+	resolvedType: string | null,
+	rows: ColumnProfileRows,
+): LookProfileResult {
+	return {
+		found: true,
+		column_id: columnId,
+		column_name: columnName,
+		table_name: rawTableName === null ? "" : displayTableName(rawTableName),
+		resolved_type: resolvedType,
+		semantic: projectSemantic(rows.semantic),
+		stats: projectStats(rows.stats),
+		type_candidates: projectTypeCandidates(rows.typeCandidates),
+		type_decision: projectTypeDecision(rows.typeDecision),
+		quality: projectQuality(rows.quality),
+		temporal: projectTemporal(rows.temporal),
+		derived: projectDerived(rows.derived),
+	};
+}
+
+/** The empty not-found shell for an unknown column_id (NOT the `{error}`
+ * envelope — the look_table `found:false` signal). */
+function notFound(columnId: string): LookProfileResult {
+	return {
+		found: false,
+		column_id: columnId,
+		column_name: "",
+		table_name: "",
+		resolved_type: null,
+		semantic: null,
+		stats: null,
+		type_candidates: [],
+		type_decision: null,
+		quality: null,
+		temporal: null,
+		derived: [],
+	};
+}
+
+/** The heavy per-column descriptive profile: every promoted per-column artifact
+ * for one column, aggregated. */
+export async function lookProfile(input: {
+	column_id: string;
+}): Promise<LookProfileResult> {
+	// Resolve the column + its table first (mirror look_table's identity read) —
+	// even an unprofiled column has a name and a resolved type.
+	const [col] = await metadataDb
+		.select({
+			columnId: columns.columnId,
+			columnName: columns.columnName,
+			resolvedType: columns.resolvedType,
+			tableName: tables.tableName,
+		})
+		.from(columns)
+		.innerJoin(tables, eq(tables.tableId, columns.tableId))
+		.where(eq(columns.columnId, input.column_id))
+		.limit(1);
+
+	if (!col) {
+		// Unknown column id — return the empty shell, not an error, so the agent can
+		// say "no such column" cleanly rather than surfacing a tool failure.
+		return notFound(input.column_id);
+	}
+
+	// The seven per-column reads share no input once the column is known — fan
+	// them out. Each `current_*` view IS the promoted run (the head join lives in
+	// the database, ADR-0008/DAT-453), so a plain by-columnId read suffices; a
+	// stage with no promoted row simply returns nothing → a null/empty block.
+	const [
+		semantic,
+		stats,
+		typeCandidates,
+		typeDecision,
+		quality,
+		temporal,
+		derived,
+	] = await Promise.all([
+		loadSemantic(input.column_id),
+		loadStats(input.column_id),
+		loadTypeCandidates(input.column_id),
+		loadTypeDecision(input.column_id),
+		loadQuality(input.column_id),
+		loadTemporal(input.column_id),
+		loadDerived(input.column_id),
+	]);
+
+	return projectColumnProfile(
+		col.columnId ?? input.column_id,
+		col.columnName ?? "",
+		col.tableName ?? null,
+		col.resolvedType ?? null,
+		{
+			semantic,
+			stats,
+			typeCandidates,
+			typeDecision,
+			quality,
+			temporal,
+			derived,
+		},
+	);
+}
+
+async function loadSemantic(columnId: string): Promise<SemanticRow | null> {
+	const [row] = await metadataDb
+		.select({
+			businessConcept: currentSemanticAnnotations.businessConcept,
+			semanticRole: currentSemanticAnnotations.semanticRole,
+			businessName: currentSemanticAnnotations.businessName,
+			entityType: currentSemanticAnnotations.entityType,
+			temporalBehavior: currentSemanticAnnotations.temporalBehavior,
+			unitSourceColumn: currentSemanticAnnotations.unitSourceColumn,
+		})
+		.from(currentSemanticAnnotations)
+		.where(eq(currentSemanticAnnotations.columnId, columnId))
+		.limit(1);
+	return row ?? null;
+}
+
+async function loadStats(columnId: string): Promise<StatsRow | null> {
+	const [row] = await metadataDb
+		.select({
+			totalCount: currentStatisticalProfiles.totalCount,
+			nullCount: currentStatisticalProfiles.nullCount,
+			distinctCount: currentStatisticalProfiles.distinctCount,
+			nullRatio: currentStatisticalProfiles.nullRatio,
+			cardinalityRatio: currentStatisticalProfiles.cardinalityRatio,
+			isUnique: currentStatisticalProfiles.isUnique,
+			isNumeric: currentStatisticalProfiles.isNumeric,
+			profileData: currentStatisticalProfiles.profileData,
+		})
+		.from(currentStatisticalProfiles)
+		.where(eq(currentStatisticalProfiles.columnId, columnId))
+		.limit(1);
+	return row ?? null;
+}
+
+async function loadTypeCandidates(
+	columnId: string,
+): Promise<TypeCandidateRow[]> {
+	return metadataDb
+		.select({
+			dataType: currentTypeCandidates.dataType,
+			confidence: currentTypeCandidates.confidence,
+			parseSuccessRate: currentTypeCandidates.parseSuccessRate,
+			detectedPattern: currentTypeCandidates.detectedPattern,
+			patternMatchRate: currentTypeCandidates.patternMatchRate,
+			detectedUnit: currentTypeCandidates.detectedUnit,
+			unitConfidence: currentTypeCandidates.unitConfidence,
+			quarantineRate: currentTypeCandidates.quarantineRate,
+		})
+		.from(currentTypeCandidates)
+		.where(eq(currentTypeCandidates.columnId, columnId))
+		.orderBy(desc(currentTypeCandidates.confidence));
+}
+
+async function loadTypeDecision(
+	columnId: string,
+): Promise<TypeDecisionRow | null> {
+	const [row] = await metadataDb
+		.select({
+			decidedType: currentTypeDecisions.decidedType,
+			decisionSource: currentTypeDecisions.decisionSource,
+			decisionReason: currentTypeDecisions.decisionReason,
+			previousType: currentTypeDecisions.previousType,
+		})
+		.from(currentTypeDecisions)
+		.where(eq(currentTypeDecisions.columnId, columnId))
+		.limit(1);
+	return row ?? null;
+}
+
+async function loadQuality(columnId: string): Promise<QualityRow | null> {
+	const [row] = await metadataDb
+		.select({
+			hasOutliers: currentStatisticalQualityMetrics.hasOutliers,
+			iqrOutlierRatio: currentStatisticalQualityMetrics.iqrOutlierRatio,
+			zscoreOutlierRatio: currentStatisticalQualityMetrics.zscoreOutlierRatio,
+			benfordCompliant: currentStatisticalQualityMetrics.benfordCompliant,
+			qualityData: currentStatisticalQualityMetrics.qualityData,
+		})
+		.from(currentStatisticalQualityMetrics)
+		.where(eq(currentStatisticalQualityMetrics.columnId, columnId))
+		.limit(1);
+	return row ?? null;
+}
+
+async function loadTemporal(columnId: string): Promise<TemporalRow | null> {
+	const [row] = await metadataDb
+		.select({
+			minTimestamp: currentTemporalColumnProfiles.minTimestamp,
+			maxTimestamp: currentTemporalColumnProfiles.maxTimestamp,
+			detectedGranularity: currentTemporalColumnProfiles.detectedGranularity,
+			completenessRatio: currentTemporalColumnProfiles.completenessRatio,
+			hasSeasonality: currentTemporalColumnProfiles.hasSeasonality,
+			hasTrend: currentTemporalColumnProfiles.hasTrend,
+			isStale: currentTemporalColumnProfiles.isStale,
+		})
+		.from(currentTemporalColumnProfiles)
+		.where(eq(currentTemporalColumnProfiles.columnId, columnId))
+		.limit(1);
+	return row ?? null;
+}
+
+async function loadDerived(columnId: string): Promise<DerivedRow[]> {
+	// `derived_column_id` is the column this derived column IS — i.e. the rows
+	// where THIS column was synthesized from others (formula + match rate).
+	return metadataDb
+		.select({
+			derivationType: currentDerivedColumns.derivationType,
+			formula: currentDerivedColumns.formula,
+			matchRate: currentDerivedColumns.matchRate,
+		})
+		.from(currentDerivedColumns)
+		.where(eq(currentDerivedColumns.derivedColumnId, columnId));
+}
+
+export const lookProfileTool = toolDefinition({
+	name: "look_profile",
+	description:
+		"Show ONE column's full descriptive profile — its semantic annotation, " +
+		"statistical profile (counts, null/cardinality ratios, numeric/string stats, " +
+		"histogram, top values), type candidates + the type decision, statistical " +
+		"quality (outliers + Benford), the temporal profile (if it's a time column), " +
+		"and any derived-column formula targeting it. Read-only; reflects the latest " +
+		"promoted analysis. Identify the column by its column_id (from look_table). " +
+		"A block is null/empty when that stage hasn't run for the column. Use " +
+		"look_table for the at-a-glance readiness grid and why_column to EXPLAIN a " +
+		"band; look_profile is the raw per-column descriptive deep-dive.",
+	inputSchema: z.object({
+		column_id: z
+			.string()
+			.describe("The column to profile (a column_id from look_table)."),
+	}),
+	outputSchema: LookProfileResult,
+}).server((input) => lookProfile(input));

--- a/packages/cockpit/src/tools/look-profile.ts
+++ b/packages/cockpit/src/tools/look-profile.ts
@@ -52,7 +52,14 @@ const NumericStats = z.object({
 	cv: z.number().nullable().optional(),
 	mad: z.number().nullable().optional(),
 	robust_cv: z.number().nullable().optional(),
-	percentiles: z.record(z.string(), z.number()).nullable().optional(),
+	// Percentile VALUES are nullable: the engine wraps each in `_finite_or_none`
+	// (profiler.py) → null on a NaN/Inf/degenerate column. A non-nullable value
+	// would fail the whole ProfileData parse and silently drop the entire stats
+	// block (numeric/string/histogram/top_values all empty).
+	percentiles: z
+		.record(z.string(), z.number().nullable())
+		.nullable()
+		.optional(),
 });
 
 const StringStats = z.object({
@@ -62,8 +69,12 @@ const StringStats = z.object({
 });
 
 const HistogramBucket = z.object({
-	bucket_min: z.number().nullable().optional(),
-	bucket_max: z.number().nullable().optional(),
+	// The engine types these `float | str` (HistogramBucket, models.py) — numeric
+	// buckets carry edges, categorical buckets carry the category label. A
+	// number-only schema would reject a string bucket and silently drop the whole
+	// stats block, exactly like the nullable-percentile bug.
+	bucket_min: z.union([z.number(), z.string()]).nullable().optional(),
+	bucket_max: z.union([z.number(), z.string()]).nullable().optional(),
 	count: z.number().nullable().optional(),
 });
 
@@ -131,7 +142,9 @@ const Stats = z.object({
 			cv: z.number().nullable(),
 			mad: z.number().nullable(),
 			robust_cv: z.number().nullable(),
-			percentiles: z.record(z.string(), z.number()).nullable(),
+			// Values nullable to match the input grammar — a null percentile leaf
+			// must survive @tanstack/ai outputSchema validation, not blow up.
+			percentiles: z.record(z.string(), z.number().nullable()).nullable(),
 		})
 		.nullable(),
 	string_stats: z
@@ -143,8 +156,9 @@ const Stats = z.object({
 		.nullable(),
 	histogram: z.array(
 		z.object({
-			bucket_min: z.number().nullable(),
-			bucket_max: z.number().nullable(),
+			// number-or-string to match the input grammar (categorical buckets).
+			bucket_min: z.union([z.number(), z.string()]).nullable(),
+			bucket_max: z.union([z.number(), z.string()]).nullable(),
 			count: z.number().nullable(),
 		}),
 	),
@@ -393,20 +407,19 @@ function projectStats(row: StatsRow | null): ProfileStats | null {
 function projectTypeCandidates(
 	rows: TypeCandidateRow[],
 ): ProfileTypeCandidate[] {
-	// Sort by confidence desc (a null confidence sinks to the bottom); `failed_examples`
-	// is deliberately omitted — it's noisy raw input the agent doesn't need.
-	return [...rows]
-		.sort((a, b) => (b.confidence ?? -1) - (a.confidence ?? -1))
-		.map((r) => ({
-			data_type: r.dataType ?? null,
-			confidence: r.confidence ?? null,
-			parse_success_rate: r.parseSuccessRate ?? null,
-			detected_pattern: r.detectedPattern ?? null,
-			pattern_match_rate: r.patternMatchRate ?? null,
-			detected_unit: r.detectedUnit ?? null,
-			unit_confidence: r.unitConfidence ?? null,
-			quarantine_rate: r.quarantineRate ?? null,
-		}));
+	// Rows arrive already confidence-desc ordered from the DB (`orderBy(desc(confidence))`
+	// in loadTypeCandidates) — trust that order, don't re-sort. `failed_examples` is
+	// deliberately omitted — it's noisy raw input the agent doesn't need.
+	return rows.map((r) => ({
+		data_type: r.dataType ?? null,
+		confidence: r.confidence ?? null,
+		parse_success_rate: r.parseSuccessRate ?? null,
+		detected_pattern: r.detectedPattern ?? null,
+		pattern_match_rate: r.patternMatchRate ?? null,
+		detected_unit: r.detectedUnit ?? null,
+		unit_confidence: r.unitConfidence ?? null,
+		quarantine_rate: r.quarantineRate ?? null,
+	}));
 }
 
 function projectTypeDecision(
@@ -621,6 +634,9 @@ async function loadStats(columnId: string): Promise<StatsRow | null> {
 async function loadTypeCandidates(
 	columnId: string,
 ): Promise<TypeCandidateRow[]> {
+	// `.limit(MAX_SAMPLE)` caps at the query level (defense-in-depth, like
+	// top_values/outlier_samples) so a pathological column can't dump an unbounded
+	// candidate list into context; `.orderBy(desc(confidence))` keeps the cap meaningful.
 	return metadataDb
 		.select({
 			dataType: currentTypeCandidates.dataType,
@@ -634,7 +650,8 @@ async function loadTypeCandidates(
 		})
 		.from(currentTypeCandidates)
 		.where(eq(currentTypeCandidates.columnId, columnId))
-		.orderBy(desc(currentTypeCandidates.confidence));
+		.orderBy(desc(currentTypeCandidates.confidence))
+		.limit(MAX_SAMPLE);
 }
 
 async function loadTypeDecision(
@@ -688,6 +705,12 @@ async function loadTemporal(columnId: string): Promise<TemporalRow | null> {
 async function loadDerived(columnId: string): Promise<DerivedRow[]> {
 	// `derived_column_id` is the column this derived column IS — i.e. the rows
 	// where THIS column was synthesized from others (formula + match rate).
+	//
+	// `current_derived_columns` is SESSION-grain (head-joined on `session:{id}`),
+	// so across multiple sessions the same derived column yields several rows.
+	// Order by `computed_at` desc so the read is DETERMINISTIC (latest first, not
+	// arbitrary), and cap at MAX_SAMPLE so it stays bounded. (Cross-lane guard —
+	// DAT-476/477/478 share this session-grain class.)
 	return metadataDb
 		.select({
 			derivationType: currentDerivedColumns.derivationType,
@@ -695,7 +718,9 @@ async function loadDerived(columnId: string): Promise<DerivedRow[]> {
 			matchRate: currentDerivedColumns.matchRate,
 		})
 		.from(currentDerivedColumns)
-		.where(eq(currentDerivedColumns.derivedColumnId, columnId));
+		.where(eq(currentDerivedColumns.derivedColumnId, columnId))
+		.orderBy(desc(currentDerivedColumns.computedAt))
+		.limit(MAX_SAMPLE);
 }
 
 export const lookProfileTool = toolDefinition({

--- a/packages/cockpit/src/tools/registry.test.ts
+++ b/packages/cockpit/src/tools/registry.test.ts
@@ -32,6 +32,7 @@ describe("tool registry (DAT-353)", () => {
 				"list_tables",
 				"list_verticals",
 				"look_table",
+				"look_profile",
 				"why_column",
 				"why_table",
 				"look_relationships",
@@ -76,6 +77,7 @@ describe("tool registry (DAT-353)", () => {
 		expect(byName.get("list_tables")?.needsApproval ?? false).toBe(false);
 		expect(byName.get("list_verticals")?.needsApproval ?? false).toBe(false);
 		expect(byName.get("look_table")?.needsApproval ?? false).toBe(false);
+		expect(byName.get("look_profile")?.needsApproval ?? false).toBe(false);
 		expect(byName.get("why_column")?.needsApproval ?? false).toBe(false);
 		expect(byName.get("why_table")?.needsApproval ?? false).toBe(false);
 		expect(byName.get("look_relationships")?.needsApproval ?? false).toBe(

--- a/packages/cockpit/src/tools/registry.ts
+++ b/packages/cockpit/src/tools/registry.ts
@@ -14,6 +14,7 @@ import { listTablesTool } from "./list-tables";
 import { listVerticalsTool } from "./list-verticals";
 import { lookCycleTool } from "./look-cycle";
 import { lookMetricTool } from "./look-metric";
+import { lookProfileTool } from "./look-profile";
 import { lookRelationshipsTool } from "./look-relationships";
 import { lookTableTool } from "./look-table";
 import { lookValidationTool } from "./look-validation";
@@ -41,6 +42,7 @@ export const tools = [
 	listVerticalsTool,
 	uploadTool,
 	lookTableTool,
+	lookProfileTool,
 	whyColumnTool,
 	whyTableTool,
 	lookRelationshipsTool,

--- a/packages/cockpit/src/ui/cockpit/canvas-registry.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-registry.ts
@@ -6,6 +6,7 @@
 // README.md for the register-don't-replace contract.
 
 import { WidgetRegistry } from "#/ui/cockpit/widget-registry";
+import { ColumnProfileWidget } from "#/ui/cockpit/widgets/column-profile";
 import { ColumnWhyWidget } from "#/ui/cockpit/widgets/column-why";
 import { CycleListWidget } from "#/ui/cockpit/widgets/cycle-list";
 import { CycleWhyWidget } from "#/ui/cockpit/widgets/cycle-why";
@@ -44,6 +45,7 @@ export const canvasRegistry = new WidgetRegistry()
 	.register({ kind: "result-grid", component: ResultGridWidget })
 	.register({ kind: "table-readiness", component: TableReadinessWidget })
 	.register({ kind: "column-why", component: ColumnWhyWidget })
+	.register({ kind: "column-profile", component: ColumnProfileWidget })
 	.register({ kind: "table-why", component: TableWhyWidget })
 	.register({ kind: "relationship-why", component: RelationshipWhyWidget })
 	.register({ kind: "relationship-list", component: RelationshipListWidget })

--- a/packages/cockpit/src/ui/cockpit/canvas-state.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-state.ts
@@ -11,6 +11,7 @@ import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
 import type { LookCycleResult } from "#/tools/look-cycle";
 import type { LookMetricResult } from "#/tools/look-metric";
+import type { LookProfileResult } from "#/tools/look-profile";
 import type { LookRelationshipsResult } from "#/tools/look-relationships";
 import type { LookTableResult } from "#/tools/look-table";
 import type { LookValidationResult } from "#/tools/look-validation";
@@ -47,6 +48,10 @@ export type CanvasState =
 	// DAT-351: per-column readiness explanation. Carries the why_column result —
 	// per-intent drivers + detector evidence + the synthesized narrative.
 	| { kind: "column-why"; why: WhyColumnResult }
+	// DAT-475: per-column descriptive profile — the heavy deep-dive (semantic,
+	// statistics, type candidates + decision, quality, temporal, derived). Carries
+	// the look_profile result; the widget renders every populated block read-only.
+	| { kind: "column-profile"; profile: LookProfileResult }
 	// DAT-434: per-table readiness explanation (the begin_session table-grain
 	// analog of column-why). Carries the why_table result.
 	| { kind: "table-why"; why: WhyTableResult }

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -47,12 +47,13 @@ describe("toolLabel", () => {
 });
 
 describe("isCanvasTool", () => {
-	it("marks the 21 canvas-producing tools clickable", () => {
-		expect(CANVAS_TOOLS.size).toBe(21);
+	it("marks the 22 canvas-producing tools clickable", () => {
+		expect(CANVAS_TOOLS.size).toBe(22);
 		for (const name of [
 			"list_sources",
 			"list_tables",
 			"look_table",
+			"look_profile",
 			"why_column",
 			"why_table",
 			"why_relationship",

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -25,6 +25,7 @@ import type { FrameResult } from "#/tools/frame";
 import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
 import type { Vertical } from "#/tools/list-verticals";
+import type { LookProfileResult } from "#/tools/look-profile";
 import type { LookRelationshipsResult } from "#/tools/look-relationships";
 import type { LookTableResult } from "#/tools/look-table";
 import type { LookValidationResult } from "#/tools/look-validation";
@@ -61,6 +62,7 @@ const TOOL_LABELS: Record<string, string> = {
 	list_verticals: "Domains",
 	list_tables: "Workspace tables",
 	look_table: "Table readiness",
+	look_profile: "Column profile",
 	why_column: "Column detail",
 	why_table: "Table detail",
 	why_relationship: "Relationship detail",
@@ -188,6 +190,19 @@ export function toolChipSummary(
 			return r.analyzed
 				? `${r.table_name} — ${cols}`
 				: `${r.table_name} — ${cols}, not yet analyzed`;
+		}
+		case "look_profile": {
+			const r = output as LookProfileResult | undefined;
+			if (!r) return "reading column profile…";
+			if (!r.found) return "column not found";
+			// `table_name` arrives in display form (projected in the tool, DAT-433).
+			const parts: string[] = [];
+			if (r.stats?.total_count != null)
+				parts.push(plural(r.stats.total_count, "row"));
+			if (r.type_candidates.length > 0)
+				parts.push(plural(r.type_candidates.length, "type candidate"));
+			const suffix = parts.length > 0 ? ` — ${parts.join(", ")}` : "";
+			return `${r.column_name} (${r.table_name})${suffix}`;
 		}
 		case "why_column": {
 			const r = output as WhyColumnResult | undefined;

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -19,6 +19,7 @@ import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
 import type { LookCycleResult } from "#/tools/look-cycle";
 import type { LookMetricResult } from "#/tools/look-metric";
+import type { LookProfileResult } from "#/tools/look-profile";
 import type { LookRelationshipsResult } from "#/tools/look-relationships";
 import type { LookTableResult } from "#/tools/look-table";
 import type { LookValidationResult } from "#/tools/look-validation";
@@ -74,6 +75,14 @@ const PROJECTORS: Record<string, CanvasProjector> = {
 	why_column: (result) =>
 		isWhyResult(result)
 			? { kind: "column-why", why: result as WhyColumnResult }
+			: null,
+	// The per-column descriptive profile (DAT-475) — same `found` discriminant
+	// guard as the why_* tools: an ERRORED call's `{ error }` output has no
+	// boolean `found`, so it won't project (would otherwise render as "No such
+	// column"); the failure surfaces in the chat rail instead.
+	look_profile: (result) =>
+		isWhyResult(result)
+			? { kind: "column-profile", profile: result as LookProfileResult }
 			: null,
 	// The per-table explanation (DAT-434) — same `found` guard.
 	why_table: (result) =>

--- a/packages/cockpit/src/ui/cockpit/widget-registry.test.ts
+++ b/packages/cockpit/src/ui/cockpit/widget-registry.test.ts
@@ -46,6 +46,10 @@ describe("WidgetRegistry (DAT-347)", () => {
 		expect(canvasRegistry.has("column-why")).toBe(true);
 	});
 
+	it("the shared canvas registry has the column-profile widget (DAT-475)", () => {
+		expect(canvasRegistry.has("column-profile")).toBe(true);
+	});
+
 	it("the shared canvas registry has the add-source-progress widget (DAT-352)", () => {
 		expect(canvasRegistry.has("add-source-progress")).toBe(true);
 	});

--- a/packages/cockpit/src/ui/cockpit/widgets/column-profile.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/column-profile.test.tsx
@@ -138,6 +138,7 @@ describe("ColumnProfileWidget (DAT-475)", () => {
 		expect(screen.getByTestId("canvas-column-profile-stats")).toBeTruthy();
 		expect(screen.getByTestId("canvas-column-profile-numeric")).toBeTruthy();
 		expect(screen.getByTestId("canvas-column-profile-topvalues")).toBeTruthy();
+		expect(screen.getByTestId("canvas-column-profile-histogram")).toBeTruthy();
 		expect(screen.getByTestId("canvas-column-profile-candidates")).toBeTruthy();
 		expect(screen.getByTestId("canvas-column-profile-decision")).toBeTruthy();
 		expect(screen.getByTestId("canvas-column-profile-quality")).toBeTruthy();
@@ -150,5 +151,13 @@ describe("ColumnProfileWidget (DAT-475)", () => {
 		expect(screen.getByText("revenue")).toBeTruthy();
 		expect(screen.getAllByText("non-compliant").length).toBeGreaterThan(0);
 		expect(screen.getByText("qty * price")).toBeTruthy();
+		// The histogram bucket renders its edges + count (0–100 · 30). The badge
+		// holds several text fragments, so assert on the block's text content.
+		expect(
+			screen.getByTestId("canvas-column-profile-histogram").textContent,
+		).toContain("0–100");
+		expect(
+			screen.getByTestId("canvas-column-profile-histogram").textContent,
+		).toContain("30");
 	});
 });

--- a/packages/cockpit/src/ui/cockpit/widgets/column-profile.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/column-profile.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+//
+// Render tests for the ColumnProfileWidget (DAT-475). Plain Mantine layout (no
+// virtualization) → blocks render under jsdom. Asserts the populated-block
+// rendering (semantic / stats / type candidates / quality / temporal / derived),
+// the not-found state, and the unprofiled (every-block-null) state. The live
+// reads are smoke-covered; the JSONB parse + caps are unit-tested in look-profile.test.ts.
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { LookProfileResult } from "#/tools/look-profile";
+import { ColumnProfileWidget } from "#/ui/cockpit/widgets/column-profile";
+import { theme } from "#/ui/theme";
+
+function renderWidget(profile: LookProfileResult) {
+	render(
+		<MantineProvider theme={theme} env="test">
+			<ColumnProfileWidget state={{ kind: "column-profile", profile }} />
+		</MantineProvider>,
+	);
+}
+
+const EMPTY: LookProfileResult = {
+	found: true,
+	column_id: "c_amount",
+	column_name: "amount",
+	table_name: "orders",
+	resolved_type: "DECIMAL(18,2)",
+	semantic: null,
+	stats: null,
+	type_candidates: [],
+	type_decision: null,
+	quality: null,
+	temporal: null,
+	derived: [],
+};
+
+const full: LookProfileResult = {
+	...EMPTY,
+	semantic: {
+		business_concept: "revenue",
+		semantic_role: "measure",
+		business_name: "Order Amount",
+		entity_type: null,
+		temporal_behavior: null,
+		unit_source_column: "currency",
+	},
+	stats: {
+		total_count: 100,
+		null_count: 5,
+		distinct_count: 80,
+		null_ratio: 0.05,
+		cardinality_ratio: 0.8,
+		is_unique: false,
+		is_numeric: true,
+		numeric_stats: {
+			min_value: 0,
+			max_value: 1000,
+			mean: 42.5,
+			stddev: 10.1,
+			skewness: 0.2,
+			kurtosis: 3.1,
+			cv: 0.24,
+			mad: 8,
+			robust_cv: 0.2,
+			percentiles: { p50: 40 },
+		},
+		string_stats: null,
+		histogram: [{ bucket_min: 0, bucket_max: 100, count: 30 }],
+		top_values: [{ value: "USD", count: 50, percentage: 0.5 }],
+	},
+	type_candidates: [
+		{
+			data_type: "DECIMAL",
+			confidence: 0.9,
+			parse_success_rate: 0.99,
+			detected_pattern: null,
+			pattern_match_rate: null,
+			detected_unit: "USD",
+			unit_confidence: 0.8,
+			quarantine_rate: 0.01,
+		},
+	],
+	type_decision: {
+		decided_type: "DECIMAL(18,2)",
+		decision_source: "detector",
+		decision_reason: "high parse rate",
+		previous_type: "VARCHAR",
+	},
+	quality: {
+		has_outliers: true,
+		iqr_outlier_ratio: 0.02,
+		zscore_outlier_ratio: 0.01,
+		benford_compliant: false,
+		benford: {
+			chi_square: 12.3,
+			p_value: 0.04,
+			is_compliant: false,
+			interpretation: "non-compliant",
+		},
+		outlier_samples: [999, 1000],
+	},
+	temporal: {
+		min_timestamp: "2020-01-01T00:00:00.000Z",
+		max_timestamp: "2021-12-31T00:00:00.000Z",
+		granularity: "day",
+		completeness: 0.97,
+		has_seasonality: true,
+		has_trend: false,
+		is_stale: false,
+	},
+	derived: [
+		{ derivation_type: "arithmetic", formula: "qty * price", match_rate: 0.98 },
+	],
+};
+
+describe("ColumnProfileWidget (DAT-475)", () => {
+	afterEach(() => cleanup());
+
+	it("renders the not-found state for an unknown column", () => {
+		renderWidget({ ...EMPTY, found: false });
+		expect(screen.getByTestId("canvas-column-profile-notfound")).toBeTruthy();
+	});
+
+	it("renders the unprofiled note when every block is null/empty", () => {
+		renderWidget(EMPTY);
+		expect(screen.getByTestId("canvas-column-profile-unprofiled")).toBeTruthy();
+		// Header (name + display table) still shows.
+		expect(screen.getByText("amount")).toBeTruthy();
+	});
+
+	it("renders every populated block", () => {
+		renderWidget(full);
+		expect(screen.getByTestId("canvas-column-profile")).toBeTruthy();
+		expect(screen.getByTestId("canvas-column-profile-semantic")).toBeTruthy();
+		expect(screen.getByTestId("canvas-column-profile-stats")).toBeTruthy();
+		expect(screen.getByTestId("canvas-column-profile-numeric")).toBeTruthy();
+		expect(screen.getByTestId("canvas-column-profile-topvalues")).toBeTruthy();
+		expect(screen.getByTestId("canvas-column-profile-candidates")).toBeTruthy();
+		expect(screen.getByTestId("canvas-column-profile-decision")).toBeTruthy();
+		expect(screen.getByTestId("canvas-column-profile-quality")).toBeTruthy();
+		expect(screen.getByTestId("canvas-column-profile-temporal")).toBeTruthy();
+		expect(screen.getByTestId("canvas-column-profile-derived")).toBeTruthy();
+		// The unprofiled note is gone when blocks are present.
+		expect(screen.queryByTestId("canvas-column-profile-unprofiled")).toBeNull();
+		// A few load-bearing values surface. "non-compliant" shows twice (the
+		// Benford verdict field + its interpretation line) — assert on count.
+		expect(screen.getByText("revenue")).toBeTruthy();
+		expect(screen.getAllByText("non-compliant").length).toBeGreaterThan(0);
+		expect(screen.getByText("qty * price")).toBeTruthy();
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/widgets/column-profile.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/column-profile.tsx
@@ -1,0 +1,391 @@
+// Column-profile widget (DAT-475) — renders the `look_profile` result: one
+// column's full descriptive deep-dive (semantic annotation, statistical profile,
+// type candidates + decision, statistical quality, temporal profile, derived
+// columns). Each block renders only when its stage produced a row; the values
+// are the engine's persisted profile — this widget only formats them.
+//
+// Reads theme/tokens only; the row type is a type-only import (erased — no server
+// code in the client bundle). Bounded: top_values / outlier_samples are already
+// capped (≤10) by the tool projection, and type_candidates / histogram are short
+// per-column lists — no virtualization needed.
+
+import { Alert, Badge, Group, Stack, Table, Text } from "@mantine/core";
+import type { ReactNode } from "react";
+import type { ProfileQuality, ProfileStats } from "#/tools/look-profile";
+import type { CanvasState } from "#/ui/cockpit/canvas-state";
+
+/** Compact numeric display — fixed-ish without forcing trailing zeros on ints. */
+function num(v: number | null | undefined): string {
+	if (v === null || v === undefined) return "—";
+	if (Number.isInteger(v)) return String(v);
+	return v.toFixed(4).replace(/\.?0+$/, "");
+}
+
+function pct(v: number | null | undefined): string {
+	if (v === null || v === undefined) return "—";
+	return `${(v * 100).toFixed(1)}%`;
+}
+
+function Field({ label, value }: { label: string; value: ReactNode }) {
+	return (
+		<Group gap={6} align="baseline">
+			<Text span size="xs" c="dimmed">
+				{label}
+			</Text>
+			<Text span size="xs" fw={500}>
+				{value}
+			</Text>
+		</Group>
+	);
+}
+
+function StatsBlock({ stats }: { stats: ProfileStats }) {
+	const { numeric_stats: n, string_stats: s } = stats;
+	return (
+		<Stack gap={4} data-testid="canvas-column-profile-stats">
+			<Text size="xs" fw={600}>
+				Statistics
+			</Text>
+			<Group gap="md" wrap="wrap">
+				<Field label="rows" value={num(stats.total_count)} />
+				<Field label="nulls" value={num(stats.null_count)} />
+				<Field label="null ratio" value={pct(stats.null_ratio)} />
+				<Field label="distinct" value={num(stats.distinct_count)} />
+				<Field label="cardinality" value={pct(stats.cardinality_ratio)} />
+				<Field
+					label="unique"
+					value={
+						stats.is_unique === null ? "—" : stats.is_unique ? "yes" : "no"
+					}
+				/>
+			</Group>
+			{n && (
+				<Group gap="md" wrap="wrap" data-testid="canvas-column-profile-numeric">
+					<Field label="min" value={num(n.min_value)} />
+					<Field label="max" value={num(n.max_value)} />
+					<Field label="mean" value={num(n.mean)} />
+					<Field label="stddev" value={num(n.stddev)} />
+					<Field label="skew" value={num(n.skewness)} />
+					<Field label="kurtosis" value={num(n.kurtosis)} />
+					<Field label="cv" value={num(n.cv)} />
+				</Group>
+			)}
+			{s && (
+				<Group gap="md" wrap="wrap" data-testid="canvas-column-profile-string">
+					<Field label="min len" value={num(s.min_length)} />
+					<Field label="max len" value={num(s.max_length)} />
+					<Field label="avg len" value={num(s.avg_length)} />
+				</Group>
+			)}
+			{stats.top_values.length > 0 && (
+				<Group
+					gap={4}
+					wrap="wrap"
+					data-testid="canvas-column-profile-topvalues"
+				>
+					<Text span size="xs" c="dimmed">
+						top values
+					</Text>
+					{stats.top_values.map((tv, i) => (
+						<Badge
+							// biome-ignore lint/suspicious/noArrayIndexKey: static parsed JSON, capped + never reordered
+							key={i}
+							size="xs"
+							variant="light"
+							color="gray"
+						>
+							{String(tv.value ?? "∅")} · {num(tv.count)}
+						</Badge>
+					))}
+				</Group>
+			)}
+		</Stack>
+	);
+}
+
+function QualityBlock({ quality }: { quality: ProfileQuality }) {
+	return (
+		<Stack gap={4} data-testid="canvas-column-profile-quality">
+			<Text size="xs" fw={600}>
+				Quality
+			</Text>
+			<Group gap="md" wrap="wrap">
+				<Field
+					label="outliers"
+					value={
+						quality.has_outliers === null
+							? "—"
+							: quality.has_outliers
+								? "yes"
+								: "no"
+					}
+				/>
+				<Field
+					label="IQR outlier ratio"
+					value={pct(quality.iqr_outlier_ratio)}
+				/>
+				<Field
+					label="z-score outlier ratio"
+					value={pct(quality.zscore_outlier_ratio)}
+				/>
+				<Field
+					label="Benford"
+					value={
+						quality.benford_compliant === null
+							? "—"
+							: quality.benford_compliant
+								? "compliant"
+								: "non-compliant"
+					}
+				/>
+			</Group>
+			{quality.benford?.interpretation && (
+				<Text size="xs" c="dimmed">
+					{quality.benford.interpretation}
+				</Text>
+			)}
+			{quality.outlier_samples.length > 0 && (
+				<Group gap={4} wrap="wrap" data-testid="canvas-column-profile-outliers">
+					<Text span size="xs" c="dimmed">
+						outlier samples
+					</Text>
+					{quality.outlier_samples.map((o, i) => (
+						<Badge
+							// biome-ignore lint/suspicious/noArrayIndexKey: static parsed JSON, capped + never reordered
+							key={i}
+							size="xs"
+							variant="light"
+							color="red"
+						>
+							{String(o)}
+						</Badge>
+					))}
+				</Group>
+			)}
+		</Stack>
+	);
+}
+
+export function ColumnProfileWidget({
+	state,
+}: {
+	state: Extract<CanvasState, { kind: "column-profile" }>;
+}) {
+	const { profile } = state;
+
+	if (!profile.found) {
+		return (
+			<Stack gap="xs" data-testid="canvas-column-profile">
+				<Text size="sm" fw={600}>
+					look_profile
+				</Text>
+				<Alert color="gray" data-testid="canvas-column-profile-notfound">
+					No such column.
+				</Alert>
+			</Stack>
+		);
+	}
+
+	const {
+		semantic,
+		stats,
+		type_candidates,
+		type_decision,
+		quality,
+		temporal,
+		derived,
+	} = profile;
+
+	const nothingProfiled =
+		!semantic &&
+		!stats &&
+		type_candidates.length === 0 &&
+		!type_decision &&
+		!quality &&
+		!temporal &&
+		derived.length === 0;
+
+	return (
+		<Stack gap="sm" data-testid="canvas-column-profile">
+			<Group justify="space-between" wrap="nowrap">
+				<Text size="sm" fw={600}>
+					{profile.column_name}{" "}
+					<Text span c="dimmed">
+						{/* table_name arrives in display form (projected in the tool). */}·{" "}
+						{profile.table_name}
+					</Text>
+				</Text>
+				<Text span size="xs" c="dimmed">
+					{profile.resolved_type ?? "—"}
+				</Text>
+			</Group>
+
+			{nothingProfiled && (
+				<Alert color="gray" data-testid="canvas-column-profile-unprofiled">
+					This column hasn't been profiled yet — run the source through
+					add_source to compute its profile.
+				</Alert>
+			)}
+
+			{semantic && (
+				<Stack gap={4} data-testid="canvas-column-profile-semantic">
+					<Text size="xs" fw={600}>
+						Semantic
+					</Text>
+					<Group gap="md" wrap="wrap">
+						<Field label="concept" value={semantic.business_concept ?? "—"} />
+						<Field label="role" value={semantic.semantic_role ?? "—"} />
+						<Field
+							label="business name"
+							value={semantic.business_name ?? "—"}
+						/>
+						<Field label="entity" value={semantic.entity_type ?? "—"} />
+						<Field
+							label="temporal behavior"
+							value={semantic.temporal_behavior ?? "—"}
+						/>
+						<Field
+							label="unit source"
+							value={semantic.unit_source_column ?? "—"}
+						/>
+					</Group>
+				</Stack>
+			)}
+
+			{stats && <StatsBlock stats={stats} />}
+
+			{type_decision && (
+				<Stack gap={4} data-testid="canvas-column-profile-decision">
+					<Text size="xs" fw={600}>
+						Type decision
+					</Text>
+					<Group gap="md" wrap="wrap">
+						<Field label="decided" value={type_decision.decided_type ?? "—"} />
+						<Field
+							label="source"
+							value={type_decision.decision_source ?? "—"}
+						/>
+						<Field
+							label="previous"
+							value={type_decision.previous_type ?? "—"}
+						/>
+					</Group>
+					{type_decision.decision_reason && (
+						<Text size="xs" c="dimmed">
+							{type_decision.decision_reason}
+						</Text>
+					)}
+				</Stack>
+			)}
+
+			{type_candidates.length > 0 && (
+				<Stack gap={4} data-testid="canvas-column-profile-candidates">
+					<Text size="xs" fw={600}>
+						Type candidates
+					</Text>
+					<Table.ScrollContainer minWidth={360}>
+						<Table striped>
+							<Table.Thead>
+								<Table.Tr>
+									<Table.Th>Type</Table.Th>
+									<Table.Th>Confidence</Table.Th>
+									<Table.Th>Parse rate</Table.Th>
+									<Table.Th>Pattern</Table.Th>
+									<Table.Th>Unit</Table.Th>
+									<Table.Th>Quarantine</Table.Th>
+								</Table.Tr>
+							</Table.Thead>
+							<Table.Tbody>
+								{type_candidates.map((c, i) => (
+									// biome-ignore lint/suspicious/noArrayIndexKey: static row list, never reordered after render
+									<Table.Tr key={i}>
+										<Table.Td>{c.data_type ?? "—"}</Table.Td>
+										<Table.Td>{pct(c.confidence)}</Table.Td>
+										<Table.Td>{pct(c.parse_success_rate)}</Table.Td>
+										<Table.Td>
+											<Text span size="xs" c="dimmed">
+												{c.detected_pattern ?? "—"}
+											</Text>
+										</Table.Td>
+										<Table.Td>
+											<Text span size="xs" c="dimmed">
+												{c.detected_unit ?? "—"}
+											</Text>
+										</Table.Td>
+										<Table.Td>{pct(c.quarantine_rate)}</Table.Td>
+									</Table.Tr>
+								))}
+							</Table.Tbody>
+						</Table>
+					</Table.ScrollContainer>
+				</Stack>
+			)}
+
+			{quality && <QualityBlock quality={quality} />}
+
+			{temporal && (
+				<Stack gap={4} data-testid="canvas-column-profile-temporal">
+					<Text size="xs" fw={600}>
+						Temporal
+					</Text>
+					<Group gap="md" wrap="wrap">
+						<Field label="from" value={temporal.min_timestamp ?? "—"} />
+						<Field label="to" value={temporal.max_timestamp ?? "—"} />
+						<Field label="granularity" value={temporal.granularity ?? "—"} />
+						<Field label="completeness" value={pct(temporal.completeness)} />
+						<Field
+							label="seasonality"
+							value={
+								temporal.has_seasonality === null
+									? "—"
+									: temporal.has_seasonality
+										? "yes"
+										: "no"
+							}
+						/>
+						<Field
+							label="trend"
+							value={
+								temporal.has_trend === null
+									? "—"
+									: temporal.has_trend
+										? "yes"
+										: "no"
+							}
+						/>
+						<Field
+							label="stale"
+							value={
+								temporal.is_stale === null
+									? "—"
+									: temporal.is_stale
+										? "yes"
+										: "no"
+							}
+						/>
+					</Group>
+				</Stack>
+			)}
+
+			{derived.length > 0 && (
+				<Stack gap={4} data-testid="canvas-column-profile-derived">
+					<Text size="xs" fw={600}>
+						Derived from
+					</Text>
+					{derived.map((d, i) => (
+						<Group
+							// biome-ignore lint/suspicious/noArrayIndexKey: static row list, never reordered after render
+							key={i}
+							gap="md"
+							wrap="wrap"
+						>
+							<Field label="type" value={d.derivation_type ?? "—"} />
+							<Field label="formula" value={d.formula ?? "—"} />
+							<Field label="match" value={pct(d.match_rate)} />
+						</Group>
+					))}
+				</Stack>
+			)}
+		</Stack>
+	);
+}

--- a/packages/cockpit/src/ui/cockpit/widgets/column-profile.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/column-profile.tsx
@@ -26,6 +26,13 @@ function pct(v: number | null | undefined): string {
 	return `${(v * 100).toFixed(1)}%`;
 }
 
+/** Format a histogram bucket edge — number (numeric bucket) or string
+ * (categorical bucket); null degrades to the em-dash. */
+function edge(v: number | string | null | undefined): string {
+	if (v === null || v === undefined) return "—";
+	return typeof v === "number" ? num(v) : v;
+}
+
 function Field({ label, value }: { label: string; value: ReactNode }) {
 	return (
 		<Group gap={6} align="baseline">
@@ -95,6 +102,28 @@ function StatsBlock({ stats }: { stats: ProfileStats }) {
 							color="gray"
 						>
 							{String(tv.value ?? "∅")} · {num(tv.count)}
+						</Badge>
+					))}
+				</Group>
+			)}
+			{stats.histogram.length > 0 && (
+				<Group
+					gap={4}
+					wrap="wrap"
+					data-testid="canvas-column-profile-histogram"
+				>
+					<Text span size="xs" c="dimmed">
+						histogram
+					</Text>
+					{stats.histogram.map((h, i) => (
+						<Badge
+							// biome-ignore lint/suspicious/noArrayIndexKey: static parsed JSON, bucket order is stable
+							key={i}
+							size="xs"
+							variant="light"
+							color="blue"
+						>
+							{edge(h.bucket_min)}–{edge(h.bucket_max)} · {num(h.count)}
 						</Badge>
 					))}
 				</Group>


### PR DESCRIPTION
Phase 1 of epic DAT-474 (cockpit read-view integration). New read-only agent tool `look_profile(column_id)` — the per-column descriptive profile (stats / type candidates + decision / quality / temporal / semantic / derived) over the existing `current_*` metadata views, plus a column-profile canvas widget. This is the descriptive half of the legacy MCP `look`, never carried to the cockpit.

- Design: [DD/33062914](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/33062914) · AC: DAT-475
- Review: spec-compliance + senior + strict panel + focused re-review — all APPROVE. Caught & fixed a real bug (a null percentile leaf dropped the entire stats block).
- Sole owner of the shared agent-tier plumbing (registry / canvas / chip) for this epic; the other 3 lanes are additive-only.
- Note: in-sandbox cockpit vitest cannot run (pre-existing zod-4 SSR defect, identical on `main`); CI is the gate. `tsc` + `biome` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)