### PR TITLE
DAT-510 + DAT-512: honest completion narration + actionable chat errors

### DIFF
--- a/packages/cockpit/src/db/cockpit/runs.ts
+++ b/packages/cockpit/src/db/cockpit/runs.ts
@@ -174,6 +174,27 @@ export async function listNonTerminalRuns(
 		.limit(limit);
 }
 
+/**
+ * The DISTINCT stages of the workspace's still-`running` runs — the in-flight set
+ * the completion narration must NOT claim finished (DAT-510). Cheap and unbounded
+ * (≤3 possible stages); newest-first ordering is irrelevant since we dedup.
+ */
+export async function listRunningStages(
+	workspaceId: string,
+): Promise<Array<RunStage>> {
+	const rows = await cockpitDb
+		.selectDistinct({ stage: sessionRuns.stage })
+		.from(sessionRuns)
+		.innerJoin(sessions, eq(sessionRuns.sessionId, sessions.id))
+		.where(
+			and(
+				eq(sessions.workspaceId, workspaceId),
+				eq(sessionRuns.status, "running"),
+			),
+		);
+	return rows.map((r) => r.stage as RunStage);
+}
+
 /** A run the completion-watcher should poll: in-flight (`running`) and not yet
  * narrated. Carries `stage` so the narration can name what finished ("the import"
  * vs "the session"). */

