### PR TITLE
DAT-486 P2a: save-on-clean learning loop + prefer-enriched table context

### DIFF
--- a/packages/cockpit/src/db/metadata/snippet-writer.integration.test.ts
+++ b/packages/cockpit/src/db/metadata/snippet-writer.integration.test.ts
@@ -2,7 +2,10 @@
 // matters lives in the SQL — the IS-NULL-aware dedup against a NULLS-DISTINCT
 // unique key — so, like the P0 conformance test, this must hit a real Postgres,
 // not a mock. A naive `ON CONFLICT` would silently duplicate; these tests prove
-// the app-level find-then-insert (first-writer-wins) actually dedups.
+// the app-level find-then-insert gives SEQUENTIAL first-writer-wins dedup (the
+// common case). Concurrent same-key saves can still double-insert — NULLS
+// DISTINCT means no DB backstop — a documented best-effort limitation
+// (saveQuerySnippet jsdoc); the proper fix is NULLS NOT DISTINCT engine-side.
 //
 // Harness: the established *.integration.test pattern — gated on
 // METADATA_DATABASE_URL, REUSING the running compose Postgres. Rows are written

--- a/packages/cockpit/src/db/metadata/snippet-writer.integration.test.ts
+++ b/packages/cockpit/src/db/metadata/snippet-writer.integration.test.ts
@@ -1,0 +1,177 @@
+// Integration coverage for save-on-clean (DAT-486 P2a). The correctness that
+// matters lives in the SQL — the IS-NULL-aware dedup against a NULLS-DISTINCT
+// unique key — so, like the P0 conformance test, this must hit a real Postgres,
+// not a mock. A naive `ON CONFLICT` would silently duplicate; these tests prove
+// the app-level find-then-insert (first-writer-wins) actually dedups.
+//
+// Harness: the established *.integration.test pattern — gated on
+// METADATA_DATABASE_URL, REUSING the running compose Postgres. Rows are written
+// under a synthetic schema_mapping_id + one investigation_sessions FK parent, so
+// cleanup is a single delete-by-session and real producer rows are never touched.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const STACK_AVAILABLE = !!process.env.METADATA_DATABASE_URL;
+
+if (STACK_AVAILABLE) {
+	const REQUIRED_DEFAULTS: Record<string, string> = {
+		COCKPIT_DATABASE_URL:
+			process.env.COCKPIT_DATABASE_URL ??
+			"postgresql://dataraum:dataraum@127.0.0.1:5432/cockpit_db",
+		DATARAUM_WORKSPACE_ID:
+			process.env.DATARAUM_WORKSPACE_ID ??
+			"00000000-0000-0000-0000-000000000001",
+		DATARAUM_CONFIG_PATH:
+			process.env.DATARAUM_CONFIG_PATH ?? "/opt/dataraum/config",
+		DATARAUM_LAKE_PATH:
+			process.env.DATARAUM_LAKE_PATH ?? "s3://dataraum-lake/lake",
+		DUCKLAKE_CATALOG_URL:
+			process.env.DUCKLAKE_CATALOG_URL ??
+			"postgresql://dataraum:dataraum@127.0.0.1:5432/lake_catalog",
+		ANTHROPIC_API_KEY:
+			process.env.ANTHROPIC_API_KEY ?? "sk-ant-test-placeholder",
+		S3_ENDPOINT: process.env.S3_ENDPOINT ?? "127.0.0.1:8333",
+		S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID ?? "dataraum",
+		S3_SECRET_ACCESS_KEY:
+			process.env.S3_SECRET_ACCESS_KEY ?? "dataraum-s3-secret",
+		S3_BUCKET: process.env.S3_BUCKET ?? "dataraum-lake",
+	};
+	for (const [k, v] of Object.entries(REQUIRED_DEFAULTS)) {
+		if (!process.env[k]) process.env[k] = v;
+	}
+}
+
+const SCHEMA = STACK_AVAILABLE
+	? `ws_${(process.env.DATARAUM_WORKSPACE_ID as string).replaceAll("-", "_")}`
+	: "";
+
+const TEST_SESSION = "dat486-write-test-session";
+// Synthetic schema_mapping_id — isolates these rows from real producer data and
+// from the P0 read fixture; cleanup is by session, so the value only scopes reads.
+const MAP = "dat486-write-test";
+
+describe.skipIf(!STACK_AVAILABLE)(
+	"saveQuerySnippet (save-on-clean, DAT-486)",
+	() => {
+		let writer: typeof import("./snippet-writer");
+		let lib: typeof import("./snippet-library");
+		// biome-ignore lint/suspicious/noExplicitAny: dynamic-imported Bun SQL client
+		let sql: any;
+
+		beforeAll(async () => {
+			writer = await import("./snippet-writer");
+			lib = await import("./snippet-library");
+			const { SQL } = await import("bun");
+			sql = new SQL(process.env.METADATA_DATABASE_URL as string);
+
+			await cleanup();
+			await sql.unsafe(
+				`INSERT INTO "${SCHEMA}".investigation_sessions
+			 (session_id, status, started_at, intent, step_count)
+			 VALUES ($1, 'complete', now(), 'test', 0)`,
+				[TEST_SESSION],
+			);
+		});
+
+		afterAll(async () => {
+			if (sql) {
+				await cleanup();
+				await sql.close();
+			}
+		});
+
+		async function cleanup(): Promise<void> {
+			await sql.unsafe(
+				`DELETE FROM "${SCHEMA}".sql_snippets WHERE session_id = $1`,
+				[TEST_SESSION],
+			);
+			await sql.unsafe(
+				`DELETE FROM "${SCHEMA}".investigation_sessions WHERE session_id = $1`,
+				[TEST_SESSION],
+			);
+		}
+
+		async function countByKey(standardField: string): Promise<number> {
+			const rows = await sql.unsafe(
+				`SELECT count(*)::int AS n FROM "${SCHEMA}".sql_snippets
+			 WHERE schema_mapping_id = $1 AND snippet_type = 'query'
+			   AND standard_field = $2 AND statement IS NULL
+			   AND aggregation IS NULL AND parameter_value IS NULL`,
+				[MAP, standardField],
+			);
+			return rows[0].n as number;
+		}
+
+		it("inserts a fresh query snippet retrievable by id", async () => {
+			const res = await writer.saveQuerySnippet({
+				schemaMappingId: MAP,
+				standardField: "learned_revenue",
+				sessionId: TEST_SESSION,
+				sql: "SELECT SUM(rev) AS value FROM lake.typed.orders",
+				description: "Learned: revenue",
+				source: "query:exec_one",
+			});
+			expect(res.deduped).toBe(false);
+
+			const row = await lib.findById(res.snippetId);
+			expect(row?.snippetType).toBe("query");
+			expect(row?.standardField).toBe("learned_revenue");
+			expect(row?.source).toBe("query:exec_one");
+			expect(row?.sql).toBe("SELECT SUM(rev) AS value FROM lake.typed.orders");
+		});
+
+		it("dedups a same-key save (NULLS DISTINCT trap) — first-writer-wins, ONE row", async () => {
+			const first = await writer.saveQuerySnippet({
+				schemaMappingId: MAP,
+				standardField: "learned_margin",
+				sessionId: TEST_SESSION,
+				sql: "SELECT 1 AS value",
+				description: "first",
+				source: "query:exec_a",
+			});
+			expect(first.deduped).toBe(false);
+
+			// Same concept key, DIFFERENT sql/source — must NOT insert a second row.
+			const second = await writer.saveQuerySnippet({
+				schemaMappingId: MAP,
+				standardField: "learned_margin",
+				sessionId: TEST_SESSION,
+				sql: "SELECT 2 AS value",
+				description: "second",
+				source: "query:exec_b",
+			});
+			expect(second.deduped).toBe(true);
+			expect(second.snippetId).toBe(first.snippetId);
+
+			// Exactly one row, and the FIRST writer's sql is the one kept.
+			expect(await countByKey("learned_margin")).toBe(1);
+			const kept = await lib.findById(first.snippetId);
+			expect(kept?.sql).toBe("SELECT 1 AS value");
+			expect(kept?.source).toBe("query:exec_a");
+		});
+
+		it("a distinct concept inserts a new row", async () => {
+			const a = await writer.saveQuerySnippet({
+				schemaMappingId: MAP,
+				standardField: "learned_a",
+				sessionId: TEST_SESSION,
+				sql: "SELECT 1 AS value",
+				description: "a",
+				source: "query:exec_x",
+			});
+			const b = await writer.saveQuerySnippet({
+				schemaMappingId: MAP,
+				standardField: "learned_b",
+				sessionId: TEST_SESSION,
+				sql: "SELECT 2 AS value",
+				description: "b",
+				source: "query:exec_x",
+			});
+			expect(a.deduped).toBe(false);
+			expect(b.deduped).toBe(false);
+			expect(b.snippetId).not.toBe(a.snippetId);
+			expect(await countByKey("learned_a")).toBe(1);
+			expect(await countByKey("learned_b")).toBe(1);
+		});
+	},
+);

