### PR TITLE
feat(engine): typed-exception failure contract owns LLM retry (DAT-503)

### DIFF
--- a/packages/engine/src/dataraum/analysis/cycles/agent.py
+++ b/packages/engine/src/dataraum/analysis/cycles/agent.py
@@ -141,12 +141,10 @@ class BusinessCycleAgent(LLMFeature):
             model=model,
         )
 
-        result = self.provider.converse(request)
-
-        if not result.success or not result.value:
-            return Result.fail(f"LLM call failed: {result.error}")
-
-        response = result.unwrap()
+        # converse raises a typed ProviderError on an API failure (DAT-503) —
+        # retryability rides the exception to the worker's durable boundary, so
+        # we don't re-wrap it. A returned Result is always a success.
+        response = self.provider.converse(request).unwrap()
 
         # 4. Parse structured output. No tool call = degraded generation — a
         # hard failure for the synthesis (DAT-439 standard: no silent rescue).

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -195,10 +195,10 @@ class SemanticAgent(LLMFeature):
             model=model,
         )
 
-        response_result = self.provider.converse(request)
-        if not response_result.success or not response_result.value:
-            return Result.fail(response_result.error or "Table synthesis LLM call failed")
-        response = response_result.value
+        # converse raises a typed ProviderError on an API failure (DAT-503) —
+        # retryability rides the exception to the worker's durable boundary, so
+        # we don't re-wrap it. A returned Result is always a success.
+        response = self.provider.converse(request).unwrap()
 
         if not response.tool_calls or response.tool_calls[0].name != "analyze_tables":
             return Result.fail("LLM did not use the analyze_tables tool")

--- a/packages/engine/src/dataraum/analysis/semantic/column_agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/column_agent.py
@@ -150,11 +150,11 @@ class ColumnAnnotationAgent(LLMFeature):
             model=model,
         )
 
-        response_result = self.provider.converse(request)
-        if not response_result.success or not response_result.value:
-            return Result.fail(response_result.error or "Column annotation LLM call failed")
-
-        response = response_result.value
+        # converse raises a typed ProviderError on an API failure (DAT-503) —
+        # transient/permanent retryability rides the exception to the worker's
+        # durable boundary, so we don't re-wrap it as a Result here. A returned
+        # Result is always a success.
+        response = self.provider.converse(request).unwrap()
 
         # Extract tool output
         if not response.tool_calls:

--- a/packages/engine/src/dataraum/analysis/slicing/agent.py
+++ b/packages/engine/src/dataraum/analysis/slicing/agent.py
@@ -124,11 +124,10 @@ class SlicingAgent(LLMFeature):
             temperature=temperature,
         )
 
-        result = self.provider.converse(request)
-        if not result.success or not result.value:
-            return Result.fail(result.error or "LLM call failed")
-
-        response = result.value
+        # converse raises a typed ProviderError on an API failure (DAT-503) —
+        # retryability rides the exception to the worker's durable boundary, so
+        # we don't re-wrap it. A returned Result is always a success.
+        response = self.provider.converse(request).unwrap()
 
         # Extract tool call result
         if not response.tool_calls:

--- a/packages/engine/src/dataraum/analysis/validation/agent.py
+++ b/packages/engine/src/dataraum/analysis/validation/agent.py
@@ -357,11 +357,10 @@ class ValidationAgent(LLMFeature):
             model=model,
         )
 
-        result = self.provider.converse(request)
-        if not result.success or not result.value:
-            return Result.fail(result.error or "LLM call failed")
-
-        response = result.value
+        # converse raises a typed ProviderError on an API failure (DAT-503) —
+        # retryability rides the exception to the worker's durable boundary, so
+        # we don't re-wrap it. A returned Result is always a success.
+        response = self.provider.converse(request).unwrap()
 
         # No tool call = degraded generation. There is no rescue: under the
         # lifecycle this is a bind ERROR — the artifact stays ``declared``

--- a/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
+++ b/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
@@ -126,11 +126,10 @@ class EnrichmentAgent(LLMFeature):
             model=model,
         )
 
-        result = self.provider.converse(request)
-        if not result.success or not result.value:
-            return Result.fail(result.error or "LLM call failed")
-
-        response = result.value
+        # converse raises a typed ProviderError on an API failure (DAT-503) —
+        # retryability rides the exception to the worker's durable boundary, so
+        # we don't re-wrap it. A returned Result is always a success.
+        response = self.provider.converse(request).unwrap()
 
         # Extract tool call result
         if not response.tool_calls:

--- a/packages/engine/src/dataraum/documentation/agent.py
+++ b/packages/engine/src/dataraum/documentation/agent.py
@@ -122,11 +122,10 @@ class BatchPlanAgent:
             model=self.model,
         )
 
-        response_result = self.provider.converse(request)
-        if not response_result.success or not response_result.value:
-            return Result.fail(response_result.error or "LLM call failed")
-
-        response = response_result.value
+        # converse raises a typed ProviderError on an API failure (DAT-503) —
+        # retryability rides the exception, so we don't re-wrap it. A returned
+        # Result is always a success.
+        response = self.provider.converse(request).unwrap()
         if not response.tool_calls:
             return Result.fail("LLM did not use the tool")
 

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -440,11 +440,10 @@ class GraphAgent(LLMFeature):
             model=model,
         )
 
-        result = self.provider.converse(request)
-        if not result.success or not result.value:
-            return Result.fail(result.error or "LLM call failed")
-
-        response = result.value
+        # converse raises a typed ProviderError on an API failure (DAT-503) —
+        # retryability rides the exception to the worker's durable boundary, so
+        # we don't re-wrap it. A returned Result is always a success.
+        response = self.provider.converse(request).unwrap()
 
         # Extract tool call result. No tool call is a bind ERROR — never guess by
         # parsing free text as JSON (DAT-439's born-loud cut): a metric that can't
@@ -782,11 +781,10 @@ class GraphAgent(LLMFeature):
             model=self.provider.get_model_for_tier(model_tier),
         )
 
-        result = self.provider.converse(request)
-        if not result.success or not result.value:
-            return Result.fail(result.error or "LLM repair call failed")
-
-        response = result.value
+        # converse raises a typed ProviderError on an API failure (DAT-503) —
+        # retryability rides the exception to the worker's durable boundary, so
+        # we don't re-wrap it. A returned Result is always a success.
+        response = self.provider.converse(request).unwrap()
         if not response.content:
             return Result.fail("LLM returned empty response")
 

--- a/packages/engine/src/dataraum/llm/providers/anthropic.py
+++ b/packages/engine/src/dataraum/llm/providers/anthropic.py
@@ -11,15 +11,15 @@ from pydantic import BaseModel
 from dataraum.core.logging import get_logger
 from dataraum.core.models.base import Result
 from dataraum.llm.providers.base import (
-    PERMANENT_ERROR_KIND,
-    TRANSIENT_ERROR_KIND,
     ConversationRequest,
     ConversationResponse,
     LLMProvider,
     Message,
+    PermanentProviderError,
+    ProviderError,
     ToolCall,
     ToolResult,
-    format_api_error,
+    TransientProviderError,
 )
 
 
@@ -41,14 +41,14 @@ _PERMANENT_STATUS_CODES = frozenset({400, 401, 403, 404, 413, 422})
 _AUTH_STATUS_CODES = frozenset({401, 403})
 
 
-def _classify_anthropic_error(exc: anthropic.APIError) -> tuple[str, str]:
-    """Categorize an Anthropic exception so the caller can act on it.
+def _classify_anthropic_error(exc: anthropic.APIError) -> ProviderError:
+    """Build the typed :class:`ProviderError` to raise for an Anthropic exception.
 