--- a/packages/cockpit/src/lib/chat-error.test.ts
+++ b/packages/cockpit/src/lib/chat-error.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { classifyChatError } from "#/lib/chat-error";
+
+describe("classifyChatError (DAT-512)", () => {
+	it("surfaces credit exhaustion as actionable, naming what to do", () => {
+		// The real Anthropic 400 the live smoke hit.
+		const e = classifyChatError(
+			'400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."}}',
+		);
+		expect(e.title).toBe("Out of API credits");
+		expect(e.body).toContain("Plans & Billing");
+	});
+
+	it("classifies a rejected API key as a config problem", () => {
+		const e = classifyChatError(
+			'401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}',
+		);
+		expect(e.title).toBe("API key rejected");
+	});
+
+	it("classifies rate limiting as transient", () => {
+		const e = classifyChatError(
+			'429 {"type":"error","error":{"type":"rate_limit_error","message":"Number of requests has exceeded your rate limit"}}',
+		);
+		expect(e.title).toBe("Rate limited");
+	});
+
+	it("classifies overload as transient", () => {
+		const e = classifyChatError(
+			'529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+		);
+		expect(e.title).toBe("Service busy");
+	});
+
+	it("falls back to the generic message for unknown errors", () => {
+		const e = classifyChatError("network error: stream closed");
+		expect(e.title).toBe("Something went wrong");
+		expect(e.body).toContain("please try again");
+	});
+
+	it("does not match a bare 'billing' substring (over-broad anchor removed)", () => {
+		// Only the SDK's exact credit phrase classifies as out-of-credits — an
+		// unrelated error that merely mentions billing must fall through.
+		const e = classifyChatError(
+			"failed to validate billing address column in customers",
+		);
+		expect(e.title).toBe("Something went wrong");
+	});
+
+	it("is case-insensitive on the matched tokens", () => {
+		const e = classifyChatError("Your Credit Balance Is Too Low");
+		expect(e.title).toBe("Out of API credits");
+	});
+
+	it("does not misclassify a generic message that merely contains a 3-digit number", () => {
+		// Guards the decision to match type tokens/phrases, not bare HTTP codes:
+		// a token count of 429 in an otherwise-unknown error must NOT read as a
+		// rate limit.
+		const e = classifyChatError("request used 4290 tokens and then failed");
+		expect(e.title).toBe("Something went wrong");
+	});
+});

--- a/packages/cockpit/src/lib/chat-error.ts
+++ b/packages/cockpit/src/lib/chat-error.ts
@@ -1,0 +1,75 @@
+// Classify a chat stream/transport error into a user-actionable message
+// (DAT-512). The raw `error.message` from useChat is a provider/transport string
+// — e.g. the Anthropic SDK's `400 {"type":"error","error":{"type":
+// "invalid_request_error","message":"Your credit balance is too low …"}}`. The
+// chat rail used to show a flat "please try again" over all of them, hiding the
+// one cause the user can act on (out of credits). This narrows the known,
+// recoverable-by-the-user cases and says what to DO; everything else keeps the
+// generic copy.
+//
+// Pure (no I/O, no React) so it's unit-testable and lives off the render path
+// (React-idiom rule 10). Match on the provider's stable error `type` tokens and
+// unambiguous phrases — NOT bare HTTP status numbers, which collide with request
+// ids and token counts in the same string.
+
+export interface ClassifiedChatError {
+	/** Alert title — the cause in a few words. */
+	title: string;
+	/** One sentence: what happened and what to do next. The body itself carries
+	 * the retry/no-retry guidance ("Top up credits" vs "try again") — there is no
+	 * separate retry affordance to gate, so no boolean is exposed. */
+	body: string;
+}
+
+export function classifyChatError(message: string): ClassifiedChatError {
+	const m = message.toLowerCase();
+
+	// Billing / credit exhaustion — a 400 invalid_request_error whose message is
+	// the credit phrase. Retrying changes nothing; the user must top up. Match the
+	// SDK's exact, stable phrase only — a bare "billing" substring would catch
+	// unrelated errors that happen to mention the word.
+	if (m.includes("credit balance is too low")) {
+		return {
+			title: "Out of API credits",
+			body: "The Anthropic API credit balance is too low to run the assistant. Top up credits in Plans & Billing, then try again.",
+		};
+	}
+
+	// Auth — the key was rejected. A server-config problem, not a user retry.
+	if (
+		m.includes("authentication_error") ||
+		m.includes("invalid x-api-key") ||
+		m.includes("x-api-key")
+	) {
+		return {
+			title: "API key rejected",
+			body: "The Anthropic API key was rejected. Check the server's ANTHROPIC_API_KEY configuration.",
+		};
+	}
+
+	// Rate limited — transient; a short wait then retry is the right move.
+	if (
+		m.includes("rate_limit") ||
+		m.includes("rate limit") ||
+		m.includes("too many requests")
+	) {
+		return {
+			title: "Rate limited",
+			body: "Too many requests in a short window. Wait a few seconds, then try again.",
+		};
+	}
+
+	// Anthropic-side overload — transient; give it a moment.
+	if (m.includes("overloaded")) {
+		return {
+			title: "Service busy",
+			body: "Anthropic is temporarily overloaded. Give it a moment and try again.",
+		};
+	}
+
+	// Unknown — keep the generic, retry-safe copy.
+	return {
+		title: "Something went wrong",
+		body: "The assistant couldn't finish that — please try again.",
+	};
+}

--- a/packages/cockpit/src/lib/completion-note.test.ts
+++ b/packages/cockpit/src/lib/completion-note.test.ts
@@ -52,3 +52,68 @@ describe("completionNote (Phase 2A — name-leak protection)", () => {
 		expect(note("begin_session")).not.toContain("begin_session");
 	});
 });
