### PR TITLE
refactor(engine): VerticalLoader facade — one loader for all four vertical families (DAT-481)

### DIFF
--- a/packages/engine/src/dataraum/analysis/cycles/config.py
+++ b/packages/engine/src/dataraum/analysis/cycles/config.py
@@ -20,9 +20,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 from dataraum.core.logging import get_logger
+from dataraum.core.vertical_loader import Family, VerticalLoader
 
 logger = get_logger(__name__)
 
@@ -30,49 +29,19 @@ logger = get_logger(__name__)
 def get_cycles_config(vertical: str, verticals_dir: Path | None = None) -> dict[str, Any]:
     """Load a vertical's cycles config, layered with ``cycle`` overlay rows.
 
-    Production path (``verticals_dir`` is ``None``): read the shipped vertical's
-    ``cycles.yaml`` (empty base when the vertical is framed — declared via the
-    cockpit, no on-disk file), then merge active ``cycle`` overlay rows via
-    :func:`dataraum.core.overlay.apply_overlay` (upsert by cycle name into
-    ``cycle_types``). An unknown vertical resolves to an EMPTY dict, never
-    raises — "no declared cycles" is a loud, explicit outcome at the phase
-    tier, not a loader crash.
-
-    Test path (explicit ``verticals_dir``): read
-    ``<verticals_dir>/<vertical>/cycles.yaml`` raw, bypassing the overlay —
-    deterministic for unit tests (mirrors ``OntologyLoader`` /
-    ``load_all_validation_specs``).
-
-    Args:
-        vertical: Vertical name (e.g. ``'finance'``).
-        verticals_dir: Root verticals directory override (tests only).
+    Thin wrapper over :class:`~dataraum.core.vertical_loader.VerticalLoader`
+    (DAT-481): the shipped ``cycles.yaml`` (empty base when the vertical is
+    framed — declared via the cockpit, no on-disk file) ⊕ active ``cycle``
+    overlay rows (upsert by cycle name into ``cycle_types``). An unknown vertical
+    resolves to an EMPTY dict, never raises — "no declared cycles" is a loud,
+    explicit outcome at the phase tier. An explicit ``verticals_dir`` reads raw
+    YAML and bypasses the overlay (tests).
 
     Returns:
         The cycles config dict (``{"cycle_types": {...}, "analysis_hints": ...}``),
         or an empty dict when neither file nor overlay declares anything.
     """
-    if verticals_dir is not None:
-        config_path = verticals_dir / vertical / "cycles.yaml"
-        if not config_path.is_file():
-            return {}
-        with open(config_path) as f:
-            return yaml.safe_load(f) or {}
-
-    from dataraum.core.config import get_config_file
-    from dataraum.core.overlay import apply_overlay
-
-    relative_path = f"verticals/{vertical}/cycles.yaml"
-    base: dict[str, Any] = {}
-    try:
-        path = get_config_file(relative_path)
-    except FileNotFoundError:
-        # Framed vertical (no on-disk file) or a vertical without a shipped
-        # cycle vocabulary — the overlay rows ARE the declared set.
-        path = None
-    if path is not None:
-        with open(path) as f:
-            base = yaml.safe_load(f) or {}
-    return apply_overlay(relative_path, base)
+    return VerticalLoader(vertical, verticals_dir).collection(Family.CYCLES)
 
 
 def get_cycle_types(vertical: str, verticals_dir: Path | None = None) -> dict[str, Any]:

--- a/packages/engine/src/dataraum/analysis/semantic/ontology.py
+++ b/packages/engine/src/dataraum/analysis/semantic/ontology.py
@@ -88,10 +88,11 @@ class OntologyLoader:
         return OntologyDefinition(**data)
 
     def list_verticals(self) -> list[str]:
-        """List available verticals with ontology definitions on disk.
+        """List the shipped (on-disk) verticals.
 
