### PR TITLE
feat(cockpit): list_tables entity facts + enriched-views summary (DAT-477)

### DIFF
--- a/packages/cockpit/src/tools/list-tables.test.ts
+++ b/packages/cockpit/src/tools/list-tables.test.ts
@@ -15,7 +15,9 @@ vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 import {
 	buildInventory,
 	type ColumnBandRow,
+	type EnrichedViewRow,
 	type InventoryTableRow,
+	type TableEntityRow,
 } from "./list-tables";
 
 // A 40-char sha-1 hex digest, as the content-keyed upload sources mint them.
@@ -173,5 +175,174 @@ describe("buildInventory (DAT-349)", () => {
 		const byId = new Map(out.map((t) => [t.table_id, t]));
 		expect(byId.get("t_orders")?.worst_band).toBe("blocked");
 		expect(byId.get("t_items")?.worst_band).toBe("ready");
+	});
+});
+
+// DAT-477: the session/detect-grain orientation buildInventory attaches per table
+// — entity classification (entity_type / is_fact) + the enriched fact/dimension
+// views built off the table. The two new row arrays default to empty, so the
+// pre-session state (no entity rows, no view rows) yields null entity facts + an
+// empty enriched_views summary on every table.
+describe("buildInventory entity + enriched_views (DAT-477)", () => {
+	it("leaves entity_type/is_fact null and enriched_views empty pre-session", () => {
+		// Two-arg call (the legacy add_source path) — no session has run.
+		const [out] = buildInventory([tableRow()], []);
+		expect(out.entity_type).toBeNull();
+		expect(out.is_fact).toBeNull();
+		expect(out.enriched_views).toEqual({
+			count: 0,
+			view_names: [],
+			any_grain_verified: null,
+		});
+	});
+
+	it("treats an explicitly empty entity/view set as the pre-session state", () => {
+		const [out] = buildInventory([tableRow()], [], [], []);
+		expect(out.entity_type).toBeNull();
+		expect(out.is_fact).toBeNull();
+		expect(out.enriched_views.count).toBe(0);
+	});
+
+	it("attaches the table's entity classification by table_id", () => {
+		const entities: TableEntityRow[] = [
+			{
+				tableId: "t_orders",
+				detectedEntityType: "transaction",
+				isFactTable: true,
+			},
+		];
+		const [out] = buildInventory([tableRow()], [], entities, []);
+		expect(out.entity_type).toBe("transaction");
+		expect(out.is_fact).toBe(true);
+	});
+
+	it("scopes the entity classification to its own table", () => {
+		const entities: TableEntityRow[] = [
+			{
+				tableId: "t_orders",
+				detectedEntityType: "transaction",
+				isFactTable: true,
+			},
+			{
+				tableId: "t_items",
+				detectedEntityType: "reference",
+				isFactTable: false,
+			},
+		];
+		const out = buildInventory(
+			[
+				tableRow({ tableId: "t_orders", tableName: "orders" }),
+				tableRow({ tableId: "t_items", tableName: "items" }),
+			],
+			[],
+			entities,
+			[],
+		);
+		const byId = new Map(out.map((t) => [t.table_id, t]));
+		expect(byId.get("t_orders")).toMatchObject({
+			entity_type: "transaction",
+			is_fact: true,
+		});
+		expect(byId.get("t_items")).toMatchObject({
+			entity_type: "reference",
+			is_fact: false,
+		});
+	});
+
+	it("summarizes the enriched views grouped under their fact table", () => {
+		// Engine builds enriched view names as `enriched_<source>__<table>`
+		// (enriched_views_phase.py); displayTableName strips the content-keyed
+		// `<source>__` segment so no digest reaches the agent (DAT-431).
+		const views: EnrichedViewRow[] = [
+			{
+				factTableId: "t_orders",
+				viewName: `enriched_src_${DIGEST}__orders`,
+				isGrainVerified: true,
+			},
+			{
+				factTableId: "t_orders",
+				viewName: `enriched_src_${DIGEST}__orders_by_region`,
+				isGrainVerified: false,
+			},
+			// A different fact table's view must not leak onto t_orders.
+			{
+				factTableId: "t_items",
+				viewName: `enriched_src_${DIGEST}__items`,
+				isGrainVerified: false,
+			},
+		];
+		const out = buildInventory(
+			[
+				tableRow({ tableId: "t_orders", tableName: "orders" }),
+				tableRow({ tableId: "t_items", tableName: "items" }),
+			],
+			[],
+			[],
+			views,
+		);
+		const byId = new Map(out.map((t) => [t.table_id, t]));
+		expect(byId.get("t_orders")?.enriched_views).toEqual({
+			count: 2,
+			view_names: ["enriched_orders", "enriched_orders_by_region"],
+			any_grain_verified: true,
+		});
+		expect(byId.get("t_items")?.enriched_views).toEqual({
+			count: 1,
+			view_names: ["enriched_items"],
+			any_grain_verified: false,
+		});
+		// The digest appears nowhere in the projected names (DAT-431).
+		expect(JSON.stringify(out)).not.toMatch(/src_[0-9a-f]{40}/);
+	});
+
+	it("drops a null/blank enriched-view name rather than emitting it", () => {
+		const views: EnrichedViewRow[] = [
+			{ factTableId: "t_orders", viewName: null, isGrainVerified: false },
+			{ factTableId: "t_orders", viewName: "", isGrainVerified: false },
+			{
+				factTableId: "t_orders",
+				viewName: `enriched_src_${DIGEST}__orders`,
+				isGrainVerified: false,
+			},
+		];
+		const [out] = buildInventory([tableRow()], [], [], views);
+		// All three count toward the fan-out, but only the named view is listed.
+		expect(out.enriched_views.count).toBe(3);
+		expect(out.enriched_views.view_names).toEqual(["enriched_orders"]);
+	});
+
+	it("keeps the existing inventory fields unchanged when entity data is present", () => {
+		const entities: TableEntityRow[] = [
+			{
+				tableId: "t_orders",
+				detectedEntityType: "transaction",
+				isFactTable: true,
+			},
+		];
+		const [out] = buildInventory(
+			[tableRow()],
+			[
+				{ tableId: "t_orders", band: "ready" },
+				{ tableId: "t_orders", band: "blocked" },
+			],
+			entities,
+			[],
+		);
+		// The DAT-349 projection is untouched — additive only.
+		expect(out).toMatchObject({
+			table_id: "t_orders",
+			table_name: "orders",
+			physical_name: `src_${DIGEST}__orders`,
+			row_count: 1000,
+			column_count: 2,
+			worst_band: "blocked",
+			analyzed: true,
+		});
+		expect(out.readiness).toEqual({
+			ready: 1,
+			investigate: 0,
+			blocked: 1,
+			unanalyzed: 0,
+		});
 	});
 });