-    Returns:
-        (kind, message): ``kind`` is "permanent" (user must fix) or
-        "transient" (retry may help). ``message`` is the human-readable
-        body of the error, with an actionable hint appended for auth
-        failures so practitioners know exactly what to fix.
+    Returns the exception *instance* whose type carries retryability — a
+    :class:`TransientProviderError` (retry may help) or
+    :class:`PermanentProviderError` (user must fix) — with the human-readable
+    body as its message, plus an actionable hint for auth failures so
+    practitioners know exactly what to fix.
 
     Classification:
         permanent — auth / forbidden / bad request / not found / payload
@@ -65,20 +65,20 @@ def _classify_anthropic_error(exc: anthropic.APIError) -> tuple[str, str]:
         if exc.status_code in _AUTH_STATUS_CODES:
             message = f"{message}. Check your ANTHROPIC_API_KEY."
         if exc.status_code in _PERMANENT_STATUS_CODES:
-            return PERMANENT_ERROR_KIND, message
-        return TRANSIENT_ERROR_KIND, message
+            return PermanentProviderError(message)
+        return TransientProviderError(message)
     # Connection / timeout errors don't have a status code; they're
     # always transient by definition.
     if isinstance(exc, anthropic.APIConnectionError):
-        return TRANSIENT_ERROR_KIND, str(exc)
+        return TransientProviderError(str(exc))
     # APIResponseValidationError: the server returned something the SDK
     # couldn't parse. Treat as permanent — retrying the same request
     # likely produces the same malformed response.
     if isinstance(exc, anthropic.APIResponseValidationError):
-        return PERMANENT_ERROR_KIND, str(exc)
+        return PermanentProviderError(str(exc))
     # Anything else under APIError — default to transient (retry is
     # the safer default than surfacing as a user error).
-    return TRANSIENT_ERROR_KIND, str(exc)
+    return TransientProviderError(str(exc))
 
 
 class AnthropicProvider(LLMProvider):
@@ -204,12 +204,22 @@ class AnthropicProvider(LLMProvider):
             )
 
         except anthropic.APIError as e:
-            kind, message = _classify_anthropic_error(e)
-            logger.error("anthropic_api_error", error=str(e), model=model, kind=kind)
-            return Result.fail(format_api_error("Anthropic", kind, message))
+            provider_error = _classify_anthropic_error(e)
+            logger.error(
+                "anthropic_api_error",
+                error=str(e),
+                model=model,
+                kind=type(provider_error).__name__,
+            )
+            # Raise the typed exception (DAT-503): retryability rides the type
+            # through the phase chain to the worker's durable boundary, not a
+            # substring of a Result.error every layer could reword.
+            raise provider_error from e
         except Exception as e:
             logger.error("anthropic_unexpected_error", error=str(e), model=model)
-            return Result.fail(f"Unexpected error calling Anthropic: {e}")
+            # Unexpected (non-API) failures are non-retryable — retrying the
+            # identical call is unlikely to clear a bug in our request shaping.
+            raise PermanentProviderError(f"Unexpected error calling Anthropic: {e}") from e
 
     def _convert_messages(self, messages: list[Message]) -> list[MessageParam]:
         """Convert our Message format to Anthropic's MessageParam format.

--- a/packages/engine/src/dataraum/llm/providers/base.py
+++ b/packages/engine/src/dataraum/llm/providers/base.py
@@ -12,35 +12,47 @@ from pydantic import BaseModel, Field
 
 from dataraum.core.models.base import Result
 
-# === API-failure classification ===
+# === API-failure classification (DAT-503) ===
 #
-# A provider tags its ``Result.error`` as transient or permanent so the durable
-# layer (the worker's ``_outcome_or_raise``) can decide retryability without a
-# provider-specific import or a brittle bare-string match. ``format_api_error``
-# (producer) and ``is_transient_error`` (consumer) are the one shared definition
-# of that tag — a round-trip test keeps them in lockstep.
-TRANSIENT_ERROR_KIND = "transient"
-PERMANENT_ERROR_KIND = "permanent"
+# A provider RAISES one of these typed exceptions on an API failure instead of
+# folding the error into ``Result.fail``. Retryability is then carried by the
+# exception *type*, not by a substring of the error string, so it survives the
+# ``converse`` -> phase-agent -> ``BasePhase.run`` -> ``run_phase`` chain
+# without any fragile re-parse. The durable boundary (the worker's
+# ``_outcome_or_raise``) classifies by ``isinstance`` and chooses the Temporal
+# retry policy accordingly.
+#
+# This deliberately crosses the "Result, not exceptions, for expected failures"
+# convention for the provider transient/permanent path specifically: a
+# transient API failure is exactly the case where retryability must live at the
+# durable/exception boundary, not as data threaded through a Result chain every
+# intermediate layer would have to forward faithfully (the substring tag this
+# replaces silently read as permanent the moment a layer reworded the message).
 
-_TRANSIENT_TAG = f"API error ({TRANSIENT_ERROR_KIND})"
 
+class ProviderError(Exception):
+    """Base for provider API failures raised out of :meth:`LLMProvider.converse`.
 
-def format_api_error(provider: str, kind: str, message: str) -> str:
-    """Render a provider API failure, embedding its transient/permanent ``kind``.
-
-    The ``({kind})`` tag is the single classification carrier read back by
-    :func:`is_transient_error` at the retry choke point.
+    Carries the human-readable provider message; the subclass *type* carries the
+    retryability the durable boundary reads.
     """
-    return f"{provider} API error ({kind}): {message}"
 
 
-def is_transient_error(error: str | None) -> bool:
-    """True if ``error`` was tagged transient by :func:`format_api_error`.
+class TransientProviderError(ProviderError):
+    """A retryable provider failure — rate limit, 5xx, timeout, connection error.
 
-    Transient failures (rate limits, 5xx, timeouts, connection errors) should be
-    retried by Temporal; permanent ones (auth, bad request) should not.
+    Retrying may succeed, so the worker raises a *retryable* Temporal error and
+    lets the workflow's LLM retry policy re-run the whole activity with backoff.
     """
-    return error is not None and _TRANSIENT_TAG in error
+
+
+class PermanentProviderError(ProviderError):
+    """A non-retryable provider failure — auth, bad request, schema, payload.
+
+    Retrying the identical request cannot help; the user must fix credentials,
+    the input, or configuration. The worker surfaces it as a non-retryable
+    Temporal error.
+    """
 
 
 # === Tool Use Models ===
@@ -112,7 +124,13 @@ class LLMProvider(ABC):
             request: Conversation request with messages, tools, etc.
 
         Returns:
-            Result containing ConversationResponse or error message
+            Result containing the ConversationResponse on success.
+
+        Raises:
+            TransientProviderError: A retryable API failure (rate limit, 5xx,
+                timeout, connection error).
+            PermanentProviderError: A non-retryable API failure (auth, bad
+                request, schema, payload, or any unexpected error).
         """
         pass
 

--- a/packages/engine/src/dataraum/pipeline/phases/base.py
+++ b/packages/engine/src/dataraum/pipeline/phases/base.py
@@ -15,6 +15,7 @@ from types import ModuleType
 from sqlalchemy import select
 
 from dataraum.core.logging import get_logger
+from dataraum.llm.providers.base import ProviderError
 from dataraum.pipeline.base import PhaseContext, PhaseResult
 from dataraum.storage import Table
 
