### PR TITLE
test(cockpit): fix select integration fixtures (DAT-422) + run integration suites in compose-smoke CI

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
     compose-smoke:
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 15
         defaults:
             run:
                 working-directory: packages/infra
@@ -84,6 +84,47 @@ jobs:
             # (The drizzle metadata drift check moved to ci.yml `schema-drift` —
             # it no longer needs the live stack: schema.sql is dumped offline
             # from the SQLAlchemy models and pulled via a scratch Postgres.)
+
+            # Cockpit integration suites (`*.integration.test.*`) against the live
+            # stack — the one place they actually execute. They need a real Postgres
+            # with the engine-created ws_<id> tables plus the bootstrapped DuckLake/S3,
+            # none of which exist in the fast, stack-less `cockpit` PR gate (ci.yml),
+            # so that gate runs unit-only and these suites self-skip there (no
+            # METADATA_DATABASE_URL). The Status=Running gate above guarantees the
+            # worker finished bootstrapping the ws_<id> schema before this runs.
+            - name: Set up Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: "1.3.14"
+
+            - name: Install cockpit deps
+              working-directory: packages/cockpit
+              run: bun install --frozen-lockfile
+
+            # Run under the BUN runtime (`bun --bun`): the metadata client imports
+            # `bun`'s SQL (vitest 5's bun-runtime support, vitest#10363) — plain
+            # `bun run` launches vitest on Node and fails to resolve `bun`. Env is the
+            # host-port view of the compose services (ports publish to the runner:
+            # postgres 5432, seaweedfs S3 8333), mirroring packages/infra/.env.example;
+            # METADATA/COCKPIT use the `dataraum` OWNER role (write access to ws_<id>),
+            # NOT the read-only cockpit_reader the cockpit container runs as.
+            - name: Cockpit integration tests
+              working-directory: packages/cockpit
+              env:
+                  COCKPIT_DATABASE_URL: postgres://dataraum:dataraum@127.0.0.1:5432/cockpit_db
+                  METADATA_DATABASE_URL: postgres://dataraum:dataraum@127.0.0.1:5432/dataraum
+                  DATARAUM_WORKSPACE_ID: 00000000-0000-0000-0000-000000000001
+                  DATARAUM_CONFIG_PATH: ../dataraum-config
+                  DATARAUM_LAKE_PATH: s3://dataraum-lake/lake
+                  DUCKLAKE_CATALOG_URL: postgresql://dataraum:dataraum@127.0.0.1:5432/dataraum_lake_catalog
+                  ANTHROPIC_API_KEY: sk-ant-placeholder-replace-me
+                  S3_ENDPOINT: 127.0.0.1:8333
+                  S3_REGION: us-east-1
+                  S3_USE_SSL: "false"
+                  S3_ACCESS_KEY_ID: dataraum
+                  S3_SECRET_ACCESS_KEY: dataraum-s3-secret
+                  S3_BUCKET: dataraum-lake
+              run: bun --bun run test:integration
 
             - name: Dump compose logs on failure
               if: failure()

--- a/packages/cockpit/src/tools/select.integration.test.ts
+++ b/packages/cockpit/src/tools/select.integration.test.ts
@@ -10,7 +10,10 @@
 // checked against the engine's consumers:
 //   - file source:     connection_config.file_uris (DISTINCT from `tables`),
 //                      source_type = the suffix-derived value (NOT "file"),
-//                      backend NULL, stage = "add_source".
+//                      backend NULL, stage = "add_source". The row is named by
+//                      its content key `src_<digest>` (DAT-422), parsed from the
+//                      staged `uploads/<digest>/<file>` URI — any passed
+//                      source_name is ignored for a file source.
 //                      (import_phase.py `_resolve_file_uris`)
 //   - database source: connection_config.tables = [{name, sql}], the backend
 //                      COLUMN set, source_type = "db_recipe", stage = "add_source".
@@ -27,6 +30,8 @@
 // Requires a running compose stack (postgres on 127.0.0.1:5432 with the
 // engine-created ws_<id>.sources table). Skipped automatically when
 // METADATA_DATABASE_URL isn't set so unit-test CI without the stack stays green.
