### PR TITLE
feat(cockpit): look_relationships joins the relationship catalog (DAT-478)

### DIFF
--- a/packages/cockpit/src/tools/look-relationships.test.ts
+++ b/packages/cockpit/src/tools/look-relationships.test.ts
@@ -1,7 +1,9 @@
-// Unit tests for look_relationships' pure row→shape projection (DAT-409). No DB —
-// the Drizzle reads are smoke-covered; here we pin the target→pair parsing, the
-// endpoint-name resolution (and its degrade-to-null miss), the JSONB parsing, the
-// top-driver cap, and the non-relationship-target guard.
+// Unit tests for look_relationships' pure row→shape projection (DAT-409) + the
+// catalog-facts union (DAT-478). No DB — the Drizzle reads are smoke-covered; here
+// we pin the target→pair parsing, the endpoint-name resolution (and its
+// degrade-to-null miss), the JSONB parsing, the top-driver cap, the
+// non-relationship-target guard, and the full-outer union of bands ⟗ catalog facts
+// (matched, bands-only, catalog-only).
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -14,11 +16,28 @@ vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 import {
 	type ColumnNameLookup,
 	projectRelationshipReadiness,
+	type RelationshipCatalogRow,
 	type RelationshipReadinessRow,
+	unionRelationships,
 } from "./look-relationships";
 
 const FROM = "c_from";
 const TO = "c_to";