--- a/packages/cockpit/src/tools/list-tables.test.ts
+++ b/packages/cockpit/src/tools/list-tables.test.ts
@@ -209,6 +209,7 @@ describe("buildInventory entity + enriched_views (DAT-477)", () => {
 				tableId: "t_orders",
 				detectedEntityType: "transaction",
 				isFactTable: true,
+				detectedAt: new Date("2026-06-01T00:00:00Z"),
 			},
 		];
 		const [out] = buildInventory([tableRow()], [], entities, []);
@@ -222,11 +223,13 @@ describe("buildInventory entity + enriched_views (DAT-477)", () => {
 				tableId: "t_orders",
 				detectedEntityType: "transaction",
 				isFactTable: true,
+				detectedAt: new Date("2026-06-01T00:00:00Z"),
 			},
 			{
 				tableId: "t_items",
 				detectedEntityType: "reference",
 				isFactTable: false,
+				detectedAt: new Date("2026-06-01T00:00:00Z"),
 			},
 		];
 		const out = buildInventory(
@@ -258,17 +261,20 @@ describe("buildInventory entity + enriched_views (DAT-477)", () => {
 				factTableId: "t_orders",
 				viewName: `enriched_src_${DIGEST}__orders`,
 				isGrainVerified: true,
+				createdAt: new Date("2026-06-01T00:00:00Z"),
 			},
 			{
 				factTableId: "t_orders",
 				viewName: `enriched_src_${DIGEST}__orders_by_region`,
 				isGrainVerified: false,
+				createdAt: new Date("2026-06-01T00:00:00Z"),
 			},
 			// A different fact table's view must not leak onto t_orders.
 			{
 				factTableId: "t_items",
 				viewName: `enriched_src_${DIGEST}__items`,
 				isGrainVerified: false,
+				createdAt: new Date("2026-06-01T00:00:00Z"),
 			},
 		];
 		const out = buildInventory(
@@ -295,20 +301,35 @@ describe("buildInventory entity + enriched_views (DAT-477)", () => {
 		expect(JSON.stringify(out)).not.toMatch(/src_[0-9a-f]{40}/);
 	});
 
-	it("drops a null/blank enriched-view name rather than emitting it", () => {
+	it("drops a null/blank enriched-view name and keeps count == view_names", () => {
 		const views: EnrichedViewRow[] = [
-			{ factTableId: "t_orders", viewName: null, isGrainVerified: false },
-			{ factTableId: "t_orders", viewName: "", isGrainVerified: false },
+			{
+				factTableId: "t_orders",
+				viewName: null,
+				isGrainVerified: false,
+				createdAt: new Date("2026-06-01T00:00:00Z"),
+			},
+			{
+				factTableId: "t_orders",
+				viewName: "",
+				isGrainVerified: false,
+				createdAt: new Date("2026-06-01T00:00:00Z"),
+			},
 			{
 				factTableId: "t_orders",
 				viewName: `enriched_src_${DIGEST}__orders`,
 				isGrainVerified: false,
+				createdAt: new Date("2026-06-01T00:00:00Z"),
 			},
 		];
 		const [out] = buildInventory([tableRow()], [], [], views);
-		// All three count toward the fan-out, but only the named view is listed.
-		expect(out.enriched_views.count).toBe(3);
+		// `count` tracks the EMITTED names, never the raw row count — a name-less
+		// stale row must not inflate `count: 3` against `view_names: [one]`.
+		expect(out.enriched_views.count).toBe(1);
 		expect(out.enriched_views.view_names).toEqual(["enriched_orders"]);
+		// But grain-verified still keys off the raw rows (here none verified), and
+		// is non-null because the fact table does carry views.
+		expect(out.enriched_views.any_grain_verified).toBe(false);
 	});
 
 	it("keeps the existing inventory fields unchanged when entity data is present", () => {
@@ -317,6 +338,7 @@ describe("buildInventory entity + enriched_views (DAT-477)", () => {
 				tableId: "t_orders",
 				detectedEntityType: "transaction",
 				isFactTable: true,
+				detectedAt: new Date("2026-06-01T00:00:00Z"),
 			},
 		];
 		const [out] = buildInventory(
@@ -343,6 +365,93 @@ describe("buildInventory entity + enriched_views (DAT-477)", () => {
 			investigate: 0,
 			blocked: 1,
 			unanalyzed: 0,
+		});
+	});
+
+	// `current_table_entities` / `current_enriched_views` are `session:{id}`-head-
+	// scoped: a multi-session workspace carries one row-set per session per table.
+	// buildInventory must pick the LATEST session deterministically (by detected_at
+	// / created_at), order-independent of the input array — never the
+	// nondeterministic "whichever row was last in the list".
+	describe("multi-session determinism (DAT-476 cross-lane guard)", () => {
+		const t1 = new Date("2026-06-01T00:00:00Z");
+		const t2 = new Date("2026-06-08T00:00:00Z");
+
+		it("picks the latest-session entity by detected_at", () => {
+			const entities: TableEntityRow[] = [
+				{
+					tableId: "t_orders",
+					detectedEntityType: "reference",
+					isFactTable: false,
+					detectedAt: t1,
+				},
+				{
+					tableId: "t_orders",
+					detectedEntityType: "transaction",
+					isFactTable: true,
+					detectedAt: t2,
+				},
+			];
+			// Newest-last in the array — the wrong row would win without the dedup.
+			const [out] = buildInventory([tableRow()], [], entities, []);
+			expect(out.entity_type).toBe("transaction");
+			expect(out.is_fact).toBe(true);
+		});
+
+		it("is order-independent — the latest entity wins newest-first too", () => {
+			const newestFirst: TableEntityRow[] = [
+				{
+					tableId: "t_orders",
+					detectedEntityType: "transaction",
+					isFactTable: true,
+					detectedAt: t2,
+				},
+				{
+					tableId: "t_orders",
+					detectedEntityType: "reference",
+					isFactTable: false,
+					detectedAt: t1,
+				},
+			];
+			const [out] = buildInventory([tableRow()], [], newestFirst, []);
+			expect(out.entity_type).toBe("transaction");
+			expect(out.is_fact).toBe(true);
+		});
+
+		it("keeps only the latest session's enriched views, not a cross-session pile", () => {
+			const views: EnrichedViewRow[] = [
+				// Older session: a single, unverified view.
+				{
+					factTableId: "t_orders",
+					viewName: `enriched_src_${DIGEST}__orders_old`,
+					isGrainVerified: false,
+					createdAt: t1,
+				},
+				// Newer session: two views, one grain-verified — this set must win
+				// whole, with no carry-over from the older session.
+				{
+					factTableId: "t_orders",
+					viewName: `enriched_src_${DIGEST}__orders`,
+					isGrainVerified: true,
+					createdAt: t2,
+				},
+				{
+					factTableId: "t_orders",
+					viewName: `enriched_src_${DIGEST}__orders_by_region`,
+					isGrainVerified: false,
+					createdAt: t2,
+				},
+			];
+			const [out] = buildInventory([tableRow()], [], [], views);
+			expect(out.enriched_views).toEqual({
+				count: 2,
+				view_names: ["enriched_orders", "enriched_orders_by_region"],
+				any_grain_verified: true,
+			});
+			// The older session's view must not leak in.
+			expect(out.enriched_views.view_names).not.toContain(
+				"enriched_orders_old",
+			);
 		});
 	});
 });

--- a/packages/cockpit/src/tools/list-tables.ts
+++ b/packages/cockpit/src/tools/list-tables.ts
@@ -1,15 +1,22 @@
-// list_tables tool (DAT-353, enriched for DAT-349) — the workspace table
-// inventory: every table across all (non-archived) sources with its provenance,
-// shape, and a per-table readiness rollup.
+// list_tables tool (DAT-353, enriched for DAT-349 + DAT-477) — the workspace
+// table inventory: every table across all (non-archived) sources with its
+// provenance, shape, a per-table readiness rollup, and (DAT-477) the dataset-
+// grain descriptive orientation the cockpit analog of MCP `look()` no-target
+// surfaces: each table's detected entity type / fact-ness plus the enriched
+// fact/dimension views built for it.
 //
-// Pure reads via the Drizzle metadata client. Two small queries — tables ⟕
-// sources (provenance) and columns ⟕ entropy_readiness (the per-column bands) —
-// fed to a pure `buildInventory` projection that rolls each table's columns up to
-// a {ready, investigate, blocked, unanalyzed} distribution + a worst band. The
+// Pure reads via the Drizzle metadata client. A few small queries — tables ⟕
+// sources (provenance), columns ⟕ entropy_readiness (the per-column bands), and
+// (DAT-477) the session/detect-grain `current_table_entities` + `current_enriched_
+// views` views — fed to a pure `buildInventory` projection that rolls each
+// table's columns up to a {ready, investigate, blocked, unanalyzed} distribution
+// + a worst band and attaches the entity facts + enriched-views summary. The
 // rollup is read-time only: the engine persists readiness PER COLUMN (no
 // table-level row), and the cockpit never re-derives a band — it counts the
-// calibrated ones. No approval (reads are unattended). The Drizzle joins are
-// smoke-covered (a live ws_<id>); the pure projection is unit-tested here.
+// calibrated ones. The entity/enriched-views data is session-grain → null/empty
+// pre-session (no `session_id` input; the current_* views resolve the promoted
+// detect run server-side). No approval (reads are unattended). The Drizzle joins
+// are smoke-covered (a live ws_<id>); the pure projection is unit-tested here.
 
 import { toolDefinition } from "@tanstack/ai";
 import { and, asc, eq, isNull } from "drizzle-orm";
@@ -18,7 +25,9 @@ import { z } from "zod";
 import { metadataDb } from "../db/metadata/client";
 import {
 	columns,
+	currentEnrichedViews,
 	currentEntropyReadiness,
+	currentTableEntities,
 	sources,
 	tables,
 } from "../db/metadata/schema";
@@ -40,6 +49,23 @@ const ReadinessRollup = z.object({
 	unanalyzed: z.number(),
 });
 export type ReadinessRollup = z.infer<typeof ReadinessRollup>;
+
+// The enriched fact/dimension views materialized for a table (DAT-477). begin_
+// session's detect builds one `enriched_views` row per fact table joined to its
+// dimensions; this summarizes the views whose `factTableId` is THIS table —
+// count + the view names + whether each view's grain was verified. Empty
+// pre-session (no detect run promoted yet).
+const EnrichedViewsSummary = z.object({
+	count: z.number(),
+	// The display names of the views built off this fact table (capped — a fact
+	// can fan out to several enriched views; the inventory is a navigation
+	// surface, so the agent gets the names, not the full join spec).
+	view_names: z.array(z.string()),
+	// True when at least one of this table's enriched views had its grain verified
+	// — a quick "the joins are trustworthy" signal; null when there are no views.
+	any_grain_verified: z.boolean().nullable(),
+});
+export type EnrichedViewsSummary = z.infer<typeof EnrichedViewsSummary>;
 
 const InventoryTable = z.object({
 	table_id: z.string(),
@@ -72,8 +98,30 @@ const InventoryTable = z.object({
 	// ready), or null when nothing is analyzed — the at-a-glance row badge.
 	worst_band: z.enum(BANDS).nullable(),
 	readiness: ReadinessRollup,
+	// --- Dataset-grain descriptive orientation (DAT-477) — session/detect grain.
+	// The entity classification begin_session's detect assigns this table: its
+	// detected entity type and whether it's a fact table. Null pre-session (no
+	// promoted detect run carries a `current_table_entities` row for this table).
+	// `.optional()` is a TYPE-boundary affordance only: buildInventory ALWAYS sets
+	// these (the server never omits them), but pre-DAT-477 `InventoryTable`
+	// fixtures in sibling widget tests predate the fields — optional lets them
+	// typecheck unchanged while the live projection stays exhaustive.
+	entity_type: z.string().nullable().optional(),
+	is_fact: z.boolean().nullable().optional(),
+	// The enriched fact/dimension views built for this table (count + names);
+	// empty pre-session.
+	enriched_views: EnrichedViewsSummary.optional(),
 });
 export type InventoryTable = z.infer<typeof InventoryTable>;
+
+/**
+ * What `buildInventory` actually produces: every DAT-477 field present (the
+ * projection never omits them). Distinct from `InventoryTable`, whose new fields
+ * are `.optional()` purely so pre-DAT-477 fixtures typecheck — the live result is
+ * always exhaustive, which the tests rely on.
+ */
+export type ProjectedInventoryTable = InventoryTable &
+	Required<Pick<InventoryTable, "entity_type" | "is_fact" | "enriched_views">>;
 
 /** One table ⟕ source provenance row, as the Drizzle select returns it. */
 export interface InventoryTableRow {
@@ -122,19 +170,48 @@ export interface ColumnBandRow {
 	band: string | null;
 }
 
+/** One `current_table_entities` row (the promoted detect run's classification). */
+export interface TableEntityRow {
+	tableId: string;
+	detectedEntityType: string | null;
+	isFactTable: boolean | null;
+}
+
 /**
- * Roll the per-column bands up to a per-table inventory. Pure (no DB) so the
- * grouping + worst-band logic is unit-testable without a live schema. Tables with
- * no columns get a zeroed rollup (analyzed=false, worst_band=null); a column with
- * a null band counts as `unanalyzed`. Assumes the engine's three-band vocabulary
- * and at most one readiness row per column. That 1:1 invariant is engine-enforced
- * (the measure step delete-before-inserts readiness scoped per table, DAT-410) —
- * NOT a DB unique constraint — and is the same contract `look_table` relies on.
+ * One `current_enriched_views` row. `factTableId` keys the view back to the fact
+ * table the inventory groups it under; `viewName` is the materialized view's
+ * name; `isGrainVerified` flags a grain-verified join.
+ */
+export interface EnrichedViewRow {
+	factTableId: string;
+	viewName: string | null;
+	isGrainVerified: boolean | null;
+}
+
+/**
+ * Roll the per-column bands up to a per-table inventory and attach the session-
+ * grain entity facts + enriched-views summary (DAT-477). Pure (no DB) so the
+ * grouping + worst-band + entity/enriched projection is unit-testable without a
+ * live schema. Tables with no columns get a zeroed rollup (analyzed=false,
+ * worst_band=null); a column with a null band counts as `unanalyzed`. Assumes the
+ * engine's three-band vocabulary and at most one readiness row per column. That
+ * 1:1 invariant is engine-enforced (the measure step delete-before-inserts
+ * readiness scoped per table, DAT-410) — NOT a DB unique constraint — and is the
+ * same contract `look_table` relies on.
+ *
+ * The entity facts (entity_type / is_fact) and enriched_views summary are
+ * session/detect grain: absent any promoted detect run the entity rows / view
+ * rows are empty, so entity_type / is_fact stay null and enriched_views is an
+ * empty summary — never invented pre-session. At most one entity row per table
+ * (the promoted run's classification); multiple enriched views can name the same
+ * fact table, so they're grouped by `factTableId`.
  */
 export function buildInventory(
 	tableRows: InventoryTableRow[],
 	columnBandRows: ColumnBandRow[],
-): InventoryTable[] {
+	tableEntityRows: TableEntityRow[] = [],
+	enrichedViewRows: EnrichedViewRow[] = [],
+): ProjectedInventoryTable[] {
 	const rollups = new Map<string, ReadinessRollup>();
 	for (const { tableId, band } of columnBandRows) {
 		let r = rollups.get(tableId);
@@ -147,6 +224,18 @@ export function buildInventory(
 		} else {
 			r.unanalyzed += 1;
 		}
+	}
+
+	// Entity classification, keyed by table_id (≤ 1 row per table on a run).
+	const entities = new Map<string, TableEntityRow>();
+	for (const e of tableEntityRows) entities.set(e.tableId, e);
+
+	// Enriched views grouped under their fact table (a fact can fan out to many).
+	const enrichedByFact = new Map<string, EnrichedViewRow[]>();
+	for (const v of enrichedViewRows) {
+		const g = enrichedByFact.get(v.factTableId);
+		if (g) g.push(v);
+		else enrichedByFact.set(v.factTableId, [v]);
 	}
 
 	return tableRows.map((t) => {
@@ -165,6 +254,8 @@ export function buildInventory(
 					: r.ready > 0
 						? "ready"
 						: null;
+		const entity = entities.get(t.tableId);
+		const views = enrichedByFact.get(t.tableId) ?? [];
 		return {
 			table_id: t.tableId,
 			// Display form for prose (the raw source name strips its exact prefix;
@@ -182,6 +273,24 @@ export function buildInventory(
 			analyzed,
 			worst_band,
 			readiness: r,
+			// Session-grain entity facts — null when no promoted detect run
+			// classified this table (pre-session, or a table the session didn't
+			// reach).
+			entity_type: entity?.detectedEntityType ?? null,
+			is_fact: entity?.isFactTable ?? null,
+			enriched_views: {
+				count: views.length,
+				// Display-mapped so no content-keyed prefix reaches LLM context; drop
+				// any view that lost its name on a stale row.
+				view_names: views
+					.map((v) => v.viewName)
+					.filter((n): n is string => n !== null && n.length > 0)
+					.map((n) => displayTableName(n)),
+				any_grain_verified:
+					views.length === 0
+						? null
+						: views.some((v) => v.isGrainVerified === true),
+			},
 		};
 	});
 }
@@ -231,6 +340,30 @@ export async function listTables(
 		)
 		.where(and(isNull(sources.archivedAt), sourceFilter));
 
+	// Session/detect-grain orientation (DAT-477). The current_* views resolve the
+	// promoted detect run server-side (the head join lives in the DB, ADR-0008),
+	// so a workspace with no sealed session yields zero rows here → entity_type/
+	// is_fact stay null and enriched_views stays empty. Read inline (no shared
+	// reader — trivial duplication is intentional, DRY'd up later). Short selects;
+	// no source filter (these views carry no source_id — the table_id / fact_table_id
+	// keys join back to the source-filtered tableRows in buildInventory, so a
+	// source filter naturally drops unrelated entity/view rows there).
+	const tableEntityRows = await metadataDb
+		.select({
+			tableId: currentTableEntities.tableId,
+			detectedEntityType: currentTableEntities.detectedEntityType,
+			isFactTable: currentTableEntities.isFactTable,
+		})
+		.from(currentTableEntities);
+
+	const enrichedViewRows = await metadataDb
+		.select({
+			factTableId: currentEnrichedViews.factTableId,
+			viewName: currentEnrichedViews.viewName,
+			isGrainVerified: currentEnrichedViews.isGrainVerified,
+		})
+		.from(currentEnrichedViews);
+
 	// View columns type as nullable (Postgres views carry no NOT NULL) —
 	// coalesce the fields the underlying tables guarantee.
 	return buildInventory(
@@ -244,6 +377,8 @@ export async function listTables(
 			sourceType: r.sourceType ?? "",
 		})),
 		columnBandRows.map((r) => ({ ...r, tableId: r.tableId ?? "" })),
+		tableEntityRows.map((r) => ({ ...r, tableId: r.tableId ?? "" })),
+		enrichedViewRows.map((r) => ({ ...r, factTableId: r.factTableId ?? "" })),
 	);
 }
 
@@ -256,7 +391,10 @@ export const listTablesTool = toolDefinition({
 		"run_sql as `lake.<layer>.<physical_name>`), layer, row count, column " +
 		"count, its source (name/type/backend), and a readiness rollup — how " +
 		"many of its columns are ready / investigate / blocked / unanalyzed plus " +
-		"the worst band.",
+		"the worst band. After a begin_session run it also carries each table's " +
+		"detected entity_type and is_fact classification, and an enriched_views " +
+		"summary (count + view_names of the fact/dimension views built off that " +
+		"table); these stay null/empty before a session has been run.",
 	inputSchema: z.object({
 		source_id: z
 			.string()

--- a/packages/cockpit/src/tools/list-tables.ts
+++ b/packages/cockpit/src/tools/list-tables.ts
@@ -19,7 +19,7 @@
 // are smoke-covered (a live ws_<id>); the pure projection is unit-tested here.
 
 import { toolDefinition } from "@tanstack/ai";
-import { and, asc, eq, isNull } from "drizzle-orm";
+import { and, asc, desc, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { metadataDb } from "../db/metadata/client";
@@ -170,22 +170,34 @@ export interface ColumnBandRow {
 	band: string | null;
 }
 
-/** One `current_table_entities` row (the promoted detect run's classification). */
+/**
+ * One `current_table_entities` row (the promoted detect run's classification).
+ * `current_table_entities` is `session:{id}`-head-scoped — one row per
+ * (table_id, session) — so a multi-session workspace yields SEVERAL rows for the
+ * same table. `detectedAt` is the tie-break: buildInventory keeps the latest per
+ * table so the pick is deterministic, never the nondeterministic "last row seen".
+ * (NOT NULL on the underlying table; the view types it nullable.)
+ */
 export interface TableEntityRow {
 	tableId: string;
 	detectedEntityType: string | null;
 	isFactTable: boolean | null;
+	detectedAt: Date | null;
 }
 
 /**
  * One `current_enriched_views` row. `factTableId` keys the view back to the fact
  * table the inventory groups it under; `viewName` is the materialized view's
- * name; `isGrainVerified` flags a grain-verified join.
+ * name; `isGrainVerified` flags a grain-verified join. Like the entity view this
+ * is `session:{id}`-head-scoped, so a fact table can carry views from several
+ * sessions; `createdAt` selects the latest session's set in buildInventory so the
+ * summary is single-session, not a cross-session pile. (NOT NULL underneath.)
  */
 export interface EnrichedViewRow {
 	factTableId: string;
 	viewName: string | null;
 	isGrainVerified: boolean | null;
+	createdAt: Date | null;
 }
 
 /**
@@ -202,9 +214,16 @@ export interface EnrichedViewRow {
  * The entity facts (entity_type / is_fact) and enriched_views summary are
  * session/detect grain: absent any promoted detect run the entity rows / view
  * rows are empty, so entity_type / is_fact stay null and enriched_views is an
- * empty summary — never invented pre-session. At most one entity row per table
- * (the promoted run's classification); multiple enriched views can name the same
- * fact table, so they're grouped by `factTableId`.
+ * empty summary — never invented pre-session. The current_* views are
+ * `session:{id}`-head-scoped, so in a MULTI-SESSION workspace one table carries
+ * several entity rows / view sets (one per session). The pick is made
+ * deterministic here — order-independent of the input arrays: the entity is the
+ * latest by `detectedAt`, and the enriched views are the set belonging to the
+ * latest `createdAt` for that fact table (not a cross-session pile). Multiple
+ * enriched views can name the same fact table in one session, so they're grouped
+ * by `factTableId`; `enriched_views.count` then equals the number of NON-blank
+ * view names emitted (never the raw row count — a stale name-less row must not
+ * inflate the count past `view_names`).
  */
 export function buildInventory(
 	tableRows: InventoryTableRow[],
@@ -226,13 +245,31 @@ export function buildInventory(
 		}
 	}
 
-	// Entity classification, keyed by table_id (≤ 1 row per table on a run).
+	// Entity classification, keyed by table_id. The view is session-head-scoped,
+	// so a multi-session workspace carries several rows per table — keep the
+	// LATEST by `detectedAt` (order-independent of the input array), so the pick
+	// is deterministic, not "whichever row arrived last".
+	const epoch = (d: Date | null): number => (d ? d.getTime() : 0);
 	const entities = new Map<string, TableEntityRow>();
-	for (const e of tableEntityRows) entities.set(e.tableId, e);
+	for (const e of tableEntityRows) {
+		const cur = entities.get(e.tableId);
+		if (!cur || epoch(e.detectedAt) >= epoch(cur.detectedAt))
+			entities.set(e.tableId, e);
+	}
 
-	// Enriched views grouped under their fact table (a fact can fan out to many).
+	// Enriched views grouped under their fact table (a fact can fan out to many in
+	// ONE session). The view is session-head-scoped too, so first pin each fact
+	// table to its LATEST session by `createdAt`, then keep only that session's
+	// views — never a cross-session pile (which would over-count and mix grains).
+	const latestEpochByFact = new Map<string, number>();
+	for (const v of enrichedViewRows) {
+		const e = epoch(v.createdAt);
+		const cur = latestEpochByFact.get(v.factTableId);
+		if (cur === undefined || e > cur) latestEpochByFact.set(v.factTableId, e);
+	}
 	const enrichedByFact = new Map<string, EnrichedViewRow[]>();
 	for (const v of enrichedViewRows) {
+		if (epoch(v.createdAt) !== latestEpochByFact.get(v.factTableId)) continue;
 		const g = enrichedByFact.get(v.factTableId);
 		if (g) g.push(v);
 		else enrichedByFact.set(v.factTableId, [v]);
@@ -256,6 +293,14 @@ export function buildInventory(
 						: null;
 		const entity = entities.get(t.tableId);
 		const views = enrichedByFact.get(t.tableId) ?? [];
+		// Display-mapped names, content-keyed prefix stripped (DAT-431); a stale
+		// row that lost its name is dropped. `count` is THIS — the number of
+		// emitted names — never `views.length`, so the agent/widget can't read
+		// `count: 3` against `view_names: ["enriched_orders"]` (uninterpretable).
+		const view_names = views
+			.map((v) => v.viewName)
+			.filter((n): n is string => n !== null && n.length > 0)
+			.map((n) => displayTableName(n));
 		return {
 			table_id: t.tableId,
 			// Display form for prose (the raw source name strips its exact prefix;
@@ -279,13 +324,11 @@ export function buildInventory(
 			entity_type: entity?.detectedEntityType ?? null,
 			is_fact: entity?.isFactTable ?? null,
 			enriched_views: {
-				count: views.length,
-				// Display-mapped so no content-keyed prefix reaches LLM context; drop
-				// any view that lost its name on a stale row.
-				view_names: views
-					.map((v) => v.viewName)
-					.filter((n): n is string => n !== null && n.length > 0)
-					.map((n) => displayTableName(n)),
+				count: view_names.length,
+				view_names,
+				// Grain-verified is a property of the view rows, so it keys off the
+				// raw set (a name-less row still carries an honest grain flag). Null
+				// only when there are no views at all for this fact table.
 				any_grain_verified:
 					views.length === 0
 						? null
@@ -299,10 +342,14 @@ export interface ListTablesInput {
 	source_id?: string;
 }
 
-/** The workspace table inventory (optionally one source), oldest source first. */
+/** The workspace table inventory (optionally one source), oldest source first.
+ * Returns `ProjectedInventoryTable[]` — buildInventory ALWAYS sets the DAT-477
+ * fields, so callers never face a `string | null | undefined` for entity_type/
+ * is_fact/enriched_views (the `.optional()` on `InventoryTable` is a fixture-only
+ * type affordance, not a runtime maybe). */
 export async function listTables(
 	input: ListTablesInput = {},
-): Promise<InventoryTable[]> {
+): Promise<ProjectedInventoryTable[]> {
 	const sourceFilter = input.source_id
 		? eq(tables.sourceId, input.source_id)
 		: undefined;
@@ -348,21 +395,29 @@ export async function listTables(
 	// no source filter (these views carry no source_id — the table_id / fact_table_id
 	// keys join back to the source-filtered tableRows in buildInventory, so a
 	// source filter naturally drops unrelated entity/view rows there).
+	// `detectedAt` / `createdAt` are the tie-break for the latest-per-table pick in
+	// buildInventory (the views are session-head-scoped → several rows per table in
+	// a multi-session workspace). The DB orderBy isn't load-bearing — buildInventory
+	// is order-independent — but newest-first keeps the wire shape intuitive.
 	const tableEntityRows = await metadataDb
 		.select({
 			tableId: currentTableEntities.tableId,
 			detectedEntityType: currentTableEntities.detectedEntityType,
 			isFactTable: currentTableEntities.isFactTable,
+			detectedAt: currentTableEntities.detectedAt,
 		})
-		.from(currentTableEntities);
+		.from(currentTableEntities)
+		.orderBy(desc(currentTableEntities.detectedAt));
 
 	const enrichedViewRows = await metadataDb
 		.select({
 			factTableId: currentEnrichedViews.factTableId,
 			viewName: currentEnrichedViews.viewName,
 			isGrainVerified: currentEnrichedViews.isGrainVerified,
+			createdAt: currentEnrichedViews.createdAt,
 		})
-		.from(currentEnrichedViews);
+		.from(currentEnrichedViews)
+		.orderBy(desc(currentEnrichedViews.createdAt));
 
 	// View columns type as nullable (Postgres views carry no NOT NULL) —
 	// coalesce the fields the underlying tables guarantee.

--- a/packages/cockpit/src/ui/cockpit/widgets/workspace-inventory.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/workspace-inventory.tsx
@@ -1,14 +1,18 @@
-// Workspace-inventory widget (DAT-349; de-noised in the redesign) — the
-// `list_tables` result as ONE row per logical table (the engine's raw / typed /
-// quarantine physical layers collapsed; the analyzed `typed` layer is shown).
-// Clicking a table name routes a look_table request through the chat loop;
-// clicking a source badge opens an in-widget SourceCard rail (local, no agent
-// round-trip); a red quarantine count opens a detail modal; Refresh re-lists.
+// Workspace-inventory widget (DAT-349; de-noised in the redesign; DAT-477 entity
+// orientation) — the `list_tables` result as ONE row per logical table (the
+// engine's raw / typed / quarantine physical layers collapsed; the analyzed
+// `typed` layer is shown). Clicking a table name routes a look_table request
+// through the chat loop; clicking a source badge opens an in-widget SourceCard
+// rail (local, no agent round-trip); a red quarantine count opens a detail
+// modal; Refresh re-lists.
 //
 // Bands are the engine's PERSISTED, calibrated values — this widget only colors
-// and title-cases them, it never recomputes readiness. Reads theme tokens only;
-// the row type is a type-only import (erased — no server code in the client
-// bundle).
+// and title-cases them, it never recomputes readiness. The entity_type / is_fact
+// classification and the enriched_views summary (DAT-477) are likewise PERSISTED,
+// session-grain values: the widget surfaces them as-is and shows nothing for the
+// pre-session null/empty state, never inventing a classification. Reads theme
+// tokens only; the row type is a type-only import (erased — no server code in the
+// client bundle).
 
 import {
 	Anchor,
@@ -38,6 +42,62 @@ import {
 // virtualizing (overkill for bounded metadata). Applies to the master list and a
 // single source's table list alike.
 const MAX_VISIBLE_ROWS = 100;
+
+// How many enriched-view names to spell out inline before collapsing to a count
+// (a fact table can fan out to several views — the cell is a glance, not a list).
+const ENRICHED_VIEW_NAMES_SHOWN = 2;
+
+/**
+ * The session-grain entity orientation for one table (DAT-477): its detected
+ * entity type + a fact marker + the count of enriched fact/dimension views built
+ * off it. Renders a neutral dash when nothing is classified yet (pre-session) so
+ * the column reads as "not analyzed", never as a blank that implies "not a fact".
+ * Pure render of PERSISTED values — colors/labels only, no recomputation.
+ */
+function EntityFacts({ table }: { table: InventoryTable }) {
+	const entity_type = table.entity_type ?? null;
+	const is_fact = table.is_fact ?? null;
+	// `enriched_views` is optional at the type boundary (pre-DAT-477 fixtures) —
+	// the server always sets it; default to the empty summary defensively.
+	const enriched_views = table.enriched_views ?? {
+		count: 0,
+		view_names: [],
+		any_grain_verified: null,
+	};
+	if (entity_type === null && is_fact === null && enriched_views.count === 0) {
+		return (
+			<Text span c="dimmed" size="xs">
+				—
+			</Text>
+		);
+	}
+	return (
+		<Group gap={4} wrap="wrap">
+			{entity_type && (
+				<Badge variant="light" color="blue" size="sm" tt="none">
+					{entity_type}
+				</Badge>
+			)}
+			{is_fact && (
+				<Badge variant="light" color="grape" size="sm" tt="none">
+					fact
+				</Badge>
+			)}
+			{enriched_views.count > 0 && (
+				<Badge
+					variant="outline"
+					color="teal"
+					size="sm"
+					tt="none"
+					data-testid={`inventory-enriched-${table.table_id}`}
+					title={enriched_views.view_names.join(", ")}
+				>
+					{enriched_views.count} view{enriched_views.count === 1 ? "" : "s"}
+				</Badge>
+			)}
+		</Group>
+	);
+}
 
 /** The per-source drill-in rail: source metadata + its logical tables' bands.
  * Built entirely from the inventory rows already in hand (no extra fetch). */
@@ -189,6 +249,34 @@ function TableDetailModal({
 						</Text>
 					)}
 
+					{/* Session-grain orientation (DAT-477): the detected entity class +
+					    the enriched fact/dimension views built off this table. Rendered
+					    only once a session has classified the table — pre-session there's
+					    nothing to show (entity null, no views). */}
+					{((table.representative.entity_type ?? null) !== null ||
+						(table.representative.enriched_views?.count ?? 0) > 0) && (
+						<Stack gap={4} data-testid="modal-entity">
+							<Text size="sm" fw={600}>
+								Entity
+							</Text>
+							<EntityFacts table={table.representative} />
+							{(table.representative.enriched_views?.view_names.length ?? 0) >
+								0 && (
+								<Text size="xs" c="dimmed">
+									{table.representative.enriched_views?.view_names
+										.slice(0, ENRICHED_VIEW_NAMES_SHOWN)
+										.join(", ")}
+									{(table.representative.enriched_views?.view_names.length ??
+										0) > ENRICHED_VIEW_NAMES_SHOWN &&
+										` +${
+											(table.representative.enriched_views?.view_names.length ??
+												0) - ENRICHED_VIEW_NAMES_SHOWN
+										} more`}
+								</Text>
+							)}
+						</Stack>
+					)}
+
 					<Stack gap={4}>
 						<Text size="sm" fw={600}>
 							Layers
@@ -310,6 +398,7 @@ export function WorkspaceInventoryWidget({
 							<Table.Tr>
 								<Table.Th>Table</Table.Th>
 								<Table.Th>Source</Table.Th>
+								<Table.Th>Entity</Table.Th>
 								<Table.Th>Rows</Table.Th>
 								<Table.Th>Cols</Table.Th>
 								<Table.Th>Readiness</Table.Th>
@@ -363,6 +452,9 @@ export function WorkspaceInventoryWidget({
 													: `${group.label} · ${lt.sourceType}`}
 											</Badge>
 										</Table.Td>
+										<Table.Td data-testid={`inventory-entity-${t.table_id}`}>
+											<EntityFacts table={t} />
+										</Table.Td>
 										<Table.Td>{t.row_count ?? "—"}</Table.Td>
 										<Table.Td>{t.column_count}</Table.Td>
 										<Table.Td>
@@ -391,7 +483,7 @@ export function WorkspaceInventoryWidget({
 							})}
 							{overflow > 0 && (
 								<Table.Tr data-testid="inventory-overflow">
-									<Table.Td colSpan={6}>
+									<Table.Td colSpan={7}>
 										<Text c="dimmed" size="xs">
 											…and {overflow} more — ask the agent to filter by source.
 										</Text>

--- a/packages/cockpit/src/ui/cockpit/widgets/workspace-inventory.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/workspace-inventory.tsx
@@ -252,8 +252,11 @@ function TableDetailModal({
 					{/* Session-grain orientation (DAT-477): the detected entity class +
 					    the enriched fact/dimension views built off this table. Rendered
 					    only once a session has classified the table — pre-session there's
-					    nothing to show (entity null, no views). */}
+					    nothing to show (entity null, no views). The show condition mirrors
+					    `EntityFacts`'s own (entity_type OR is_fact OR a view) so the
+					    is_fact-true / entity_type-null case isn't silently hidden here. */}
 					{((table.representative.entity_type ?? null) !== null ||
+						(table.representative.is_fact ?? null) !== null ||
 						(table.representative.enriched_views?.count ?? 0) > 0) && (
 						<Stack gap={4} data-testid="modal-entity">
 							<Text size="sm" fw={600}>


### PR DESCRIPTION
Phase 3 of epic DAT-474. Additive enrichment of `list_tables`: per-table entity facts (entity_type / is_fact) from `current_table_entities` and an enriched-views summary from `current_enriched_views`. Existing inventory + readiness rollup unchanged.

- Design: [DD/33062914](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/33062914) · AC: DAT-477
- Review: spec + senior + strict + re-review — all APPROVE. Caught & fixed: `count` could overstate `view_names`; session-grain entity/view reads made deterministic (latest-session, order-independent).
- In-lane (list-tables.ts / workspace-inventory.tsx / list-tables.test.ts only). `tsc` + `biome` green; CI is the vitest gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)