+
+import { createHash } from "node:crypto";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -127,12 +132,20 @@ describe.skipIf(!STACK_AVAILABLE)(
 		}
 
 		it("writes a file source with file_uris + a suffix-derived source_type (not 'file')", async () => {
-			const name = `sel398_file_${Date.now()}`;
+			// DAT-422: a file source is content-keyed — `select` ignores any passed
+			// source_name and names the row `src_<digest>`, parsed from the locked
+			// `uploads/<digest>/<file>` staged-upload URI (select/mappers.ts
+			// contentKeyedSourceName); a non-upload-shaped URI is rejected loud, so
+			// the fixture MUST be that shape. A fresh per-test sha-1 digest keeps the
+			// row unique in the shared workspace (the old `Date.now()` role).
+			const digest = createHash("sha1")
+				.update(`sel398_file_${Date.now()}`)
+				.digest("hex");
+			const name = `src_${digest}`;
 			writtenNames.push(name);
-			const uri = `s3://${process.env.S3_BUCKET}/sel398/${name}.csv`;
+			const uri = `s3://${process.env.S3_BUCKET}/uploads/${digest}/orders.csv`;
 
 			const result = await persistSelection({
-				source_name: name,
 				schema: { sourceKind: "file", source: uri, tables: [] },
 			});
 
@@ -188,18 +201,25 @@ describe.skipIf(!STACK_AVAILABLE)(
 		});
 
 		it("UPSERTs on the unique name — re-selecting re-points config without a duplicate-name error", async () => {
-			const name = `sel398_upsert_${Date.now()}`;
+			// The UNIQUE name a file source UPSERTs on is its content key `src_<digest>`
+			// (DAT-422), so the two selects must share ONE digest to target the same
+			// row. Re-pointing that digest at a different staged file (csv → parquet)
+			// re-points connection_config in place — an UPSERT, not a duplicate-name
+			// error.
+			const digest = createHash("sha1")
+				.update(`sel398_upsert_${Date.now()}`)
+				.digest("hex");
+			const name = `src_${digest}`;
 			writtenNames.push(name);
-			const csv = `s3://${process.env.S3_BUCKET}/sel398/${name}.csv`;
-			const parquet = `s3://${process.env.S3_BUCKET}/sel398/${name}.parquet`;
+			const base = `s3://${process.env.S3_BUCKET}/uploads/${digest}`;
+			const csv = `${base}/data.csv`;
+			const parquet = `${base}/data.parquet`;
 
 			await persistSelection({
-				source_name: name,
 				schema: { sourceKind: "file", source: csv, tables: [] },
 			});
-			// Re-select the same name with a different file — must update, not error.
+			// Re-select the same content key with a different file — must update, not error.
 			await persistSelection({
-				source_name: name,
 				schema: { sourceKind: "file", source: parquet, tables: [] },
 			});
 


### PR DESCRIPTION
## What

Two things, both surfaced by the recent `vitest → 5.0.0-beta.4` bump (which made `select.integration.test.ts` *actually run* under the bun runtime):

1. **Fix the stale file-source fixtures in `select.integration.test.ts`.** The old vitest errored before the suite executed, masking that the fixtures predate DAT-422 content-keying. They built bucket URIs like `s3://<bucket>/sel398/<name>.csv`, which `contentKeyedSourceName` now rejects loud — a file source is content-keyed, so the persisted row is named `src_<digest>`, parsed from the locked `uploads/<digest>/<file>` upload shape.
   - Both file tests now use upload-shaped URIs + a fresh per-test sha-1 digest (the old `Date.now()` uniqueness role), read back / clean up by the content key `src_<digest>`, and drop the (ignored) `source_name`.
   - The **db test is untouched** — it never hits `contentKeyedSourceName`.
   - All 3 pass against a live `ws_<id>.sources` (verified locally; full integration project 47/47 green).

2. **Run the integration suites in CI** — added to **`compose-smoke`**, the only job with a live stack (engine-created `ws_<id>` tables + bootstrapped DuckLake/S3). Invoked the same `bun run` way as the unit tests, just where the stack lives.
   - Runs under the **bun runtime** (`bun --bun run test:integration`) — the metadata client imports `bun`'s `SQL` (vitest 5's bun-runtime support, vitest#10363); plain `bun run` launches vitest on Node and can't resolve `bun`.
   - Host-port view of the compose services (postgres `5432`, seaweedfs S3 `8333`); `METADATA`/`COCKPIT` use the `dataraum` **owner** role (write access to `ws_<id>`), not the read-only `cockpit_reader` the container runs as.
   - Placed **after** the worker-heartbeat gate that guarantees the `ws_<id>` schema exists.

The fast, stack-less `cockpit` PR gate in `ci.yml` stays **unit-only** — these suites self-skip there without `METADATA_DATABASE_URL`, so the fast gate is unaffected.

## Verification

- `select.integration.test.ts`: 3/3 pass against the live stack.
- Full `bun --bun run test:integration`: 8 files, 47 tests pass.
- `bun run check` (biome), `bun run typecheck`, `bun run test` (unit, 987 pass) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)