+
+function catalogRow(
+	overrides: Partial<RelationshipCatalogRow> = {},
+): RelationshipCatalogRow {
+	return {
+		fromColumnId: FROM,
+		toColumnId: TO,
+		relationshipType: "foreign_key",
+		cardinality: "many_to_one",
+		confidence: 0.91,
+		detectionMethod: "fk_inference",
+		isConfirmed: true,
+		...overrides,
+	};
+}
 
 function row(
 	overrides: Partial<RelationshipReadinessRow> = {},
@@ -85,6 +104,27 @@ describe("projectRelationshipReadiness (DAT-409)", () => {
 		expect(out.top_drivers).toEqual([
 			{ label: "Referential Integrity", state: "high", impact_delta: 0.3 },
 		]);
+		// No catalog row passed — the facts default to null (a bands-only row).
+		expect(out.relationship_type).toBeNull();
+		expect(out.cardinality).toBeNull();
+		expect(out.confidence).toBeNull();
+		expect(out.detection_method).toBeNull();
+		expect(out.is_confirmed).toBeNull();
+	});
+
+	it("joins catalog facts when a matching catalog row is supplied (DAT-478)", () => {
+		const out = projectRelationshipReadiness(row(), names(), catalogRow());
+		expect(out).not.toBeNull();
+		if (!out) return;
+		// Bands unchanged…
+		expect(out.band).toBe("investigate");
+		expect(out.intents).toHaveLength(2);
+		// …and the catalog facts ride alongside.
+		expect(out.relationship_type).toBe("foreign_key");
+		expect(out.cardinality).toBe("many_to_one");
+		expect(out.confidence).toBe(0.91);
+		expect(out.detection_method).toBe("fk_inference");
+		expect(out.is_confirmed).toBe(true);
 	});
 
 	it("returns null for a non-relationship target (defensive guard)", () => {
@@ -155,5 +195,113 @@ describe("projectRelationshipReadiness (DAT-409)", () => {
 		expect(out?.to_table_name).toBe("invoices");
 		expect(out?.from_column_id).toBe(FROM);
 		expect(out?.to_column_id).toBe(TO);
+	});
+});
+
+describe("unionRelationships (DAT-478)", () => {
+	const OTHER_FROM = "c_other_from";
+	const OTHER_TO = "c_other_to";
+
+	function wideNames(): ColumnNameLookup {
+		return new Map([
+			[FROM, { columnName: "invoice_id", tableName: "payments" }],
+			[TO, { columnName: "invoice_id", tableName: "invoices" }],
+			[OTHER_FROM, { columnName: "customer_id", tableName: "orders" }],
+			[OTHER_TO, { columnName: "customer_id", tableName: "customers" }],
+		]);
+	}
+
+	it("matches a readiness row to its catalog row by the directional pair", () => {
+		const out = unionRelationships([row()], [catalogRow()], wideNames());
+		expect(out).toHaveLength(1);
+		const rel = out[0];
+		// Bands…
+		expect(rel.band).toBe("investigate");
+		expect(rel.intents).toHaveLength(2);
+		// …and catalog facts on the SAME row.
+		expect(rel.relationship_type).toBe("foreign_key");
+		expect(rel.cardinality).toBe("many_to_one");
+		expect(rel.confidence).toBe(0.91);
+		expect(rel.is_confirmed).toBe(true);
+	});
+
+	it("surfaces a bands-only readiness row (no catalog match) with null facts", () => {
+		// Catalog covers a DIFFERENT pair — the readiness row must still surface.
+		const out = unionRelationships(
+			[row()],
+			[catalogRow({ fromColumnId: OTHER_FROM, toColumnId: OTHER_TO })],
+			wideNames(),
+		);
+		const bands = out.find((r) => r.from_column_id === FROM);
+		expect(bands).toBeDefined();
+		expect(bands?.band).toBe("investigate");
+		expect(bands?.relationship_type).toBeNull();
+		expect(bands?.cardinality).toBeNull();
+		expect(bands?.confidence).toBeNull();
+		expect(bands?.is_confirmed).toBeNull();
+	});
+
+	it("surfaces a catalog-only relationship (no readiness row) with null bands", () => {
+		// Readiness covers a DIFFERENT pair — the catalog relationship must still surface.
+		const out = unionRelationships(
+			[row({ target: `relationship:${OTHER_FROM}::${OTHER_TO}` })],
+			[catalogRow()],
+			wideNames(),
+		);
+		const catalogOnly = out.find((r) => r.from_column_id === FROM);
+		expect(catalogOnly).toBeDefined();
+		// Facts present…
+		expect(catalogOnly?.relationship_type).toBe("foreign_key");
+		expect(catalogOnly?.is_confirmed).toBe(true);
+		// …bands/intents null — never dropped.
+		expect(catalogOnly?.band).toBeNull();
+		expect(catalogOnly?.worst_intent_risk).toBeNull();
+		expect(catalogOnly?.intents).toEqual([]);
+		expect(catalogOnly?.top_drivers).toEqual([]);
+		// Endpoints still resolved for the catalog-only side.
+		expect(catalogOnly?.from_table_name).toBe("payments");
+		expect(catalogOnly?.to_column_name).toBe("invoice_id");
+	});
+
+	it("keeps both sides — readiness order first, catalog-only appended", () => {
+		const out = unionRelationships(
+			[row()],
+			[
+				catalogRow(),
+				catalogRow({ fromColumnId: OTHER_FROM, toColumnId: OTHER_TO }),
+			],
+			wideNames(),
+		);
+		expect(out).toHaveLength(2);
+		// The matched readiness row leads (its query order is preserved)…
+		expect(out[0].from_column_id).toBe(FROM);
+		expect(out[0].band).toBe("investigate");
+		// …then the catalog-only relationship the readiness pass didn't cover.
+		expect(out[1].from_column_id).toBe(OTHER_FROM);
+		expect(out[1].band).toBeNull();
+		expect(out[1].relationship_type).toBe("foreign_key");
+	});
+
+	it("skips a catalog row with a missing endpoint id (no stable pair key)", () => {
+		const out = unionRelationships(
+			[],
+			[catalogRow({ toColumnId: null })],
+			wideNames(),
+		);
+		expect(out).toEqual([]);
+	});
+
+	it("drops a readiness row whose target isn't a relationship key", () => {
+		const out = unionRelationships(
+			[row({ target: "table:t1" })],
+			[catalogRow()],
+			wideNames(),
+		);
+		// The non-relationship readiness row is dropped, but its catalog match still
+		// surfaces catalog-only (the pair is valid in the catalog).
+		expect(out).toHaveLength(1);
+		expect(out[0].from_column_id).toBe(FROM);
+		expect(out[0].band).toBeNull();
+		expect(out[0].relationship_type).toBe("foreign_key");
 	});
 });

--- a/packages/cockpit/src/tools/look-relationships.test.ts
+++ b/packages/cockpit/src/tools/look-relationships.test.ts
@@ -310,12 +310,13 @@ describe("unionRelationships (DAT-478)", () => {
 	it("picks the llm/confirmed row when a pair has BOTH a candidate and an llm row (deterministic winner)", () => {
 		// One promoted run carries multiple rows per directional pair — a structural
 		// `candidate` (is_confirmed=false) AND the `llm` row the selector confirmed
-		// (uniqueness includes detection_method). The non-`candidate` row must win
-		// regardless of input order, so the surfaced facts are deterministic.
+		// (uniqueness includes detection_method). The higher-precedence row (llm beats
+		// candidate) must win regardless of input order, so the surfaced facts are
+		// deterministic — and confidence does NOT flip it (the candidate's is higher).
 		const candidate = catalogRow({
 			detectionMethod: "candidate",
 			isConfirmed: false,
-			confidence: 0.99, // higher confidence must NOT beat being non-`candidate`
+			confidence: 0.99, // higher confidence must NOT beat the higher-precedence method
 			relationshipType: "structural_candidate",
 			cardinality: "unknown",
 		});
@@ -341,15 +342,79 @@ describe("unionRelationships (DAT-478)", () => {
 		}
 	});
 
-	it("prefers the higher-confidence row among same-method (non-candidate) rows", () => {
-		// Two defined rows on one pair (e.g. an llm + a keeper) — confidence breaks
-		// the tie once both are non-`candidate`.
+	it("picks `manual` over `llm` regardless of confidence — precedence dominates (both orderings)", () => {
+		// The engine's readiness pass picks the representative by METHOD PRECEDENCE
+		// (`manual > keeper > llm > candidate`), NOT confidence — so the facts we join
+		// onto that band must come from the same row. `manual(0.7)` must beat `llm(0.9)`
+		// even though the llm confidence is higher, or the facts contradict the band.
+		const manual = catalogRow({
+			detectionMethod: "manual",
+			confidence: 0.7,
+			relationshipType: "foreign_key",
+			cardinality: "one_to_one",
+		});
+		const llm = catalogRow({
+			detectionMethod: "llm",
+			confidence: 0.9, // higher confidence must NOT beat the higher-precedence method
+			relationshipType: "association",
+			cardinality: "many_to_one",
+		});
+		for (const catalog of [
+			[manual, llm],
+			[llm, manual],
+		]) {
+			const out = unionRelationships([row()], catalog, wideNames());
+			expect(out).toHaveLength(1);
+			expect(out[0].detection_method).toBe("manual");
+			expect(out[0].confidence).toBe(0.7);
+			expect(out[0].relationship_type).toBe("foreign_key");
+			expect(out[0].cardinality).toBe("one_to_one");
+		}
+	});
+
+	it("picks `keeper` over `llm` regardless of confidence — precedence dominates (both orderings)", () => {
+		// keeper outranks llm in the engine's precedence map, so a `keeper(0.6)` row
+		// wins over an `llm(0.95)` row — confidence never crosses the method boundary.
+		const keeper = catalogRow({
+			detectionMethod: "keeper",
+			confidence: 0.6,
+			relationshipType: "foreign_key",
+			cardinality: "one_to_one",
+		});
+		const llm = catalogRow({
+			detectionMethod: "llm",
+			confidence: 0.95, // higher confidence must NOT beat the higher-precedence method
+			relationshipType: "association",
+			cardinality: "many_to_one",
+		});
+		for (const catalog of [
+			[keeper, llm],
+			[llm, keeper],
+		]) {
+			const out = unionRelationships([row()], catalog, wideNames());
+			expect(out).toHaveLength(1);
+			expect(out[0].detection_method).toBe("keeper");
+			expect(out[0].confidence).toBe(0.6);
+			expect(out[0].relationship_type).toBe("foreign_key");
+			expect(out[0].cardinality).toBe("one_to_one");
+		}
+	});
+
+	it("prefers the higher-confidence row among same-method rows (intra-method tiebreak ONLY)", () => {
+		// Confidence is the tiebreak only WITHIN one detection_method — two `llm` rows
+		// on the same pair resolve to the higher-confidence one. (Across methods,
+		// precedence dominates — see the manual/keeper-over-llm tests above.)
 		const lo = catalogRow({ detectionMethod: "llm", confidence: 0.6 });
-		const hi = catalogRow({ detectionMethod: "keeper", confidence: 0.95 });
+		const hi = catalogRow({
+			detectionMethod: "llm",
+			confidence: 0.95,
+			cardinality: "one_to_one",
+		});
 		const out = unionRelationships([row()], [lo, hi], wideNames());
 		expect(out).toHaveLength(1);
-		expect(out[0].detection_method).toBe("keeper");
+		expect(out[0].detection_method).toBe("llm");
 		expect(out[0].confidence).toBe(0.95);
+		expect(out[0].cardinality).toBe("one_to_one");
 	});
 
 	it("excludes a candidate-only pair with no readiness row (readiness contract)", () => {

--- a/packages/cockpit/src/tools/look-relationships.test.ts
+++ b/packages/cockpit/src/tools/look-relationships.test.ts
@@ -33,7 +33,9 @@ function catalogRow(
 		relationshipType: "foreign_key",
 		cardinality: "many_to_one",
 		confidence: 0.91,
-		detectionMethod: "fk_inference",
+		// Real `detection_method` values are `candidate | llm | manual | keeper`
+		// (engine `relationships/db_models.py`). A confirmed FK is `llm`.
+		detectionMethod: "llm",
 		isConfirmed: true,
 		...overrides,
 	};
@@ -123,7 +125,7 @@ describe("projectRelationshipReadiness (DAT-409)", () => {
 		expect(out.relationship_type).toBe("foreign_key");
 		expect(out.cardinality).toBe("many_to_one");
 		expect(out.confidence).toBe(0.91);
-		expect(out.detection_method).toBe("fk_inference");
+		expect(out.detection_method).toBe("llm");
 		expect(out.is_confirmed).toBe(true);
 	});
 
@@ -294,14 +296,84 @@ describe("unionRelationships (DAT-478)", () => {
 	it("drops a readiness row whose target isn't a relationship key", () => {
 		const out = unionRelationships(
 			[row({ target: "table:t1" })],
-			[catalogRow()],
+			[catalogRow({ detectionMethod: "llm" })],
 			wideNames(),
 		);
-		// The non-relationship readiness row is dropped, but its catalog match still
-		// surfaces catalog-only (the pair is valid in the catalog).
+		// The non-relationship readiness row is dropped, but its (llm) catalog match
+		// still surfaces catalog-only (the pair is valid + defined in the catalog).
 		expect(out).toHaveLength(1);
 		expect(out[0].from_column_id).toBe(FROM);
 		expect(out[0].band).toBeNull();
 		expect(out[0].relationship_type).toBe("foreign_key");
+	});
+
+	it("picks the llm/confirmed row when a pair has BOTH a candidate and an llm row (deterministic winner)", () => {
+		// One promoted run carries multiple rows per directional pair — a structural
+		// `candidate` (is_confirmed=false) AND the `llm` row the selector confirmed
+		// (uniqueness includes detection_method). The non-`candidate` row must win
+		// regardless of input order, so the surfaced facts are deterministic.
+		const candidate = catalogRow({
+			detectionMethod: "candidate",
+			isConfirmed: false,
+			confidence: 0.99, // higher confidence must NOT beat being non-`candidate`
+			relationshipType: "structural_candidate",
+			cardinality: "unknown",
+		});
+		const llm = catalogRow({
+			detectionMethod: "llm",
+			isConfirmed: true,
+			confidence: 0.8,
+			relationshipType: "foreign_key",
+			cardinality: "many_to_one",
+		});
+		// Both orderings resolve to the same winner.
+		for (const catalog of [
+			[candidate, llm],
+			[llm, candidate],
+		]) {
+			const out = unionRelationships([row()], catalog, wideNames());
+			expect(out).toHaveLength(1);
+			expect(out[0].detection_method).toBe("llm");
+			expect(out[0].is_confirmed).toBe(true);
+			expect(out[0].relationship_type).toBe("foreign_key");
+			expect(out[0].cardinality).toBe("many_to_one");
+			expect(out[0].confidence).toBe(0.8);
+		}
+	});
+
+	it("prefers the higher-confidence row among same-method (non-candidate) rows", () => {
+		// Two defined rows on one pair (e.g. an llm + a keeper) — confidence breaks
+		// the tie once both are non-`candidate`.
+		const lo = catalogRow({ detectionMethod: "llm", confidence: 0.6 });
+		const hi = catalogRow({ detectionMethod: "keeper", confidence: 0.95 });
+		const out = unionRelationships([row()], [lo, hi], wideNames());
+		expect(out).toHaveLength(1);
+		expect(out[0].detection_method).toBe("keeper");
+		expect(out[0].confidence).toBe(0.95);
+	});
+
+	it("excludes a candidate-only pair with no readiness row (readiness contract)", () => {
+		// A bare structural `candidate` the LLM never confirmed, with no band row, is
+		// NOT a catalog relationship — the engine scores `detection_method != 'candidate'`,
+		// so it must not surface as a catalog-only relationship.
+		const out = unionRelationships(
+			[],
+			[catalogRow({ detectionMethod: "candidate", isConfirmed: false })],
+			wideNames(),
+		);
+		expect(out).toEqual([]);
+	});
+
+	it("surfaces a candidate pair that DOES have a readiness band row (bands lead, candidate facts ride)", () => {
+		// The exclusion is candidate-only-AND-no-band. When a readiness row exists for
+		// the pair, the (candidate) facts still ride on it — the row is real.
+		const out = unionRelationships(
+			[row()],
+			[catalogRow({ detectionMethod: "candidate", isConfirmed: false })],
+			wideNames(),
+		);
+		expect(out).toHaveLength(1);
+		expect(out[0].band).toBe("investigate");
+		expect(out[0].detection_method).toBe("candidate");
 	});
 });

--- a/packages/cockpit/src/tools/look-relationships.ts
+++ b/packages/cockpit/src/tools/look-relationships.ts
@@ -26,7 +26,7 @@
 // are unit-tested here via `projectRelationshipReadiness` / `unionRelationships`.
 
 import { toolDefinition } from "@tanstack/ai";
-import { and, asc, eq, inArray, like } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, like } from "drizzle-orm";
 import { z } from "zod";
 
 import { metadataDb } from "../db/metadata/client";
@@ -246,12 +246,38 @@ function projectCatalogOnly(
 }
 
 /**
+ * The per-pair catalog winner: a confirmed FK carries MULTIPLE catalog rows in one
+ * promoted run — a structural `candidate` row AND an `llm`/`manual`/`keeper` row
+ * (uniqueness is `(session_id, run_id, from_column_id, to_column_id, detection_method)`).
+ * The facts we surface (`relationship_type` / `is_confirmed` / …) must be deterministic,
+ * so per pair we prefer a NON-`candidate` row (the durable catalog — the same
+ * `detection_method != 'candidate'` contract the readiness pass scores), then the
+ * highest `confidence`. Returns true when `next` should replace the current `best`.
+ */
+function catalogRowBeats(
+	next: RelationshipCatalogRow,
+	best: RelationshipCatalogRow,
+): boolean {
+	const nextDefined = next.detectionMethod !== "candidate";
+	const bestDefined = best.detectionMethod !== "candidate";
+	if (nextDefined !== bestDefined) return nextDefined;
+	return (next.confidence ?? -1) > (best.confidence ?? -1);
+}
+
+/**
  * Full-outer union of readiness bands and catalog facts, keyed by the directional
  * column pair (`relationship:{from}::{to}`). Pure + unit-testable. Order: readiness
  * rows first (their query order is preserved — they carry the bands the grid sorts
  * around), then any catalog-only relationships the readiness pass didn't cover.
- * Neither side is dropped: a bands-only row keeps null catalog facts, a catalog-only
- * relationship keeps null bands/intents.
+ * Neither side is dropped except by the candidate-only policy below: a bands-only row
+ * keeps null catalog facts, a catalog-only relationship keeps null bands/intents.
+ *
+ * Two determinism guarantees (DAT-478 review): (1) per pair the winning catalog row
+ * is chosen by {@link catalogRowBeats} — non-`candidate` then highest confidence — so
+ * which facts surface never depends on row order; (2) a pair whose ONLY catalog rows
+ * are `candidate` AND that has no readiness band row is dropped, mirroring the
+ * readiness contract (`detection_method != 'candidate'`): a bare structural candidate
+ * the LLM never confirmed is not a catalog relationship.
  */
 export function unionRelationships(
 	readinessRows: RelationshipReadinessRow[],
@@ -261,7 +287,9 @@ export function unionRelationships(
 	const catalogByPair = new Map<string, RelationshipCatalogRow>();
 	for (const c of catalogRows) {
 		if (!c.fromColumnId || !c.toColumnId) continue;
-		catalogByPair.set(relationshipTargetKey(c.fromColumnId, c.toColumnId), c);
+		const key = relationshipTargetKey(c.fromColumnId, c.toColumnId);
+		const best = catalogByPair.get(key);
+		if (!best || catalogRowBeats(c, best)) catalogByPair.set(key, c);
 	}
 
 	const out: RelationshipReadiness[] = [];
@@ -283,6 +311,11 @@ export function unionRelationships(
 
 	for (const [key, c] of catalogByPair) {
 		if (matchedPairs.has(key)) continue;
+		// Candidate-only policy: a pair the readiness pass didn't score (no band row)
+		// whose winning catalog row is still a bare structural `candidate` is NOT a
+		// catalog relationship — drop it (the engine's `detection_method != 'candidate'`
+		// contract). Only confirmed/manual/keeper rows surface catalog-only.
+		if (c.detectionMethod === "candidate") continue;
 		const projected = projectCatalogOnly(c, names);
 		if (projected) out.push(projected);
 	}
@@ -321,10 +354,14 @@ export async function lookRelationships(
 		};
 	}
 
+	// Two independent reads off the same promoted run — the relationship-readiness
+	// bands and the relationship catalog. Fire them in parallel: neither depends on
+	// the other (both key off sessionId; the union joins them in memory afterward).
+	//
 	// The current_* view IS the promoted run (ADR-0008/DAT-453): the head join
 	// lives in the database. `target` carries the identity (relationship rows
 	// have null table_id/column_id), so filter by the `relationship:%` prefix.
-	const rawRows = await metadataDb
+	const readinessQuery = metadataDb
 		.select({
 			target: currentEntropyReadiness.target,
 			band: currentEntropyReadiness.band,
@@ -340,18 +377,12 @@ export async function lookRelationships(
 			),
 		)
 		.orderBy(asc(currentEntropyReadiness.target));
-	// View columns type as nullable (Postgres views carry no NOT NULL) —
-	// coalesce the identity fields the underlying table guarantees.
-	const readinessRows: RelationshipReadinessRow[] = rawRows.map((r) => ({
-		...r,
-		target: r.target ?? "",
-	}));
 
 	// The relationship catalog for this session (DAT-478) — WHAT each relationship
 	// is. The view is already sealed to the promoted detect run by its own
 	// `session:{id}` head EXISTS clause, so a sessionId filter reads the same run as
 	// the readiness rows above. Joined onto the bands by the directional column pair.
-	const catalogRows: RelationshipCatalogRow[] = await metadataDb
+	const catalogQuery = metadataDb
 		.select({
 			fromColumnId: currentRelationships.fromColumnId,
 			toColumnId: currentRelationships.toColumnId,
@@ -362,7 +393,31 @@ export async function lookRelationships(
 			isConfirmed: currentRelationships.isConfirmed,
 		})
 		.from(currentRelationships)
-		.where(eq(currentRelationships.sessionId, input.session_id));
+		.where(eq(currentRelationships.sessionId, input.session_id))
+		// Deterministic catalog order so the per-pair winner is reproducible across
+		// reads: a confirmed FK carries BOTH a structural `candidate` row and an
+		// `llm`/`manual`/`keeper` row in the same promoted run (uniqueness is
+		// `(session_id, run_id, from_column_id, to_column_id, detection_method)`).
+		// `unionRelationships` owns the winner choice (prefer non-`candidate`, then
+		// highest confidence); this ORDER BY pins the row order it folds over so two
+		// reads never disagree. NULL confidence sorts last.
+		.orderBy(
+			asc(currentRelationships.fromColumnId),
+			asc(currentRelationships.toColumnId),
+			desc(currentRelationships.confidence),
+		);
+
+	const [rawRows, catalogRows] = await Promise.all([
+		readinessQuery,
+		catalogQuery,
+	]);
+
+	// View columns type as nullable (Postgres views carry no NOT NULL) —
+	// coalesce the identity fields the underlying table guarantees.
+	const readinessRows: RelationshipReadinessRow[] = rawRows.map((r) => ({
+		...r,
+		target: r.target ?? "",
+	}));
 
 	// Batch-resolve endpoint names across BOTH sides of the union — every column id
 	// a readiness target or a catalog row references — then one join to

--- a/packages/cockpit/src/tools/look-relationships.ts
+++ b/packages/cockpit/src/tools/look-relationships.ts
@@ -245,22 +245,47 @@ function projectCatalogOnly(
 	};
 }
 
+// Representative-row precedence for a directional column pair (DAT-408), mirrored
+// from the engine: a user teach (manual) wins over an LLM confirmation, which wins
+// over a structural candidate; keeper sits between manual and llm. This is the SAME
+// map the engine's readiness pass uses to pick the representative relationship it
+// measures (`entropy/detectors/loaders.py` `load_representative_relationship`,
+// docstring: "that is the relationship the readiness measures"). Higher wins.
+// `look_relationships` joins catalog facts onto that readiness band, so the facts it
+// surfaces MUST come from the same representative row — selection by precedence, NOT
+// confidence, or `manual(0.7)+llm(0.9)` surfaces `llm` while the engine measured
+// `manual`, and the facts contradict the band on the same grid row.
+const REL_METHOD_PRECEDENCE: Record<string, number> = {
+	manual: 4,
+	keeper: 3,
+	llm: 2,
+	candidate: 1,
+};
+
+const relMethodRank = (method: string | null): number =>
+	REL_METHOD_PRECEDENCE[method ?? ""] ?? 0;
+
 /**
  * The per-pair catalog winner: a confirmed FK carries MULTIPLE catalog rows in one
  * promoted run — a structural `candidate` row AND an `llm`/`manual`/`keeper` row
  * (uniqueness is `(session_id, run_id, from_column_id, to_column_id, detection_method)`).
- * The facts we surface (`relationship_type` / `is_confirmed` / …) must be deterministic,
- * so per pair we prefer a NON-`candidate` row (the durable catalog — the same
- * `detection_method != 'candidate'` contract the readiness pass scores), then the
- * highest `confidence`. Returns true when `next` should replace the current `best`.
+ * The facts we surface (`relationship_type` / `is_confirmed` / …) must match the
+ * representative row the engine's readiness pass measured, so per pair we pick by the
+ * engine's METHOD PRECEDENCE (`manual > keeper > llm > candidate`), NOT confidence —
+ * else the surfaced facts can contradict the band on the same row. Confidence is only
+ * the final tiebreak among rows of the SAME `detection_method`. The candidate-only
+ * exclusion (no band → drop) stays in {@link unionRelationships}: candidate is the
+ * lowest precedence, so a pair with candidate + any other method already resolves to
+ * the other method here. Returns true when `next` should replace the current `best`.
  */
 function catalogRowBeats(
 	next: RelationshipCatalogRow,
 	best: RelationshipCatalogRow,
 ): boolean {
-	const nextDefined = next.detectionMethod !== "candidate";
-	const bestDefined = best.detectionMethod !== "candidate";
-	if (nextDefined !== bestDefined) return nextDefined;
+	const nextRank = relMethodRank(next.detectionMethod);
+	const bestRank = relMethodRank(best.detectionMethod);
+	if (nextRank !== bestRank) return nextRank > bestRank;
+	// Same detection_method — confidence breaks the tie.
 	return (next.confidence ?? -1) > (best.confidence ?? -1);
 }
 
@@ -273,11 +298,13 @@ function catalogRowBeats(
  * keeps null catalog facts, a catalog-only relationship keeps null bands/intents.
  *
  * Two determinism guarantees (DAT-478 review): (1) per pair the winning catalog row
- * is chosen by {@link catalogRowBeats} — non-`candidate` then highest confidence — so
- * which facts surface never depends on row order; (2) a pair whose ONLY catalog rows
- * are `candidate` AND that has no readiness band row is dropped, mirroring the
- * readiness contract (`detection_method != 'candidate'`): a bare structural candidate
- * the LLM never confirmed is not a catalog relationship.
+ * is chosen by {@link catalogRowBeats} — the engine's method precedence
+ * (`manual > keeper > llm > candidate`), confidence only as the same-method tiebreak —
+ * so the facts surface from the SAME representative row the engine's readiness pass
+ * measured, never depending on row order; (2) a pair whose ONLY catalog rows are
+ * `candidate` AND that has no readiness band row is dropped, mirroring the readiness
+ * contract (`detection_method != 'candidate'`): a bare structural candidate the LLM
+ * never confirmed is not a catalog relationship.
  */
 export function unionRelationships(
 	readinessRows: RelationshipReadinessRow[],
@@ -394,13 +421,14 @@ export async function lookRelationships(
 		})
 		.from(currentRelationships)
 		.where(eq(currentRelationships.sessionId, input.session_id))
-		// Deterministic catalog order so the per-pair winner is reproducible across
-		// reads: a confirmed FK carries BOTH a structural `candidate` row and an
-		// `llm`/`manual`/`keeper` row in the same promoted run (uniqueness is
-		// `(session_id, run_id, from_column_id, to_column_id, detection_method)`).
-		// `unionRelationships` owns the winner choice (prefer non-`candidate`, then
-		// highest confidence); this ORDER BY pins the row order it folds over so two
-		// reads never disagree. NULL confidence sorts last.
+		// The in-memory fold owns winner selection — `unionRelationships` /
+		// `catalogRowBeats` pick the per-pair representative by the engine's method
+		// precedence (`manual > keeper > llm > candidate`), confidence only as the
+		// same-method tiebreak. So this ORDER BY does NOT decide the winner; it only
+		// stabilizes the INPUT order the fold sees so two reads never disagree on the
+		// rare exact-tie (same method AND same confidence). Note Postgres `DESC`
+		// defaults to NULLS FIRST, so a NULL-confidence row sorts BEFORE a real one
+		// here — harmless, since the fold compares confidence (NULL → -1) itself.
 		.orderBy(
 			asc(currentRelationships.fromColumnId),
 			asc(currentRelationships.toColumnId),

--- a/packages/cockpit/src/tools/look-relationships.ts
+++ b/packages/cockpit/src/tools/look-relationships.ts
@@ -11,8 +11,19 @@
 // the top quality drivers. It reads the PERSISTED band, never re-deriving it (the
 // engine owns the rollup). Read-only → no approval.
 //
-// The DB join is browser-smoke-covered; the pure row→shape projection is
-// unit-tested here via `projectRelationshipReadiness`.
+// DAT-478 — the readiness bands say HOW READY each relationship is; the
+// relationship *catalog* (`current_relationships`) says WHAT each one is
+// (type/cardinality/confidence/detection-method/confirmed). This joins the
+// catalog facts onto the band rows by the directional column-pair so the agent
+// gets what + how-ready in ONE call, at the same session/detect grain. The
+// catalog view is already sealed to the promoted run by its own `session:{id}`
+// head EXISTS clause, so a plain sessionId filter reads the same run. The union
+// is full-outer by column-pair key: a catalog relationship with no readiness row
+// surfaces catalog-only (bands null), and a readiness row with no catalog match
+// surfaces bands-only (catalog facts null) — neither side is dropped.
+//
+// The DB join is browser-smoke-covered; the pure row→shape projection + union
+// are unit-tested here via `projectRelationshipReadiness` / `unionRelationships`.
 
 import { toolDefinition } from "@tanstack/ai";
 import { and, asc, eq, inArray, like } from "drizzle-orm";
@@ -26,11 +37,13 @@ import {
 } from "../db/metadata/readiness-schemas";
 import {
 	parseRelationshipTarget,
+	relationshipTargetKey,
 	sessionHeadTarget,
 } from "../db/metadata/relationship-target";
 import {
 	columns,
 	currentEntropyReadiness,
+	currentRelationships,
 	metadataSnapshotHead,
 	tables,
 } from "../db/metadata/schema";
@@ -67,6 +80,15 @@ const RelationshipReadiness = z.object({
 	worst_intent_risk: z.number().nullable(),
 	intents: z.array(IntentBand),
 	top_drivers: z.array(TopDriver),
+	// Catalog facts (DAT-478) — WHAT the relationship is, from `current_relationships`,
+	// joined by the directional column pair. Null when no catalog row matches this
+	// pair (a bands-only row), the same way the bands above go null on a catalog-only
+	// relationship that has no readiness row yet.
+	relationship_type: z.string().nullable(),
+	cardinality: z.string().nullable(),
+	confidence: z.number().nullable(),
+	detection_method: z.string().nullable(),
+	is_confirmed: z.boolean().nullable(),
 });
 export type RelationshipReadiness = z.infer<typeof RelationshipReadiness>;
 
@@ -92,40 +114,97 @@ export interface RelationshipReadinessRow {
 	topDrivers: unknown;
 }
 
+/** One `current_relationships` catalog row (the facts join), as Drizzle returns it. */
+export interface RelationshipCatalogRow {
+	fromColumnId: string | null;
+	toColumnId: string | null;
+	relationshipType: string | null;
+	cardinality: string | null;
+	confidence: number | null;
+	detectionMethod: string | null;
+	isConfirmed: boolean | null;
+}
+
+/** The catalog facts as they ride on the tool's output shape (null when no match). */
+type CatalogFacts = Pick<
+	RelationshipReadiness,
+	| "relationship_type"
+	| "cardinality"
+	| "confidence"
+	| "detection_method"
+	| "is_confirmed"
+>;
+
+const NO_CATALOG_FACTS: CatalogFacts = {
+	relationship_type: null,
+	cardinality: null,
+	confidence: null,
+	detection_method: null,
+	is_confirmed: null,
+};
+
 /** Endpoint name lookup: column_id → its column + owning table name. */
 export type ColumnNameLookup = Map<
 	string,
 	{ columnName: string; tableName: string }
 >;
 
-/**
- * Project one relationship-readiness row to the tool's shape. Pure (no DB) so the
- * target-parsing + JSONB-parsing + name-resolution is unit-testable. Returns null
- * for a row whose target isn't a parseable relationship key (a defensive guard —
- * the query already filters to `relationship:%`). A malformed JSONB blob degrades
- * to empty intents/drivers rather than throwing.
- */
-export function projectRelationshipReadiness(
-	row: RelationshipReadinessRow,
+/** Resolve the from/to endpoint name fields for a column pair (display-form, DAT-431). */
+function endpointNames(
+	fromColumnId: string,
+	toColumnId: string,
 	names: ColumnNameLookup,
-): RelationshipReadiness | null {
-	const pair = parseRelationshipTarget(row.target);
-	if (!pair) return null;
-
-	const intents = PersistedIntent.array().safeParse(row.intents);
-	const drivers = ReadinessDriver.array().safeParse(row.topDrivers);
-	const from = names.get(pair.fromColumnId);
-	const to = names.get(pair.toColumnId);
-
+): Pick<
+	RelationshipReadiness,
+	"from_table_name" | "from_column_name" | "to_table_name" | "to_column_name"
+> {
+	const from = names.get(fromColumnId);
+	const to = names.get(toColumnId);
 	return {
-		from_column_id: pair.fromColumnId,
-		to_column_id: pair.toColumnId,
 		// This result goes back to the agent — strip the content-keyed
 		// `src_<digest>__` prefix so no hash name reaches LLM context (DAT-431).
 		from_table_name: from ? displayTableName(from.tableName) : null,
 		from_column_name: from?.columnName ?? null,
 		to_table_name: to ? displayTableName(to.tableName) : null,
 		to_column_name: to?.columnName ?? null,
+	};
+}
+
+/** The catalog facts a row carries, defaulting every field to null on no match. */
+function catalogFacts(row: RelationshipCatalogRow | undefined): CatalogFacts {
+	if (!row) return NO_CATALOG_FACTS;
+	return {
+		relationship_type: row.relationshipType ?? null,
+		cardinality: row.cardinality ?? null,
+		confidence: row.confidence ?? null,
+		detection_method: row.detectionMethod ?? null,
+		is_confirmed: row.isConfirmed ?? null,
+	};
+}
+
+/**
+ * Project one relationship-readiness row to the tool's shape, joining the matching
+ * catalog row's facts (or nulls when none). Pure (no DB) so the target-parsing +
+ * JSONB-parsing + name-resolution is unit-testable. Returns null for a row whose
+ * target isn't a parseable relationship key (a defensive guard — the query already
+ * filters to `relationship:%`). A malformed JSONB blob degrades to empty
+ * intents/drivers rather than throwing.
+ */
+export function projectRelationshipReadiness(
+	row: RelationshipReadinessRow,
+	names: ColumnNameLookup,
+	catalog?: RelationshipCatalogRow,
+): RelationshipReadiness | null {
+	const pair = parseRelationshipTarget(row.target);
+	if (!pair) return null;
+
+	const intents = PersistedIntent.array().safeParse(row.intents);
+	const drivers = ReadinessDriver.array().safeParse(row.topDrivers);
+
+	return {
+		from_column_id: pair.fromColumnId,
+		to_column_id: pair.toColumnId,
+		...endpointNames(pair.fromColumnId, pair.toColumnId, names),
 		band: row.band ?? null,
 		worst_intent_risk: row.worstIntentRisk ?? null,
 		intents: intents.success
@@ -142,7 +221,73 @@ export function projectRelationshipReadiness(
 					impact_delta: d.impact_delta,
 				}))
 			: [],
+		...catalogFacts(catalog),
 	};
+}
+
+/** Project a catalog-only relationship (no readiness row) to the tool's shape:
+ * the facts + endpoints, with every band/intent field null. Skipped when either
+ * endpoint id is missing (it can't form a stable pair key for the drill-down). */
+function projectCatalogOnly(
+	row: RelationshipCatalogRow,
+	names: ColumnNameLookup,
+): RelationshipReadiness | null {
+	if (!row.fromColumnId || !row.toColumnId) return null;
+	return {
+		from_column_id: row.fromColumnId,
+		to_column_id: row.toColumnId,
+		...endpointNames(row.fromColumnId, row.toColumnId, names),
+		band: null,
+		worst_intent_risk: null,
+		intents: [],
+		top_drivers: [],
+		...catalogFacts(row),
+	};
+}
+
+/**
+ * Full-outer union of readiness bands and catalog facts, keyed by the directional
+ * column pair (`relationship:{from}::{to}`). Pure + unit-testable. Order: readiness
+ * rows first (their query order is preserved — they carry the bands the grid sorts
+ * around), then any catalog-only relationships the readiness pass didn't cover.
+ * Neither side is dropped: a bands-only row keeps null catalog facts, a catalog-only
+ * relationship keeps null bands/intents.
+ */
+export function unionRelationships(
+	readinessRows: RelationshipReadinessRow[],
+	catalogRows: RelationshipCatalogRow[],
+	names: ColumnNameLookup,
+): RelationshipReadiness[] {
+	const catalogByPair = new Map<string, RelationshipCatalogRow>();
+	for (const c of catalogRows) {
+		if (!c.fromColumnId || !c.toColumnId) continue;
+		catalogByPair.set(relationshipTargetKey(c.fromColumnId, c.toColumnId), c);
+	}
+
+	const out: RelationshipReadiness[] = [];
+	const matchedPairs = new Set<string>();
+	for (const r of readinessRows) {
+		const pair = parseRelationshipTarget(r.target);
+		const key = pair
+			? relationshipTargetKey(pair.fromColumnId, pair.toColumnId)
+			: null;
+		const projected = projectRelationshipReadiness(
+			r,
+			names,
+			key ? catalogByPair.get(key) : undefined,
+		);
+		if (!projected) continue;
+		out.push(projected);
+		if (key) matchedPairs.add(key);
+	}
+
+	for (const [key, c] of catalogByPair) {
+		if (matchedPairs.has(key)) continue;
+		const projected = projectCatalogOnly(c, names);
+		if (projected) out.push(projected);
+	}
+
+	return out;
 }
 
 export interface LookRelationshipsInput {
@@ -202,13 +347,29 @@ export async function lookRelationships(
 		target: r.target ?? "",
 	}));
 
-	// Batch-resolve endpoint names: collect every column id the targets reference,
-	// then one join to columns⟕tables. Avoids an N+1 over relationships.
-	const names = await loadColumnNames(readinessRows);
+	// The relationship catalog for this session (DAT-478) — WHAT each relationship
+	// is. The view is already sealed to the promoted detect run by its own
+	// `session:{id}` head EXISTS clause, so a sessionId filter reads the same run as
+	// the readiness rows above. Joined onto the bands by the directional column pair.
+	const catalogRows: RelationshipCatalogRow[] = await metadataDb
+		.select({
+			fromColumnId: currentRelationships.fromColumnId,
+			toColumnId: currentRelationships.toColumnId,
+			relationshipType: currentRelationships.relationshipType,
+			cardinality: currentRelationships.cardinality,
+			confidence: currentRelationships.confidence,
+			detectionMethod: currentRelationships.detectionMethod,
+			isConfirmed: currentRelationships.isConfirmed,
+		})
+		.from(currentRelationships)
+		.where(eq(currentRelationships.sessionId, input.session_id));
 
-	const relationships = readinessRows
-		.map((r) => projectRelationshipReadiness(r, names))
-		.filter((r): r is RelationshipReadiness => r !== null);
+	// Batch-resolve endpoint names across BOTH sides of the union — every column id
+	// a readiness target or a catalog row references — then one join to
+	// columns⟕tables. Avoids an N+1 over relationships.
+	const names = await loadColumnNames(readinessRows, catalogRows);
+
+	const relationships = unionRelationships(readinessRows, catalogRows, names);
 
 	const pending = await getPendingOverlays();
 
@@ -220,9 +381,12 @@ export async function lookRelationships(
 	};
 }
 
-/** Resolve the from/to column + table names referenced by the readiness targets. */
+/** Resolve the from/to column + table names referenced across both union sides —
+ * the readiness targets AND the catalog rows (catalog-only relationships need
+ * endpoint names too). */
 async function loadColumnNames(
 	rows: RelationshipReadinessRow[],
+	catalogRows: RelationshipCatalogRow[],
 ): Promise<ColumnNameLookup> {
 	const ids = new Set<string>();
 	for (const r of rows) {
@@ -231,6 +395,10 @@ async function loadColumnNames(
 			ids.add(pair.fromColumnId);
 			ids.add(pair.toColumnId);
 		}
+	}
+	for (const c of catalogRows) {
+		if (c.fromColumnId) ids.add(c.fromColumnId);
+		if (c.toColumnId) ids.add(c.toColumnId);
 	}
 	const lookup: ColumnNameLookup = new Map();
 	if (ids.size === 0) return lookup;
@@ -261,9 +429,11 @@ export const lookRelationshipsTool = toolDefinition({
 		"Show a begin_session session's per-relationship readiness — ready/investigate/" +
 		"blocked across the query, aggregation, and reporting intents — with the top " +
 		"quality drivers per relationship, identified by its directional column pair " +
-		"(from_column_id → to_column_id). Read-only; reflects the promoted detect run " +
-		"for the session. pending_teaches counts un-applied teaches across the " +
-		"workspace; if > 0, suggest a `replay` before trusting the bands. Use " +
+		"(from_column_id → to_column_id). Each relationship also carries its catalog " +
+		"facts (relationship_type, cardinality, confidence, detection_method, " +
+		"is_confirmed) — WHAT it is alongside HOW READY it is. Read-only; reflects the " +
+		"promoted detect run for the session. pending_teaches counts un-applied teaches " +
+		"across the workspace; if > 0, suggest a `replay` before trusting the bands. Use " +
 		"`why_relationship` to explain a specific relationship's band.",
 	inputSchema: z.object({
 		session_id: z

--- a/packages/cockpit/src/ui/cockpit/widgets/relationship-list.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/relationship-list.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 //
 // Render tests for the RelationshipListWidget (DAT-434): rows with endpoint
-// labels + band badges, the not-analyzed / empty states, the overflow cap
-// (rule 15), and the why_relationship click-through — ids in the model-only
-// refs part, never the bubble (the table-readiness precedent).
+// labels + band badges, the catalog facts (DAT-478: type/cardinality/confidence/
+// confirmed), the not-analyzed / empty states, the overflow cap (rule 15), and the
+// why_relationship click-through — ids in the model-only refs part, never the
+// bubble (the table-readiness precedent).
 
 import { MantineProvider } from "@mantine/core";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
@@ -42,6 +43,11 @@ const REL = {
 	top_drivers: [
 		{ label: "Referential Integrity", state: "low", impact_delta: 0.05 },
 	],
+	relationship_type: "foreign_key",
+	cardinality: "many_to_one",
+	confidence: 0.91,
+	detection_method: "fk_inference",
+	is_confirmed: true,
 };
 
 const analyzed: LookRelationshipsResult = {
@@ -66,6 +72,35 @@ describe("RelationshipListWidget (DAT-434)", () => {
 		expect(screen.getByText("Referential Integrity")).toBeTruthy();
 		expect(document.body.textContent).not.toContain("c_orders_customer");
 		expect(document.body.textContent).not.toContain("sess-1");
+	});
+
+	it("renders the catalog facts — type · cardinality, confidence, confirmed (DAT-478)", () => {
+		renderWidget(analyzed);
+		const facts = screen.getByTestId(
+			"relationship-facts-c_orders_customer->c_customers_id",
+		);
+		// humanizeIdentifier turns foreign_key → "Foreign key", joined to cardinality.
+		expect(facts.textContent).toContain("Foreign key · many_to_one");
+		expect(facts.textContent).toContain("confidence 0.91");
+		expect(facts.textContent).toContain("confirmed");
+	});
+
+	it("degrades a bands-only relationship's facts cell to a dash (DAT-478)", () => {
+		const bandsOnly = {
+			...REL,
+			relationship_type: null,
+			cardinality: null,
+			confidence: null,
+			detection_method: null,
+			is_confirmed: null,
+		};
+		renderWidget({ ...analyzed, relationships: [bandsOnly] });
+		// The row still renders (band + endpoints), the facts cell is just a dash.
+		expect(screen.getByText("orders.customer_id")).toBeTruthy();
+		expect(
+			screen.getByTestId("relationship-facts-c_orders_customer->c_customers_id")
+				.textContent,
+		).toBe("—");
 	});
 
 	it("renders the not-analyzed state pointing at begin_session", () => {

--- a/packages/cockpit/src/ui/cockpit/widgets/relationship-list.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/relationship-list.test.tsx
@@ -46,7 +46,9 @@ const REL = {
 	relationship_type: "foreign_key",
 	cardinality: "many_to_one",
 	confidence: 0.91,
-	detection_method: "fk_inference",
+	// Real `detection_method` values are `candidate | llm | manual | keeper`
+	// (engine `relationships/db_models.py`). A confirmed FK is `llm`.
+	detection_method: "llm",
 	is_confirmed: true,
 };
 
@@ -97,6 +99,45 @@ describe("RelationshipListWidget (DAT-434)", () => {
 		renderWidget({ ...analyzed, relationships: [bandsOnly] });
 		// The row still renders (band + endpoints), the facts cell is just a dash.
 		expect(screen.getByText("orders.customer_id")).toBeTruthy();
+		expect(
+			screen.getByTestId("relationship-facts-c_orders_customer->c_customers_id")
+				.textContent,
+		).toBe("—");
+	});
+
+	it("renders a catalog-only row — facts present, band a dash (DAT-478)", () => {
+		// A relationship the readiness pass didn't score (no band) but the catalog
+		// knows: the facts cell carries the type/confidence, the band cell degrades.
+		const catalogOnly = {
+			...REL,
+			band: null,
+			worst_intent_risk: null,
+			intents: [],
+			top_drivers: [],
+		};
+		renderWidget({ ...analyzed, relationships: [catalogOnly] });
+		const facts = screen.getByTestId(
+			"relationship-facts-c_orders_customer->c_customers_id",
+		);
+		expect(facts.textContent).toContain("Foreign key · many_to_one");
+		expect(facts.textContent).toContain("confidence 0.91");
+		// The band cell shows the no-band dash, the row still renders.
+		expect(screen.getByText("orders.customer_id")).toBeTruthy();
+		expect(screen.queryByText("Ready")).toBeNull();
+	});
+
+	it("degrades an all-null-but-is_confirmed=false facts cell to a plain dash (DAT-478)", () => {
+		// is_confirmed=false is not a fact to show on its own — with no type/cardinality
+		// and no confidence the cell must be a bare dash, not empty chrome.
+		const detectedUnconfirmed = {
+			...REL,
+			relationship_type: null,
+			cardinality: null,
+			confidence: null,
+			detection_method: "candidate",
+			is_confirmed: false,
+		};
+		renderWidget({ ...analyzed, relationships: [detectedUnconfirmed] });
 		expect(
 			screen.getByTestId("relationship-facts-c_orders_customer->c_customers_id")
 				.textContent,

--- a/packages/cockpit/src/ui/cockpit/widgets/relationship-list.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/relationship-list.tsx
@@ -39,8 +39,12 @@ function CatalogFactsCell({ rel }: { rel: RelationshipReadiness }) {
 		? humanizeIdentifier(rel.relationship_type)
 		: null;
 	const headline = [type, rel.cardinality].filter(Boolean).join(" · ");
+	// A row carries real facts only when there's something to SHOW: a type/cardinality
+	// headline, a confidence caption, or a confirmed badge. `is_confirmed === false`
+	// (detected, not confirmed) renders nothing on its own — without a headline or
+	// confidence it must degrade to a plain dash, not an empty-headline cell + chrome.
 	const hasFacts =
-		headline.length > 0 || rel.confidence !== null || rel.is_confirmed !== null;
+		headline.length > 0 || rel.confidence !== null || rel.is_confirmed === true;
 
 	if (!hasFacts) {
 		return (

--- a/packages/cockpit/src/ui/cockpit/widgets/relationship-list.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/relationship-list.tsx
@@ -1,13 +1,18 @@
 // Relationship-list widget (DAT-434) — renders the `look_relationships` result
-// as one row per relationship pair: endpoints (display names), readiness band,
-// top drivers. A row click drives the why_relationship drill-down through the
-// chat loop — the column ids ride as model-only refs (forwardedProps), never in
-// the visible bubble (the DAT-462 flip; the table-readiness → why_column precedent).
+// as one row per relationship pair: endpoints (display names), the catalog facts
+// (DAT-478: type/cardinality/confidence/confirmed — WHAT it is), the readiness
+// band (HOW READY it is), and top drivers. A row click drives the why_relationship
+// drill-down through the chat loop — the column ids ride as model-only refs
+// (forwardedProps), never in the visible bubble (the DAT-462 flip; the
+// table-readiness → why_column precedent).
 //
 // Endpoint names arrive in DISPLAY form (`src_<digest>__` stripped, DAT-431);
-// the band is the engine's persisted value — never recomputed here.
+// the band + catalog facts are the engine's persisted values — never recomputed
+// here. Either side of the union can be null (a bands-only or catalog-only
+// relationship), so every cell degrades to a dash rather than omitting the row.
 
-import { Alert, Anchor, Stack, Table, Text } from "@mantine/core";
+import { Alert, Anchor, Badge, Group, Stack, Table, Text } from "@mantine/core";
+import { humanizeIdentifier } from "#/lib/display-names";
 import type { RelationshipReadiness } from "#/tools/look-relationships";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
 import { useCockpitActions } from "#/ui/cockpit/cockpit-state";
@@ -23,6 +28,51 @@ import {
 const MAX_VISIBLE_ROWS = 100;
 
 const TOP_DRIVERS_SHOWN = 2;
+
+const DASH = "—";
+
+/** The catalog facts cell (DAT-478): type · cardinality, with a confidence caption
+ * and a confirmed badge. Every fact is nullable (a bands-only row carries none), so
+ * the cell degrades to a dash rather than rendering empty chrome. */
+function CatalogFactsCell({ rel }: { rel: RelationshipReadiness }) {
+	const type = rel.relationship_type
+		? humanizeIdentifier(rel.relationship_type)
+		: null;
+	const headline = [type, rel.cardinality].filter(Boolean).join(" · ");
+	const hasFacts =
+		headline.length > 0 || rel.confidence !== null || rel.is_confirmed !== null;
+
+	if (!hasFacts) {
+		return (
+			<Text span size="xs" c="dimmed">
+				{DASH}
+			</Text>
+		);
+	}
+
+	return (
+		<Stack gap={2}>
+			<Group gap="xs" align="center">
+				<Text span size="sm">
+					{headline || DASH}
+				</Text>
+				{rel.is_confirmed && (
+					<Badge size="xs" color="green" variant="light">
+						confirmed
+					</Badge>
+				)}
+			</Group>
+			{rel.confidence !== null && (
+				<Text span size="xs" c="dimmed">
+					{rel.detection_method
+						? `${humanizeIdentifier(rel.detection_method)} · `
+						: ""}
+					confidence {rel.confidence.toFixed(2)}
+				</Text>
+			)}
+		</Stack>
+	);
+}
 
 export function RelationshipListWidget({
 	state,
@@ -103,6 +153,7 @@ export function RelationshipListWidget({
 						<Table.Tr>
 							<Table.Th>From</Table.Th>
 							<Table.Th>To</Table.Th>
+							<Table.Th>Relationship</Table.Th>
 							<Table.Th>Band</Table.Th>
 							<Table.Th>Top drivers</Table.Th>
 						</Table.Tr>
@@ -135,6 +186,9 @@ export function RelationshipListWidget({
 												rel.to_column_name,
 											)}
 										</Text>
+									</Table.Td>
+									<Table.Td data-testid={`relationship-facts-${key}`}>
+										<CatalogFactsCell rel={rel} />
 									</Table.Td>
 									<Table.Td>
 										<BandBadge band={rel.band} />


### PR DESCRIPTION
Phase 4 of epic DAT-474. Additive enrichment of `look_relationships`: joins the `current_relationships` catalog (type / cardinality / confidence / detection_method / is_confirmed) onto the per-relationship readiness bands by directional column-pair (full-outer; neither side dropped). Existing readiness output unchanged.

- Design: [DD/33062914](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/33062914) · AC: DAT-478
- Review: spec + senior + strict panel + TWO re-reviews — all APPROVE. Caught & fixed: nondeterministic `is_confirmed` (multiple `detection_method` rows per pair), then anchored the winner to the engine readiness representative via method precedence (`manual>keeper>llm>candidate`) so facts match the band.
- In-lane (look-relationships.ts / relationship-list.tsx + tests only). `tsc` + `biome` green; CI is the vitest gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)