### PR TITLE
DAT-494: lift exact_reuse — surface snippet SQL + teach faithful reuse in the prompt

### DIFF
--- a/packages/cockpit/src/prompts/query.ts
+++ b/packages/cockpit/src/prompts/query.ts
@@ -3,16 +3,20 @@
 // The nested chat() inside the `answer` tool turns a natural-language question
 // into grounded SQL by REUSING validated snippets from the SQL Knowledge Base. A
 // faithful port of the engine's `dataraum-config/llm/prompts/query_analysis.yaml`
-// reuse-steering — KB-first, match by METADATA (not raw SQL, which the search no
-// longer returns), name each step after its ontology concept — with the engine's
-// gating dropped (no contract / confidence / entropy-dimension assumptions; no
-// metric_type / validation_notes / suggested_format). The sub-agent VALIDATES the
-// composed SQL via run_steps and reads a bounded headline; the FULL result streams
-// browser-side from the grid handle, so it never ferries rows into context.
+// reuse-steering — KB-first, match by METADATA then reproduce the validated SQL
+// the search now surfaces (DAT-494), name each step after its ontology concept —
+// with the engine's gating dropped (no contract / confidence / entropy-dimension
+// assumptions; no metric_type / validation_notes / suggested_format). The sub-agent
+// VALIDATES the composed SQL via run_steps and reads a bounded headline; the FULL
+// result streams browser-side from the grid handle, so it never ferries rows into
+// context.
 //
 // House style mirrors the orchestrator / why prompts: second-person, <tag>-
 // structured, byte-stable so it can be sent as a cached system block — the per-
 // turn context (question + schema + vocabulary) rides in the user turn.
