### PR TITLE
feat(cockpit): surface answer confidence on the result widget (DAT-500)

### DIFF
--- a/packages/cockpit/src/ui/cockpit/canvas-registry.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-registry.ts
@@ -6,6 +6,7 @@
 // README.md for the register-don't-replace contract.
 
 import { WidgetRegistry } from "#/ui/cockpit/widget-registry";
+import { AnswerResultWidget } from "#/ui/cockpit/widgets/answer-result";
 import { ColumnProfileWidget } from "#/ui/cockpit/widgets/column-profile";
 import { ColumnWhyWidget } from "#/ui/cockpit/widgets/column-why";
 import { CycleListWidget } from "#/ui/cockpit/widgets/cycle-list";
@@ -44,6 +45,7 @@ export const canvasRegistry = new WidgetRegistry()
 	.register({ kind: "schema-preview", component: SchemaPreviewWidget })
 	.register({ kind: "model-frame", component: ModelFrameWidget })
 	.register({ kind: "result-grid", component: ResultGridWidget })
+	.register({ kind: "answer-result", component: AnswerResultWidget })
 	.register({ kind: "table-readiness", component: TableReadinessWidget })
 	.register({ kind: "column-why", component: ColumnWhyWidget })
 	.register({ kind: "column-profile", component: ColumnProfileWidget })

--- a/packages/cockpit/src/ui/cockpit/canvas-state.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-state.ts
@@ -115,6 +115,12 @@ export type CanvasState =
 			sql: string;
 			params?: (string | number | boolean | null)[];
 	  }
+	// DAT-500: the `answer` tool's result — the streaming table PLUS the
+	// confidence the answer carries (quality band, grounded ratio, per-concept
+	// reuse, assumptions). All of it is already in the AnswerSchema result; the
+	// projector surfaces it here instead of dropping it. The grid streams via the
+	// same result-grid path (the table is unchanged; confidence rides on top).
+	| { kind: "answer-result"; sql: string; confidence: AnswerConfidence }
 	// A file-upload area (redesign) — projected by the `upload` UI tool so the user
 	// can drop local files; NOT a permanent chat fixture. Carries nothing; the
 	// widget owns the dropzone + drives connect on upload.
@@ -122,3 +128,21 @@ export type CanvasState =
 
 /** Every `kind` a canvas member can have — handy for registry/test exhaustion. */
 export type CanvasKind = CanvasState["kind"];
+
+/** The confidence an `answer` result carries, lifted onto the canvas (DAT-500).
+ * Every field comes straight from the AnswerSchema result — nothing is recomputed;
+ * the projector only renames to the canvas's camelCase idiom. */
+export interface AnswerConfidence {
+	/** Worst readiness band across the touched tables, or null if none analyzed. */
+	band: "ready" | "investigate" | "blocked" | null;
+	/** Optional band note from `data_quality`. */
+	note?: string;
+	/** Share of the answer's SQL grounded in validated snippets (0..1). */
+	groundedRatio: number;
+	/** The per-concept reuse counts behind the grounded ratio. */
+	reuse: { exactReuse: number; adapted: number; fresh: number };
+	/** Plain-sentence ambiguity decisions the answer made (may be empty). */
+	assumptions: string[];
+	/** The business concepts the answer draws on (provenance; may be empty). */
+	conceptsUsed: string[];
+}

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
@@ -311,6 +311,88 @@ describe("toolResultToCanvas", () => {
 		expect(toolResultToCanvas("run_sql", {}, undefined)).toBeNull();
 	});
 