@@ -70,10 +71,21 @@ class BasePhase(ABC):
         """Execute the phase.
 
         Wraps _run with wall-clock timing and error handling.
+
+        A :class:`~dataraum.llm.providers.base.ProviderError` is NOT flattened
+        into a FAILED ``PhaseResult`` (DAT-503): retryability rides the
+        exception *type* to the worker's durable boundary, so it must propagate
+        unchanged. Flattening it would lose the transient/permanent distinction
+        and make every LLM 429 a non-retryable phase failure. The enclosing
+        ``session_scope`` rolls the phase's partial writes back on the raise.
         """
         start = time.monotonic()
         try:
             result = self._run(ctx)
+        except ProviderError:
+            # Let the typed provider failure propagate to _outcome_or_raise,
+            # which classifies it for Temporal retry. session_scope rolls back.
+            raise
         except Exception as e:
             elapsed = time.monotonic() - start
             tb = traceback.format_exc()

--- a/packages/engine/src/dataraum/worker/activities.py
+++ b/packages/engine/src/dataraum/worker/activities.py
@@ -20,12 +20,15 @@ the rare commit conflict raises and is absorbed by Temporal's activity retry.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
 
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
-from dataraum.llm.providers.base import is_transient_error
+from dataraum.llm.providers.base import ProviderError, TransientProviderError
 from dataraum.pipeline.base import PhaseStatus
 from dataraum.worker.activity import (
     OPERATING_MODEL_DETECTOR_PHASES,
@@ -61,6 +64,60 @@ from dataraum.worker.contracts import (
 
 if TYPE_CHECKING:
     from dataraum.core.connections import ConnectionManager
+
+
+# Heartbeat cadence for the long-running ``metrics`` activity (DAT-503). Well
+# under the call's ``heartbeat_timeout`` (60s in workflows.py) so a missed pulse
+# is unambiguous worker death, not a slow LLM wave.
+_HEARTBEAT_INTERVAL_SECONDS = 15.0
+
+
+@contextmanager
+def _heartbeat_pulse(interval: float = _HEARTBEAT_INTERVAL_SECONDS) -> Iterator[None]:
+    """Pulse ``activity.heartbeat()`` from a daemon thread while a sync body runs.
+
+    The phase body is a single blocking call (no per-wave hook), so the pulse
+    can't ride the work itself — a background thread emits a heartbeat every
+    ``interval`` seconds until the body returns or raises, then stops. Lets the
+    activity declare a short ``heartbeat_timeout`` for fast worker-death
+    detection without the phase having to thread a progress callback. The pulse
+    is a no-op outside an activity context (unit tests), so it stays test-safe.
+    """
+    stop = threading.Event()
+
+    def _beat() -> None:
+        while not stop.wait(interval):
+            try:
+                activity.heartbeat()
+            except RuntimeError:
+                # Not inside an activity execution context (e.g. a unit test) —
+                # nothing to heartbeat against; stop quietly.
+                return
+
+    thread = threading.Thread(target=_beat, name="metrics-heartbeat", daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        thread.join(timeout=interval)
+
+
+def _provider_app_error(exc: ProviderError) -> ApplicationError:
+    """Translate a typed provider failure into the right Temporal error (DAT-503).
+
+    A :class:`TransientProviderError` (rate limit, 5xx, timeout, connection)
+    becomes the retryable ``TransientPhaseFailure`` — absent from the LLM retry
+    policy's ``non_retryable_error_types``, so Temporal re-runs the whole
+    activity with backoff. Any other provider failure (auth, bad request,
+    schema, unexpected) is permanent → the non-retryable ``PhaseFailed``. The
+    message is the provider's own — preserved verbatim for the cockpit's
+    failure surface.
+    """
+    message = str(exc)
+    if isinstance(exc, TransientProviderError):
+        return ApplicationError(message, type="TransientPhaseFailure")
+    return ApplicationError(message, type="PhaseFailed", non_retryable=True)
 
 
 class PhaseActivities:
@@ -207,8 +264,7 @@ class PhaseActivities:
         Source-free: scopes to the session's selected typed tables (which may
         span sources), persisting ``detection_method='candidate'`` rows.
         """
-        run = run_session_phase(self._manager, "relationships", payload.identity, payload.table_ids)
-        return self._outcome_or_raise(run, "relationships")
+        return self._run_session_or_raise("relationships", payload.identity, payload.table_ids)
 
     @activity.defn(name="semantic_per_table")
     def run_semantic_per_table(self, payload: SessionScopedInput) -> PhaseOutcome:
@@ -219,10 +275,7 @@ class PhaseActivities:
         real Anthropic calls; needs a working ``ANTHROPIC_API_KEY`` + the session's
         ``vertical``.
         """
-        run = run_session_phase(
-            self._manager, "semantic_per_table", payload.identity, payload.table_ids
-        )
-        return self._outcome_or_raise(run, "semantic_per_table")
+        return self._run_session_or_raise("semantic_per_table", payload.identity, payload.table_ids)
 
     @activity.defn(name="aggregation_lineage")
     def run_aggregation_lineage(self, payload: SessionScopedInput) -> PhaseOutcome:
@@ -234,10 +287,9 @@ class PhaseActivities:
         run-versioned, feeding the ``structural_reconciliation`` witness at the
         terminal ``session_detect``.
         """
-        run = run_session_phase(
-            self._manager, "aggregation_lineage", payload.identity, payload.table_ids
+        return self._run_session_or_raise(
+            "aggregation_lineage", payload.identity, payload.table_ids
         )
-        return self._outcome_or_raise(run, "aggregation_lineage")
 
     @activity.defn(name="enriched_views")
     def run_enriched_views(self, payload: SessionScopedInput) -> PhaseOutcome:
@@ -250,10 +302,7 @@ class PhaseActivities:
         the user's durable relationship teaches are folded in. Makes real Anthropic
         calls (the enrichment agent); needs ``ANTHROPIC_API_KEY``.
         """
-        run = run_session_phase(
-            self._manager, "enriched_views", payload.identity, payload.table_ids
-        )
-        return self._outcome_or_raise(run, "enriched_views")
+        return self._run_session_or_raise("enriched_views", payload.identity, payload.table_ids)
 
     # --- value layer (DAT-403) — source-free, session-scoped, after enriched_views ---
 
@@ -265,8 +314,7 @@ class PhaseActivities:
         ``SliceDefinition`` rows for the fact tables that carry an enriched view.
         Makes real Anthropic calls (the slicing agent); needs ``ANTHROPIC_API_KEY``.
         """
-        run = run_session_phase(self._manager, "slicing", payload.identity, payload.table_ids)
-        return self._outcome_or_raise(run, "slicing")
+        return self._run_session_or_raise("slicing", payload.identity, payload.table_ids)
 
     @activity.defn(name="slicing_view")
     def run_slicing_view(self, payload: SessionScopedInput) -> PhaseOutcome:
@@ -276,8 +324,7 @@ class PhaseActivities:
         dimension columns, registering a ``slicing_view`` lake artifact per fact
         table. No LLM call.
         """
-        run = run_session_phase(self._manager, "slicing_view", payload.identity, payload.table_ids)
-        return self._outcome_or_raise(run, "slicing_view")
+        return self._run_session_or_raise("slicing_view", payload.identity, payload.table_ids)
 
     @activity.defn(name="slice_analysis")
     def run_slice_analysis(self, payload: SessionScopedInput) -> PhaseOutcome:
@@ -286,10 +333,7 @@ class PhaseActivities:
         Executes each slice definition's SQL to create the per-value slice tables,
         registers them, and runs statistics + quality on each. No LLM call.
         """
-        run = run_session_phase(
-            self._manager, "slice_analysis", payload.identity, payload.table_ids
-        )
-        return self._outcome_or_raise(run, "slice_analysis")
+        return self._run_session_or_raise("slice_analysis", payload.identity, payload.table_ids)
 
     @activity.defn(name="temporal_slice_analysis")
     def run_temporal_slice_analysis(self, payload: SessionScopedInput) -> PhaseOutcome:
@@ -299,10 +343,9 @@ class PhaseActivities:
         per slice. No LLM call. (Per-column ColumnSliceProfile production was cut in
         the DAT-442 reset; dimensional_entropy reads typed values directly via NMI.)
         """
-        run = run_session_phase(
-            self._manager, "temporal_slice_analysis", payload.identity, payload.table_ids
+        return self._run_session_or_raise(
+            "temporal_slice_analysis", payload.identity, payload.table_ids
         )
-        return self._outcome_or_raise(run, "temporal_slice_analysis")
 
     @activity.defn(name="correlations")
     def run_correlations(self, payload: SessionScopedInput) -> PhaseOutcome:
@@ -311,8 +354,7 @@ class PhaseActivities:
         Finds same-table and cross-table derived columns (sums, ratios, …),
         persisting ``DerivedColumn`` formula metadata. No view, no LLM call.
         """
-        run = run_session_phase(self._manager, "correlations", payload.identity, payload.table_ids)
-        return self._outcome_or_raise(run, "correlations")
+        return self._run_session_or_raise("correlations", payload.identity, payload.table_ids)
 
     @activity.defn(name="session_materialize_overlays")
     def run_session_materialize_overlays(self, identity: SessionIdentity) -> PhaseOutcome:
@@ -396,8 +438,7 @@ class PhaseActivities:
         (``ctx.config["base_runs"]``); the phase performs NO head resolution
         itself. Makes real Anthropic calls (SQL generation per declared spec).
         """
-        run = run_session_phase(
-            self._manager,
+        return self._run_session_or_raise(
             "validation",
             payload.identity,
             payload.scope.table_ids,
@@ -408,7 +449,6 @@ class PhaseActivities:
                 }
             },
         )
-        return self._outcome_or_raise(run, "validation")
 
     @activity.defn(name="business_cycles")
     def run_business_cycles(self, payload: OperatingModelScopedInput) -> PhaseOutcome:
@@ -420,8 +460,7 @@ class PhaseActivities:
         synthesis call over the declared vocabulary). Runs after ``validation``
         so cycle health can read this run's validation results (DAT-455).
         """
-        run = run_session_phase(
-            self._manager,
+        return self._run_session_or_raise(
             "business_cycles",
             payload.identity,
             payload.scope.table_ids,
@@ -432,7 +471,6 @@ class PhaseActivities:
                 }
             },
         )
-        return self._outcome_or_raise(run, "business_cycles")
 
     @activity.defn(name="metrics")
     def run_metrics(self, payload: OperatingModelScopedInput) -> PhaseOutcome:
@@ -449,24 +487,25 @@ class PhaseActivities:
 
         This is the longest-running activity on the spine — up to
         ``_MAX_CONCURRENT_METRICS`` concurrent compositions, ``ceil(N/10)`` LLM
-        waves for ``N`` declared metrics. Like the other phase activities it does
-        NOT heartbeat; a worker crash mid-run is recovered by the workflow's retry
-        policy once the shared ``start_to_close_timeout`` fires.
+        waves for ``N`` declared metrics. It HEARTBEATS (DAT-503): a background
+        pulser emits ``activity.heartbeat()`` while the synchronous phase runs,
+        so a worker that dies mid-run is detected at the call's
+        ``heartbeat_timeout`` (seconds) instead of only at the much longer
+        ``start_to_close_timeout`` — the run fails over to a retry far sooner.
         """
-        run = run_session_phase(
-            self._manager,
-            "metrics",
-            payload.identity,
-            payload.scope.table_ids,
-            extra_config={
-                "base_runs": {
-                    "relationship_run_id": payload.scope.relationship_run_id,
-                    "semantic_runs": payload.scope.semantic_runs,
+        with _heartbeat_pulse():
+            return self._run_session_or_raise(
+                "metrics",
+                payload.identity,
+                payload.scope.table_ids,
+                extra_config={
+                    "base_runs": {
+                        "relationship_run_id": payload.scope.relationship_run_id,
+                        "semantic_runs": payload.scope.semantic_runs,
+                    },
+                    "workspace_id": payload.identity.workspace_id,
                 },
-                "workspace_id": payload.identity.workspace_id,
-            },
-        )
-        return self._outcome_or_raise(run, "metrics")
+            )
 
     @activity.defn(name="operating_model_detect")
     def run_operating_model_detect(self, identity: SessionIdentity) -> PhaseOutcome:
@@ -513,15 +552,43 @@ class PhaseActivities:
         identity: SourceIdentity,
         table_ids: list[str],
     ) -> PhaseOutcome:
-        """Run a phase; turn a deterministic phase failure into a non-retryable error.
+        """Run an add_source phase; classify its failure for Temporal retry.
 
         A FAILED ``PhaseRun`` means the phase itself decided it cannot proceed
-        (bad path, missing config) — permanent, so we raise a non-retryable
-        ``ApplicationError`` rather than burning Temporal retries. Transient
-        failures (e.g. a DuckLake optimistic-commit conflict) raise out of
-        ``run_phase`` as ordinary exceptions and stay retryable by default.
+        (bad path, missing config) — deterministic, so we raise a non-retryable
+        ``PhaseFailed`` rather than burning Temporal retries. A transient
+        provider failure (an LLM 429 / 5xx / connection error) raises a typed
+        :class:`ProviderError` out of the phase body; we translate it to the
+        retryable ``TransientPhaseFailure`` here (DAT-503). Infrastructure
+        failures (e.g. a DuckLake optimistic-commit conflict) raise ordinary
+        exceptions and stay retryable by default.
         """
-        run = run_phase(self._manager, phase_name, identity, table_ids)
+        try:
+            run = run_phase(self._manager, phase_name, identity, table_ids)
+        except ProviderError as exc:
+            raise _provider_app_error(exc) from exc
+        return self._outcome_or_raise(run, phase_name)
+
+    def _run_session_or_raise(
+        self,
+        phase_name: str,
+        identity: SessionIdentity,
+        table_ids: list[str],
+        extra_config: dict[str, Any] | None = None,
+    ) -> PhaseOutcome:
+        """Run a begin_session / operating_model phase; classify failure for retry.
+
+        Session-scoped sibling of :meth:`_run_or_raise`: a transient
+        :class:`ProviderError` raised out of the phase body becomes the
+        retryable ``TransientPhaseFailure``; a deterministic FAILED ``PhaseRun``
+        becomes the non-retryable ``PhaseFailed`` (DAT-503).
+        """
+        try:
+            run = run_session_phase(
+                self._manager, phase_name, identity, table_ids, extra_config=extra_config
+            )
+        except ProviderError as exc:
+            raise _provider_app_error(exc) from exc
         return self._outcome_or_raise(run, phase_name)
 
     def _outcome_or_raise(self, run: PhaseRun, phase_name: str) -> PhaseOutcome:
@@ -529,19 +596,13 @@ class PhaseActivities:
 
         Shared by the add_source (``run_phase``) and begin_session
         (``run_session_phase`` / ``begin_session_select``) activity paths.
-        A FAILED run is normally a deterministic, permanent phase failure →
-        non-retryable ``PhaseFailed``. The exception is a *transient* provider
-        failure (an LLM 429 / 5xx / connection error the provider tagged via
-        ``format_api_error``): that is not deterministic, so raise a retryable
-        error and let Temporal re-run the whole activity with backoff (the
-        ``RetryPolicy``'s durable safety net the SDK's in-process retries can't
-        replace). Anything else (completed / skipped) is a normal outcome.
+        A FAILED run is a deterministic, permanent phase failure →
+        non-retryable ``PhaseFailed`` (a transient provider failure never
+        reaches here — it raises a typed :class:`ProviderError` out of the
+        phase body, which :meth:`_run_or_raise` / :meth:`_run_session_or_raise`
+        translate). Anything else (completed / skipped) is a normal outcome.
         """
         if run.status == PhaseStatus.FAILED.value:
             message = run.error or f"Phase '{phase_name}' failed"
-            if is_transient_error(run.error):
-                # Retryable: ``TransientPhaseFailure`` is absent from the
-                # workflow ``RetryPolicy``'s ``non_retryable_error_types``.
-                raise ApplicationError(message, type="TransientPhaseFailure")
             raise ApplicationError(message, type="PhaseFailed", non_retryable=True)
         return PhaseOutcome(status=run.status, summary=run.summary)

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -60,10 +60,32 @@ with workflow.unsafe.imports_passed_through():
     )
 
 # A deterministic phase failure is raised by the activity as a non-retryable
