### PR TITLE
DAT-511: operating_model refuses an unpromoted session — engine guard + cockpit pre-check

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -29,7 +29,14 @@ reproduces post-fix, the date-ordering count (2) and the metric grounding
 failures become real precision findings (the A4 due-date fix was supposed to
 zero the former).
 
-- **Status**: pending (blocked on DAT-511; smoke rerun owes eval the clean-leg verdict)
+**DAT-511 guard landed**: `resolve_operating_model_scope` now fails born-loud
+(non-retryable `PhaseFailed`) when the session has linked tables but no promoted
+begin_session head — operating_model can no longer ground over a partial
+workspace. Eval drivers must await `beginSessionWorkflow` completion before
+starting `operatingModelWorkflow` (the sequential runner already does); a driver
+that pipelines them will now fail fast instead of producing quiet noise.
+
+- **Status**: pending (DAT-511 merged; smoke rerun owes eval the clean-leg verdict)
 
 ## 2026-06-11 (pre-merge sweep): relationship_discovery gaps preserved from LANE-NOTES
 

--- a/packages/cockpit/src/db/cockpit/runs.ts
+++ b/packages/cockpit/src/db/cockpit/runs.ts
@@ -214,3 +214,32 @@ export async function listWatchableRuns(
 		.limit(limit);
 	return rows.map((r) => ({ ...r, stage: r.stage as RunStage }));
 }
+
+/**
+ * Whether the engine session has an in-flight run at `stage` (DAT-511). The
+ * `operating_model` tool pre-checks `begin_session` here so a user (or the
+ * agent, mis-narrated per DAT-510) can't start the operating model against a
+ * session that hasn't promoted yet — the engine guards the same precondition
+ * born-loud (`resolve_operating_model_scope`); this check just turns the
+ * workflow failure into a friendly in-chat sentence. Conservative on staleness:
+ * a crashed run lingering as `running` blocks until the reload reconcile
+ * (`reconcileActiveRuns`) sweeps it terminal.
+ */
+export async function hasRunningRun(
+	engineSessionId: string,
+	stage: RunStage,
+): Promise<boolean> {
+	const [row] = await cockpitDb
+		.select({ id: sessionRuns.id })
+		.from(sessionRuns)
+		.innerJoin(sessions, eq(sessionRuns.sessionId, sessions.id))
+		.where(
+			and(
+				eq(sessions.engineSessionId, engineSessionId),
+				eq(sessionRuns.stage, stage),
+				eq(sessionRuns.status, "running"),
+			),
+		)
+		.limit(1);
+	return row !== undefined;
+}

