### PR TITLE
DAT-513: readiness grain pick made visible — stage labels + verdict history

### DIFF
--- a/packages/cockpit/src/tools/agent-name-leaks.test.ts
+++ b/packages/cockpit/src/tools/agent-name-leaks.test.ts
@@ -114,6 +114,8 @@ describe("agent name-leak property (DAT-433)", () => {
 			columnName: "amount",
 			tableName: RAW_ORDERS,
 			band: "investigate",
+			bandStage: "add_source",
+			bandComputedAt: null,
 			worstIntentRisk: 0.42,
 			intents: [],
 		};
@@ -129,7 +131,13 @@ describe("agent name-leak property (DAT-433)", () => {
 		const out = projectWhyTable(
 			"t_orders",
 			RAW_ORDERS,
-			{ band: "investigate", worstIntentRisk: 0.42, intents: [] },
+			{
+				band: "investigate",
+				bandStage: "session_detect",
+				bandComputedAt: null,
+				worstIntentRisk: 0.42,
+				intents: [],
+			},
 			evidenceRows,
 			0,
 		);
@@ -158,7 +166,13 @@ describe("agent name-leak property (DAT-433)", () => {
 			"c_from",
 			"c_to",
 			endpoints,
-			{ band: "investigate", worstIntentRisk: 0.3, intents: [] },
+			{
+				band: "investigate",
+				bandStage: "session_detect",
+				bandComputedAt: null,
+				worstIntentRisk: 0.3,
+				intents: [],
+			},
 			evidenceRows,
 			0,
 		);

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -163,7 +163,9 @@ export interface ReadinessRow {
 	columnName: string;
 	resolvedType: string | null;
 	band: string | null;
-	/** Stage of the picked verdict (DAT-513); null/absent when unanalyzed. */
+	/** Stage of the picked verdict (DAT-513); null/absent when unanalyzed.
+	 * No run_id/history here by design — the grid labels the pick, why_column
+	 * carries the full verdict history. */
 	bandStage?: string | null;
 	worstIntentRisk: number | null;
 	intents: unknown;

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -34,7 +34,7 @@ import {
 	tables,
 } from "../db/metadata/schema";
 import { displayTableName, stripSrcDigests } from "../lib/display-names";
-import { pickCurrentRow } from "./readiness-grain";
+import { pickCurrentRow, stageOfRow } from "./readiness-grain";
 
 // The persisted JSONB grammar (intents / top_drivers) lives in
 // `readiness-schemas.ts`, shared with why_column. Parsed leniently below: a
@@ -73,6 +73,9 @@ const ColumnReadiness = z.object({
 	resolved_type: z.string().nullable(),
 	// null band = this column has no readiness row yet (not analyzed).
 	band: z.string().nullable(),
+	// WHICH pipeline stage sealed the shown band (DAT-513): add_source /
+	// session_detect / operating_model — the grain pick made visible.
+	band_stage: z.string().nullable(),
 	worst_intent_risk: z.number().nullable(),
 	intents: z.array(IntentBand),
 	top_drivers: z.array(TopDriver),
@@ -160,6 +163,8 @@ export interface ReadinessRow {
 	columnName: string;
 	resolvedType: string | null;
 	band: string | null;
+	/** Stage of the picked verdict (DAT-513); null/absent when unanalyzed. */
+	bandStage?: string | null;
 	worstIntentRisk: number | null;
 	intents: unknown;
 	topDrivers: unknown;
@@ -214,6 +219,7 @@ export function projectColumnReadiness(row: ReadinessRow): ColumnReadiness {
 		column_name: row.columnName,
 		resolved_type: row.resolvedType,
 		band: row.band ?? null,
+		band_stage: row.band == null ? null : (row.bandStage ?? null),
 		worst_intent_risk: row.worstIntentRisk ?? null,
 		intents: intents.success
 			? intents.data.map((i) => ({
@@ -465,6 +471,7 @@ async function loadColumnGrid(tableId: string): Promise<ColumnReadiness[]> {
 		return projectColumnReadiness({
 			...r,
 			band: readiness?.band ?? null,
+			bandStage: readiness === undefined ? null : stageOfRow(readiness),
 			worstIntentRisk: readiness?.worstIntentRisk ?? null,
 			intents: readiness?.intents ?? null,
 			topDrivers: readiness?.topDrivers ?? null,

--- a/packages/cockpit/src/tools/readiness-grain.test.ts
+++ b/packages/cockpit/src/tools/readiness-grain.test.ts
@@ -8,6 +8,8 @@ import {
 	type GrainRow,
 	mergeCurrentEvidence,
 	pickCurrentRow,
+	projectVerdictHistory,
+	stageOfRow,
 } from "./readiness-grain";
 
 type Row = GrainRow & { id: string; detectorId: string | null };
@@ -130,5 +132,90 @@ describe("mergeCurrentEvidence", () => {
 
 	it("returns empty for empty input", () => {
 		expect(mergeCurrentEvidence([])).toEqual([]);
+	});
+});
+
+describe("stageOfRow", () => {
+	it("labels each head bit, operating_model first", () => {
+		expect(stageOfRow(row("a", { viaTableHead: true }))).toBe("add_source");
+		expect(stageOfRow(row("b", { viaSessionHead: true }))).toBe(
+			"session_detect",
+		);
+		expect(stageOfRow(row("c", { viaOperatingModelHead: true }))).toBe(
+			"operating_model",
+		);
+		expect(stageOfRow(row("d"))).toBe("unknown");
+	});
+});
+
+describe("projectVerdictHistory", () => {
+	const histRow = (
+		id: string,
+		overrides: Partial<
+			GrainRow & {
+				band: string | null;
+				worstIntentRisk: number | null;
+				sessionId: string | null;
+				runId: string | null;
+			}
+		> = {},
+	) => ({
+		...row(id),
+		band: "blocked",
+		worstIntentRisk: 0.8,
+		sessionId: "sess-1",
+		runId: id,
+		...overrides,
+	});
+
+	it("labels every snapshot and sorts oldest first", () => {
+		const history = projectVerdictHistory([
+			histRow("run-ses", {
+				viaSessionHead: true,
+				band: "ready",
+				computedAt: new Date("2026-06-11T10:00:00Z"),
+			}),
+			histRow("run-add", {
+				viaTableHead: true,
+				computedAt: new Date("2026-06-11T09:00:00Z"),
+			}),
+		]);
+		expect(history.map((h) => [h.stage, h.band])).toEqual([
+			["add_source", "blocked"],
+			["session_detect", "ready"],
+		]);
+		// No evidence rows passed → signal counts honestly absent, not 0.
+		expect(history.every((h) => h.signals === null)).toBe(true);
+	});
+
+	it("counts distinct detectors per run from unmerged evidence", () => {
+		const history = projectVerdictHistory(
+			[
+				histRow("run-add", { viaTableHead: true }),
+				histRow("run-ses", {
+					viaSessionHead: true,
+					computedAt: new Date("2026-06-11T10:00:00Z"),
+				}),
+			],
+			[
+				{ runId: "run-add", detectorId: "null_ratio" },
+				{ runId: "run-add", detectorId: "type_fidelity" },
+				{ runId: "run-add", detectorId: "type_fidelity" }, // dup → 1
+				{ runId: "run-ses", detectorId: "temporal_behavior" },
+			],
+		);
+		expect(history.map((h) => h.signals)).toEqual([2, 1]);
+	});
+
+	it("keeps cross-session rows visible — the disclosure surface", () => {
+		const history = projectVerdictHistory([
+			histRow("s1-run", { viaSessionHead: true, sessionId: "sess-1" }),
+			histRow("s2-run", {
+				viaSessionHead: true,
+				sessionId: "sess-2",
+				computedAt: new Date("2026-06-11T11:00:00Z"),
+			}),
+		]);
+		expect(history.map((h) => h.session_id)).toEqual(["sess-1", "sess-2"]);
 	});
 });

--- a/packages/cockpit/src/tools/readiness-grain.test.ts
+++ b/packages/cockpit/src/tools/readiness-grain.test.ts
@@ -188,7 +188,7 @@ describe("projectVerdictHistory", () => {
 		expect(history.every((h) => h.signals === null)).toBe(true);
 	});
 
-	it("counts distinct detectors per run from unmerged evidence", () => {
+	it("counts detectors CUMULATIVELY by stage — the scope each rollup ran over", () => {
 		const history = projectVerdictHistory(
 			[
 				histRow("run-add", { viaTableHead: true }),
@@ -196,15 +196,33 @@ describe("projectVerdictHistory", () => {
 					viaSessionHead: true,
 					computedAt: new Date("2026-06-11T10:00:00Z"),
 				}),
+				histRow("run-om", {
+					viaOperatingModelHead: true,
+					computedAt: new Date("2026-06-11T11:00:00Z"),
+				}),
 			],
 			[
-				{ runId: "run-add", detectorId: "null_ratio" },
-				{ runId: "run-add", detectorId: "type_fidelity" },
-				{ runId: "run-add", detectorId: "type_fidelity" }, // dup → 1
-				{ runId: "run-ses", detectorId: "temporal_behavior" },
+				row("e1", { detectorId: "null_ratio", viaTableHead: true }),
+				row("e2", { detectorId: "type_fidelity", viaTableHead: true }),
+				row("e3", { detectorId: "type_fidelity", viaTableHead: true }), // dup → 1
+				row("e4", { detectorId: "temporal_behavior", viaSessionHead: true }),
+				row("e5", {
+					detectorId: "cross_table_consistency",
+					viaOperatingModelHead: true,
+				}),
 			],
 		);
-		expect(history.map((h) => h.signals)).toEqual([2, 1]);
+		// add_source sees its own 2; session adds temporal_behavior (3); the
+		// operating_model rollup ran over everything (4).
+		expect(history.map((h) => h.signals)).toEqual([2, 3, 4]);
+	});
+
+	it("emits null signals for a row whose stage is unknown", () => {
+		const history = projectVerdictHistory(
+			[histRow("legacy", { runId: null })], // no grain bits → unknown
+			[row("e1", { detectorId: "null_ratio", viaTableHead: true })],
+		);
+		expect(history[0]?.signals).toBeNull();
 	});
 
 	it("keeps cross-session rows visible — the disclosure surface", () => {

--- a/packages/cockpit/src/tools/readiness-grain.ts
+++ b/packages/cockpit/src/tools/readiness-grain.ts
@@ -17,6 +17,8 @@
 // at the cockpit's read edge. SQL stays grain-unpinned; the pick is explicit,
 // pure, and unit-tested (the DAT-474 deterministic-pick rule).
 
+import { z } from "zod";
+
 /** The head discriminators + recency every multi-grain view row carries. */
 export interface GrainRow {
 	viaTableHead: boolean | null;
@@ -121,14 +123,27 @@ export interface VerdictHistoryEntry {
 	computed_at: string | null;
 	session_id: string | null;
 	run_id: string | null;
-	/** Distinct detectors backing that run's evidence — shows WHY a later
-	 * snapshot supersedes (more evidence), null when the caller passed none. */
+	/** Distinct detectors the stage's rollup drew on — CUMULATIVE by stage,
+	 * because each stage's readiness is recomputed over the run-resolved merge
+	 * of every earlier grain (engine `_resolve_runs`): the growing count is
+	 * exactly WHY a later snapshot supersedes. null when the caller passed no
+	 * evidence or the row's stage is unknown. */
 	signals: number | null;
 }
 
+/** Pipeline order for cumulative evidence attribution; unknown is excluded. */
+const STAGE_ORDER: Record<GrainStage, number> = {
+	add_source: 0,
+	session_detect: 1,
+	operating_model: 2,
+	unknown: -1,
+};
+
 /** Project a target's coexisting readiness rows into the labeled history.
  * `evidenceRows` (optional) are the UNMERGED entropy-object rows for the same
- * target — used only to count distinct detectors per run. */
+ * target — their grain bits attribute each detector to a stage, and a history
+ * row counts every detector at or below its own stage (cumulative — the scope
+ * its rollup was actually computed over). */
 export function projectVerdictHistory(
 	readinessRows: readonly (GrainRow & {
 		band: string | null;
@@ -136,30 +151,47 @@ export function projectVerdictHistory(
 		sessionId: string | null;
 		runId: string | null;
 	})[],
-	evidenceRows: readonly {
-		runId: string | null;
-		detectorId: string | null;
-	}[] = [],
+	evidenceRows: readonly (GrainRow & { detectorId: string | null })[] = [],
 ): VerdictHistoryEntry[] {
-	const detectorsByRun = new Map<string, Set<string>>();
-	for (const e of evidenceRows) {
-		if (e.runId === null || e.detectorId === null) continue;
-		const set = detectorsByRun.get(e.runId);
-		if (set === undefined) detectorsByRun.set(e.runId, new Set([e.detectorId]));
-		else set.add(e.detectorId);
+	function signalsAtOrBelow(stage: GrainStage): number | null {
+		if (evidenceRows.length === 0 || stage === "unknown") return null;
+		const cap = STAGE_ORDER[stage];
+		const detectors = new Set<string>();
+		for (const e of evidenceRows) {
+			if (e.detectorId === null) continue;
+			const order = STAGE_ORDER[stageOfRow(e)];
+			// Legacy rows without grain bits rank as add_source-era evidence.
+			if ((order === -1 ? 0 : order) <= cap) detectors.add(e.detectorId);
+		}
+		return detectors.size;
 	}
-	return readinessRows
-		.map((r) => ({
-			stage: stageOfRow(r),
-			band: r.band ?? "",
-			worst_intent_risk: r.worstIntentRisk ?? null,
-			computed_at: r.computedAt?.toISOString() ?? null,
-			session_id: r.sessionId ?? null,
-			run_id: r.runId ?? null,
-			signals:
-				evidenceRows.length === 0
-					? null
-					: (detectorsByRun.get(r.runId ?? "")?.size ?? 0),
-		}))
-		.sort((a, b) => (a.computed_at ?? "").localeCompare(b.computed_at ?? ""));
+	return (
+		readinessRows
+			.map((r) => {
+				const stage = stageOfRow(r);
+				return {
+					stage,
+					band: r.band ?? "",
+					worst_intent_risk: r.worstIntentRisk ?? null,
+					computed_at: r.computedAt?.toISOString() ?? null,
+					session_id: r.sessionId ?? null,
+					run_id: r.runId ?? null,
+					signals: signalsAtOrBelow(stage),
+				};
+			})
+			// ISO strings sort chronologically; null → "" sorts before any real
+			// timestamp (oldest first).
+			.sort((a, b) => (a.computed_at ?? "").localeCompare(b.computed_at ?? ""))
+	);
 }
+
+/** Zod mirror of {@link VerdictHistoryEntry} for the tools' output schemas. */
+export const VerdictHistorySchema = z.object({
+	stage: z.string(),
+	band: z.string(),
+	worst_intent_risk: z.number().nullable(),
+	computed_at: z.string().nullable(),
+	session_id: z.string().nullable(),
+	run_id: z.string().nullable(),
+	signals: z.number().nullable(),
+});

--- a/packages/cockpit/src/tools/readiness-grain.ts
+++ b/packages/cockpit/src/tools/readiness-grain.ts
@@ -30,6 +30,24 @@ function isSessionGrain(row: GrainRow): boolean {
 	return row.viaSessionHead === true || row.viaOperatingModelHead === true;
 }
 
+/** The pipeline stage a snapshot row was sealed by (DAT-513). The pick is only
+ * evaluable if the caller can SEE it — every surface that shows a picked
+ * verdict labels it with this stage. `operating_model` outranks
+ * `session_detect` in the label when both bits are set (they never are today:
+ * a row is sealed by exactly one head; the order is defensive). */
+export type GrainStage =
+	| "add_source"
+	| "session_detect"
+	| "operating_model"
+	| "unknown";
+
+export function stageOfRow(row: GrainRow): GrainStage {
+	if (row.viaOperatingModelHead === true) return "operating_model";
+	if (row.viaSessionHead === true) return "session_detect";
+	if (row.viaTableHead === true) return "add_source";
+	return "unknown";
+}
+
 /** Latest by computedAt; null sorts oldest; ties keep the earlier row —
  * "earlier" meaning input-array order, so an `.orderBy` added at a call site
  * would silently change the tie-break. Ties are genuinely arbitrary today. */
@@ -91,4 +109,57 @@ export function mergeCurrentEvidence<
 		if (picked !== undefined) merged.push(picked);
 	}
 	return merged;
+}
+
+/** One snapshot row in a target's verdict history (DAT-513) — the disclosure
+ * surface for the pick: every coexisting row, labeled, oldest first. Cross-
+ * session rows appear here instead of being silently dropped. */
+export interface VerdictHistoryEntry {
+	stage: GrainStage;
+	band: string;
+	worst_intent_risk: number | null;
+	computed_at: string | null;
+	session_id: string | null;
+	run_id: string | null;
+	/** Distinct detectors backing that run's evidence — shows WHY a later
+	 * snapshot supersedes (more evidence), null when the caller passed none. */
+	signals: number | null;
+}
+
+/** Project a target's coexisting readiness rows into the labeled history.
+ * `evidenceRows` (optional) are the UNMERGED entropy-object rows for the same
+ * target — used only to count distinct detectors per run. */
+export function projectVerdictHistory(
+	readinessRows: readonly (GrainRow & {
+		band: string | null;
+		worstIntentRisk: number | null;
+		sessionId: string | null;
+		runId: string | null;
+	})[],
+	evidenceRows: readonly {
+		runId: string | null;
+		detectorId: string | null;
+	}[] = [],
+): VerdictHistoryEntry[] {
+	const detectorsByRun = new Map<string, Set<string>>();
+	for (const e of evidenceRows) {
+		if (e.runId === null || e.detectorId === null) continue;
+		const set = detectorsByRun.get(e.runId);
+		if (set === undefined) detectorsByRun.set(e.runId, new Set([e.detectorId]));
+		else set.add(e.detectorId);
+	}
+	return readinessRows
+		.map((r) => ({
+			stage: stageOfRow(r),
+			band: r.band ?? "",
+			worst_intent_risk: r.worstIntentRisk ?? null,
+			computed_at: r.computedAt?.toISOString() ?? null,
+			session_id: r.sessionId ?? null,
+			run_id: r.runId ?? null,
+			signals:
+				evidenceRows.length === 0
+					? null
+					: (detectorsByRun.get(r.runId ?? "")?.size ?? 0),
+		}))
+		.sort((a, b) => (a.computed_at ?? "").localeCompare(b.computed_at ?? ""));
 }

--- a/packages/cockpit/src/tools/why-column.test.ts
+++ b/packages/cockpit/src/tools/why-column.test.ts
@@ -23,6 +23,8 @@ function readiness(overrides: Partial<WhyReadinessRow> = {}): WhyReadinessRow {
 		columnName: "amount",
 		tableName: "orders",
 		band: "investigate",
+		bandStage: "session_detect",
+		bandComputedAt: new Date("2026-06-11T10:00:00Z"),
 		worstIntentRisk: 0.42,
 		intents: [
 			{

--- a/packages/cockpit/src/tools/why-column.ts
+++ b/packages/cockpit/src/tools/why-column.ts
@@ -40,6 +40,7 @@ import {
 	projectVerdictHistory,
 	stageOfRow,
 	type VerdictHistoryEntry,
+	VerdictHistorySchema,
 } from "./readiness-grain";
 
 // The persisted JSONB grammar (intents / drivers) is shared with look_table —
@@ -63,16 +64,6 @@ const EvidenceSignal = z.object({
 	// detector), rendered agent-safe via `renderEvidenceDetail` (DAT-433) — the
 	// narrative + the widget render it as-is.
 	detail: z.string(),
-});
-
-const VerdictHistory = z.object({
-	stage: z.string(),
-	band: z.string(),
-	worst_intent_risk: z.number().nullable(),
-	computed_at: z.string().nullable(),
-	session_id: z.string().nullable(),
-	run_id: z.string().nullable(),
-	signals: z.number().nullable(),
 });
 
 const WhyColumnResult = z.object({
@@ -101,7 +92,7 @@ const WhyColumnResult = z.object({
 	// Every coexisting readiness snapshot for this column (add_source →
 	// session → operating_model, oldest first), each labeled with its stage,
 	// session, run, and detector count — the disclosure for the pick above.
-	verdict_history: z.array(VerdictHistory),
+	verdict_history: z.array(VerdictHistorySchema),
 	analysis: z.string(),
 	pending_teaches: z.number(),
 });
@@ -368,8 +359,9 @@ export const whyColumnTool = toolDefinition({
 		"names the pipeline stage that sealed the shown verdict (add_source / " +
 		"session_detect / operating_model), and verdict_history lists every " +
 		"coexisting snapshot (oldest first) so you can see how the verdict " +
-		"evolved as evidence accrued — later stages are computed over strictly " +
-		"more evidence; they supersede, they don't disagree.",
+		"evolved as evidence accrued — each entry's signals counts the detectors " +
+		"its rollup ran over, so later stages carry strictly more; they " +
+		"supersede earlier ones, they don't disagree.",
 	inputSchema: z.object({
 		column_id: z
 			.string()

--- a/packages/cockpit/src/tools/why-column.ts
+++ b/packages/cockpit/src/tools/why-column.ts
@@ -34,7 +34,13 @@ import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { getWhyInstructions } from "../prompts";
-import { mergeCurrentEvidence, pickCurrentRow } from "./readiness-grain";
+import {
+	mergeCurrentEvidence,
+	pickCurrentRow,
+	projectVerdictHistory,
+	stageOfRow,
+	type VerdictHistoryEntry,
+} from "./readiness-grain";
 
 // The persisted JSONB grammar (intents / drivers) is shared with look_table —
 // see `db/metadata/readiness-schemas.ts`. Parsed leniently below.
@@ -59,6 +65,16 @@ const EvidenceSignal = z.object({
 	detail: z.string(),
 });
 
+const VerdictHistory = z.object({
+	stage: z.string(),
+	band: z.string(),
+	worst_intent_risk: z.number().nullable(),
+	computed_at: z.string().nullable(),
+	session_id: z.string().nullable(),
+	run_id: z.string().nullable(),
+	signals: z.number().nullable(),
+});
+
 const WhyColumnResult = z.object({
 	column_id: z.string(),
 	column_name: z.string(),
@@ -71,6 +87,10 @@ const WhyColumnResult = z.object({
 	found: z.boolean(),
 	// null band = no readiness row yet (not analyzed).
 	band: z.string().nullable(),
+	// WHICH pipeline stage sealed the shown verdict (DAT-513) — the pick is
+	// only evaluable if the caller can see it. null when unanalyzed.
+	band_stage: z.string().nullable(),
+	band_computed_at: z.string().nullable(),
 	worst_intent_risk: z.number().nullable(),
 	analyzed: z.boolean(),
 	intents: z.array(IntentExplanation),
@@ -78,6 +98,10 @@ const WhyColumnResult = z.object({
 	// How many detector signals back this explanation — surfaced so the narrative
 	// (and the reader) can see when the picture is partial (orphaned detectors).
 	signal_count: z.number(),
+	// Every coexisting readiness snapshot for this column (add_source →
+	// session → operating_model, oldest first), each labeled with its stage,
+	// session, run, and detector count — the disclosure for the pick above.
+	verdict_history: z.array(VerdictHistory),
 	analysis: z.string(),
 	pending_teaches: z.number(),
 });
@@ -93,6 +117,9 @@ export interface WhyReadinessRow {
 	/** Raw physical table name (`src_<digest>__<stem>`) — projected to display form. */
 	tableName: string;
 	band: string | null;
+	/** Stage that sealed the picked verdict (DAT-513); null when unanalyzed. */
+	bandStage: string | null;
+	bandComputedAt: Date | null;
 	worstIntentRisk: number | null;
 	intents: unknown;
 }
@@ -117,6 +144,7 @@ export function projectWhyData(
 	readiness: WhyReadinessRow,
 	evidenceRows: WhyEvidenceRow[],
 	pendingTeaches: number,
+	verdictHistory: VerdictHistoryEntry[] = [],
 ): WhyColumnData {
 	const parsed = PersistedIntent.array().safeParse(readiness.intents);
 	const intents: z.infer<typeof IntentExplanation>[] = parsed.success
@@ -147,11 +175,17 @@ export function projectWhyData(
 		table_name: displayTableName(readiness.tableName),
 		found: true,
 		band: readiness.band ?? null,
+		band_stage: readiness.band === null ? null : (readiness.bandStage ?? null),
+		band_computed_at:
+			readiness.band === null
+				? null
+				: (readiness.bandComputedAt?.toISOString() ?? null),
 		worst_intent_risk: readiness.worstIntentRisk ?? null,
 		analyzed: readiness.band !== null,
 		intents,
 		evidence,
 		signal_count: evidence.length,
+		verdict_history: verdictHistory,
 		pending_teaches: pendingTeaches,
 	};
 }
@@ -227,11 +261,14 @@ export async function whyColumn(
 			table_name: "",
 			found: false,
 			band: null,
+			band_stage: null,
+			band_computed_at: null,
 			worst_intent_risk: null,
 			analyzed: false,
 			intents: [],
 			evidence: [],
 			signal_count: 0,
+			verdict_history: [],
 			analysis: "",
 			pending_teaches: 0,
 		};
@@ -242,20 +279,21 @@ export async function whyColumn(
 	// run → empty views → unanalyzed (null band). The view is multi-grain
 	// (add_source table head + session-grain heads coexist) — fetch all grains
 	// and pick explicitly: session re-roll supersedes the add_source verdict.
-	const readinessRow = pickCurrentRow(
-		await metadataDb
-			.select({
-				band: currentEntropyReadiness.band,
-				worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
-				intents: currentEntropyReadiness.intents,
-				computedAt: currentEntropyReadiness.computedAt,
-				viaTableHead: currentEntropyReadiness.viaTableHead,
-				viaSessionHead: currentEntropyReadiness.viaSessionHead,
-				viaOperatingModelHead: currentEntropyReadiness.viaOperatingModelHead,
-			})
-			.from(currentEntropyReadiness)
-			.where(eq(currentEntropyReadiness.columnId, input.column_id)),
-	);
+	const allReadinessRows = await metadataDb
+		.select({
+			band: currentEntropyReadiness.band,
+			worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
+			intents: currentEntropyReadiness.intents,
+			computedAt: currentEntropyReadiness.computedAt,
+			sessionId: currentEntropyReadiness.sessionId,
+			runId: currentEntropyReadiness.runId,
+			viaTableHead: currentEntropyReadiness.viaTableHead,
+			viaSessionHead: currentEntropyReadiness.viaSessionHead,
+			viaOperatingModelHead: currentEntropyReadiness.viaOperatingModelHead,
+		})
+		.from(currentEntropyReadiness)
+		.where(eq(currentEntropyReadiness.columnId, input.column_id));
+	const readinessRow = pickCurrentRow(allReadinessRows);
 
 	// View columns type as nullable (Postgres views carry no NOT NULL); the
 	// underlying tables guarantee these — coalesce at the edge.
@@ -264,6 +302,8 @@ export async function whyColumn(
 		columnName: col.columnName ?? "",
 		tableName: col.tableName ?? "",
 		band: readinessRow?.band ?? null,
+		bandStage: readinessRow === undefined ? null : stageOfRow(readinessRow),
+		bandComputedAt: readinessRow?.computedAt ?? null,
 		worstIntentRisk: readinessRow?.worstIntentRisk ?? null,
 		intents: readinessRow?.intents ?? null,
 	};
@@ -273,24 +313,24 @@ export async function whyColumn(
 	// detectors keep their table-head row; re-adjudicated detectors (e.g.
 	// temporal_behavior's session pass) and operating_model fan-out rows
 	// (cross_table_consistency on failed criticals) show the session verdict.
-	const rawEvidence = mergeCurrentEvidence(
-		await metadataDb
-			.select({
-				layer: currentEntropyObjects.layer,
-				dimension: currentEntropyObjects.dimension,
-				subDimension: currentEntropyObjects.subDimension,
-				score: currentEntropyObjects.score,
-				detectorId: currentEntropyObjects.detectorId,
-				evidence: currentEntropyObjects.evidence,
-				computedAt: currentEntropyObjects.computedAt,
-				viaTableHead: currentEntropyObjects.viaTableHead,
-				viaSessionHead: currentEntropyObjects.viaSessionHead,
-				viaOperatingModelHead: currentEntropyObjects.viaOperatingModelHead,
-			})
-			.from(currentEntropyObjects)
-			.where(eq(currentEntropyObjects.columnId, input.column_id))
-			.orderBy(asc(currentEntropyObjects.dimension)),
-	);
+	const unmergedEvidence = await metadataDb
+		.select({
+			layer: currentEntropyObjects.layer,
+			dimension: currentEntropyObjects.dimension,
+			subDimension: currentEntropyObjects.subDimension,
+			score: currentEntropyObjects.score,
+			detectorId: currentEntropyObjects.detectorId,
+			evidence: currentEntropyObjects.evidence,
+			computedAt: currentEntropyObjects.computedAt,
+			runId: currentEntropyObjects.runId,
+			viaTableHead: currentEntropyObjects.viaTableHead,
+			viaSessionHead: currentEntropyObjects.viaSessionHead,
+			viaOperatingModelHead: currentEntropyObjects.viaOperatingModelHead,
+		})
+		.from(currentEntropyObjects)
+		.where(eq(currentEntropyObjects.columnId, input.column_id))
+		.orderBy(asc(currentEntropyObjects.dimension));
+	const rawEvidence = mergeCurrentEvidence(unmergedEvidence);
 	const evidenceRows = rawEvidence.map((e) => ({
 		layer: e.layer ?? "",
 		dimension: e.dimension ?? "",
@@ -301,7 +341,12 @@ export async function whyColumn(
 	}));
 
 	const pending = await getPendingOverlays();
-	const data = projectWhyData(readiness, evidenceRows, pending.length);
+	const data = projectWhyData(
+		readiness,
+		evidenceRows,
+		pending.length,
+		projectVerdictHistory(allReadinessRows, unmergedEvidence),
+	);
 
 	// Nothing to explain when the column has no readiness row — skip the LLM call
 	// (no cost, no risk of fabricating an explanation for absent data).
@@ -319,7 +364,12 @@ export const whyColumnTool = toolDefinition({
 		"evidence, with a short synthesized explanation. Read-only. Use after " +
 		"look_table to drill into a specific column. Identify the column by its " +
 		"column_id (from look_table). signal_count shows how many detector signals " +
-		"back the explanation — a low count means the picture is partial.",
+		"back the explanation — a low count means the picture is partial. band_stage " +
+		"names the pipeline stage that sealed the shown verdict (add_source / " +
+		"session_detect / operating_model), and verdict_history lists every " +
+		"coexisting snapshot (oldest first) so you can see how the verdict " +
+		"evolved as evidence accrued — later stages are computed over strictly " +
+		"more evidence; they supersede, they don't disagree.",
 	inputSchema: z.object({
 		column_id: z
 			.string()

--- a/packages/cockpit/src/tools/why-relationship.test.ts
+++ b/packages/cockpit/src/tools/why-relationship.test.ts
@@ -31,6 +31,8 @@ function readiness(
 	overrides: Partial<WhyRelReadinessRow> = {},
 ): WhyRelReadinessRow {
 	return {
+		bandStage: "session_detect",
+		bandComputedAt: new Date("2026-06-11T10:00:00Z"),
 		band: "investigate",
 		worstIntentRisk: 0.42,
 		intents: [

--- a/packages/cockpit/src/tools/why-relationship.ts
+++ b/packages/cockpit/src/tools/why-relationship.ts
@@ -41,6 +41,7 @@ import {
 	projectVerdictHistory,
 	stageOfRow,
 	type VerdictHistoryEntry,
+	VerdictHistorySchema,
 } from "./readiness-grain";
 
 // --- Tool output (mirrors why_column, keyed on the relationship pair).
@@ -57,16 +58,6 @@ const EvidenceSignal = z.object({
 	detector_id: z.string(),
 	score: z.number(),
 	detail: z.string(),
-});
-
-const VerdictHistory = z.object({
-	stage: z.string(),
-	band: z.string(),
-	worst_intent_risk: z.number().nullable(),
-	computed_at: z.string().nullable(),
-	session_id: z.string().nullable(),
-	run_id: z.string().nullable(),
-	signals: z.number().nullable(),
 });
 
 const WhyRelationshipResult = z.object({
@@ -93,7 +84,7 @@ const WhyRelationshipResult = z.object({
 	evidence: z.array(EvidenceSignal),
 	signal_count: z.number(),
 	// Every coexisting readiness snapshot for this pair, oldest first.
-	verdict_history: z.array(VerdictHistory),
+	verdict_history: z.array(VerdictHistorySchema),
 	analysis: z.string(),
 	pending_teaches: z.number(),
 });

--- a/packages/cockpit/src/tools/why-relationship.ts
+++ b/packages/cockpit/src/tools/why-relationship.ts
@@ -35,7 +35,13 @@ import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { getWhyInstructions } from "../prompts";
-import { mergeCurrentEvidence, pickCurrentRow } from "./readiness-grain";
+import {
+	mergeCurrentEvidence,
+	pickCurrentRow,
+	projectVerdictHistory,
+	stageOfRow,
+	type VerdictHistoryEntry,
+} from "./readiness-grain";
 
 // --- Tool output (mirrors why_column, keyed on the relationship pair).
 
@@ -53,6 +59,16 @@ const EvidenceSignal = z.object({
 	detail: z.string(),
 });
 
+const VerdictHistory = z.object({
+	stage: z.string(),
+	band: z.string(),
+	worst_intent_risk: z.number().nullable(),
+	computed_at: z.string().nullable(),
+	session_id: z.string().nullable(),
+	run_id: z.string().nullable(),
+	signals: z.number().nullable(),
+});
+
 const WhyRelationshipResult = z.object({
 	from_column_id: z.string(),
 	to_column_id: z.string(),
@@ -67,11 +83,17 @@ const WhyRelationshipResult = z.object({
 	// — distinct from "found but not analyzed".
 	found: z.boolean(),
 	band: z.string().nullable(),
+	// WHICH pipeline stage sealed the shown verdict (DAT-513) + when. null
+	// when unanalyzed.
+	band_stage: z.string().nullable(),
+	band_computed_at: z.string().nullable(),
 	worst_intent_risk: z.number().nullable(),
 	analyzed: z.boolean(),
 	intents: z.array(IntentExplanation),
 	evidence: z.array(EvidenceSignal),
 	signal_count: z.number(),
+	// Every coexisting readiness snapshot for this pair, oldest first.
+	verdict_history: z.array(VerdictHistory),
 	analysis: z.string(),
 	pending_teaches: z.number(),
 });
@@ -83,6 +105,9 @@ export type WhyRelationshipData = Omit<WhyRelationshipResult, "analysis">;
 /** The relationship's readiness row from the promoted run (null fields = no row). */
 export interface WhyRelReadinessRow {
 	band: string | null;
+	/** Stage that sealed the picked verdict (DAT-513); null when unanalyzed. */
+	bandStage: string | null;
+	bandComputedAt: Date | null;
 	worstIntentRisk: number | null;
 	intents: unknown;
 }
@@ -119,6 +144,7 @@ export function projectWhyRelationship(
 	readiness: WhyRelReadinessRow | null,
 	evidenceRows: WhyRelEvidenceRow[],
 	pendingTeaches: number,
+	verdictHistory: VerdictHistoryEntry[] = [],
 ): WhyRelationshipData {
 	const parsed = readiness
 		? PersistedIntent.array().safeParse(readiness.intents)
@@ -163,11 +189,17 @@ export function projectWhyRelationship(
 		// the pair in the promoted run.
 		found: readiness !== null || evidence.length > 0,
 		band: readiness?.band ?? null,
+		band_stage: readiness?.band == null ? null : (readiness.bandStage ?? null),
+		band_computed_at:
+			readiness?.band == null
+				? null
+				: (readiness.bandComputedAt?.toISOString() ?? null),
 		worst_intent_risk: readiness?.worstIntentRisk ?? null,
 		analyzed: (readiness?.band ?? null) !== null,
 		intents,
 		evidence,
 		signal_count: evidence.length,
+		verdict_history: verdictHistory,
 		pending_teaches: pendingTeaches,
 	};
 }
@@ -241,53 +273,54 @@ export async function whyRelationship(
 	// Relationship targets are written by session-grain runs only, but the pick
 	// keeps the read uniform with why_column/why_table (and deterministic should
 	// a second grain ever appear).
-	const readinessRow = pickCurrentRow(
-		await metadataDb
-			.select({
-				band: currentEntropyReadiness.band,
-				worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
-				intents: currentEntropyReadiness.intents,
-				computedAt: currentEntropyReadiness.computedAt,
-				viaTableHead: currentEntropyReadiness.viaTableHead,
-				viaSessionHead: currentEntropyReadiness.viaSessionHead,
-				viaOperatingModelHead: currentEntropyReadiness.viaOperatingModelHead,
-			})
-			.from(currentEntropyReadiness)
-			.where(
-				and(
-					eq(currentEntropyReadiness.sessionId, input.session_id),
-					eq(currentEntropyReadiness.target, target),
-				),
+	const allReadinessRows = await metadataDb
+		.select({
+			band: currentEntropyReadiness.band,
+			worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
+			intents: currentEntropyReadiness.intents,
+			computedAt: currentEntropyReadiness.computedAt,
+			sessionId: currentEntropyReadiness.sessionId,
+			runId: currentEntropyReadiness.runId,
+			viaTableHead: currentEntropyReadiness.viaTableHead,
+			viaSessionHead: currentEntropyReadiness.viaSessionHead,
+			viaOperatingModelHead: currentEntropyReadiness.viaOperatingModelHead,
+		})
+		.from(currentEntropyReadiness)
+		.where(
+			and(
+				eq(currentEntropyReadiness.sessionId, input.session_id),
+				eq(currentEntropyReadiness.target, target),
 			),
-	);
+		);
+	const readinessRow = pickCurrentRow(allReadinessRows);
 
 	// Evidence is keyed by the relationship target (relationship rows have no
 	// column_id); the view scopes to the promoted run, so stale runs can't
 	// inflate signal_count. View columns type as nullable (Postgres views carry
 	// no NOT NULL) — coalesce at the edge.
-	const rawEvidence = mergeCurrentEvidence(
-		await metadataDb
-			.select({
-				layer: currentEntropyObjects.layer,
-				dimension: currentEntropyObjects.dimension,
-				subDimension: currentEntropyObjects.subDimension,
-				score: currentEntropyObjects.score,
-				detectorId: currentEntropyObjects.detectorId,
-				evidence: currentEntropyObjects.evidence,
-				computedAt: currentEntropyObjects.computedAt,
-				viaTableHead: currentEntropyObjects.viaTableHead,
-				viaSessionHead: currentEntropyObjects.viaSessionHead,
-				viaOperatingModelHead: currentEntropyObjects.viaOperatingModelHead,
-			})
-			.from(currentEntropyObjects)
-			.where(
-				and(
-					eq(currentEntropyObjects.sessionId, input.session_id),
-					eq(currentEntropyObjects.target, target),
-				),
-			)
-			.orderBy(asc(currentEntropyObjects.dimension)),
-	);
+	const unmergedEvidence = await metadataDb
+		.select({
+			layer: currentEntropyObjects.layer,
+			dimension: currentEntropyObjects.dimension,
+			subDimension: currentEntropyObjects.subDimension,
+			score: currentEntropyObjects.score,
+			detectorId: currentEntropyObjects.detectorId,
+			evidence: currentEntropyObjects.evidence,
+			computedAt: currentEntropyObjects.computedAt,
+			runId: currentEntropyObjects.runId,
+			viaTableHead: currentEntropyObjects.viaTableHead,
+			viaSessionHead: currentEntropyObjects.viaSessionHead,
+			viaOperatingModelHead: currentEntropyObjects.viaOperatingModelHead,
+		})
+		.from(currentEntropyObjects)
+		.where(
+			and(
+				eq(currentEntropyObjects.sessionId, input.session_id),
+				eq(currentEntropyObjects.target, target),
+			),
+		)
+		.orderBy(asc(currentEntropyObjects.dimension));
+	const rawEvidence = mergeCurrentEvidence(unmergedEvidence);
 	const evidenceRows = rawEvidence.map((e) => ({
 		layer: e.layer ?? "",
 		dimension: e.dimension ?? "",
@@ -302,9 +335,16 @@ export async function whyRelationship(
 		input.from_column_id,
 		input.to_column_id,
 		endpoints,
-		readinessRow ?? null,
+		readinessRow === undefined
+			? null
+			: {
+					...readinessRow,
+					bandStage: stageOfRow(readinessRow),
+					bandComputedAt: readinessRow.computedAt ?? null,
+				},
 		evidenceRows,
 		pending.length,
+		projectVerdictHistory(allReadinessRows, unmergedEvidence),
 	);
 
 	// Nothing to explain when there's no readiness row — skip the LLM call.

--- a/packages/cockpit/src/tools/why-table.test.ts
+++ b/packages/cockpit/src/tools/why-table.test.ts
@@ -24,6 +24,8 @@ function readiness(
 ): WhyTableReadinessRow {
 	return {
 		band: "investigate",
+		bandStage: "session_detect",
+		bandComputedAt: new Date("2026-06-11T10:00:00Z"),
 		worstIntentRisk: 0.42,
 		intents: [
 			{

--- a/packages/cockpit/src/tools/why-table.ts
+++ b/packages/cockpit/src/tools/why-table.ts
@@ -41,6 +41,7 @@ import {
 	projectVerdictHistory,
 	stageOfRow,
 	type VerdictHistoryEntry,
+	VerdictHistorySchema,
 } from "./readiness-grain";
 
 // --- Tool output (mirrors why_column / why_relationship, keyed on the table).
@@ -57,16 +58,6 @@ const EvidenceSignal = z.object({
 	detector_id: z.string(),
 	score: z.number(),
 	detail: z.string(),
-});
-
-const VerdictHistory = z.object({
-	stage: z.string(),
-	band: z.string(),
-	worst_intent_risk: z.number().nullable(),
-	computed_at: z.string().nullable(),
-	session_id: z.string().nullable(),
-	run_id: z.string().nullable(),
-	signals: z.number().nullable(),
 });
 
 const WhyTableResult = z.object({
@@ -90,7 +81,7 @@ const WhyTableResult = z.object({
 	signal_count: z.number(),
 	// Every coexisting readiness snapshot for this target, oldest first — the
 	// disclosure for the pick above.
-	verdict_history: z.array(VerdictHistory),
+	verdict_history: z.array(VerdictHistorySchema),
 	analysis: z.string(),
 	pending_teaches: z.number(),
 });

--- a/packages/cockpit/src/tools/why-table.ts
+++ b/packages/cockpit/src/tools/why-table.ts
@@ -35,7 +35,13 @@ import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { getWhyInstructions } from "../prompts";
-import { mergeCurrentEvidence, pickCurrentRow } from "./readiness-grain";
+import {
+	mergeCurrentEvidence,
+	pickCurrentRow,
+	projectVerdictHistory,
+	stageOfRow,
+	type VerdictHistoryEntry,
+} from "./readiness-grain";
 
 // --- Tool output (mirrors why_column / why_relationship, keyed on the table).
 
@@ -53,6 +59,16 @@ const EvidenceSignal = z.object({
 	detail: z.string(),
 });
 
+const VerdictHistory = z.object({
+	stage: z.string(),
+	band: z.string(),
+	worst_intent_risk: z.number().nullable(),
+	computed_at: z.string().nullable(),
+	session_id: z.string().nullable(),
+	run_id: z.string().nullable(),
+	signals: z.number().nullable(),
+});
+
 const WhyTableResult = z.object({
 	table_id: z.string(),
 	// Display name (`src_<digest>__` prefix stripped, DAT-431 — this result feeds
@@ -63,11 +79,18 @@ const WhyTableResult = z.object({
 	// the promoted run — distinct from "found but not analyzed".
 	found: z.boolean(),
 	band: z.string().nullable(),
+	// WHICH pipeline stage sealed the shown verdict (DAT-513) + when — the
+	// pick is only evaluable if the caller can see it. null when unanalyzed.
+	band_stage: z.string().nullable(),
+	band_computed_at: z.string().nullable(),
 	worst_intent_risk: z.number().nullable(),
 	analyzed: z.boolean(),
 	intents: z.array(IntentExplanation),
 	evidence: z.array(EvidenceSignal),
 	signal_count: z.number(),
+	// Every coexisting readiness snapshot for this target, oldest first — the
+	// disclosure for the pick above.
+	verdict_history: z.array(VerdictHistory),
 	analysis: z.string(),
 	pending_teaches: z.number(),
 });
@@ -79,6 +102,9 @@ export type WhyTableData = Omit<WhyTableResult, "analysis">;
 /** The table's readiness row from the promoted run (null fields = no row). */
 export interface WhyTableReadinessRow {
 	band: string | null;
+	/** Stage that sealed the picked verdict (DAT-513); null when unanalyzed. */
+	bandStage: string | null;
+	bandComputedAt: Date | null;
 	worstIntentRisk: number | null;
 	intents: unknown;
 }
@@ -106,6 +132,7 @@ export function projectWhyTable(
 	readiness: WhyTableReadinessRow | null,
 	evidenceRows: WhyTableEvidenceRow[],
 	pendingTeaches: number,
+	verdictHistory: VerdictHistoryEntry[] = [],
 ): WhyTableData {
 	const parsed = readiness
 		? PersistedIntent.array().safeParse(readiness.intents)
@@ -139,11 +166,17 @@ export function projectWhyTable(
 		// the table in the promoted run.
 		found: readiness !== null || evidence.length > 0,
 		band: readiness?.band ?? null,
+		band_stage: readiness?.band == null ? null : (readiness.bandStage ?? null),
+		band_computed_at:
+			readiness?.band == null
+				? null
+				: (readiness.bandComputedAt?.toISOString() ?? null),
 		worst_intent_risk: readiness?.worstIntentRisk ?? null,
 		analyzed: (readiness?.band ?? null) !== null,
 		intents,
 		evidence,
 		signal_count: evidence.length,
+		verdict_history: verdictHistory,
 		pending_teaches: pendingTeaches,
 	};
 }
@@ -225,53 +258,54 @@ export async function whyTable(
 	// `entropy_readiness.session_id` is NOT NULL even on add_source rows, so the
 	// session scope alone does not exclude the table-head grain — pick explicitly
 	// (session re-roll supersedes the add_source verdict).
-	const readinessRow = pickCurrentRow(
-		await metadataDb
-			.select({
-				band: currentEntropyReadiness.band,
-				worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
-				intents: currentEntropyReadiness.intents,
-				computedAt: currentEntropyReadiness.computedAt,
-				viaTableHead: currentEntropyReadiness.viaTableHead,
-				viaSessionHead: currentEntropyReadiness.viaSessionHead,
-				viaOperatingModelHead: currentEntropyReadiness.viaOperatingModelHead,
-			})
-			.from(currentEntropyReadiness)
-			.where(
-				and(
-					eq(currentEntropyReadiness.sessionId, input.session_id),
-					eq(currentEntropyReadiness.target, target),
-				),
+	const allReadinessRows = await metadataDb
+		.select({
+			band: currentEntropyReadiness.band,
+			worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
+			intents: currentEntropyReadiness.intents,
+			computedAt: currentEntropyReadiness.computedAt,
+			sessionId: currentEntropyReadiness.sessionId,
+			runId: currentEntropyReadiness.runId,
+			viaTableHead: currentEntropyReadiness.viaTableHead,
+			viaSessionHead: currentEntropyReadiness.viaSessionHead,
+			viaOperatingModelHead: currentEntropyReadiness.viaOperatingModelHead,
+		})
+		.from(currentEntropyReadiness)
+		.where(
+			and(
+				eq(currentEntropyReadiness.sessionId, input.session_id),
+				eq(currentEntropyReadiness.target, target),
 			),
-	);
+		);
+	const readinessRow = pickCurrentRow(allReadinessRows);
 
 	// Evidence is keyed by the table target (table-grain rows have no column_id);
 	// the view scopes to the promoted run, so stale runs can't inflate signal_count.
 	// Merge per detector across grains: a session re-adjudication wins over the
 	// add_source row for the same detector.
-	const rawEvidence = mergeCurrentEvidence(
-		await metadataDb
-			.select({
-				layer: currentEntropyObjects.layer,
-				dimension: currentEntropyObjects.dimension,
-				subDimension: currentEntropyObjects.subDimension,
-				score: currentEntropyObjects.score,
-				detectorId: currentEntropyObjects.detectorId,
-				evidence: currentEntropyObjects.evidence,
-				computedAt: currentEntropyObjects.computedAt,
-				viaTableHead: currentEntropyObjects.viaTableHead,
-				viaSessionHead: currentEntropyObjects.viaSessionHead,
-				viaOperatingModelHead: currentEntropyObjects.viaOperatingModelHead,
-			})
-			.from(currentEntropyObjects)
-			.where(
-				and(
-					eq(currentEntropyObjects.sessionId, input.session_id),
-					eq(currentEntropyObjects.target, target),
-				),
-			)
-			.orderBy(asc(currentEntropyObjects.dimension)),
-	);
+	const unmergedEvidence = await metadataDb
+		.select({
+			layer: currentEntropyObjects.layer,
+			dimension: currentEntropyObjects.dimension,
+			subDimension: currentEntropyObjects.subDimension,
+			score: currentEntropyObjects.score,
+			detectorId: currentEntropyObjects.detectorId,
+			evidence: currentEntropyObjects.evidence,
+			computedAt: currentEntropyObjects.computedAt,
+			runId: currentEntropyObjects.runId,
+			viaTableHead: currentEntropyObjects.viaTableHead,
+			viaSessionHead: currentEntropyObjects.viaSessionHead,
+			viaOperatingModelHead: currentEntropyObjects.viaOperatingModelHead,
+		})
+		.from(currentEntropyObjects)
+		.where(
+			and(
+				eq(currentEntropyObjects.sessionId, input.session_id),
+				eq(currentEntropyObjects.target, target),
+			),
+		)
+		.orderBy(asc(currentEntropyObjects.dimension));
+	const rawEvidence = mergeCurrentEvidence(unmergedEvidence);
 	// View columns type as nullable (Postgres views carry no NOT NULL); the
 	// underlying table guarantees these — coalesce at the edge.
 	const evidenceRows: WhyTableEvidenceRow[] = rawEvidence.map((e) => ({
@@ -287,9 +321,16 @@ export async function whyTable(
 	const data = projectWhyTable(
 		input.table_id,
 		tableName,
-		readinessRow ?? null,
+		readinessRow === undefined
+			? null
+			: {
+					...readinessRow,
+					bandStage: stageOfRow(readinessRow),
+					bandComputedAt: readinessRow.computedAt ?? null,
+				},
 		evidenceRows,
 		pending.length,
+		projectVerdictHistory(allReadinessRows, unmergedEvidence),
 	);
 
 	// Nothing to explain when there's no readiness row — skip the LLM call.

--- a/packages/cockpit/src/ui/cockpit/widgets/column-why.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/column-why.test.tsx
@@ -27,6 +27,8 @@ const analyzed: WhyColumnResult = {
 	table_name: "orders",
 	found: true,
 	band: "investigate",
+	band_stage: "session_detect",
+	band_computed_at: "2026-06-11T10:00:00.000Z",
 	worst_intent_risk: 0.42,
 	analyzed: true,
 	intents: [
@@ -54,6 +56,26 @@ const analyzed: WhyColumnResult = {
 		},
 	],
 	signal_count: 1,
+	verdict_history: [
+		{
+			stage: "add_source",
+			band: "blocked",
+			worst_intent_risk: 0.8,
+			computed_at: "2026-06-11T09:00:00.000Z",
+			session_id: "sess-1",
+			run_id: "run-add",
+			signals: 7,
+		},
+		{
+			stage: "session_detect",
+			band: "investigate",
+			worst_intent_risk: 0.42,
+			computed_at: "2026-06-11T10:00:00.000Z",
+			session_id: "sess-1",
+			run_id: "run-ses",
+			signals: 12,
+		},
+	],
 	analysis: "amount has no declared unit, so summing it could mix currencies.",
 	pending_teaches: 0,
 };
@@ -103,6 +125,26 @@ describe("ColumnWhyWidget (DAT-351)", () => {
 				},
 			],
 			signal_count: 1,
+			verdict_history: [
+				{
+					stage: "add_source",
+					band: "blocked",
+					worst_intent_risk: 0.8,
+					computed_at: "2026-06-11T09:00:00.000Z",
+					session_id: "sess-1",
+					run_id: "run-add",
+					signals: 7,
+				},
+				{
+					stage: "session_detect",
+					band: "investigate",
+					worst_intent_risk: 0.42,
+					computed_at: "2026-06-11T10:00:00.000Z",
+					session_id: "sess-1",
+					run_id: "run-ses",
+					signals: 12,
+				},
+			],
 		});
 		// Empty dimension → a dash, not a hollow cell; the detector still humanizes.
 		expect(

--- a/packages/cockpit/src/ui/cockpit/widgets/column-why.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/column-why.tsx
@@ -15,6 +15,7 @@ import {
 	IntentDriversBlock,
 	PendingTeachAlert,
 	SignalsCaption,
+	VerdictProvenance,
 } from "#/ui/cockpit/widgets/why-detail";
 
 export function ColumnWhyWidget({
@@ -63,6 +64,13 @@ export function ColumnWhyWidget({
 				</Text>
 				<BandBadge band={why.band} />
 			</Group>
+
+			<VerdictProvenance
+				stage={why.band_stage}
+				computedAt={why.band_computed_at}
+				history={why.verdict_history}
+				testId="canvas-column-why-provenance"
+			/>
 
 			<SignalsCaption
 				count={why.signal_count}

--- a/packages/cockpit/src/ui/cockpit/widgets/relationship-why.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/relationship-why.test.tsx
@@ -29,6 +29,8 @@ const analyzed: WhyRelationshipResult = {
 	to_column_name: "id",
 	found: true,
 	band: "ready",
+	band_stage: "session_detect",
+	band_computed_at: "2026-06-11T10:00:00.000Z",
 	worst_intent_risk: 0.1,
 	analyzed: true,
 	intents: [
@@ -48,6 +50,7 @@ const analyzed: WhyRelationshipResult = {
 		},
 	],
 	signal_count: 1,
+	verdict_history: [],
 	analysis: "The join key is clean: orphan ratio is negligible.",
 	pending_teaches: 0,
 };

--- a/packages/cockpit/src/ui/cockpit/widgets/relationship-why.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/relationship-why.tsx
@@ -15,6 +15,7 @@ import {
 	PendingTeachAlert,
 	relationshipEndpointLabel,
 	SignalsCaption,
+	VerdictProvenance,
 } from "#/ui/cockpit/widgets/why-detail";
 
 export function RelationshipWhyWidget({
@@ -72,6 +73,13 @@ export function RelationshipWhyWidget({
 				</Text>
 				<BandBadge band={why.band} />
 			</Group>
+
+			<VerdictProvenance
+				stage={why.band_stage}
+				computedAt={why.band_computed_at}
+				history={why.verdict_history}
+				testId="canvas-relationship-why-provenance"
+			/>
 
 			<SignalsCaption
 				count={why.signal_count}

--- a/packages/cockpit/src/ui/cockpit/widgets/table-readiness.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-readiness.test.tsx
@@ -49,6 +49,7 @@ const analyzed: LookTableResult = {
 			column_name: "amount",
 			resolved_type: "DECIMAL(18,2)",
 			band: "investigate",
+			band_stage: "session_detect",
 			worst_intent_risk: 0.42,
 			// The persisted intent keys are the engine's network NODE names
 			// (`*_intent`), not the bare words — the widget matches on these.
@@ -66,6 +67,7 @@ const analyzed: LookTableResult = {
 			column_name: "id",
 			resolved_type: "INTEGER",
 			band: "ready",
+			band_stage: "add_source",
 			worst_intent_risk: 0.05,
 			intents: [{ intent: "query_intent", band: "ready", risk: 0.05 }],
 			top_drivers: [],
@@ -144,6 +146,7 @@ describe("TableReadinessWidget (DAT-350)", () => {
 					column_name: "x",
 					resolved_type: null,
 					band: null,
+					band_stage: null,
 					worst_intent_risk: null,
 					intents: [],
 					top_drivers: [],

--- a/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
@@ -21,7 +21,7 @@ import {
 	INTENT_LABEL,
 	INTENTS,
 } from "#/ui/cockpit/widgets/band-badge";
-import { PendingTeachAlert } from "#/ui/cockpit/widgets/why-detail";
+import { PendingTeachAlert, stageLabel } from "#/ui/cockpit/widgets/why-detail";
 
 // The begin_session whole-table band (DAT-415): the `dimension_coverage` rollup
 // for the table, sealed at the session head — distinct from, and shown above, the
@@ -251,7 +251,16 @@ export function TableReadinessWidget({
 											{c.resolved_type ?? "—"}
 										</Text>
 									</Table.Td>
-									<Table.Td>
+									<Table.Td
+										// The band's provenance (DAT-513): which pipeline stage
+										// sealed the shown verdict — visible on hover, drilled via
+										// why_column's verdict history.
+										title={
+											c.band_stage === null
+												? undefined
+												: `as of ${stageLabel(c.band_stage)}`
+										}
+									>
 										<BandBadge band={c.band} />
 									</Table.Td>
 									{INTENTS.map((intent) => (

--- a/packages/cockpit/src/ui/cockpit/widgets/table-why.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-why.test.tsx
@@ -26,6 +26,8 @@ const analyzed: WhyTableResult = {
 	table_name: "orders",
 	found: true,
 	band: "investigate",
+	band_stage: "session_detect",
+	band_computed_at: "2026-06-11T10:00:00.000Z",
 	worst_intent_risk: 0.42,
 	analyzed: true,
 	intents: [
@@ -53,6 +55,7 @@ const analyzed: WhyTableResult = {
 		},
 	],
 	signal_count: 1,
+	verdict_history: [],
 	analysis: "orders lacks dimensional coverage for reliable aggregation.",
 	pending_teaches: 0,
 };

--- a/packages/cockpit/src/ui/cockpit/widgets/table-why.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-why.tsx
@@ -15,6 +15,7 @@ import {
 	IntentDriversBlock,
 	PendingTeachAlert,
 	SignalsCaption,
+	VerdictProvenance,
 } from "#/ui/cockpit/widgets/why-detail";
 
 export function TableWhyWidget({
@@ -64,6 +65,13 @@ export function TableWhyWidget({
 				</Text>
 				<BandBadge band={why.band} />
 			</Group>
+
+			<VerdictProvenance
+				stage={why.band_stage}
+				computedAt={why.band_computed_at}
+				history={why.verdict_history}
+				testId="canvas-table-why-provenance"
+			/>
 
 			<SignalsCaption
 				count={why.signal_count}

--- a/packages/cockpit/src/ui/cockpit/widgets/why-detail.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/why-detail.tsx
@@ -211,7 +211,7 @@ export function VerdictProvenance({
 						<Group
 							gap="xs"
 							wrap="nowrap"
-							key={`${h.run_id ?? h.stage}-${h.computed_at ?? ""}`}
+							key={h.run_id ?? `${h.stage}-${h.computed_at ?? ""}`}
 						>
 							<Text size="xs" c="dimmed" w={140}>
 								{stageLabel(h.stage)}

--- a/packages/cockpit/src/ui/cockpit/widgets/why-detail.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/why-detail.tsx
@@ -151,3 +151,80 @@ export function EvidenceTable({
 		</Table.ScrollContainer>
 	);
 }
+
+// --- Verdict provenance (DAT-513) — the pick made visible. The shown band is
+// ONE of possibly several coexisting snapshot rows (add_source → session →
+// operating_model); this caption names which one, and the history lists them
+// all (oldest first) so a practitioner sees the verdict evolve as evidence
+// accrued. Later stages are computed over strictly more evidence — they
+// supersede earlier ones, they don't disagree with them.
+
+/** One readiness snapshot in a target's history — mirrors the tools' shape. */
+export interface VerdictHistoryRow {
+	stage: string;
+	band: string;
+	worst_intent_risk: number | null;
+	computed_at: string | null;
+	session_id: string | null;
+	run_id: string | null;
+	signals: number | null;
+}
+
+const STAGE_LABEL: Record<string, string> = {
+	add_source: "import",
+	session_detect: "session analysis",
+	operating_model: "operating model",
+};
+
+/** Human label for a pipeline stage; falls through to the raw stage string. */
+export function stageLabel(stage: string | null): string | null {
+	return stage === null ? null : (STAGE_LABEL[stage] ?? stage);
+}
+
+function historyTime(iso: string | null): string {
+	return iso === null ? "—" : new Date(iso).toLocaleString();
+}
+
+/** "as of <stage> · <time>" caption + the snapshot history (shown only when
+ * more than one snapshot coexists — a single row adds nothing). */
+export function VerdictProvenance({
+	stage,
+	computedAt,
+	history,
+	testId,
+}: {
+	stage: string | null;
+	computedAt: string | null;
+	history: VerdictHistoryRow[];
+	testId: string;
+}) {
+	if (stage === null) return null;
+	return (
+		<Stack gap={4} data-testid={testId}>
+			<Text size="xs" c="dimmed" data-testid={`${testId}-stage`}>
+				as of {stageLabel(stage)}
+				{computedAt !== null && ` · ${historyTime(computedAt)}`}
+			</Text>
+			{history.length > 1 && (
+				<Stack gap={2} data-testid={`${testId}-history`}>
+					{history.map((h) => (
+						<Group
+							gap="xs"
+							wrap="nowrap"
+							key={`${h.run_id ?? h.stage}-${h.computed_at ?? ""}`}
+						>
+							<Text size="xs" c="dimmed" w={140}>
+								{stageLabel(h.stage)}
+							</Text>
+							<BandBadge band={h.band} />
+							<Text size="xs" c="dimmed">
+								{historyTime(h.computed_at)}
+								{h.signals !== null && ` · ${h.signals} signals`}
+							</Text>
+						</Group>
+					))}
+				</Stack>
+			)}
+		</Stack>
+	);
+}


### PR DESCRIPTION
## Task

[DAT-513](https://real-dataraum.atlassian.net/browse/DAT-513) — follow-up to DAT-509 (#285), design decided with Philipp after the 2026-06-11 live smoke. Child of DAT-442.

## The problem

DAT-509's grain-precedence pick is semantically right (each stage's readiness row is recomputed over the run-resolved merge of every earlier grain — engine `_resolve_runs` — so snapshots are build states of one verdict, not competing opinions) but **invisible**: no surface said which stage/run/session the shown band came from, and the cross-session latest-`computedAt` tie-break was undisclosed. An unlabeled pick is indistinguishable from an arbitrary one.

## What changed (agreed design: one labeled verdict + history)

- **`readiness-grain.ts`**: `stageOfRow` (add_source / session_detect / operating_model from the head discriminators) + `projectVerdictHistory` — every coexisting snapshot, labeled, oldest first, with **stage-cumulative** `signals` (distinct detectors each rollup actually ran over: 7 → 12 → 13, the legible "why later supersedes") + shared `VerdictHistorySchema`.
- **why_column / why_table / why_relationship**: results gain `band_stage`, `band_computed_at`, and `verdict_history[]`. The history doubles as the cross-session disclosure — other sessions' rows are visible, not silently dropped. Tool description teaches the agent: later stages supersede, they don't disagree.
- **look_table**: per-column `band_stage`; the readiness grid band cell gets an "as of <stage>" tooltip.
- **Widgets**: shared `VerdictProvenance` block ("as of operating model · <time>" + history list when >1 snapshots) rendered in all three why widgets.
- Unchanged by design: list_tables tallies (aggregate grain), whole-table `loadTableBand` (single-grain by construction), the engine view's latest-promoted-wins filter.

## Review

senior-code-reviewer: APPROVE with 2 fixes — both applied (per-run signal slices were misleading for the operating_model row → reworked to stage-cumulative counting, which also eliminated the null-runId collision; Zod schema DRY'd into readiness-grain; React key + comment nits).

## Gates

biome / tsc / vitest **1081 passed** / vite build — all green.

## Other lanes in flight

none (DAT-509 #285 merged; #286 docs pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)