-# ApplicationError of this type; transient failures (e.g. a DuckLake
-# optimistic-commit conflict) raise normally and stay retryable.
+# ApplicationError of type ``PhaseFailed``; a transient provider failure raises
+# ``TransientPhaseFailure`` (absent here) and stays retryable, as do
+# infrastructure failures (e.g. a DuckLake optimistic-commit conflict).
 _RETRY = RetryPolicy(maximum_attempts=5, non_retryable_error_types=["PhaseFailed"])
+
+# LLM-calling activities (DAT-503): a transient provider failure (429 / 5xx /
+# timeout) is exactly the case Temporal's durable retry exists for. The
+# defaults' 100ms initial / 100s cap retries a rate limit far too fast and
+# gives up after 5 tries; this policy backs off to a >=60s ceiling and allows
+# more attempts so a real upstream outage is ridden out across the LLM's own
+# Retry-After windows. ``PhaseFailed`` stays non-retryable (a permanent auth /
+# bad-request error must not burn the budget).
+_LLM_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=1),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(seconds=60),
+    maximum_attempts=8,
+    non_retryable_error_types=["PhaseFailed"],
+)
 _TIMEOUT = timedelta(minutes=10)
+
+# The ``metrics`` activity heartbeats (DAT-503): a missed pulse within this
+# window means the worker died, failing the run over to a retry far sooner than
+# the 10-minute ``start_to_close_timeout`` would. Comfortably above the
+# activity's 15s pulse cadence so a slow LLM wave never trips it.
+_HEARTBEAT_TIMEOUT = timedelta(seconds=60)
 
 # The table-local analytics phases, in dependency order. ``typing`` precedes
 # them (it mints the typed id). Detectors no longer run at the child's tail; the