--- a/packages/cockpit/src/tools/operating-model.test.ts
+++ b/packages/cockpit/src/tools/operating-model.test.ts
@@ -19,6 +19,7 @@ const h = vi.hoisted(() => ({
 		temporalTaskQueue: "dataraum-pipeline",
 	} as Record<string, unknown>,
 	recordRun: vi.fn(async () => {}),
+	hasRunningRun: vi.fn(async () => false),
 }));
 
 vi.mock("#/config", () => ({
@@ -32,7 +33,10 @@ vi.mock("#/config", () => ({
 vi.mock("#/db/cockpit/registry", () => ({
 	resolveActiveWorkspace: vi.fn(async () => h.config.dataraumWorkspaceId),
 }));
-vi.mock("#/db/cockpit/runs", () => ({ recordRun: h.recordRun }));
+vi.mock("#/db/cockpit/runs", () => ({
+	recordRun: h.recordRun,
+	hasRunningRun: h.hasRunningRun,
+}));
 
 const startMock = vi.fn(async (_name: string, _opts: unknown) => ({
 	firstExecutionRunId: "run-xyz",
@@ -113,5 +117,23 @@ describe("operatingModel (DAT-440)", () => {
 			workflowId: `operatingmodel-${WS}-sess-1`,
 			runId: "run-xyz",
 		});
+	});
+
+	it("refuses with { error } while begin_session is still running (DAT-511)", async () => {
+		// The engine guards the same precondition born-loud; the tool turns the
+		// would-be workflow failure into an agent-actionable sentence — and
+		// must NOT start the workflow or record a run.
+		h.hasRunningRun.mockResolvedValueOnce(true);
+		const result = await operatingModel({ session_id: "sess-1" });
+		expect(result).toMatchObject({
+			error: expect.stringContaining("begin_session is still running"),
+		});
+		expect(startMock).not.toHaveBeenCalled();
+		expect(h.recordRun).not.toHaveBeenCalled();
+	});
+
+	it("checks the begin_session stage for the requested session", async () => {
+		await operatingModel({ session_id: "sess-1" });
+		expect(h.hasRunningRun).toHaveBeenCalledWith("sess-1", "begin_session");
 	});
 });

--- a/packages/cockpit/src/tools/operating-model.ts
+++ b/packages/cockpit/src/tools/operating-model.ts
@@ -25,13 +25,14 @@ import { z } from "zod";
 
 import { config } from "../config";
 import { resolveActiveWorkspace } from "../db/cockpit/registry";
-import { recordRun } from "../db/cockpit/runs";
+import { hasRunningRun, recordRun } from "../db/cockpit/runs";
 import type {
 	OperatingModelInput,
 	OperatingModelResult,
 	SessionIdentity,
 } from "../temporal/types";
 import { operatingModelWorkflowId } from "../temporal/workflow-id";
+import { type AgentError, withAgentError } from "./agent-error";
 
 export interface OperatingModelToolInput {
 	// The begin_session session to run the stage over — its table set anchors
@@ -52,7 +53,7 @@ export interface OperatingModelToolResult {
  */
 export async function operatingModel(
 	input: OperatingModelToolInput,
-): Promise<OperatingModelToolResult> {
+): Promise<OperatingModelToolResult | AgentError> {
 	if (
 		!config.temporalHost ||
 		!config.temporalNamespace ||
@@ -62,6 +63,20 @@ export async function operatingModel(
 			"Temporal client is not configured. Set TEMPORAL_HOST, " +
 				"TEMPORAL_NAMESPACE, TEMPORAL_TASK_QUEUE in the cockpit env.",
 		);
+	}
+
+	// Sequencing pre-check (DAT-511): the operating model grounds on the
+	// promoted begin_session workspace — starting it mid-session pins an empty
+	// relationship context (the engine refuses born-loud; this check turns
+	// that workflow failure into an agent-actionable sentence instead).
+	if (await hasRunningRun(input.session_id, "begin_session")) {
+		return {
+			error:
+				`begin_session is still running for session '${input.session_id}' — ` +
+				"the operating model grounds on the session's promoted workspace. " +
+				"Wait for the session to finish (you'll be told when it does), " +
+				"then run operating_model again.",
+		};
 	}
 
 	const workspaceId = await resolveActiveWorkspace();
@@ -129,7 +144,9 @@ export const operatingModelTool = toolDefinition({
 		"run_id; the run proceeds in the background and its progress shows live " +
 		"in the canvas — you'll be told automatically when it finishes, so don't " +
 		"poll for status; then use look_validation to see the outcomes. " +
-		"Re-running the same session_id re-evaluates its validations.",
+		"Re-running the same session_id re-evaluates its validations. " +
+		"Precondition: the session's begin_session run must have FINISHED — " +
+		"while it is still running this returns { error } instead of starting.",
 	inputSchema: z.object({
 		session_id: z
 			.string()
@@ -137,9 +154,11 @@ export const operatingModelTool = toolDefinition({
 				"The begin_session session to run the stage over (its session_id; the engine re-reads the session's table set).",
 			),
 	}),
-	outputSchema: z.object({
-		workflow_id: z.string(),
-		run_id: z.string(),
-		session_id: z.string(),
-	}),
+	outputSchema: withAgentError(
+		z.object({
+			workflow_id: z.string(),
+			run_id: z.string(),
+			session_id: z.string(),
+		}),
+	),
 }).server((input) => operatingModel(input));

--- a/packages/engine/src/dataraum/lifecycle/base_runs.py
+++ b/packages/engine/src/dataraum/lifecycle/base_runs.py
@@ -59,9 +59,11 @@ def resolve_operating_model_base_runs(
         table_ids: the session's typed tables.
 
     Returns:
-        The pinned map. Unresolved heads are recorded as absent (fail-closed
-        at the readers), and logged — a missing begin_session head on a
-        session that is supposed to have one is worth seeing.
+        The pinned map. An unresolved SEMANTIC head is recorded as absent
+        (fail-closed at the readers: that table's annotations stay empty). An
+        unresolved relationship head (``relationship_run_id=None``) is logged
+        here but REFUSED by the only caller (``resolve_operating_model_scope``,
+        DAT-511) — it is not a state downstream code handles.
     """
     # "detect" is begin_session's promoted stage on the session target (see
     # promote_session_run) — distinct from operating_model's own head, which

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -766,28 +766,33 @@ def resolve_operating_model_scope(
     resolution downstream.
 
     Raises:
-        RuntimeError: workspace mismatch, unknown session, or a session with
-            no linked tables (begin_session must have run) — fail loud, the
-            workflow has nothing to operate on.
-        ApplicationError: linked tables but no promoted begin_session head —
-            the session is mid-flight or failed (DAT-511); non-retryable
-            (``PhaseFailed``), grounding must not run over a partial workspace.
+        ApplicationError: every pre-flight refusal — workspace mismatch,
+            unknown session, no linked tables, or (DAT-511) linked tables but
+            no promoted begin_session head (mid-flight or failed session;
+            grounding must not run over a partial workspace). All deterministic
+            until the world changes, hence non-retryable ``PhaseFailed`` —
+            a plain ``RuntimeError`` would burn the retry policy's 5 attempts
+            on a structurally-impossible state.
     """
     from dataraum.lifecycle import resolve_operating_model_base_runs
 
     active_workspace_id = get_active_workspace_id()
     if identity.workspace_id != active_workspace_id:
-        raise RuntimeError(
+        raise ApplicationError(
             f"Workspace mismatch: operating_model resolve targets '{identity.workspace_id}' "
-            f"but this worker is bound to '{active_workspace_id}'."
+            f"but this worker is bound to '{active_workspace_id}'.",
+            type="PhaseFailed",
+            non_retryable=True,
         )
 
     with manager.session_scope() as session:
         inv_session = session.get(InvestigationSession, identity.session_id)
         if inv_session is None:
-            raise RuntimeError(
+            raise ApplicationError(
                 f"InvestigationSession '{identity.session_id}' not found — "
-                "operating_model runs over an existing journey session."
+                "operating_model runs over an existing journey session.",
+                type="PhaseFailed",
+                non_retryable=True,
             )
         # Born-loud on a typo'd / never-framed vertical (DAT-480): an unknown
         # name would silently resolve to no declared validations/cycles/metrics
@@ -796,9 +801,11 @@ def resolve_operating_model_scope(
         require_known_vertical(inv_session.vertical)
         table_ids = tables_for_session(session, identity.session_id)
         if not table_ids:
-            raise RuntimeError(
+            raise ApplicationError(
                 f"Session '{identity.session_id}' has no linked tables — "
-                "begin_session must compose the workspace before operating_model runs."
+                "begin_session must compose the workspace before operating_model runs.",
+                type="PhaseFailed",
+                non_retryable=True,
             )
         base_runs = resolve_operating_model_base_runs(session, identity.session_id, table_ids)
         if base_runs.relationship_run_id is None:

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -23,6 +23,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import func, select
+from temporalio.exceptions import ApplicationError
 
 from dataraum.core.config import load_phase_config, load_pipeline_config
 from dataraum.core.logging import get_logger
@@ -768,6 +769,9 @@ def resolve_operating_model_scope(
         RuntimeError: workspace mismatch, unknown session, or a session with
             no linked tables (begin_session must have run) — fail loud, the
             workflow has nothing to operate on.
+        ApplicationError: linked tables but no promoted begin_session head —
+            the session is mid-flight or failed (DAT-511); non-retryable
+            (``PhaseFailed``), grounding must not run over a partial workspace.
     """
     from dataraum.lifecycle import resolve_operating_model_base_runs
 
@@ -797,6 +801,22 @@ def resolve_operating_model_scope(
                 "begin_session must compose the workspace before operating_model runs."
             )
         base_runs = resolve_operating_model_base_runs(session, identity.session_id, table_ids)
+        if base_runs.relationship_run_id is None:
+            # Born-loud (DAT-511): linked tables but no promoted begin_session
+            # head means the session is mid-flight or failed — grounding would
+            # run with empty relationship/enriched-view context and band over a
+            # partial workspace (the 2026-06-11 live-smoke failure). The
+            # `session_tables` check above can't catch this: begin_session's
+            # SELECT phase writes those rows minutes before its promote.
+            # Non-retryable — deterministic until begin_session promotes; the
+            # caller re-runs once it has (the cockpit tool pre-checks this).
+            raise ApplicationError(
+                f"Session '{identity.session_id}' has no promoted begin_session "
+                "run — begin_session is still running or failed. Let it finish, "
+                "then re-run operating_model.",
+                type="PhaseFailed",
+                non_retryable=True,
+            )
 
     logger.info(
         "operating_model_scope_resolved",

--- a/packages/engine/tests/unit/worker/test_operating_model_activity.py
+++ b/packages/engine/tests/unit/worker/test_operating_model_activity.py
@@ -15,6 +15,7 @@ import pytest
 from sqlalchemy import create_engine, event, select
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
+from temporalio.exceptions import ApplicationError
 
 from dataraum.investigation.db_models import InvestigationSession, SessionTable
 from dataraum.storage import MetadataSnapshotHead, Table, init_database, session_head_target
@@ -104,14 +105,18 @@ class TestResolveOperatingModelScope:
         # tbl-2 has no promoted semantic head → absent, never guessed.
         assert scope.semantic_runs == {"tbl-1": "run-sem-1"}
 
-    def test_unpromoted_session_pins_nothing(self, monkeypatch, session_factory):
+    def test_unpromoted_session_fails_born_loud(self, monkeypatch, session_factory):
+        """Linked tables but no promoted begin_session head = mid-flight or
+        failed session (DAT-511) — refuse to ground over a partial workspace
+        instead of pinning None and warning (the 2026-06-11 live-smoke bug).
+        Non-retryable: deterministic until begin_session promotes."""
         monkeypatch.setattr(activity_mod, "get_active_workspace_id", lambda: "ws-1")
         _seed_session(session_factory, ["tbl-1"])
 
-        scope = resolve_operating_model_scope(_manager(session_factory), _IDENTITY)
-
-        assert scope.relationship_run_id is None  # fail-closed at the readers
-        assert scope.semantic_runs == {}
+        with pytest.raises(ApplicationError, match="no promoted begin_session") as exc:
+            resolve_operating_model_scope(_manager(session_factory), _IDENTITY)
+        assert exc.value.non_retryable is True
+        assert exc.value.type == "PhaseFailed"
 
     def test_no_linked_tables_fails_loud(self, monkeypatch, session_factory):
         monkeypatch.setattr(activity_mod, "get_active_workspace_id", lambda: "ws-1")

--- a/packages/engine/tests/unit/worker/test_operating_model_activity.py
+++ b/packages/engine/tests/unit/worker/test_operating_model_activity.py
@@ -124,13 +124,13 @@ class TestResolveOperatingModelScope:
             s.add(InvestigationSession(session_id=_IDENTITY.session_id, intent="test"))
             s.commit()
 
-        with pytest.raises(RuntimeError, match="no linked tables"):
+        with pytest.raises(ApplicationError, match="no linked tables"):
             resolve_operating_model_scope(_manager(session_factory), _IDENTITY)
 
     def test_unknown_session_fails_loud(self, monkeypatch, session_factory):
         monkeypatch.setattr(activity_mod, "get_active_workspace_id", lambda: "ws-1")
 
-        with pytest.raises(RuntimeError, match="not found"):
+        with pytest.raises(ApplicationError, match="not found"):
             resolve_operating_model_scope(_manager(session_factory), _IDENTITY)
 
     def test_typod_vertical_fails_born_loud(self, monkeypatch, session_factory):
@@ -153,7 +153,7 @@ class TestResolveOperatingModelScope:
     def test_workspace_mismatch_refused(self, monkeypatch, session_factory):
         monkeypatch.setattr(activity_mod, "get_active_workspace_id", lambda: "ws-OTHER")
 
-        with pytest.raises(RuntimeError, match="Workspace mismatch"):
+        with pytest.raises(ApplicationError, match="Workspace mismatch"):
             resolve_operating_model_scope(_manager(session_factory), _IDENTITY)
 
 


### PR DESCRIPTION
## Task

[DAT-511](https://real-dataraum.atlassian.net/browse/DAT-511) — found by the 2026-06-11 live smoke: the operating model started ~90s before begin_session promoted (DAT-510 mis-narration), `resolve_operating_model_scope` pinned `relationship_run_id=None` with only a log warning, and the whole run grounded with empty relationship/enriched-view context. Approach = option B (refined with Philipp): engine fail-loud + cockpit pre-check. Durable-wait explicitly rejected.

## What changed

**Engine (the contract):** `resolve_operating_model_scope` raises non-retryable `ApplicationError(type="PhaseFailed")` when the session has linked tables but no promoted begin_session head — the `session_tables` check can't catch this (begin_session's SELECT phase writes those rows minutes before promote). Review pass also promoted the three sibling pre-flight guards (workspace mismatch / unknown session / no linked tables) from `RuntimeError` — which burned 5 retry attempts on deterministic failures — to the same convention. The test pinning the old silent-None behavior flips to pin the loud failure (asserting message + `non_retryable` + type); `base_runs.py` docstring updated (None is refused at the resolver now, not handled at readers).

**Cockpit (the UX complement):** the `operating_model` tool pre-checks cockpit_db `session_runs` (`stage='begin_session'`, `status='running'` joined via `sessions.engineSessionId`) before touching Temporal and returns the agent-error envelope — the normal flow gets a sentence in chat instead of a workflow failure. New `hasRunningRun` helper; tool description documents the precondition; TOCTOU is harmless by design (the engine guard catches the inverse direction).

**Handoff:** the pending live-smoke entry now tells eval drivers to await `beginSessionWorkflow` before `operatingModelWorkflow`.

Deliberately NOT taken from review: aligning the cockpit message to the engine's "or failed" — the pre-check only fires on `status='running'`, so "is still running" is precise for its layer; a *failed* begin_session passes the pre-check and gets the engine's message, which names that case.

## Acceptance

- [x] Starting operating_model before begin_session promotes fails with an explicit reason (engine, non-retryable) — regression-pinned
- [x] The cockpit flow refuses with `{ error }` and starts nothing (no Temporal call, no recordRun) — unit-pinned
- [x] No durable-wait machinery, no progress-widget changes
- [ ] Clean-leg smoke rerun (the eval handoff's pending verdict) — rides on this merge + topped-up API credits

## Reviews

senior-code-reviewer: APPROVE (sibling-guard promotion + base_runs docstring folded in). spec-compliance-reviewer: COMPLIANT (14/14 traced, no scope creep).

## Gates

Engine: ruff format/check, mypy, vulture, worker suite 56 passed. Cockpit: biome, tsc, vitest 1083 passed, vite build.

## Other lanes in flight

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)