### PR TITLE
fix(engine): dedup slice tables in temporal_slice_analysis (drift UniqueViolation)

### DIFF
--- a/packages/engine/src/dataraum/pipeline/phases/temporal_slice_analysis_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/temporal_slice_analysis_phase.py
@@ -175,6 +175,20 @@ class TemporalSliceAnalysisPhase(BasePhase):
         total_period_analyses = 0
         errors: list[str] = []
         time_columns_used: set[str] = set()
+        # Each physical slice table is drift-analysed exactly once per run. Two
+        # slice definitions for the same fact table + dimension (the slicing
+        # agent can emit a column twice, and ``_propagate_enriched_dimensions``
+        # adds more — ``slice_definitions`` has no per-run uniqueness guard)
+        # resolve to the same source-qualified prefix and so match the same
+        # slice tables. Persisting a slice table's drift twice in one activity
+        # appends duplicate ``(slice_table_name, column_name, run_id)`` rows
+        # under the production session's ``autoflush=False`` (the run-scoped
+        # delete in ``persist_drift_results`` does not flush the prior batch),
+        # violating ``uq_drift_slice_column_run``. The analysis is independent
+        # of which definition routed us here — same source ⇒ same time column
+        # and period bounds — so deduping is loss-free. (Root cause — duplicate
+        # ``SliceDefinition`` rows at the writer — tracked in DAT-496.)
+        processed_slice_tables: set[str] = set()
 
         for slice_def in slice_definitions:
             tc_entry = table_time_columns.get(slice_def.table_id)
@@ -240,6 +254,9 @@ class TemporalSliceAnalysisPhase(BasePhase):
             )
 
             for si in slice_infos:
+                if si.slice_table_name in processed_slice_tables:
+                    continue
+                processed_slice_tables.add(si.slice_table_name)
                 try:
                     drift_result = analyze_column_drift(
                         slice_table_name=si.slice_table_name,

--- a/packages/engine/tests/integration/pipeline/test_temporal_slice_analysis_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_temporal_slice_analysis_phase.py
@@ -443,6 +443,181 @@ class TestTemporalSliceAnalysisPhase:
         )
         assert result.outputs["time_columns"] == ["date"]
 
