### PR TITLE
DAT-509: cockpit read alignment after DAT-442 — triple-head precedence, contested caveat, columns_used

### DIFF
--- a/packages/cockpit/scripts/smoke-dat-509.sh
+++ b/packages/cockpit/scripts/smoke-dat-509.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Lane smoke for DAT-509 — self-contained: scratch Postgres + the engine's
+# materialized ws/_read schemas (same recipe as pull-metadata.sh), then
+# scripts/smoke-dat-509.ts seeds multi-grain rows and asserts the changed
+# tools' reads through the REAL views. No running stack, no LLM calls
+# (ANTHROPIC_API_KEY is a dummy; the asserted paths never synthesize).
+#
+# Requires docker + uv + bun. Run from packages/cockpit:
+#   bash scripts/smoke-dat-509.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.." # packages/cockpit
+
+WORKSPACE_ID="${DATARAUM_WORKSPACE_ID:-00000000-0000-0000-0000-000000000001}"
+SCHEMA_NAME="ws_${WORKSPACE_ID//-/_}"
+READ_SCHEMA="${SCHEMA_NAME}_read"
+PG_IMAGE="postgres:17"
+CONTAINER="dataraum-smoke-509-$$"
+
+trap 'docker rm -f "$CONTAINER" >/dev/null 2>&1 || true' EXIT
+docker run --rm -d --name "$CONTAINER" \
+    -e POSTGRES_PASSWORD=scratch -e POSTGRES_DB=scratch \
+    -p "127.0.0.1::5432" "$PG_IMAGE" >/dev/null
+PG_PORT=$(docker port "$CONTAINER" 5432/tcp | head -1 | awk -F: '{print $NF}')
+for _ in $(seq 1 100); do
+    docker exec "$CONTAINER" pg_isready -h 127.0.0.1 -U postgres -q 2>/dev/null && break
+    sleep 0.3
+done
+docker exec "$CONTAINER" pg_isready -h 127.0.0.1 -U postgres -q
+
+docker exec "$CONTAINER" psql -U postgres -d scratch -v ON_ERROR_STOP=1 \
+    -c "CREATE SCHEMA $SCHEMA_NAME" -c "CREATE SCHEMA $READ_SCHEMA" >/dev/null
+(
+    echo "SET search_path TO $SCHEMA_NAME;"
+    cat ../engine/schema.sql
+    sed -e "s/__READ__/$READ_SCHEMA/g" -e "s/__WS__/$SCHEMA_NAME/g" ../engine/schema_read.sql
+) | docker exec -i "$CONTAINER" psql -U postgres -d scratch -v ON_ERROR_STOP=1 -f - >/dev/null
+echo "→ materialized $SCHEMA_NAME + $READ_SCHEMA"
+
+export DATARAUM_WORKSPACE_ID="$WORKSPACE_ID"
+export METADATA_DATABASE_URL="postgresql://postgres:scratch@localhost:$PG_PORT/scratch"
+# Required-but-unused by the smoke's read paths — dummies, validated only.
+export COCKPIT_DATABASE_URL="postgresql://postgres:scratch@localhost:$PG_PORT/scratch"
+export DATARAUM_CONFIG_PATH="/tmp/dataraum-config-unused"
+export DATARAUM_LAKE_PATH="/tmp/dataraum-lake-unused"
+export DUCKLAKE_CATALOG_URL="postgresql://postgres:scratch@localhost:$PG_PORT/scratch"
+export ANTHROPIC_API_KEY="smoke-dummy-never-called"
+export S3_ENDPOINT="localhost:9999"
+export S3_ACCESS_KEY_ID="smoke" S3_SECRET_ACCESS_KEY="smoke" S3_BUCKET="smoke"
+export S3_USE_SSL="false" DUCKLAKE_SKIP_INSTALL="1"
+
+bun run scripts/smoke-dat-509.ts

--- a/packages/cockpit/scripts/smoke-dat-509.ts
+++ b/packages/cockpit/scripts/smoke-dat-509.ts
@@ -1,0 +1,153 @@
+// Lane smoke for DAT-509 — the multi-grain read alignment against a REAL
+// materialized ws schema (scratch Postgres; run via scripts/smoke-dat-509.sh).
+//
+// The unit tests pin the pure pick/merge logic; this exercises the actual SQL
+// the changed tools emit against the real views (current_entropy_readiness /
+// current_entropy_objects / current_semantic_annotations /
+// current_validation_results), with rows seeded at BOTH grains:
+//
+//   - column c-1 carries an add_source table-head readiness row (blocked) AND
+//     a later session-head re-roll (ready) → every surface must report READY;
+//   - column c-2 carries a contested point_in_time annotation → the query
+//     sub-agent's schema block must tag it;
+//   - one executed validation result carries digest-prefixed columns_used →
+//     why_validation must surface them stripped.
+//
+// No LLM is touched: the asserted paths are the non-synthesis ones (and
+// why_column runs on the readiness-less column, where analysis is skipped).
+//
+// Run from packages/cockpit:  bash scripts/smoke-dat-509.sh
+
+import assert from "node:assert/strict";
+import { SQL } from "bun";
+
+import { config } from "#/config";
+import { listTables } from "#/tools/list-tables";
+import { lookTable } from "#/tools/look-table";
+import { lookValidation } from "#/tools/look-validation";
+import { buildSchemaBlock } from "#/tools/query-context";
+import { whyColumn } from "#/tools/why-column";
+import { whyTable } from "#/tools/why-table";
+import { whyValidation } from "#/tools/why-validation";
+
+const WS = `ws_${config.dataraumWorkspaceId.replaceAll("-", "_")}`;
+const DIGEST = "204bc8e118543a6c35654c1f68c43539a2e226f2";
+
+async function seed(): Promise<void> {
+	const sql = new SQL(config.metadataDatabaseUrl);
+	// Raw inserts into the ws schema; the tools read the _read views on top.
+	await sql.unsafe(`
+		INSERT INTO ${WS}.investigation_sessions
+			(session_id, status, started_at, intent, step_count)
+		VALUES ('sess-1', 'active', '2026-06-11T08:00:00', 'exploratory', 0);
+
+		INSERT INTO ${WS}.sources
+			(source_id, name, source_type, created_at, updated_at)
+		VALUES ('src-1', 'erp', 'csv', '2026-06-11T08:00:00', '2026-06-11T08:00:00');
+
+		INSERT INTO ${WS}.tables
+			(table_id, source_id, table_name, layer, created_at, row_count)
+		VALUES ('t-1', 'src-1', 'orders', 'typed', '2026-06-11T08:00:00', 10);
+
+		INSERT INTO ${WS}.columns
+			(column_id, table_id, column_name, column_position, resolved_type)
+		VALUES
+			('c-1', 't-1', 'amount', 1, 'DECIMAL'),
+			('c-2', 't-1', 'balance', 2, 'DECIMAL');
+
+		INSERT INTO ${WS}.metadata_snapshot_head
+			(head_id, target, stage, run_id, promoted_at, version)
+		VALUES
+			('h-add', 'table:t-1',    'detect',              'run-add', '2026-06-11T09:00:00', 1),
+			('h-ses', 'session:sess-1', 'detect',            'run-ses', '2026-06-11T10:00:00', 1),
+			('h-sem', 'table:t-1',    'semantic_per_column', 'run-sem', '2026-06-11T09:30:00', 1),
+			('h-om',  'session:sess-1', 'operating_model',   'run-om',  '2026-06-11T11:00:00', 1);
+
+		-- The fault line: same column, table-head verdict (blocked) + a later
+		-- session re-roll (ready). The session-grain row must win everywhere.
+		INSERT INTO ${WS}.entropy_readiness
+			(readiness_id, session_id, target, table_id, column_id, run_id,
+			 band, worst_intent_risk, intents, computed_at)
+		VALUES
+			('r-add', 'sess-1', 'column:c-1', 't-1', 'c-1', 'run-add',
+			 'blocked', 0.9, '[]'::jsonb, '2026-06-11T09:00:00'),
+			('r-ses', 'sess-1', 'column:c-1', 't-1', 'c-1', 'run-ses',
+			 'ready', 0.1, '[]'::jsonb, '2026-06-11T10:00:00');
+
+		-- Contested stock/flow annotation for c-2 (semantic_per_column head).
+		INSERT INTO ${WS}.semantic_annotations
+			(annotation_id, session_id, column_id, run_id, business_concept,
+			 temporal_behavior, temporal_behavior_contested, annotated_at)
+		VALUES ('a-1', 'sess-1', 'c-2', 'run-sem', 'account_balance',
+			 'point_in_time', true, '2026-06-11T09:30:00');
+
+		-- Executed validation with digest-prefixed columns_used (operating_model head).
+		INSERT INTO ${WS}.validation_results
+			(result_id, session_id, run_id, validation_id, table_ids, columns_used,
+			 status, severity, passed, message, executed_at)
+		VALUES ('v-1', 'sess-1', 'run-om', 'tb_gl_reconciliation',
+			 '["t-1"]'::json, '["src_${DIGEST}__orders.amount"]'::json,
+			 'executed', 'critical', false, 'TB does not reconcile',
+			 '2026-06-11T11:00:00');
+	`);
+	await sql.close();
+}
+
+async function main(): Promise<void> {
+	await seed();
+
+	// 1. look_table: the per-column grid picks the session re-roll over the
+	//    stale add_source verdict, and carries the semantic join.
+	const grid = await lookTable({ table_id: "t-1" });
+	const amount = grid.columns.find((c) => c.column_name === "amount");
+	const balance = grid.columns.find((c) => c.column_name === "balance");
+	assert.equal(amount?.band, "ready", "look_table: session re-roll must win");
+	assert.equal(balance?.band, null, "look_table: no readiness → unanalyzed");
+	assert.equal(balance?.semantic?.business_concept, "account_balance");
+
+	// 2. list_tables: the band tally counts the picked grain, not both rows.
+	const inventory = await listTables();
+	const orders = inventory.find((t) => t.table_name === "orders");
+	assert.equal(orders?.readiness.ready, 1, "list_tables: ready=1 (c-1 picked)");
+	assert.equal(orders?.readiness.blocked, 0, "list_tables: stale row not counted");
+	assert.equal(orders?.readiness.unanalyzed, 1, "list_tables: c-2 unanalyzed");
+	assert.equal(orders?.worst_band, "ready");
+
+	// 3. why_column on the readiness-less column: SQL executes, no LLM call
+	//    (analyzed=false), found=true.
+	const why = await whyColumn({ column_id: "c-2" });
+	assert.equal(why.found, true);
+	assert.equal(why.analyzed, false, "why_column: c-2 has no readiness row");
+	assert.equal(why.analysis, "", "why_column: no synthesis without readiness");
+
+	// 4. why_table: no table-target readiness seeded → unanalyzed shell, both
+	//    queries execute (pick + merge over the real views).
+	const whyT = await whyTable({ session_id: "sess-1", table_id: "t-1" });
+	assert.equal(whyT.analyzed, false);
+
+	// 5. The query sub-agent's schema block: stock/flow + contested markers.
+	const block = await buildSchemaBlock();
+	assert.ok(
+		block.includes(
+			'"balance" :: DECIMAL  [concept: account_balance] (point_in_time)  [stock/flow contested]',
+		),
+		`schema block must tag the contested stock — got:\n${block}`,
+	);
+
+	// 6. why_validation: columns_used surfaced, digest-stripped.
+	const whyV = await whyValidation({
+		session_id: "sess-1",
+		validation_id: "tb_gl_reconciliation",
+	});
+	assert.equal(whyV.found, true);
+	assert.deepEqual(whyV.columns_used, ["orders.amount"]);
+
+	// 7. look_validation: the promoted operating_model head reads as analyzed.
+	const lookV = await lookValidation({ session_id: "sess-1" });
+	assert.equal(lookV.analyzed, true);
+
+	console.log("smoke-dat-509: ALL GREEN (7 surfaces, multi-grain seed)");
+}
+
+await main();
+process.exit(0);

