### PR TITLE
chore(cockpit): DAT-474 review nits — comment fix + entity-facts guard dedup

### DIFF
--- a/packages/cockpit/src/tools/look-relationships.ts
+++ b/packages/cockpit/src/tools/look-relationships.ts
@@ -249,7 +249,7 @@ function projectCatalogOnly(
 // from the engine: a user teach (manual) wins over an LLM confirmation, which wins
 // over a structural candidate; keeper sits between manual and llm. This is the SAME
 // map the engine's readiness pass uses to pick the representative relationship it
-// measures (`entropy/detectors/loaders.py` `load_representative_relationship`,
+// measures (`entropy/detectors/loaders.py` `load_relationship_for_pair`,
 // docstring: "that is the relationship the readiness measures"). Higher wins.
 // `look_relationships` joins catalog facts onto that readiness band, so the facts it
 // surfaces MUST come from the same representative row — selection by precedence, NOT

--- a/packages/cockpit/src/ui/cockpit/widgets/workspace-inventory.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/workspace-inventory.tsx
@@ -47,6 +47,18 @@ const MAX_VISIBLE_ROWS = 100;
 // (a fact table can fan out to several views — the cell is a glance, not a list).
 const ENRICHED_VIEW_NAMES_SHOWN = 2;
 
+/** Does a table carry any entity facts to show — an entity classification or a
+ * materialized enriched view? Shared by EntityFacts + the detail modal so their
+ * two show/hide conditions never drift (the is_fact-true / entity_type-null case
+ * must show in both). */
+function hasEntityFacts(t: InventoryTable): boolean {
+	return (
+		(t.entity_type ?? null) !== null ||
+		(t.is_fact ?? null) !== null ||
+		(t.enriched_views?.count ?? 0) > 0
+	);
+}
+
 /**
  * The session-grain entity orientation for one table (DAT-477): its detected
  * entity type + a fact marker + the count of enriched fact/dimension views built
@@ -64,7 +76,7 @@ function EntityFacts({ table }: { table: InventoryTable }) {
 		view_names: [],
 		any_grain_verified: null,
 	};
-	if (entity_type === null && is_fact === null && enriched_views.count === 0) {
+	if (!hasEntityFacts(table)) {
 		return (
 			<Text span c="dimmed" size="xs">
 				—
@@ -255,9 +267,7 @@ function TableDetailModal({
 					    nothing to show (entity null, no views). The show condition mirrors
 					    `EntityFacts`'s own (entity_type OR is_fact OR a view) so the
 					    is_fact-true / entity_type-null case isn't silently hidden here. */}
-					{((table.representative.entity_type ?? null) !== null ||
-						(table.representative.is_fact ?? null) !== null ||
-						(table.representative.enriched_views?.count ?? 0) > 0) && (
+					{hasEntityFacts(table.representative) && (
 						<Stack gap={4} data-testid="modal-entity">
 							<Text size="sm" fw={600}>
 								Entity


### PR DESCRIPTION
Post-merge cleanup of the two non-blocking nits from the DAT-474 review (epic DAT-474, all 4 phases merged #266–269).

- **`look-relationships.ts`** — the method-precedence comment cited a non-existent engine fn `load_representative_relationship`; the real one is **`load_relationship_for_pair`** (`entropy/detectors/loaders.py:293`). Verified against the engine.
- **`workspace-inventory.tsx`** — `EntityFacts` and the detail modal each re-derived the same "has entity facts" show/hide condition inline; extracted a shared **`hasEntityFacts()`** so the two can't drift (the is_fact-true / entity_type-null case shows in both).

Behavior-preserving (a comment + a DRY extraction). `biome` + `tsc` + `build` green; CI runs vitest on the clean runner.

**Investigated, not a bug (so not fixed):** the 477 `column_count` nit — the band-sum on line 313 includes `unanalyzed`, and the `columnBandRows` query LEFT-JOINs readiness, so every column is counted; `column_count` already equals the true column count (0 only when a table genuinely has no columns). The reviewers misread it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)