### PR TITLE
DAT-527: cockpit layout + chat auto-scroll fixes + tool-routing contract

### DIFF
--- a/packages/cockpit/src/tools/registry.test.ts
+++ b/packages/cockpit/src/tools/registry.test.ts
@@ -30,6 +30,7 @@ vi.mock("#/db/cockpit/runs", () => ({
 	hasRunningRun: async () => false,
 }));
 
+import { CANVAS_TOOLS, CHIP_ONLY } from "#/ui/cockpit/tool-result-to-canvas";
 import { tools } from "./registry";
 
 describe("tool registry (DAT-353)", () => {
@@ -70,6 +71,31 @@ describe("tool registry (DAT-353)", () => {
 				"upload",
 			]),
 		);
+	});
+
+	it("routes every registered tool to exactly one surface — canvas XOR chip-only (DAT-527)", () => {
+		// The guardrail for the DAT-526 P1 registry split: a tool must be consciously
+		// routed — projected to the canvas (PROJECTORS/CANVAS_TOOLS) OR explicitly
+		// chip-only — never silently un-routed. XOR catches BOTH gaps: in neither
+		// (forgotten) and in both (contradiction).
+		for (const tool of tools) {
+			const inCanvas = CANVAS_TOOLS.has(tool.name);
+			const inChip = CHIP_ONLY.has(tool.name);
+			expect(
+				inCanvas !== inChip,
+				`${tool.name} must be in exactly one of PROJECTORS / CHIP_ONLY (canvas=${inCanvas}, chip=${inChip})`,
+			).toBe(true);
+		}
+	});
+
+	it("has no stale CHIP_ONLY entries — every name is a registered tool (DAT-527)", () => {
+		const names = new Set<string>(tools.map((t) => t.name));
+		for (const name of CHIP_ONLY) {
+			expect(
+				names.has(name),
+				`CHIP_ONLY '${name}' is not a registered tool`,
+			).toBe(true);
+		}
 	});
 
 	it("declares NO approval gate on any tool — every tool runs directly", () => {

--- a/packages/cockpit/src/ui/cockpit/chat-rail.tsx
+++ b/packages/cockpit/src/ui/cockpit/chat-rail.tsx
@@ -190,7 +190,7 @@ export function ChatRail() {
 		const el = streamRef.current;
 		const content = contentRef.current;
 		if (!el || !content) return;
-		const stick = () => {
+		const stick: ResizeObserverCallback = (_entries, _observer) => {
 			if (followRef.current) el.scrollTop = el.scrollHeight;
 		};
 		// Fires on observe (initial pin) and on every content-height change — a new

--- a/packages/cockpit/src/ui/cockpit/chat-rail.tsx
+++ b/packages/cockpit/src/ui/cockpit/chat-rail.tsx
@@ -13,11 +13,12 @@
 // Streaming is driven ONLY by user submit (never on mount → SSR-safe).
 
 import { Alert, Box, Card, Group, Loader, Stack, Text } from "@mantine/core";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { classifyChatError } from "#/lib/chat-error";
 import { useCockpit } from "#/ui/cockpit/cockpit-state";
 import { Composer } from "#/ui/cockpit/composer";
 import { MarkdownMessage } from "#/ui/cockpit/markdown";
+import { isNearBottom } from "#/ui/cockpit/scroll-stick";
 import {
 	lastUserMessageIndex,
 	type ToolCallPartLike,
@@ -163,15 +164,41 @@ export function ChatRail() {
 	// so a non-canvas pin can't happen here.
 	const onRehydrate = (callId: string) => pinCanvas(callId);
 
-	// Keep the conversation pinned to the latest as it streams: the composer sits
+	// Keep the conversation pinned to the latest as it streams — the composer sits
 	// at the foot of a height-bounded rail and the stream scrolls INTERNALLY (see
-	// the cockpit route's fixed height + the messages box's `minHeight: 0`), so on
-	// every message/token tick we snap the scroll to the bottom.
+	// the cockpit route's fixed height + the messages box's `minHeight: 0`). Two
+	// rules the old unconditional `scrollTop = scrollHeight` on every messages tick
+	// got wrong (DAT-527):
+	//   1. Stick to the bottom ONLY when the user is already there. `followRef`
+	//      tracks it from the scroll handler, so scrolling UP to read history
+	//      during a streaming turn is never yanked back down.
+	//   2. Re-pin AFTER layout settles. A tall tool-card / widget grows its height
+	//      asynchronously, so a one-shot snap read scrollHeight too early and landed
+	//      short of the true bottom (worse the longer the chat). A ResizeObserver on
+	//      the content re-snaps whenever its height changes while the user follows.
+	// External-system effect with cleanup (conventions rule 2).
 	const streamRef = useRef<HTMLDivElement>(null);
+	const contentRef = useRef<HTMLDivElement>(null);
+	const followRef = useRef(true);
+
+	const onScroll = useCallback(() => {
+		const el = streamRef.current;
+		if (el) followRef.current = isNearBottom(el);
+	}, []);
+
 	useEffect(() => {
 		const el = streamRef.current;
-		if (el && messages.length > 0) el.scrollTop = el.scrollHeight;
-	}, [messages]);
+		const content = contentRef.current;
+		if (!el || !content) return;
+		const stick = () => {
+			if (followRef.current) el.scrollTop = el.scrollHeight;
+		};
+		// Fires on observe (initial pin) and on every content-height change — a new
+		// message, a streaming token, or a widget finishing its async layout.
+		const observer = new ResizeObserver(stick);
+		observer.observe(content);
+		return () => observer.disconnect();
+	}, []);
 
 	// A tool-call part can recur across messages (e.g. the persisted assistant
 	// tool-call plus its completion in a later teed turn — same part id, two
@@ -201,10 +228,11 @@ export function ChatRail() {
 		<Stack gap="sm" h="100%" data-testid="chat-rail">
 			<Box
 				ref={streamRef}
+				onScroll={onScroll}
 				style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
 				data-testid="chat-messages"
 			>
-				<Stack gap="xs" p="xs">
+				<Stack ref={contentRef} gap="xs" p="xs">
 					{messages.map((m, mi) =>
 						m.parts.map((part, i) => {
 							if (part.type === "text") {

--- a/packages/cockpit/src/ui/cockpit/cockpit-view.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-view.test.tsx
@@ -81,6 +81,9 @@ describe("CockpitView — landing vs working split", () => {
 		expect(chat.style.width).toBe("28%");
 		expect(chat.style.minWidth).toBe("22rem");
 		expect(chat.style.maxWidth).toBe("");
+		// The canvas holds a floor so the chat's 22rem + flexShrink:0 can't squeeze
+		// it to zero on a narrow window (DAT-527 review).
+		expect(screen.getByTestId("region-work").style.minWidth).toBe("28rem");
 	});
 
 	it("mod+slash focuses the chat input (landing)", () => {

--- a/packages/cockpit/src/ui/cockpit/cockpit-view.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-view.test.tsx
@@ -68,12 +68,19 @@ describe("CockpitView — landing vs working split", () => {
 		h.messages = [aMessage];
 		renderView();
 		expect(screen.queryByTestId("cockpit-landing")).toBeNull();
-		expect(screen.getByTestId("region-chat")).toBeTruthy();
+		const chat = screen.getByTestId("region-chat");
+		expect(chat).toBeTruthy();
 		expect(screen.getByTestId("chat-rail")).toBeTruthy();
 		expect(screen.getByTestId("region-canvas")).toBeTruthy();
 		expect(screen.getByTestId("focus-canvas")).toBeTruthy();
 		// The decorative stage strip is gone.
 		expect(screen.queryByTestId("stage-navigator")).toBeNull();
+		// Relative width split (DAT-527): the chat holds a proportional 28% with a
+		// 22rem floor and NO upper clamp, so it scales with the window instead of
+		// capping at 26rem while the canvas hogs the slack.
+		expect(chat.style.width).toBe("28%");
+		expect(chat.style.minWidth).toBe("22rem");
+		expect(chat.style.maxWidth).toBe("");
 	});
 
 	it("mod+slash focuses the chat input (landing)", () => {

--- a/packages/cockpit/src/ui/cockpit/cockpit-view.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-view.tsx
@@ -58,15 +58,15 @@ export function CockpitView() {
 				ref={chatRef}
 				data-testid="region-chat"
 				style={{
-					// The chat is a STABLE column: it tracks the window proportionally but
-					// is clamped 20–26rem so it never sprawls on a wide monitor nor
-					// collapses below readable on a small one. The canvas (flex:1) absorbs
-					// all the slack, so resizing the window grows the canvas, not the chat.
-					// No divider border here — the raised canvas card edge is the only,
-					// quiet separation between the two areas.
+					// The chat is a RELATIVE column: it holds 28% of the work area so it
+					// scales WITH the window (chat and canvas grow together), with a 22rem
+					// floor so it never collapses below readable on a laptop. No upper
+					// clamp — on a wide monitor the chat keeps its proportion instead of
+					// capping while the canvas hogs the slack (DAT-527, from real usage:
+					// the chat content earns the proportional room). No divider border —
+					// the raised canvas card edge is the only, quiet separation.
 					width: "28%",
-					minWidth: "20rem",
-					maxWidth: "26rem",
+					minWidth: "22rem",
 					flexShrink: 0,
 					overflow: "hidden",
 				}}

--- a/packages/cockpit/src/ui/cockpit/cockpit-view.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-view.tsx
@@ -75,7 +75,11 @@ export function CockpitView() {
 			</Box>
 			<Stack
 				gap="md"
-				style={{ flex: 1, overflow: "hidden" }}
+				// The canvas takes the slack (flex:1) but holds a 28rem floor so the chat's
+				// 22rem floor + flexShrink:0 can't squeeze it toward zero on a narrow
+				// window (DAT-527 review): below ~50rem the nowrap row overflows to a
+				// horizontal scroll rather than collapsing the canvas.
+				style={{ flex: 1, minWidth: "28rem", overflow: "hidden" }}
 				data-testid="region-work"
 			>
 				{/* Rehydration banner (DAT-354): shown only while the canvas is pinned

--- a/packages/cockpit/src/ui/cockpit/scroll-stick.test.ts
+++ b/packages/cockpit/src/ui/cockpit/scroll-stick.test.ts
@@ -1,0 +1,41 @@
+// Unit tests for the chat-rail stick-to-bottom decision (DAT-527).
+
+import { describe, expect, it } from "vitest";
+
+import { isNearBottom, STICK_THRESHOLD_PX } from "./scroll-stick";
+
+describe("isNearBottom (DAT-527)", () => {
+	it("is true at the exact bottom", () => {
+		// scrollTop + clientHeight === scrollHeight → distance 0.
+		expect(
+			isNearBottom({ scrollTop: 900, scrollHeight: 1000, clientHeight: 100 }),
+		).toBe(true);
+	});
+
+	it("is true within the slack threshold of the bottom", () => {
+		// distance = 1000 - (860 + 100) = 40 ≤ 64.
+		expect(
+			isNearBottom({ scrollTop: 860, scrollHeight: 1000, clientHeight: 100 }),
+		).toBe(true);
+	});
+
+	it("is false once scrolled further up than the threshold", () => {
+		// distance = 1000 - (700 + 100) = 200 > 64 → reading history, don't yank.
+		expect(
+			isNearBottom({ scrollTop: 700, scrollHeight: 1000, clientHeight: 100 }),
+		).toBe(false);
+	});
+
+	it("is true when content is shorter than the viewport (nothing to scroll)", () => {
+		expect(
+			isNearBottom({ scrollTop: 0, scrollHeight: 80, clientHeight: 100 }),
+		).toBe(true);
+	});
+
+	it("honors a custom threshold", () => {
+		const metrics = { scrollTop: 860, scrollHeight: 1000, clientHeight: 100 };
+		// distance 40: within the default 64, outside a tight 10.
+		expect(isNearBottom(metrics, STICK_THRESHOLD_PX)).toBe(true);
+		expect(isNearBottom(metrics, 10)).toBe(false);
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/scroll-stick.ts
+++ b/packages/cockpit/src/ui/cockpit/scroll-stick.ts
@@ -1,0 +1,23 @@
+// Pure "stick to bottom" decision for the chat rail (DAT-527). Extracted so the
+// follow-the-stream rule is unit-tested without a DOM (conventions rule 10).
+//
+// The rail auto-scrolls to the newest content ONLY when the user is already near
+// the bottom — i.e. following the stream. Scrolled further up means they're
+// reading history during a streaming turn and must NOT be yanked back down (the
+// bug where scrolling up mid-load snapped you to the bottom on every token tick).
+
+/** Within this many px of the bottom still counts as "following the stream", so a
+ * new message / a widget growing its height keeps the user pinned to the latest.
+ * A small slack absorbs sub-pixel rounding + the last line's leading. */
+export const STICK_THRESHOLD_PX = 64;
+
+/** True when the scroll position is within `threshold` px of the bottom (the user
+ * is following the stream). Pure — operates on plain scroll metrics so it tests
+ * without a DOM. */
+export function isNearBottom(
+	metrics: { scrollTop: number; scrollHeight: number; clientHeight: number },
+	threshold: number = STICK_THRESHOLD_PX,
+): boolean {
+	const { scrollTop, scrollHeight, clientHeight } = metrics;
+	return scrollHeight - (scrollTop + clientHeight) <= threshold;
+}

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -325,6 +325,24 @@ export const CANVAS_TOOLS: ReadonlySet<string> = new Set(
 	Object.keys(PROJECTORS),
 );
 
+/**
+ * Tools whose result deliberately renders ONLY as a chat-rail chip — no canvas
+ * member (write/declare tools + reads with no widget). EXPLICIT, not merely
+ * "absent from PROJECTORS", so the routing-completeness contract test
+ * (`registry.test.ts`) can assert every registered tool is CONSCIOUSLY routed: a
+ * new tool must land in `PROJECTORS` OR here, never silently un-routed — the
+ * guardrail for the DAT-526 P1 registry split. Disjoint from `CANVAS_TOOLS`.
+ */
+export const CHIP_ONLY: ReadonlySet<string> = new Set([
+	"list_verticals", // catalogue → chip summary, no widget
+	"use_vertical", // adopt = control-plane write, no renderable surface (DAT-523)
+	"probe", // quick data check, summarized in the chip
+	"teach", // writes an overlay row; outcome surfaces after a re-run, not a widget
+	"teach_validation",
+	"teach_cycle",
+	// NB teach_metric is NOT here — an override projects the metric-shadow canvas.
+]);
+
 /** A tool whose result maps to a canvas member → its chip is clickable. */
 export function isCanvasTool(toolName: string): boolean {
 	return toolName in PROJECTORS;


### PR DESCRIPTION
P0 of the **Cockpit Autonomy epic (DAT-526)**. Three small, deterministic UX fixes — refined down from the design's vague §2 (chat-inline target / table-fold / prompt change all dropped as spurious after a code+usage reality check). Cockpit-only; **engine untouched**.

## Changes

1. **Relative chat/canvas width split** (`cockpit-view.tsx`) — dropped the chat's `maxWidth: 26rem` clamp so its `28%` is honored relatively (chat + canvas scale together instead of the chat capping while the canvas hogs slack), raised `minWidth` 20→22rem, and gave the canvas a `28rem` floor so a narrow window overflows rather than collapsing it.
2. **Follow-aware chat auto-scroll** (`chat-rail.tsx`) — replaced the unconditional `scrollTop = scrollHeight` on every messages tick with: stick-to-bottom **only when the user is already near it** (`followRef` from `onScroll`), and a `ResizeObserver` that re-pins **after async layout settles** so a tall widget lands at the true bottom. Fixes the "scroll-up-during-stream gets yanked" and "doesn't stick to the last widget, worse the longer the chat" bugs. At-bottom decision extracted to a pure, unit-tested helper (`scroll-stick.ts`).
3. **Tool-routing completeness contract** (`tool-result-to-canvas.ts` + `registry.test.ts`) — explicit `CHIP_ONLY` set beside `CANVAS_TOOLS`; a test asserts every registered tool is canvas-XOR-chip + no stale entries. The guardrail so the P1 registry split can't silently leave a tool un-routed.

## Review & smoke

- **Three-reviewer-equivalent gate:** spec-compliance **COMPLIANT** (6/6 ACs); senior **2 findings, both resolved** — canvas min-width floor added (#2), and the flagged scroll feedback-loop (#1) verified a non-issue (scroll events are async + `scrollTop` clamps, so a programmatic snap can't false-flip `followRef`; no guard needed).
- **Browser smoke** (cockpit container built from this branch): width scales past the old cap at 1920px; both floors hold at 820px; initial-pin, follow-on-growth, and scroll-up-not-yanked all verified; 2 live LLM turns, 0 console errors.

Gates: biome · tsc · 1107 unit tests · Nitro build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)