--- a/packages/cockpit/src/tools/agent-name-leaks.test.ts
+++ b/packages/cockpit/src/tools/agent-name-leaks.test.ts
@@ -250,6 +250,7 @@ describe("agent name-leak property (DAT-433)", () => {
 				severity: "error",
 				passed: false,
 				message: `12 rows in ${RAW_ORDERS} have no match`,
+				columnsUsed: [`${RAW_ORDERS}.customer_id`],
 			},
 		);
 		expect(JSON.stringify(out)).not.toMatch(LEAK);
@@ -280,6 +281,7 @@ describe("agent name-leak property (DAT-433)", () => {
 				sqlUsed: `SELECT count(*) FROM lake.typed.${RAW_ORDERS} o LEFT JOIN lake.typed.${RAW_CUSTOMERS} c ON o.customer_id = c.id`,
 				executedAt: new Date("2026-06-07T12:00:00Z"),
 				details: { table: RAW_ORDERS, failing_rows: 12 },
+				columnsUsed: [`${RAW_ORDERS}.customer_id`],
 			},
 			0,
 		);

--- a/packages/cockpit/src/tools/list-tables.ts
+++ b/packages/cockpit/src/tools/list-tables.ts
@@ -32,8 +32,8 @@ import {
 	tables,
 } from "../db/metadata/schema";
 import { displayTableName } from "../lib/display-names";
-import { pickCurrentRow } from "./readiness-grain";
 import { fileName } from "../lib/file-uri";
+import { pickCurrentRow } from "./readiness-grain";
 
 // The calibrated bands the engine emits (entropy_readiness.band). A column with
 // no readiness row (left-join miss) counts as `unanalyzed`, never as a band.

--- a/packages/cockpit/src/tools/list-tables.ts
+++ b/packages/cockpit/src/tools/list-tables.ts
@@ -19,7 +19,7 @@
 // are smoke-covered (a live ws_<id>); the pure projection is unit-tested here.
 
 import { toolDefinition } from "@tanstack/ai";
