### PR TITLE
fix(engine): retry transient LLM failures; roll back FAILED phases

### DIFF
--- a/packages/engine/src/dataraum/llm/providers/anthropic.py
+++ b/packages/engine/src/dataraum/llm/providers/anthropic.py
@@ -11,12 +11,15 @@ from pydantic import BaseModel
 from dataraum.core.logging import get_logger
 from dataraum.core.models.base import Result
 from dataraum.llm.providers.base import (
+    PERMANENT_ERROR_KIND,
+    TRANSIENT_ERROR_KIND,
     ConversationRequest,
     ConversationResponse,
     LLMProvider,
     Message,
     ToolCall,
     ToolResult,
+    format_api_error,
 )
 
 
@@ -62,20 +65,20 @@ def _classify_anthropic_error(exc: anthropic.APIError) -> tuple[str, str]:
         if exc.status_code in _AUTH_STATUS_CODES:
             message = f"{message}. Check your ANTHROPIC_API_KEY."
         if exc.status_code in _PERMANENT_STATUS_CODES:
-            return "permanent", message
-        return "transient", message
+            return PERMANENT_ERROR_KIND, message
+        return TRANSIENT_ERROR_KIND, message
     # Connection / timeout errors don't have a status code; they're
     # always transient by definition.
     if isinstance(exc, anthropic.APIConnectionError):
-        return "transient", str(exc)
+        return TRANSIENT_ERROR_KIND, str(exc)
     # APIResponseValidationError: the server returned something the SDK
     # couldn't parse. Treat as permanent — retrying the same request
     # likely produces the same malformed response.
     if isinstance(exc, anthropic.APIResponseValidationError):
-        return "permanent", str(exc)
+        return PERMANENT_ERROR_KIND, str(exc)
     # Anything else under APIError — default to transient (retry is
     # the safer default than surfacing as a user error).
-    return "transient", str(exc)
+    return TRANSIENT_ERROR_KIND, str(exc)
 
 
 class AnthropicProvider(LLMProvider):
@@ -203,7 +206,7 @@ class AnthropicProvider(LLMProvider):
         except anthropic.APIError as e:
             kind, message = _classify_anthropic_error(e)
             logger.error("anthropic_api_error", error=str(e), model=model, kind=kind)
-            return Result.fail(f"Anthropic API error ({kind}): {message}")
+            return Result.fail(format_api_error("Anthropic", kind, message))
         except Exception as e:
             logger.error("anthropic_unexpected_error", error=str(e), model=model)
             return Result.fail(f"Unexpected error calling Anthropic: {e}")

--- a/packages/engine/src/dataraum/llm/providers/base.py
+++ b/packages/engine/src/dataraum/llm/providers/base.py
@@ -12,6 +12,37 @@ from pydantic import BaseModel, Field
 
 from dataraum.core.models.base import Result
 
+# === API-failure classification ===
+#
+# A provider tags its ``Result.error`` as transient or permanent so the durable
+# layer (the worker's ``_outcome_or_raise``) can decide retryability without a
+# provider-specific import or a brittle bare-string match. ``format_api_error``
+# (producer) and ``is_transient_error`` (consumer) are the one shared definition
+# of that tag — a round-trip test keeps them in lockstep.
+TRANSIENT_ERROR_KIND = "transient"
+PERMANENT_ERROR_KIND = "permanent"
+
+_TRANSIENT_TAG = f"API error ({TRANSIENT_ERROR_KIND})"
+
+
+def format_api_error(provider: str, kind: str, message: str) -> str:
+    """Render a provider API failure, embedding its transient/permanent ``kind``.
+
+    The ``({kind})`` tag is the single classification carrier read back by
+    :func:`is_transient_error` at the retry choke point.
+    """
+    return f"{provider} API error ({kind}): {message}"
+
+
+def is_transient_error(error: str | None) -> bool:
+    """True if ``error`` was tagged transient by :func:`format_api_error`.
+
+    Transient failures (rate limits, 5xx, timeouts, connection errors) should be
+    retried by Temporal; permanent ones (auth, bad request) should not.
+    """
+    return error is not None and _TRANSIENT_TAG in error
+
+
 # === Tool Use Models ===
 
 