@@ -346,7 +368,7 @@ class AddSourceWorkflow:
             identity,
             result_type=PhaseOutcome,
             start_to_close_timeout=_TIMEOUT,
-            retry_policy=_RETRY,
+            retry_policy=_LLM_RETRY,
         )
         # Single terminal detector pass (DAT-394): runs every wired detector
         # source-wide after the reduce, then persists readiness. Replaces the old
@@ -395,6 +417,29 @@ class AddSourceWorkflow:
 # (aggregation_lineage lives in the VALUE order below — its dependency is the
 # slice substrate, not this spine.)
 _SESSION_PHASE_ORDER = ("relationships", "semantic_per_table")
+
+# The phase activities that make real Anthropic calls (DAT-503) — they get the
+# LLM-shaped ``_LLM_RETRY`` so a transient provider failure is ridden out with
+# >=60s backoff instead of the default fast-give-up. Everything else (structural
+# detection, deterministic slice arithmetic, promotes) keeps ``_RETRY``. Kept
+# beside the chain orders so a new LLM phase can't silently inherit ``_RETRY``.
+_LLM_PHASES = frozenset(
+    {
+        "semantic_per_column",
+        "semantic_per_table",
+        "slicing",
+        "enriched_views",
+        "validation",
+        "business_cycles",
+        "metrics",
+    }
+)
+
+
+def _retry_for(phase: str) -> RetryPolicy:
+    """Pick the LLM-shaped retry for an LLM-calling phase, else the default."""
+    return _LLM_RETRY if phase in _LLM_PHASES else _RETRY
+
 
 # The value layer (DAT-403), in dependency order, runs AFTER ``enriched_views``:
 # slice the fact tables (LLM), narrow each to a slicing view, materialize + profile
@@ -518,7 +563,7 @@ class BeginSessionWorkflow:
                 scoped,
                 result_type=PhaseOutcome,
                 start_to_close_timeout=_TIMEOUT,
-                retry_policy=_RETRY,
+                retry_policy=_retry_for(phase),
             )
 
         # Materialize durable relationship teaches (DAT-409): after the llm pass, fold
@@ -545,7 +590,7 @@ class BeginSessionWorkflow:
             scoped,
             result_type=PhaseOutcome,
             start_to_close_timeout=_TIMEOUT,
-            retry_policy=_RETRY,
+            retry_policy=_LLM_RETRY,
         )
 
         # Value layer (DAT-403): slicing → slicing_view → slice_analysis →
@@ -560,7 +605,7 @@ class BeginSessionWorkflow:
                 scoped,
                 result_type=PhaseOutcome,
                 start_to_close_timeout=_TIMEOUT,
-                retry_policy=_RETRY,
+                retry_policy=_retry_for(phase),
             )
 
         # Terminal relationship detect (DAT-408): runs the relationship detectors
@@ -689,7 +734,7 @@ class OperatingModelWorkflow:
             scoped,
             result_type=PhaseOutcome,
             start_to_close_timeout=_TIMEOUT,
-            retry_policy=_RETRY,
+            retry_policy=_LLM_RETRY,
         )
 
         # Terminal-for-evidence detect (DAT-432/L7): score this run's executed
@@ -717,7 +762,7 @@ class OperatingModelWorkflow:
             scoped,
             result_type=PhaseOutcome,
             start_to_close_timeout=_TIMEOUT,
-            retry_policy=_RETRY,
+            retry_policy=_LLM_RETRY,
         )
 
         # Third lifecycle family (DAT-456): the declared metric graphs (vertical
@@ -732,7 +777,8 @@ class OperatingModelWorkflow:
             scoped,
             result_type=PhaseOutcome,
             start_to_close_timeout=_TIMEOUT,
-            retry_policy=_RETRY,
+            heartbeat_timeout=_HEARTBEAT_TIMEOUT,
+            retry_policy=_LLM_RETRY,
         )
 
         # Terminal promote: flip (session:{id}, "operating_model") to this run.

--- a/packages/engine/tests/integration/analysis/validation/test_agent.py
+++ b/packages/engine/tests/integration/analysis/validation/test_agent.py
@@ -12,6 +12,7 @@ from dataraum.analysis.validation.models import (
 )
 from dataraum.core.models.base import Result
 from dataraum.lifecycle import BaseRunMap
+from dataraum.llm.providers.base import TransientProviderError
 
 
 @pytest.fixture
