### PR TITLE
fix(worker): operating_model_detect scores over the pinned scope tables (DAT-506)

### DIFF
--- a/packages/engine/src/dataraum/worker/activities.py
+++ b/packages/engine/src/dataraum/worker/activities.py
@@ -549,7 +549,7 @@ class PhaseActivities:
             )
 
     @activity.defn(name="operating_model_detect")
-    def run_operating_model_detect(self, run: RunRef) -> PhaseOutcome:
+    def run_operating_model_detect(self, payload: OperatingModelScopedInput) -> PhaseOutcome:
         """Terminal detector pass for operating_model (DAT-432/L7).
 
         Scores this run's executed validation results — cross_table_consistency,
@@ -562,16 +562,24 @@ class PhaseActivities:
         ``operating_model`` head (failed runs never surface; review wave-1
         corrected an overclaim here).
         """
+        run = payload.run
         if run.run_id is None:
             raise ApplicationError(
                 "operating_model_detect requires a stamped run.run_id.",
                 type="PhaseFailed",
                 non_retryable=True,
             )
+        # The OM run never anchors ``run_tables`` (begin_session owns them), so
+        # detect must score over the table set PINNED at operating_model_resolve
+        # (ADR-0008: payload.scope.table_ids) — the same pin validation / cycles /
+        # metrics read. Without it, ``tables_for_run(om_run)`` is empty and the
+        # whole pass no-ops (``detect_no_run_tables``), so cross_table_consistency
+        # silently scores nothing.
         count = run_detectors(
             self._manager,
             run_id=run.run_id,
             detector_phases=OPERATING_MODEL_DETECTOR_PHASES,
+            table_ids=payload.scope.table_ids,
         )
         return PhaseOutcome(
             status=PhaseStatus.COMPLETED.value,

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -464,6 +464,7 @@ def run_detectors(
     *,
     run_id: str,
     detector_phases: tuple[str, ...] = _DETECTOR_PHASES,
+    table_ids: list[str] | None = None,
 ) -> int:
     """Run every wired detector once over the run's tables — the terminal ``detect`` step.
 
@@ -489,7 +490,12 @@ def run_detectors(
 
     total = 0
     with manager.session_scope() as session, manager.duckdb_cursor() as cursor:
-        table_ids = tables_for_run(session, run_id)
+        # ``table_ids`` is supplied explicitly by operating_model_detect — its run
+        # never anchors ``run_tables`` (those belong to begin_session), so it passes
+        # the scope PINNED at operating_model_resolve (ADR-0008). add_source /
+        # begin_session leave it None and resolve their own ``run_tables`` here.
+        if table_ids is None:
+            table_ids = tables_for_run(session, run_id)
         if not table_ids:
             # add_source links its typed tables in ``typing`` (same transaction as
             # the Table row), so an empty set here means the run has no tables —

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -754,8 +754,10 @@ class OperatingModelWorkflow:
 
         # First lifecycle family (DAT-438): every declared validation (vertical
         # ⊕ teach rows) is declared for this run, bound (SQL vs workspace),
-        # executed. Ungroundable specs surface as declared-with-reason. The
-        # phases read the catalog head's run_tables (no table set on the wire).
+        # executed. Ungroundable specs surface as declared-with-reason. Every OM
+        # phase — validation, detect, cycles, metrics — reads the table set PINNED
+        # at resolve (``scope.table_ids``, ADR-0008), not the live catalog head, so
+        # a concurrent begin_session promote cannot shift the set mid-run.
         scoped = OperatingModelScopedInput(run=run, scope=scope, vertical=vertical)
         self._progress.phase = "validation"
         outcome = await workflow.execute_activity(
@@ -775,7 +777,7 @@ class OperatingModelWorkflow:
         self._progress.phase = "operating_model_detect"
         await workflow.execute_activity(
             "operating_model_detect",
-            run,
+            scoped,
             result_type=PhaseOutcome,
             start_to_close_timeout=_TIMEOUT,
             retry_policy=_RETRY,


### PR DESCRIPTION
## What

`operating_model_detect` was the only OM phase wired with a bare `RunRef` instead of `OperatingModelScopedInput` (validation / cycles / metrics all take the scoped input). It called `run_detectors(run_id=om_run)` → `tables_for_run(om_run)`, which is **empty**: the OM run never anchors `run_tables` (begin_session owns them). Result: `detect_no_run_tables`, zero detectors run, and **`cross_table_consistency` silently scored nothing** — every head-resolved reader saw no OM-band bands.

## How it was caught

The DAT-508 eval driver re-point exercised the full OM path on real data: 4 `cross_table_consistency` recall failures ("produced no score"), and a direct check confirmed **zero rows** in `ws_<id>.entropy_objects` for the detector. The worker log showed the `detect_no_run_tables` warning on the OM run.

## Fix

- `run_detectors` gains an optional explicit `table_ids`.
- `operating_model_detect` now takes `OperatingModelScopedInput` and passes `payload.scope.table_ids` — the table set **pinned at `operating_model_resolve`** (ADR-0008), exactly what the sibling OM phases read.
- The workflow passes `scoped`, not `run`.
- `add_source` / `begin_session` detect are unchanged (`table_ids=None` → `tables_for_run` as before).

## Verification

On a full Tier-3 eval run against this fix, the OM detect writes records again (`terminal_detect_done … detector_records: 33`) and all 4 `cross_table_consistency` recall tests pass. Engine ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)