+	it("maps answer to an answer-result, lifting the confidence onto the canvas (DAT-500)", () => {
+		const result = {
+			answer: "Total revenue is 42.",
+			grid: { sql: "SELECT SUM(revenue) AS value FROM t" },
+			assumptions: ["Treated 2024 as the fiscal year."],
+			concepts_used: ["revenue"],
+			tables_touched: ["t"],
+			data_quality: { band: "investigate", note: "one table not analyzed" },
+			components: [],
+			reliability: {
+				grounded_ratio: 0.5,
+				exact_reuse: 1,
+				adapted: 0,
+				fresh: 1,
+			},
+		};
+		expect(toolResultToCanvas("answer", result)).toEqual({
+			kind: "answer-result",
+			sql: "SELECT SUM(revenue) AS value FROM t",
+			confidence: {
+				band: "investigate",
+				note: "one table not analyzed",
+				groundedRatio: 0.5,
+				reuse: { exactReuse: 1, adapted: 0, fresh: 1 },
+				assumptions: ["Treated 2024 as the fiscal year."],
+				conceptsUsed: ["revenue"],
+			},
+		});
+	});
+
+	it("answer with no analyzed table yields a null band + zeroed reuse (no throw)", () => {
+		expect(
+			toolResultToCanvas("answer", {
+				grid: { sql: "SELECT 1" },
+				data_quality: null,
+				assumptions: [],
+				concepts_used: [],
+			}),
+		).toEqual({
+			kind: "answer-result",
+			sql: "SELECT 1",
+			confidence: {
+				band: null,
+				note: undefined,
+				groundedRatio: 0,
+				reuse: { exactReuse: 0, adapted: 0, fresh: 0 },
+				assumptions: [],
+				conceptsUsed: [],
+			},
+		});
+	});
+
+	it("returns null for answer with no grid or an agent error (canvas unchanged)", () => {
+		expect(toolResultToCanvas("answer", { grid: null })).toBeNull();
+		expect(toolResultToCanvas("answer", {})).toBeNull();
+		expect(toolResultToCanvas("answer", { error: "boom" })).toBeNull();
+	});
+
+	it("tolerates a drifted answer result without throwing (non-object fields, bad types)", () => {
+		// data_quality a bare string, reliability a string, concepts_used with a
+		// non-string member — all must degrade to defaults, never throw.
+		const state = toolResultToCanvas("answer", {
+			grid: { sql: "SELECT 1" },
+			data_quality: "ready",
+			reliability: "n/a",
+			assumptions: ["ok", 42, null],
+			concepts_used: ["revenue", 7],
+		});
+		expect(state).toEqual({
+			kind: "answer-result",
+			sql: "SELECT 1",
+			confidence: {
+				band: null,
+				note: undefined,
+				groundedRatio: 0,
+				reuse: { exactReuse: 0, adapted: 0, fresh: 0 },
+				assumptions: ["ok"],
+				conceptsUsed: ["revenue"],
+			},
+		});
+	});
+
 	it("maps a teach_metric OVERRIDE to the metric-shadow key (DAT-482)", () => {
 		expect(
 			toolResultToCanvas("teach_metric", {

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -29,11 +29,53 @@ import type { WhyMetricResult } from "#/tools/why-metric";
 import type { WhyRelationshipResult } from "#/tools/why-relationship";
 import type { WhyTableResult } from "#/tools/why-table";
 import type { WhyValidationResult } from "#/tools/why-validation";
-import type { CanvasState } from "#/ui/cockpit/canvas-state";
+import type { AnswerConfidence, CanvasState } from "#/ui/cockpit/canvas-state";
 
 /** Projects one tool's result (+ call input) to a CanvasState, or null to leave
  * the canvas unchanged. */
 type CanvasProjector = (result: unknown, input: unknown) => CanvasState | null;
+
+/**
+ * Lift the confidence an `answer` result carries onto the canvas (DAT-500).
+ * Reads defensively from the `unknown` tool result (cockpit boundary rule): every
+ * field is optional/absent-tolerant, so a degenerate or drifted result still
+ * yields a sane (zeroed / null-band) confidence rather than throwing.
+ */
+function readAnswerConfidence(
+	result: Record<string, unknown> | null,
+): AnswerConfidence {
+	const num = (v: unknown): number =>
+		typeof v === "number" && Number.isFinite(v) ? v : 0;
+	const strings = (v: unknown): string[] =>
+		Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+	// Object-type guard before any field access, so a drifted result that makes
+	// data_quality/reliability a non-object (e.g. a bare string) yields defaults,
+	// not a throw — the whole point of reading defensively.
+	const asObject = (v: unknown): Record<string, unknown> | null =>
+		v !== null && typeof v === "object" && !Array.isArray(v)
+			? (v as Record<string, unknown>)
+			: null;
+
+	const dq = asObject(result?.data_quality);
+	const band =
+		dq?.band === "ready" || dq?.band === "investigate" || dq?.band === "blocked"
+			? dq.band
+			: null;
+	const rel = asObject(result?.reliability);
+
+	return {
+		band,
+		note: typeof dq?.note === "string" ? dq.note : undefined,
+		groundedRatio: num(rel?.grounded_ratio),
+		reuse: {
+			exactReuse: num(rel?.exact_reuse),
+			adapted: num(rel?.adapted),
+			fresh: num(rel?.fresh),
+		},
+		assumptions: strings(result?.assumptions),
+		conceptsUsed: strings(result?.concepts_used),
+	};
+}
 
 /** A complete why_* result carries the boolean `found` discriminant — the SDK's
  * errored-call output (`{ error: string }`) does not, and must not project. */
@@ -254,13 +296,21 @@ const PROJECTORS: Record<string, CanvasProjector> = {
 	// the FULL result from the composed statement. Unlike run_sql, the grid SQL is
 	// in the RESULT (result.grid.sql) — the composed final_sql isn't in the call
 	// input (just the question). An errored sub-agent (`{ error }`, no grid) or a
-	// run with no runnable query (grid null) leaves the canvas unchanged.
+	// run with no runnable query (grid null) leaves the canvas unchanged. When a
+	// grid IS present, the confidence the answer carries rides onto the canvas with
+	// it (DAT-500) instead of being dropped — band, grounded ratio, reuse, assumptions.
 	answer: (result) => {
 		if (isAgentError(result)) return null;
-		const grid = (result as { grid?: { sql?: unknown } | null } | null)?.grid;
-		return grid && typeof grid.sql === "string" && grid.sql.length > 0
-			? { kind: "result-grid", sql: grid.sql }
-			: null;
+		const r = result as Record<string, unknown> | null;
+		const grid = (r?.grid ?? null) as { sql?: unknown } | null;
+		if (!grid || typeof grid.sql !== "string" || grid.sql.length === 0) {
+			return null;
+		}
+		return {
+			kind: "answer-result",
+			sql: grid.sql,
+			confidence: readAnswerConfidence(r),
+		};
 	},
 	// The `upload` UI tool carries no data — it just opens the upload area so the
 	// user can drop local files.

--- a/packages/cockpit/src/ui/cockpit/widgets/answer-result.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/answer-result.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+// Render tests for the PURE ConfidenceStrip (DAT-500). The AnswerResultWidget
+// itself wraps the streaming result-grid (I/O), covered by the result-grid tests
+// + the smoke; here we assert the confidence surface renders from a plain value:
+// band, grounded %, reuse pills, concepts, assumptions — and degrades cleanly when
+// nothing is analyzed / nothing is reused.
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { AnswerConfidence } from "#/ui/cockpit/canvas-state";
+import { ConfidenceStrip } from "#/ui/cockpit/widgets/answer-result";
+import { theme } from "#/ui/theme";
+
+afterEach(cleanup);
+
+function renderStrip(confidence: AnswerConfidence) {
+	render(
+		<MantineProvider theme={theme} env="test">
+			<ConfidenceStrip confidence={confidence} />
+		</MantineProvider>,
+	);
+}
+
+const FULL: AnswerConfidence = {
+	band: "investigate",
+	note: "one table not analyzed",
+	groundedRatio: 0.5,
+	reuse: { exactReuse: 1, adapted: 0, fresh: 1 },
+	assumptions: ["Treated 2024 as the fiscal year."],
+	conceptsUsed: ["revenue", "cost"],
+};
+
+describe("ConfidenceStrip", () => {
+	it("renders the band, grounded %, reuse counts, concepts, and assumptions", () => {
+		renderStrip(FULL);
+		// Band (humanized title-case from BandBadge).
+		expect(screen.getByText("Investigate")).toBeTruthy();
+		// Grounded ratio → rounded percentage.
+		expect(screen.getByText("50% grounded")).toBeTruthy();
+		// Reuse pills.
+		expect(screen.getByText("1 reused")).toBeTruthy();
+		expect(screen.getByText("0 adapted")).toBeTruthy();
+		expect(screen.getByText("1 fresh")).toBeTruthy();
+		// Concepts + assumptions.
+		expect(screen.getByText("revenue")).toBeTruthy();
+		expect(screen.getByText("cost")).toBeTruthy();
+		expect(screen.getByText("• Treated 2024 as the fiscal year.")).toBeTruthy();
+		expect(screen.getByText("one table not analyzed")).toBeTruthy();
+	});
+
+	it("renders a muted dash for an absent band and 0% grounded", () => {
+		renderStrip({
+			band: null,
+			groundedRatio: 0,
+			reuse: { exactReuse: 0, adapted: 0, fresh: 0 },
+			assumptions: [],
+			conceptsUsed: [],
+		});
+		expect(screen.getByText("—")).toBeTruthy();
+		expect(screen.getByText("0% grounded")).toBeTruthy();
+		// No assumptions / concepts blocks when their arrays are empty.
+		expect(screen.queryByTestId("answer-assumptions")).toBeNull();
+		expect(screen.queryByTestId("answer-concepts")).toBeNull();
+	});
+
+	it("rounds the grounded ratio to a whole percent", () => {
+		renderStrip({ ...FULL, groundedRatio: 0.666 });
+		expect(screen.getByText("67% grounded")).toBeTruthy();
+	});
+
+	it("renders each readiness band", () => {
+		renderStrip({ ...FULL, band: "ready" });
+		expect(screen.getByText("Ready")).toBeTruthy();
+		cleanup();
+		renderStrip({ ...FULL, band: "blocked" });
+		expect(screen.getByText("Blocked")).toBeTruthy();
+	});
+
+	it("renders the fully-grounded case as 100%", () => {
+		renderStrip({
+			...FULL,
+			groundedRatio: 1,
+			reuse: { exactReuse: 3, adapted: 0, fresh: 0 },
+		});
+		expect(screen.getByText("100% grounded")).toBeTruthy();
+		expect(screen.getByText("3 reused")).toBeTruthy();
+		expect(screen.getByText("0 fresh")).toBeTruthy();
+	});
+
+	it("caps long concept / assumption arrays with an overflow tail", () => {
+		renderStrip({
+			...FULL,
+			conceptsUsed: Array.from({ length: 25 }, (_, i) => `concept_${i}`),
+			assumptions: Array.from({ length: 14 }, (_, i) => `assumption ${i}`),
+		});
+		// 20 concepts shown, 5 more; 10 assumptions shown, 4 more.
+		expect(screen.getByText("concept_0")).toBeTruthy();
+		expect(screen.queryByText("concept_20")).toBeNull();
+		expect(screen.getByText("…and 5 more")).toBeTruthy();
+		expect(screen.getByText("• assumption 0")).toBeTruthy();
+		expect(screen.queryByText("• assumption 10")).toBeNull();
+		expect(screen.getByText("…and 4 more")).toBeTruthy();
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/widgets/answer-result.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/answer-result.tsx
@@ -1,0 +1,140 @@
+// Answer-result widget (DAT-500) — the human-facing answer surface: the streaming
+// result table PLUS the confidence the answer carries. Expressing our confidence
+// in a result is core to dataraum; the `answer` tool already computes the band,
+// grounded ratio, per-concept reuse, and assumptions (all in the AnswerSchema
+// result), but the projector used to drop them and render only the table. This
+// surfaces them. The table itself is the unchanged result-grid stream — confidence
+// rides on top.
+//
+// Splits in two: ConfidenceStrip is a PURE render (no I/O, unit-tested); the
+// registered AnswerResultWidget composes the strip over the streaming grid (the
+// grid owns the fetch, so it's covered by the result-grid tests + the smoke).
+
+import { Badge, Group, Stack, Text } from "@mantine/core";
+
+import type { AnswerConfidence, CanvasState } from "#/ui/cockpit/canvas-state";
+import { BandBadge } from "#/ui/cockpit/widgets/band-badge";
+import { ResultGridWidget } from "#/ui/cockpit/widgets/result-grid";
+
+// Bound both model-controlled arrays — the answer tool does not cap them, so a
+// pathological answer could enumerate dozens (cockpit "bound every data surface"
+// rule; evidence-detail MAX_ARRAY_ITEMS precedent). Overflow shows a muted tail.
+const MAX_CONCEPTS = 20;
+const MAX_ASSUMPTIONS = 10;
+
+/**
+ * Pure confidence strip: quality band + grounded % + per-concept reuse pills +
+ * the concepts used and assumptions made. No I/O, so it renders from a plain
+ * value and is unit-testable without the streaming grid.
+ */
+export function ConfidenceStrip({
+	confidence,
+}: {
+	confidence: AnswerConfidence;
+}) {
+	const { band, note, groundedRatio, reuse, assumptions, conceptsUsed } =
+		confidence;
+	const grounded = Math.round(groundedRatio * 100);
+	return (
+		<Stack gap="xs" mb="sm" data-testid="answer-confidence">
+			<Group gap="xs" wrap="wrap">
+				<Text size="sm" fw={500}>
+					Confidence
+				</Text>
+				<BandBadge band={band} />
+				<Badge
+					variant="light"
+					color="blue"
+					size="sm"
+					tt="none"
+					data-testid="answer-grounded"
+				>
+					{grounded}% grounded
+				</Badge>
+				<Group gap={6} wrap="nowrap" data-testid="answer-reuse">
+					<Badge variant="light" color="green" size="sm" tt="none">
+						{reuse.exactReuse} reused
+					</Badge>
+					<Badge variant="light" color="yellow" size="sm" tt="none">
+						{reuse.adapted} adapted
+					</Badge>
+					<Badge variant="light" color="gray" size="sm" tt="none">
+						{reuse.fresh} fresh
+					</Badge>
+				</Group>
+			</Group>
+
+			{note && (
+				<Text size="xs" c="dimmed">
+					{note}
+				</Text>
+			)}
+
+			{conceptsUsed.length > 0 && (
+				<Group gap={6} wrap="wrap" data-testid="answer-concepts">
+					<Text size="xs" c="dimmed">
+						Concepts:
+					</Text>
+					{conceptsUsed.slice(0, MAX_CONCEPTS).map((concept, i) => (
+						<Badge
+							// biome-ignore lint/suspicious/noArrayIndexKey: model output, no reorder
+							key={i}
+							variant="outline"
+							color="gray"
+							size="xs"
+							tt="none"
+						>
+							{concept}
+						</Badge>
+					))}
+					{conceptsUsed.length > MAX_CONCEPTS && (
+						<Text size="xs" c="dimmed">
+							…and {conceptsUsed.length - MAX_CONCEPTS} more
+						</Text>
+					)}
+				</Group>
+			)}
+
+			{assumptions.length > 0 && (
+				<Stack gap={2} data-testid="answer-assumptions">
+					<Text size="xs" c="dimmed" fw={500}>
+						Assumptions
+					</Text>
+					{assumptions.slice(0, MAX_ASSUMPTIONS).map((assumption, i) => (
+						<Text
+							// biome-ignore lint/suspicious/noArrayIndexKey: model output, no reorder
+							key={i}
+							size="xs"
+							c="dimmed"
+						>
+							• {assumption}
+						</Text>
+					))}
+					{assumptions.length > MAX_ASSUMPTIONS && (
+						<Text size="xs" c="dimmed">
+							…and {assumptions.length - MAX_ASSUMPTIONS} more
+						</Text>
+					)}
+				</Stack>
+			)}
+		</Stack>
+	);
+}
+
+/**
+ * The registered widget: the confidence strip on top, the streaming result table
+ * below. The table reuses the run_sql result-grid stream verbatim (same NDJSON
+ * endpoint, virtualization, and sort) — confidence is purely additive.
+ */
+export function AnswerResultWidget({
+	state,
+}: {
+	state: Extract<CanvasState, { kind: "answer-result" }>;
+}) {
+	return (
+		<div data-testid="canvas-answer-result">
+			<ConfidenceStrip confidence={state.confidence} />
+			<ResultGridWidget state={{ kind: "result-grid", sql: state.sql }} />
+		</div>
+	);
+}


### PR DESCRIPTION
## What

Expressing our confidence in a result is core to dataraum, but the answer result widget rendered **only the table**. The `answer` tool already computes the full confidence read — `data_quality` band, `reliability.grounded_ratio`, per-concept reuse (`exact_reuse`/`adapted`/`fresh`), `assumptions`, `concepts_used` — and ships it to the client, but the projector dropped all of it and forwarded just the grid SQL.

This surfaces it:
- New **`answer-result`** canvas kind carrying the grid SQL + a camelCase `AnswerConfidence` (canvas-state.ts).
- The `answer` projector lifts the confidence off the (unknown) tool result via a defensive `readAnswerConfidence` — every field narrowed, object-type-guarded, zeroed/null defaults on a drifted result, never throws (tool-result-to-canvas.ts).
- New **`AnswerResultWidget`** = a pure `ConfidenceStrip` (band badge reusing the shared `BandBadge` + grounded % + reuse pills + concepts + assumptions, both arrays **bounded with an overflow tail**) over the **unchanged** streaming `ResultGridWidget`.
- One `register()` line. `run_sql` keeps its plain `result-grid` path.

Cockpit-only presentation. **No engine change, no new data** — the table behavior (virtualization, truncation banner, error/empty states) is inherited verbatim.

## Out of scope (deliberately)
- **Uncapped streaming** of the answer grid → stays **DAT-490** (the table still inherits the run_sql cap; "first only a table is fine").
- **Charts** for a result → future.
- **Aggregate usage report / ops dashboard** → DAT-488 (parked). This surfaces only the *current* result's confidence (from `components`/`reliability`, live).

## Tests
Projector: full result → `answer-result` with confidence; null-band/zeroed degenerate; agent-error/no-grid → null; a drifted result (non-object `data_quality`/`reliability`, bad-typed arrays) degrades without throwing. Widget (`ConfidenceStrip`, real Mantine in jsdom): each band, fully-grounded (100%), no-reuse, rounding, and the cap/overflow tail. Full cockpit suite green (1064), tsc + biome + build clean.

## Reviewers
senior-code-reviewer **APPROVE** (fixes applied: unbounded-DOM cap + overflow tail, index keys, object-type guard, edge-case tests) · spec-compliance-reviewer **COMPLIANT** (fixes applied: per-band + fully-grounded test coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)