--- a/packages/engine/src/dataraum/worker/activities.py
+++ b/packages/engine/src/dataraum/worker/activities.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
+from dataraum.llm.providers.base import is_transient_error
 from dataraum.pipeline.base import PhaseStatus
 from dataraum.worker.activity import (
     SESSION_DETECTOR_PHASES,
@@ -483,17 +484,23 @@ class PhaseActivities:
         return self._outcome_or_raise(run, phase_name)
 
     def _outcome_or_raise(self, run: PhaseRun, phase_name: str) -> PhaseOutcome:
-        """Translate a ``PhaseRun`` into a ``PhaseOutcome`` / non-retryable failure.
+        """Translate a ``PhaseRun`` into a ``PhaseOutcome`` / failure to raise.
 
         Shared by the add_source (``run_phase``) and begin_session
-        (``run_session_phase`` / ``begin_session_select``) activity paths: a
-        FAILED run is a deterministic, permanent phase failure → non-retryable
-        ``PhaseFailed``; anything else (completed / skipped) is a normal outcome.
+        (``run_session_phase`` / ``begin_session_select``) activity paths.
+        A FAILED run is normally a deterministic, permanent phase failure →
+        non-retryable ``PhaseFailed``. The exception is a *transient* provider
+        failure (an LLM 429 / 5xx / connection error the provider tagged via
+        ``format_api_error``): that is not deterministic, so raise a retryable
+        error and let Temporal re-run the whole activity with backoff (the
+        ``RetryPolicy``'s durable safety net the SDK's in-process retries can't
+        replace). Anything else (completed / skipped) is a normal outcome.
         """
         if run.status == PhaseStatus.FAILED.value:
-            raise ApplicationError(
-                run.error or f"Phase '{phase_name}' failed",
-                type="PhaseFailed",
-                non_retryable=True,
-            )
+            message = run.error or f"Phase '{phase_name}' failed"
+            if is_transient_error(run.error):
+                # Retryable: ``TransientPhaseFailure`` is absent from the
+                # workflow ``RetryPolicy``'s ``non_retryable_error_types``.
+                raise ApplicationError(message, type="TransientPhaseFailure")
+            raise ApplicationError(message, type="PhaseFailed", non_retryable=True)
         return PhaseOutcome(status=run.status, summary=run.summary)

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -220,6 +220,14 @@ def run_phase(
 
         result = phase.run(ctx)
 
+        # A FAILED phase persists nothing: roll back its partial writes so
+        # session_scope's commit-on-clean-exit is a no-op. This is what makes a
+        # transient-failure activity retry safe — the retry (same run_id) starts
+        # from a clean slate instead of clashing with attempt 1's committed rows
+        # (a within-run UNIQUE) or relying on every writer to delete-by-run_id.
+        if result.status == PhaseStatus.FAILED:
+            session.rollback()
+
     logger.info(
         "activity.phase_done",
         phase=phase_name,
@@ -476,6 +484,14 @@ def run_session_phase(
             return PhaseRun(status=PhaseStatus.SKIPPED.value, summary=skip_reason)
 
         result = phase.run(ctx)
+
+        # A FAILED phase persists nothing: roll back its partial writes so
+        # session_scope's commit-on-clean-exit is a no-op. This is what makes a
+        # transient-failure activity retry safe — the retry (same run_id) starts
+        # from a clean slate instead of clashing with attempt 1's committed rows
+        # (a within-run UNIQUE) or relying on every writer to delete-by-run_id.
+        if result.status == PhaseStatus.FAILED:
+            session.rollback()
 
     logger.info(
         "activity.session_phase_done",

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -269,6 +269,38 @@ def test_workspace_mismatch_fails_loud(worker_manager: ConnectionManager) -> Non
     assert "some-other-workspace" in (result.error or "")
 
 
+def test_failed_phase_rolls_back_partial_writes(
+    worker_manager: ConnectionManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A FAILED phase commits nothing — its partial writes are rolled back.
+
+    This is what makes a transient-failure activity retry safe: the retry re-runs
+    under the SAME run_id, so attempt 1 must not leave committed rows for it to
+    clash with (e.g. a within-run UNIQUE on a non-idempotent writer). A stub phase
+    writes a Source then returns FAILED; the row must not survive.
+    """
+    import dataraum.worker.activity as activity_mod
+    from dataraum.pipeline.base import PhaseResult
+
+    ghost_id = str(uuid4())
+
+    class WriteThenFailPhase:
+        def should_skip(self, ctx: object) -> None:
+            return None
+
+        def run(self, ctx: object) -> PhaseResult:
+            ctx.session.add(Source(source_id=ghost_id, name="ghost", source_type="csv"))  # type: ignore[attr-defined]
+            return PhaseResult.failed("simulated transient failure")
+
+    monkeypatch.setattr(activity_mod, "get_phase_class", lambda _name: WriteThenFailPhase)
+
+    run = run_phase(worker_manager, "typing", _identity(str(uuid4())), [])
+    assert run.status == "failed"
+
+    with worker_manager.session_scope() as session:
+        assert session.get(Source, ghost_id) is None
+
+
 def test_addsource_runs_under_nondefault_workspace(
     pg_url_clean: str,
     lake_anchor,  # noqa: ANN001

--- a/packages/engine/tests/unit/llm/test_anthropic_provider.py
+++ b/packages/engine/tests/unit/llm/test_anthropic_provider.py
@@ -18,7 +18,14 @@ from dataraum.llm.providers.anthropic import (
     AnthropicProvider,
     _classify_anthropic_error,
 )
-from dataraum.llm.providers.base import ConversationRequest, Message
+from dataraum.llm.providers.base import (
+    PERMANENT_ERROR_KIND,
+    TRANSIENT_ERROR_KIND,
+    ConversationRequest,
+    Message,
+    format_api_error,
+    is_transient_error,
+)
 
 
 def _config() -> AnthropicConfig:
@@ -105,3 +112,31 @@ class TestConverseSurfacesClassification:
         result = provider.converse(_request())
         assert not result.success
         assert "transient" in (result.error or "")
+        # The consumer's predicate (worker retry choke point) agrees end-to-end.
+        assert is_transient_error(result.error)
+
+
+class TestTransientErrorPredicate:
+    """``format_api_error`` (producer) and ``is_transient_error`` (the worker's
+    retry choke point) are the one shared classification contract."""
+
+    def test_transient_round_trips(self) -> None:
+        msg = format_api_error("Anthropic", TRANSIENT_ERROR_KIND, "429 rate limit")
+        assert is_transient_error(msg) is True
+
+    def test_permanent_is_not_transient(self) -> None:
+        msg = format_api_error("Anthropic", PERMANENT_ERROR_KIND, "401 unauthorized")
+        assert is_transient_error(msg) is False
+
+    def test_none_and_unrelated_are_not_transient(self) -> None:
+        assert is_transient_error(None) is False
+        assert is_transient_error("No typed tables found. Run typing phase first.") is False
+
+    def test_tag_survives_real_error_wrapping(self) -> None:
+        # The classification must survive the concatenation the phase/agent layers
+        # apply before the string reaches ``_outcome_or_raise`` — else a transient
+        # failure silently reads as permanent and is never retried.
+        inner = format_api_error("Anthropic", TRANSIENT_ERROR_KIND, "429 rate limit")
+        assert is_transient_error(f"LLM call failed: {inner}")  # agent wrap
+        assert is_transient_error(f"RuntimeError: {inner}")  # BasePhase.run wrap
+        assert is_transient_error(f"Cycle grounding failed: {inner}")  # phase wrap

--- a/packages/engine/tests/unit/worker/test_outcome_or_raise.py
+++ b/packages/engine/tests/unit/worker/test_outcome_or_raise.py
@@ -1,0 +1,69 @@
+"""The activity retry choke point: ``PhaseActivities._outcome_or_raise``.
+
+A FAILED phase is normally a deterministic, non-retryable ``PhaseFailed``. The
+exception is a *transient* provider failure (an LLM 429 / 5xx / connection
+error tagged by ``format_api_error``): that raises a retryable error so
+Temporal re-runs the activity with backoff instead of surfacing on attempt 1.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+from dataraum.llm.providers.base import (
+    PERMANENT_ERROR_KIND,
+    TRANSIENT_ERROR_KIND,
+    format_api_error,
+)
+from dataraum.pipeline.base import PhaseStatus
+from dataraum.worker.activities import PhaseActivities
+from dataraum.worker.activity import PhaseRun
+from dataraum.worker.workflows import _RETRY
+
+
+def _acts() -> PhaseActivities:
+    # ``_outcome_or_raise`` never touches the manager.
+    return PhaseActivities(MagicMock())
+
+
+def _failed(error: str) -> PhaseRun:
+    return PhaseRun(status=PhaseStatus.FAILED.value, error=error)
+
+
+def test_transient_failure_is_retryable() -> None:
+    run = _failed(format_api_error("Anthropic", TRANSIENT_ERROR_KIND, "429 rate limit"))
+    with pytest.raises(ApplicationError) as ei:
+        _acts()._outcome_or_raise(run, "slicing")
+    assert ei.value.non_retryable is False
+    assert ei.value.type == "TransientPhaseFailure"
+    # The retryable type must be absent from the policy's non-retryable list,
+    # else Temporal would still refuse to retry it.
+    assert "TransientPhaseFailure" not in (_RETRY.non_retryable_error_types or ())
+
+
+def test_permanent_provider_failure_stays_non_retryable() -> None:
+    run = _failed(format_api_error("Anthropic", PERMANENT_ERROR_KIND, "401 unauthorized"))
+    with pytest.raises(ApplicationError) as ei:
+        _acts()._outcome_or_raise(run, "semantic_per_table")
+    assert ei.value.non_retryable is True
+    assert ei.value.type == "PhaseFailed"
+    assert "PhaseFailed" in (_RETRY.non_retryable_error_types or ())
+
+
+def test_deterministic_failure_stays_non_retryable() -> None:
+    # A non-provider failure (no transient tag) is deterministic → PhaseFailed.
+    run = _failed("No typed tables found. Run typing phase first.")
+    with pytest.raises(ApplicationError) as ei:
+        _acts()._outcome_or_raise(run, "relationships")
+    assert ei.value.non_retryable is True
+    assert ei.value.type == "PhaseFailed"
+
+
+def test_completed_run_returns_outcome() -> None:
+    run = PhaseRun(status=PhaseStatus.COMPLETED.value, summary="2 drift summaries")
+    outcome = _acts()._outcome_or_raise(run, "slicing")
+    assert outcome.status == PhaseStatus.COMPLETED.value
+    assert outcome.summary == "2 drift summaries"


### PR DESCRIPTION
## Bug

A transient Anthropic **429** during a session phase surfaced as a hard failure (the user worked around it by upgrading to Tier 2). The provider already classifies 429 as transient (`Anthropic API error (transient): …`), but `_outcome_or_raise` collapsed **every** FAILED phase to `non_retryable PhaseFailed`, opting it out of Temporal's `RetryPolicy(maximum_attempts=5)` — contradicting the stated intent (`workflows.py`: *"transient failures … raise normally and stay retryable"*).

## Fix 1 — choke point

Lift the provider's transient/permanent tag to a **shared contract** — `format_api_error` (producer) + `is_transient_error` (consumer) in `llm/providers/base.py`, keyed on a shared constant, with a round-trip test. `_outcome_or_raise` now raises a **retryable** `ApplicationError(type="TransientPhaseFailure")` (absent from the policy's `non_retryable_error_types`) for transient failures; permanent + deterministic failures stay `non_retryable PhaseFailed`.

## Fix 2 — roll back FAILED phases (surfaced in review)

Making activities retryable exposed a latent hazard: a phase that **returns** `PhaseResult.failed` (rather than raising) exits `session_scope` cleanly and **commits its partial writes**. A same-`run_id` retry then re-runs a non-idempotent writer — e.g. `lifecycle.declare_artifact`, declared *before* the LLM call in the operating_model phases (`business_cycles`/`validation`/`metrics`) — into a within-run `LifecycleArtifact` UNIQUE.

`run_phase` / `run_session_phase` now `session.rollback()` on a FAILED result. A failed phase persists nothing, so any retry starts clean **regardless of writer idempotency** — the general enabler for safe transient retries.

## Tests

- Predicate round-trip + tag-survives-real-wrapping (`is_transient_error` through phase/agent concatenation).
- `_outcome_or_raise`: transient → retryable, permanent + deterministic → non-retryable, completed passthrough; asserts the type matches the policy.
- Rollback integration test — a write-then-fail phase leaves nothing committed; **proven red without the fix**.
- `--testmon` sweep: 161 passed (incl. `test_validation_phase`, `test_begin_session_activity`).

## Follow-ups (DAT-496)

Retry-backoff tuning (`maximum_attempts=5` ≈ 31s may undershoot a 429 cooldown); and the byzantine skip / delete-by-run_id cleanup now that failed phases roll back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)