+//
+// NOTE: this is a template literal — do NOT use backticks inside it (they close
+// the string). Refer to code/identifiers in plain words (e.g. SQL, snippet_id).
 
 /**
  * The query sub-agent's reasoning + reuse instructions. The model is given the
@@ -26,18 +30,20 @@ export function getQueryInstructions(): string {
 <reasoning>
 Work through every question in this order:
 1. UNDERSTAND — restate what is asked. Identify the business concepts involved and which tables/columns represent them (use the [concept: …] tags to map question terms to columns).
-2. SEARCH THE KB FIRST — call snippet_search with concepts/statements/graph_ids drawn ONLY from the available vocabulary. The validated snippets are pre-tested calculation graphs; prefer them.
+2. SEARCH THE KB FIRST — call snippet_search with concepts/statements/graph_ids drawn ONLY from the available vocabulary. The validated snippets are pre-tested, schema-grounded calculations — prefer them, and reproduce a fitting one faithfully (see <reuse>).
 3. COMPOSE — break the answer into standalone steps, one per business concept, then a final_sql that combines them. Reuse snippet steps where they fit (see <reuse>).
 4. VALIDATE — call run_steps with your steps + final_sql to confirm the SQL runs and to read a bounded headline sample. Repair and re-validate if it returns an error.
 5. ANSWER — state the result in plain language, including the headline number(s) from the validated sample.
 </reasoning>
 
 <reuse>
-Once a concept is a validated snippet, reuse it. snippet_search returns each snippet's METADATA — snippet_id, standard_field (the concept), statement, aggregation, column_mappings (the validated column expressions, e.g. {"revenue": "SUM(\\"Betrag\\")"}), and input_fields — but NOT raw SQL. Match by this metadata, never by reading SQL:
-- Match on standard_field + statement + aggregation to identify WHAT a snippet computes; use column_mappings to confirm it uses the right concrete columns.
-- Snippets sharing a graph_id form one calculation chain — pull the whole chain when you need the formula.
-- REUSE: a snippet fits → set the step's snippet_id to it and write the SQL from its column_mappings. ADAPT: it is close but needs a change (a different filter, grain) → set snippet_id AND write your adapted SQL. FRESH: nothing fits → omit snippet_id and write new SQL.
-- Mix reused, adapted, and fresh steps freely.
+The snippet KB is the workspace's accumulated, schema-tested way to compute each concept — minted by the grounding pass and grown from every clean answer, including yours. The system MEASURES how much of your answer reproduces these validated snippets: faithful reproduction keeps a concept's computation stable, comparable across questions, and provably grounded; re-deriving equivalent math (writing -SUM(x) where the snippet computes SUM(-x)) returns the same number but silently breaks that grounding. So once a concept is a validated snippet, reuse it faithfully.
+
+snippet_search returns each snippet's concept keys (standard_field / statement / aggregation), its validated SQL (the canonical computation), and column_mappings (a secondary, graph-level hint — NOT a per-concept source of truth). Match a step to a snippet by the concept keys, then:
+- REUSE: a snippet computes what your step needs → set the step's snippet_id to it and REPRODUCE its validated SQL faithfully — same expression, same form — changing ONLY the table reference to lake.<layer>.<name> as the schema shows it (the stored snippet uses a bare table name). Do not rephrase math that already matches.
+- ADAPT: the snippet is close but the question genuinely needs something it does NOT compute — a different grain or period, or a tighter/more-correct filter (e.g. the snippet sums all expenses but the question asks specifically for cost of goods sold) → set its snippet_id AND write your adapted SQL, and note what you changed. Adapt for a real difference, never just to reword.
+- FRESH: nothing fits → omit snippet_id and write new SQL.
+Snippets sharing a graph_id form one calculation chain — pull the whole chain when you need the formula. Mix reused, adapted, and fresh steps freely.
 </reuse>
 
 <steps>

--- a/packages/cockpit/src/tools/snippet-search.test.ts
+++ b/packages/cockpit/src/tools/snippet-search.test.ts
@@ -34,7 +34,7 @@ const graph = (): SnippetGraph => ({
 			parameterValue: null,
 			normalizedExpression: "sum(betrag)",
 			inputFields: null,
-			sql: 'SELECT SUM("Betrag") AS revenue FROM journal_lines',
+			sql: 'SELECT SUM("Betrag") AS value FROM journal_lines',
 			description: "Revenue from the income statement",
 			columnMappings: { revenue: 'SUM("Betrag")' },
 			source: "graph:dso",
@@ -56,16 +56,15 @@ describe("projectGraph", () => {
 			standard_field: "revenue",
 			statement: "income_statement",
 			aggregation: "sum",
-			// DAT-494: the validated sql IS surfaced — the model reproduces it.
-			sql: 'SELECT SUM("Betrag") AS revenue FROM journal_lines',
+			// DAT-494: the validated sql IS surfaced (the real store aliases AS value)
+			// — the model reproduces it; only the producer-internal
+			// normalized_expression is dropped.
+			sql: 'SELECT SUM("Betrag") AS value FROM journal_lines',
 			description: "Revenue from the income statement",
 			column_mappings: { revenue: 'SUM("Betrag")' },
 			input_fields: null,
 			parameter_value: null,
 		});
-		// The validated sql is now part of the projection (DAT-494, the thing the
-		// model reproduces) — but the producer-internal normalized_expression stays out.
-		expect(s.sql).toBe('SELECT SUM("Betrag") AS revenue FROM journal_lines');
 		expect("normalized_expression" in s).toBe(false);
 	});
 });

--- a/packages/cockpit/src/tools/snippet-search.test.ts
+++ b/packages/cockpit/src/tools/snippet-search.test.ts
@@ -43,7 +43,7 @@ const graph = (): SnippetGraph => ({
 });
 
 describe("projectGraph", () => {
-	it("projects metadata and DROPS the raw SQL + normalized_expression", () => {
+	it("projects the concept keys + the validated sql; DROPS only normalized_expression", () => {
 		const p = projectGraph(graph());
 		expect(p.graph_id).toBe("dso");
 		expect(p.source).toBe("graph:dso");
@@ -56,14 +56,16 @@ describe("projectGraph", () => {
 			standard_field: "revenue",
 			statement: "income_statement",
 			aggregation: "sum",
+			// DAT-494: the validated sql IS surfaced — the model reproduces it.
+			sql: 'SELECT SUM("Betrag") AS revenue FROM journal_lines',
 			description: "Revenue from the income statement",
 			column_mappings: { revenue: 'SUM("Betrag")' },
 			input_fields: null,
 			parameter_value: null,
 		});
-		// The raw SQL body never leaves the library — it must NOT be in the projection.
-		expect(JSON.stringify(p)).not.toContain("FROM journal_lines");
-		expect("sql" in s).toBe(false);
+		// The validated sql is now part of the projection (DAT-494, the thing the
+		// model reproduces) — but the producer-internal normalized_expression stays out.
+		expect(s.sql).toBe('SELECT SUM("Betrag") AS revenue FROM journal_lines');
 		expect("normalized_expression" in s).toBe(false);
 	});
 });

--- a/packages/cockpit/src/tools/snippet-search.ts
+++ b/packages/cockpit/src/tools/snippet-search.ts
@@ -8,16 +8,19 @@
 // (`findGraphsByKeys` / `getSearchVocabulary`, keyed on `config.dataraumWorkspaceId`
 // — the dashed-UUID workspace VALUE, NOT the `ws_` schema name).
 //
-// The tool returns a METADATA PROJECTION, never raw SQL bodies: snippet_id +
-// the concept keys (standard_field / statement / aggregation) + the validated
-// column expressions (column_mappings) + dependencies (input_fields) — enough to
-// MATCH a snippet by metadata and reconstruct its SQL grounded in the validated
-// column expressions, while keeping the sub-agent's context lean. The reuse is
-// then CLASSIFIED (not substituted) by `classifyComponents` (query.ts): when the
-// model declares reuse (sets snippet_id) and its SQL matches the stored one
-// (modulo the table qualifier), the component is tagged `exact_reuse` — but the
-// model's executable (qualified) SQL is kept, since the stored bare-name form
-// would not resolve in the cockpit's lake.<layer>.<name> execution context.
+// The tool returns the concept-key metadata PLUS the snippet's validated `sql`
+// body (DAT-494): snippet_id + the concept keys (standard_field / statement /
+// aggregation) + the validated `sql` (the canonical, execution-tested computation)
+// + the column expressions (column_mappings) + dependencies (input_fields). The
+// model REPRODUCES the validated `sql` faithfully rather than reconstructing from
+// the looser, graph-level column_mappings — that faithful reproduction is what
+// lets the reuse classify as `exact_reuse` (snippet bodies are tiny single-SELECTs,
+// so this is cheap on context). The reuse is still CLASSIFIED, not SUBSTITUTED, by
+// `classifyComponents` (query.ts): the model declares reuse (sets snippet_id) and
+// addresses the table as lake.<layer>.<name>, so its executable (qualified) SQL is
+// what runs; the stored BARE-name form would not resolve in the cockpit's execution
+// context (the reason P1 classifies rather than substitutes), and
+// `canonicalizeForReuse` strips the qualifier only for the equality DECISION.
 //
 // `buildVocabularyBlock` formats the searchable keys (`get_search_vocabulary`,
 // `graph:%`-curated only) as a prompt block — the engine's `<available_search_keys>`
@@ -36,16 +39,22 @@ import {
 } from "../db/metadata/snippet-library";
 import { withAgentError } from "./agent-error";
 
-// The per-snippet metadata projection — every reusable signal EXCEPT the raw SQL
-// body (`sql`) and the producer-side `normalized_expression`. `column_mappings`
-// carries the validated SQL expression fragments (e.g. {"revenue":"SUM(\"Betrag\")"}),
-// which is the lean, reusable essence the model grounds its SQL in.
+// The per-snippet projection the model reuses from: the concept keys + the
+// validated `sql` (the AUTHORITATIVE computation to reproduce, DAT-494) + the
+// column expressions (column_mappings — a secondary, graph-level hint, NOT a
+// per-concept source of truth; the `sql` is the thing to reproduce) + formula
+// dependencies (input_fields). The producer-side `normalized_expression` stays
+// internal.
 const SnippetMeta = z.object({
 	snippet_id: z.string(),
 	snippet_type: z.string(),
 	standard_field: z.string().nullable(),
 	statement: z.string().nullable(),
 	aggregation: z.string().nullable(),
+	// The validated, execution-tested SQL body — the canonical computation the
+	// model reproduces faithfully, re-qualifying the table to lake.<layer>.<name>.
+	// NOT NULL in the store.
+	sql: z.string(),
 	description: z.string(),
 	// JSONB blobs — concrete column expressions + formula dependencies + the
 	// constant value. Passed through as-is (validated leniently by the model's use).
@@ -71,7 +80,9 @@ export interface SnippetSearchInput {
 	graph_ids?: string[];
 }
 
-/** Project one library `SnippetRow` to the lean metadata shape (drops raw SQL). */
+/** Project one library `SnippetRow` to the reuse shape — concept keys + the
+ * validated `sql` to reproduce (DAT-494). Drops only the internal
+ * `normalized_expression`. */
 function projectSnippet(s: SnippetRow): z.infer<typeof SnippetMeta> {
 	return {
 		snippet_id: s.snippetId,
@@ -79,6 +90,7 @@ function projectSnippet(s: SnippetRow): z.infer<typeof SnippetMeta> {
 		standard_field: s.standardField,
 		statement: s.statement,
 		aggregation: s.aggregation,
+		sql: s.sql,
 		description: s.description,
 		column_mappings: s.columnMappings,
 		input_fields: s.inputFields,
@@ -139,10 +151,11 @@ export const snippetSearchTool = toolDefinition({
 		"`concepts` (business concepts like 'revenue', 'accounts_receivable'), " +
 		"`statements` (e.g. 'income_statement'), and/or `graph_ids` (specific " +
 		"calculation graphs like 'dso'). Returns matching graphs with each snippet's " +
-		"metadata — snippet_id, the concept keys, the validated column expressions " +
-		"(column_mappings), and dependencies — but NOT the raw SQL. Match by this " +
-		"metadata; set a step's snippet_id to the chosen snippet to declare reuse. " +
-		"Returns [] when nothing is curated for those keys yet.",
+		"concept keys, its validated `sql` (the canonical computation to reproduce), " +
+		"the column expressions (column_mappings), and dependencies. Match by the " +
+		"concept keys, then reproduce the chosen snippet's validated SQL — set the " +
+		"step's snippet_id to declare reuse. Returns [] when nothing is curated for " +
+		"those keys yet.",
 	inputSchema: z.object({
 		concepts: z
 			.array(z.string())

--- a/packages/cockpit/src/tools/snippet-search.ts
+++ b/packages/cockpit/src/tools/snippet-search.ts
@@ -98,7 +98,8 @@ function projectSnippet(s: SnippetRow): z.infer<typeof SnippetMeta> {
 	};
 }
 
-/** Project a library `SnippetGraph` to the tool's metadata projection. */
+/** Project a library `SnippetGraph` to the reuse shape — concept keys, the
+ * validated `sql`, and the column expressions (DAT-494). */
 export function projectGraph(g: SnippetGraph): SnippetGraphProjection {
 	return {
 		graph_id: g.graphId,
@@ -109,8 +110,9 @@ export function projectGraph(g: SnippetGraph): SnippetGraphProjection {
 }
 
 /**
- * Search the snippet KB by vocabulary keys and return matching graphs as a
- * metadata projection (no raw SQL). At least one key category is required — an
+ * Search the snippet KB by vocabulary keys and return matching graphs — concept
+ * keys + each snippet's validated `sql` to reproduce (DAT-494). At least one key
+ * category is required — an
  * all-empty call is agent-fixable (`{ error }`) so the model picks keys from the
  * advertised vocabulary instead of searching blindly. An empty match set is a
  * legitimate `[]` (nothing curated for those keys yet), not an error.


### PR DESCRIPTION
## What

Lifts `exact_reuse` for the cockpit `answer` query sub-agent. After DAT-486 aligned the consumer's *tables* with the producer, reuse still landed on `adapted` even for faithful computations — because the agent never saw the snippet's SQL (it reconstructed from the loose, whole-graph `column_mappings`) and the prompt never explained *why* reuse matters.

Two changes, **cockpit-only, classifier + engine untouched**:

1. **Surface the validated `sql`** in `snippet_search` (`tools/snippet-search.ts`). Previously dropped (P1's metadata-only contract); now the model can *reproduce* the canonical computation instead of re-deriving it. `column_mappings` is demoted to a secondary hint (its whole-graph per-concept unreliability is **DAT-495**); `normalized_expression` stays internal.
2. **Rewrite the `<reuse>` prompt** (`prompts/query.ts`): restore the (dropped-in-port) why-it-matters rationale updated for measured grounding; REUSE = "reproduce the validated SQL faithfully, re-qualify ONLY the bare table to `lake.<layer>.<name>`"; keep an explicit ADAPT clause with a concrete genuine-improvement cue so legitimate adaptations stay `adapted`.

No classifier change is needed — `classifyComponents` already tags `exact_reuse` when the model's SQL is AST-equal to `record.sql` modulo the qualifier; DAT-494 just gives the agent the SQL to reproduce.

## Why this is the right fix (not DAT-492)

The headline `-SUM(x)` vs `SUM(-x)` divergence is **sign-distribution**, *out of DAT-492's scope* (commutative-order / quote-style / frame-case). Faithful reproduction is the actual fix; DAT-492 stays a deferred cosmetic backstop, and 494-first *shrinks* what it must normalize.

## Verification

- **Reviewers:** spec-compliance COMPLIANT (classifier + engine zero-diff), senior APPROVE, strict APPROVED — strict **empirically verified** through the real `sqlEquivalent` path: a re-qualified faithful reproduction → `exact_reuse`, a genuine added-filter adaptation → stays `adapted`.
- **Gates:** biome, typecheck, 1043 unit tests.
- **Live smoke (fresh re-onboard, both images from this branch), A/B vs the DAT-486 run:**
  - "total revenue" → flipped **`adapted` → `exact_reuse`** (reproduced `graph:revenue` faithfully; nothing re-saved).
  - "revenue by month" → correctly **`adapted`** — reused the snippet's exact `SUM(net_amount) * -1` math, adapted *only* the month grain.
  - Answers correct; 0 console errors.

## Follow-ups (tracked)
- **DAT-495** — GraphAgent `column_mappings` is whole-graph, not per-concept (producer quality).
- **DAT-492** — canonical normalization backstop (commutative / quote / frame-case), defer-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)