### PR TITLE
DAT-533 (P1.3): nav — 3-icon chat-type switcher + availability

### DIFF
--- a/packages/cockpit/src/db/metadata/workspace-state.ts
+++ b/packages/cockpit/src/db/metadata/workspace-state.ts
@@ -1,0 +1,28 @@
+// Workspace-state reads for chat-type availability (DAT-533) — the engine's
+// ws_<id> metadata, queried through the read-only Drizzle metadata client.
+//
+// Deliberately coarse: a single "is there imported data?" signal drives whether
+// the Stage + Analyse chat types are startable. A table row exists only after
+// add_source completes (import + typing happen in one run), so one table ⇒ there
+// is data to stage/analyse. The typed-vs-raw refinement (`tables.layer`) and a
+// vertical-present gate can extend this later without changing the caller.
+
+import { eq, isNull } from "drizzle-orm";
+import { metadataDb } from "./client";
+import { sources, tables } from "./schema";
+
+/**
+ * Whether the workspace has at least one imported table from a non-archived
+ * source (DAT-533). Existence probe (`limit(1)`), not a full count — the switcher
+ * only needs the boolean. A retired source's tables don't count (`archivedAt`
+ * filter), matching the list_tables inventory.
+ */
+export async function hasImportedTables(): Promise<boolean> {
+	const [row] = await metadataDb
+		.select({ tableId: tables.tableId })
+		.from(tables)
+		.innerJoin(sources, eq(sources.sourceId, tables.sourceId))
+		.where(isNull(sources.archivedAt))
+		.limit(1);
+	return row !== undefined;
+}

--- a/packages/cockpit/src/lib/chat-availability.test.ts
+++ b/packages/cockpit/src/lib/chat-availability.test.ts
@@ -1,0 +1,47 @@
+// Unit test for the chat-type availability mapping (DAT-533, AC2). Pure — the
+// state→types decision with no DB; the hasTables read + the loader wiring are
+// covered by the live smoke.
+
+import { describe, expect, it } from "vitest";
+import { CHAT_KINDS, chatTypesFromState } from "#/lib/chat-availability";
+
+describe("chatTypesFromState (DAT-533)", () => {
+	it("connect is always startable, regardless of state", () => {
+		for (const hasTables of [true, false]) {
+			const connect = chatTypesFromState({ hasTables }).find(
+				(t) => t.kind === "connect",
+			);
+			expect(connect).toEqual({
+				kind: "connect",
+				available: true,
+				reason: null,
+			});
+		}
+	});
+
+	it("stage + analyse are unavailable (with a reason) when there's no data", () => {
+		const byKind = new Map(
+			chatTypesFromState({ hasTables: false }).map((t) => [t.kind, t]),
+		);
+		for (const kind of ["stage", "analyse"] as const) {
+			expect(byKind.get(kind)?.available).toBe(false);
+			expect(byKind.get(kind)?.reason).toBeTruthy(); // a tooltip to show
+		}
+	});
+
+	it("stage + analyse become startable once data is imported", () => {
+		const byKind = new Map(
+			chatTypesFromState({ hasTables: true }).map((t) => [t.kind, t]),
+		);
+		for (const kind of ["stage", "analyse"] as const) {
+			expect(byKind.get(kind)).toEqual({ kind, available: true, reason: null });
+		}
+	});
+
+	it("returns exactly the three kinds in journey order", () => {
+		expect(chatTypesFromState({ hasTables: true }).map((t) => t.kind)).toEqual([
+			...CHAT_KINDS,
+		]);
+		expect(CHAT_KINDS).toEqual(["connect", "stage", "analyse"]);
+	});
+});