+    def test_duplicate_slice_definitions_persist_drift_once(
+        self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+    ):
+        """Two slice defs for the same fact+dimension persist drift exactly once.
+
+        Regression (prod ``uq_drift_slice_column_run`` UniqueViolation): the
+        slicing agent (+ enriched-dimension propagation) can emit two
+        ``SliceDefinition`` rows for the same fact table and dimension in one
+        run — there is no per-run uniqueness guard. Both resolve to the same
+        source-qualified prefix and so match the same physical slice table, so
+        the phase used to persist that table's drift twice. Under the
+        production session's ``autoflush=False`` the run-scoped delete in
+        ``persist_drift_results`` does not flush the prior batch, so the second
+        write appended duplicate ``(slice_table_name, column_name, run_id)``
+        rows and the commit blew up. The phase now drift-analyses each physical
+        slice table once per run.
+        """
+        from datetime import UTC, datetime
+
+        from sqlalchemy import select
+
+        from dataraum.analysis.semantic.db_models import TableEntity
+        from dataraum.analysis.slicing.db_models import SliceDefinition
+        from dataraum.analysis.temporal import TemporalColumnProfile
+        from dataraum.analysis.temporal_slicing.db_models import ColumnDriftSummary
+
+        phase = TemporalSliceAnalysisPhase()
+        source_id = str(uuid4())
+        fact_id = str(uuid4())
+        date_col_id = str(uuid4())
+        region_col_id = str(uuid4())
+
+        source = Source(source_id=source_id, name="orders_src", source_type="csv")
+        session.add(source)
+
+        fact = Table(
+            table_id=fact_id,
+            source_id=source_id,
+            table_name="orders",
+            layer="typed",
+            duckdb_path="typed_orders",
+            row_count=100,
+        )
+        session.add(fact)
+
+        session.add(
+            Column(
+                column_id=date_col_id,
+                table_id=fact_id,
+                column_name="date",
+                column_position=0,
+                raw_type="VARCHAR",
+                resolved_type="DATE",
+            )
+        )
+        session.add(
+            Column(
+                column_id=region_col_id,
+                table_id=fact_id,
+                column_name="region",
+                column_position=1,
+                raw_type="VARCHAR",
+                resolved_type="VARCHAR",
+            )
+        )
+        session.commit()
+
+        session.add(
+            TemporalColumnProfile(
+                profile_id=str(uuid4()),
+                column_id=date_col_id,
+                profiled_at=datetime.now(UTC),
+                min_timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+                max_timestamp=datetime(2024, 6, 30, tzinfo=UTC),
+                detected_granularity="daily",
+                profile_data={},
+            )
+        )
+        session.add(TableEntity(table_id=fact_id, detected_entity_type="order", time_column="date"))
+
+        # Two slice definitions for the SAME fact + dimension — the prod
+        # condition with no per-run uniqueness guard. Both resolve to the
+        # prefix ``slice_typed_orders_region_``.
+        for _ in range(2):
+            session.add(
+                SliceDefinition(
+                    table_id=fact_id,
+                    column_id=region_col_id,
+                    slice_priority=1,
+                    slice_type="categorical",
+                    distinct_values=["us"],
+                    reasoning="region",
+                )
+            )
+
+        # One physical slice table both defs match, with its own column metadata.
+        slice_name = "slice_typed_orders_region_us"
+        slice_table_id = str(uuid4())
+        session.add(
+            Table(
+                table_id=slice_table_id,
+                source_id=source_id,
+                table_name=slice_name,
+                layer="slice",
+                duckdb_path=slice_name,
+                row_count=4,
+            )
+        )
+        session.add(
+            Column(
+                column_id=str(uuid4()),
+                table_id=slice_table_id,
+                column_name="region",
+                column_position=1,
+                raw_type="VARCHAR",
+                resolved_type="VARCHAR",
+            )
+        )
+        session.commit()
+
+        duckdb_conn.execute(f"""
+            CREATE OR REPLACE VIEW "{slice_name}" AS
+            SELECT '2024-01-15'::DATE AS date, 'us' AS region UNION ALL
+            SELECT '2024-02-15'::DATE, 'us' UNION ALL
+            SELECT '2024-03-15'::DATE, 'eu' UNION ALL
+            SELECT '2024-04-15'::DATE, 'eu'
+        """)
+
+        ctx = PhaseContext(
+            session=session,
+            duckdb_conn=duckdb_conn,
+            table_ids=[fact_id],
+            config={},
+            session_id=baseline_session_id(),
+        )
+
+        # Mirror the production session — the run-scoped delete only cleans up
+        # across activity retries, not within one run, when adds aren't flushed.
+        session.autoflush = False
+        result = phase.run(ctx)
+        session.commit()  # surfaces the duplicate-key violation if it regresses
+
+        assert result.status == PhaseStatus.COMPLETED, (
+            f"Phase failed: {result.error}, outputs: {result.outputs}"
+        )
+        rows = (
+            session.execute(
+                select(ColumnDriftSummary).where(
+                    ColumnDriftSummary.slice_table_name == slice_name,
+                    ColumnDriftSummary.column_name == "region",
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1, f"expected one drift row per (slice, column), got {len(rows)}"
+
+        # Period rows share the same dedup guard. ``TemporalSliceAnalysis`` has no
+        # DB UNIQUE, so a double-visit would silently duplicate period labels
+        # rather than raise — assert each label persists once.
+        from dataraum.analysis.temporal_slicing.db_models import TemporalSliceAnalysis
+
+        period_labels = (
+            session.execute(
+                select(TemporalSliceAnalysis.period_label).where(
+                    TemporalSliceAnalysis.slice_table_name == slice_name
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(period_labels) == len(set(period_labels)), (
+            f"period rows duplicated for the slice table: {period_labels}"
+        )
+
     def test_success_no_slice_definitions(
         self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection
     ):


### PR DESCRIPTION
## Bug (user-reported)

`begin_session` over 2 tables failed in **Slice analysis** with:

```
UniqueViolation: duplicate key value violates unique constraint "uq_drift_slice_column_run"
Key (slice_table_name, column_name, run_id)=(slice_upload_..._alles_erledigt, lieferant, cd6d6a0d-...) already exists.
```

## Root cause

`temporal_slice_analysis` loops over `SliceDefinition` rows and prefix-matches them to physical slice tables. `SliceDefinition` has **no per-run uniqueness guard** — the slicing agent + `_propagate_enriched_dimensions` can emit two defs for the same fact+dimension in one run. Both resolve to the same source-qualified prefix → the **same physical slice table is drift-persisted twice in one activity**.

`persist_drift_results` is delete-then-insert, idempotent *across* retries but not *within* one activity: under the production session's `autoflush=False` the second `delete` doesn't flush the first batch's pending inserts, so both commit → duplicate key. Surfaced on a **re-run** after a Tier-1 429 killed the first attempt.

## Fix

Drift-analyse each physical slice table once per run (`processed_slice_tables`). Loss-free — the analysis is independent of which definition routed there (same source ⇒ same time column + period bounds), and it covers the period-metrics persistence in the same loop.

## Tests

Regression test reproduces the crash faithfully (`autoflush=False`) — **proven red without the fix (2 rows), green with it** — and asserts the period-rows path isn't doubled either.

## Follow-up

The writer-level root fix (preventing duplicate `SliceDefinition` rows) is tracked in **DAT-496**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)