-import { and, asc, desc, eq, isNull } from "drizzle-orm";
+import { and, asc, desc, eq, isNotNull, isNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { metadataDb } from "../db/metadata/client";
@@ -32,6 +32,7 @@ import {
 	tables,
 } from "../db/metadata/schema";
 import { displayTableName } from "../lib/display-names";
+import { pickCurrentRow } from "./readiness-grain";
 import { fileName } from "../lib/file-uri";
 
 // The calibrated bands the engine emits (entropy_readiness.band). A column with
@@ -371,21 +372,44 @@ export async function listTables(
 		.where(and(isNull(sources.archivedAt), sourceFilter))
 		.orderBy(asc(sources.createdAt), asc(tables.tableName));
 
-	const columnBandRows = await metadataDb
-		.select({ tableId: columns.tableId, band: currentEntropyReadiness.band })
+	// Per-column bands, all grains: the readiness view is multi-grain (the
+	// add_source table-head row and a session-grain re-roll coexist per column),
+	// so a single-row LEFT JOIN either double-counts or freezes the add_source
+	// verdict. Fetch columns and readiness separately and pick per column —
+	// session re-roll wins (readiness-grain.ts). The readiness fetch is
+	// workspace-wide (no source join — modest row counts); rows for columns
+	// outside the filter simply never match below.
+	const columnRows = await metadataDb
+		.select({ tableId: columns.tableId, columnId: columns.columnId })
 		.from(columns)
 		.innerJoin(tables, eq(tables.tableId, columns.tableId))
 		.innerJoin(sources, eq(sources.sourceId, tables.sourceId))
-		.leftJoin(
-			currentEntropyReadiness,
-			and(
-				eq(currentEntropyReadiness.columnId, columns.columnId),
-				// Pin the add_source grain — see why_column; prevents double-
-				// counting columns once a session head is promoted.
-				eq(currentEntropyReadiness.viaTableHead, true),
-			),
-		)
 		.where(and(isNull(sources.archivedAt), sourceFilter));
+
+	const readinessRows = await metadataDb
+		.select({
+			columnId: currentEntropyReadiness.columnId,
+			band: currentEntropyReadiness.band,
+			computedAt: currentEntropyReadiness.computedAt,
+			viaTableHead: currentEntropyReadiness.viaTableHead,
+			viaSessionHead: currentEntropyReadiness.viaSessionHead,
+			viaOperatingModelHead: currentEntropyReadiness.viaOperatingModelHead,
+		})
+		.from(currentEntropyReadiness)
+		.where(isNotNull(currentEntropyReadiness.columnId));
+
+	const grainsByColumn = new Map<string, typeof readinessRows>();
+	for (const row of readinessRows) {
+		const key = row.columnId ?? "";
+		const group = grainsByColumn.get(key);
+		if (group === undefined) grainsByColumn.set(key, [row]);
+		else group.push(row);
+	}
+	const columnBandRows = columnRows.map((c) => ({
+		tableId: c.tableId,
+		band:
+			pickCurrentRow(grainsByColumn.get(c.columnId ?? "") ?? [])?.band ?? null,
+	}));
 
 	// Session/detect-grain orientation (DAT-477). The current_* views resolve the
 	// promoted detect run server-side (the head join lives in the DB, ADR-0008),

--- a/packages/cockpit/src/tools/list-tables.ts
+++ b/packages/cockpit/src/tools/list-tables.ts
@@ -19,7 +19,7 @@
 // are smoke-covered (a live ws_<id>); the pure projection is unit-tested here.
 
 import { toolDefinition } from "@tanstack/ai";
-import { and, asc, desc, eq, isNotNull, isNull } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, isNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { metadataDb } from "../db/metadata/client";
@@ -376,9 +376,8 @@ export async function listTables(
 	// add_source table-head row and a session-grain re-roll coexist per column),
 	// so a single-row LEFT JOIN either double-counts or freezes the add_source
 	// verdict. Fetch columns and readiness separately and pick per column —
-	// session re-roll wins (readiness-grain.ts). The readiness fetch is
-	// workspace-wide (no source join — modest row counts); rows for columns
-	// outside the filter simply never match below.
+	// session re-roll wins (readiness-grain.ts). The readiness fetch is bounded
+	// to the inventory's tables (column-grain rows carry table_id, DAT-408).
 	const columnRows = await metadataDb
 		.select({ tableId: columns.tableId, columnId: columns.columnId })
 		.from(columns)
@@ -386,17 +385,29 @@ export async function listTables(
 		.innerJoin(sources, eq(sources.sourceId, tables.sourceId))
 		.where(and(isNull(sources.archivedAt), sourceFilter));
 
-	const readinessRows = await metadataDb
-		.select({
-			columnId: currentEntropyReadiness.columnId,
-			band: currentEntropyReadiness.band,
-			computedAt: currentEntropyReadiness.computedAt,
-			viaTableHead: currentEntropyReadiness.viaTableHead,
-			viaSessionHead: currentEntropyReadiness.viaSessionHead,
-			viaOperatingModelHead: currentEntropyReadiness.viaOperatingModelHead,
-		})
-		.from(currentEntropyReadiness)
-		.where(isNotNull(currentEntropyReadiness.columnId));
+	const tableIds = tableRows
+		.map((t) => t.tableId ?? "")
+		.filter((id) => id !== "");
+	const readinessRows =
+		tableIds.length === 0
+			? []
+			: await metadataDb
+					.select({
+						columnId: currentEntropyReadiness.columnId,
+						band: currentEntropyReadiness.band,
+						computedAt: currentEntropyReadiness.computedAt,
+						viaTableHead: currentEntropyReadiness.viaTableHead,
+						viaSessionHead: currentEntropyReadiness.viaSessionHead,
+						viaOperatingModelHead:
+							currentEntropyReadiness.viaOperatingModelHead,
+					})
+					.from(currentEntropyReadiness)
+					.where(
+						and(
+							inArray(currentEntropyReadiness.tableId, tableIds),
+							isNotNull(currentEntropyReadiness.columnId),
+						),
+					);
 
 	const grainsByColumn = new Map<string, typeof readinessRows>();
 	for (const row of readinessRows) {

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -540,6 +540,10 @@ async function loadTableBand(
 				eq(currentEntropyReadiness.target, tableTargetKey(tableName)),
 			),
 		)
+		// Safe without a grain pick: `table:{name}` targets are written only by
+		// session-grain runs (add_source persists column targets only), and the
+		// view's latest-promoted-wins dedup leaves ≤1 session-grain row per
+		// (session_id, target).
 		.limit(1);
 	return row ? projectTableBand(row) : null;
 }

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -16,7 +16,7 @@
 // rows); the pure row→shape projection is unit-tested directly here.
 
 import { toolDefinition } from "@tanstack/ai";
-import { and, asc, desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, isNotNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { metadataDb } from "../db/metadata/client";
@@ -34,6 +34,7 @@ import {
 	tables,
 } from "../db/metadata/schema";
 import { displayTableName, stripSrcDigests } from "../lib/display-names";
+import { pickCurrentRow } from "./readiness-grain";
 
 // The persisted JSONB grammar (intents / top_drivers) lives in
 // `readiness-schemas.ts`, shared with why_column. Parsed leniently below: a
@@ -397,20 +398,19 @@ export async function lookTable(
 	);
 }
 
-/** Resolve a table's per-column readiness grid (the add_source view). The
- * current_* view IS the promoted run (ADR-0008/DAT-453) — the head join lives
- * in the database, so a plain LEFT JOIN suffices; no promoted run (never
- * detected) ⇒ the view is empty ⇒ every column reads back unanalyzed. */
+/** Resolve a table's per-column readiness grid. The current_* view IS the
+ * promoted run (ADR-0008/DAT-453), but it is multi-grain — the add_source
+ * table-head row and a session-grain re-roll coexist per column — which a
+ * single-row LEFT JOIN can't express. Readiness is fetched separately (all
+ * grains) and picked per column: the session re-roll supersedes the add_source
+ * verdict. No promoted run (never detected) ⇒ the view is empty ⇒ every
+ * column reads back unanalyzed. */
 async function loadColumnGrid(tableId: string): Promise<ColumnReadiness[]> {
-	const rows = await metadataDb
+	const colRows = await metadataDb
 		.select({
 			columnId: columns.columnId,
 			columnName: columns.columnName,
 			resolvedType: columns.resolvedType,
-			band: currentEntropyReadiness.band,
-			worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
-			intents: currentEntropyReadiness.intents,
-			topDrivers: currentEntropyReadiness.topDrivers,
 			// Light per-column semantics (DAT-476) — begin_session's
 			// `semantic_per_column` annotation, head-resolved by the view. Left-join
 			// nullable: an unannotated column reads all three null → semantic: null.
@@ -420,30 +420,58 @@ async function loadColumnGrid(tableId: string): Promise<ColumnReadiness[]> {
 		})
 		.from(columns)
 		.leftJoin(
-			currentEntropyReadiness,
-			and(
-				eq(currentEntropyReadiness.columnId, columns.columnId),
-				// Pin the add_source grain — see why_column; without it the grid
-				// fans out to two rows per column once a session head is promoted.
-				eq(currentEntropyReadiness.viaTableHead, true),
-			),
-		)
-		.leftJoin(
 			currentSemanticAnnotations,
 			eq(currentSemanticAnnotations.columnId, columns.columnId),
 		)
 		.where(eq(columns.tableId, tableId))
 		.orderBy(asc(columns.columnPosition));
 
+	// Column-grain readiness rows carry table_id (the DAT-408 delete scope);
+	// the table-target row has column_id NULL and is excluded here.
+	const readinessRows = await metadataDb
+		.select({
+			columnId: currentEntropyReadiness.columnId,
+			band: currentEntropyReadiness.band,
+			worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
+			intents: currentEntropyReadiness.intents,
+			topDrivers: currentEntropyReadiness.topDrivers,
+			computedAt: currentEntropyReadiness.computedAt,
+			viaTableHead: currentEntropyReadiness.viaTableHead,
+			viaSessionHead: currentEntropyReadiness.viaSessionHead,
+			viaOperatingModelHead: currentEntropyReadiness.viaOperatingModelHead,
+		})
+		.from(currentEntropyReadiness)
+		.where(
+			and(
+				eq(currentEntropyReadiness.tableId, tableId),
+				isNotNull(currentEntropyReadiness.columnId),
+			),
+		);
+
+	const grainsByColumn = new Map<string, typeof readinessRows>();
+	for (const row of readinessRows) {
+		const key = row.columnId ?? "";
+		const group = grainsByColumn.get(key);
+		if (group === undefined) grainsByColumn.set(key, [row]);
+		else group.push(row);
+	}
+
 	// View columns type as nullable (Postgres views carry no NOT NULL) — the
 	// identity fields are guaranteed by the underlying tables; coalesce.
-	return rows.map((r) =>
-		projectColumnReadiness({
+	return colRows.map((r) => {
+		const readiness = pickCurrentRow(
+			grainsByColumn.get(r.columnId ?? "") ?? [],
+		);
+		return projectColumnReadiness({
 			...r,
+			band: readiness?.band ?? null,
+			worstIntentRisk: readiness?.worstIntentRisk ?? null,
+			intents: readiness?.intents ?? null,
+			topDrivers: readiness?.topDrivers ?? null,
 			columnId: r.columnId ?? "",
 			columnName: r.columnName ?? "",
-		}),
-	);
+		});
+	});
 }
 
 /** The `current_table_entities` filter for one table (DAT-476). The view is

--- a/packages/cockpit/src/tools/look-validation.test.ts
+++ b/packages/cockpit/src/tools/look-validation.test.ts
@@ -34,6 +34,7 @@ describe("projectValidationOverview (DAT-440)", () => {
 			severity: "error",
 			passed: false,
 			message: "12 invoices have no matching journal entry",
+			columnsUsed: ["invoices.amount", "journal_lines.debit"],
 		};
 
 		expect(projectValidationOverview(artifact, result)).toEqual({
@@ -44,6 +45,7 @@ describe("projectValidationOverview (DAT-440)", () => {
 			status: "executed",
 			passed: false,
 			message: "12 invoices have no matching journal entry",
+			columns_used: ["invoices.amount", "journal_lines.debit"],
 		});
 	});
 
@@ -78,11 +80,13 @@ describe("projectValidationOverview (DAT-440)", () => {
 			severity: null,
 			passed: true,
 			message: `checked src_${D1}__orders rows`,
+			columnsUsed: [`src_${D1}__orders.amount`],
 		};
 
 		const projected = projectValidationOverview(artifact, result);
 		expect(projected.state_reason).toBe("Missing required tables: orders");
 		expect(projected.message).toBe("checked orders rows");
+		expect(projected.columns_used).toEqual(["orders.amount"]);
 		expect(JSON.stringify(projected)).not.toMatch(/src_[0-9a-f]{40}/);
 	});
 

--- a/packages/cockpit/src/tools/look-validation.ts
+++ b/packages/cockpit/src/tools/look-validation.ts
@@ -54,6 +54,11 @@ const ValidationOverview = z.object({
 	status: z.string().nullable(),
 	passed: z.boolean().nullable(),
 	message: z.string().nullable(),
+	// The exact "table.column" entries the executed check read (DAT-509) — the
+	// same set a failed critical fans its column-grain entropy out to, so the
+	// agent can name the implicated columns (and drill in via look_table).
+	// Empty until executed.
+	columns_used: z.array(z.string()),
 });
 export type ValidationOverview = z.infer<typeof ValidationOverview>;
 
@@ -67,12 +72,27 @@ const LookValidationResult = z.object({
 });
 export type LookValidationResult = z.infer<typeof LookValidationResult>;
 
+/**
+ * Narrow the `columns_used` JSON column to its engine contract: a list of
+ * LLM-declared "table.column" strings, possibly carrying the physical
+ * `src_<digest>__` prefix — digest-stripped like every engine string surfaced
+ * to the agent. Anything off-contract degrades to empty, never throws.
+ */
+export function columnsUsedStrings(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value
+		.filter((entry): entry is string => typeof entry === "string")
+		.map((entry) => stripSrcDigests(entry));
+}
+
 /** One current_validation_results row, keyed by its validation_id. */
 export interface ValidationResultRow {
 	status: string | null;
 	severity: string | null;
 	passed: boolean | null;
 	message: string | null;
+	// JSON column — unknown at the boundary, narrowed in the projector.
+	columnsUsed: unknown;
 }
 
 /**
@@ -97,6 +117,7 @@ export function projectValidationOverview(
 		status: result?.status ?? null,
 		passed: result?.passed ?? null,
 		message: result?.message == null ? null : stripSrcDigests(result.message),
+		columns_used: columnsUsedStrings(result?.columnsUsed),
 	};
 }
 
@@ -137,6 +158,7 @@ export async function lookValidation(
 			severity: currentValidationResults.severity,
 			passed: currentValidationResults.passed,
 			message: currentValidationResults.message,
+			columnsUsed: currentValidationResults.columnsUsed,
 		})
 		.from(currentValidationResults)
 		.where(eq(currentValidationResults.sessionId, input.session_id));
@@ -148,6 +170,7 @@ export async function lookValidation(
 				severity: r.severity,
 				passed: r.passed,
 				message: r.message,
+				columnsUsed: r.columnsUsed,
 			},
 		]),
 	);

--- a/packages/cockpit/src/tools/query-context.test.ts
+++ b/packages/cockpit/src/tools/query-context.test.ts
@@ -35,9 +35,19 @@ const columnRows: SchemaColumnRow[] = [
 ];
 
 const concepts: SchemaConceptRow[] = [
-	{ columnId: "c1", businessConcept: "amount" },
+	{
+		columnId: "c1",
+		businessConcept: "amount",
+		temporalBehavior: null,
+		temporalBehaviorContested: null,
+	},
 	// c2 has no concept; c3 maps to account_classification.
-	{ columnId: "c3", businessConcept: "account_classification" },
+	{
+		columnId: "c3",
+		businessConcept: "account_classification",
+		temporalBehavior: null,
+		temporalBehaviorContested: null,
+	},
 ];
 
 describe("formatSchema", () => {
@@ -78,6 +88,35 @@ describe("formatSchema", () => {
 		expect(block).toContain(
 			'- "account_type" :: VARCHAR  [concept: account_classification]',
 		);
+	});
+
+	it("marks the resolved stock/flow behaviour and an open contest (DAT-509)", () => {
+		const semantics: SchemaConceptRow[] = [
+			{
+				columnId: "c1",
+				businessConcept: "account_balance",
+				temporalBehavior: "point_in_time",
+				temporalBehaviorContested: true,
+			},
+			// A resolved, uncontested flow renders the marker without the caveat —
+			// even with no concept mapped.
+			{
+				columnId: "c3",
+				businessConcept: null,
+				temporalBehavior: "additive",
+				temporalBehaviorContested: false,
+			},
+		];
+		const block = formatSchema(tables, columnRows, semantics);
+		expect(block).toContain(
+			'- "Betrag" :: DECIMAL  [concept: account_balance] (point_in_time)  [stock/flow contested]',
+		);
+		const accountLine = block
+			.split("\n")
+			.find((l) => l.includes('"account_type"'));
+		expect(accountLine).toBe('  - "account_type" :: VARCHAR (additive)');
+		// The instruction header explains both markers to the sub-agent.
+		expect(block).toContain("never SUM it across periods");
 	});
 
 	it("omits the concept tag for an unmapped column", () => {

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -125,10 +125,17 @@ export interface SchemaColumnRow {
 	resolvedType: string | null;
 }
 
-/** The promoted semantic concept for a column (the field-mapping replacement). */
+/** The promoted semantic concept for a column (the field-mapping replacement),
+ * plus the resolved stock/flow adjudication (DAT-509): `temporalBehavior` is
+ * the pooled-resolved value the resolve layer wrote onto the annotation
+ * (`additive` = flow, `point_in_time` = stock — never SUM a stock across
+ * periods), and `temporalBehaviorContested` marks an open witness conflict the
+ * agent must caveat instead of silently aggregating over. */
 export interface SchemaConceptRow {
 	columnId: string;
 	businessConcept: string | null;
+	temporalBehavior: string | null;
+	temporalBehaviorContested: boolean | null;
 }
 
 /**
@@ -146,9 +153,10 @@ export function formatSchema(
 		return "<schema>\n(No queryable tables in the workspace yet — nothing to query.)\n</schema>";
 	}
 
-	const conceptByColumn = new Map<string, string>();
+	const conceptByColumn = new Map<string, SchemaConceptRow>();
 	for (const c of conceptRows) {
-		if (c.businessConcept) conceptByColumn.set(c.columnId, c.businessConcept);
+		if (c.businessConcept || c.temporalBehavior)
+			conceptByColumn.set(c.columnId, c);
 	}
 
 	const columnsByTable = new Map<string, SchemaColumnRow[]>();
@@ -169,9 +177,20 @@ export function formatSchema(
 		const address = `${LAKE_ALIAS}.${schemaForLayer(t.layer)}.${t.physicalName}`;
 		const colLines = cols.map((c) => {
 			const type = c.resolvedType ?? "unknown";
-			const concept = conceptByColumn.get(c.columnId);
-			const conceptTag = concept ? `  [concept: ${concept}]` : "";
-			return `  - "${c.name}" :: ${type}${conceptTag}`;
+			const semantic = conceptByColumn.get(c.columnId);
+			const conceptTag = semantic?.businessConcept
+				? `  [concept: ${semantic.businessConcept}]`
+				: "";
+			// Mirror the engine's render (graphs/context.py): the resolved
+			// stock/flow behaviour as a parenthesized marker; an open witness
+			// conflict becomes an explicit caveat tag (DAT-509).
+			const temporalTag = semantic?.temporalBehavior
+				? ` (${semantic.temporalBehavior})`
+				: "";
+			const contestedTag = semantic?.temporalBehaviorContested
+				? "  [stock/flow contested]"
+				: "";
+			return `  - "${c.name}" :: ${type}${conceptTag}${temporalTag}${contestedTag}`;
 		});
 		return `Table ${address}:\n${colLines.join("\n")}`;
 	});
@@ -180,7 +199,11 @@ export function formatSchema(
 		"<schema>\n" +
 		`Address each table in SQL as ${LAKE_ALIAS}.<layer>.<name> exactly as shown ` +
 		"(quote column names with double quotes). Use a column's [concept: …] tag to " +
-		"map a question's business terms to the concrete column.\n\n" +
+		"map a question's business terms to the concrete column. A column marked " +
+		"(point_in_time) is a stock — never SUM it across periods (use the last or " +
+		"average value); (additive) is a flow and sums safely. A column tagged " +
+		"[stock/flow contested] has disagreeing evidence about which it is — state " +
+		"that caveat in your answer when aggregating over it.\n\n" +
 		`${tableBlocks.join("\n\n")}\n` +
 		"</schema>"
 	);
@@ -246,6 +269,9 @@ export async function buildSchemaBlock(): Promise<string> {
 		.select({
 			columnId: currentSemanticAnnotations.columnId,
 			businessConcept: currentSemanticAnnotations.businessConcept,
+			temporalBehavior: currentSemanticAnnotations.temporalBehavior,
+			temporalBehaviorContested:
+				currentSemanticAnnotations.temporalBehaviorContested,
 		})
 		.from(currentSemanticAnnotations);
 
@@ -260,6 +286,8 @@ export async function buildSchemaBlock(): Promise<string> {
 		conceptRows.map((c) => ({
 			columnId: c.columnId ?? "",
 			businessConcept: c.businessConcept ?? null,
+			temporalBehavior: c.temporalBehavior ?? null,
+			temporalBehaviorContested: c.temporalBehaviorContested ?? null,
 		})),
 	);
 }

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -155,7 +155,7 @@ export function formatSchema(
 
 	const conceptByColumn = new Map<string, SchemaConceptRow>();
 	for (const c of conceptRows) {
-		if (c.businessConcept || c.temporalBehavior)
+		if (c.businessConcept || c.temporalBehavior || c.temporalBehaviorContested)
 			conceptByColumn.set(c.columnId, c);
 	}
 

--- a/packages/cockpit/src/tools/readiness-grain.test.ts
+++ b/packages/cockpit/src/tools/readiness-grain.test.ts
@@ -12,10 +12,7 @@ import {
 
 type Row = GrainRow & { id: string; detectorId: string | null };
 
-function row(
-	id: string,
-	overrides: Partial<Omit<Row, "id">> = {},
-): Row {
+function row(id: string, overrides: Partial<Omit<Row, "id">> = {}): Row {
 	return {
 		id,
 		detectorId: null,
@@ -118,10 +115,7 @@ describe("mergeCurrentEvidence", () => {
 			}),
 			row("tf", { detectorId: "type_fidelity", viaTableHead: true }),
 		];
-		expect(mergeCurrentEvidence(rows).map((r) => r.id)).toEqual([
-			"ctc",
-			"tf",
-		]);
+		expect(mergeCurrentEvidence(rows).map((r) => r.id)).toEqual(["ctc", "tf"]);
 	});
 
 	it("preserves the input's first-occurrence detector order", () => {

--- a/packages/cockpit/src/tools/readiness-grain.test.ts
+++ b/packages/cockpit/src/tools/readiness-grain.test.ts
@@ -1,0 +1,140 @@
+// Unit tests for the grain-precedence helpers (DAT-509). Pure functions — no
+// DB, no mocks. These pin the rank the engine uses at every run-resolved read
+// (session-grain over table-grain, latest within a grain) so a cockpit read can
+// never silently show the stale add_source verdict once a session re-rolled it.
+import { describe, expect, it } from "vitest";
+
+import {
+	type GrainRow,
+	mergeCurrentEvidence,
+	pickCurrentRow,
+} from "./readiness-grain";
+
+type Row = GrainRow & { id: string; detectorId: string | null };
+
+function row(
+	id: string,
+	overrides: Partial<Omit<Row, "id">> = {},
+): Row {
+	return {
+		id,
+		detectorId: null,
+		viaTableHead: false,
+		viaSessionHead: false,
+		viaOperatingModelHead: false,
+		computedAt: new Date("2026-06-01T00:00:00Z"),
+		...overrides,
+	};
+}
+
+describe("pickCurrentRow", () => {
+	it("returns undefined on an empty set", () => {
+		expect(pickCurrentRow([])).toBeUndefined();
+	});
+
+	it("prefers the session-grain row over the add_source table-head row", () => {
+		// Even when the table-head row is NEWER — the session re-roll already
+		// merged the table-grain detectors (engine run resolution), so it is the
+		// complete verdict.
+		const tableRow = row("table", {
+			viaTableHead: true,
+			computedAt: new Date("2026-06-10T00:00:00Z"),
+		});
+		const sessionRow = row("session", {
+			viaSessionHead: true,
+			computedAt: new Date("2026-06-05T00:00:00Z"),
+		});
+		expect(pickCurrentRow([tableRow, sessionRow])?.id).toBe("session");
+	});
+
+	it("treats an operating_model-head row as session-grain", () => {
+		const tableRow = row("table", { viaTableHead: true });
+		const omRow = row("om", { viaOperatingModelHead: true });
+		expect(pickCurrentRow([tableRow, omRow])?.id).toBe("om");
+	});
+
+	it("picks the latest session-grain row across sessions", () => {
+		// Multi-session workspace: one session-grain row per session survives the
+		// view's per-session dedup — the cockpit read (no session input) takes the
+		// most recent verdict.
+		const older = row("s1", {
+			viaSessionHead: true,
+			computedAt: new Date("2026-06-03T00:00:00Z"),
+		});
+		const newer = row("s2", {
+			viaSessionHead: true,
+			computedAt: new Date("2026-06-09T00:00:00Z"),
+		});
+		expect(pickCurrentRow([older, newer])?.id).toBe("s2");
+	});
+
+	it("falls back to the table-head row when no session-grain row exists", () => {
+		const tableRow = row("table", { viaTableHead: true });
+		const stray = row("stray"); // no head bits at all
+		expect(pickCurrentRow([stray, tableRow])?.id).toBe("table");
+	});
+
+	it("falls back to the latest row when no discriminator is set", () => {
+		const older = row("old", { computedAt: new Date("2026-06-01T00:00:00Z") });
+		const newer = row("new", { computedAt: new Date("2026-06-02T00:00:00Z") });
+		expect(pickCurrentRow([older, newer])?.id).toBe("new");
+	});
+
+	it("sorts null computedAt as oldest and keeps the first row on ties", () => {
+		const dated = row("dated", {
+			viaSessionHead: true,
+			computedAt: new Date("2026-06-01T00:00:00Z"),
+		});
+		const undated = row("undated", { viaSessionHead: true, computedAt: null });
+		expect(pickCurrentRow([undated, dated])?.id).toBe("dated");
+
+		const tieA = row("a", { viaSessionHead: true });
+		const tieB = row("b", { viaSessionHead: true });
+		expect(pickCurrentRow([tieA, tieB])?.id).toBe("a");
+	});
+});
+
+describe("mergeCurrentEvidence", () => {
+	it("keeps one row per detector, session-grain winning", () => {
+		// temporal_behavior re-adjudicated by the session; null_ratio is
+		// add_source-only — each detector resolves independently.
+		const rows = [
+			row("tb-stale", { detectorId: "temporal_behavior", viaTableHead: true }),
+			row("tb-fresh", {
+				detectorId: "temporal_behavior",
+				viaSessionHead: true,
+			}),
+			row("nr", { detectorId: "null_ratio", viaTableHead: true }),
+		];
+		const merged = mergeCurrentEvidence(rows);
+		expect(merged.map((r) => r.id)).toEqual(["tb-fresh", "nr"]);
+	});
+
+	it("keeps operating_model fan-out rows (no table-grain sibling)", () => {
+		const rows = [
+			row("ctc", {
+				detectorId: "cross_table_consistency",
+				viaOperatingModelHead: true,
+			}),
+			row("tf", { detectorId: "type_fidelity", viaTableHead: true }),
+		];
+		expect(mergeCurrentEvidence(rows).map((r) => r.id)).toEqual([
+			"ctc",
+			"tf",
+		]);
+	});
+
+	it("preserves the input's first-occurrence detector order", () => {
+		// Callers ORDER BY dimension — the merge must not reshuffle it.
+		const rows = [
+			row("b1", { detectorId: "benford", viaTableHead: true }),
+			row("a1", { detectorId: "null_ratio", viaTableHead: true }),
+			row("b2", { detectorId: "benford", viaSessionHead: true }),
+		];
+		expect(mergeCurrentEvidence(rows).map((r) => r.id)).toEqual(["b2", "a1"]);
+	});
+
+	it("returns empty for empty input", () => {
+		expect(mergeCurrentEvidence([])).toEqual([]);
+	});
+});

--- a/packages/cockpit/src/tools/readiness-grain.ts
+++ b/packages/cockpit/src/tools/readiness-grain.ts
@@ -30,7 +30,9 @@ function isSessionGrain(row: GrainRow): boolean {
 	return row.viaSessionHead === true || row.viaOperatingModelHead === true;
 }
 
-/** Latest by computedAt; null sorts oldest; ties keep the earlier row. */
+/** Latest by computedAt; null sorts oldest; ties keep the earlier row —
+ * "earlier" meaning input-array order, so an `.orderBy` added at a call site
+ * would silently change the tie-break. Ties are genuinely arbitrary today. */
 function latest<T extends GrainRow>(rows: readonly T[]): T | undefined {
 	let best: T | undefined;
 	for (const row of rows) {

--- a/packages/cockpit/src/tools/readiness-grain.ts
+++ b/packages/cockpit/src/tools/readiness-grain.ts
@@ -1,0 +1,92 @@
+// Grain precedence for the multi-head current_* entropy views (DAT-509).
+//
+// `current_entropy_objects` / `current_entropy_readiness` are multi-grain
+// (ADR-0008 + DAT-442): one target can carry a row sealed by the add_source
+// TABLE head and, once begin_session / operating_model run, a second row
+// sealed by a SESSION-grain head. The view dedupes only between the two
+// session-grain heads (detect vs operating_model, latest-promoted-wins) — the
+// table-head row coexists, and `entropy_readiness.session_id` is NOT NULL even
+// on add_source rows, so a session-scoped WHERE does not exclude it either.
+// An unpinned `.limit(1)` therefore picks an arbitrary grain, and a
+// `via_table_head` pin shows the stale add_source verdict forever (missing
+// re-adjudications like temporal_behavior's session pass and the
+// operating_model cross_table_consistency fan-out).
+//
+// The engine ranks session-grain over table-grain at every run-resolved read
+// (entropy/core/storage.py `load_for_tables`); these helpers mirror that rank
+// at the cockpit's read edge. SQL stays grain-unpinned; the pick is explicit,
+// pure, and unit-tested (the DAT-474 deterministic-pick rule).
+
+/** The head discriminators + recency every multi-grain view row carries. */
+export interface GrainRow {
+	viaTableHead: boolean | null;
+	viaSessionHead: boolean | null;
+	viaOperatingModelHead: boolean | null;
+	computedAt: Date | null;
+}
+
+/** Session-grain = sealed by a begin_session detect or operating_model head. */
+function isSessionGrain(row: GrainRow): boolean {
+	return row.viaSessionHead === true || row.viaOperatingModelHead === true;
+}
+
+/** Latest by computedAt; null sorts oldest; ties keep the earlier row. */
+function latest<T extends GrainRow>(rows: readonly T[]): T | undefined {
+	let best: T | undefined;
+	for (const row of rows) {
+		if (best === undefined) {
+			best = row;
+			continue;
+		}
+		const bestAt = best.computedAt?.getTime() ?? Number.NEGATIVE_INFINITY;
+		const rowAt = row.computedAt?.getTime() ?? Number.NEGATIVE_INFINITY;
+		if (rowAt > bestAt) best = row;
+	}
+	return best;
+}
+
+/**
+ * Pick THE current row for one target: the latest session-grain row when any
+ * exists (a session's re-roll supersedes the add_source verdict — it was built
+ * over the run-resolved merge of both grains), else the table-head row, else —
+ * for rows that predate the discriminators or carry none — the latest row.
+ */
+export function pickCurrentRow<T extends GrainRow>(
+	rows: readonly T[],
+): T | undefined {
+	const session = rows.filter(isSessionGrain);
+	if (session.length > 0) return latest(session);
+	const table = rows.filter((r) => r.viaTableHead === true);
+	if (table.length > 0) return latest(table);
+	return latest(rows);
+}
+
+/**
+ * Merge a multi-grain evidence row set: one row per detector, session-grain
+ * winning over table-grain per detector (add_source-only detectors keep their
+ * table-head row; re-adjudicated detectors show the session verdict). Output
+ * preserves the input's first-occurrence detector order, so callers' ORDER BY
+ * survives the merge.
+ */
+export function mergeCurrentEvidence<
+	T extends GrainRow & { detectorId: string | null },
+>(rows: readonly T[]): T[] {
+	const order: string[] = [];
+	const byDetector = new Map<string, T[]>();
+	for (const row of rows) {
+		const key = row.detectorId ?? "";
+		const group = byDetector.get(key);
+		if (group === undefined) {
+			order.push(key);
+			byDetector.set(key, [row]);
+		} else {
+			group.push(row);
+		}
+	}
+	const merged: T[] = [];
+	for (const key of order) {
+		const picked = pickCurrentRow(byDetector.get(key) ?? []);
+		if (picked !== undefined) merged.push(picked);
+	}
+	return merged;
+}

--- a/packages/cockpit/src/tools/why-column.ts
+++ b/packages/cockpit/src/tools/why-column.ts
@@ -33,8 +33,8 @@ import {
 import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
-import { mergeCurrentEvidence, pickCurrentRow } from "./readiness-grain";
 import { getWhyInstructions } from "../prompts";
+import { mergeCurrentEvidence, pickCurrentRow } from "./readiness-grain";
 
 // The persisted JSONB grammar (intents / drivers) is shared with look_table —
 // see `db/metadata/readiness-schemas.ts`. Parsed leniently below.

--- a/packages/cockpit/src/tools/why-column.ts
+++ b/packages/cockpit/src/tools/why-column.ts
@@ -14,7 +14,7 @@
 
 import { chat, toolDefinition } from "@tanstack/ai";
 import { createAnthropicChat } from "@tanstack/ai-anthropic";
-import { and, asc, eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { config } from "../config";
@@ -33,6 +33,7 @@ import {
 import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
+import { mergeCurrentEvidence, pickCurrentRow } from "./readiness-grain";
 import { getWhyInstructions } from "../prompts";
 
 // The persisted JSONB grammar (intents / drivers) is shared with look_table —
@@ -238,25 +239,23 @@ export async function whyColumn(
 
 	// The current_* views ARE the promoted run (ADR-0008/DAT-453): the head join
 	// lives in the database — no head resolution, no runId plumbing. No promoted
-	// run → empty views → unanalyzed (null band).
-	const [readinessRow] = await metadataDb
-		.select({
-			band: currentEntropyReadiness.band,
-			worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
-			intents: currentEntropyReadiness.intents,
-		})
-		.from(currentEntropyReadiness)
-		.where(
-			and(
-				eq(currentEntropyReadiness.columnId, input.column_id),
-				// Pin the add_source grain: after begin_session, a column has a
-				// second current row sealed by the session head (different
-				// detector subset) — via_table_head keeps the old head-join
-				// semantics deterministic.
-				eq(currentEntropyReadiness.viaTableHead, true),
-			),
-		)
-		.limit(1);
+	// run → empty views → unanalyzed (null band). The view is multi-grain
+	// (add_source table head + session-grain heads coexist) — fetch all grains
+	// and pick explicitly: session re-roll supersedes the add_source verdict.
+	const readinessRow = pickCurrentRow(
+		await metadataDb
+			.select({
+				band: currentEntropyReadiness.band,
+				worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
+				intents: currentEntropyReadiness.intents,
+				computedAt: currentEntropyReadiness.computedAt,
+				viaTableHead: currentEntropyReadiness.viaTableHead,
+				viaSessionHead: currentEntropyReadiness.viaSessionHead,
+				viaOperatingModelHead: currentEntropyReadiness.viaOperatingModelHead,
+			})
+			.from(currentEntropyReadiness)
+			.where(eq(currentEntropyReadiness.columnId, input.column_id)),
+	);
 
 	// View columns type as nullable (Postgres views carry no NOT NULL); the
 	// underlying tables guarantee these — coalesce at the edge.
@@ -270,24 +269,28 @@ export async function whyColumn(
 	};
 
 	// Evidence comes from the same promoted-run view, so stale runs can't mix in
-	// or inflate signal_count.
-	const rawEvidence = await metadataDb
-		.select({
-			layer: currentEntropyObjects.layer,
-			dimension: currentEntropyObjects.dimension,
-			subDimension: currentEntropyObjects.subDimension,
-			score: currentEntropyObjects.score,
-			detectorId: currentEntropyObjects.detectorId,
-			evidence: currentEntropyObjects.evidence,
-		})
-		.from(currentEntropyObjects)
-		.where(
-			and(
-				eq(currentEntropyObjects.columnId, input.column_id),
-				eq(currentEntropyObjects.viaTableHead, true),
-			),
-		)
-		.orderBy(asc(currentEntropyObjects.dimension));
+	// or inflate signal_count. Multi-grain merge per detector: add_source-only
+	// detectors keep their table-head row; re-adjudicated detectors (e.g.
+	// temporal_behavior's session pass) and operating_model fan-out rows
+	// (cross_table_consistency on failed criticals) show the session verdict.
+	const rawEvidence = mergeCurrentEvidence(
+		await metadataDb
+			.select({
+				layer: currentEntropyObjects.layer,
+				dimension: currentEntropyObjects.dimension,
+				subDimension: currentEntropyObjects.subDimension,
+				score: currentEntropyObjects.score,
+				detectorId: currentEntropyObjects.detectorId,
+				evidence: currentEntropyObjects.evidence,
+				computedAt: currentEntropyObjects.computedAt,
+				viaTableHead: currentEntropyObjects.viaTableHead,
+				viaSessionHead: currentEntropyObjects.viaSessionHead,
+				viaOperatingModelHead: currentEntropyObjects.viaOperatingModelHead,
+			})
+			.from(currentEntropyObjects)
+			.where(eq(currentEntropyObjects.columnId, input.column_id))
+			.orderBy(asc(currentEntropyObjects.dimension)),
+	);
 	const evidenceRows = rawEvidence.map((e) => ({
 		layer: e.layer ?? "",
 		dimension: e.dimension ?? "",

--- a/packages/cockpit/src/tools/why-relationship.ts
+++ b/packages/cockpit/src/tools/why-relationship.ts
@@ -35,6 +35,7 @@ import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { getWhyInstructions } from "../prompts";
+import { mergeCurrentEvidence, pickCurrentRow } from "./readiness-grain";
 
 // --- Tool output (mirrors why_column, keyed on the relationship pair).
 
@@ -237,42 +238,56 @@ export async function whyRelationship(
 	// The current_* views ARE the promoted run (ADR-0008/DAT-453): the head join
 	// lives in the database — no head resolution, no runId plumbing. No promoted
 	// run → empty views → unanalyzed.
-	const [readinessRow] = await metadataDb
-		.select({
-			band: currentEntropyReadiness.band,
-			worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
-			intents: currentEntropyReadiness.intents,
-		})
-		.from(currentEntropyReadiness)
-		.where(
-			and(
-				eq(currentEntropyReadiness.sessionId, input.session_id),
-				eq(currentEntropyReadiness.target, target),
+	// Relationship targets are written by session-grain runs only, but the pick
+	// keeps the read uniform with why_column/why_table (and deterministic should
+	// a second grain ever appear).
+	const readinessRow = pickCurrentRow(
+		await metadataDb
+			.select({
+				band: currentEntropyReadiness.band,
+				worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
+				intents: currentEntropyReadiness.intents,
+				computedAt: currentEntropyReadiness.computedAt,
+				viaTableHead: currentEntropyReadiness.viaTableHead,
+				viaSessionHead: currentEntropyReadiness.viaSessionHead,
+				viaOperatingModelHead: currentEntropyReadiness.viaOperatingModelHead,
+			})
+			.from(currentEntropyReadiness)
+			.where(
+				and(
+					eq(currentEntropyReadiness.sessionId, input.session_id),
+					eq(currentEntropyReadiness.target, target),
+				),
 			),
-		)
-		.limit(1);
+	);
 
 	// Evidence is keyed by the relationship target (relationship rows have no
 	// column_id); the view scopes to the promoted run, so stale runs can't
 	// inflate signal_count. View columns type as nullable (Postgres views carry
 	// no NOT NULL) — coalesce at the edge.
-	const rawEvidence = await metadataDb
-		.select({
-			layer: currentEntropyObjects.layer,
-			dimension: currentEntropyObjects.dimension,
-			subDimension: currentEntropyObjects.subDimension,
-			score: currentEntropyObjects.score,
-			detectorId: currentEntropyObjects.detectorId,
-			evidence: currentEntropyObjects.evidence,
-		})
-		.from(currentEntropyObjects)
-		.where(
-			and(
-				eq(currentEntropyObjects.sessionId, input.session_id),
-				eq(currentEntropyObjects.target, target),
-			),
-		)
-		.orderBy(asc(currentEntropyObjects.dimension));
+	const rawEvidence = mergeCurrentEvidence(
+		await metadataDb
+			.select({
+				layer: currentEntropyObjects.layer,
+				dimension: currentEntropyObjects.dimension,
+				subDimension: currentEntropyObjects.subDimension,
+				score: currentEntropyObjects.score,
+				detectorId: currentEntropyObjects.detectorId,
+				evidence: currentEntropyObjects.evidence,
+				computedAt: currentEntropyObjects.computedAt,
+				viaTableHead: currentEntropyObjects.viaTableHead,
+				viaSessionHead: currentEntropyObjects.viaSessionHead,
+				viaOperatingModelHead: currentEntropyObjects.viaOperatingModelHead,
+			})
+			.from(currentEntropyObjects)
+			.where(
+				and(
+					eq(currentEntropyObjects.sessionId, input.session_id),
+					eq(currentEntropyObjects.target, target),
+				),
+			)
+			.orderBy(asc(currentEntropyObjects.dimension)),
+	);
 	const evidenceRows = rawEvidence.map((e) => ({
 		layer: e.layer ?? "",
 		dimension: e.dimension ?? "",

--- a/packages/cockpit/src/tools/why-table.ts
+++ b/packages/cockpit/src/tools/why-table.ts
@@ -35,6 +35,7 @@ import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { getWhyInstructions } from "../prompts";
+import { mergeCurrentEvidence, pickCurrentRow } from "./readiness-grain";
 
 // --- Tool output (mirrors why_column / why_relationship, keyed on the table).
 
@@ -221,40 +222,56 @@ export async function whyTable(
 	// The current_* views ARE the promoted run (ADR-0008/DAT-453): the head
 	// join lives in the database, so no head resolution and no runId plumbing
 	// here. No promoted run → the views are empty for the session → unanalyzed.
-	const [readinessRow] = await metadataDb
-		.select({
-			band: currentEntropyReadiness.band,
-			worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
-			intents: currentEntropyReadiness.intents,
-		})
-		.from(currentEntropyReadiness)
-		.where(
-			and(
-				eq(currentEntropyReadiness.sessionId, input.session_id),
-				eq(currentEntropyReadiness.target, target),
+	// `entropy_readiness.session_id` is NOT NULL even on add_source rows, so the
+	// session scope alone does not exclude the table-head grain — pick explicitly
+	// (session re-roll supersedes the add_source verdict).
+	const readinessRow = pickCurrentRow(
+		await metadataDb
+			.select({
+				band: currentEntropyReadiness.band,
+				worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
+				intents: currentEntropyReadiness.intents,
+				computedAt: currentEntropyReadiness.computedAt,
+				viaTableHead: currentEntropyReadiness.viaTableHead,
+				viaSessionHead: currentEntropyReadiness.viaSessionHead,
+				viaOperatingModelHead: currentEntropyReadiness.viaOperatingModelHead,
+			})
+			.from(currentEntropyReadiness)
+			.where(
+				and(
+					eq(currentEntropyReadiness.sessionId, input.session_id),
+					eq(currentEntropyReadiness.target, target),
+				),
 			),
-		)
-		.limit(1);
+	);
 
 	// Evidence is keyed by the table target (table-grain rows have no column_id);
 	// the view scopes to the promoted run, so stale runs can't inflate signal_count.
-	const rawEvidence = await metadataDb
-		.select({
-			layer: currentEntropyObjects.layer,
-			dimension: currentEntropyObjects.dimension,
-			subDimension: currentEntropyObjects.subDimension,
-			score: currentEntropyObjects.score,
-			detectorId: currentEntropyObjects.detectorId,
-			evidence: currentEntropyObjects.evidence,
-		})
-		.from(currentEntropyObjects)
-		.where(
-			and(
-				eq(currentEntropyObjects.sessionId, input.session_id),
-				eq(currentEntropyObjects.target, target),
-			),
-		)
-		.orderBy(asc(currentEntropyObjects.dimension));
+	// Merge per detector across grains: a session re-adjudication wins over the
+	// add_source row for the same detector.
+	const rawEvidence = mergeCurrentEvidence(
+		await metadataDb
+			.select({
+				layer: currentEntropyObjects.layer,
+				dimension: currentEntropyObjects.dimension,
+				subDimension: currentEntropyObjects.subDimension,
+				score: currentEntropyObjects.score,
+				detectorId: currentEntropyObjects.detectorId,
+				evidence: currentEntropyObjects.evidence,
+				computedAt: currentEntropyObjects.computedAt,
+				viaTableHead: currentEntropyObjects.viaTableHead,
+				viaSessionHead: currentEntropyObjects.viaSessionHead,
+				viaOperatingModelHead: currentEntropyObjects.viaOperatingModelHead,
+			})
+			.from(currentEntropyObjects)
+			.where(
+				and(
+					eq(currentEntropyObjects.sessionId, input.session_id),
+					eq(currentEntropyObjects.target, target),
+				),
+			)
+			.orderBy(asc(currentEntropyObjects.dimension)),
+	);
 	// View columns type as nullable (Postgres views carry no NOT NULL); the
 	// underlying table guarantees these — coalesce at the edge.
 	const evidenceRows: WhyTableEvidenceRow[] = rawEvidence.map((e) => ({

--- a/packages/cockpit/src/tools/why-validation.test.ts
+++ b/packages/cockpit/src/tools/why-validation.test.ts
@@ -36,6 +36,7 @@ const executedResult: WhyValidationResultRow = {
 	sqlUsed: "SELECT i.id FROM invoices i LEFT JOIN payments p ON …",
 	executedAt: new Date("2026-06-07T12:00:00Z"),
 	details: { failing_rows: 12 },
+	columnsUsed: ["invoices.id", "payments.invoice_id"],
 };
 
 describe("projectWhyValidation (DAT-440)", () => {
@@ -61,6 +62,7 @@ describe("projectWhyValidation (DAT-440)", () => {
 			sql_used: "SELECT i.id FROM invoices i LEFT JOIN payments p ON …",
 			executed_at: "2026-06-07T12:00:00.000Z",
 			details: JSON.stringify({ failing_rows: 12 }),
+			columns_used: ["invoices.id", "payments.invoice_id"],
 			pending_teaches: 2,
 		});
 	});
@@ -120,6 +122,7 @@ describe("projectWhyValidation (DAT-440)", () => {
 				sqlUsed: `SELECT count(*) FROM lake.typed.src_${D1}__orders`,
 				executedAt: null,
 				details: { table: `src_${D1}__orders` },
+				columnsUsed: [`src_${D1}__orders.amount`],
 			},
 			0,
 		);

--- a/packages/cockpit/src/tools/why-validation.ts
+++ b/packages/cockpit/src/tools/why-validation.ts
@@ -27,6 +27,7 @@ import {
 import { getPendingOverlays } from "../db/metadata/pending-overlays";
 import { currentValidationResults } from "../db/metadata/schema";
 import { renderEvidenceDetail, stripSrcDigests } from "../lib/display-names";
+import { columnsUsedStrings } from "./look-validation";
 
 // --- Tool output (mirrors the why_* found/anatomy conventions, keyed on the
 // validation id).
@@ -58,6 +59,9 @@ const WhyValidationResult = z.object({
 	// The result's detail payload, rendered through the shared evidence
 	// sanitizer — "" when absent.
 	details: z.string(),
+	// The exact "table.column" entries the executed check read (DAT-509) —
+	// which columns a failed check implicates. Empty until executed.
+	columns_used: z.array(z.string()),
 	pending_teaches: z.number(),
 });
 export type WhyValidationResult = z.infer<typeof WhyValidationResult>;
@@ -75,6 +79,8 @@ export interface WhyValidationResultRow {
 	sqlUsed: string | null;
 	executedAt: Date | null;
 	details: unknown;
+	// JSON column — unknown at the boundary, narrowed by columnsUsedStrings.
+	columnsUsed: unknown;
 }
 
 /**
@@ -109,6 +115,7 @@ export function projectWhyValidation(
 		sql_used: result?.sqlUsed == null ? null : stripSrcDigests(result.sqlUsed),
 		executed_at: result?.executedAt?.toISOString() ?? null,
 		details: renderEvidenceDetail(result?.details),
+		columns_used: columnsUsedStrings(result?.columnsUsed),
 		pending_teaches: pendingTeaches,
 	};
 }
@@ -142,6 +149,7 @@ export async function whyValidation(
 			sqlUsed: currentValidationResults.sqlUsed,
 			executedAt: currentValidationResults.executedAt,
 			details: currentValidationResults.details,
+			columnsUsed: currentValidationResults.columnsUsed,
 		})
 		.from(currentValidationResults)
 		.where(

--- a/packages/cockpit/src/ui/cockpit/widgets/validation-list.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/validation-list.test.tsx
@@ -38,6 +38,7 @@ const EXECUTED = {
 	status: "executed",
 	passed: false,
 	message: "12 invoices have no matching journal entry",
+	columns_used: ["invoices.id", "journal_lines.invoice_id"],
 };
 
 const BLOCKED = {
@@ -49,6 +50,7 @@ const BLOCKED = {
 	status: null,
 	passed: null,
 	message: null,
+	columns_used: [],
 };
 
 const analyzed: LookValidationResult = {

--- a/packages/cockpit/src/ui/cockpit/widgets/validation-why.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/validation-why.test.tsx
@@ -81,6 +81,9 @@ describe("ValidationWhyWidget (DAT-440)", () => {
 			screen.getByTestId("canvas-validation-why-message").textContent,
 		).toContain("12 invoices have no matching journal entry");
 		expect(
+			screen.getByTestId("canvas-validation-why-columns").textContent,
+		).toContain("invoices.id");
+		expect(
 			screen.getByTestId("canvas-validation-why-sql").textContent,
 		).toContain("LEFT JOIN payments");
 		expect(

--- a/packages/cockpit/src/ui/cockpit/widgets/validation-why.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/validation-why.test.tsx
@@ -36,6 +36,7 @@ const EXECUTED: WhyValidationResult = {
 		"SELECT i.id FROM invoices i LEFT JOIN payments p ON i.id = p.invoice_id",
 	executed_at: "2026-06-07T12:00:00.000Z",
 	details: JSON.stringify({ failing_rows: 12 }),
+	columns_used: ["invoices.id", "payments.invoice_id"],
 	pending_teaches: 0,
 };
 

--- a/packages/cockpit/src/ui/cockpit/widgets/validation-why.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/validation-why.tsx
@@ -68,6 +68,15 @@ export function ValidationWhyWidget({
 				</Text>
 			)}
 
+			{/* The exact columns the executed check read (DAT-509) — a failed
+			    critical fans its column-grain entropy out to these, so they name
+			    where to look next. */}
+			{why.columns_used.length > 0 && (
+				<Text size="xs" c="dimmed" data-testid="canvas-validation-why-columns">
+					Columns checked: {why.columns_used.join(", ")}
+				</Text>
+			)}
+
 			<Group gap="md" wrap="wrap">
 				{why.severity && (
 					<Text


### PR DESCRIPTION
## Task

[DAT-509](https://real-dataraum.atlassian.net/browse/DAT-509) — cockpit read alignment after the DAT-442 merge (#284). Child of DAT-442.

## Contract consumed

No locked contract — reads the regenerated drizzle metadata mirror (`schema.ts` @ main, post-#284) and the engine's dual/triple-grain `current_*` view semantics (`packages/engine/schema_read.sql`).

## What changed

- **NEW `src/tools/readiness-grain.ts`** — pure grain-precedence helpers (`pickCurrentRow`, `mergeCurrentEvidence`): session-grain (`via_session_head` OR `via_operating_model_head`) wins over the add_source table-head row; latest `computedAt` within a grain; per-detector merge for evidence. Mirrors the engine's `load_for_tables` rank.
- **why_column / why_table / why_relationship** — `viaTableHead` pins and unordered `.limit(1)` reads replaced with explicit pick/merge. why_column now shows session re-adjudications (temporal_behavior) and operating_model fan-out (cross_table_consistency). Refinement finding: `entropy_readiness.session_id` is NOT NULL even on add_source rows, so why_table's session-scoped read was genuinely ambiguous between grains — a real fix, not hygiene.
- **look_table / list_tables** — readiness moved out of the pinned LEFT JOINs into bounded separate fetches + per-column pick. `look_relationships` audited safe (relationship targets are session-grain-only; view dedupes per session).
- **look_validation / why_validation + validation-why widget** — surface `validation_results.columns_used` (\"table.column\" strings, digest-stripped); a failed check now names its exact columns.
- **query-context** — the query sub-agent's `<schema>` block renders the resolved stock/flow marker (`(point_in_time)`/`(additive)`, mirroring engine `graphs/context.py`) plus a `[stock/flow contested]` caveat tag, with don't-SUM-a-stock instructions.

Deferred (per ticket): the optional `currentClaimWitnesses` evidence block in why_column.

## Acceptance criteria

- [x] No cockpit readiness/entropy read picks between multiple "current" rows implicitly (all 7 consumers swept; spec reviewer confirmed none missed)
- [x] why_column on a re-adjudicated column shows the session-head verdict (smoke assertion 1/3)
- [x] A failed critical validation surfaces its columns_used in look_validation/why_validation (smoke assertion 6)
- [x] The contested flag is visible to the SQL-writing agent's context (smoke assertion 5)
- [x] Gates: biome / tsc / vitest 1076 / build all green

## Lane smoke

```
bash scripts/smoke-dat-509.sh
→ materialized ws_… + ws_…_read   (scratch PG, engine schema.sql + schema_read.sql)
smoke-dat-509: ALL GREEN (7 surfaces, multi-grain seed)
```
Seeds a column with a blocked add_source verdict + a later ready session re-roll, a contested point_in_time annotation, and a digest-prefixed columns_used result — asserts every changed read through the REAL views, no LLM calls.

## Reviews

senior-code-reviewer: APPROVE (3 improvements — all applied: bounded list_tables readiness fetch, contested-only guard, widget assertion). spec-compliance-reviewer: COMPLIANT (19/19 requirements traced).

## Other lanes in flight

#245 docs(adr): ADR-0009 — entropy measures disagreement between witnesses

🤖 Generated with [Claude Code](https://claude.com/claude-code)