### PR TITLE
feat(cockpit): look_table entity header + per-column semantics (DAT-476)

### DIFF
--- a/packages/cockpit/src/tools/look-table.test.ts
+++ b/packages/cockpit/src/tools/look-table.test.ts
@@ -21,6 +21,7 @@ import {
 	type ReadinessRow,
 	type TableBandRow,
 	type TableEntityRow,
+	tableEntityWhere,
 } from "./look-table";
 
 function row(overrides: Partial<ReadinessRow> = {}): ReadinessRow {
@@ -175,7 +176,11 @@ function entityRow(overrides: Partial<TableEntityRow> = {}): TableEntityRow {
 		detectedEntityType: "transaction",
 		isFactTable: true,
 		isDimensionTable: false,
-		grainColumns: ["order_id", "line_no"],
+		// The engine ALWAYS persists grain as the DICT shape `{"columns": [...]}`
+		// (`analysis/semantic/processor.py`), NOT a bare array — fixture it that way
+		// so the projection's real-shape parse is exercised (the bare-array form
+		// only ever shows up as a tolerated fallback).
+		grainColumns: { columns: ["order_id", "line_no"] },
 		timeColumn: "order_date",
 		description: "One row per order line item.",
 		...overrides,
@@ -183,7 +188,7 @@ function entityRow(overrides: Partial<TableEntityRow> = {}): TableEntityRow {
 }
 
 describe("projectTableEntity (DAT-476)", () => {
-	it("maps the descriptive header straight through, grain as a name array", () => {
+	it("maps the descriptive header through, grain from the engine's {columns:[…]} dict", () => {
 		expect(projectTableEntity(entityRow())).toEqual({
 			entity_type: "transaction",
 			is_fact_table: true,
@@ -194,14 +199,82 @@ describe("projectTableEntity (DAT-476)", () => {
 		});
 	});
 
-	it("degrades a malformed/absent grain blob to an empty grain rather than throwing", () => {
+	it("tolerates a bare string[] grain (defensive fallback)", () => {
+		expect(
+			projectTableEntity(entityRow({ grainColumns: ["order_id"] })).grain,
+		).toEqual(["order_id"]);
+	});
+
+	it("degrades a genuinely malformed/absent grain blob to an empty grain rather than throwing", () => {
 		expect(projectTableEntity(entityRow({ grainColumns: null })).grain).toEqual(
 			[],
 		);
+		// Neither the dict-with-`columns` nor the bare-array shape.
 		expect(
 			projectTableEntity(entityRow({ grainColumns: { not: "an array" } }))
 				.grain,
 		).toEqual([]);
+		expect(
+			projectTableEntity(entityRow({ grainColumns: { columns: "nope" } }))
+				.grain,
+		).toEqual([]);
+	});
+
+	it("strips src_<digest>__ prefixes from grain / time_column / description", () => {
+		// Engine free-text/name fields can carry the content-keyed source prefix;
+		// the projection digest-strips them before they reach the tool output.
+		const D = "204bc8e118543a6c35654c1f68c43539a2e226f2";
+		const out = projectTableEntity(
+			entityRow({
+				grainColumns: { columns: [`src_${D}__order_id`, "line_no"] },
+				timeColumn: `src_${D}__order_date`,
+				description: `One row per line in src_${D}__orders.`,
+			}),
+		);
+		expect(out.grain).toEqual(["order_id", "line_no"]);
+		expect(out.time_column).toBe("order_date");
+		// The 40-hex digest is gone from every projected field.
+		expect(JSON.stringify(out)).not.toMatch(/src_[0-9a-f]{40}/);
+	});
+});
+
+// The drizzle SQL predicate is a self-referential object whose bound literals
+// live in `Param` nodes (a `value` + `encoder` pair); collect just those via a
+// cycle-safe walk. The column refs back-reference the whole table schema, so
+// matching on column names would leak every sibling column — the bound VALUES
+// are the unambiguous signal of what the predicate actually filters on.
+function boundValues(predicate: unknown): string[] {
+	const seen = new Set<unknown>();
+	const out: string[] = [];
+	const walk = (o: unknown, depth: number) => {
+		if (depth > 8 || o === null || typeof o !== "object" || seen.has(o)) return;
+		seen.add(o);
+		const rec = o as Record<string, unknown>;
+		if ("value" in rec && "encoder" in rec && typeof rec.value === "string") {
+			out.push(rec.value);
+		}
+		for (const v of Object.values(rec)) walk(v, depth + 1);
+	};
+	walk(predicate, 0);
+	return out.sort();
+}
+
+describe("tableEntityWhere (DAT-476 — deterministic entity pick)", () => {
+	it("scopes to the passed session_id (binds both table_id and session_id)", () => {
+		// current_table_entities is session-head-scoped (one row per (table_id,
+		// session)), so a multi-session workspace must filter on the caller's
+		// session_id — not pick an arbitrary session's row. Assert the composed
+		// predicate binds BOTH the table_id and the session_id literals.
+		expect(boundValues(tableEntityWhere("t_orders", "sess_1"))).toEqual([
+			"sess_1",
+			"t_orders",
+		]);
+	});
+
+	it("filters table_id alone when no session_id is passed", () => {
+		// No session filter → the call-site `detected_at desc` order then yields the
+		// deterministic latest entity (not an arbitrary session's row).
+		expect(boundValues(tableEntityWhere("t_orders"))).toEqual(["t_orders"]);
 	});
 });
 

--- a/packages/cockpit/src/tools/look-table.test.ts
+++ b/packages/cockpit/src/tools/look-table.test.ts
@@ -14,10 +14,13 @@ vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 
 import {
 	projectColumnReadiness,
+	projectColumnSemantic,
 	projectLookTable,
 	projectTableBand,
+	projectTableEntity,
 	type ReadinessRow,
 	type TableBandRow,
+	type TableEntityRow,
 } from "./look-table";
 
 function row(overrides: Partial<ReadinessRow> = {}): ReadinessRow {
@@ -27,6 +30,11 @@ function row(overrides: Partial<ReadinessRow> = {}): ReadinessRow {
 		resolvedType: "DECIMAL(18,2)",
 		band: "investigate",
 		worstIntentRisk: 0.42,
+		// Light per-column semantics (DAT-476) — populated by default; the
+		// unannotated case overrides all three to null.
+		businessConcept: "monetary_amount",
+		semanticRole: "measure",
+		businessName: "Order Amount",
 		intents: [
 			{ intent: "query", band: "ready", risk: 0.1, drivers: [] },
 			{
@@ -75,6 +83,12 @@ describe("projectColumnReadiness (DAT-350)", () => {
 		expect(out.top_drivers).toEqual([
 			{ label: "Unit Documentation", state: "high", impact_delta: 0.3 },
 		]);
+		// The light semantic triple rides alongside (DAT-476).
+		expect(out.semantic).toEqual({
+			business_concept: "monetary_amount",
+			semantic_role: "measure",
+			business_name: "Order Amount",
+		});
 	});
 
 	it("treats a left-join miss (no readiness row) as not-analyzed", () => {
@@ -84,12 +98,17 @@ describe("projectColumnReadiness (DAT-350)", () => {
 				worstIntentRisk: null,
 				intents: null,
 				topDrivers: null,
+				businessConcept: null,
+				semanticRole: null,
+				businessName: null,
 			}),
 		);
 		expect(out.band).toBeNull();
 		expect(out.worst_intent_risk).toBeNull();
 		expect(out.intents).toEqual([]);
 		expect(out.top_drivers).toEqual([]);
+		// Unannotated column (semantic left-join also missed) → null semantic block.
+		expect(out.semantic).toBeNull();
 	});
 
 	it("caps top drivers at 3 (the overview shows the worst few)", () => {
@@ -114,6 +133,75 @@ describe("projectColumnReadiness (DAT-350)", () => {
 		// The scalar band still comes through — it's a real column, just with a
 		// blob we couldn't parse.
 		expect(out.band).toBe("investigate");
+	});
+});
+
+describe("projectColumnSemantic (DAT-476)", () => {
+	it("projects the light semantic triple when the column is annotated", () => {
+		expect(projectColumnSemantic(row())).toEqual({
+			business_concept: "monetary_amount",
+			semantic_role: "measure",
+			business_name: "Order Amount",
+		});
+	});
+
+	it("is null when the column is unannotated (every semantic field absent)", () => {
+		const out = projectColumnSemantic(
+			row({ businessConcept: null, semanticRole: null, businessName: null }),
+		);
+		expect(out).toBeNull();
+	});
+
+	it("keeps the block (partial fields) when at least one field is present", () => {
+		// A partial annotation (e.g. only a business_concept) is still an annotation —
+		// the block survives with the absent fields null, not collapsed to null.
+		const out = projectColumnSemantic(
+			row({
+				businessConcept: "monetary_amount",
+				semanticRole: null,
+				businessName: null,
+			}),
+		);
+		expect(out).toEqual({
+			business_concept: "monetary_amount",
+			semantic_role: null,
+			business_name: null,
+		});
+	});
+});
+
+function entityRow(overrides: Partial<TableEntityRow> = {}): TableEntityRow {
+	return {
+		detectedEntityType: "transaction",
+		isFactTable: true,
+		isDimensionTable: false,
+		grainColumns: ["order_id", "line_no"],
+		timeColumn: "order_date",
+		description: "One row per order line item.",
+		...overrides,
+	};
+}
+
+describe("projectTableEntity (DAT-476)", () => {
+	it("maps the descriptive header straight through, grain as a name array", () => {
+		expect(projectTableEntity(entityRow())).toEqual({
+			entity_type: "transaction",
+			is_fact_table: true,
+			is_dimension_table: false,
+			grain: ["order_id", "line_no"],
+			time_column: "order_date",
+			description: "One row per order line item.",
+		});
+	});
+
+	it("degrades a malformed/absent grain blob to an empty grain rather than throwing", () => {
+		expect(projectTableEntity(entityRow({ grainColumns: null })).grain).toEqual(
+			[],
+		);
+		expect(
+			projectTableEntity(entityRow({ grainColumns: { not: "an array" } }))
+				.grain,
+		).toEqual([]);
 	});
 });
 
@@ -199,18 +287,23 @@ describe("projectLookTable (DAT-433)", () => {
 			[projectColumnReadiness(row())],
 			null,
 			2,
+			projectTableEntity(entityRow()),
 		);
 		expect(out.table_name).toBe("orders");
 		expect(out.physical_name).toBe(`src_${DIGEST}__orders`);
 		expect(out.analyzed).toBe(true);
 		expect(out.pending_teaches).toBe(2);
+		// The entity header carries straight through (DAT-476).
+		expect(out.entity?.entity_type).toBe("transaction");
+		expect(out.entity?.is_fact_table).toBe(true);
+		expect(out.entity?.grain).toEqual(["order_id", "line_no"]);
 		// The digest appears ONLY in the sanctioned physical_name (the run_sql
 		// round-trip key) — nowhere else in the projection.
 		const { physical_name: _pn, ...rest } = out;
 		expect(JSON.stringify(rest)).not.toMatch(/src_[0-9a-f]{40}/);
 	});
 
-	it("returns the empty not-found shell for a stale table id", () => {
+	it("returns the empty not-found shell for a stale table id — entity null", () => {
 		const out = projectLookTable("t_gone", null, [], null, 0);
 		expect(out).toEqual({
 			table_id: "t_gone",
@@ -220,7 +313,21 @@ describe("projectLookTable (DAT-433)", () => {
 			pending_teaches: 0,
 			columns: [],
 			table_readiness: null,
+			entity: null,
 		});
+	});
+
+	it("entity is null pre-session (no promoted detect run)", () => {
+		// No entity arg — the default (null) models a table that hasn't been through
+		// a begin_session detect run yet; the descriptive header is absent.
+		const out = projectLookTable(
+			"t_orders",
+			"orders",
+			[projectColumnReadiness(row())],
+			null,
+			0,
+		);
+		expect(out.entity).toBeNull();
 	});
 
 	it("analyzed reflects whether any column carries a band", () => {

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -29,6 +29,8 @@ import { tableTargetKey } from "../db/metadata/relationship-target";
 import {
 	columns,
 	currentEntropyReadiness,
+	currentSemanticAnnotations,
+	currentTableEntities,
 	tables,
 } from "../db/metadata/schema";
 import { displayTableName } from "../lib/display-names";
@@ -51,6 +53,19 @@ const TopDriver = z.object({
 	impact_delta: z.number(),
 });
 
+// Light per-column semantics (DAT-476) — the cockpit analog of MCP
+// `look(target="table")`'s per-column semantic line. begin_session's
+// `semantic_per_column` annotation, head-resolved by `current_semantic_annotations`.
+// Null when the column carries no promoted annotation (unannotated /
+// pre-session). The full annotation (units, temporal behavior, evidence, …) is a
+// drill-down concern; this is the at-a-glance triple.
+const ColumnSemantic = z.object({
+	business_concept: z.string().nullable(),
+	semantic_role: z.string().nullable(),
+	business_name: z.string().nullable(),
+});
+export type ColumnSemantic = z.infer<typeof ColumnSemantic>;
+
 const ColumnReadiness = z.object({
 	column_id: z.string(),
 	column_name: z.string(),
@@ -60,6 +75,11 @@ const ColumnReadiness = z.object({
 	worst_intent_risk: z.number().nullable(),
 	intents: z.array(IntentBand),
 	top_drivers: z.array(TopDriver),
+	// Light semantics from begin_session's per-column annotation (DAT-476); null
+	// when the column is unannotated. Additive — independent of the band grid.
+	// Optional so the type stays back-compat for hand-built fixtures; the
+	// projection ALWAYS sets it (null or block), so it's present at runtime.
+	semantic: ColumnSemantic.nullable().optional(),
 });
 export type ColumnReadiness = z.infer<typeof ColumnReadiness>;
 
@@ -74,6 +94,22 @@ const TableReadiness = z.object({
 	top_drivers: z.array(TopDriver),
 });
 export type TableReadiness = z.infer<typeof TableReadiness>;
+
+// The table descriptive header (DAT-476) — the cockpit analog of MCP
+// `look(target="table")`'s entity block: what kind of table this is (fact /
+// dimension), its grain, its time column, and a short description.
+// begin_session's `detect` writes it; `current_table_entities` head-resolves to
+// the promoted run. Null when no detect run has promoted (pre-session).
+const TableEntity = z.object({
+	entity_type: z.string().nullable(),
+	is_fact_table: z.boolean().nullable(),
+	is_dimension_table: z.boolean().nullable(),
+	// The column names that uniquely identify a row (the table's grain).
+	grain: z.array(z.string()),
+	time_column: z.string().nullable(),
+	description: z.string().nullable(),
+});
+export type TableEntity = z.infer<typeof TableEntity>;
 
 const LookTableResult = z.object({
 	table_id: z.string(),
@@ -100,6 +136,13 @@ const LookTableResult = z.object({
 	// for this table (never begun / table not in the session). The per-column grid
 	// above is add_source-grain; this is the begin_session whole-table rollup.
 	table_readiness: TableReadiness.nullable(),
+	// The table descriptive header (DAT-476) — entity type / fact-dimension / grain
+	// / time column / description from `current_table_entities`. Session/detect grain
+	// → null pre-session (no promoted detect run). Independent of any session_id
+	// input; the view is head-resolved, so a plain select by table_id suffices.
+	// Optional so the type stays back-compat for hand-built fixtures; the
+	// projection ALWAYS sets it (null or block), so it's present at runtime.
+	entity: TableEntity.nullable().optional(),
 });
 export type LookTableResult = z.infer<typeof LookTableResult>;
 
@@ -107,7 +150,9 @@ export type LookTableResult = z.infer<typeof LookTableResult>;
 // shows the full ranked list).
 const TOP_DRIVERS_SHOWN = 3;
 
-/** One joined (columns ⟕ entropy_readiness) row, as Drizzle returns it. */
+/** One joined (columns ⟕ entropy_readiness ⟕ semantic_annotations) row, as
+ * Drizzle returns it. The semantic fields are left-join-nullable — a column with
+ * no promoted annotation reads them all null and projects `semantic: null`. */
 export interface ReadinessRow {
 	columnId: string;
 	columnName: string;
@@ -116,6 +161,36 @@ export interface ReadinessRow {
 	worstIntentRisk: number | null;
 	intents: unknown;
 	topDrivers: unknown;
+	// Light semantics from the `current_semantic_annotations` left join (DAT-476).
+	// Optional so callers that don't join the view still satisfy the type; absent
+	// (undefined) or null is treated as unannotated.
+	businessConcept?: string | null;
+	semanticRole?: string | null;
+	businessName?: string | null;
+}
+
+/** Project the light semantic triple for one column (DAT-476). Pure (no DB).
+ * Null when the column carries no annotation at all — every field absent means
+ * the `semantic_per_column` join missed (unannotated / pre-session), so the
+ * column gets no semantic block rather than a triple of nulls. */
+export function projectColumnSemantic(
+	row: ReadinessRow,
+): ColumnSemantic | null {
+	const businessConcept = row.businessConcept ?? null;
+	const semanticRole = row.semanticRole ?? null;
+	const businessName = row.businessName ?? null;
+	if (
+		businessConcept === null &&
+		semanticRole === null &&
+		businessName === null
+	) {
+		return null;
+	}
+	return {
+		business_concept: businessConcept,
+		semantic_role: semanticRole,
+		business_name: businessName,
+	};
 }
 
 /**
@@ -123,6 +198,7 @@ export interface ReadinessRow {
  * JSONB-parsing + null-handling logic is unit-testable without a live schema.
  * A column with no readiness row (left-join miss) keeps `band: null` and empty
  * intents/drivers; a malformed JSONB blob degrades to empty rather than throwing.
+ * The light semantic triple (DAT-476) rides alongside, null when unannotated.
  */
 export function projectColumnReadiness(row: ReadinessRow): ColumnReadiness {
 	const intents = PersistedIntent.array().safeParse(row.intents);
@@ -147,6 +223,7 @@ export function projectColumnReadiness(row: ReadinessRow): ColumnReadiness {
 					impact_delta: d.impact_delta,
 				}))
 			: [],
+		semantic: projectColumnSemantic(row),
 	};
 }
 
@@ -188,6 +265,36 @@ export function projectTableBand(row: TableBandRow): TableReadiness {
 	};
 }
 
+/** One `current_table_entities` row, as Drizzle returns it. grainColumns is the
+ * persisted JSON array of column names (the table's grain). */
+export interface TableEntityRow {
+	detectedEntityType: string | null;
+	isFactTable: boolean | null;
+	isDimensionTable: boolean | null;
+	grainColumns: unknown;
+	timeColumn: string | null;
+	description: string | null;
+}
+
+/**
+ * Project the table-entity header row to the tool shape (DAT-476). Pure (no DB).
+ * `grain_columns` is a persisted JSON array of column names; a malformed/absent
+ * blob degrades to an empty grain rather than throwing. The remaining fields map
+ * straight through (the view is head-resolved, so a present row IS the promoted
+ * detect run). The caller passes null when no entity row exists (pre-session).
+ */
+export function projectTableEntity(row: TableEntityRow): TableEntity {
+	const grain = z.array(z.string()).safeParse(row.grainColumns);
+	return {
+		entity_type: row.detectedEntityType ?? null,
+		is_fact_table: row.isFactTable ?? null,
+		is_dimension_table: row.isDimensionTable ?? null,
+		grain: grain.success ? grain.data : [],
+		time_column: row.timeColumn ?? null,
+		description: row.description ?? null,
+	};
+}
+
 export interface LookTableInput {
 	table_id: string;
 	// Optional: when this table is being inspected inside a begin_session, the
@@ -201,7 +308,9 @@ export interface LookTableInput {
  * display/physical name split is unit-testable: `table_name` is the display
  * form for prose (digest prefix stripped, DAT-433), `physical_name` the raw
  * DuckDB name run_sql addresses. A null rawTableName (stale table id) yields
- * the empty not-found shell.
+ * the empty not-found shell. `entity` is the optional DAT-476 descriptive header
+ * (defaulted null = pre-session / no promoted detect run) — last + defaulted so
+ * it's purely additive on the existing call shape.
  */
 export function projectLookTable(
 	tableId: string,
@@ -209,6 +318,7 @@ export function projectLookTable(
 	cols: ColumnReadiness[],
 	tableReadiness: TableReadiness | null,
 	pendingTeaches: number,
+	entity: TableEntity | null = null,
 ): LookTableResult {
 	return {
 		table_id: tableId,
@@ -218,6 +328,7 @@ export function projectLookTable(
 		pending_teaches: pendingTeaches,
 		columns: cols,
 		table_readiness: tableReadiness,
+		entity,
 	};
 }
 
@@ -237,14 +348,18 @@ export async function lookTable(
 		return projectLookTable(input.table_id, null, [], null, 0);
 	}
 
-	// Three independent reads once the table is known: the per-column grid (its own
-	// add_source `table:{id}` head), the table-grain band (the begin_session
-	// `session:{id}` head — a different head), and the workspace teach count. Fan
-	// them out — they share no input, so sequential awaits only add latency to the
-	// hot path. table_readiness stays null without a session_id (add_source view).
+	// Four independent reads once the table is known: the per-column grid (its own
+	// add_source `table:{id}` head, now carrying the light semantic join), the
+	// table descriptive header (DAT-476 — `current_table_entities`, head-resolved,
+	// session/detect grain so null pre-session), the table-grain band (the
+	// begin_session `session:{id}` head — a different head), and the workspace teach
+	// count. Fan them out — they share no input, so sequential awaits only add
+	// latency. table_readiness stays null without a session_id (add_source view);
+	// entity stays null until a detect run promotes (independent of session_id).
 	const tableName = table.tableName ?? "";
-	const [cols, tableReadiness, pending] = await Promise.all([
+	const [cols, entity, tableReadiness, pending] = await Promise.all([
 		loadColumnGrid(input.table_id),
+		loadTableEntity(input.table_id),
 		input.session_id ? loadTableBand(input.session_id, tableName) : null,
 		getPendingOverlays(),
 	]);
@@ -255,6 +370,7 @@ export async function lookTable(
 		cols,
 		tableReadiness,
 		pending.length,
+		entity,
 	);
 }
 
@@ -272,6 +388,12 @@ async function loadColumnGrid(tableId: string): Promise<ColumnReadiness[]> {
 			worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
 			intents: currentEntropyReadiness.intents,
 			topDrivers: currentEntropyReadiness.topDrivers,
+			// Light per-column semantics (DAT-476) — begin_session's
+			// `semantic_per_column` annotation, head-resolved by the view. Left-join
+			// nullable: an unannotated column reads all three null → semantic: null.
+			businessConcept: currentSemanticAnnotations.businessConcept,
+			semanticRole: currentSemanticAnnotations.semanticRole,
+			businessName: currentSemanticAnnotations.businessName,
 		})
 		.from(columns)
 		.leftJoin(
@@ -282,6 +404,10 @@ async function loadColumnGrid(tableId: string): Promise<ColumnReadiness[]> {
 				// fans out to two rows per column once a session head is promoted.
 				eq(currentEntropyReadiness.viaTableHead, true),
 			),
+		)
+		.leftJoin(
+			currentSemanticAnnotations,
+			eq(currentSemanticAnnotations.columnId, columns.columnId),
 		)
 		.where(eq(columns.tableId, tableId))
 		.orderBy(asc(columns.columnPosition));
@@ -295,6 +421,26 @@ async function loadColumnGrid(tableId: string): Promise<ColumnReadiness[]> {
 			columnName: r.columnName ?? "",
 		}),
 	);
+}
+
+/** Resolve a table's descriptive header (DAT-476) — entity type / fact-dimension
+ * / grain / time column / description from `current_table_entities`. The view is
+ * head-resolved (the promoted `detect` run), so a plain select by table_id
+ * suffices; null when no detect run has promoted (pre-session). */
+async function loadTableEntity(tableId: string): Promise<TableEntity | null> {
+	const [row] = await metadataDb
+		.select({
+			detectedEntityType: currentTableEntities.detectedEntityType,
+			isFactTable: currentTableEntities.isFactTable,
+			isDimensionTable: currentTableEntities.isDimensionTable,
+			grainColumns: currentTableEntities.grainColumns,
+			timeColumn: currentTableEntities.timeColumn,
+			description: currentTableEntities.description,
+		})
+		.from(currentTableEntities)
+		.where(eq(currentTableEntities.tableId, tableId))
+		.limit(1);
+	return row ? projectTableEntity(row) : null;
 }
 
 /** Resolve a session's table-grain readiness band for one table (DAT-415).
@@ -333,7 +479,11 @@ export const lookTableTool = toolDefinition({
 		"is the DuckDB name — use it ONLY to address the table in run_sql as " +
 		"`lake.<layer>.<physical_name>`. Pass a begin_session session_id to also " +
 		"get the table's whole-table readiness band (table_readiness) from that " +
-		"session; use `why_table` to explain it. pending_teaches counts un-applied " +
+		"session; use `why_table` to explain it. Also returns the table's " +
+		"descriptive header (entity: type, fact/dimension, grain, time column, " +
+		"description) and light per-column semantics (columns[].semantic: business " +
+		"concept, semantic role, business name) — both from begin_session analysis, " +
+		"so null/empty before a session has run. pending_teaches counts un-applied " +
 		"teaches across the workspace (not scoped to this table); if > 0, suggest " +
 		"a `replay` before trusting the bands. Use `why_column` to explain a " +
 		"specific column's band.",

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -16,7 +16,7 @@
 // rows); the pure row→shape projection is unit-tested directly here.
 
 import { toolDefinition } from "@tanstack/ai";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { metadataDb } from "../db/metadata/client";
@@ -33,7 +33,7 @@ import {
 	currentTableEntities,
 	tables,
 } from "../db/metadata/schema";
-import { displayTableName } from "../lib/display-names";
+import { displayTableName, stripSrcDigests } from "../lib/display-names";
 
 // The persisted JSONB grammar (intents / top_drivers) lives in
 // `readiness-schemas.ts`, shared with why_column. Parsed leniently below: a
@@ -138,8 +138,9 @@ const LookTableResult = z.object({
 	table_readiness: TableReadiness.nullable(),
 	// The table descriptive header (DAT-476) — entity type / fact-dimension / grain
 	// / time column / description from `current_table_entities`. Session/detect grain
-	// → null pre-session (no promoted detect run). Independent of any session_id
-	// input; the view is head-resolved, so a plain select by table_id suffices.
+	// → null pre-session (no promoted detect run). The view is one row per
+	// (table_id, session), so it's scoped to the passed session_id when given, else
+	// the latest detected entity (a deterministic pick, not an arbitrary session's).
 	// Optional so the type stays back-compat for hand-built fixtures; the
 	// projection ALWAYS sets it (null or block), so it's present at runtime.
 	entity: TableEntity.nullable().optional(),
@@ -189,7 +190,11 @@ export function projectColumnSemantic(
 	return {
 		business_concept: businessConcept,
 		semantic_role: semanticRole,
-		business_name: businessName,
+		// business_name is engine free-text (the human-readable column label) and
+		// can carry a raw `src_<digest>__` prefix — strip it before it reaches the
+		// result / widget (sibling precedent: why-cycle.ts). concept/role are
+		// engine-controlled identifiers, not free-text, so they pass through.
+		business_name: businessName == null ? null : stripSrcDigests(businessName),
 	};
 }
 
@@ -266,7 +271,9 @@ export function projectTableBand(row: TableBandRow): TableReadiness {
 }
 
 /** One `current_table_entities` row, as Drizzle returns it. grainColumns is the
- * persisted JSON array of column names (the table's grain). */
+ * persisted grain — the engine writes the DICT shape `{"columns": [...]}`
+ * (`semantic/processor.py`), so the parser below accepts that (and tolerates a
+ * bare `string[]` for safety). */
 export interface TableEntityRow {
 	detectedEntityType: string | null;
 	isFactTable: boolean | null;
@@ -276,22 +283,37 @@ export interface TableEntityRow {
 	description: string | null;
 }
 
+// The persisted grain shape. The engine ALWAYS writes the dict form
+// `{"columns": [...]}` (`analysis/semantic/processor.py:343`; the engine's own
+// reader `graphs/context.py` accepts both), so the dict is the real shape; the
+// bare array is tolerated as a fallback. Anything else degrades to [].
+const GrainColumns = z.union([
+	z.object({ columns: z.array(z.string()) }).transform((g) => g.columns),
+	z.array(z.string()),
+]);
+
 /**
  * Project the table-entity header row to the tool shape (DAT-476). Pure (no DB).
- * `grain_columns` is a persisted JSON array of column names; a malformed/absent
- * blob degrades to an empty grain rather than throwing. The remaining fields map
- * straight through (the view is head-resolved, so a present row IS the promoted
- * detect run). The caller passes null when no entity row exists (pre-session).
+ * `grain_columns` is the engine's persisted dict `{"columns": [...]}` (bare
+ * array tolerated); a genuinely malformed/absent blob degrades to an empty grain
+ * rather than throwing. The remaining fields map straight through (the view is
+ * head-resolved, so a present row IS the promoted detect run), but the engine
+ * free-text fields (description / business name surrogate) can carry raw
+ * `src_<digest>__` prefixes, so they're digest-stripped before reaching the
+ * result (sibling precedent: why-cycle.ts). The caller passes null when no entity
+ * row exists (pre-session).
  */
 export function projectTableEntity(row: TableEntityRow): TableEntity {
-	const grain = z.array(z.string()).safeParse(row.grainColumns);
+	const grain = GrainColumns.safeParse(row.grainColumns);
 	return {
 		entity_type: row.detectedEntityType ?? null,
 		is_fact_table: row.isFactTable ?? null,
 		is_dimension_table: row.isDimensionTable ?? null,
-		grain: grain.success ? grain.data : [],
-		time_column: row.timeColumn ?? null,
-		description: row.description ?? null,
+		grain: grain.success ? grain.data.map(stripSrcDigests) : [],
+		time_column:
+			row.timeColumn == null ? null : stripSrcDigests(row.timeColumn),
+		description:
+			row.description == null ? null : stripSrcDigests(row.description),
 	};
 }
 
@@ -350,16 +372,17 @@ export async function lookTable(
 
 	// Four independent reads once the table is known: the per-column grid (its own
 	// add_source `table:{id}` head, now carrying the light semantic join), the
-	// table descriptive header (DAT-476 — `current_table_entities`, head-resolved,
-	// session/detect grain so null pre-session), the table-grain band (the
-	// begin_session `session:{id}` head — a different head), and the workspace teach
-	// count. Fan them out — they share no input, so sequential awaits only add
-	// latency. table_readiness stays null without a session_id (add_source view);
-	// entity stays null until a detect run promotes (independent of session_id).
+	// table descriptive header (DAT-476 — `current_table_entities`, a
+	// `session:{id}`-detect-head view so scoped to the passed session_id when
+	// given, else the latest detected entity), the table-grain band (the
+	// begin_session `session:{id}` head), and the workspace teach count. Fan them
+	// out — they share no input, so sequential awaits only add latency.
+	// table_readiness stays null without a session_id (add_source view); entity
+	// stays null until a detect run promotes (for the chosen session/latest scope).
 	const tableName = table.tableName ?? "";
 	const [cols, entity, tableReadiness, pending] = await Promise.all([
 		loadColumnGrid(input.table_id),
-		loadTableEntity(input.table_id),
+		loadTableEntity(input.table_id, input.session_id),
 		input.session_id ? loadTableBand(input.session_id, tableName) : null,
 		getPendingOverlays(),
 	]);
@@ -423,11 +446,34 @@ async function loadColumnGrid(tableId: string): Promise<ColumnReadiness[]> {
 	);
 }
 
+/** The `current_table_entities` filter for one table (DAT-476). The view is
+ * `session:{id}`-detect-head-scoped — ONE row per (table_id, session), NOT
+ * table-grain — so filtering on table_id alone picks an arbitrary session's row
+ * in a multi-session workspace. When a session_id is passed we scope to it
+ * (mirror loadTableBand); otherwise we filter on table_id alone and let the
+ * `detected_at desc` order at the call site pick the latest deterministically.
+ * Pure (no DB) so the scoping decision is unit-testable. */
+export function tableEntityWhere(tableId: string, sessionId?: string) {
+	return sessionId
+		? and(
+				eq(currentTableEntities.tableId, tableId),
+				eq(currentTableEntities.sessionId, sessionId),
+			)
+		: eq(currentTableEntities.tableId, tableId);
+}
+
 /** Resolve a table's descriptive header (DAT-476) — entity type / fact-dimension
  * / grain / time column / description from `current_table_entities`. The view is
- * head-resolved (the promoted `detect` run), so a plain select by table_id
- * suffices; null when no detect run has promoted (pre-session). */
-async function loadTableEntity(tableId: string): Promise<TableEntity | null> {
+ * `session:{id}`-detect-head-scoped (one row per (table_id, session), NOT
+ * table-grain), so the {@link tableEntityWhere} filter scopes to the passed
+ * session_id when given; the `detected_at desc` order then picks the latest
+ * detected entity deterministically (vs an arbitrary session's row). Null when no
+ * detect run has promoted for the chosen scope (pre-session). */
+async function loadTableEntity(
+	tableId: string,
+	sessionId?: string,
+): Promise<TableEntity | null> {
+	const where = tableEntityWhere(tableId, sessionId);
 	const [row] = await metadataDb
 		.select({
 			detectedEntityType: currentTableEntities.detectedEntityType,
@@ -438,7 +484,8 @@ async function loadTableEntity(tableId: string): Promise<TableEntity | null> {
 			description: currentTableEntities.description,
 		})
 		.from(currentTableEntities)
-		.where(eq(currentTableEntities.tableId, tableId))
+		.where(where)
+		.orderBy(desc(currentTableEntities.detectedAt))
 		.limit(1);
 	return row ? projectTableEntity(row) : null;
 }

--- a/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
@@ -7,8 +7,13 @@
 // Reads theme/tokens only; the row type is a type-only import (erased — no server
 // code in the client bundle).
 
-import { Alert, Anchor, Group, Stack, Table, Text } from "@mantine/core";
-import type { TableReadiness } from "#/tools/look-table";
+import { Alert, Anchor, Badge, Group, Stack, Table, Text } from "@mantine/core";
+import { humanizeIdentifier } from "#/lib/display-names";
+import type {
+	ColumnSemantic,
+	TableEntity,
+	TableReadiness,
+} from "#/tools/look-table";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
 import { useCockpitActions } from "#/ui/cockpit/cockpit-state";
 import {
@@ -54,6 +59,81 @@ function TableBandSummary({ band }: { band: TableReadiness }) {
 						</Text>
 					))}
 				</Group>
+			)}
+		</Group>
+	);
+}
+
+// The table descriptive header (DAT-476) — the cockpit analog of MCP
+// `look(target="table")`'s entity block: what kind of table this is (fact /
+// dimension), its grain, its time column, and a short description. Rendered above
+// the per-column grid; only present once a begin_session detect run has promoted
+// (else `entity` is null and this is skipped). Additive — it colors/labels the
+// engine-persisted values, never recomputes them.
+function TableEntityHeader({ entity }: { entity: TableEntity }) {
+	// The kind chips read straight from the persisted flags; an entity with neither
+	// flag set (a plain table) shows no kind chip rather than a misleading one.
+	const kinds: string[] = [];
+	if (entity.is_fact_table) kinds.push("Fact table");
+	if (entity.is_dimension_table) kinds.push("Dimension table");
+	return (
+		<Stack gap={4} data-testid="canvas-table-readiness-entity">
+			<Group gap="xs" align="center" wrap="wrap">
+				{entity.entity_type && (
+					<Badge variant="light" size="sm" tt="none">
+						{humanizeIdentifier(entity.entity_type) || entity.entity_type}
+					</Badge>
+				)}
+				{kinds.map((k) => (
+					<Badge key={k} variant="outline" size="sm" tt="none" color="gray">
+						{k}
+					</Badge>
+				))}
+				{entity.grain.length > 0 && (
+					<Text span size="xs" c="dimmed">
+						Grain: {entity.grain.join(", ")}
+					</Text>
+				)}
+				{entity.time_column && (
+					<Text span size="xs" c="dimmed">
+						Time: {entity.time_column}
+					</Text>
+				)}
+			</Group>
+			{entity.description && (
+				<Text size="sm" c="dimmed">
+					{entity.description}
+				</Text>
+			)}
+		</Stack>
+	);
+}
+
+// Light per-column semantics (DAT-476): the business name / concept / role triple
+// from begin_session's `semantic_per_column` annotation, shown as compact chips
+// under the column name. Null (unannotated) renders nothing — the column row stays
+// the bare add_source view.
+function ColumnSemanticChips({ semantic }: { semantic: ColumnSemantic }) {
+	const businessName = semantic.business_name;
+	const concept = semantic.business_concept;
+	const role = semantic.semantic_role;
+	if (!businessName && !concept && !role) return null;
+	return (
+		<Group gap={4} wrap="wrap" mt={2} data-testid="readiness-semantic">
+			{businessName && (
+				<Text span size="xs" c="dimmed" fs="italic">
+					{businessName}
+				</Text>
+			)}
+			{concept && (
+				<Badge variant="dot" size="xs" tt="none" color="blue">
+					{humanizeIdentifier(concept) || concept}
+				</Badge>
+			)}
+			{role && (
+				<Badge variant="dot" size="xs" tt="none" color="grape">
+					{humanizeIdentifier(role) || role}
+				</Badge>
 			)}
 		</Group>
 	);
@@ -109,6 +189,8 @@ export function TableReadinessWidget({
 				{tableLabel} — readiness
 			</Text>
 
+			{readiness.entity && <TableEntityHeader entity={readiness.entity} />}
+
 			{readiness.table_readiness && (
 				<TableBandSummary band={readiness.table_readiness} />
 			)}
@@ -158,6 +240,9 @@ export function TableReadinessWidget({
 										>
 											{c.column_name}
 										</Anchor>
+										{c.semantic && (
+											<ColumnSemanticChips semantic={c.semantic} />
+										)}
 									</Table.Td>
 									<Table.Td>
 										<Text span c="dimmed" size="xs">

--- a/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
@@ -114,10 +114,12 @@ function TableEntityHeader({ entity }: { entity: TableEntity }) {
 // under the column name. Null (unannotated) renders nothing — the column row stays
 // the bare add_source view.
 function ColumnSemanticChips({ semantic }: { semantic: ColumnSemantic }) {
+	// The caller guards `{c.semantic && …}` and the projection returns null when
+	// every field is absent, so a non-null `semantic` always has ≥1 field — no
+	// all-null guard needed here; each chip is individually conditional below.
 	const businessName = semantic.business_name;
 	const concept = semantic.business_concept;
 	const role = semantic.semantic_role;
-	if (!businessName && !concept && !role) return null;
 	return (
 		<Group gap={4} wrap="wrap" mt={2} data-testid="readiness-semantic">
 			{businessName && (


### PR DESCRIPTION
Phase 2 of epic DAT-474. Additive enrichment of `look_table`: a table-level entity block (entity_type / fact-dim / grain / time_column / description) from `current_table_entities`, plus per-column light semantics (business_concept / role / business_name) from `current_semantic_annotations`. Existing readiness output unchanged.

- Design: [DD/33062914](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/33062914) · AC: DAT-476
- Review: spec + senior + strict + re-review — all APPROVE. Caught & fixed: dead `grain` (engine persists `{"columns":[…]}`, not an array), nondeterministic entity pick (now session-scoped/latest), and a digest leak on free-text.
- In-lane (look-table.ts / table-readiness.tsx / look-table.test.ts only). `tsc` + `biome` green; CI is the vitest gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)