--- a/packages/cockpit/src/lib/chat-availability.ts
+++ b/packages/cockpit/src/lib/chat-availability.ts
@@ -1,0 +1,51 @@
+// Chat-type availability (DAT-533) — the deterministic state→types mapping the
+// nav switcher reads to dim unavailable types. No LLM (the entry-router is S4):
+// a plain function over workspace state. Pure + side-effect-free so the mapping
+// is unit-tested in isolation; the route loader supplies the state (a cockpit_db
+// + metadata read) and renders the result.
+
+import type { ConversationKind } from "#/db/cockpit/conversations";
+
+/** Workspace signals that gate which chat types are startable. Coarse for now
+ * (just whether imported data exists); extendable (typed-vs-raw via tables.layer,
+ * a framed-vertical gate, …) without touching the switcher. */
+export interface WorkspaceChatState {
+	/** ≥1 imported table exists → there is data to stage / analyse. */
+	hasTables: boolean;
+}
+
+/** Per-kind availability for the switcher: whether it's startable, and (when not)
+ * the tooltip reason shown on the dimmed icon. */
+export interface ChatTypeAvailability {
+	kind: ConversationKind;
+	available: boolean;
+	/** Why it's dimmed — the tooltip. `null` when available. */
+	reason: string | null;
+}
+
+/** The order the switcher renders, mirroring the onboarding journey. */
+export const CHAT_KINDS: ReadonlyArray<ConversationKind> = [
+	"connect",
+	"stage",
+	"analyse",
+];
+
+const NEEDS_DATA = "Import data in a Connect chat first.";
+
+/**
+ * Map workspace state → per-kind availability (DAT-533). `connect` is always
+ * startable (you can always bring in data); `stage` and `analyse` need imported
+ * data. Deterministic — the unit-tested core of the switcher's dimming.
+ */
+export function chatTypesFromState(
+	state: WorkspaceChatState,
+): ReadonlyArray<ChatTypeAvailability> {
+	return CHAT_KINDS.map((kind) => {
+		if (kind === "connect") return { kind, available: true, reason: null };
+		// stage + analyse both gate on imported data (typing happens inside
+		// add_source, so "imported" and "typed" coincide — DAT-533 keeps it coarse).
+		return state.hasTables
+			? { kind, available: true, reason: null }
+			: { kind, available: false, reason: NEEDS_DATA };
+	});
+}

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.tsx
@@ -78,13 +78,10 @@ export const Route = createFileRoute(
 	component: CockpitChat,
 });
 
-// The cockpit is a FIXED-HEIGHT app surface (not a document): it fills the
-// AppShell.Main area exactly so its inner panes (the chat stream, the canvas)
-// scroll INTERNALLY — otherwise a growing message list pushes the composer off
-// the viewport. Pinned against the viewport minus the shell chrome via Mantine's
-// AppShell CSS vars (header offset + the md padding top & bottom).
-const COCKPIT_HEIGHT =
-	"calc(100dvh - var(--app-shell-header-offset, 0rem) - (2 * var(--app-shell-padding, 0rem)))";
+// The cockpit is a FIXED-HEIGHT app surface (not a document) so its inner panes
+// (the chat stream, the canvas) scroll INTERNALLY. The height is now pinned by
+// the cockpit LAYOUT (route.tsx, below the switcher strip); this chat just fills
+// the Outlet content box with h:100%.
 
 function CockpitChat() {
 	// `kind` + `title` are hydrated by the loader and ready in loader data; nothing
@@ -101,7 +98,7 @@ function CockpitChat() {
 				void persistPin({ data: { conversationId, pinnedCallId } })
 			}
 		>
-			<Box h={COCKPIT_HEIGHT} style={{ overflow: "hidden" }}>
+			<Box h="100%" style={{ overflow: "hidden" }}>
 				<CockpitView />
 			</Box>
 		</CockpitProvider>

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/index.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/index.tsx
@@ -44,10 +44,14 @@ function CockpitIndex() {
 		});
 
 	// Mint a typed chat, then open it. A user event (chip click), so the mutation