--- a/packages/cockpit/src/db/metadata/snippet-writer.ts
+++ b/packages/cockpit/src/db/metadata/snippet-writer.ts
@@ -1,0 +1,117 @@
+// Snippet WRITE surface (DAT-486 P2a) — save-on-clean persists a learned
+// `query:` snippet so the library grows from real questions and reuse compounds.
+//
+// Mirrors the engine's query-type save path (query/agent.py `_save_novel_snippets`
+// → snippet_library.py `save_snippet`): concept-keyed, first-writer-wins. The
+// snippet identity is the 6-col `uq_snippet_semantic_key`; for a `query` snippet
+// statement/aggregation/parameter_value are all NULL, so dedup CANNOT be a DB
+// `ON CONFLICT` — the unique key is NULLS DISTINCT, so a null-bearing key never
+// conflicts and every save would duplicate. We replicate the engine's app-level
+// `_find_by_key_any`: SELECT by key with explicit IS-NULL matching, then INSERT
+// only if absent. The cockpit writes the raw `sql_snippets` table through the
+// control-plane write surface (write-surface.ts), granted SELECT,INSERT to
+// cockpit_reader (storage/read_views.py).
+//
+// Scope: this writes ONLY `query`-type snippets (the cockpit answer tool's
+// learned SQL). Cross-`snippet_type` reconciliation/promotion against the
+// graph-minted extract/formula snippets is a separate layer (DAT-493).
+
+import { randomUUID } from "node:crypto";
+import { and, eq, isNull, type SQL } from "drizzle-orm";
+
+import { metadataDb } from "./client";
+import { sqlSnippetsWrite } from "./write-surface";
+
+/**
+ * The concept-key a learned `query:` snippet populates — the subset of
+ * `uq_snippet_semantic_key` that matters for this path. snippet_type is always
+ * `query`; statement/aggregation/parameter_value are always NULL.
+ */
+export interface QuerySnippetKey {
+	/** The dashed-UUID workspace_id VALUE (`config.dataraumWorkspaceId`). */
+	schemaMappingId: string;
+	/** The concept the step computes (the answer tool's `Component.name`). */
+	standardField: string;
+}
+
+export interface SaveQuerySnippetInput extends QuerySnippetKey {
+	/** A valid `investigation_sessions` id (NOT-NULL FK). */
+	sessionId: string;
+	sql: string;
+	description: string;
+	/** Provenance, e.g. `query:<runId>`. */
+	source: string;
+	llmModel?: string | null;
+}
+
+export interface SaveQuerySnippetResult {
+	snippetId: string;
+	/** true when a snippet with the same key already existed and was KEPT (first-writer-wins). */
+	deduped: boolean;
+}
+
+/**
+ * The full semantic key for a `query` snippet, IS-NULL-aware. statement /
+ * aggregation / parameter_value are NULL for query snippets and the unique
+ * constraint is NULLS DISTINCT, so these MUST be `isNull(...)` — `eq(col, null)`
+ * renders `col = NULL`, which never matches, and dedup would silently fail.
+ * Filters `snippet_type = 'query'`: a query save dedups only against other query
+ * snippets, never the graph-minted extract/formula rows (mirrors the engine's
+ * `_find_by_key_any`, which keys by the same snippet_type).
+ */
+export function queryKeyConditions(key: QuerySnippetKey): SQL {
+	return and(
+		eq(sqlSnippetsWrite.snippetType, "query"),
+		eq(sqlSnippetsWrite.standardField, key.standardField),
+		isNull(sqlSnippetsWrite.statement),
+		isNull(sqlSnippetsWrite.aggregation),
+		eq(sqlSnippetsWrite.schemaMappingId, key.schemaMappingId),
+		isNull(sqlSnippetsWrite.parameterValue),
+	) as SQL;
+}
+
+/**
+ * Save a learned `query:` snippet, first-writer-wins. If a snippet with the same
+ * concept key already exists it is KEPT and its id returned (`deduped: true`) —
+ * the first clean computation of a concept becomes the reusable one, matching the
+ * engine's healthy-existing branch. Otherwise a new row is inserted.
+ *
+ * The caller gates WHICH steps reach here (only `fresh`/`adapted` components, not
+ * `exact_reuse` — saving a reused step would re-write the curated `graph:` row it
+ * came from).
+ */
+export async function saveQuerySnippet(
+	input: SaveQuerySnippetInput,
+): Promise<SaveQuerySnippetResult> {
+	const existing = await metadataDb
+		.select({ snippetId: sqlSnippetsWrite.snippetId })
+		.from(sqlSnippetsWrite)
+		.where(queryKeyConditions(input))
+		.limit(1);
+	if (existing.length > 0) {
+		return { snippetId: existing[0].snippetId, deduped: true };
+	}
+
+	const snippetId = randomUUID();
+	const now = new Date();
+	await metadataDb.insert(sqlSnippetsWrite).values({
+		snippetId,
+		sessionId: input.sessionId,
+		snippetType: "query",
+		standardField: input.standardField,
+		statement: null,
+		aggregation: null,
+		schemaMappingId: input.schemaMappingId,
+		parameterValue: null,
+		sql: input.sql,
+		description: input.description,
+		columnMappings: {},
+		source: input.source,
+		llmModel: input.llmModel ?? null,
+		executionCount: 0,
+		failureCount: 0,
+		createdAt: now,
+		updatedAt: now,
+	});
+	return { snippetId, deduped: false };
+}