+
+describe("completionNote (DAT-510 — narration boundary)", () => {
+	const body = (note: ReturnType<typeof completionNote>) =>
+		(note.parts[0] as { content: string }).content;
+
+	it("anchors to THIS run when nothing else is in flight", () => {
+		const note = completionNote("add_source", {
+			failed: false,
+			failureMessage: null,
+		});
+		expect(body(note)).toContain(
+			"Narrate ONLY the data import — do not state or imply any other run finished.",
+		);
+	});
+
+	it("names a single still-running stage as off-limits", () => {
+		// add_source landed while begin_session is still running — the bug was the
+		// agent narrating the session as done. The note must forbid that.
+		const note = completionNote(
+			"add_source",
+			{ failed: false, failureMessage: null },
+			["begin_session"],
+		);
+		expect(body(note)).toContain("the analysis session is still running");
+		expect(body(note)).toContain("narrate ONLY the data import");
+		expect(body(note)).toContain("do NOT say or imply it has finished");
+	});
+
+	it("lists multiple still-running stages with plural agreement", () => {
+		const note = completionNote(
+			"add_source",
+			{ failed: false, failureMessage: null },
+			["begin_session", "operating_model"],
+		);
+		expect(body(note)).toContain(
+			"the analysis session and operating-model run are still running",
+		);
+		expect(body(note)).toContain("do NOT say or imply they have finished");
+	});
+
+	it("excludes this run's own stage and dedups the in-flight set", () => {
+		// The finished run may still appear in a racy snapshot; it must never be
+		// listed as "still running", and duplicates collapse.
+		const note = completionNote(
+			"begin_session",
+			{ failed: false, failureMessage: null },
+			["begin_session", "add_source", "add_source"],
+		);
+		expect(body(note)).toContain("the data import is still running");
+		expect(body(note)).not.toContain("analysis session is still running");
+		// Single remaining stage → singular agreement.
+		expect(body(note)).toContain("do NOT say or imply it has finished");
+	});
+
+	it("falls back to the solo-run boundary when in-flight collapses to empty", () => {
+		const note = completionNote(
+			"operating_model",
+			{ failed: false, failureMessage: null },
+			["operating_model"],
+		);
+		expect(body(note)).toContain(
+			"Narrate ONLY the operating-model run — do not state or imply any other run finished.",
+		);
+	});
+});

--- a/packages/cockpit/src/lib/completion-note.ts
+++ b/packages/cockpit/src/lib/completion-note.ts
@@ -22,6 +22,13 @@ export interface RunOutcome {
 	failureMessage: string | null;
 }
 