-        Lists only baked-in verticals — overlay rows can't add a wholly
-        new vertical (they augment a vertical whose YAML exists). Returns
+        File-globs ``verticals/*/ontology.yaml`` only — *framed* verticals
+        (declared via the cockpit ``frame`` stage; they live entirely in overlay
+        rows with no on-disk file, DAT-480) are NOT enumerated here. Returns
         ``[]`` if the verticals root doesn't exist.
         """
         root = self.verticals_dir if self.verticals_dir is not None else get_config_dir("verticals")

--- a/packages/engine/src/dataraum/analysis/semantic/ontology.py
+++ b/packages/engine/src/dataraum/analysis/semantic/ontology.py
@@ -1,21 +1,19 @@
 """Ontology loading from configuration files.
 
-Loads ontology definitions from config/verticals/<vertical>/ontology.yaml.
-Reads go through :func:`dataraum.core.config.load_yaml_config` so the
-workspace's active overlay rows (DAT-343; ``concept`` and
-``concept_property`` types per DAT-371) are merged onto the baked-in
-YAML. Custom ``verticals_dir`` (test fixtures) bypasses the overlay —
-they're deterministic.
+Loads ontology definitions from config/verticals/<vertical>/ontology.yaml
+through the shared :class:`~dataraum.core.vertical_loader.VerticalLoader`
+(DAT-481), so the workspace's active overlay rows (DAT-343; ``concept`` and
+``concept_property`` types per DAT-371) are merged onto the baked-in YAML.
+Custom ``verticals_dir`` (test fixtures) bypasses the overlay — deterministic.
 """
 
 from pathlib import Path
 
-import yaml
 from pydantic import BaseModel, Field
 
-from dataraum.core.config import get_config_dir, load_yaml_config
-from dataraum.core.overlay import apply_overlay
+from dataraum.core.config import get_config_dir
 from dataraum.core.vertical import VerticalKind, resolve_vertical
+from dataraum.core.vertical_loader import Family, VerticalLoader
 
 
 class OntologyConcept(BaseModel):
@@ -66,44 +64,27 @@ class OntologyLoader:
     def load(self, vertical: str) -> OntologyDefinition | None:
         """Load an ontology definition for a vertical.
 
-        Production path (``verticals_dir`` is ``None``) goes through
-        :func:`load_yaml_config` so any active overlay rows for
-        ``verticals/<vertical>/ontology.yaml`` are merged in. The test
-        path (explicit ``verticals_dir``) reads YAML directly and
-        bypasses the overlay.
+        Resolution is the shared :class:`VerticalLoader.collection` (DAT-481):
+        production (``verticals_dir`` is ``None``) reads the shipped baseline ⊕
+        overlay rows; the test path (explicit ``verticals_dir``) reads raw YAML
+        and bypasses the overlay.
 
         Args:
             vertical: Vertical name (e.g. ``'finance'`` or ``'_adhoc'``).
 
         Returns:
-            Loaded (and overlay-merged) ontology definition. A builtin
-            vertical resolves its baked-in YAML; a framed vertical (declared
-            via the cockpit `frame` stage — no on-disk directory, since the
-            config tree is read-only) resolves overlay-only. ``None`` only on
-            the test path when the YAML doesn't exist.
+            The (overlay-merged) ontology definition — a builtin resolves its
+            baked-in YAML, a framed vertical resolves overlay-only. ``None`` only
+            on the production path for an UNKNOWN vertical (a typo or one never
+            framed) — the single ``None`` case, owned by ``resolve_vertical``
+            (DAT-480); every known/placeholder/framed name resolves to a
+            (possibly empty) definition.
         """
-        if self.verticals_dir is None:
-            # The shipped/framed/placeholder/unknown discrimination lives in
-            # one place (DAT-480): an UNKNOWN name (typo, or never framed) is
-            # the only `None` case. Everything else resolves — shipped /
-            # placeholder read their on-disk baseline (⊕ overlay); a framed
-            # vertical has no file, so it materializes from overlay rows alone.
-            relative = f"verticals/{vertical}/ontology.yaml"
-            if resolve_vertical(vertical) is VerticalKind.UNKNOWN:
-                return None
-            try:
-                data = load_yaml_config(relative)
-            except FileNotFoundError:
-                data = apply_overlay(relative, {"name": vertical, "concepts": []})
-            return OntologyDefinition(**data)
-
-        ontology_path = self.verticals_dir / vertical / "ontology.yaml"
-        if not ontology_path.exists():
+        # DAT-480: an UNKNOWN production vertical is the only None case. The test
+        # path is deterministic (no overlay), so the guard is production-only.
+        if self.verticals_dir is None and resolve_vertical(vertical) is VerticalKind.UNKNOWN:
             return None
-
-        with open(ontology_path) as f:
-            data = yaml.safe_load(f)
-
+        data = VerticalLoader(vertical, self.verticals_dir).collection(Family.CONCEPTS)
         return OntologyDefinition(**data)
 
     def list_verticals(self) -> list[str]:

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -254,12 +254,12 @@ def ground_columns(
     # prioritizes mapping those concepts to actual columns. OVERLAY-AWARE: the
     # declared set is the vertical's shipped graphs ⊕ `metric` overlay teach rows
     # (get_metric_definitions), so a FRAMED vertical's metrics — declared at frame
-    # time, no on-disk directory — steer grounding too. load_all() is file-only and
-    # returns nothing for a framed/_adhoc vertical (DAT-471 AC3). The worker
+    # time, no on-disk directory — steer grounding too (a file-only read would
+    # return nothing for a framed/_adhoc vertical — DAT-471 AC3). The worker
     # bootstrap installs the overlay resolver process-wide, so it resolves here in
     # the add_source semantic phase exactly as it does in the operating_model
     # metrics phase.
-    metric_loader = GraphLoader(vertical=ontology)
+    metric_loader = GraphLoader()
     for graph_id, defn in get_metric_definitions(ontology).items():
         # A declared metric that won't parse is skipped for this grounding HINT —
         # its born-loud handling (declared-with-reason) is the metrics phase's job

--- a/packages/engine/src/dataraum/analysis/validation/config.py
+++ b/packages/engine/src/dataraum/analysis/validation/config.py
@@ -12,33 +12,14 @@ reads raw YAML and bypasses the overlay.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from dataraum.analysis.validation.models import (
     ValidationSpec,
 )
 from dataraum.core.logging import get_logger
+from dataraum.core.vertical_loader import Family, VerticalLoader
 
 logger = get_logger(__name__)
-
-
-def _read_spec_dir(validations_dir: Path) -> list[dict[str, Any]]:
-    """Parse every per-id YAML file in a validations directory.
-
-    Per-file reads are raw (``yaml.safe_load``) — the overlay applies at the
-    *collection* level (``verticals/<v>/validations``), not per file.
-    """
-    import yaml
-
-    entries: list[dict[str, Any]] = []
-    for yaml_file in sorted(validations_dir.rglob("*.yaml")):
-        with open(yaml_file) as f:
-            data = yaml.safe_load(f)
-        if not data or not isinstance(data, dict):
-            logger.warning("validation_spec_empty", file=str(yaml_file))
-            continue
-        entries.append(data)
-    return entries
 
 
 def load_all_validation_specs(
@@ -46,45 +27,21 @@ def load_all_validation_specs(
 ) -> dict[str, ValidationSpec]:
     """Load a vertical's validation specs, layered with overlay teach rows.
 
-    Production path (``verticals_dir`` is ``None``): read the shipped
-    vertical's ``validations/`` directory (empty base when the vertical is
-    framed — declared via the cockpit, no on-disk directory), then merge
-    active ``validation`` overlay rows via
-    :func:`dataraum.core.overlay.apply_overlay` (upsert by
-    ``validation_id``). An unknown vertical resolves to an EMPTY dict, never
-    raises — "no declared validations" is a loud, explicit outcome at the
-    phase tier, not a loader crash.
-
-    Test path (explicit ``verticals_dir``): read
-    ``<verticals_dir>/<vertical>/validations`` raw, bypassing the overlay —
-    deterministic for unit tests (mirrors ``OntologyLoader``).
-
-    Args:
-        vertical: Vertical name (e.g. ``'finance'``).
-        verticals_dir: Root verticals directory override (tests only).
+    Thin wrapper over :class:`~dataraum.core.vertical_loader.VerticalLoader`
+    (DAT-481): the shipped ``validations/`` directory (empty base when the
+    vertical is framed — declared via the cockpit, no on-disk directory) ⊕
+    active ``validation`` overlay rows (upsert by ``validation_id``). An unknown
+    vertical resolves to an EMPTY dict, never raises — "no declared validations"
+    is a loud, explicit outcome at the phase tier. An explicit ``verticals_dir``
+    reads raw YAML and bypasses the overlay (tests).
 
     Returns:
         Dict mapping validation_id to ValidationSpec.
     """
-    if verticals_dir is not None:
-        spec_dir = verticals_dir / vertical / "validations"
-        entries = _read_spec_dir(spec_dir) if spec_dir.is_dir() else []
-    else:
-        from dataraum.core.config import get_config_dir
-        from dataraum.core.overlay import apply_overlay
-
-        try:
-            spec_dir = get_config_dir(f"verticals/{vertical}/validations")
-        except FileNotFoundError:
-            # Framed vertical (no on-disk directory) or a vertical without
-            # shipped validations — the overlay rows ARE the declared set.
-            spec_dir = None
-        base_entries = _read_spec_dir(spec_dir) if spec_dir is not None else []
-        merged = apply_overlay(f"verticals/{vertical}/validations", {"validations": base_entries})
-        entries = merged.get("validations") or []
+    collection = VerticalLoader(vertical, verticals_dir).collection(Family.VALIDATIONS)
 
     specs: dict[str, ValidationSpec] = {}
-    for data in entries:
+    for data in collection.get("validations") or []:
         spec = ValidationSpec.model_validate(data)
         specs[spec.validation_id] = spec
         logger.debug("validation_spec_loaded", validation_id=spec.validation_id)

--- a/packages/engine/src/dataraum/core/overlay.py
+++ b/packages/engine/src/dataraum/core/overlay.py
@@ -355,15 +355,36 @@ _REGISTRY: Final[dict[str, _ApplierSpec]] = {
 }
 
 
-# Vertical ontology files live at ``verticals/<vertical>/ontology.yaml``;
-# the validation collection is the logical path ``verticals/<vertical>/validations``
-# (a directory merged to one dict by its loader, not a single file). These
-# constants keep the path-parsing in one place.
-_VERTICAL_ONTOLOGY_PREFIX = "verticals/"
-_VERTICAL_ONTOLOGY_SUFFIX = "/ontology.yaml"
-_VERTICAL_VALIDATIONS_SUFFIX = "/validations"
-_VERTICAL_CYCLES_SUFFIX = "/cycles.yaml"
-_VERTICAL_METRICS_SUFFIX = "/metrics"
+# Vertical-scoped overlay families. A teach row's target file lives under
+# ``verticals/<vertical>/<suffix>`` and is filtered by ``payload.vertical`` (the
+# vertical isn't in the row type, it's in the payload). Adding a vertical family
+# is ONE row here — not a new branch in :func:`apply_overlay` (DAT-481).
+_VERTICAL_PREFIX = "verticals/"
+
+
+@dataclass(frozen=True)
+class _VerticalFamily:
+    """A vertical overlay family: path suffix + ordered (teach_type, applier) pairs.
+
+    Rows are filtered to a pair's ``teach_type`` AND the path's vertical, then
+    merged in order. ``ontology.yaml`` has two pairs — ``concept`` defines /
+    replaces a whole entry, then ``concept_property`` patches one field on the
+    (possibly just-replaced) concept — so order matters; the others have one.
+    """
+
+    suffix: str
+    appliers: tuple[tuple[str, Callable[[dict[str, Any], list[OverlayRow]], dict[str, Any]]], ...]
+
+
+_VERTICAL_REGISTRY: Final[tuple[_VerticalFamily, ...]] = (
+    _VerticalFamily(
+        "/ontology.yaml",
+        (("concept", _apply_concept), ("concept_property", _apply_concept_property)),
+    ),
+    _VerticalFamily("/validations", (("validation", _apply_validation),)),
+    _VerticalFamily("/cycles.yaml", (("cycle", _apply_cycle),)),
+    _VerticalFamily("/metrics", (("metric", _apply_metric),)),
+)
 
 
 def apply_overlay(relative_path: str, base: dict[str, Any]) -> dict[str, Any]:
@@ -403,53 +424,21 @@ def apply_overlay(relative_path: str, base: dict[str, Any]) -> dict[str, Any]:
     if not rows:
         return base
 
-    if relative_path.startswith(_VERTICAL_ONTOLOGY_PREFIX) and relative_path.endswith(
-        _VERTICAL_ONTOLOGY_SUFFIX
-    ):
-        vertical = relative_path[len(_VERTICAL_ONTOLOGY_PREFIX) : -len(_VERTICAL_ONTOLOGY_SUFFIX)]
-        concept_rows = [
-            r for r in rows if r.type == "concept" and r.payload.get("vertical") == vertical
-        ]
-        property_rows = [
-            r
-            for r in rows
-            if r.type == "concept_property" and r.payload.get("vertical") == vertical
-        ]
-        merged = base
-        if concept_rows:
-            merged = _apply_concept(merged, concept_rows)
-        if property_rows:
-            merged = _apply_concept_property(merged, property_rows)
-        return merged
-
-    if relative_path.startswith(_VERTICAL_ONTOLOGY_PREFIX) and relative_path.endswith(
-        _VERTICAL_VALIDATIONS_SUFFIX
-    ):
-        vertical = relative_path[
-            len(_VERTICAL_ONTOLOGY_PREFIX) : -len(_VERTICAL_VALIDATIONS_SUFFIX)
-        ]
-        validation_rows = [
-            r for r in rows if r.type == "validation" and r.payload.get("vertical") == vertical
-        ]
-        return _apply_validation(base, validation_rows) if validation_rows else base
-
-    if relative_path.startswith(_VERTICAL_ONTOLOGY_PREFIX) and relative_path.endswith(
-        _VERTICAL_CYCLES_SUFFIX
-    ):
-        vertical = relative_path[len(_VERTICAL_ONTOLOGY_PREFIX) : -len(_VERTICAL_CYCLES_SUFFIX)]
-        cycle_rows = [
-            r for r in rows if r.type == "cycle" and r.payload.get("vertical") == vertical
-        ]
-        return _apply_cycle(base, cycle_rows) if cycle_rows else base
-
-    if relative_path.startswith(_VERTICAL_ONTOLOGY_PREFIX) and relative_path.endswith(
-        _VERTICAL_METRICS_SUFFIX
-    ):
-        vertical = relative_path[len(_VERTICAL_ONTOLOGY_PREFIX) : -len(_VERTICAL_METRICS_SUFFIX)]
-        metric_rows = [
-            r for r in rows if r.type == "metric" and r.payload.get("vertical") == vertical
-        ]
-        return _apply_metric(base, metric_rows) if metric_rows else base
+    if relative_path.startswith(_VERTICAL_PREFIX):
+        for family in _VERTICAL_REGISTRY:
+            if not relative_path.endswith(family.suffix):
+                continue
+            vertical = relative_path[len(_VERTICAL_PREFIX) : -len(family.suffix)]
+            merged = base
+            for teach_type, apply in family.appliers:
+                matching = [
+                    r
+                    for r in rows
+                    if r.type == teach_type and r.payload.get("vertical") == vertical
+                ]
+                if matching:
+                    merged = apply(merged, matching)
+            return merged
 
     merged = base
     for teach_type, spec in _REGISTRY.items():

--- a/packages/engine/src/dataraum/core/vertical_loader.py
+++ b/packages/engine/src/dataraum/core/vertical_loader.py
@@ -1,0 +1,142 @@
+"""One loader for a vertical's config collections (DAT-481).
+
+Every vertical "family" — concepts, validations, cycles, metrics — loads the
+same way: read the shipped vertical's on-disk config (a *directory* of per-id
+YAML files for validations/metrics, a *single file* for concepts/cycles), fall
+back to an empty base when the vertical is *framed* (declared via the cockpit
+``frame`` stage — no on-disk path), then layer the workspace's overlay teach
+rows on top (:func:`dataraum.core.overlay.apply_overlay`). An explicit
+``verticals_dir`` (tests / fixtures) reads raw YAML and bypasses the overlay.
+
+This collapses the four copy-pasted loaders (``graphs/config``,
+``validation/config``, ``cycles/config``, ``semantic/ontology``) and their
+duplicate directory walks into one place. The facade owns LOAD + LAYER; each
+family still parses the raw dicts into its own model (``TransformationGraph`` /
+``ValidationSpec`` / ``OntologyDefinition`` / cycle dicts) — ``collection()``
+returns merged raw dicts, never typed objects.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Final
+
+import yaml
+
+from dataraum.core.config import get_config_dir, get_config_file
+from dataraum.core.overlay import apply_overlay
+
+
+class Family(StrEnum):
+    """A vertical config collection."""
+
+    CONCEPTS = "concepts"
+    VALIDATIONS = "validations"
+    CYCLES = "cycles"
+    METRICS = "metrics"
+
+
+@dataclass(frozen=True)
+class _FamilySpec:
+    """How one family resolves: where it lives, file-vs-dir, and its empty base."""
+
+    subpath: str  # path under ``verticals/<vertical>/``
+    is_dir: bool  # directory of per-id YAML files vs a single file
+    list_key: str | None  # dir families wrap entries as ``{list_key: [...]}``
+    empty_base: Callable[[str], dict[str, Any]]  # framed / missing-source base
+
+
+# Adding a vertical family is one row here (+ its overlay applier in
+# ``core.overlay``'s ``_VERTICAL_REGISTRY``) — not a new loader.
+_SPECS: Final[dict[Family, _FamilySpec]] = {
+    Family.CONCEPTS: _FamilySpec(
+        "ontology.yaml", False, None, lambda v: {"name": v, "concepts": []}
+    ),
+    Family.VALIDATIONS: _FamilySpec(
+        "validations", True, "validations", lambda v: {"validations": []}
+    ),
+    Family.CYCLES: _FamilySpec("cycles.yaml", False, None, lambda v: {}),
+    Family.METRICS: _FamilySpec("metrics", True, "metrics", lambda v: {"metrics": []}),
+}
+
+
+def _walk_dir(directory: Path) -> list[dict[str, Any]]:
+    """Recurse a vertical collection directory, one raw dict per YAML document.
+
+    The single directory walk replacing ``graphs/config._read_metric_dir``,
+    ``validation/config._read_spec_dir``, and ``GraphLoader._load_directory``.
+    Recurses (collections nest by category), supports multi-document files
+    (``---``), and skips empty / non-mapping documents.
+    """
+    entries: list[dict[str, Any]] = []
+    for yaml_file in sorted(directory.rglob("*.yaml")):
+        with open(yaml_file) as f:
+            for doc in yaml.safe_load_all(f):
+                if doc and isinstance(doc, dict):
+                    entries.append(doc)
+    return entries
+
+
+class VerticalLoader:
+    """Load a vertical's config collections, overlay-aware (DAT-481)."""
+
+    def __init__(self, vertical: str, verticals_dir: Path | None = None) -> None:
+        """Initialize.
+
+        Args:
+            vertical: Vertical name (e.g. ``'finance'``).
+            verticals_dir: Root verticals dir override. ``None`` (production)
+                resolves the config tree and layers overlay rows; an explicit
+                path (tests / fixtures) reads raw YAML and bypasses the overlay.
+        """
+        self.vertical = vertical
+        self.verticals_dir = verticals_dir
+
+    def collection(self, family: Family) -> dict[str, Any]:
+        """Return a family's merged (library ⊕ overlay) raw config dict.
+
+        Dir families (validations/metrics) return ``{list_key: [entry, ...]}``;
+        single-file families (concepts/cycles) return the file's merged dict. A
+        framed vertical with no on-disk source resolves to the family's empty
+        base (⊕ any overlay rows) — never raises; "nothing declared" is a loud
+        outcome at the phase tier, not a loader crash.
+        """
+        spec = _SPECS[family]
+        if self.verticals_dir is not None:
+            return self._read_raw(spec)
+        relative = f"verticals/{self.vertical}/{spec.subpath}"
+        return apply_overlay(relative, self._read_base(spec, relative))
+
+    def _read_raw(self, spec: _FamilySpec) -> dict[str, Any]:
+        """Test path: raw on-disk read under ``verticals_dir``, no overlay."""
+        assert self.verticals_dir is not None
+        path = self.verticals_dir / self.vertical / spec.subpath
+        if spec.is_dir:
+            assert spec.list_key is not None
+            return {spec.list_key: _walk_dir(path) if path.is_dir() else []}
+        if not path.is_file():
+            return spec.empty_base(self.vertical)
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+
+    def _read_base(self, spec: _FamilySpec, relative: str) -> dict[str, Any]:
+        """Production base: the on-disk config, or the empty (framed) base."""
+        if spec.is_dir:
+            assert spec.list_key is not None
+            try:
+                directory = get_config_dir(relative)
+            except FileNotFoundError:
+                return spec.empty_base(self.vertical)  # framed / no shipped dir
+            return {spec.list_key: _walk_dir(directory)}
+        try:
+            path = get_config_file(relative)
+        except FileNotFoundError:
+            return spec.empty_base(self.vertical)
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+
+
+__all__ = ["Family", "VerticalLoader"]

--- a/packages/engine/src/dataraum/graphs/__init__.py
+++ b/packages/engine/src/dataraum/graphs/__init__.py
@@ -6,10 +6,11 @@ data schemas and generate executable SQL.
 
 Usage:
     from dataraum.graphs import GraphLoader, GraphAgent, ExecutionContext
+    from dataraum.graphs.config import get_metric_definitions
 
-    loader = GraphLoader(vertical="finance")
-    loader.load_all()
-    graph = loader.get_graph("dso")
+    loader = GraphLoader()
+    loader.graphs.update(loader.graphs_from_definitions(get_metric_definitions("finance")))
+    graph = loader.graphs["dso"]
 
     agent = GraphAgent(config, provider, renderer)
     context = ExecutionContext.with_rich_context(

--- a/packages/engine/src/dataraum/graphs/config.py
+++ b/packages/engine/src/dataraum/graphs/config.py
@@ -23,73 +23,27 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 from dataraum.core.logging import get_logger
+from dataraum.core.vertical_loader import Family, VerticalLoader
 
 logger = get_logger(__name__)
-
-
-def _read_metric_dir(metrics_dir: Path) -> list[dict[str, Any]]:
-    """Read every metric graph YAML under ``metrics_dir`` into raw dicts.
-
-    Recurses (graphs are nested by category, e.g. ``working_capital/dso.yaml``)
-    and supports multi-document files (``---`` separators), mirroring
-    :meth:`GraphLoader._load_directory`. Returns the raw definition dicts (each
-    carrying a top-level ``graph_id``); parsing into ``TransformationGraph`` is
-    the loader's job.
-    """
-    entries: list[dict[str, Any]] = []
-    for yaml_file in sorted(metrics_dir.rglob("*.yaml")):
-        with open(yaml_file) as f:
-            for doc in yaml.safe_load_all(f):
-                if doc:
-                    entries.append(doc)
-    return entries
 
 
 def get_metrics_config(vertical: str, verticals_dir: Path | None = None) -> dict[str, Any]:
     """Load a vertical's metric graphs, layered with ``metric`` overlay rows.
 
-    Production path (``verticals_dir`` is ``None``): read the shipped vertical's
-    ``metrics/`` directory (empty base when the vertical is framed — declared
-    via the cockpit, no on-disk directory), then merge active ``metric`` overlay
-    rows via :func:`dataraum.core.overlay.apply_overlay` (upsert by
-    ``graph_id``). An unknown vertical resolves to an EMPTY collection, never
-    raises — "no declared metrics" is a loud, explicit outcome at the phase
-    tier, not a loader crash.
-
-    Test path (explicit ``verticals_dir``): read
-    ``<verticals_dir>/<vertical>/metrics`` raw, bypassing the overlay —
-    deterministic for unit tests (mirrors ``OntologyLoader`` /
-    ``load_all_validation_specs`` / ``get_cycles_config``).
-
-    Args:
-        vertical: Vertical name (e.g. ``'finance'``).
-        verticals_dir: Root verticals directory override (tests only).
+    Thin wrapper over :class:`~dataraum.core.vertical_loader.VerticalLoader`
+    (DAT-481): the shipped ``metrics/`` directory (empty base when the vertical
+    is framed — declared via the cockpit, no on-disk directory) ⊕ active
+    ``metric`` overlay rows (upsert by ``graph_id``). An unknown vertical
+    resolves to an EMPTY collection, never raises — "no declared metrics" is a
+    loud, explicit outcome at the phase tier. An explicit ``verticals_dir`` reads
+    raw YAML and bypasses the overlay (tests).
 
     Returns:
-        ``{"metrics": [graph_def_dict, ...]}`` — the merged collection, or
-        ``{"metrics": []}`` when neither directory nor overlay declares anything.
+        ``{"metrics": [graph_def_dict, ...]}`` — the merged collection.
     """
-    if verticals_dir is not None:
-        metrics_dir = verticals_dir / vertical / "metrics"
-        entries = _read_metric_dir(metrics_dir) if metrics_dir.is_dir() else []
-        return {"metrics": entries}
-
-    from dataraum.core.config import get_config_dir
-    from dataraum.core.overlay import apply_overlay
-
-    config_dir: Path | None
-    try:
-        config_dir = get_config_dir(f"verticals/{vertical}/metrics")
-    except FileNotFoundError:
-        # Framed vertical (no on-disk directory) or a vertical without shipped
-        # metrics — the overlay rows ARE the declared set.
-        config_dir = None
-    base_entries = _read_metric_dir(config_dir) if config_dir is not None else []
-    merged = apply_overlay(f"verticals/{vertical}/metrics", {"metrics": base_entries})
-    return {"metrics": merged.get("metrics") or []}
+    return VerticalLoader(vertical, verticals_dir).collection(Family.METRICS)
 
 
 def get_metric_definitions(

--- a/packages/engine/src/dataraum/graphs/loader.py
+++ b/packages/engine/src/dataraum/graphs/loader.py
@@ -1,12 +1,18 @@
-"""Transformation graph loader.
+"""Transformation graph parser.
 
-Loads metric graphs from YAML files in vertical config directories.
+Parses already-merged metric-graph definition dicts into
+:class:`~dataraum.graphs.models.TransformationGraph` objects. The definitions
+come from the overlay-aware declared set
+(:func:`dataraum.graphs.config.get_metric_definitions` — shipped graphs ⊕
+``metric`` overlay teach rows); the loader no longer reads directories itself
+(DAT-481 retired the file-only ``load_all`` footgun — see #264).
 
 Usage:
     from dataraum.graphs.loader import GraphLoader
+    from dataraum.graphs.config import get_metric_definitions
 
-    loader = GraphLoader(vertical="finance")
-    loader.load_all()
+    loader = GraphLoader()
+    loader.graphs.update(loader.graphs_from_definitions(get_metric_definitions("finance")))
     metrics = loader.get_metric_graphs()
 """
 
@@ -14,8 +20,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-
-import yaml
 
 from .models import (
     GraphMetadata,
@@ -42,73 +46,29 @@ class GraphLoadError(Exception):
 
 
 class GraphLoader:
-    """Load metric transformation graphs from YAML files.
+    """Parse metric transformation-graph definition dicts into graphs.
 
-    Directory structure:
-        config/verticals/{vertical}/metrics/
-        ├── working_capital/
-        ├── liquidity/
-        └── profitability/
+    Seeded via :meth:`graphs_from_definitions` from the overlay-aware declared
+    set (:func:`dataraum.graphs.config.get_metric_definitions`); holds the
+    parsed graphs in :attr:`graphs`. It does NOT read directories — DAT-481
+    retired the file-only ``load_all`` (the #264 footgun: it bypassed the
+    overlay, so framed/taught metrics were invisible).
     """
 
-    def __init__(self, graphs_dir: Path | None = None, *, vertical: str | None = None):
-        """Initialize loader.
-
-        Args:
-            graphs_dir: Root directory containing graphs.
-                        Defaults to config/verticals/<vertical>/
-            vertical: Vertical name, required when graphs_dir is None.
-        """
-        if graphs_dir is None:
-            if vertical is None:
-                raise ValueError("vertical is required when graphs_dir is not provided")
-            from dataraum.core.config import get_config_dir
-
-            # Resolve the vertical's dir WITHOUT a fail-loud existence check
-            # (the unknown-vertical guard lives once at run entry, DAT-480). A
-            # framed vertical (declared via the cockpit `frame` stage — its
-            # concepts live in config_overlay, with no on-disk directory)
-            # legitimately ships no metric graphs. `load_all` already returns {}
-            # for a missing dir, so resolving the path here and letting load_all
-            # handle absence is what lets grounding run for a framed vertical
-            # (the `add_source` semantic phase grounds against framed concepts
-            # via the overlay-aware OntologyLoader, then asks GraphLoader for
-            # metric standard-fields).
-            graphs_dir = get_config_dir("verticals") / vertical
-        self.graphs_dir = graphs_dir
+    def __init__(self) -> None:
         self.graphs: dict[str, TransformationGraph] = {}
-        self._load_errors: list[GraphLoadError] = []
-
-    def load_all(self) -> dict[str, TransformationGraph]:
-        """Load all transformation graphs from the directory.
-
-        Returns:
-            Dict mapping graph_id to TransformationGraph
-        """
-        self.graphs.clear()
-        self._load_errors.clear()
-
-        if not self.graphs_dir.exists():
-            return {}
-
-        metrics_dir = self.graphs_dir / "metrics"
-        if metrics_dir.exists():
-            self._load_directory(metrics_dir)
-
-        return self.graphs
 
     def graphs_from_definitions(
         self, definitions: dict[str, dict[str, Any]]
     ) -> dict[str, TransformationGraph]:
         """Parse already-merged graph definition dicts into graphs.
 
-        The overlay-aware counterpart of :meth:`load_all`: BOTH the
-        operating_model metrics phase AND the add_source semantic grounding-hint
-        path (``ground_columns``) load their declared set via
+        The single metric-parse entry point. BOTH the operating_model metrics
+        phase AND the add_source semantic grounding-hint path (``ground_columns``)
+        load their declared set via
         :func:`dataraum.graphs.config.get_metric_definitions` (shipped graphs ⊕
         ``metric`` overlay teach rows) and parse them here, so a taught/framed
-        metric is groundable + executable exactly like a shipped one. ``load_all``
-        stays file-only, retained for callers that need the shipped-only set.
+        metric is groundable + executable exactly like a shipped one.
 
         Raises:
             GraphLoadError: a definition is malformed (missing ``graph_id`` /
@@ -121,45 +81,6 @@ class GraphLoader:
             # A sentinel "path" — these dicts come from the overlay-merged
             # collection, not a file on disk; it only labels parse errors.
             graphs[graph_id] = self._parse_graph(Path(f"<overlay:{graph_id}>"), data)
-        return graphs
-
-    def _load_directory(self, directory: Path) -> None:
-        """Recursively load graphs from a directory.
-
-        Supports multi-document YAML files (separated by ---).
-        """
-        for yaml_file in directory.rglob("*.yaml"):
-            try:
-                graphs = self.load_graphs_from_file(yaml_file)
-                for graph in graphs:
-                    self.graphs[graph.graph_id] = graph
-            except GraphLoadError as e:
-                self._load_errors.append(e)
-            except Exception as e:
-                self._load_errors.append(GraphLoadError(yaml_file, str(e)))
-
-    def load_graphs_from_file(self, yaml_path: Path) -> list[TransformationGraph]:
-        """Load all transformation graphs from a YAML file.
-
-        Supports multi-document YAML files (separated by ---).
-
-        Args:
-            yaml_path: Path to the YAML file
-
-        Returns:
-            List of TransformationGraph instances
-
-        Raises:
-            GraphLoadError: If the YAML is invalid or missing required fields
-        """
-        with open(yaml_path) as f:
-            documents = list(yaml.safe_load_all(f))
-
-        graphs = []
-        for doc in documents:
-            if doc:
-                graphs.append(self._parse_graph(yaml_path, doc))
-
         return graphs
 
     def _parse_graph(self, path: Path, data: dict[str, Any]) -> TransformationGraph:
@@ -317,10 +238,6 @@ class GraphLoader:
     def get_metric_graphs(self) -> list[TransformationGraph]:
         """Get all metric graphs."""
         return list(self.graphs.values())
-
-    def get_load_errors(self) -> list[GraphLoadError]:
-        """Get any errors encountered during loading."""
-        return self._load_errors.copy()
 
     def get_all_abstract_fields(self) -> set[str]:
         """Get all abstract fields used across all graphs.

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -195,7 +195,7 @@ class MetricsPhase(BasePhase):
 
         # Parse declared definitions into graphs. A definition that won't parse
         # stays declared with the parse error recorded — visibly impossible.
-        loader = GraphLoader(vertical=vertical)
+        loader = GraphLoader()
         graphs: dict[str, TransformationGraph] = {}
         for graph_id, defn in declared_defs.items():
             try:

--- a/packages/engine/tests/unit/analysis/semantic/test_grounding_step.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_grounding_step.py
@@ -109,8 +109,9 @@ class TestGroundColumns:
         assert len(rows) == 2
         assert {r.semantic_role for r in rows} == {"key", "measure"}
         assert all(r.annotated_by == "test-model" for r in rows)
-        # Standard-field concepts come from the active metric graphs for `finance`.
-        mock_graph_cls.assert_called_once_with(vertical="finance")
+        # Standard-field concepts come from the active metric graphs, seeded via
+        # graphs_from_definitions (the loader no longer resolves a vertical dir).
+        mock_graph_cls.assert_called_once_with()
 
     def test_disabled_config_gate_fails(self, session) -> None:
         config = MagicMock()

--- a/packages/engine/tests/unit/core/test_vertical_loader.py
+++ b/packages/engine/tests/unit/core/test_vertical_loader.py
@@ -1,0 +1,134 @@
+"""Tests for the unified VerticalLoader facade (DAT-481).
+
+One loader for all four vertical families (concepts / validations / cycles /
+metrics), across the three resolution modes: shipped (on-disk), framed
+(overlay-only), and the explicit-``verticals_dir`` test path (raw, no overlay).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dataraum.core.overlay import (
+    OverlayRow,
+    reset_overlay_resolver_for_tests,
+    set_overlay_resolver,
+)
+from dataraum.core.vertical_loader import Family, VerticalLoader
+
+
+@pytest.fixture(autouse=True)
+def _clean_resolver() -> Iterator[None]:
+    reset_overlay_resolver_for_tests()
+    yield
+    reset_overlay_resolver_for_tests()
+
+
+class TestShipped:
+    """The shipped finance vertical resolves all four families off disk."""
+
+    def test_metrics(self) -> None:
+        metrics = VerticalLoader("finance").collection(Family.METRICS)["metrics"]
+        assert any(m.get("graph_id") == "dso" for m in metrics)
+
+    def test_validations(self) -> None:
+        validations = VerticalLoader("finance").collection(Family.VALIDATIONS)["validations"]
+        assert len(validations) >= 1
+
+    def test_cycles(self) -> None:
+        cycles = VerticalLoader("finance").collection(Family.CYCLES)
+        assert cycles.get("cycle_types")
+
+    def test_concepts(self) -> None:
+        ontology = VerticalLoader("finance").collection(Family.CONCEPTS)
+        assert ontology["name"]
+        assert ontology["concepts"]
+
+
+class TestFramed:
+    """A framed vertical (no on-disk dir) resolves overlay rows only."""
+
+    def test_metric_row_resolves(self) -> None:
+        set_overlay_resolver(
+            lambda: [
+                OverlayRow(
+                    type="metric",
+                    payload={"vertical": "sales", "graph_id": "win_rate", "output": {}},
+                )
+            ]
+        )
+        metrics = VerticalLoader("sales").collection(Family.METRICS)["metrics"]
+        assert [m["graph_id"] for m in metrics] == ["win_rate"]
+
+    def test_concept_row_resolves(self) -> None:
+        set_overlay_resolver(
+            lambda: [
+                OverlayRow(
+                    type="concept",
+                    payload={"vertical": "sales", "name": "deal_value"},
+                )
+            ]
+        )
+        ontology = VerticalLoader("sales").collection(Family.CONCEPTS)
+        assert ontology["name"] == "sales"
+        assert [c["name"] for c in ontology["concepts"]] == ["deal_value"]
+
+
+class TestEmptyAndUnknown:
+    """No on-disk source AND no overlay → the family's empty base, never a raise."""
+
+    def test_dir_families_empty_list(self) -> None:
+        assert VerticalLoader("nope").collection(Family.METRICS) == {"metrics": []}
+        assert VerticalLoader("nope").collection(Family.VALIDATIONS) == {"validations": []}
+
+    def test_cycles_empty_dict(self) -> None:
+        assert VerticalLoader("nope").collection(Family.CYCLES) == {}
+
+    def test_concepts_empty_carries_name(self) -> None:
+        assert VerticalLoader("nope").collection(Family.CONCEPTS) == {
+            "name": "nope",
+            "concepts": [],
+        }
+
+
+class TestTestPathBypassesOverlay:
+    """An explicit ``verticals_dir`` reads raw YAML and ignores the overlay."""
+
+    @staticmethod
+    def _seed(root: Path) -> None:
+        vroot = root / "myvert"
+        (vroot / "metrics" / "cat").mkdir(parents=True)
+        (vroot / "metrics" / "cat" / "m1.yaml").write_text(
+            yaml.safe_dump({"graph_id": "m1", "metadata": {"name": "m1"}, "output": {}})
+        )
+        (vroot / "validations").mkdir()
+        (vroot / "validations" / "v1.yaml").write_text(yaml.safe_dump({"validation_id": "v1"}))
+        (vroot / "cycles.yaml").write_text(yaml.safe_dump({"cycle_types": {"c1": {}}}))
+        (vroot / "ontology.yaml").write_text(
+            yaml.safe_dump({"name": "myvert", "concepts": [{"name": "x"}]})
+        )
+
+    def test_reads_raw_ignoring_overlay(self, tmp_path: Path) -> None:
+        self._seed(tmp_path)
+        # A registered resolver MUST NOT leak into the explicit-dir test path.
+        set_overlay_resolver(
+            lambda: [OverlayRow(type="metric", payload={"vertical": "myvert", "graph_id": "ghost"})]
+        )
+        loader = VerticalLoader("myvert", verticals_dir=tmp_path)
+
+        assert [m["graph_id"] for m in loader.collection(Family.METRICS)["metrics"]] == ["m1"]
+        assert [
+            v["validation_id"] for v in loader.collection(Family.VALIDATIONS)["validations"]
+        ] == ["v1"]
+        assert loader.collection(Family.CYCLES) == {"cycle_types": {"c1": {}}}
+        assert loader.collection(Family.CONCEPTS)["concepts"] == [{"name": "x"}]
+
+    def test_missing_test_path_is_empty_base(self, tmp_path: Path) -> None:
+        loader = VerticalLoader("absent", verticals_dir=tmp_path)
+        assert loader.collection(Family.METRICS) == {"metrics": []}
+        assert loader.collection(Family.CYCLES) == {}
+        assert loader.collection(Family.CONCEPTS) == {"name": "absent", "concepts": []}

--- a/packages/engine/tests/unit/core/test_vertical_loader.py
+++ b/packages/engine/tests/unit/core/test_vertical_loader.py
@@ -77,6 +77,30 @@ class TestFramed:
         assert ontology["name"] == "sales"
         assert [c["name"] for c in ontology["concepts"]] == ["deal_value"]
 
+    def test_validation_row_resolves(self) -> None:
+        set_overlay_resolver(
+            lambda: [
+                OverlayRow(
+                    type="validation",
+                    payload={"vertical": "sales", "validation_id": "v_pipeline_stage"},
+                )
+            ]
+        )
+        validations = VerticalLoader("sales").collection(Family.VALIDATIONS)["validations"]
+        assert [v["validation_id"] for v in validations] == ["v_pipeline_stage"]
+
+    def test_cycle_row_resolves(self) -> None:
+        set_overlay_resolver(
+            lambda: [
+                OverlayRow(
+                    type="cycle",
+                    payload={"vertical": "sales", "name": "sales_cycle"},
+                )
+            ]
+        )
+        cycle_types = VerticalLoader("sales").collection(Family.CYCLES)["cycle_types"]
+        assert "sales_cycle" in cycle_types
+
 
 class TestEmptyAndUnknown:
     """No on-disk source AND no overlay → the family's empty base, never a raise."""

--- a/packages/engine/tests/unit/graphs/test_loader.py
+++ b/packages/engine/tests/unit/graphs/test_loader.py
@@ -1,126 +1,97 @@
-"""Tests for graphs/loader.py - graph loading."""
+"""Tests for graphs/loader.py — GraphLoader parses definition dicts into graphs.
+
+DAT-481 retired the file-only directory loader (``load_all``); the loader is now
+seeded from the overlay-aware declared set (``get_metric_definitions``) via
+``graphs_from_definitions`` — exactly as the metrics phase / grounding do.
+"""
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
+from dataraum.graphs.config import get_metric_definitions
 from dataraum.graphs.loader import GraphLoader
 
 
+def _finance_loader() -> GraphLoader:
+    """A GraphLoader seeded with the finance vertical's declared metric graphs.
+
+    Mirrors production: parse the overlay-aware declared set via
+    ``graphs_from_definitions``. No overlay resolver is registered in unit tests,
+    so this resolves the shipped finance set off disk.
+    """
+    loader = GraphLoader()
+    loader.graphs.update(loader.graphs_from_definitions(get_metric_definitions("finance")))
+    return loader
+
+
 class TestGraphLoaderBasics:
-    """Basic GraphLoader functionality tests."""
-
-    def test_loader_init_with_vertical(self) -> None:
-        """Loader resolves config/verticals/finance path from vertical name."""
-        loader = GraphLoader(vertical="finance")
-        assert loader.graphs_dir.name == "finance"
-        assert loader.graphs_dir.parent.name == "verticals"
-
-    def test_loader_init_no_args_raises(self) -> None:
-        """Loader without vertical or graphs_dir raises ValueError."""
-        with pytest.raises(ValueError, match="vertical is required"):
-            GraphLoader()
-
-    def test_loader_init_framed_vertical_no_dir_does_not_raise(self) -> None:
-        """A framed vertical (cockpit `frame` overlay-only, no on-disk dir) must
-        NOT crash the constructor — it legitimately ships no metric graphs.
-
-        Regression: the `add_source` semantic phase grounds a framed vertical's
-        columns (concepts resolved via the overlay-aware OntologyLoader) and then
-        asks GraphLoader for metric standard-fields. An on-construction fail-loud
-        on the missing dir crashed the whole phase with
-        `FileNotFoundError: .../verticals/<framed> does not exist`. The path now
-        resolves and `load_all` degrades to an empty graph set (the
-        unknown-vertical guard lives once at run entry, DAT-480).
-        """
-        loader = GraphLoader(vertical="a_framed_vertical_with_no_on_disk_dir")
-        assert loader.graphs_dir.name == "a_framed_vertical_with_no_on_disk_dir"
-        assert loader.load_all() == {}
-        assert not loader.get_all_abstract_fields()
-
-    def test_loader_init_custom_path(self, tmp_path: Path) -> None:
-        """Loader accepts custom path."""
-        loader = GraphLoader(graphs_dir=tmp_path)
-        assert loader.graphs_dir == tmp_path
-
-    def test_load_all_empty_dir(self, tmp_path: Path) -> None:
-        """Loading from empty directory returns empty dict."""
-        loader = GraphLoader(graphs_dir=tmp_path)
-        graphs = loader.load_all()
-        assert graphs == {}
+    def test_empty_loader_has_no_graphs(self) -> None:
+        """A fresh loader holds no graphs until seeded."""
+        assert GraphLoader().graphs == {}
 
 
 class TestLoadMetricGraphs:
-    """Tests for loading metric graphs from verticals."""
+    """Seeding from the finance declared set populates the graphs."""
 
     @pytest.fixture
     def loader(self) -> GraphLoader:
-        """Create loader with finance vertical."""
-        loader = GraphLoader(vertical="finance")
-        loader.load_all()
-        return loader
+        return _finance_loader()
 
     def test_metric_graphs_loaded(self, loader: GraphLoader) -> None:
-        """Metric graphs are loaded."""
-        metrics = loader.get_metric_graphs()
-        assert len(metrics) >= 1
+        """Metric graphs are present after seeding."""
+        assert len(loader.get_metric_graphs()) >= 1
 
     def test_quality_metrics_not_loaded(self, loader: GraphLoader) -> None:
-        """Quality metrics were relocated out of verticals — not loaded by default."""
+        """Quality metrics were relocated out of verticals — not in the finance set."""
         assert loader.graphs.get("data_completeness") is None
         assert loader.graphs.get("data_freshness") is None
         assert loader.graphs.get("anomaly_rate") is None
 
 
 class TestValidateStandardFields:
-    """Tests for validate_standard_fields() method."""
+    """Tests for validate_standard_fields() against a vertical's ontology."""
 
     def test_all_known_fields_no_warnings(self) -> None:
         """Finance graphs + finance ontology = no warnings."""
-        loader = GraphLoader(vertical="finance")
-        loader.load_all()
-        warnings = loader.validate_standard_fields("finance")
-        assert warnings == []
+        loader = _finance_loader()
+        assert loader.validate_standard_fields("finance") == []
 
-    def test_unknown_field_produces_warning(self, tmp_path: Path) -> None:
-        """Graph with made-up standard_field = warning."""
-        metrics_dir = tmp_path / "metrics"
-        metrics_dir.mkdir()
-        graph_yaml = metrics_dir / "fake.yaml"
-        graph_yaml.write_text(
-            """
-graph_id: fake_metric
-version: "1.0"
-metadata:
-  name: Fake Metric
-  description: Test metric
-  category: test
-  source: system
-output:
-  type: scalar
-  metric_id: fake
-dependencies:
-  extract_nonexistent:
-    level: 1
-    type: extract
-    source:
-      standard_field: nonexistent_concept_xyz
-    output_step: true
-"""
+    def test_unknown_field_produces_warning(self) -> None:
+        """A graph with a made-up standard_field warns — parsed straight from a
+        definition dict, no file IO."""
+        loader = GraphLoader()
+        loader.graphs.update(
+            loader.graphs_from_definitions(
+                {
+                    "fake_metric": {
+                        "graph_id": "fake_metric",
+                        "version": "1.0",
+                        "metadata": {
+                            "name": "Fake Metric",
+                            "description": "Test metric",
+                            "category": "test",
+                            "source": "system",
+                        },
+                        "output": {"type": "scalar", "metric_id": "fake"},
+                        "dependencies": {
+                            "extract_nonexistent": {
+                                "level": 1,
+                                "type": "extract",
+                                "source": {"standard_field": "nonexistent_concept_xyz"},
+                                "output_step": True,
+                            }
+                        },
+                    }
+                }
+            )
         )
-
-        loader = GraphLoader(graphs_dir=tmp_path)
-        loader.load_all()
 
         warnings = loader.validate_standard_fields("finance")
         assert len(warnings) == 1
         assert "nonexistent_concept_xyz" in warnings[0]
         assert "finance" in warnings[0]
 
-    def test_no_ontology_returns_empty(self, tmp_path: Path) -> None:
-        """Nonexistent vertical returns no warnings."""
-        loader = GraphLoader(graphs_dir=tmp_path)
-        warnings = loader.validate_standard_fields("nonexistent_vertical")
-        assert warnings == []
+    def test_no_ontology_returns_empty(self) -> None:
+        """An unknown vertical resolves to no ontology → no warnings."""
+        assert GraphLoader().validate_standard_fields("nonexistent_vertical") == []

--- a/packages/engine/tests/unit/graphs/test_profitability_metrics.py
+++ b/packages/engine/tests/unit/graphs/test_profitability_metrics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from dataraum.graphs.config import get_metric_definitions
 from dataraum.graphs.loader import GraphLoader
 from dataraum.graphs.models import OutputType
 
@@ -24,9 +25,9 @@ PERCENTAGE_METRICS = {"gross_margin", "operating_margin", "ebitda_margin", "net_
 
 @pytest.fixture(scope="module")
 def loader() -> GraphLoader:
-    """Load all finance graphs once for the module."""
-    loader = GraphLoader(vertical="finance")
-    loader.load_all()
+    """Seed the finance declared metric graphs once for the module."""
+    loader = GraphLoader()
+    loader.graphs.update(loader.graphs_from_definitions(get_metric_definitions("finance")))
     return loader
 
 


### PR DESCRIPTION
**DAT-481** (epic DAT-479 · vertical-loading consolidation V2+V3) · design [DD/33161217](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/33161217) §V2+§V3 · blocked-by DAT-480 (✅ #265)

Pure **behaviour-preserving** refactor: one loader replaces four copy-pasted ones.

## Problem
Each vertical "family" (concepts/validations/cycles/metrics) had its own loader repeating the same shape — `verticals_dir` test-vs-prod branch → resolve on-disk path → `FileNotFoundError` → empty *framed* base → `apply_overlay` — copy-pasted ×4, with **three** duplicate recursive YAML dir-walks. `apply_overlay` had four hardcoded vertical-suffix branches. `GraphLoader.load_all` was a file-only footgun (bypassed the overlay → caused the #264 grounding bug) with no real caller post-#264.

## What changed (5 commits)
1. **V3** — retire `GraphLoader.load_all` + its whole directory-loading half (`_load_directory`/`load_graphs_from_file`/`get_load_errors` + the `vertical`/`graphs_dir` constructor). `GraphLoader` is now a pure parser seeded by `graphs_from_definitions` (the single metric-parse entry point); both prod callers → `GraphLoader()`.
2. **Facade** — new `core/vertical_loader.py`: `VerticalLoader.collection(Family)` owns `{resolve path (file|dir), read, framed empty-base fallback}`; one `_walk_dir` replaces the dir-walks; the merge stays in `apply_overlay`; returns **raw dicts** (parsing stays family-specific). `get_metrics_config` / `load_all_validation_specs` / `get_cycles_config` become thin wrappers.
3. **Concepts** — `OntologyLoader.load` folds onto the facade, keeping the DAT-480 production-path `resolve_vertical` UNKNOWN→None guard. All four families now load through one place.
4. **Overlay** — `apply_overlay`'s 4 hardcoded vertical-suffix branches → a `_VERTICAL_REGISTRY` of `_VerticalFamily(suffix, ordered (teach_type, applier) pairs)` + one dispatch loop (ontology keeps its `concept`→`concept_property` ordering). Adding a vertical family is now one registry row.
5. review fixes — `list_verticals` docstring corrected for framed verticals; framed validations+cycles test coverage.

## Behaviour-preservation
Shipped + framed + empty resolution is unchanged for all four families; the born-loud unknown-vertical guard stays DAT-480's run-entry job (the loaders still resolve unknown → empty). One **test-only** delta: `OntologyLoader.load` on the explicit-`verticals_dir` path, for a missing file, now returns an empty `OntologyDefinition` rather than `None` — nothing asserts/relies on the old `None`; production `None` is unchanged.

## Tests
New `tests/unit/core/test_vertical_loader.py` — 4 families × shipped/framed/empty/test-path (13 cases). The ex-`load_all` graph tests reseed via `graphs_from_definitions(get_metric_definitions(...))`. **Full unit suite 1373 green** · ruff + mypy + vulture clean.

## Reviewers (pre-merge)
- senior-code-reviewer: **APPROVE**
- spec-compliance-reviewer: **COMPLIANT** (all 5 ACs; DAT-428 confirmed out of scope)

## Scope
- **DAT-428 split out** (not absorbed) — `unit` is a phase-config teach, orthogonal + writer-less without its cockpit half. Own ticket.
- Cross-repo: none — pure refactor, no detector/response-shape change, no eval/testdata handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)