--- a/packages/cockpit/src/db/metadata/snippet-writer.ts
+++ b/packages/cockpit/src/db/metadata/snippet-writer.ts
@@ -79,6 +79,21 @@ export function queryKeyConditions(key: QuerySnippetKey): SQL {
  * The caller gates WHICH steps reach here (only `fresh`/`adapted` components, not
  * `exact_reuse` — saving a reused step would re-write the curated `graph:` row it
  * came from).
+ *
+ * Concurrency: the dedup is SELECT-then-INSERT with NO DB backstop — the
+ * `uq_snippet_semantic_key` constraint is NULLS DISTINCT, so a null-bearing
+ * `query:` key (statement/aggregation/parameter_value all NULL) never raises a
+ * unique violation. Two CONCURRENT saves of the same concept can therefore both
+ * miss the SELECT and both insert. This is low-harm (a duplicate `query:` row;
+ * both are reusable, the next sequential save dedups, and the cross-type
+ * reconciliation DAT-493 collapses them) and acceptable for this best-effort
+ * path. The proper backstop — `NULLS NOT DISTINCT` on the engine constraint, so
+ * the DB enforces what the app-level IS-NULL match intends — is deferred.
+ *
+ * Failure-replacement: the engine's `save_snippet` REPLACES a row with
+ * `failure_count > 0`; this path always keeps the existing row. No cockpit path
+ * sets `failure_count` yet (usage/quarantine is P2b/DAT-488) and the grant has no
+ * UPDATE, so it cannot bite — folded into P2b when failure tracking lands.
  */
 export async function saveQuerySnippet(
 	input: SaveQuerySnippetInput,

--- a/packages/cockpit/src/db/metadata/write-surface.ts
+++ b/packages/cockpit/src/db/metadata/write-surface.ts
@@ -2,11 +2,12 @@
 //
 // The generated mirror (./schema.ts) introspects the promoted-READ schema —
 // views only, by design: the cockpit_reader role cannot SELECT raw run-stamped
-// tables. But three un-versioned CONTROL tables are deliberate cockpit writes:
+// tables. But four un-versioned CONTROL tables are deliberate cockpit writes:
 //
 //   sources                — register a data source before addSourceWorkflow
 //   investigation_sessions — open the session a workflow runs under
 //   config_overlay         — the teach vocabulary IS overlay rows
+//   sql_snippets           — save-on-clean grows the snippet library (DAT-486)
 //
 // The engine bootstrap grants the reader role exactly these verbs on exactly
 // these tables (storage/read_views.py::_CONTROL_WRITE_GRANTS); everything else
@@ -16,8 +17,10 @@
 
 import {
 	integer,
+	json,
 	jsonb,
 	pgSchema,
+	text,
 	timestamp,
 	varchar,
 } from "drizzle-orm/pg-core";
@@ -72,4 +75,35 @@ export const configOverlayWrite = rawSchema.table("config_overlay", {
 	payload: jsonb("payload").notNull(),
 	createdAt: timestamp("created_at", { mode: "date" }).notNull(),
 	supersededAt: timestamp("superseded_at", { mode: "date" }),
+});
+
+/**
+ * Raw `sql_snippets` — SELECT (IS-NULL-aware dedup lookup) + INSERT a learned
+ * `query:` snippet on a clean run (save-on-clean, DAT-486). Only the columns the
+ * writer touches; the engine SQLAlchemy model owns the full shape. The NOT-NULL
+ * columns with no DB default — `description`, `column_mappings`, `execution_count`,
+ * `failure_count`, `created_at`, `updated_at` — must be set on every insert
+ * (the model's defaults are ORM-side, not server defaults). `column_mappings`
+ * is `json` (not `jsonb`) to match the column type. Identity/quality columns the
+ * cockpit never writes (last_used_at, column_hash, provenance, input_fields,
+ * normalized_expression) are omitted.
+ */
+export const sqlSnippetsWrite = rawSchema.table("sql_snippets", {
+	snippetId: varchar("snippet_id").primaryKey(),
+	sessionId: varchar("session_id").notNull(),
+	snippetType: varchar("snippet_type").notNull(),
+	standardField: varchar("standard_field"),
+	statement: varchar("statement"),
+	aggregation: varchar("aggregation"),
+	schemaMappingId: varchar("schema_mapping_id").notNull(),
+	parameterValue: varchar("parameter_value"),
+	sql: text("sql").notNull(),
+	description: text("description").notNull(),
+	columnMappings: json("column_mappings").notNull(),
+	source: varchar("source").notNull(),
+	llmModel: varchar("llm_model"),
+	executionCount: integer("execution_count").notNull(),
+	failureCount: integer("failure_count").notNull(),
+	createdAt: timestamp("created_at", { mode: "date" }).notNull(),
+	updatedAt: timestamp("updated_at", { mode: "date" }).notNull(),
 });

--- a/packages/cockpit/src/tools/query-context.test.ts
+++ b/packages/cockpit/src/tools/query-context.test.ts
@@ -12,6 +12,7 @@ vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 
 import {
 	formatSchema,
+	preferEnriched,
 	type SchemaColumnRow,
 	type SchemaConceptRow,
 	type SchemaTableRow,
@@ -44,6 +45,31 @@ describe("formatSchema", () => {
 		const block = formatSchema(tables, columnRows, concepts);
 		expect(block).toContain("Table lake.typed.journal_lines:");
 		expect(block).toContain("Table lake.typed.chart_of_accounts:");
+	});
+
+	it("addresses an enriched view in the typed schema (lake.typed.<view>)", () => {
+		// enriched views live in the typed DuckDB schema (schema_for_layer), so the
+		// address is lake.typed.<view> — NOT lake.enriched.<view>.
+		const block = formatSchema(
+			[
+				{
+					tableId: "e1",
+					physicalName: "enriched_src__orders",
+					layer: "enriched",
+				},
+			],
+			[
+				{
+					tableId: "e1",
+					columnId: "ec1",
+					name: "region",
+					resolvedType: "VARCHAR",
+				},
+			],
+			[],
+		);
+		expect(block).toContain("Table lake.typed.enriched_src__orders:");
+		expect(block).not.toContain("lake.enriched.");
 	});
 
 	it("shows each column's type and its [concept] tag when mapped", () => {
@@ -84,7 +110,29 @@ describe("formatSchema", () => {
 
 	it("notes an empty workspace", () => {
 		const block = formatSchema([], [], []);
-		expect(block).toContain("No typed tables in the workspace yet");
+		expect(block).toContain("No queryable tables in the workspace yet");
 		expect(block).toContain("<schema>");
+	});
+});
+
+describe("preferEnriched (mirror the engine's prefer-enriched rule)", () => {
+	const t = (layer: string, physicalName: string) => ({ layer, physicalName });
+
+	it("returns ONLY enriched rows when any exist (all-or-nothing)", () => {
+		const rows = [
+			t("typed", "orders"),
+			t("enriched", "enriched_orders"),
+			t("typed", "regions"),
+		];
+		expect(preferEnriched(rows)).toEqual([t("enriched", "enriched_orders")]);
+	});
+
+	it("falls back to the typed rows when no enriched view exists", () => {
+		const rows = [t("typed", "orders"), t("typed", "regions")];
+		expect(preferEnriched(rows)).toEqual(rows);
+	});
+
+	it("returns empty for an empty input", () => {
+		expect(preferEnriched([])).toEqual([]);
 	});
 });

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -15,8 +15,16 @@
 // otherwise the `typed` tables. The producer GraphAgent mints snippets against the
 // same enriched views, so matching its table context is what lets the consumer's
 // reuse classify as exact_reuse rather than adapted. raw / quarantine stay
-// ingestion-internal. The pure `formatSchema` + `preferEnriched` are unit-tested;
-// the thin Drizzle reads are smoke/integration-covered.
+// ingestion-internal.
+//
+// An enriched view's columns come from a LIVE `DESCRIBE` on the READ_ONLY lake
+// reader (mirroring the engine's `_describe_table`), NOT the column metadata: the
+// view is `SELECT f.*, <dim cols>` but the engine registers Column metadata for
+// the dim columns ONLY, so a metadata read would hide the fact's measures. DESCRIBE
+// returns the full set (names + types, no `[concept:]` tags — the engine drops them
+// too); a lake-read failure falls back to the typed tables. The pure `formatSchema`
+// + `preferEnriched` are unit-tested; the Drizzle reads + the DESCRIBE are
+// smoke/integration-covered.
 
 import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 
@@ -27,7 +35,8 @@ import {
 	sources,
 	tables,
 } from "../db/metadata/schema";
-import { LAKE_ALIAS } from "../duckdb/lake";
+import { getLakeConnection, LAKE_ALIAS } from "../duckdb/lake";
+import { readerToResult } from "../duckdb/query-result";
 
 /** The clean, analysis-ready layer a question is answered over. */
 const TYPED_LAYER = "typed";
@@ -54,6 +63,49 @@ function schemaForLayer(layer: string): string {
 export function preferEnriched<T extends { layer: string }>(rows: T[]): T[] {
 	const enriched = rows.filter((r) => r.layer === ENRICHED_LAYER);
 	return enriched.length > 0 ? enriched : rows;
+}
+
+/**
+ * The live columns of each enriched view, via `DESCRIBE` on the READ_ONLY lake
+ * reader — the same source the engine's GraphAgent uses (`_describe_table`). The
+ * enriched VIEW is `SELECT f.*, <dim cols>`, but the engine registers Column
+ * METADATA for the dim columns ONLY, so a metadata read would hide the fact's
+ * measures; DESCRIBE returns the full set. Returns null when the lake read fails
+ * (views not yet checkpointed / lake unreachable) so the caller can fall back to
+ * the typed tables — a degraded but non-empty schema block beats a hard failure.
+ * Carries names + types only (no `[concept:]` tags), as the engine's enriched
+ * schema_info does.
+ */
+async function describeEnrichedViews(
+	views: SchemaTableRow[],
+): Promise<SchemaColumnRow[] | null> {
+	try {
+		const conn = await getLakeConnection();
+		const out: SchemaColumnRow[] = [];
+		for (const v of views) {
+			const address = `${LAKE_ALIAS}.${schemaForLayer(v.layer)}."${v.physicalName}"`;
+			const reader = await conn.runAndReadAll(`DESCRIBE ${address}`);
+			for (const r of readerToResult(reader).rows) {
+				const name = r.column_name;
+				if (typeof name !== "string") continue;
+				out.push({
+					tableId: v.tableId,
+					// Synthetic id — enriched columns carry no semantic annotation, so it
+					// is never used for a concept lookup (concepts are [] for this path).
+					columnId: `${v.tableId}:${name}`,
+					name,
+					resolvedType:
+						typeof r.column_type === "string" ? r.column_type : null,
+				});
+			}
+		}
+		return out;
+	} catch (err) {
+		console.warn(
+			`[cockpit] enriched DESCRIBE failed — falling back to typed tables: ${err}`,
+		);
+		return null;
+	}
 }
 
 /** One typed table — addressed in SQL as `lake.typed.<physicalName>`. */
@@ -135,9 +187,12 @@ export function formatSchema(
 }
 
 /**
- * Read the typed-layer schema for the active workspace and format it as the
- * sub-agent's `<schema>` block. Three lean reads (tables, columns, semantic
- * concepts) over non-archived sources, joined in the pure `formatSchema`.
+ * Read the schema for the active workspace and format it as the sub-agent's
+ * `<schema>` block. Prefer-enriched: when begin_session has materialized enriched
+ * views, surface ONLY those (columns from a live DESCRIBE — metadata registers dim
+ * columns only, so it would hide the fact's measures), falling back to the typed
+ * tables on a lake-read failure. The typed path reads columns + semantic concepts
+ * from metadata, so typed columns keep their `[concept:]` tags.
  */
 export async function buildSchemaBlock(): Promise<string> {
 	const tableRows = await metadataDb
@@ -156,6 +211,25 @@ export async function buildSchemaBlock(): Promise<string> {
 		)
 		.orderBy(asc(tables.tableName));
 
+	const mapped: SchemaTableRow[] = tableRows.map((t) => ({
+		tableId: t.tableId ?? "",
+		physicalName: t.physicalName ?? "",
+		layer: t.layer ?? TYPED_LAYER,
+	}));
+
+	// Prefer-enriched (mirror graphs/agent.py _build_schema_info): when enriched
+	// views exist, surface ONLY those — columns from a live DESCRIBE (the view is
+	// `SELECT f.*, dims`; metadata registers dims only). Fall through to the typed
+	// tables if the lake read fails (views not yet checkpointed / unreachable).
+	const enrichedViews = mapped.filter((t) => t.layer === ENRICHED_LAYER);
+	if (enrichedViews.length > 0) {
+		const enrichedColumns = await describeEnrichedViews(enrichedViews);
+		if (enrichedColumns)
+			return formatSchema(enrichedViews, enrichedColumns, []);
+	}
+
+	// Typed path: metadata columns + their semantic-concept tags.
+	const typedTables = mapped.filter((t) => t.layer === TYPED_LAYER);
 	const columnRows = await metadataDb
 		.select({
 			tableId: columns.tableId,
@@ -166,12 +240,7 @@ export async function buildSchemaBlock(): Promise<string> {
 		.from(columns)
 		.innerJoin(tables, eq(tables.tableId, columns.tableId))
 		.innerJoin(sources, eq(sources.sourceId, tables.sourceId))
-		.where(
-			and(
-				isNull(sources.archivedAt),
-				inArray(tables.layer, [TYPED_LAYER, ENRICHED_LAYER]),
-			),
-		);
+		.where(and(isNull(sources.archivedAt), eq(tables.layer, TYPED_LAYER)));
 
 	const conceptRows = await metadataDb
 		.select({
@@ -180,19 +249,8 @@ export async function buildSchemaBlock(): Promise<string> {
 		})
 		.from(currentSemanticAnnotations);
 
-	// Prefer-enriched (mirror graphs/agent.py): when enriched views exist, surface
-	// ONLY those; else the typed tables. formatSchema renders only the shown
-	// tables' columns, so passing the full typed+enriched column set is safe.
-	const shownTables = preferEnriched(
-		tableRows.map((t) => ({
-			tableId: t.tableId ?? "",
-			physicalName: t.physicalName ?? "",
-			layer: t.layer ?? TYPED_LAYER,
-		})),
-	);
-
 	return formatSchema(
-		shownTables,
+		typedTables,
 		columnRows.map((c) => ({
 			tableId: c.tableId ?? "",
 			columnId: c.columnId ?? "",

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -8,12 +8,17 @@
 // promoted semantic run — so the model maps a question's terms to concrete columns
 // inline, no separate field-mapping artifact (DAT-485: field_mappings NOT built).
 //
-// Only the `typed` layer is surfaced: that's the clean, analysis-ready data a
-// question is answered over (raw / quarantine are ingestion-internal). The pure
-// `formatSchema` is unit-tested; the thin Drizzle reads are smoke/integration-
-// covered.
+// Prefer-enriched (DAT-486): mirrors the engine's shared schema_info builder
+// (graphs/agent.py `_build_schema_info`) — when begin_session has materialized
+// enriched views (pre-joined fact+dimension supersets, layer `enriched`, which
+// resolve to the `typed` DuckDB schema via schema_for_layer), surface ONLY those;
+// otherwise the `typed` tables. The producer GraphAgent mints snippets against the
+// same enriched views, so matching its table context is what lets the consumer's
+// reuse classify as exact_reuse rather than adapted. raw / quarantine stay
+// ingestion-internal. The pure `formatSchema` + `preferEnriched` are unit-tested;
+// the thin Drizzle reads are smoke/integration-covered.
 
-import { and, asc, eq, isNull } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 
 import { metadataDb } from "../db/metadata/client";
 import {
@@ -26,6 +31,30 @@ import { LAKE_ALIAS } from "../duckdb/lake";
 
 /** The clean, analysis-ready layer a question is answered over. */
 const TYPED_LAYER = "typed";
+/** Pre-joined fact+dimension supersets begin_session materializes (DAT-486). */
+const ENRICHED_LAYER = "enriched";
+
+/**
+ * The DuckDB schema that physically holds a layer's artifacts. Mirrors the
+ * engine's core/duckdb_naming.schema_for_layer: enriched views are derived
+ * artifacts of typed tables, so they live in the `typed` schema (addressed as
+ * `lake.typed.<view_name>`), not a sibling `enriched` schema.
+ */
+function schemaForLayer(layer: string): string {
+	return layer === ENRICHED_LAYER ? TYPED_LAYER : layer;
+}
+
+/**
+ * Mirror the engine's prefer-enriched rule (graphs/agent.py `_build_schema_info`):
+ * when ANY enriched view exists, surface ONLY the enriched views (pre-joined
+ * supersets of the typed facts they're built from); otherwise the typed tables.
+ * All-or-nothing, matching the producer — so the consumer addresses the same
+ * tables the snippets were minted against. Pure; unit-tested.
+ */
+export function preferEnriched<T extends { layer: string }>(rows: T[]): T[] {
+	const enriched = rows.filter((r) => r.layer === ENRICHED_LAYER);
+	return enriched.length > 0 ? enriched : rows;
+}
 
 /** One typed table — addressed in SQL as `lake.typed.<physicalName>`. */
 export interface SchemaTableRow {
@@ -62,7 +91,7 @@ export function formatSchema(
 	conceptRows: SchemaConceptRow[],
 ): string {
 	if (tableRows.length === 0) {
-		return "<schema>\n(No typed tables in the workspace yet — nothing to query.)\n</schema>";
+		return "<schema>\n(No queryable tables in the workspace yet — nothing to query.)\n</schema>";
 	}
 
 	const conceptByColumn = new Map<string, string>();
@@ -85,7 +114,7 @@ export function formatSchema(
 		const cols = [...(columnsByTable.get(t.tableId) ?? [])].sort((a, b) =>
 			a.name.localeCompare(b.name),
 		);
-		const address = `${LAKE_ALIAS}.${t.layer}.${t.physicalName}`;
+		const address = `${LAKE_ALIAS}.${schemaForLayer(t.layer)}.${t.physicalName}`;
 		const colLines = cols.map((c) => {
 			const type = c.resolvedType ?? "unknown";
 			const concept = conceptByColumn.get(c.columnId);
@@ -119,7 +148,12 @@ export async function buildSchemaBlock(): Promise<string> {
 		})
 		.from(tables)
 		.innerJoin(sources, eq(sources.sourceId, tables.sourceId))
-		.where(and(isNull(sources.archivedAt), eq(tables.layer, TYPED_LAYER)))
+		.where(
+			and(
+				isNull(sources.archivedAt),
+				inArray(tables.layer, [TYPED_LAYER, ENRICHED_LAYER]),
+			),
+		)
 		.orderBy(asc(tables.tableName));
 
 	const columnRows = await metadataDb
@@ -132,7 +166,12 @@ export async function buildSchemaBlock(): Promise<string> {
 		.from(columns)
 		.innerJoin(tables, eq(tables.tableId, columns.tableId))
 		.innerJoin(sources, eq(sources.sourceId, tables.sourceId))
-		.where(and(isNull(sources.archivedAt), eq(tables.layer, TYPED_LAYER)));
+		.where(
+			and(
+				isNull(sources.archivedAt),
+				inArray(tables.layer, [TYPED_LAYER, ENRICHED_LAYER]),
+			),
+		);
 
 	const conceptRows = await metadataDb
 		.select({
@@ -141,12 +180,19 @@ export async function buildSchemaBlock(): Promise<string> {
 		})
 		.from(currentSemanticAnnotations);
 
-	return formatSchema(
+	// Prefer-enriched (mirror graphs/agent.py): when enriched views exist, surface
+	// ONLY those; else the typed tables. formatSchema renders only the shown
+	// tables' columns, so passing the full typed+enriched column set is safe.
+	const shownTables = preferEnriched(
 		tableRows.map((t) => ({
 			tableId: t.tableId ?? "",
 			physicalName: t.physicalName ?? "",
 			layer: t.layer ?? TYPED_LAYER,
 		})),
+	);
+
+	return formatSchema(
+		shownTables,
 		columnRows.map((c) => ({
 			tableId: c.tableId ?? "",
 			columnId: c.columnId ?? "",

--- a/packages/cockpit/src/tools/query.test.ts
+++ b/packages/cockpit/src/tools/query.test.ts
@@ -3,7 +3,7 @@
 // and answer assembly from the captured validated run. The sub-agent's chat()
 // loop itself is exercised by the live smoke (it calls the real LLM).
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("#/config", () => ({
 	config: { dataraumWorkspaceId: "ws-test", anthropicApiKey: "k" },
@@ -25,9 +25,24 @@ vi.mock("#/tools/list-tables", () => ({
 	listTables: () => listTablesMock(),
 }));
 
+// save-on-clean: saveQuerySnippet is the write boundary, currentSessionId the FK
+// anchor — both mocked so the persist GATING/skip/best-effort logic is testable.
+const saveQuerySnippetMock = vi.fn();
+vi.mock("#/db/metadata/snippet-writer", () => ({
+	// biome-ignore lint/suspicious/noExplicitAny: passthrough to the spy.
+	saveQuerySnippet: (...a: any[]) => saveQuerySnippetMock(...a),
+}));
+const currentSessionIdMock = vi.fn();
+vi.mock("#/prompts/workspace-context", () => ({
+	currentSessionId: () => currentSessionIdMock(),
+}));
+
 import {
 	assembleAnswer,
+	type Component,
 	classifyComponents,
+	componentsToSave,
+	persistLearnedSnippets,
 	type QueryDraft,
 	readDataQuality,
 } from "./query";
@@ -224,5 +239,98 @@ describe("assembleAnswer", () => {
 			null,
 		);
 		expect(out.grid).toBeNull();
+	});
+});
+
+const comp = (
+	name: string,
+	usage: Component["usage"],
+	sql = "SELECT 1",
+): Component => ({
+	name,
+	sql,
+	snippet_id: usage === "fresh" ? null : "s1",
+	usage,
+});
+
+describe("componentsToSave (save-on-clean gate)", () => {
+	it("keeps fresh and adapted, drops exact_reuse", () => {
+		const out = componentsToSave([
+			comp("a", "fresh"),
+			comp("b", "exact_reuse"),
+			comp("c", "adapted"),
+		]);
+		expect(out.map((c) => c.name)).toEqual(["a", "c"]);
+	});
+
+	it("returns empty when every component is exact_reuse", () => {
+		expect(componentsToSave([comp("a", "exact_reuse")])).toEqual([]);
+	});
+});
+
+describe("persistLearnedSnippets (save-on-clean)", () => {
+	beforeEach(() => {
+		saveQuerySnippetMock.mockReset();
+		currentSessionIdMock.mockReset();
+	});
+
+	it("saves only fresh/adapted under the current session, sharing one query: source", async () => {
+		currentSessionIdMock.mockResolvedValue("sess-1");
+		saveQuerySnippetMock.mockResolvedValue({ snippetId: "x", deduped: false });
+
+		await persistLearnedSnippets({
+			composedSql: "WITH revenue AS (...) SELECT ...",
+			components: [
+				comp("revenue", "fresh", "SELECT SUM(rev) AS value"),
+				comp("reused", "exact_reuse"),
+				comp("margin", "adapted", "SELECT SUM(m) AS value"),
+			],
+		});
+
+		// fresh + adapted only — exact_reuse is skipped.
+		expect(saveQuerySnippetMock).toHaveBeenCalledTimes(2);
+		const args = saveQuerySnippetMock.mock.calls.map((c) => c[0]);
+		expect(args.map((a) => a.standardField)).toEqual(["revenue", "margin"]);
+		expect(args.every((a) => a.sessionId === "sess-1")).toBe(true);
+		expect(args.every((a) => a.schemaMappingId === "ws-test")).toBe(true);
+		// one provenance group per answer; the executable sql is carried through.
+		expect(args[0].source).toMatch(/^query:/);
+		expect(args[1].source).toBe(args[0].source);
+		expect(args[0].sql).toBe("SELECT SUM(rev) AS value");
+	});
+
+	it("skips entirely when there is no current session (the NOT-NULL FK anchor)", async () => {
+		currentSessionIdMock.mockResolvedValue(null);
+		await persistLearnedSnippets({
+			composedSql: "x",
+			components: [comp("a", "fresh")],
+		});
+		expect(saveQuerySnippetMock).not.toHaveBeenCalled();
+	});
+
+	it("is a no-op for a null run or no fresh/adapted components (before touching the session)", async () => {
+		await persistLearnedSnippets(null);
+		await persistLearnedSnippets({
+			composedSql: "x",
+			components: [comp("a", "exact_reuse")],
+		});
+		expect(currentSessionIdMock).not.toHaveBeenCalled();
+		expect(saveQuerySnippetMock).not.toHaveBeenCalled();
+	});
+
+	it("best-effort: swallows a save failure (never fails the answer)", async () => {
+		currentSessionIdMock.mockResolvedValue("sess-1");
+		saveQuerySnippetMock.mockRejectedValue(new Error("permission denied"));
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		await expect(
+			persistLearnedSnippets({
+				composedSql: "x",
+				components: [comp("a", "fresh")],
+			}),
+		).resolves.toBeUndefined();
+		expect(warnSpy).toHaveBeenCalled();
+
+		warnSpy.mockRestore();
 	});
 });

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -27,12 +27,14 @@
 // The outer tool wraps the sub-agent in `asAgentError`: a failed run becomes the
 // `{ error }` envelope the orchestrator reads and retries, not a dead turn.
 
+import { randomUUID } from "node:crypto";
 import { chat, maxIterations, toolDefinition } from "@tanstack/ai";
 import { createAnthropicChat } from "@tanstack/ai-anthropic";
 import { z } from "zod";
 
 import { config } from "../config";
 import { findById } from "../db/metadata/snippet-library";
+import { saveQuerySnippet } from "../db/metadata/snippet-writer";
 import {
 	composeStandalone,
 	runSteps,
@@ -46,6 +48,7 @@ import {
 	QUERY_SUBAGENT_MAX_ITERATIONS,
 } from "../llm";
 import { getQueryInstructions } from "../prompts";
+import { currentSessionId } from "../prompts/workspace-context";
 import { asAgentError, withAgentError } from "./agent-error";
 import { listTables } from "./list-tables";
 import { buildSchemaBlock } from "./query-context";
@@ -364,6 +367,57 @@ export function assembleAnswer(
 	};
 }
 
+// --- Save-on-clean (DAT-486 P2a): the learning loop.
+
+/**
+ * The components save-on-clean persists: the freshly-composed ones (`fresh`,
+ * `adapted`). `exact_reuse` is skipped — that step already reproduced a curated
+ * snippet, so saving a `query:` copy of the same concept is redundant (it would
+ * just dedup), and re-saving over a `graph:` row is exactly what we must avoid.
+ * Pure — unit-tested.
+ */
+export function componentsToSave(components: Component[]): Component[] {
+	return components.filter((c) => c.usage === "fresh" || c.usage === "adapted");
+}
+
+/**
+ * Persist a clean run's freshly-composed concept steps as learned `query:`
+ * snippets so the library grows from real questions and reuse compounds (P2a).
+ * Keyed by concept (standardField = the CTE name), first-writer-wins; all of one
+ * answer's saved steps share one `query:<runId>` provenance group.
+ *
+ * Best-effort: a learning side-effect must NEVER fail the answer (the product),
+ * so every error — including `permission denied` before the engine re-bootstraps
+ * with the sql_snippets grant (read_views.py) — is logged and swallowed. Skipped
+ * when there's no current session to anchor the NOT-NULL FK (the answer ran
+ * outside any session) and when nothing fresh/adapted was composed.
+ */
+export async function persistLearnedSnippets(
+	validated: ValidatedRun | null,
+): Promise<void> {
+	if (!validated) return;
+	const toSave = componentsToSave(validated.components);
+	if (toSave.length === 0) return;
+	try {
+		const sessionId = await currentSessionId();
+		if (!sessionId) return;
+		const source = `query:${randomUUID()}`;
+		for (const c of toSave) {
+			await saveQuerySnippet({
+				schemaMappingId: config.dataraumWorkspaceId,
+				standardField: c.name,
+				sessionId,
+				sql: c.sql,
+				description: `Learned from a query: ${c.name}`,
+				source,
+				llmModel: MODEL,
+			});
+		}
+	} catch (err) {
+		console.warn(`[cockpit] save-on-clean failed: ${err}`);
+	}
+}
+
 /**
  * The query sub-agent: ONE nested chat() over [snippet_search, run_steps] with the
  * concrete `QueryDraftSchema`, then deterministic post-processing (the grid +
@@ -401,6 +455,9 @@ export async function querySubAgent(
 	});
 
 	const dataQuality = await readDataQuality(draft.tables_touched);
+	// Save-on-clean (P2a): grow the snippet library from this answer's fresh/
+	// adapted steps. Best-effort — never blocks or fails the answer.
+	await persistLearnedSnippets(captured.value);
 	return assembleAnswer(draft, captured.value, dataQuality);
 }
 

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -458,8 +458,10 @@ export async function querySubAgent(
 
 	const dataQuality = await readDataQuality(draft.tables_touched);
 	// Save-on-clean (P2a): grow the snippet library from this answer's fresh/
-	// adapted steps. Best-effort — never blocks or fails the answer.
-	await persistLearnedSnippets(captured.value);
+	// adapted steps. Fire-and-forget — the learning write runs AFTER the answer is
+	// assembled and is never on the answer's critical path; persistLearnedSnippets
+	// swallows its own errors, so it can neither block nor fail the answer.
+	void persistLearnedSnippets(captured.value);
 	return assembleAnswer(draft, captured.value, dataQuality);
 }
 

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -219,9 +219,11 @@ export async function classifyComponents(
 			});
 			continue;
 		}
-		// AST-canonical comparison (polyglot, cross-language byte-identical with the
-		// engine's sqlglot — DAT-485 spike): exact_reuse when the model reproduced
-		// the validated snippet modulo cosmetic variance, else adapted. The model's
+		// AST-canonical comparison (polyglot round-trip; DAT-485): exact_reuse when
+		// the model reproduced the validated snippet modulo cosmetic variance, else
+		// adapted. Self-consistent — polyglot canonicalizes BOTH sides — so it does
+		// NOT assume cross-language agreement with the engine's sqlglot (the stress-
+		// test found they diverge; one canonicalizer in both is DAT-492). The model's
 		// executable SQL is always KEPT (classify, don't substitute).
 		const usage = (await sqlEquivalent(step.sql, record.sql))
 			? "exact_reuse"

--- a/packages/engine/src/dataraum/storage/read_views.py
+++ b/packages/engine/src/dataraum/storage/read_views.py
@@ -260,9 +260,12 @@ def materialize_read_schema(connection: Connection, workspace_schema: str) -> in
 
 # The cockpit's CONTROL-PLANE write surface (DAT-453): the only raw tables the
 # reader role can touch, with the minimum verbs. Registering a source, opening
-# a session, and teaching (config_overlay) are deliberate cockpit writes — the
-# teach vocabulary IS overlay rows. Everything else stays read-only via the
-# read schema. SELECT is included because INSERT … RETURNING needs it.
+# a session, teaching (config_overlay), and saving a learned query snippet
+# (sql_snippets, DAT-486) are deliberate cockpit writes — the teach vocabulary
+# IS overlay rows, and save-on-clean grows the snippet library from real
+# questions. Everything else stays read-only via the read schema. SELECT is
+# included because INSERT … RETURNING needs it (and sql_snippets reads its own
+# key for the IS-NULL-aware dedup lookup before INSERT-if-absent).
 #
 # ``sources`` carries a COLUMN-level UPDATE: the cockpit's select upsert is
 # ``INSERT … ON CONFLICT DO UPDATE`` and Postgres checks the UPDATE privilege
@@ -279,6 +282,12 @@ _CONTROL_WRITE_GRANTS: dict[str, str] = {
     ),
     "investigation_sessions": "SELECT, INSERT",
     "config_overlay": "SELECT, INSERT, UPDATE",
+    # save-on-clean (DAT-486): the cockpit query tool saves learned `query:`
+    # snippets. SELECT for the IS-NULL-aware key lookup (the unique key has
+    # nullable columns and Postgres is NULLS DISTINCT, so dedup is app-level,
+    # not ON CONFLICT) + INSERT-if-absent (first-writer-wins). No UPDATE:
+    # failure-replacement / usage telemetry is P2b (DAT-488).
+    "sql_snippets": "SELECT, INSERT",
 }
 
 


### PR DESCRIPTION
## What

P2a of the query migration (DAT-483). The cockpit `answer` query tool now **saves the freshly-composed concept steps of a clean run as learned `query:` snippets** in the engine-owned `sql_snippets` table — so the snippet library grows from real questions and reuse compounds. Plus it **aligns the consumer's table context with the producer** (prefer-enriched), which was the actual bug behind reuse always landing on `adapted`.

Refine outcome + scope: see the DAT-486 implement-ready comment.

## Phases

1. **Engine grant** (`15c4ef88`) — `sql_snippets: "SELECT, INSERT"` added to `_CONTROL_WRITE_GRANTS`. Minimal surface (no UPDATE — failure-replacement is P2b).
2. **Write seam** (`75826d2a`) — `sqlSnippetsWrite` raw-table + `saveQuerySnippet()`. Dedup is **app-level** (SELECT-by-key with explicit `IS NULL` matching, INSERT-if-absent, first-writer-wins), NOT `ON CONFLICT`: the unique key is `NULLS DISTINCT`, so a null-bearing `query:` key never conflicts. Integration-tested against real Postgres.
3. **Wire save-on-clean** (`c30efbc5`) — `querySubAgent` saves fresh/adapted components after a clean run, gated to `{fresh, adapted}` (skips `exact_reuse`), under the ambient `currentSessionId()` FK. Fire-and-forget + best-effort (`cbd231f2`).
4. **prefer-enriched table context** (`e4ba4a46`) — mirrors the engine's `graphs/agent.py _build_schema_info`: when enriched views exist, surface ONLY those. **Enriched view columns come from a live `DESCRIBE`** (`02248a0c`), not metadata — the engine registers Column metadata for dim columns only, so a metadata read would hide the fact's measures.

## Review + verification

- **Reviewers:** spec-compliance COMPLIANT (all 7 items, no scope creep), senior APPROVE, strict NEEDS-WORK → all findings resolved (the HIGH one — prefer-enriched hiding fact measures — fixed via the live DESCRIBE).
- **Gates:** biome + typecheck + 1043 unit tests; writer dedup integration-tested vs real Postgres.
- **Live smoke (fresh stack built from this branch):** runtime grant verified (`cockpit_reader` INSERT), `query:` snippets saved, an answer aggregated fact measures (`SUM(debit/credit)`) through the enriched view — proving the DESCRIBE fix — and **every** consumer query read `FROM lake.typed.enriched_…` (same surface the 11 `graph:` snippets mint against). 0 console errors.

## Deferred (tracked)

- Cross-language canonical / polyglot-in-Python → DAT-492.
- Cross-`snippet_type` de-dup / promotion → DAT-493.
- Usage telemetry / failure-quarantine → DAT-488 (P2b).
- Stage-gate `answer()` → DAT-489.
- **Lift `exact_reuse`** (surface snippet SQL + teach the reuse intent in the prompt) → new follow-up filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)