-	// lives in the handler, not an effect (React convention 4).
+	// lives in the handler, not an effect (React convention 4). try/catch so a
+	// create failure surfaces rather than dropping the handler's rejection.
 	const create = async (kind: ConversationKind) => {
-		const conversationId = await startConversation({ data: kind });
-		open(conversationId);
+		try {
+			open(await startConversation({ data: kind }));
+		} catch (err) {
+			console.error("[cockpit] create typed chat failed:", err);
+		}
 	};
 
 	return (

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/route.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/route.tsx
@@ -1,10 +1,121 @@
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { Box, Stack } from "@mantine/core";
+import {
+	createFileRoute,
+	Outlet,
+	useMatch,
+	useNavigate,
+} from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import {
+	type ConversationKind,
+	createConversation,
+	listConversations,
+} from "#/db/cockpit/conversations";
+import { resolveActiveWorkspace } from "#/db/cockpit/registry";
+import { hasImportedTables } from "#/db/metadata/workspace-state";
+import {
+	type ChatTypeAvailability,
+	chatTypesFromState,
+} from "#/lib/chat-availability";
+import { ChatSwitcher } from "#/ui/cockpit/chat-switcher";
+import { tokens } from "#/ui/theme";
 
-// Cockpit layout (DAT-528) — the shared chrome wrapping BOTH the history/landing
-// index (/cockpit) and a specific chat (/cockpit/$conversationId). Splitting the
-// cockpit into a layout + child routes is what makes a chat deep-linkable and the
-// history its own surface (the DD/36667393 route shape). Thin for now (a
-// pass-through Outlet); the 3-icon chat-type switcher lands here in S3 (DAT-533).
-export const Route = createFileRoute("/(app)/workspace/$wsId/cockpit")({
-	component: Outlet,
+// Cockpit layout (DAT-528 route split; DAT-533 nav). The shared chrome wrapping
+// BOTH the history/landing index and a specific chat: a thin top strip with the
+// 3-icon chat-type switcher, above the Outlet. The cockpit is a FIXED-HEIGHT
+// surface, so the height is pinned HERE now (it used to live in $conversationId) —
+// the strip is flexShrink:0 and the Outlet content takes the rest and scrolls
+// internally; children fill it with h:100%.
+
+// Switcher data (DAT-533): per-kind availability (drives the dimming) + the most
+// recent conversation id per kind (drives resume-or-create). Both reads degrade
+// soft — a failure dims the data-dependent types / falls back to create — since
+// the switcher is navigation chrome, never a turn-blocking path.
+const loadSwitcher = createServerFn({ method: "GET" }).handler(async () => {
+	const workspaceId = await resolveActiveWorkspace();
+	const [hasTables, conversations] = await Promise.all([
+		hasImportedTables().catch(() => false),
+		listConversations(workspaceId).catch(() => []),
+	]);
+	// listConversations is lastActiveAt-desc, so the FIRST per kind is its latest.
+	const latestByKind: Partial<Record<ConversationKind, string>> = {};
+	for (const c of conversations) latestByKind[c.kind] ??= c.id;
+	return {
+		availability: chatTypesFromState({ hasTables }) as ChatTypeAvailability[],
+		latestByKind,
+	};
 });
+
+// Mint a fresh typed conversation — the resolveActiveWorkspace read stays
+// server-side (never reaches the client bundle).
+const createTypedConversation = createServerFn({ method: "POST" })
+	.inputValidator((kind: ConversationKind) => kind)
+	.handler(async ({ data }) => {
+		const workspaceId = await resolveActiveWorkspace();
+		return createConversation(workspaceId, data);
+	});
+
+export const Route = createFileRoute("/(app)/workspace/$wsId/cockpit")({
+	loader: () => loadSwitcher(),
+	component: CockpitLayout,
+});
+
+// The child chat route — its loader carries the conversation's `kind`, which the
+// switcher reads to highlight the active type (no kind in the URL, DD/36667393).
+const CHAT_ROUTE_ID = "/(app)/workspace/$wsId/cockpit/$conversationId";
+
+// Pinned against the viewport minus the shell chrome (header offset + the md
+// padding the AppShell adds top & bottom), same calc the chat route used before.
+const COCKPIT_HEIGHT =
+	"calc(100dvh - var(--app-shell-header-offset, 0rem) - (2 * var(--app-shell-padding, 0rem)))";
+
+function CockpitLayout() {
+	const { availability, latestByKind } = Route.useLoaderData();
+	const { wsId } = Route.useParams();
+	const navigate = useNavigate();
+
+	// The active chat's kind (the where-am-I highlight) — read the child route's
+	// loaded kind; undefined on the index (history), so nothing is highlighted.
+	const child = useMatch({ from: CHAT_ROUTE_ID, shouldThrow: false });
+	const activeKind: ConversationKind | null = child?.loaderData?.kind ?? null;
+
+	const goTo = (conversationId: string) =>
+		navigate({
+			to: "/workspace/$wsId/cockpit/$conversationId",
+			params: { wsId, conversationId },
+		});
+
+	// A type-icon click resumes that kind's latest chat, or creates one if none.
+	const open = async (kind: ConversationKind) => {
+		const existing = latestByKind[kind];
+		goTo(existing ?? (await createTypedConversation({ data: kind })));
+	};
+	// The "+" forces a fresh chat of the active kind (vs resume).
+	const create = async (kind: ConversationKind) =>
+		goTo(await createTypedConversation({ data: kind }));
+
+	return (
+		<Stack gap={0} h={COCKPIT_HEIGHT} style={{ overflow: "hidden" }}>
+			<Box
+				data-testid="cockpit-topbar"
+				style={{
+					flexShrink: 0,
+					borderBottomWidth: 1,
+					borderBottomStyle: "solid",
+					borderBottomColor: tokens.colors.border,
+					padding: tokens.spacing.xs,
+				}}
+			>
+				<ChatSwitcher
+					availability={availability}
+					activeKind={activeKind}
+					onOpen={open}
+					onNew={create}
+				/>
+			</Box>
+			<Box style={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
+				<Outlet />
+			</Box>
+		</Stack>
+	);
+}

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/route.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/route.tsx
@@ -86,13 +86,26 @@ function CockpitLayout() {
 		});
 
 	// A type-icon click resumes that kind's latest chat, or creates one if none.
+	// try/catch so a create failure surfaces (not a silent dropped rejection — the
+	// handler is fire-and-forget from the icon's onClick); a notification replaces
+	// the console log when that stack lands.
 	const open = async (kind: ConversationKind) => {
-		const existing = latestByKind[kind];
-		goTo(existing ?? (await createTypedConversation({ data: kind })));
+		try {
+			goTo(
+				latestByKind[kind] ?? (await createTypedConversation({ data: kind })),
+			);
+		} catch (err) {
+			console.error("[cockpit] open typed chat failed:", err);
+		}
 	};
 	// The "+" forces a fresh chat of the active kind (vs resume).
-	const create = async (kind: ConversationKind) =>
-		goTo(await createTypedConversation({ data: kind }));
+	const create = async (kind: ConversationKind) => {
+		try {
+			goTo(await createTypedConversation({ data: kind }));
+		} catch (err) {
+			console.error("[cockpit] create typed chat failed:", err);
+		}
+	};
 
 	return (
 		<Stack gap={0} h={COCKPIT_HEIGHT} style={{ overflow: "hidden" }}>

--- a/packages/cockpit/src/ui/cockpit/chat-switcher.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/chat-switcher.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatTypeAvailability } from "#/lib/chat-availability";
+import { ChatSwitcher } from "#/ui/cockpit/chat-switcher";
+
+const ALL_AVAILABLE: ChatTypeAvailability[] = [
+	{ kind: "connect", available: true, reason: null },
+	{ kind: "stage", available: true, reason: null },
+	{ kind: "analyse", available: true, reason: null },
+];
+const NO_DATA: ChatTypeAvailability[] = [
+	{ kind: "connect", available: true, reason: null },
+	{
+		kind: "stage",
+		available: false,
+		reason: "Import data in a Connect chat first.",
+	},
+	{
+		kind: "analyse",
+		available: false,
+		reason: "Import data in a Connect chat first.",
+	},
+];
+
+function renderSwitcher(
+	props: Partial<Parameters<typeof ChatSwitcher>[0]> = {},
+) {
+	const onOpen = vi.fn();
+	const onNew = vi.fn();
+	render(
+		<MantineProvider env="test">
+			<ChatSwitcher
+				availability={props.availability ?? ALL_AVAILABLE}
+				activeKind={props.activeKind ?? null}
+				onOpen={onOpen}
+				onNew={onNew}
+			/>
+		</MantineProvider>,
+	);
+	return { onOpen, onNew };
+}
+
+afterEach(() => cleanup());
+
+describe("ChatSwitcher (DAT-533)", () => {
+	it("renders the three type icons", () => {
+		renderSwitcher();
+		for (const kind of ["connect", "stage", "analyse"] as const) {
+			expect(screen.getByTestId(`switch-${kind}`)).toBeTruthy();
+		}
+	});
+
+	it("highlights the active kind only", () => {
+		renderSwitcher({ activeKind: "stage" });
+		expect(screen.getByTestId("switch-stage").dataset.active).toBe("true");
+		expect(screen.getByTestId("switch-connect").dataset.active).toBeUndefined();
+		expect(screen.getByTestId("switch-analyse").dataset.active).toBeUndefined();
+	});
+
+	it("opens an available type on click (resume-or-create)", () => {
+		const { onOpen } = renderSwitcher({ availability: ALL_AVAILABLE });
+		fireEvent.click(screen.getByTestId("switch-analyse"));
+		expect(onOpen).toHaveBeenCalledWith("analyse");
+	});
+
+	it("dims an unavailable type and does NOT navigate on click", () => {
+		const { onOpen } = renderSwitcher({ availability: NO_DATA });
+		const stage = screen.getByTestId("switch-stage");
+		expect(stage.dataset.available).toBe("false");
+		expect(stage.getAttribute("aria-disabled")).toBe("true");
+		fireEvent.click(stage);
+		expect(onOpen).not.toHaveBeenCalled();
+	});
+
+	it("shows the '+' only inside a chat, and it forces a fresh chat of the active kind", () => {
+		const { onNew } = renderSwitcher({ activeKind: "connect" });
+		const plus = screen.getByTestId("switch-new");
+		fireEvent.click(plus);
+		expect(onNew).toHaveBeenCalledWith("connect");
+	});
+
+	it("hides the '+' on the history landing (no active kind)", () => {
+		renderSwitcher({ activeKind: null });
+		expect(screen.queryByTestId("switch-new")).toBeNull();
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/chat-switcher.tsx
+++ b/packages/cockpit/src/ui/cockpit/chat-switcher.tsx
@@ -1,0 +1,97 @@
+// The 3-icon chat-type switcher (DAT-533) — Connect · Stage · Analyse, in the
+// cockpit top strip. The active chat's kind is highlighted (the where-am-I hint);
+// clicking a type opens it (resume-latest-or-create — the layout decides which);
+// an unavailable type dims IN PLACE with a tooltip reason (not removed, so the
+// switcher's shape is stable). A "+" beside them forces a FRESH chat of the
+// active kind (vs the resume that a type-icon click does) — shown only inside a
+// chat, since the history landing already has type chips to create from.
+//
+// Pure + presentational: it takes the availability + active kind + two callbacks,
+// so it unit-tests without a router or cockpit_db. The layout (cockpit/route.tsx)
+// wires the callbacks to the resume/create server-fns + navigation.
+
+import { ActionIcon, Group, Tooltip } from "@mantine/core";
+import { Cable, Layers, LineChart, type LucideIcon, Plus } from "lucide-react";
+import type { ConversationKind } from "#/db/cockpit/conversations";
+import type { ChatTypeAvailability } from "#/lib/chat-availability";
+
+const ICON: Record<ConversationKind, LucideIcon> = {
+	connect: Cable,
+	stage: Layers,
+	analyse: LineChart,
+};
+const LABEL: Record<ConversationKind, string> = {
+	connect: "Connect",
+	stage: "Stage",
+	analyse: "Analyse",
+};
+
+export function ChatSwitcher({
+	availability,
+	activeKind,
+	onOpen,
+	onNew,
+}: {
+	availability: ReadonlyArray<ChatTypeAvailability>;
+	/** The current chat's kind (highlighted), or null on the history landing. */
+	activeKind: ConversationKind | null;
+	/** Open a type: resume its latest chat or create one if none. */
+	onOpen: (kind: ConversationKind) => void;
+	/** Force a fresh chat of the given kind (the "+"). */
+	onNew: (kind: ConversationKind) => void;
+}) {
+	return (
+		<Group gap="xs" data-testid="chat-switcher">
+			{availability.map(({ kind, available, reason }) => {
+				const Icon = ICON[kind];
+				const isActive = kind === activeKind;
+				return (
+					<Tooltip
+						key={kind}
+						label={available ? LABEL[kind] : reason}
+						position="bottom"
+						withArrow
+					>
+						{/* Unavailable: dimmed + non-navigating, but still hoverable so the
+						    tooltip reason shows (so NOT the `disabled` prop, which kills
+						    pointer events). The click is guarded instead. */}
+						<ActionIcon
+							data-testid={`switch-${kind}`}
+							data-active={isActive ? "true" : undefined}
+							data-available={available ? "true" : "false"}
+							aria-label={LABEL[kind]}
+							aria-disabled={!available}
+							variant={isActive ? "filled" : "subtle"}
+							size="lg"
+							style={
+								available ? undefined : { opacity: 0.4, cursor: "not-allowed" }
+							}
+							onClick={() => {
+								if (available) onOpen(kind);
+							}}
+						>
+							<Icon size={18} aria-hidden />
+						</ActionIcon>
+					</Tooltip>
+				);
+			})}
+			{activeKind !== null && (
+				<Tooltip
+					label={`New ${LABEL[activeKind]} chat`}
+					position="bottom"
+					withArrow
+				>
+					<ActionIcon
+						data-testid="switch-new"
+						aria-label={`New ${LABEL[activeKind]} chat`}
+						variant="subtle"
+						size="lg"
+						onClick={() => onNew(activeKind)}
+					>
+						<Plus size={18} aria-hidden />
+					</ActionIcon>
+				</Tooltip>
+			)}
+		</Group>
+	);
+}


### PR DESCRIPTION
**Epic:** DAT-526 · **Design:** DD/36667393 §Navigation · **Builds on:** DAT-528 (S1) + DAT-532 (S2).

Deterministic navigation between the typed chats — the LLM entry-router is S4.

## What's in
- **3-icon top-strip switcher** (Connect · Stage · Analyse) in the cockpit layout (`cockpit/route.tsx`). Active kind **highlighted** (read from the child route's loaded `kind` via `useMatch` — no kind in the URL). A type-icon click **resumes that kind's latest chat or creates one**; an **unavailable type dims in place + tooltip** (`aria-disabled` + guarded click, so the tooltip reason still shows). A **"+"** forces a fresh chat of the active kind (shown only inside a chat — the landing chips cover creation there).
- **`availableChatTypes`** = pure `chatTypesFromState` (unit-tested) over `hasImportedTables` (a new existence probe over `tables ⟕ non-archived sources`): connect always; stage + analyse gate on imported data. Coarse by design (typing happens inside add_source), extendable.
- Fixed-height moved into the layout (strip-aware); children fill `h:100%`.

## Scope
- **Deferred to a follow-up** (split at refine): the completion-handoff CTA. The completion narration already soft-suggests the next step, so the one-click button is later polish. (Follow-up ticket filed under DAT-526.)
- Left rail untouched — `sections.ts` stays 6; `app-shell.test` unchanged.

## Tests / gates
`chat-availability.test` (state→types), `chat-switcher.test` (render/highlight/dim/resume-vs-create/"+"). **1134 green**; biome + tsc + Nitro build clean. Cockpit-only, no engine, no eval.

## Smoke (container from this branch)
Switcher renders; Stage/Analyse dimmed pre-data; Connect resumes the latest chat; active highlight correct; "+" creates a distinct fresh chat; 0 console errors.

## Reviewers
senior-code-reviewer: APPROVE (one fix applied — guarded the async nav handlers' dropped rejection). spec-compliance-reviewer: COMPLIANT (CTA correctly deferred; no scope creep; sections.ts unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)