### PR TITLE
DAT-504: lake convergence — db_recipe raw-schema write + eligibility quarantine idempotency

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,20 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-11 (DAT-504): lake convergence — db_recipe raw-schema write + eligibility quarantine idempotency
+
+No detector or recall impact — substrate-placement and idempotency fixes only.
+`extract_backend` now writes recipe tables into `lake.raw` via
+`CREATE OR REPLACE` (they used to land in `lake.main` in production while
+metadata claimed layer="raw") and restores the connection's (catalog, schema)
+pair after extraction. Eligibility's column drop is now the convergent
+rebuild-from-recipe → one-shot `lake.quarantine."quarantine_columns_<bare>"`
+replace → drop sequence; lake failures fail the activity instead of degrading
+to warnings. Shipped `lake.main` strays are NOT cleaned up (workspaces are
+disposable per DD/34045953) — a wiped stack is the clean baseline.
+
+- **Status**: no action needed in eval/testdata
+
 ## 2026-06-11 (live smoke): first full clean-corpus journey on main — numbers SUSPECT until DAT-511
 
 The deferred live operating_model smoke ran end-to-end on a wiped stack (main =

--- a/.claude/platform-status.md
+++ b/.claude/platform-status.md
@@ -5,6 +5,7 @@ Row is added when a lane opens its PR; removed when the PR merges.
 
 | Task | Worktree | Branch | PR | Contract | Status |
 |---|---|---|---|---|---|
+| DAT-504 | (agent worktree) | fix/dat-504-lake-convergence | #288 | — | lane smoke green, awaiting review |
 
 _(previously merged: DAT-320 #110, DAT-324 #111, DAT-321 #113, DAT-323 #114, DAT-325 #115, DAT-358 #128, DAT-340 #129, DAT-339 substrate #132, bun toolchain #133, DAT-400 #191, DAT-406 #192, DAT-414 #213, DAT-433 #225, DAT-437 #230, DAT-436 #231, Intent enforcement #232, DAT-449 #234, DAT-451 #236, DAT-454 CI gates #237, DAT-452 #238, DAT-434 #240, DAT-435 #242, DAT-439 #243, DAT-440 #244; DAT-354/DAT-352 shipped via the DAT-339 lanes)_
 

--- a/packages/engine/src/dataraum/analysis/eligibility/evaluator.py
+++ b/packages/engine/src/dataraum/analysis/eligibility/evaluator.py
@@ -168,11 +168,16 @@ def quarantine_and_drop_columns(
     selects = []
     for column, reason in columns_data:
         escaped_reason = reason.replace("'", "''") if reason else "Unknown"
+        # Column names can legitimately contain quotes (CSV headers, MSSQL) —
+        # escape per context: '' inside the single-quoted literal, "" inside
+        # the double-quoted identifiers.
+        escaped_col = column.column_name.replace("'", "''")
+        escaped_col_ident = column.column_name.replace('"', '""')
         selects.append(f"""
             SELECT
                 ROW_NUMBER() OVER () as _row_id,
-                '{column.column_name}' as _column_name,
-                CAST("{column.column_name}" AS VARCHAR) as _value,
+                '{escaped_col}' as _column_name,
+                CAST("{escaped_col_ident}" AS VARCHAR) as _value,
                 '{escaped_reason}' as _quarantine_reason,
                 CURRENT_TIMESTAMP as _quarantined_at
             FROM {typed_fqn}
@@ -181,4 +186,5 @@ def quarantine_and_drop_columns(
 
     # 3. Drop the quarantined columns — present for sure after step 1.
     for column, _reason in columns_data:
-        conn.execute(f'ALTER TABLE {typed_fqn} DROP COLUMN "{column.column_name}"')
+        escaped_col_ident = column.column_name.replace('"', '""')
+        conn.execute(f'ALTER TABLE {typed_fqn} DROP COLUMN "{escaped_col_ident}"')

--- a/packages/engine/src/dataraum/analysis/eligibility/evaluator.py
+++ b/packages/engine/src/dataraum/analysis/eligibility/evaluator.py
@@ -115,50 +115,70 @@ def quarantine_and_drop_columns(
     conn: Any,  # DuckDB connection
     typed_table: str,
     columns_data: list[tuple[Any, str]],
+    *,
+    typed_recipe_ddl: str,
 ) -> None:
-    """Move column data to quarantine and drop from typed table.
+    """Quarantine ineligible columns and drop them from the typed table (DAT-504).
+
+    Convergent under Temporal at-least-once redelivery — every lake write is an
+    idempotent overwrite under a run-stable name:
+
+    1. Re-execute the run's stored typed ``MaterializationRecipe`` DDL, restoring
+       the full-column typed table regardless of what a prior partial attempt
+       left behind. The recipe row is READ-only — it must keep reproducing the
+       full-column table for exactly this convergence to work.
+    2. ``CREATE OR REPLACE`` the companion quarantine table in
+       ``lake.quarantine`` in one shot (no append — a re-run replaces, never
+       duplicates).
+    3. ``ALTER TABLE … DROP COLUMN`` each quarantined column — guaranteed
+       present after the rebuild, so the drop can't error on a re-run.
+
+    Any failure propagates to the caller — a lake failure fails the phase
+    (no swallowed-warning downgrade).
 
     Args:
-        conn: DuckDB connection
+        conn: DuckDB connection with the ``lake`` catalog attached.
         typed_table: Bare name of the typed table (e.g., ``"source__orders"``
             — the ``<source>__<table>`` form stored on ``Table.duckdb_path``
             post-DAT-341).
-        columns_data: List of (Column, reason) tuples to drop
+        columns_data: List of (Column, reason) tuples to drop.
+        typed_recipe_ddl: The run's stored typed-layer materialization DDL
+            (``CREATE OR REPLACE TABLE lake.typed.… AS SELECT …``), re-executed
+            verbatim to restore the full-column table.
     """
-    # ``typed_table`` is already the bare name post-DAT-341 (no ``typed_``
-    # prefix to strip). The companion quarantine-helper table uses the same
-    # base so layer-aware cleanup locates it.
-    quarantine_table = f"quarantine_columns_{typed_table}"
+    # Lazy imports, mirroring the loaders: avoid pulling the DuckLake bootstrap
+    # surface into module-load.
+    from dataraum.core.duckdb_naming import schema_for_layer
+    from dataraum.server.storage import LAKE_CATALOG_ALIAS
 
-    # Create quarantine table if not exists
-    conn.execute(f"""
-        CREATE TABLE IF NOT EXISTS "{quarantine_table}" (
-            _row_id INTEGER,
-            _column_name VARCHAR,
-            _value VARCHAR,
-            _quarantine_reason VARCHAR,
-            _quarantined_at TIMESTAMP
-        )
-    """)
+    typed_fqn = f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("typed")}."{typed_table}"'
+    # Run-stable companion name in the quarantine layer schema — same bare base
+    # as the typed table so layer-aware cleanup locates it. The typing phase's
+    # cast-failure quarantine already owns ``lake.quarantine."<bare>"``, so the
+    # column-quarantine keeps its distinct ``quarantine_columns_`` prefix.
+    quarantine_fqn = (
+        f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("quarantine")}."quarantine_columns_{typed_table}"'
+    )
 
-    # For each column, insert data then drop
+    # 1. Restore the full-column typed table from the run's recipe.
+    conn.execute(typed_recipe_ddl)
+
+    # 2. One-shot quarantine snapshot: one SELECT per quarantined column,
+    # unioned, replacing the table as a whole.
+    selects = []
     for column, reason in columns_data:
-        # Escape reason for SQL
         escaped_reason = reason.replace("'", "''") if reason else "Unknown"
-
-        # Insert column data into quarantine
-        conn.execute(f"""
-            INSERT INTO "{quarantine_table}"
+        selects.append(f"""
             SELECT
                 ROW_NUMBER() OVER () as _row_id,
                 '{column.column_name}' as _column_name,
                 CAST("{column.column_name}" AS VARCHAR) as _value,
                 '{escaped_reason}' as _quarantine_reason,
                 CURRENT_TIMESTAMP as _quarantined_at
-            FROM "{typed_table}"
+            FROM {typed_fqn}
         """)
+    conn.execute(f"CREATE OR REPLACE TABLE {quarantine_fqn} AS {' UNION ALL '.join(selects)}")
 
-        # Drop column from typed table
-        conn.execute(f"""
-            ALTER TABLE "{typed_table}" DROP COLUMN "{column.column_name}"
-        """)
+    # 3. Drop the quarantined columns — present for sure after step 1.
+    for column, _reason in columns_data:
+        conn.execute(f'ALTER TABLE {typed_fqn} DROP COLUMN "{column.column_name}"')

--- a/packages/engine/src/dataraum/pipeline/phases/column_eligibility_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/column_eligibility_phase.py
@@ -19,11 +19,12 @@ from dataraum.analysis.eligibility.evaluator import (
     quarantine_and_drop_columns,
 )
 from dataraum.analysis.statistics.db_models import StatisticalProfile
+from dataraum.analysis.typing.db_models import MaterializationRecipe
 from dataraum.core.logging import get_logger
 from dataraum.pipeline.base import PhaseContext, PhaseResult
 from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.registry import analysis_phase
-from dataraum.storage import Column
+from dataraum.storage import Column, Table
 from dataraum.storage.upsert import upsert
 
 if TYPE_CHECKING:
@@ -77,6 +78,33 @@ class ColumnEligibilityPhase(BasePhase):
             return "No columns found"
 
         return None
+
+    def _typed_recipe_ddl(self, ctx: PhaseContext, table: Table) -> str:
+        """The run's stored typed ``MaterializationRecipe`` DDL for ``table``.
+
+        Grain ``(typed table_id, "typed", ctx.run_id)`` — written by both typing
+        paths (resolution + the strongly-typed copy) before eligibility runs.
+        The row is READ-only here: the convergent drop sequence (DAT-504)
+        depends on it reproducing the FULL-column typed table, so it is never
+        overwritten with post-drop DDL. Absence is a bug upstream — fail loud,
+        no fallback.
+        """
+        # A None run_id (non-run callers, mirrors the profiles query above)
+        # compiles to ``run_id IS NULL``.
+        recipe = ctx.session.execute(
+            select(MaterializationRecipe).where(
+                MaterializationRecipe.table_id == table.table_id,
+                MaterializationRecipe.layer == "typed",
+                MaterializationRecipe.run_id == ctx.run_id,
+            )
+        ).scalar_one_or_none()
+        if recipe is None:
+            raise RuntimeError(
+                f"No typed materialization recipe for table {table.table_name} "
+                f"({table.table_id}) at run {ctx.run_id} — typing stores it before "
+                "eligibility runs; cannot drop columns convergently without it."
+            )
+        return recipe.ddl
 
     def _run(self, ctx: PhaseContext) -> PhaseResult:
         """Run column eligibility evaluation."""
@@ -169,37 +197,34 @@ class ColumnEligibilityPhase(BasePhase):
         # Upsert on ``(column_id, run_id)`` so a retry refreshes rows in place.
         upsert(ctx.session, ColumnEligibilityRecord, rows, index_elements=["column_id", "run_id"])
 
-        # Drop ineligible columns from DuckDB tables
+        # Drop ineligible columns from the lake (DAT-504 convergent sequence):
+        # rebuild the typed table from the run's stored recipe, snapshot the
+        # quarantined columns in one shot, then drop them. A lake failure
+        # propagates and fails the activity (rollback per 9d262fde) — no
+        # warning downgrade; warnings remain only for the structural
+        # no-duckdb_path case below.
         for table_id, columns_data in columns_to_drop.items():
             table = table_map[table_id]
             if not table.duckdb_path:
                 warnings.append(f"Table {table.table_name} has no DuckDB path, cannot drop columns")
                 continue
 
-            try:
-                quarantine_and_drop_columns(
-                    ctx.duckdb_conn,
-                    table.duckdb_path,
-                    columns_data,
-                )
+            quarantine_and_drop_columns(
+                ctx.duckdb_conn,
+                table.duckdb_path,
+                columns_data,
+                typed_recipe_ddl=self._typed_recipe_ddl(ctx, table),
+            )
 
-                for column, _ in columns_data:
-                    ctx.session.delete(column)
+            for column, _ in columns_data:
+                ctx.session.delete(column)
 
-                logger.debug(
-                    "columns_dropped",
-                    table=table.table_name,
-                    dropped_count=len(columns_data),
-                    columns=[c.column_name for c, _ in columns_data],
-                )
-
-            except Exception as e:
-                warnings.append(f"Failed to drop columns from {table.table_name}: {e}")
-                logger.warning(
-                    "column_drop_failed",
-                    table=table.table_name,
-                    error=str(e),
-                )
+            logger.debug(
+                "columns_dropped",
+                table=table.table_name,
+                dropped_count=len(columns_data),
+                columns=[c.column_name for c, _ in columns_data],
+            )
 
         return PhaseResult.success(
             outputs={

--- a/packages/engine/src/dataraum/sources/backends.py
+++ b/packages/engine/src/dataraum/sources/backends.py
@@ -129,6 +129,7 @@ def extract_backend(
     # restores BOTH. Extraction targets are composed as ``lake.raw`` FQNs,
     # never against the connection's USE state.
     snapshot_row = duckdb_conn.execute("SELECT current_catalog(), current_schema()").fetchone()
+    # ("memory", "main") is unreachable with a live connection; defensive.
     restore_catalog, restore_schema = snapshot_row if snapshot_row else ("memory", "main")
 
     # 1. Install + load extension. Honors the image's pre-baked extension

--- a/packages/engine/src/dataraum/sources/backends.py
+++ b/packages/engine/src/dataraum/sources/backends.py
@@ -1,7 +1,7 @@
 """Backend extraction via DuckDB ATTACH.
 
 Every supported database backend is accessed through a DuckDB extension.
-This module materializes recipe queries into local raw tables and
+This module materializes recipe queries into ``lake.raw`` tables and
 harvests structural metadata (PK/FK/indexes) for downstream phases.
 """
 
@@ -81,12 +81,15 @@ def extract_backend(
     duckdb_conn: duckdb.DuckDBPyConnection,
     raw_prefix: str = "raw_",
 ) -> Result[BackendExtractionResult]:
-    """Materialize each recipe query into a `raw_{name}` table in DuckDB.
+    """Materialize each recipe query into a ``lake.raw`` table (DAT-504).
 
     Steps: INSTALL + LOAD the backend extension; ATTACH READ_ONLY;
     `USE src` so the user's SQL can reference attached tables by
-    `schema.table` without an alias prefix; CREATE TABLE per query;
-    restore catalog; DETACH.
+    `schema.table` without an alias prefix; CREATE OR REPLACE per query
+    into ``lake.raw`` (the same lake-convergent target the csv/json/parquet
+    loaders write — idempotent overwrite under a run-stable name, so a
+    Temporal redelivery converges instead of colliding on leftovers);
+    restore the snapshotted (catalog, schema) pair; DETACH.
 
     Fails loud at every step (DAT-274 pattern). On failure mid-extraction
     we still attempt to DETACH so the connection is left clean.
@@ -95,13 +98,19 @@ def extract_backend(
         backend: One of `mssql`, `postgres`, `mysql`, `sqlite`.
         url: Connection URL resolved from the credential chain.
         queries: Recipe tables (name + sql), order preserved.
-        duckdb_conn: DuckDB connection to materialize against.
+        duckdb_conn: DuckDB connection to materialize against. Must have the
+            ``lake`` catalog attached (the production session connection does).
         raw_prefix: Prefix applied to the recipe table name in DuckDB.
 
     Returns:
         Result with the list of extracted tables. Zero-row tables are
         surfaced as warnings, not errors.
     """
+    # Lazy imports, mirroring the csv/json/parquet loaders: avoid pulling the
+    # DuckLake bootstrap surface into module-load.
+    from dataraum.core.duckdb_naming import schema_for_layer
+    from dataraum.server.storage import LAKE_CATALOG_ALIAS
+
     if backend not in SUPPORTED_BACKENDS:
         return Result.fail(
             f"Unsupported backend: {backend}. Supported: {', '.join(sorted(SUPPORTED_BACKENDS))}"
@@ -111,15 +120,16 @@ def extract_backend(
 
     extension = BACKEND_EXTENSIONS[backend]
     attach_type = BACKEND_ATTACH_TYPES[backend]
+    raw_schema = schema_for_layer("raw")
 
-    # 0. Snapshot the connection's default catalog BEFORE we switch into
-    # the attached source. For in-memory connections this is "memory"; for
-    # file-backed connections (the production case — session data.duckdb)
-    # it's named after the file. Tables we create here must live in the
-    # ORIGINAL catalog (not the read-only attached one), so all CREATE /
-    # SELECT / information_schema queries qualify with this name.
-    default_catalog_row = duckdb_conn.execute("SELECT current_catalog()").fetchone()
-    default_catalog = default_catalog_row[0] if default_catalog_row else "memory"
+    # 0. Snapshot the connection's (catalog, schema) pair BEFORE we switch
+    # into the attached source. The production session connection sits at
+    # ``lake.typed`` (ConnectionManager._init_duckdb); restoring only the
+    # catalog would strand it at ``<catalog>.main``, so the finally block
+    # restores BOTH. Extraction targets are composed as ``lake.raw`` FQNs,
+    # never against the connection's USE state.
+    snapshot_row = duckdb_conn.execute("SELECT current_catalog(), current_schema()").fetchone()
+    restore_catalog, restore_schema = snapshot_row if snapshot_row else ("memory", "main")
 
     # 1. Install + load extension. Honors the image's pre-baked extension
     # cache, same contract as bootstrap_lake / apply_s3_secret
@@ -180,27 +190,23 @@ def extract_backend(
         else:
             for q in queries:
                 duckdb_table = f"{raw_prefix}{q.name}"
+                # Cross-catalog CTAS: read from the attached source (current
+                # catalog), write into the lake's raw schema. CREATE OR
+                # REPLACE so a redelivery overwrites the leftover instead of
+                # colliding (lake convergence rule, DAT-504).
+                target_fqn = f'{LAKE_CATALOG_ALIAS}.{raw_schema}."{duckdb_table}"'
                 try:
-                    duckdb_conn.execute(
-                        f'CREATE TABLE {default_catalog}.main."{duckdb_table}" AS {q.sql}'
-                    )
+                    duckdb_conn.execute(f"CREATE OR REPLACE TABLE {target_fqn} AS {q.sql}")
                 except Exception as exc:
                     extraction_error = f"Recipe table '{q.name}' SELECT failed: {exc}"
                     break
 
-                row_count_row = duckdb_conn.execute(
-                    f'SELECT count(*) FROM {default_catalog}.main."{duckdb_table}"'
-                ).fetchone()
+                row_count_row = duckdb_conn.execute(f"SELECT count(*) FROM {target_fqn}").fetchone()
                 row_count = int(row_count_row[0]) if row_count_row else 0
 
-                col_rows = duckdb_conn.execute(
-                    "SELECT column_name, data_type "
-                    "FROM information_schema.columns "
-                    "WHERE table_catalog = ? AND table_schema = 'main' "
-                    "AND table_name = ? "
-                    "ORDER BY ordinal_position",
-                    [default_catalog, duckdb_table],
-                ).fetchall()
+                # DESCRIBE the FQN directly — information_schema would need
+                # catalog/schema filtering that DESCRIBE already encodes.
+                col_rows = duckdb_conn.execute(f"DESCRIBE {target_fqn}").fetchall()
                 columns = [(str(r[0]), str(r[1])) for r in col_rows]
 
                 if row_count == 0:
@@ -215,12 +221,17 @@ def extract_backend(
                     )
                 )
     finally:
-        # Restore default catalog and DETACH. Suppress secondary errors —
-        # the primary error (if any) is already captured.
+        # Restore the snapshotted (catalog, schema) pair and DETACH. Restoring
+        # only the catalog would leave the connection at ``<catalog>.main`` —
+        # in production that strands the session connection off ``lake.typed``
+        # (DAT-504). Suppress secondary errors — the primary error (if any) is
+        # already captured.
         try:
-            duckdb_conn.execute(f"USE {default_catalog}")
+            duckdb_conn.execute(f'USE "{restore_catalog}"."{restore_schema}"')
         except Exception:
-            _log.debug("USE %s failed during cleanup", default_catalog, exc_info=True)
+            _log.debug(
+                "USE %s.%s failed during cleanup", restore_catalog, restore_schema, exc_info=True
+            )
         try:
             duckdb_conn.execute(f"DETACH {_ATTACH_ALIAS}")
         except Exception:

--- a/packages/engine/tests/integration/pipeline/test_column_eligibility_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_column_eligibility_phase.py
@@ -17,6 +17,8 @@ EXCLUDE`` from the recipe-rebuilt table — see the DAT-504 refine notes).
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from sqlalchemy import select
 
@@ -77,6 +79,7 @@ def test_all_null_key_named_column_drops_without_failing_the_run(
 
 def _typed_table_and_recipe(harness):
     """The typed table's (bare name, full-column recipe DDL, all-null Column)."""
+    # expire_on_commit=False keeps .column_name accessible after session close
     with harness.session_factory() as session:
         typed_table = session.execute(select(Table).where(Table.layer == "typed")).scalar_one()
         recipe = session.execute(
@@ -185,6 +188,50 @@ class TestLakeConvergence:
         assert len(quarantine_rows) == 4
         assert placements == ["quarantine"]
 
+        # Metadata-side convergence: exactly ONE eligibility record for the
+        # dropped column — guards the NULL-run_id NULLS-DISTINCT
+        # duplicate-insert hazard on redelivery.
+        with harness.session_factory() as session:
+            records = (
+                session.execute(
+                    select(ColumnEligibilityRecord).where(
+                        ColumnEligibilityRecord.column_name == "logikal30_id"
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert len(records) == 1
+
+    def test_quoted_column_name_survives_quarantine_and_drop(self, harness) -> None:
+        """Column names can legitimately contain quotes (CSV headers, MSSQL);
+        the quarantine SELECT's literal and the CAST/DROP identifiers must
+        each be escaped for their context — and stay convergent on a re-run."""
+        bare = "positions_quoted"
+        quoted_col = 'it\'s "qty"'
+        ident = quoted_col.replace('"', '""')
+        recipe_ddl = (
+            f'CREATE OR REPLACE TABLE lake.typed."{bare}" AS '
+            f"SELECT * FROM (VALUES (1, 'a'), (2, 'b')) t(id, \"{ident}\")"
+        )
+        harness.duckdb_conn.execute(recipe_ddl)
+        # The function only reads .column_name — a stand-in Column suffices.
+        column = SimpleNamespace(column_name=quoted_col)
+
+        for _ in range(2):
+            quarantine_and_drop_columns(
+                harness.duckdb_conn,
+                bare,
+                [(column, "Column has 100% null values")],
+                typed_recipe_ddl=recipe_ddl,
+            )
+
+        typed_cols, quarantine_rows, placements = _lake_state(harness, bare)
+        assert typed_cols == ["id"]
+        assert len(quarantine_rows) == 2
+        assert {r[1] for r in quarantine_rows} == {quoted_col}
+        assert placements == ["quarantine"]
+
     def test_missing_recipe_fails_loud(self, harness, csv_with_all_null_id_column) -> None:
         """No stored typed recipe at the run grain = fail the phase, no
         fallback drop — convergence depends on the rebuild step."""
@@ -196,6 +243,7 @@ class TestLakeConvergence:
                 select(MaterializationRecipe).where(
                     MaterializationRecipe.table_id == typed_table.table_id,
                     MaterializationRecipe.layer == "typed",
+                    MaterializationRecipe.run_id.is_(None),
                 )
             ).scalar_one()
             session.delete(recipe)

--- a/packages/engine/tests/integration/pipeline/test_column_eligibility_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_column_eligibility_phase.py
@@ -7,6 +7,12 @@ name-only key inference with no structural evidence and no teach escape
 hatch. An all-null key-named column is now dropped + recorded INELIGIBLE
 like any other, and the run continues; key-ness claims live downstream where
 relationship evidence exists.
+
+Also pins the DAT-504 lake-convergent drop sequence against the real DuckLake
+fixture: rebuild-from-recipe → one-shot quarantine replace → column drop, plus
+the DuckLake capability assumption it relies on (``ALTER TABLE … DROP COLUMN``
+on a DuckLake table; fallback if it ever regresses: ``CREATE OR REPLACE …
+EXCLUDE`` from the recipe-rebuilt table — see the DAT-504 refine notes).
 """
 
 from __future__ import annotations
@@ -15,6 +21,8 @@ import pytest
 from sqlalchemy import select
 
 from dataraum.analysis.eligibility.db_models import ColumnEligibilityRecord
+from dataraum.analysis.eligibility.evaluator import quarantine_and_drop_columns
+from dataraum.analysis.typing.db_models import MaterializationRecipe
 from dataraum.pipeline.base import PhaseStatus
 from dataraum.storage import Column, Table
 
@@ -65,3 +73,135 @@ def test_all_null_key_named_column_drops_without_failing_the_run(
         )
         assert "logikal30_id" not in typed_names
         assert {"id", "amount"} <= typed_names
+
+
+def _typed_table_and_recipe(harness):
+    """The typed table's (bare name, full-column recipe DDL, all-null Column)."""
+    with harness.session_factory() as session:
+        typed_table = session.execute(select(Table).where(Table.layer == "typed")).scalar_one()
+        recipe = session.execute(
+            select(MaterializationRecipe).where(
+                MaterializationRecipe.table_id == typed_table.table_id,
+                MaterializationRecipe.layer == "typed",
+            )
+        ).scalar_one()
+        column = session.execute(
+            select(Column).where(
+                Column.table_id == typed_table.table_id,
+                Column.column_name == "logikal30_id",
+            )
+        ).scalar_one()
+        return typed_table.duckdb_path, recipe.ddl, column
+
+
+def _lake_state(harness, bare: str) -> tuple[list[str], list[tuple], list[str]]:
+    """(typed columns, quarantine rows, quarantine-table placements) for ``bare``."""
+    typed_cols = [
+        r[0] for r in harness.duckdb_conn.execute(f'DESCRIBE lake.typed."{bare}"').fetchall()
+    ]
+    quarantine_rows = harness.duckdb_conn.execute(
+        "SELECT _row_id, _column_name, _value, _quarantine_reason "
+        f'FROM lake.quarantine."quarantine_columns_{bare}" ORDER BY _row_id'
+    ).fetchall()
+    placements = [
+        r[0]
+        for r in harness.duckdb_conn.execute(
+            "SELECT schema_name FROM duckdb_tables() WHERE database_name = 'lake' "
+            f"AND table_name = 'quarantine_columns_{bare}'"
+        ).fetchall()
+    ]
+    return typed_cols, quarantine_rows, placements
+
+
+class TestLakeConvergence:
+    """DAT-504: the eligibility lake body converges under at-least-once redelivery."""
+
+    def _import_type_profile(self, harness, csv_path) -> None:
+        result = harness.run_import(source_path=csv_path, source_name="positions")
+        assert result.status == PhaseStatus.COMPLETED, result.error
+        for step in ("typing", "statistics"):
+            result = harness.run_phase(step)
+            assert result.status == PhaseStatus.COMPLETED, result.error
+
+    def test_eligibility_body_executed_twice_converges(
+        self, harness, csv_with_all_null_id_column
+    ) -> None:
+        """The lake body run twice under the same run grain lands on identical
+        state — proving DuckLake's ALTER DROP COLUMN and the rebuild-replace-drop
+        sequence (the old append+swallow path duplicated quarantine rows and
+        errored on the second drop)."""
+        self._import_type_profile(harness, csv_with_all_null_id_column)
+        bare, recipe_ddl, column = _typed_table_and_recipe(harness)
+
+        states = []
+        for _ in range(2):
+            quarantine_and_drop_columns(
+                harness.duckdb_conn,
+                bare,
+                [(column, "Column has 100% null values")],
+                typed_recipe_ddl=recipe_ddl,
+            )
+            states.append(_lake_state(harness, bare))
+
+        first, second = states
+        assert first == second
+        typed_cols, quarantine_rows, placements = second
+        assert "logikal30_id" not in typed_cols
+        assert {"id", "amount"} <= set(typed_cols)
+        # One row per source row for the single quarantined column — 4, not 8.
+        assert len(quarantine_rows) == 4
+        assert {r[1] for r in quarantine_rows} == {"logikal30_id"}
+        # Relocated to lake.quarantine — the old unqualified CREATE landed in
+        # whatever schema the connection USEd (lake.typed in production).
+        assert placements == ["quarantine"]
+
+    def test_phase_redelivery_after_lake_mutation_converges(
+        self, harness, csv_with_all_null_id_column
+    ) -> None:
+        """The dangerous interleaving: the lake body already ran but the
+        metadata commit was lost; the redelivered phase re-evaluates against
+        full Column metadata and must converge — the old path swallowed the
+        failing ALTER as a warning and left appended quarantine duplicates."""
+        self._import_type_profile(harness, csv_with_all_null_id_column)
+        bare, recipe_ddl, column = _typed_table_and_recipe(harness)
+
+        # First delivery's lake mutations (metadata untouched).
+        quarantine_and_drop_columns(
+            harness.duckdb_conn,
+            bare,
+            [(column, "Column has 100% null values")],
+            typed_recipe_ddl=recipe_ddl,
+        )
+
+        # Redelivery: the full phase against unchanged metadata.
+        result = harness.run_phase("column_eligibility")
+        assert result.status == PhaseStatus.COMPLETED, result.error
+        assert result.outputs is not None
+        assert result.outputs["dropped"] == 1
+        assert not result.warnings, f"swallowed lake failure: {result.warnings}"
+
+        typed_cols, quarantine_rows, placements = _lake_state(harness, bare)
+        assert "logikal30_id" not in typed_cols
+        assert len(quarantine_rows) == 4
+        assert placements == ["quarantine"]
+
+    def test_missing_recipe_fails_loud(self, harness, csv_with_all_null_id_column) -> None:
+        """No stored typed recipe at the run grain = fail the phase, no
+        fallback drop — convergence depends on the rebuild step."""
+        self._import_type_profile(harness, csv_with_all_null_id_column)
+
+        with harness.session_factory() as session:
+            typed_table = session.execute(select(Table).where(Table.layer == "typed")).scalar_one()
+            recipe = session.execute(
+                select(MaterializationRecipe).where(
+                    MaterializationRecipe.table_id == typed_table.table_id,
+                    MaterializationRecipe.layer == "typed",
+                )
+            ).scalar_one()
+            session.delete(recipe)
+            session.commit()
+
+        result = harness.run_phase("column_eligibility")
+        assert result.status == PhaseStatus.FAILED
+        assert result.error is not None
+        assert "materialization recipe" in result.error

--- a/packages/engine/tests/integration/sources/test_db_recipe_lake.py
+++ b/packages/engine/tests/integration/sources/test_db_recipe_lake.py
@@ -1,0 +1,120 @@
+"""db_recipe extraction against the real DuckLake fixture (DAT-504).
+
+The unit tests in ``tests/unit/sources/test_extract_backend.py`` use a plain
+in-memory ``lake`` alias; this file proves the lake-convergent extraction
+against the actual DuckLake catalog (testcontainer Postgres + tmp DATA_PATH),
+including the capability assumption it relies on:
+
+* cross-catalog CTAS — ``CREATE OR REPLACE TABLE lake.raw.… AS SELECT`` reading
+  from an ATTACHed backend while the connection sits inside the source catalog.
+  (If DuckLake ever rejects this, the fallback is a temp-table hop via the
+  in-memory catalog — see the DAT-504 refine notes.)
+
+And the production wiring around it:
+
+* the table lands in ``lake.raw`` (the live bug wrote ``lake.main`` because the
+  session connection USEs ``lake.typed``), with the metadata contract
+  (``layer="raw"`` + bare ``duckdb_path``) resolving to the physical table;
+* a second execution over leftovers converges (CREATE OR REPLACE, no
+  collision);
+* the USE-restore returns the connection to the snapshotted ``lake.typed``
+  pair instead of stranding it at ``lake.main``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from dataraum.sources.backends import extract_backend
+from dataraum.sources.db_recipe import RecipeTable
+
+
+@pytest.fixture
+def sqlite_source(tmp_path: Path) -> str:
+    """A small sqlite database standing in for the customer backend."""
+    db_path = tmp_path / "source.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE customers (
+            customer_id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            region TEXT
+        );
+        INSERT INTO customers VALUES
+            (1, 'Acme Corp', 'EMEA'),
+            (2, 'Globex',    'APAC'),
+            (3, 'Initech',   'AMER');
+        """
+    )
+    conn.commit()
+    conn.close()
+    return str(db_path)
+
+
+def test_extract_lands_in_lake_raw_and_converges(integration_duckdb, sqlite_source) -> None:
+    from dataraum.core.duckdb_naming import schema_for_layer
+    from dataraum.server.storage import LAKE_CATALOG_ALIAS
+
+    conn = integration_duckdb
+
+    # Run TWICE: the second execution hits the first run's leftover raw table
+    # and must overwrite it (lake convergence), not collide.
+    result = None
+    for attempt in (1, 2):
+        result = extract_backend(
+            backend="sqlite",
+            url=sqlite_source,
+            queries=[RecipeTable(name="customers", sql="SELECT * FROM customers")],
+            duckdb_conn=conn,
+            raw_prefix="src__",
+        )
+        assert result.success, f"attempt {attempt}: {result.error}"
+    assert result is not None
+    extracted = result.unwrap().tables[0]
+    assert extracted.duckdb_table == "src__customers"
+    assert extracted.row_count == 3
+
+    # The physical table lives in lake.raw and ONLY there — the DAT-504 live
+    # bug parked it in lake.main while metadata claimed layer="raw".
+    placements = conn.execute(
+        "SELECT schema_name FROM duckdb_tables() "
+        f"WHERE database_name = '{LAKE_CATALOG_ALIAS}' AND table_name = 'src__customers'"
+    ).fetchall()
+    assert [r[0] for r in placements] == ["raw"]
+    main_strays = conn.execute(
+        "SELECT table_name FROM duckdb_tables() "
+        f"WHERE database_name = '{LAKE_CATALOG_ALIAS}' AND schema_name = 'main'"
+    ).fetchall()
+    assert main_strays == []
+
+    # Metadata contract: import registers layer="raw" + bare duckdb_path; the
+    # composed FQN must resolve via DESCRIBE with the harvested columns.
+    fqn = f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("raw")}."{extracted.duckdb_table}"'
+    described = conn.execute(f"DESCRIBE {fqn}").fetchall()
+    assert [(str(r[0]), str(r[1])) for r in described] == extracted.columns
+    (count,) = conn.execute(f"SELECT count(*) FROM {fqn}").fetchone()
+    assert count == 3
+
+    # USE-restore: the session connection must sit back at lake.typed — the
+    # old catalog-only restore stranded it at lake.main.
+    pair = conn.execute("SELECT current_catalog(), current_schema()").fetchone()
+    assert pair == (LAKE_CATALOG_ALIAS, "typed")
+
+
+def test_failed_extract_restores_lake_typed_pair(integration_duckdb, sqlite_source) -> None:
+    from dataraum.server.storage import LAKE_CATALOG_ALIAS
+
+    conn = integration_duckdb
+    result = extract_backend(
+        backend="sqlite",
+        url=sqlite_source,
+        queries=[RecipeTable(name="bad", sql="SELECT * FROM no_such_table")],
+        duckdb_conn=conn,
+    )
+    assert not result.success
+    pair = conn.execute("SELECT current_catalog(), current_schema()").fetchone()
+    assert pair == (LAKE_CATALOG_ALIAS, "typed")

--- a/packages/engine/tests/integration/sources/test_db_recipe_mssql.py
+++ b/packages/engine/tests/integration/sources/test_db_recipe_mssql.py
@@ -62,6 +62,11 @@ def mssql_url() -> str:
 @pytest.fixture
 def duckdb_conn():
     conn = duckdb.connect(":memory:")
+    # Post-DAT-504 extraction targets ``lake.raw`` FQNs; stand in for the
+    # production lake catalog (the real DuckLake fixture is exercised in
+    # test_db_recipe_lake.py).
+    conn.execute("ATTACH ':memory:' AS lake")
+    conn.execute("CREATE SCHEMA lake.raw")
     yield conn
     conn.close()
 
@@ -190,7 +195,7 @@ class TestRealMSSQLExtraction:
         # The extractor already materialized aw_orders. Pull one row through
         # the same DuckDB connection to confirm value round-trip.
         row = duckdb_conn.execute(
-            "SELECT SalesOrderID, OrderDate FROM aw_orders ORDER BY SalesOrderID LIMIT 1"
+            'SELECT SalesOrderID, OrderDate FROM lake.raw."aw_orders" ORDER BY SalesOrderID LIMIT 1'
         ).fetchone()
         assert row is not None
         order_id, order_date = row
@@ -217,7 +222,8 @@ class TestRealMSSQLExtraction:
         )
         assert result.success, result.error
         row = duckdb_conn.execute(
-            "SELECT ListPrice FROM aw_prices WHERE ListPrice > 0 ORDER BY ProductID LIMIT 1"
+            'SELECT ListPrice FROM lake.raw."aw_prices" '
+            "WHERE ListPrice > 0 ORDER BY ProductID LIMIT 1"
         ).fetchone()
         assert row is not None
         (price,) = row

--- a/packages/engine/tests/unit/sources/test_extract_backend.py
+++ b/packages/engine/tests/unit/sources/test_extract_backend.py
@@ -4,6 +4,12 @@ Sqlite is a real backend (not a mock) so these tests exercise the
 actual INSTALL/LOAD/ATTACH/CREATE TABLE/DETACH pipeline end-to-end.
 The mssql-specific behavior is covered in the integration smoke test
 in Phase 7.
+
+Post-DAT-504 the extraction targets ``lake.raw`` FQNs (the same convergent
+write the csv/json/parquet loaders do). These unit tests keep that cheap with
+an in-memory ``ATTACH ':memory:' AS lake`` + ``CREATE SCHEMA lake.raw`` —
+the real DuckLake catalog is exercised in
+``tests/integration/sources/test_db_recipe_lake.py``.
 """
 
 from __future__ import annotations
@@ -20,6 +26,13 @@ from dataraum.sources.backends import (
     extract_backend,
 )
 from dataraum.sources.db_recipe import RecipeTable
+
+
+def _attach_lake(conn: duckdb.DuckDBPyConnection) -> None:
+    """Stand in for the production lake catalog on a unit-test connection."""
+    conn.execute("ATTACH ':memory:' AS lake")
+    conn.execute("CREATE SCHEMA lake.raw")
+    conn.execute("CREATE SCHEMA lake.typed")
 
 
 @pytest.fixture
@@ -60,6 +73,7 @@ def sqlite_source(tmp_path: Path) -> str:
 @pytest.fixture
 def duckdb_conn():
     conn = duckdb.connect(":memory:")
+    _attach_lake(conn)
     yield conn
     conn.close()
 
@@ -112,16 +126,53 @@ class TestExtractBackendHappyPath:
         rows_by_name = {t.name: t.row_count for t in result.unwrap().tables}
         assert rows_by_name == {"customers": 3, "orders": 4}
 
-    def test_creates_real_duckdb_tables(self, sqlite_source, duckdb_conn):
+    def test_creates_real_duckdb_tables_in_lake_raw(self, sqlite_source, duckdb_conn):
         extract_backend(
             backend="sqlite",
             url=sqlite_source,
             queries=[RecipeTable(name="customers", sql="SELECT * FROM customers")],
             duckdb_conn=duckdb_conn,
         )
-        # After extraction, the DuckDB connection should hold the raw table.
-        actual_rows = duckdb_conn.execute("SELECT count(*) FROM raw_customers").fetchone()
+        # After extraction, the raw table lives in lake.raw (DAT-504).
+        actual_rows = duckdb_conn.execute(
+            'SELECT count(*) FROM lake.raw."raw_customers"'
+        ).fetchone()
         assert actual_rows[0] == 3
+
+    def test_no_stray_table_outside_lake_raw(self, sqlite_source, duckdb_conn):
+        """The DAT-504 live bug: tables used to land in ``<catalog>.main`` while
+        metadata registered layer="raw" → ``lake.raw``. Pin that NOTHING lands
+        outside the raw schema."""
+        extract_backend(
+            backend="sqlite",
+            url=sqlite_source,
+            queries=[RecipeTable(name="customers", sql="SELECT * FROM customers")],
+            duckdb_conn=duckdb_conn,
+        )
+        strays = duckdb_conn.execute(
+            "SELECT database_name, schema_name, table_name FROM duckdb_tables() "
+            "WHERE NOT (database_name = 'lake' AND schema_name = 'raw')"
+        ).fetchall()
+        assert strays == []
+
+    def test_second_execution_with_leftovers_converges(self, sqlite_source, duckdb_conn):
+        """CREATE OR REPLACE: a redelivery overwrites the leftover raw table
+        instead of colliding (lake convergence rule)."""
+        for _ in range(2):
+            result = extract_backend(
+                backend="sqlite",
+                url=sqlite_source,
+                queries=[RecipeTable(name="customers", sql="SELECT * FROM customers")],
+                duckdb_conn=duckdb_conn,
+            )
+            assert result.success, result.error
+            assert result.unwrap().tables[0].row_count == 3
+        count = duckdb_conn.execute(
+            "SELECT count(*) FROM duckdb_tables() "
+            "WHERE database_name = 'lake' AND schema_name = 'raw' "
+            "AND table_name = 'raw_customers'"
+        ).fetchone()
+        assert count[0] == 1
 
     def test_user_sql_with_where_clause(self, sqlite_source, duckdb_conn):
         result = extract_backend(
@@ -156,7 +207,7 @@ class TestExtractBackendHappyPath:
         )
         assert result.success, result.error
         rows = duckdb_conn.execute(
-            "SELECT customer_name FROM raw_orders_with_customer ORDER BY order_id"
+            'SELECT customer_name FROM lake.raw."raw_orders_with_customer" ORDER BY order_id'
         ).fetchall()
         assert [r[0] for r in rows] == ["Acme Corp", "Acme Corp", "Globex", "Initech"]
 
@@ -266,6 +317,33 @@ class TestExtractBackendCleanup:
         result = duckdb_conn.execute("SELECT current_catalog()").fetchone()
         assert result[0] == "memory"
 
+    def test_use_restore_keeps_catalog_and_schema_pair(self, sqlite_source, duckdb_conn):
+        """The third DAT-504 bug: the old ``USE {catalog}`` restore stranded the
+        connection at ``<catalog>.main``. Production sits at ``lake.typed`` —
+        the restore must bring back the snapshotted (catalog, schema) PAIR."""
+        duckdb_conn.execute("USE lake.typed")
+        result = extract_backend(
+            backend="sqlite",
+            url=sqlite_source,
+            queries=[RecipeTable(name="customers", sql="SELECT * FROM customers")],
+            duckdb_conn=duckdb_conn,
+        )
+        assert result.success, result.error
+        pair = duckdb_conn.execute("SELECT current_catalog(), current_schema()").fetchone()
+        assert pair == ("lake", "typed")
+
+    def test_use_restore_keeps_pair_after_sql_failure(self, sqlite_source, duckdb_conn):
+        duckdb_conn.execute("USE lake.typed")
+        result = extract_backend(
+            backend="sqlite",
+            url=sqlite_source,
+            queries=[RecipeTable(name="bad", sql="SELECT * FROM no_such_table")],
+            duckdb_conn=duckdb_conn,
+        )
+        assert not result.success
+        pair = duckdb_conn.execute("SELECT current_catalog(), current_schema()").fetchone()
+        assert pair == ("lake", "typed")
+
 
 class TestExtensionCachePreBake:
     """The image pre-bakes extensions (worker.Dockerfile): extract_backend must
@@ -305,6 +383,7 @@ class TestExtensionCachePreBake:
         monkeypatch.setenv("DUCKDB_EXTENSION_DIRECTORY", str(ext_dir))
         monkeypatch.setenv("DUCKLAKE_SKIP_INSTALL", "1")
         conn = duckdb.connect(":memory:")
+        _attach_lake(conn)
         try:
             result = extract_backend(
                 backend="sqlite",
@@ -319,17 +398,15 @@ class TestExtensionCachePreBake:
 
 
 class TestExtractBackendFileBackedConnection:
-    """In production the DuckDB connection is file-backed (session data.duckdb),
-    not :memory:. extract_backend must use the connection's actual catalog name
-    rather than a hardcoded "memory" — otherwise CREATE TABLE fails with
-    "Catalog Error: Catalog with name memory does not exist".
-    """
+    """A file-backed connection (its default catalog named after the file) must
+    behave exactly like :memory:: extraction lands in ``lake.raw`` regardless of
+    the connection's own catalog, and the USE-restore brings back the file
+    catalog afterwards."""
 
-    def test_extracts_into_file_backed_catalog(self, sqlite_source, tmp_path):
-        """File-backed DuckDB has a catalog named after the file. Recipe tables
-        must materialize there, not in a phantom 'memory' catalog."""
+    def test_extracts_into_lake_raw_not_file_catalog(self, sqlite_source, tmp_path):
         db_path = tmp_path / "session_data.duckdb"
         conn = duckdb.connect(str(db_path))
+        _attach_lake(conn)
         try:
             result = extract_backend(
                 backend="sqlite",
@@ -343,13 +420,16 @@ class TestExtractBackendFileBackedConnection:
             assert len(result.value.tables) == 1
             assert result.value.tables[0].duckdb_table == "aw_customers"
 
-            # The materialized table lives in the file-backed catalog, not in "memory".
-            current_catalog = conn.execute("SELECT current_catalog()").fetchone()[0]
-            count = conn.execute(
-                f'SELECT count(*) FROM {current_catalog}.main."aw_customers"'
-            ).fetchone()
+            # The materialized table lives in lake.raw, NOT in the file catalog.
+            count = conn.execute('SELECT count(*) FROM lake.raw."aw_customers"').fetchone()
             assert count is not None
             assert count[0] >= 1
+            file_catalog = conn.execute("SELECT current_catalog()").fetchone()[0]
+            strays = conn.execute(
+                "SELECT table_name FROM duckdb_tables() WHERE database_name = ?",
+                [file_catalog],
+            ).fetchall()
+            assert strays == []
         finally:
             conn.close()
 
@@ -357,6 +437,7 @@ class TestExtractBackendFileBackedConnection:
         """The finally-block USE must restore the file-backed catalog, not 'memory'."""
         db_path = tmp_path / "session_data.duckdb"
         conn = duckdb.connect(str(db_path))
+        _attach_lake(conn)
         try:
             expected_catalog = conn.execute("SELECT current_catalog()").fetchone()[0]
             extract_backend(


### PR DESCRIPTION
## Task

DAT-504 — https://real-dataraum.atlassian.net/browse/DAT-504 (Phase 3 of epic DAT-501, design DD/34045953 §4)

Approach per the approved refine comment on the ticket (2026-06-11).

## What changed

**db_recipe (`sources/backends.py`)** — three confirmed bugs in one cut:
- recipe tables now `CREATE OR REPLACE` into `lake.raw."<table>"` (csv/json/parquet loader pattern) instead of plain `CREATE TABLE` into `{default_catalog}.main` — in production (`USE lake.typed` at init) strays landed in `lake.main` while metadata registered layer="raw"
- column harvest via `DESCRIBE <fqn>` instead of information_schema
- the USE-restore snapshots and restores the **(catalog, schema) pair** — the old catalog-only restore stranded the session connection at `<catalog>.main`

Signature unchanged; FQN composed inside backends.py. `import_phase.py` untouched (DAT-502's lane owns `_rollback_partial_load`).

**Eligibility (`analysis/eligibility/evaluator.py` + `pipeline/phases/column_eligibility_phase.py`)** — quarantine-append + swallowed ALTER-drop replaced with the convergent sequence: re-execute the run's stored typed `MaterializationRecipe` DDL (grain `(typed_table_id,'typed',run_id)`, absence fails loud, recipe row READ-only) → `CREATE OR REPLACE lake.quarantine."quarantine_columns_<bare>"` in one shot → drop the quarantined columns. The try/except warning-downgrade is gone — a lake failure fails the activity (rollback per 9d262fde); warnings remain only for the structural no-duckdb_path case. `quarantine_columns_*` has zero readers, so the relocation is consumer-safe.

Both DuckLake capability assumptions **proven against the real fixture** (no fallbacks needed): cross-catalog CTAS from an ATTACHed backend into `lake.raw`, and `ALTER TABLE … DROP COLUMN` on a DuckLake table.

No cleanup for shipped `lake.main` strays — workspaces are disposable per DD/34045953.

## Acceptance criteria

- [x] Integration test against the DuckLake fixture: db_recipe import lands the physical table in the raw schema and the metadata `duckdb_path` resolves to it (`tests/integration/sources/test_db_recipe_lake.py`)
- [x] Re-executing the db_recipe import body converges (no collision, no `lake.main` stray)
- [x] Re-executing the eligibility phase body converges: no duplicate quarantine rows, column drop idempotent, no swallowed errors (`TestLakeConvergence` in `tests/integration/pipeline/test_column_eligibility_phase.py`)
- [x] No `{current_catalog}.main` writes remain in the engine (grep gate: only comments mention `.main`)

## Lane smoke

```
uv run pytest tests/integration/sources/test_db_recipe_lake.py \
              tests/integration/pipeline/test_column_eligibility_phase.py -q
6 passed in 6.38s   (real DuckLake fixture: testcontainer PG + tmp DATA_PATH)

uv run ruff format && uv run ruff check && uv run mypy src/ && uv run vulture src/dataraum vulture_whitelist.py --min-confidence 80
all clean
uv run pytest --testmon tests -q
1806 passed, 8 skipped
```

## Other lanes in flight

- DAT-502 lane (epic DAT-501) owns `pipeline/phases/import_phase.py` (`_rollback_partial_load`) — file sets are disjoint by design, no merge conflict expected.
- Open PRs: #245 (ADR-0009 docs, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)