@@ -386,8 +387,13 @@ class TestValidationAgentGenerateSQL:
         assert generated.is_valid is False
         assert "Missing required columns" in generated.validation_error
 
-    def test_generate_sql_llm_error(self, validation_agent, mock_provider):
-        """Test handling of LLM errors."""
+    def test_generate_sql_llm_error_propagates(self, validation_agent, mock_provider):
+        """A provider API failure raises a typed ProviderError (DAT-503).
+
+        converse no longer folds the error into a Result.fail; the agent lets
+        the typed exception propagate so retryability rides it to the worker's
+        durable boundary, not a substring of a Result the agent would re-wrap.
+        """
         spec = ValidationSpec(
             validation_id="test",
             name="Test",
@@ -398,12 +404,10 @@ class TestValidationAgentGenerateSQL:
 
         schema = {"table_name": "test", "duckdb_path": "test", "columns": []}
 
-        mock_provider.converse.return_value = Result.fail("API error")
+        mock_provider.converse.side_effect = TransientProviderError("API error")
 
-        result = validation_agent._generate_sql(spec, schema)
-
-        assert not result.success
-        assert "API error" in result.error
+        with pytest.raises(TransientProviderError, match="API error"):
+            validation_agent._generate_sql(spec, schema)
 
     def test_generate_sql_disabled_feature(self, validation_agent):
         """Test when validation feature is disabled."""

--- a/packages/engine/tests/unit/documentation/test_agent.py
+++ b/packages/engine/tests/unit/documentation/test_agent.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from dataraum.core.models.base import Result
 from dataraum.documentation.agent import BatchActionPlan, BatchPlanAgent
-from dataraum.llm.providers.base import ConversationResponse, ToolCall
+from dataraum.llm.providers.base import (
+    ConversationResponse,
+    PermanentProviderError,
+    ToolCall,
+)
 
 
 def _make_agent() -> tuple[BatchPlanAgent, MagicMock]:
@@ -70,13 +76,14 @@ class TestGenerateBatchPlan:
         assert len(plan.items) == 1
         assert plan.items[0].recommended_action == "concept_property"
 
-    def test_llm_failure(self) -> None:
+    def test_llm_failure_propagates(self) -> None:
+        # converse raises a typed ProviderError on an API failure (DAT-503); the
+        # agent lets it propagate rather than re-wrapping it as a Result.fail.
         agent, provider = _make_agent()
-        provider.converse.return_value = Result.fail("API error")
+        provider.converse.side_effect = PermanentProviderError("API error")
 
-        result = agent.generate_batch_plan(SAMPLE_CONTEXT)
-        assert not result.success
-        assert "API error" in (result.error or "")
+        with pytest.raises(PermanentProviderError, match="API error"):
+            agent.generate_batch_plan(SAMPLE_CONTEXT)
 
     def test_no_tool_call(self) -> None:
         agent, provider = _make_agent()

--- a/packages/engine/tests/unit/llm/test_anthropic_provider.py
+++ b/packages/engine/tests/unit/llm/test_anthropic_provider.py
@@ -1,8 +1,10 @@
-"""Tests for AnthropicProvider error classification.
+"""Tests for AnthropicProvider error classification (DAT-503 typed channel).
 
-Hard-fail policy: callers should be able to distinguish transient
-(retry might help) from permanent (user must fix) errors purely from
-the Result.fail message.
+Hard-fail policy: ``converse`` RAISES a typed provider exception on an API
+failure — :class:`TransientProviderError` (retry may help) vs
+:class:`PermanentProviderError` (user must fix) — so retryability rides the
+exception *type* to the worker's durable boundary instead of a substring of a
+Result.error every intermediate layer would have to forward faithfully.
 """
 
 from __future__ import annotations
@@ -19,12 +21,10 @@ from dataraum.llm.providers.anthropic import (
     _classify_anthropic_error,
 )
 from dataraum.llm.providers.base import (
-    PERMANENT_ERROR_KIND,
-    TRANSIENT_ERROR_KIND,
     ConversationRequest,
     Message,
-    format_api_error,
-    is_transient_error,
+    PermanentProviderError,
+    TransientProviderError,
 )
 
 
@@ -54,42 +54,38 @@ def _status_error(status_code: int) -> anthropic.APIStatusError:
 
 
 class TestErrorClassification:
-    """_classify_anthropic_error sorts SDK exceptions into transient/permanent."""
+    """_classify_anthropic_error sorts SDK exceptions into typed provider errors."""
 
     @pytest.mark.parametrize("status", [400, 401, 403, 404, 413, 422])
     def test_permanent_status_codes(self, status: int) -> None:
-        kind, _ = _classify_anthropic_error(_status_error(status))
-        assert kind == "permanent"
+        assert isinstance(_classify_anthropic_error(_status_error(status)), PermanentProviderError)
 
     @pytest.mark.parametrize("status", [408, 409, 429, 500, 502, 503, 529])
     def test_transient_status_codes(self, status: int) -> None:
-        kind, _ = _classify_anthropic_error(_status_error(status))
-        assert kind == "transient"
+        assert isinstance(_classify_anthropic_error(_status_error(status)), TransientProviderError)
 
     def test_timeout_is_transient(self) -> None:
         exc = anthropic.APITimeoutError(request=MagicMock(spec=httpx.Request))
-        kind, _ = _classify_anthropic_error(exc)
-        assert kind == "transient"
+        assert isinstance(_classify_anthropic_error(exc), TransientProviderError)
 
     def test_connection_error_is_transient(self) -> None:
         exc = anthropic.APIConnectionError(request=MagicMock(spec=httpx.Request))
-        kind, _ = _classify_anthropic_error(exc)
-        assert kind == "transient"
+        assert isinstance(_classify_anthropic_error(exc), TransientProviderError)
 
     @pytest.mark.parametrize("status", [401, 403])
     def test_auth_errors_hint_at_api_key(self, status: int) -> None:
         """401/403 errors must mention ANTHROPIC_API_KEY so the practitioner
         knows what to fix."""
-        kind, message = _classify_anthropic_error(_status_error(status))
-        assert kind == "permanent"
-        assert "ANTHROPIC_API_KEY" in message
+        err = _classify_anthropic_error(_status_error(status))
+        assert isinstance(err, PermanentProviderError)
+        assert "ANTHROPIC_API_KEY" in str(err)
 
 
-class TestConverseSurfacesClassification:
-    """Result.fail messages encode the error kind so callers don't need to
-    inspect the original exception."""
+class TestConverseRaisesTypedError:
+    """converse raises the typed exception so callers don't inspect the SDK
+    exception — and so a transient failure stays retryable end-to-end."""
 
-    def test_permanent_error_message(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_permanent_error_raises_permanent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         provider = _provider()
 
         def boom(**_: object) -> object:
@@ -97,11 +93,11 @@ class TestConverseSurfacesClassification:
 
         monkeypatch.setattr(provider.client.messages, "create", boom)
 
-        result = provider.converse(_request())
-        assert not result.success
-        assert "permanent" in (result.error or "")
+        with pytest.raises(PermanentProviderError) as ei:
+            provider.converse(_request())
+        assert "ANTHROPIC_API_KEY" in str(ei.value)
 
-    def test_transient_error_message(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_transient_error_raises_transient(self, monkeypatch: pytest.MonkeyPatch) -> None:
         provider = _provider()
 
         def boom(**_: object) -> object:
@@ -109,34 +105,34 @@ class TestConverseSurfacesClassification:
 
         monkeypatch.setattr(provider.client.messages, "create", boom)
 
-        result = provider.converse(_request())
-        assert not result.success
-        assert "transient" in (result.error or "")
-        # The consumer's predicate (worker retry choke point) agrees end-to-end.
-        assert is_transient_error(result.error)
+        with pytest.raises(TransientProviderError):
+            provider.converse(_request())
 
+    def test_unexpected_error_is_permanent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A non-API failure (a bug in request shaping) is non-retryable — retrying
+        # the identical call cannot clear it.
+        provider = _provider()
 
-class TestTransientErrorPredicate:
-    """``format_api_error`` (producer) and ``is_transient_error`` (the worker's
-    retry choke point) are the one shared classification contract."""
+        def boom(**_: object) -> object:
+            raise ValueError("malformed kwargs")
 
-    def test_transient_round_trips(self) -> None:
-        msg = format_api_error("Anthropic", TRANSIENT_ERROR_KIND, "429 rate limit")
-        assert is_transient_error(msg) is True
+        monkeypatch.setattr(provider.client.messages, "create", boom)
 
-    def test_permanent_is_not_transient(self) -> None:
-        msg = format_api_error("Anthropic", PERMANENT_ERROR_KIND, "401 unauthorized")
-        assert is_transient_error(msg) is False
+        with pytest.raises(PermanentProviderError) as ei:
+            provider.converse(_request())
+        assert "malformed kwargs" in str(ei.value)
 
-    def test_none_and_unrelated_are_not_transient(self) -> None:
-        assert is_transient_error(None) is False
-        assert is_transient_error("No typed tables found. Run typing phase first.") is False
+    def test_transient_chains_the_sdk_cause(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The original SDK exception is preserved as __cause__ so the workflow's
+        # _failure_message __cause__ walk can surface the innermost message.
+        provider = _provider()
+        original = _status_error(529)
 
-    def test_tag_survives_real_error_wrapping(self) -> None:
-        # The classification must survive the concatenation the phase/agent layers
-        # apply before the string reaches ``_outcome_or_raise`` — else a transient
-        # failure silently reads as permanent and is never retried.
-        inner = format_api_error("Anthropic", TRANSIENT_ERROR_KIND, "429 rate limit")
-        assert is_transient_error(f"LLM call failed: {inner}")  # agent wrap
-        assert is_transient_error(f"RuntimeError: {inner}")  # BasePhase.run wrap
-        assert is_transient_error(f"Cycle grounding failed: {inner}")  # phase wrap
+        def boom(**_: object) -> object:
+            raise original
+
+        monkeypatch.setattr(provider.client.messages, "create", boom)
+
+        with pytest.raises(TransientProviderError) as ei:
+            provider.converse(_request())
+        assert ei.value.__cause__ is original

--- a/packages/engine/tests/unit/worker/test_llm_retry_and_heartbeat.py
+++ b/packages/engine/tests/unit/worker/test_llm_retry_and_heartbeat.py
@@ -1,0 +1,75 @@
+"""LLM retry policy + metrics heartbeat (DAT-503).
+
+The LLM-calling activities get a backoff-shaped retry distinct from the default,
+and the long-running ``metrics`` activity heartbeats from a background pulser so
+worker death is detected at the short heartbeat window, not the 10-minute
+start-to-close timeout.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import timedelta
+
+from dataraum.worker.activities import _heartbeat_pulse
+from dataraum.worker.workflows import (
+    _HEARTBEAT_TIMEOUT,
+    _LLM_PHASES,
+    _LLM_RETRY,
+    _RETRY,
+    _retry_for,
+)
+
+
+def test_llm_retry_backs_off_to_at_least_60s_and_allows_more_attempts() -> None:
+    # A real upstream outage must be ridden out across the LLM's Retry-After
+    # windows, not given up after 5 fast tries.
+    assert _LLM_RETRY.maximum_interval is not None
+    assert _LLM_RETRY.maximum_interval >= timedelta(seconds=60)
+    assert (_LLM_RETRY.maximum_attempts or 0) >= 8
+    # A permanent failure must still short-circuit on both policies.
+    assert "PhaseFailed" in (_LLM_RETRY.non_retryable_error_types or ())
+    assert "PhaseFailed" in (_RETRY.non_retryable_error_types or ())
+    # A transient failure must stay retryable.
+    assert "TransientPhaseFailure" not in (_LLM_RETRY.non_retryable_error_types or ())
+
+
+def test_retry_for_picks_llm_policy_only_for_llm_phases() -> None:
+    for phase in (
+        "semantic_per_column",
+        "semantic_per_table",
+        "slicing",
+        "enriched_views",
+        "validation",
+        "business_cycles",
+        "metrics",
+    ):
+        assert phase in _LLM_PHASES
+        assert _retry_for(phase) is _LLM_RETRY
+    for phase in (
+        "relationships",
+        "aggregation_lineage",
+        "slicing_view",
+        "slice_analysis",
+        "temporal_slice_analysis",
+        "correlations",
+    ):
+        assert _retry_for(phase) is _RETRY
+
+
+def test_heartbeat_timeout_is_above_pulse_cadence() -> None:
+    # A slow LLM wave between pulses must not trip the heartbeat timeout.
+    assert _HEARTBEAT_TIMEOUT > timedelta(seconds=15)
+
+
+def test_heartbeat_pulse_starts_and_stops_a_thread() -> None:
+    # Outside an activity context activity.heartbeat() raises RuntimeError, which
+    # the pulser swallows — so the context manager is a clean no-op-safe wrapper
+    # that always tears its thread down. Use a tiny interval to exercise a beat.
+    before = threading.active_count()
+    with _heartbeat_pulse(interval=0.01):
+        time.sleep(0.05)
+    # Give the daemon a moment to exit after stop.set().
+    time.sleep(0.05)
+    assert threading.active_count() <= before

--- a/packages/engine/tests/unit/worker/test_outcome_or_raise.py
+++ b/packages/engine/tests/unit/worker/test_outcome_or_raise.py
@@ -1,9 +1,10 @@
-"""The activity retry choke point: ``PhaseActivities._outcome_or_raise``.
+"""The activity retry choke point: ``PhaseActivities`` failure classification.
 
-A FAILED phase is normally a deterministic, non-retryable ``PhaseFailed``. The
-exception is a *transient* provider failure (an LLM 429 / 5xx / connection
-error tagged by ``format_api_error``): that raises a retryable error so
-Temporal re-runs the activity with backoff instead of surfacing on attempt 1.
+Retryability rides the exception *type* (DAT-503): a transient
+:class:`TransientProviderError` raised out of the phase body becomes the
+retryable ``TransientPhaseFailure``; a deterministic FAILED ``PhaseRun`` and a
+permanent provider failure become the non-retryable ``PhaseFailed``. The worker
+classifies at this boundary — not by parsing a substring of the error string.
 """
 
 from __future__ import annotations
@@ -14,14 +15,14 @@ import pytest
 from temporalio.exceptions import ApplicationError
 
 from dataraum.llm.providers.base import (
-    PERMANENT_ERROR_KIND,
-    TRANSIENT_ERROR_KIND,
-    format_api_error,
+    PermanentProviderError,
+    TransientProviderError,
 )
 from dataraum.pipeline.base import PhaseStatus
-from dataraum.worker.activities import PhaseActivities
+from dataraum.worker.activities import PhaseActivities, _provider_app_error
 from dataraum.worker.activity import PhaseRun
-from dataraum.worker.workflows import _RETRY
+from dataraum.worker.contracts import SessionIdentity, SessionScopedInput
+from dataraum.worker.workflows import _LLM_RETRY, _RETRY
 
 
 def _acts() -> PhaseActivities:
@@ -33,28 +34,36 @@ def _failed(error: str) -> PhaseRun:
     return PhaseRun(status=PhaseStatus.FAILED.value, error=error)
 
 
-def test_transient_failure_is_retryable() -> None:
-    run = _failed(format_api_error("Anthropic", TRANSIENT_ERROR_KIND, "429 rate limit"))
-    with pytest.raises(ApplicationError) as ei:
-        _acts()._outcome_or_raise(run, "slicing")
-    assert ei.value.non_retryable is False
-    assert ei.value.type == "TransientPhaseFailure"
-    # The retryable type must be absent from the policy's non-retryable list,
+def _identity() -> SessionIdentity:
+    return SessionIdentity(workspace_id="ws", session_id="sess", run_id="run", vertical="finance")
+
+
+# --- _provider_app_error: the typed-exception -> Temporal-error translation ---
+
+
+def test_transient_provider_error_maps_to_retryable() -> None:
+    err = _provider_app_error(TransientProviderError("429 rate limit"))
+    assert isinstance(err, ApplicationError)
+    assert err.type == "TransientPhaseFailure"
+    assert err.non_retryable is False
+    assert "429 rate limit" in str(err)
+    # The retryable type must be absent from BOTH policies' non-retryable lists,
     # else Temporal would still refuse to retry it.
     assert "TransientPhaseFailure" not in (_RETRY.non_retryable_error_types or ())
+    assert "TransientPhaseFailure" not in (_LLM_RETRY.non_retryable_error_types or ())
 
 
-def test_permanent_provider_failure_stays_non_retryable() -> None:
-    run = _failed(format_api_error("Anthropic", PERMANENT_ERROR_KIND, "401 unauthorized"))
-    with pytest.raises(ApplicationError) as ei:
-        _acts()._outcome_or_raise(run, "semantic_per_table")
-    assert ei.value.non_retryable is True
-    assert ei.value.type == "PhaseFailed"
-    assert "PhaseFailed" in (_RETRY.non_retryable_error_types or ())
+def test_permanent_provider_error_maps_to_non_retryable() -> None:
+    err = _provider_app_error(PermanentProviderError("401 unauthorized"))
+    assert err.type == "PhaseFailed"
+    assert err.non_retryable is True
+    assert "PhaseFailed" in (_LLM_RETRY.non_retryable_error_types or ())
+
+
+# --- _outcome_or_raise: deterministic FAILED is permanent ---
 
 
 def test_deterministic_failure_stays_non_retryable() -> None:
-    # A non-provider failure (no transient tag) is deterministic → PhaseFailed.
     run = _failed("No typed tables found. Run typing phase first.")
     with pytest.raises(ApplicationError) as ei:
         _acts()._outcome_or_raise(run, "relationships")
@@ -67,3 +76,64 @@ def test_completed_run_returns_outcome() -> None:
     outcome = _acts()._outcome_or_raise(run, "slicing")
     assert outcome.status == PhaseStatus.COMPLETED.value
     assert outcome.summary == "2 drift summaries"
+
+
+# --- the propagation seam: a typed ProviderError out of the phase body ---
+
+
+def test_transient_provider_error_propagates_as_retryable(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A transient failure raised out of run_session_phase becomes retryable.
+    def boom(*_a: object, **_k: object) -> PhaseRun:
+        raise TransientProviderError("Anthropic 429 rate limit")
+
+    monkeypatch.setattr("dataraum.worker.activities.run_session_phase", boom)
+    with pytest.raises(ApplicationError) as ei:
+        _acts().run_relationships(SessionScopedInput(identity=_identity(), table_ids=["t1"]))
+    assert ei.value.type == "TransientPhaseFailure"
+    assert ei.value.non_retryable is False
+
+
+def test_permanent_provider_error_propagates_as_non_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(*_a: object, **_k: object) -> PhaseRun:
+        raise PermanentProviderError("Anthropic 401 unauthorized. Check your ANTHROPIC_API_KEY.")
+
+    monkeypatch.setattr("dataraum.worker.activities.run_session_phase", boom)
+    with pytest.raises(ApplicationError) as ei:
+        _acts().run_semantic_per_table(SessionScopedInput(identity=_identity(), table_ids=["t1"]))
+    assert ei.value.type == "PhaseFailed"
+    assert ei.value.non_retryable is True
+    assert "ANTHROPIC_API_KEY" in str(ei.value)
+
+
+def test_simulated_429_then_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulated-429 retry at the run_session_phase / classification seam (DAT-503).
+
+    Attempt 1 raises a transient 429 → the activity raises the retryable
+    ``TransientPhaseFailure`` (Temporal would re-run it). Attempt 2 succeeds →
+    the activity returns the COMPLETED outcome. This proves the retryable
+    classification end-to-end without a Temporal test server (which stalls CI).
+    """
+    calls = {"n": 0}
+
+    def flaky(*_a: object, **_k: object) -> PhaseRun:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TransientProviderError("Anthropic 429 rate limit")
+        return PhaseRun(status=PhaseStatus.COMPLETED.value, summary="ok on retry")
+
+    monkeypatch.setattr("dataraum.worker.activities.run_session_phase", flaky)
+    acts = _acts()
+    payload = SessionScopedInput(identity=_identity(), table_ids=["t1"])
+
+    # Attempt 1: retryable failure.
+    with pytest.raises(ApplicationError) as ei:
+        acts.run_relationships(payload)
+    assert ei.value.type == "TransientPhaseFailure"
+
+    # Attempt 2 (Temporal's retry): success.
+    outcome = acts.run_relationships(payload)
+    assert outcome.status == PhaseStatus.COMPLETED.value
+    assert outcome.summary == "ok on retry"
+    assert calls["n"] == 2


### PR DESCRIPTION
Replace the substring transient-tag protocol with a typed-exception channel so retryability survives the converse -> phase-agent -> BasePhase.run -> run_phase chain without a fragile re-parse, and lives at the durable/exception boundary instead of as data threaded through the Result chain.

- llm/providers/base.py: add ProviderError + Transient/PermanentProviderError; delete format_api_error / is_transient_error / the *_ERROR_KIND tags.
- AnthropicProvider.converse RAISES the typed exception (transient vs permanent by status) instead of folding it into Result.fail; unexpected errors are permanent. The SDK exception is chained as __cause__ so the workflow's _failure_message walk surfaces the innermost message.
- BasePhase.run re-raises ProviderError (does NOT flatten to FAILED); the enclosing session_scope rolls back partial writes on the raise.
- run_phase / run_session_phase let the typed exception propagate.
- worker/activities.py: _run_or_raise / _run_session_or_raise translate a ProviderError to the retryable TransientPhaseFailure (transient) or non-retryable PhaseFailed (permanent); _outcome_or_raise classifies only the deterministic FAILED PhaseRun. Every begin_session/operating_model phase routes through _run_session_or_raise.
- workflows.py: split _RETRY (default) + _LLM_RETRY (>=60s ceiling, 8 attempts) applied to LLM-calling activities only (_retry_for / _LLM_PHASES); metrics also gets heartbeat_timeout. metrics activity heartbeats via a background pulser (_heartbeat_pulse).
- Phase agents (semantic, slicing, enriched_views, validation, cycles, graphs, documentation): drop the dead `if not result.success` re-wrap — converse now raises, so a returned Result is always a success.
- Tests rewritten to the typed model (test_anthropic_provider, test_outcome_or_raise, + new test_llm_retry_and_heartbeat); the rollback integration test stays verbatim; simulated-429 retry proven at the run_session_phase / classification unit seam.