### PR TITLE
feat(cockpit): commutative + identifier canonicalization for snippet reuse (DAT-492)

### DIFF
--- a/packages/cockpit/src/lib/sql-canonical.test.ts
+++ b/packages/cockpit/src/lib/sql-canonical.test.ts
@@ -1,15 +1,18 @@
-// canonicalSql golden + behavior test (DAT-485). Locks the TS side of the
-// cross-engine canonical contract proven in spikes/dat485-canonical (polyglot ≡
-// sqlglot byte-for-byte). Uses the real polyglot WASM (in-process, no DB).
+// canonicalSql golden + behavior test (DAT-485, DAT-492). Locks the TS canonical
+// form: polyglot parse → AST normalize (commutative-operand sort + identifier-quote
+// drop) → render. Uses the real polyglot WASM (in-process, no DB). Self-contained —
+// there is no cross-engine byte-agreement contract (DAT-492 refine).
 
 import { describe, expect, it } from "vitest";
 
 import { canonicalSql, sqlEquivalent } from "./sql-canonical";
 
 describe("canonicalSql", () => {
-	it("collapses case / whitespace / keyword-casing to one canonical form", async () => {
+	it("collapses case / whitespace / keyword-casing / quotes / identifier-case to one form", async () => {
+		// DAT-492: redundant identifier quotes drop + identifier names case-fold
+		// (`"Amount"` → `amount`); the `'Sale'` string literal keeps its case.
 		const golden =
-			'SELECT SUM("Amount") AS value FROM enriched_transactions WHERE "Type" ILIKE \'Sale\'';
+			"SELECT SUM(amount) AS value FROM enriched_transactions WHERE type ILIKE 'Sale'";
 		expect(
 			await canonicalSql(
 				'SELECT SUM("Amount") as value FROM enriched_transactions WHERE "Type" ILIKE \'Sale\'',
@@ -45,6 +48,128 @@ describe("canonicalSql", () => {
 			await sqlEquivalent(
 				'SELECT SUM("Amount") AS value FROM t',
 				'SELECT SUM("Amount") AS revenue FROM t',
+			),
+		).toBe(false);
+	});
+
+	// --- DAT-492: identifier-quote normalization -------------------------------
+
+	it("collapses a redundantly-quoted identifier onto its bare form (exact_reuse tail)", async () => {
+		expect(
+			await sqlEquivalent(
+				'SELECT SUM("credit") AS value FROM j',
+				"SELECT SUM(credit) AS value FROM j",
+			),
+		).toBe(true);
+	});
+
+	it("collapses the live-smoke shape (quoted journal-line filter ≡ bare)", async () => {
+		expect(
+			await sqlEquivalent(
+				'SELECT SUM("credit" - "debit") AS value FROM journal_lines WHERE "account_id" BETWEEN 4000 AND 4999',
+				"SELECT SUM(credit - debit) AS value FROM journal_lines WHERE account_id BETWEEN 4000 AND 4999",
+			),
+		).toBe(true);
+	});
+
+	it("case-folds identifier names (DuckDB is case-insensitive)", async () => {
+		expect(
+			await sqlEquivalent(
+				'SELECT SUM("Credit") AS value FROM Journal',
+				"SELECT SUM(credit) AS value FROM journal",
+			),
+		).toBe(true);
+	});
+
+	it("preserves string-literal case (does NOT fold literals)", async () => {
+		// The folding touches identifiers only — `'Sale'` and `'sale'` stay distinct.
+		expect(
+			await sqlEquivalent(
+				"SELECT * FROM t WHERE x = 'Sale'",
+				"SELECT * FROM t WHERE x = 'sale'",
+			),
+		).toBe(false);
+	});
+
+	it("does NOT corrupt a genuinely quote-requiring identifier (keeps quotes, folds case)", async () => {
+		// A name with a space cannot be a bare identifier — its quotes are kept, but
+		// the name still case-folds.
+		expect(await canonicalSql('SELECT "Weird Name" FROM t')).toContain(
+			'"weird name"',
+		);
+	});
+
+	// --- DAT-492: commutative-operand order ------------------------------------
+
+	it("sorts commutative AND operands to a canonical order", async () => {
+		expect(
+			await sqlEquivalent(
+				"SELECT * FROM t WHERE b = 2 AND a = 1",
+				"SELECT * FROM t WHERE a = 1 AND b = 2",
+			),
+		).toBe(true);
+	});
+
+	it("canonicalizes a 3-operand commutative chain regardless of order", async () => {
+		expect(
+			await sqlEquivalent(
+				"SELECT * FROM t WHERE c AND a AND b",
+				"SELECT * FROM t WHERE b AND c AND a",
+			),
+		).toBe(true);
+	});
+
+	it("sorts commutative OR operands to a canonical order", async () => {
+		expect(
+			await sqlEquivalent(
+				"SELECT * FROM t WHERE b = 2 OR a = 1",
+				"SELECT * FROM t WHERE a = 1 OR b = 2",
+			),
+		).toBe(true);
+	});
+
+	it("sorts commutative arithmetic (+ and *) operands", async () => {
+		expect(
+			await sqlEquivalent(
+				"SELECT (revenue + cost) AS v FROM t",
+				"SELECT (cost + revenue) AS v FROM t",
+			),
+		).toBe(true);
+		expect(
+			await sqlEquivalent(
+				"SELECT (qty * price) AS v FROM t",
+				"SELECT (price * qty) AS v FROM t",
+			),
+		).toBe(true);
+	});
+
+	it("does NOT reorder NON-commutative operators (- and /)", async () => {
+		expect(
+			await sqlEquivalent(
+				"SELECT (a - b) AS v FROM t",
+				"SELECT (b - a) AS v FROM t",
+			),
+		).toBe(false);
+		expect(
+			await sqlEquivalent(
+				"SELECT (a / b) AS v FROM t",
+				"SELECT (b / a) AS v FROM t",
+			),
+		).toBe(false);
+	});
+
+	it("preserves inner non-commutative order even under a commutative parent (live-smoke shape)", async () => {
+		// The `+` operands reorder, but each `-` operand order is preserved.
+		expect(
+			await sqlEquivalent(
+				"SELECT (a - b) + (c - d) AS v FROM t",
+				"SELECT (c - d) + (a - b) AS v FROM t",
+			),
+		).toBe(true);
+		expect(
+			await sqlEquivalent(
+				"SELECT (a - b) + (c - d) AS v FROM t",
+				"SELECT (a - b) + (d - c) AS v FROM t",
 			),
 		).toBe(false);
 	});

--- a/packages/cockpit/src/lib/sql-canonical.ts
+++ b/packages/cockpit/src/lib/sql-canonical.ts
@@ -1,40 +1,47 @@
-// Canonical SQL for snippet identity (DAT-485, the comparison fix).
+// Canonical SQL for snippet identity (DAT-485 comparison fix; DAT-492 tail).
 //
 // Snippet sameness can't be decided by string normalization — an LLM writes the
 // same computation slightly differently each time (alias, spacing, keyword case,
-// operand order, table qualifier). The robust key is an AST round-trip: parse the
-// SQL and re-render it in a canonical form, so cosmetic variance collapses while
-// real structural/identifier differences survive. This is exactly what the engine
-// does for view DDL (`core/sql_normalize.canonical_sql`, sqlglot) and the retired
-// MCP `cte_parser` did for snippets.
+// operand order, identifier quoting, table qualifier). The robust key is an AST
+// round-trip: parse the SQL, normalize the tree, and re-render it canonically, so
+// cosmetic variance collapses while real structural/identifier differences survive.
 //
 // We use polyglot (@polyglot-sql/sdk — a Rust SQL parser via WASM, DuckDB dialect)
-// for the TS side. P1 canonicalizes BOTH sides of every comparison with polyglot,
-// so reuse classification is self-consistent regardless of how a snippet was
-// produced — it never compares a sqlglot key to a polyglot key.
+// for the TS side. Every comparison canonicalizes BOTH sides with polyglot, so
+// reuse classification is self-consistent regardless of how a snippet was produced.
 //
-// CROSS-LANGUAGE CAVEAT (the DAT-485 stress-test, not the small spike): polyglot
-// (TS) and the engine's sqlglot (Python) do NOT agree byte-for-byte on common SQL.
-// They render DATE_TRUNC('month') unit-casing, IS NOT NULL / NOT LIKE negation,
-// abbreviated window frames, SUBSTRING(.. FROM ..), and INTERVAL units differently,
-// and polyglot can't parse EXTRACT(.. FROM ..) / TABLESAMPLE. So a SHARED canonical
-// key computed by two different engines would miss. The fix for CROSS-LANGUAGE
-// snippet sharing (P2a / GraphAgent overlap, DAT-486) is ONE engine in both —
-// polyglot bound into Python — not two native engines. Deferred normalization gaps
-// both engines share (cross-engine-consistent but still under-matching): commutative
-// operand order (DAT-492) and frame-keyword case.
+// SELF-CONTAINED — no cross-engine key. The engine's sqlglot canonical
+// (`core/sql_normalize`) is used only for view DDL and the future snippet de-dup
+// pass (DAT-493); it re-canonicalizes stored SQL in-situ with its own single
+// engine, so polyglot (here) and sqlglot (there) never need to byte-agree. (The
+// DAT-485 stress-test proved two native engines do NOT share a byte-for-byte key;
+// the DAT-492 refine settled that nothing requires them to.)
+//
+// The AST normalization beyond a bare round-trip (DAT-492):
+//   1. Commutative-operand sort — `WHERE b AND a` ≡ `WHERE a AND b` (and OR / + / *
+//      chains). The parse tree preserves operand order; we flatten each commutative
+//      chain, sort the operands by a stable key, and rebuild, so order stops
+//      fragmenting identity. NON-commutative operators (-, /, comparisons) are left
+//      untouched — `a - b` must NOT equal `b - a`.
+//   2. Identifier normalization — `"Credit"` ≡ `credit`. DuckDB folds identifier
+//      case, so we lowercase identifier names, and polyglot preserves quote style,
+//      so we also drop the quote when the folded spelling is unambiguous (bare-
+//      identifier charset). Genuinely quote-requiring names (spaces, etc.) keep their
+//      quotes (still case-folded), and the generator re-quotes reserved words on its
+//      own, so the key never goes invalid. Only identifier nodes are touched — string
+//      literals keep their case (`'Sale'` ≠ `'sale'`).
 //
 // `lake.<layer>.` qualifier strip rides on top: the cockpit addresses
-// `lake.typed.<name>` while stored snippets are bare, and the AST preserves
-// identifiers, so we strip the qualifier for the comparison only (never the SQL
+// `lake.typed.<name>` while stored snippets are bare, and the generated SQL
+// preserves the qualifier, so we strip it for the comparison only (never the SQL
 // that runs). Layered over the engine-byte-compat primitives in snippet-normalize.
 
 import * as Polyglot from "@polyglot-sql/sdk";
 
 import { canonicalizeForReuse, normalizeSql } from "./snippet-normalize";
 
-// polyglot is WASM — `init()` must resolve once before transpile. Memoize it so a
-// burst of canonicalSql() calls shares one initialization; a failed init clears
+// polyglot is WASM — `init()` must resolve once before parse/generate. Memoize it
+// so a burst of canonicalSql() calls shares one initialization; a failed init clears
 // the memo so a later call can retry (and the catch below degrades gracefully).
 let initPromise: Promise<unknown> | null = null;
 function ensureInit(): Promise<unknown> {
@@ -47,28 +54,165 @@ function ensureInit(): Promise<unknown> {
 	return initPromise;
 }
 
+// --- AST normalization (DAT-492) -------------------------------------------------
+//
+// The polyglot AST is plain tagged-union JSON: every expression is `{ <tag>: data }`
+// (one key), e.g. `{ and: { left, right, ... } }`, and identifiers are bare structs
+// `{ name, quoted, ... }`. We normalize that JSON directly — `Polyglot.generate`
+// accepts the same shape — rather than via the `ast.*` helpers (which expect a
+// different wrapper). Everything below is typed against `unknown` and narrowed.
+
 /**
- * Canonical SQL for snippet-identity comparison: polyglot AST round-trip
- * (collapses case / whitespace / keyword-casing / formatting) + the
+ * Binary operators whose operands may be reordered without changing meaning.
+ * `sub`/`div`/`mod`, the comparisons, and `concat` (the polyglot tag for `||`)
+ * are deliberately absent — none is commutative.
+ */
+const COMMUTATIVE_TAGS = new Set(["and", "or", "add", "mul"]);
+/** Identifier spelling that means the same thing bare or double-quoted. */
+const BARE_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/** A parsed identifier struct: has a string `name` and a boolean `quoted` flag. */
+function isIdentifierNode(
+	value: unknown,
+): value is Record<string, unknown> & { name: string; quoted: boolean } {
+	return (
+		isRecord(value) &&
+		typeof value.name === "string" &&
+		typeof value.quoted === "boolean"
+	);
+}
+
+/** The single tag of a tagged-union expression node, or null if not one. */
+function soleTag(value: Record<string, unknown>): string | null {
+	const keys = Object.keys(value);
+	return keys.length === 1 ? keys[0] : null;
+}
+
+/**
+ * Deterministic serialization for operand ordering: object keys are sorted, so two
+ * structurally-equal (already-normalized) operands serialize identically regardless
+ * of key order. Used only as a sort key, never rendered.
+ */
+function stableKey(value: unknown): string {
+	return JSON.stringify(value, (_key, val) =>
+		isRecord(val)
+			? Object.fromEntries(
+					Object.keys(val)
+						.sort()
+						.map((k) => [k, val[k]]),
+				)
+			: val,
+	);
+}
+
+/** Collect the operands of a same-tag commutative chain, each normalized. */
+function flattenCommutative(
+	node: Record<string, unknown>,
+	tag: string,
+	out: unknown[],
+): unknown[] {
+	const data = node[tag];
+	if (isRecord(data)) {
+		for (const side of [data.left, data.right]) {
+			if (isRecord(side) && soleTag(side) === tag) {
+				flattenCommutative(side, tag, out);
+			} else {
+				out.push(normalizeNode(side));
+			}
+		}
+	}
+	return out;
+}
+
+/**
+ * Rebuild a commutative chain as a left-nested tree of the given operands. Only the
+ * structural + comment fields are emitted; any other binary-op data is intentionally
+ * dropped (it is cosmetic for our key, and a generate failure would fail soft anyway).
+ */
+function rebuildLeftNested(tag: string, operands: unknown[]): unknown {
+	let acc = operands[0];
+	for (let i = 1; i < operands.length; i++) {
+		acc = {
+			[tag]: {
+				left: acc,
+				right: operands[i],
+				left_comments: [],
+				operator_comments: [],
+				trailing_comments: [],
+			},
+		};
+	}
+	return acc;
+}
+
+/** Recursively canonicalize a polyglot AST node (commutative sort + quote drop). */
+function normalizeNode(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(normalizeNode);
+	if (!isRecord(value)) return value;
+
+	if (isIdentifierNode(value)) {
+		// DuckDB folds identifier case, so lowercase the name (`"Credit"` ≡ `credit`);
+		// drop the quote when the folded spelling is a bare identifier. Only identifier
+		// structs are touched — string literals are NOT identifier nodes, so literal
+		// case is preserved (`'Sale'` stays `'Sale'`).
+		const name = value.name.toLowerCase();
+		return {
+			...value,
+			name,
+			quoted: BARE_IDENTIFIER.test(name) ? false : value.quoted,
+		};
+	}
+
+	const tag = soleTag(value);
+	if (tag !== null && COMMUTATIVE_TAGS.has(tag)) {
+		const operands = flattenCommutative(value, tag, []);
+		if (operands.length >= 2) {
+			operands.sort((a, b) => {
+				const ka = stableKey(a);
+				const kb = stableKey(b);
+				return ka < kb ? -1 : ka > kb ? 1 : 0;
+			});
+			return rebuildLeftNested(tag, operands);
+		}
+	}
+
+	const out: Record<string, unknown> = {};
+	for (const [key, child] of Object.entries(value)) {
+		out[key] = normalizeNode(child);
+	}
+	return out;
+}
+
+/**
+ * Canonical SQL for snippet-identity comparison: polyglot parse → AST normalize
+ * (commutative-operand sort + identifier-quote drop, DAT-492) → render, then the
  * `lake.<layer>.` qualifier strip.
  *
- * FAIL-SOFT: on any polyglot init/parse failure it falls back to the string
- * normalizer (`normalizeSql ∘ canonicalizeForReuse`). A query polyglot can't
- * parse then only weakens the reuse TAG (it won't match unless the other side
- * also fell back to the same string form) — it never throws, so a weird query
- * never breaks the answer. Comparison is self-consistent because both sides of a
- * compare run through this same function.
+ * FAIL-SOFT: on any polyglot init/parse/generate failure it falls back to the
+ * string normalizer (`normalizeSql ∘ canonicalizeForReuse`). A query polyglot can't
+ * parse then only weakens the reuse TAG (it won't match unless the other side also
+ * fell back to the same string form) — it never throws, so a weird query never
+ * breaks the answer. Comparison is self-consistent because both sides of a compare
+ * run through this same function.
  */
 export async function canonicalSql(sql: string): Promise<string> {
 	try {
 		await ensureInit();
 		const duckdb = Polyglot.Dialect.DuckDB;
-		const result = Polyglot.transpile(sql, duckdb, duckdb);
-		if (result.success && result.sql != null) {
-			const rendered = Array.isArray(result.sql)
-				? result.sql.join(" ")
-				: result.sql;
-			return canonicalizeForReuse(rendered);
+		const parsed = Polyglot.parse(sql, duckdb);
+		if (parsed.success && Array.isArray(parsed.ast)) {
+			const normalized = (parsed.ast as unknown[]).map(normalizeNode);
+			const generated = Polyglot.generate(normalized, duckdb);
+			if (generated.success && generated.sql != null) {
+				const rendered = Array.isArray(generated.sql)
+					? generated.sql.join(" ")
+					: generated.sql;
+				return canonicalizeForReuse(rendered);
+			}
 		}
 	} catch {
 		// fall through to the string fallback


### PR DESCRIPTION
## What

`canonicalSql` (`packages/cockpit/src/lib/sql-canonical.ts`) is the comparison key behind the query sub-agent's **exact_reuse vs adapted** classification. The polyglot transpile round-trip preserved operand order, identifier quote style, and identifier case — so a faithfully-reproduced snippet still missed `exact_reuse`. Live DAT-485 smoke: `SUM("credit" - "debit") … "account_id"` did not collapse onto the bare stored form.

Switches the canonicalizer from `transpile(duckdb,duckdb)` to **parse → AST-normalize → generate**:

- **Commutative-operand sort** (`and`/`or`/`add`/`mul`): flatten the associative chain, sort operands by a stable key, rebuild left-nested. Non-commutative operators (`-`, `/`, comparisons, `concat`) are left untouched (`a - b` ≠ `b - a`).
- **Identifier normalization**: lowercase the name (DuckDB folds identifier case, so `"Credit"` ≡ `credit`) and drop the quote when the folded spelling is a bare identifier. Quote-requiring names (spaces, etc.) keep their quotes; the generator re-quotes reserved words itself, so the key never goes invalid. **String literals are not identifier nodes, so literal case is preserved** (`'Sale'` ≠ `'sale'`).
- Keeps the `lake.<layer>.` qualifier strip and the **fail-soft** string fallback on any parse/generate failure.

The AST is plain tagged-union JSON that `Polyglot.generate` accepts directly; the normalization manipulates that JSON (typed against `unknown`, narrowed via guards) — the `ast.*` helpers don't traverse `parse()` output.

## Scope

Cockpit-only and **self-contained** — every comparison runs both sides through the same function, so no cross-engine byte-agreement is required (per the DAT-492 refine, which dissolved the cross-engine idea). Engine-side de-dup parity is DAT-493's; **no engine files touched, no cross-engine contract test**.

## Tests

`src/lib/sql-canonical.test.ts` (real polyglot WASM, no mocks): updated golden + commutative AND/OR/3-chain/arithmetic, non-commutative preservation (incl. nested under a commutative parent — the live-smoke shape), quote-drop, **case-fold**, **literal-case preserved**, quote-requiring identifier kept, fail-soft. Full cockpit unit suite green (1054), `tsc` + biome clean.

## Reviewers

Senior-code-reviewer **APPROVE** · spec-compliance-reviewer **COMPLIANT** (case-folding added after, addressing the reviewer's "un-folded case = gap or safe under-match?" question; the one real risk — folding literals — is explicitly guarded by a test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)