+/** Join labels into a readable "a", "a and b", "a, b and c" phrase. Called only
+ * with a non-empty list (the caller guards on `stillRunning.length`). */
+function joinLabels(labels: string[]): string {
+	if (labels.length <= 1) return labels.join("");
+	return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
+}
+
 /**
  * Build the model-only completion note. role "user" so the transcript ends on a
  * user turn (a no-prefill model requires that) and the converter keeps it;
@@ -32,10 +39,18 @@ export interface RunOutcome {
  * protection the retired `workflow_status` projection applied (DAT-433): a
  * content-keyed `src_<digest>` or a staged-upload s3 URI must never reach the
  * model. The agent is told NOT to echo run/workflow ids either.
+ *
+ * `inFlight` is the set of OTHER stages still running for this workspace at
+ * narration time. The note runs against the full transcript, which carries the
+ * user's whole-journey intent, so without an explicit boundary the agent
+ * narrates one stage ahead — announcing a stage that's only just started, or
+ * still running, as finished (DAT-510). We anchor it to THIS run and name the
+ * still-running stages as off-limits.
  */
 export function completionNote(
 	stage: RunStage,
 	outcome: RunOutcome,
+	inFlight: RunStage[] = [],
 ): UIMessage {
 	const label = STAGE_LABEL[stage];
 	const result = outcome.failed
@@ -45,8 +60,19 @@ export function completionNote(
 					: ""
 			}`
 		: "finished successfully";
+	// Dedup + drop this run's own stage; map to user-facing labels.
+	const stillRunning = [...new Set(inFlight)]
+		.filter((s) => s !== stage)
+		.map((s) => STAGE_LABEL[s]);
+	const boundary = stillRunning.length
+		? ` Note: the ${joinLabels(stillRunning)} ${
+				stillRunning.length > 1 ? "are" : "is"
+			} still running — narrate ONLY the ${label}, and do NOT say or imply ${
+				stillRunning.length > 1 ? "they have" : "it has"
+			} finished.`
+		: ` Narrate ONLY the ${label} — do not state or imply any other run finished.`;
 	const body =
-		`[system event] The ${label} just ${result}. ` +
+		`[system event] The ${label} just ${result}.${boundary} ` +
 		"Tell the user it's done in one or two sentences and suggest the next step " +
 		"in the onboarding journey. Inspect the workspace with your tools if you " +
 		"need specifics; don't mention this note or any run/workflow ids.";

--- a/packages/cockpit/src/lib/completion-watcher.ts
+++ b/packages/cockpit/src/lib/completion-watcher.ts
@@ -31,6 +31,7 @@ import {
 } from "#/db/cockpit/conversations";
 import {
 	claimRunNarration,
+	listRunningStages,
 	listWatchableRuns,
 	markRunStatus,
 	type WatchableRun,
@@ -168,13 +169,17 @@ async function watchLoop(
 			);
 			// The atomic claim is the once-only guard across tabs.
 			if (await claimRunNarration(run.workflowId, run.runId)) {
-				await narrateCompletion(conversationId, run, progress, signal).catch(
-					(err) => {
-						console.warn(
-							`[completion-watcher] narrate failed for run ${run.runId}: ${err}`,
-						);
-					},
-				);
+				await narrateCompletion(
+					conversationId,
+					workspaceId,
+					run,
+					progress,
+					signal,
+				).catch((err) => {
+					console.warn(
+						`[completion-watcher] narrate failed for run ${run.runId}: ${err}`,
+					);
+				});
 			}
 		}
 	}
@@ -184,14 +189,25 @@ async function watchLoop(
  * published over the bus. Aborts with the stream (the linked controller). */
 async function narrateCompletion(
 	conversationId: string,
+	workspaceId: string,
 	run: WatchableRun,
 	progress: WorkflowProgress,
 	signal: AbortSignal,
 ): Promise<void> {
-	const note = completionNote(run.stage, {
-		failed: terminalRunStatus(progress) === "failed",
-		failureMessage: progress.failure?.message ?? null,
-	});
+	// The OTHER stages still running for this workspace — the agent must narrate
+	// only THIS run and not claim these finished (DAT-510). The just-finished run
+	// is already marked terminal upstream, so it's excluded from this set. On a DB
+	// hiccup, degrade to `[]` (the solo-run boundary): safe direction — the note
+	// still pins to this run, it just can't name the others.
+	const inFlight = await listRunningStages(workspaceId).catch(() => []);
+	const note = completionNote(
+		run.stage,
+		{
+			failed: terminalRunStatus(progress) === "failed",
+			failureMessage: progress.failure?.message ?? null,
+		},
+		inFlight,
+	);
 	await appendMessages(conversationId, [{ message: note, modelOnly: true }]);
 	const modelMessages = buildModelMessages(
 		await loadModelTranscript(conversationId),

--- a/packages/cockpit/src/ui/cockpit/chat-rail.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/chat-rail.test.tsx
@@ -183,6 +183,22 @@ describe("ChatRail (DAT-353)", () => {
 		// …and the canvas stops spinning rather than showing a generic error widget.
 		expect(screen.getByTestId("canvas-kind").textContent).toBe("empty");
 	});
+
+	it("classifies an actionable provider error into a cause + next step (DAT-512)", () => {
+		h.error = new Error(
+			'400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API."}}',
+		);
+		renderRail();
+		const alert = screen.getByTestId("chat-error");
+		// The cause is the headline, not a blanket "Something went wrong"…
+		expect(alert.textContent).toContain("Out of API credits");
+		expect(alert.textContent).toContain("Plans & Billing");
+		// …and the body says what to DO (top up) instead of the blind
+		// "please try again" prompt the generic fallback would show.
+		expect(alert.textContent).not.toContain("please try again");
+		// The raw provider string stays available for debugging.
+		expect(alert.textContent).toContain("credit balance is too low");
+	});
 });
 
 describe("ChatRail tool-result chips (DAT-354)", () => {

--- a/packages/cockpit/src/ui/cockpit/chat-rail.tsx
+++ b/packages/cockpit/src/ui/cockpit/chat-rail.tsx
@@ -14,6 +14,7 @@
 
 import { Alert, Box, Card, Group, Loader, Stack, Text } from "@mantine/core";
 import { useEffect, useRef } from "react";
+import { classifyChatError } from "#/lib/chat-error";
 import { useCockpit } from "#/ui/cockpit/cockpit-state";
 import { Composer } from "#/ui/cockpit/composer";
 import { MarkdownMessage } from "#/ui/cockpit/markdown";
@@ -152,6 +153,9 @@ function ToolCallCard({
 
 export function ChatRail() {
 	const { messages, isLoading, error, pinCanvas } = useCockpit();
+	// Turn the raw provider/transport error into a cause + next step (DAT-512).
+	// Derived during render — no effect, no mirrored state (React-idiom rule 1).
+	const classifiedError = error ? classifyChatError(error.message) : null;
 
 	// A completed canvas-tool chip click pins the canvas to that call's result.
 	// The provider re-derives the canvas from the call id (canvasFromCallId), so
@@ -264,12 +268,13 @@ export function ChatRail() {
 						<Alert
 							color="red"
 							variant="light"
-							title="Something went wrong"
+							title={classifiedError?.title ?? "Something went wrong"}
 							data-testid="chat-error"
 						>
 							<Stack gap="xs">
 								<Text size="sm">
-									The assistant couldn't finish that — please try again.
+									{classifiedError?.body ??
+										"The assistant couldn't finish that — please try again."}
 								</Text>
 								{/* Raw provider/transport error tucked away — never dump JSON
 								    (401 x-api-key, request_id, …) at the user; keep it for debugging. */}


### PR DESCRIPTION
## What

Two cockpit-only chat-surface honesty fixes surfaced by the DAT-509 live smoke, wrapped in one PR (same concern, disjoint files).

### DAT-510 — completion narration mis-attributes the finished run
The run-completion watcher runs an agent turn against the **full transcript** when a background Temporal run lands. Because the transcript carries the user's whole-journey intent, the agent narrated one stage ahead — e.g. the data import finished and it told the user the *analysis session* was done.

Fix = give the agent ground truth:
- `completionNote(stage, outcome, inFlight)` now takes the set of **other still-running stages** and constrains the note to narrate **only this run**, naming the in-flight stages as off-limits (singular/plural agreement; falls back to a solo-run boundary when nothing else runs).
- New `listRunningStages(workspaceId)` returns the distinct `running` stages; the watcher threads `workspaceId` into `narrateCompletion` and passes the set. The just-finished run is marked terminal *before* the query, so it's excluded.

### DAT-512 — actionable provider errors hidden behind "please try again"
The chat-rail error Alert showed a flat "Something went wrong / please try again" with the raw `error.message` collapsed — hiding the one cause the user can act on (out of API credits).

Fix:
- New pure `classifyChatError(message)` → `{ title, body }` maps known provider error tokens/phrases (credit exhaustion, auth, rate-limit, overloaded) to a cause + next step; generic fallback otherwise. Matches the SDK's stable phrases, not bare HTTP status numbers (guarded by a no-false-positive test).
- `chat-rail.tsx` derives `classifiedError` during render (React-idiom rule 1) and shows the actionable title/body, keeping the raw provider string in the `<details>` for debugging.

## Tests / gates

- New: `chat-error.test.ts` (per-category + case-insensitivity + bare-number & bare-"billing" false-positive guards), boundary-copy cases in `completion-note.test.ts`, a classified-billing-error case in `chat-rail.test.tsx`.
- Gates green: biome `check`, `tsc`, full vitest (1096), vite `build`.

## Review

senior-code-reviewer **APPROVE** + spec-compliance-reviewer **COMPLIANT**. Both flagged the over-broad `"billing"` anchor (narrowed to the exact SDK phrase) and `canRetry` being unused on the render path (dropped — the body copy already carries the retry/no-retry guidance); both addressed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)