### PR TITLE
DAT-534 (P1.4): assisted entry (Haiku nav-agent) + readiness + begin_session pre-check

### DIFF
--- a/packages/cockpit/scripts/smoke-begin-session.ts
+++ b/packages/cockpit/scripts/smoke-begin-session.ts
@@ -140,6 +140,9 @@ async function main(): Promise<void> {
 		// The vertical is the WORKSPACE property (seeded = finance in ingest); the
 		// driver sources it from the registry (DAT-506), so no vertical arg here.
 		const begun = await beginSession({ table_ids: tableIds });
+		// beginSession returns a born-loud {error} when the workspace has no typed
+		// tables (DAT-534); the smoke ingested above, so it must have started.
+		if ("error" in begun) throw new Error(`begin_session refused: ${begun.error}`);
 		console.log(
 			`✓ begin_session started: workflow=${begun.workflow_id} session=${begun.session_id}`,
 		);

--- a/packages/cockpit/scripts/smoke-operating-model.ts
+++ b/packages/cockpit/scripts/smoke-operating-model.ts
@@ -149,6 +149,9 @@ async function main(): Promise<void> {
 		// ---- begin_session: compose the workspace ---------------------------------
 		// Vertical is the workspace property (seeded = finance); the driver sources it.
 		const begun = await beginSession({ table_ids: tableIds });
+		// beginSession now returns a born-loud {error} when the workspace has no
+		// typed tables (DAT-534); the smoke ingested above, so it must have started.
+		if ("error" in begun) throw new Error(`begin_session refused: ${begun.error}`);
 		await client.workflow.getHandle(begun.workflow_id, begun.run_id).result();
 		console.log(`✓ begin_session completed: session=${begun.session_id}`);
 

--- a/packages/cockpit/src/lib/chat-readiness.test.ts
+++ b/packages/cockpit/src/lib/chat-readiness.test.ts
@@ -1,0 +1,46 @@
+// Unit test for the in-chat readiness mapping (DAT-534). Pure — state→signal,
+// no DB; the loader wiring + render are covered by the banner test + smoke.
+
+import { describe, expect, it } from "vitest";
+import { chatReadiness } from "#/lib/chat-readiness";
+
+describe("chatReadiness (DAT-534)", () => {
+	it("connect is always ready — no banner, regardless of state", () => {
+		for (const hasTables of [true, false]) {
+			for (const hasActiveRun of [true, false]) {
+				expect(
+					chatReadiness("connect", { hasTables, hasActiveRun }),
+				).toBeNull();
+			}
+		}
+	});
+
+	it("stage/analyse with no data → do-X-first (blocked)", () => {
+		for (const kind of ["stage", "analyse"] as const) {
+			const r = chatReadiness(kind, { hasTables: false, hasActiveRun: false });
+			expect(r?.tone).toBe("blocked");
+			expect(r?.message).toMatch(/import/i);
+		}
+	});
+
+	it("stage/analyse with data + an in-flight run → wait-for-Y (waiting)", () => {
+		for (const kind of ["stage", "analyse"] as const) {
+			const r = chatReadiness(kind, { hasTables: true, hasActiveRun: true });
+			expect(r?.tone).toBe("waiting");
+		}
+	});
+
+	it("stage/analyse with data and no run → ready (no banner)", () => {
+		for (const kind of ["stage", "analyse"] as const) {
+			expect(
+				chatReadiness(kind, { hasTables: true, hasActiveRun: false }),
+			).toBeNull();
+		}
+	});
+
+	it("no data takes precedence over an in-flight run (import-first is the message)", () => {
+		expect(
+			chatReadiness("stage", { hasTables: false, hasActiveRun: true })?.tone,
+		).toBe("blocked");
+	});
+});

--- a/packages/cockpit/src/lib/chat-readiness.ts
+++ b/packages/cockpit/src/lib/chat-readiness.ts
@@ -1,0 +1,48 @@
+// In-chat readiness (DAT-534) — a NON-BLOCKING signal shown inside a chat when
+// its kind can't meaningfully act yet: do-X-first (no data imported) or
+// wait-for-Y (a run is in progress). Derived from workspace data-state + the
+// chat's own in-flight runs. Rendered as a greyed banner; it never disables the
+// composer (the agent can still explain / guide). Pure so the state→message
+// mapping is unit-tested in isolation; the chat route loader supplies the state.
+
+import type { ConversationKind } from "#/db/cockpit/conversations";
+
+export interface ChatReadinessState {
+	/** ≥1 imported table exists in the workspace (the data to stage / analyse). */
+	hasTables: boolean;
+	/** This chat has a Temporal run in progress (conversation-scoped, DAT-528). */
+	hasActiveRun: boolean;
+}
+
+export interface ChatReadiness {
+	/** `blocked` = do X first (greyed, advisory); `waiting` = a run is finishing. */
+	tone: "blocked" | "waiting";
+	message: string;
+}
+
+/**
+ * The readiness signal for a chat of `kind`, or `null` when it's ready to act (no
+ * banner). `connect` is always ready — you can always bring in data. `stage` and
+ * `analyse` need imported data first (do-X-first), and yield to an in-flight run
+ * (wait-for-Y). Advisory only: never blocks input.
+ */
+export function chatReadiness(
+	kind: ConversationKind,
+	state: ChatReadinessState,
+): ChatReadiness | null {
+	if (kind === "connect") return null;
+	if (!state.hasTables) {
+		return {
+			tone: "blocked",
+			message: "No data yet — import some in a Connect chat first.",
+		};
+	}
+	if (state.hasActiveRun) {
+		return {
+			tone: "waiting",
+			message:
+				"A run is in progress — results will appear here when it finishes.",
+		};
+	}
+	return null;
+}

--- a/packages/cockpit/src/lib/nav-agent.test.ts
+++ b/packages/cockpit/src/lib/nav-agent.test.ts
@@ -53,6 +53,11 @@ describe("classifyOpeningMessage (DAT-534)", () => {
 		).toBe("connect");
 		expect(warn).toHaveBeenCalled();
 		warn.mockRestore();
+		// NB: the SAME catch handles an async chat() rejection. Asserting that via
+		// `h.chat.mockRejectedValue(...)` is not feasible here — a rejecting
+		// `@tanstack/ai` module-mock surfaces as an "unhandled rejection" in this
+		// vitest setup even though the SUT catches it (a harness quirk). The sync
+		// adapter throw above drives the identical catch → fallback path.
 	});
 
 	it("honors a custom fallback", async () => {

--- a/packages/cockpit/src/lib/nav-agent.test.ts
+++ b/packages/cockpit/src/lib/nav-agent.test.ts
@@ -1,0 +1,64 @@
+// Unit test for the landing nav-agent classifier (DAT-534). The Haiku call is
+// mocked at the @tanstack/ai boundary; what's tested is the REAL logic around it
+// — the availability filter and the best-effort fallback (an LLM error or an
+// unavailable pick must land on a safe kind, never throw).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+	chat: vi.fn(),
+	createAnthropicChat: vi.fn(() => ({})),
+}));
+
+vi.mock("@tanstack/ai", () => ({ chat: h.chat }));
+vi.mock("@tanstack/ai-anthropic", () => ({
+	createAnthropicChat: h.createAnthropicChat,
+}));
+vi.mock("#/config", () => ({ config: { anthropicApiKey: "sk-test" } }));
+
+import { classifyOpeningMessage } from "#/lib/nav-agent";
+
+beforeEach(() => {
+	h.chat.mockReset();
+	h.createAnthropicChat.mockReset();
+	h.createAnthropicChat.mockReturnValue({});
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("classifyOpeningMessage (DAT-534)", () => {
+	it("returns the model's pick when it is available", async () => {
+		h.chat.mockResolvedValue({ kind: "stage" });
+		expect(
+			await classifyOpeningMessage("teach the model", ["connect", "stage"]),
+		).toBe("stage");
+	});
+
+	it("falls back when the model picks an UNAVAILABLE type", async () => {
+		h.chat.mockResolvedValue({ kind: "analyse" });
+		// analyse not in the available set (no data yet) → fall back to connect.
+		expect(await classifyOpeningMessage("what is revenue?", ["connect"])).toBe(
+			"connect",
+		);
+	});
+
+	it("falls back (no throw) when the LLM call fails", async () => {
+		const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+		// Fail at adapter construction (called synchronously inside the try) — same
+		// catch → fallback path, without a rejecting module-mock promise.
+		h.createAnthropicChat.mockImplementation(() => {
+			throw new Error("haiku down");
+		});
+		expect(
+			await classifyOpeningMessage("anything", ["connect", "stage", "analyse"]),
+		).toBe("connect");
+		expect(warn).toHaveBeenCalled();
+		warn.mockRestore();
+	});
+
+	it("honors a custom fallback", async () => {
+		h.chat.mockResolvedValue({ kind: "analyse" });
+		expect(
+			await classifyOpeningMessage("x", ["connect", "stage"], "stage"),
+		).toBe("stage");
+	});
+});

--- a/packages/cockpit/src/lib/nav-agent.ts
+++ b/packages/cockpit/src/lib/nav-agent.ts
@@ -1,0 +1,55 @@
+// Landing nav-agent (DAT-534) — the "tell" entry. A thin Haiku ONE-SHOT that
+// classifies the user's opening message into a chat kind (connect | stage |
+// analyse), biased by what's currently startable. Nested `chat()` with an
+// outputSchema, the proven `answer`-tool pattern; runs ONLY at chat creation,
+// never mid-conversation.
+//
+// BEST-EFFORT by design: any failure — an LLM error, an unavailable or garbled
+// pick — falls back to a safe kind. The deterministic type chips are the escape
+// hatch, so a wrong guess costs only a new chat. SERVER-ONLY (adapter + key).
+
+import { chat } from "@tanstack/ai";
+import { createAnthropicChat } from "@tanstack/ai-anthropic";
+import { z } from "zod";
+
+import { config } from "#/config";
+import type { ConversationKind } from "#/db/cockpit/conversations";
+import { MAX_OUTPUT_TOKENS, NAV_MODEL } from "#/llm";
+
+const KINDS = ["connect", "stage", "analyse"] as const;
+
+const SYSTEM = `You route a data practitioner's opening message to ONE of three chat types. Reply with the single best type.
+- connect: bring data in — preview a source, choose a vertical/ontology, import tables.
+- stage: build the analytical model over ALREADY-IMPORTED tables — relationships, validations, business cycles, metrics; teaching/corrections.
+- analyse: answer analytical questions about imported data ("what's total revenue?", "monthly trend").
+If the message is vague, a greeting, or about getting started, choose connect. Prefer a type listed as available.`;
+
+/**
+ * Classify the opening message into a chat kind via a Haiku one-shot, biased by
+ * the `available` set. Returns `fallback` (default `connect`) on ANY failure or
+ * when the model picks an unavailable type — best-effort, since the chips bypass
+ * this entirely and a wrong guess is recovered by starting a new chat.
+ */
+export async function classifyOpeningMessage(
+	message: string,
+	available: ReadonlyArray<ConversationKind>,
+	fallback: ConversationKind = "connect",
+): Promise<ConversationKind> {
+	try {
+		const result = await chat({
+			adapter: createAnthropicChat(NAV_MODEL, config.anthropicApiKey),
+			modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
+			systemPrompts: [
+				{ content: `${SYSTEM}\nAvailable: ${available.join(", ")}.` },
+			],
+			messages: [{ role: "user", content: message }],
+			outputSchema: z.object({ kind: z.enum(KINDS) }),
+		});
+		// Honor availability: an unavailable pick falls back (the user lands in a
+		// chat they can actually act in; e.g. "analyse X" with no data → connect).
+		return available.includes(result.kind) ? result.kind : fallback;
+	} catch (err) {
+		console.error("[nav-agent] classify failed — falling back:", err);
+		return fallback;
+	}
+}

--- a/packages/cockpit/src/llm.ts
+++ b/packages/cockpit/src/llm.ts
@@ -17,6 +17,12 @@
 
 export const MODEL = "claude-sonnet-4-6";
 
+// The landing nav-agent's model (DAT-534) — a cheap Haiku one-shot that classifies
+// the opening message into a chat kind. Undated alias, mirroring MODEL's
+// `claude-sonnet-4-6` (auto-resolves to the latest 4.5 snapshot); fall back to the
+// dated `claude-haiku-4-5-20251001` only if the alias ever fails to resolve.
+export const NAV_MODEL = "claude-haiku-4-5";
+
 export const MAX_OUTPUT_TOKENS = 24576;
 
 // The agent-loop iteration ceiling for /api/chat. chat() defaults to

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.tsx
@@ -1,12 +1,16 @@
-import { Box } from "@mantine/core";
+import { Box, Stack } from "@mantine/core";
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import {
 	getConversation,
 	loadDisplayMessages,
 } from "#/db/cockpit/conversations";
+import { listRunningStages } from "#/db/cockpit/runs";
 import { loadUiState, saveUiState } from "#/db/cockpit/ui-state";
+import { hasImportedTables } from "#/db/metadata/workspace-state";
+import { chatReadiness } from "#/lib/chat-readiness";
 import { reconcileActiveRuns } from "#/temporal/reconcile";
+import { ChatReadinessBanner } from "#/ui/cockpit/chat-readiness-banner";
 import { CockpitProvider } from "#/ui/cockpit/cockpit-state";
 import { CockpitView } from "#/ui/cockpit/cockpit-view";
 
@@ -28,10 +32,15 @@ const loadChat = createServerFn({ method: "GET", strict: { output: false } })
 		try {
 			const conversation = await getConversation(conversationId);
 			if (!conversation) return { notFound: true as const };
-			const [initialMessages, uiState] = await Promise.all([
-				loadDisplayMessages(conversationId),
-				loadUiState(conversationId),
-			]);
+			// Readiness inputs (DAT-534) alongside hydration — both soft (a read blip
+			// just drops the advisory banner, never the chat).
+			const [initialMessages, uiState, hasTables, runningStages] =
+				await Promise.all([
+					loadDisplayMessages(conversationId),
+					loadUiState(conversationId),
+					hasImportedTables().catch(() => false),
+					listRunningStages(conversationId).catch(() => []),
+				]);
 			void reconcileActiveRuns(conversationId);
 			return {
 				notFound: false as const,
@@ -40,6 +49,10 @@ const loadChat = createServerFn({ method: "GET", strict: { output: false } })
 				title: conversation.title,
 				initialMessages,
 				uiState,
+				readiness: chatReadiness(conversation.kind, {
+					hasTables,
+					hasActiveRun: runningStages.length > 0,
+				}),
 			};
 		} catch (err) {
 			console.error(
@@ -53,6 +66,7 @@ const loadChat = createServerFn({ method: "GET", strict: { output: false } })
 				title: null,
 				initialMessages: undefined,
 				uiState: null,
+				readiness: null,
 			};
 		}
 	});
@@ -84,11 +98,12 @@ export const Route = createFileRoute(
 // the Outlet content box with h:100%.
 
 function CockpitChat() {
-	// `kind` + `title` are hydrated by the loader and ready in loader data; nothing
-	// consumes them yet (S1 stores + routes by kind, it does not fence behaviour).
-	// S2 (DAT-532) threads `kind` into CockpitProvider to select the toolstack —
-	// the seam is here, not a dead prop now.
-	const { conversationId, initialMessages, uiState } = Route.useLoaderData();
+	// `kind` selects the toolstack + prompt SERVER-SIDE (DAT-532, in /api/chat) and
+	// drives the readiness banner (DAT-534); `title` is the history label. The
+	// readiness banner is advisory + non-blocking — shown only when the chat's kind
+	// can't act yet (no data / a run in progress).
+	const { conversationId, initialMessages, uiState, readiness } =
+		Route.useLoaderData();
 	return (
 		<CockpitProvider
 			conversationId={conversationId}
@@ -98,9 +113,12 @@ function CockpitChat() {
 				void persistPin({ data: { conversationId, pinnedCallId } })
 			}
 		>
-			<Box h="100%" style={{ overflow: "hidden" }}>
-				<CockpitView />
-			</Box>
+			<Stack gap="xs" h="100%" style={{ overflow: "hidden" }}>
+				{readiness && <ChatReadinessBanner readiness={readiness} />}
+				<Box style={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
+					<CockpitView />
+				</Box>
+			</Stack>
 		</CockpitProvider>
 	);
 }

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack } from "@mantine/core";
-import { createFileRoute, notFound } from "@tanstack/react-router";
+import { createFileRoute, notFound, useLocation } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import {
 	getConversation,
@@ -104,11 +104,16 @@ function CockpitChat() {
 	// can't act yet (no data / a run in progress).
 	const { conversationId, initialMessages, uiState, readiness } =
 		Route.useLoaderData();
+	// The landing nav-agent's opening message (DAT-534), carried in router state —
+	// CockpitProvider sends it once on mount into the empty chat. Absent on a normal
+	// open (switcher / reload after the first turn). Loosely shaped, so narrowed here.
+	const seedMessage = (useLocation().state as { seed?: string }).seed;
 	return (
 		<CockpitProvider
 			conversationId={conversationId}
 			initialMessages={initialMessages}
 			initialUiState={uiState}
+			seedMessage={seedMessage}
 			onPersistPin={(pinnedCallId) =>
 				void persistPin({ data: { conversationId, pinnedCallId } })
 			}

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/index.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/index.tsx
@@ -6,12 +6,14 @@ import {
 	listConversations,
 } from "#/db/cockpit/conversations";
 import { resolveActiveWorkspace } from "#/db/cockpit/registry";
+import { hasImportedTables } from "#/db/metadata/workspace-state";
+import { chatTypesFromState } from "#/lib/chat-availability";
+import { classifyOpeningMessage } from "#/lib/nav-agent";
 import { CockpitHome } from "#/ui/cockpit/cockpit-home";
 
-// The cockpit landing (DAT-528): recent chat history + type chips. A chat has a
-// TYPE chosen up front (connect | stage | analyse), so the entry point creates a
-// TYPED conversation and deep-links into it — there is no free-text composer here
-// anymore (the Haiku entry-router that infers the type is S4, DAT-534). Both
+// The cockpit landing (DAT-528 + DAT-534): "tell or click". The free composer
+// (tell) routes through the Haiku nav-agent → a typed chat seeded with the
+// message; the type chips (click) create a typed chat deterministically. Both
 // server fns resolve the active workspace server-side (the registry read never
 // reaches the client bundle); the plugin strips these handlers from the client.
 
@@ -25,6 +27,21 @@ const startConversation = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		const workspaceId = await resolveActiveWorkspace();
 		return createConversation(workspaceId, data);
+	});
+
+// The "tell" entry (DAT-534): classify the opening message into a kind (Haiku,
+// best-effort, biased by what's startable), then create that typed chat. The
+// caller seeds the message into the new chat client-side (router state).
+const routeOpeningMessage = createServerFn({ method: "POST" })
+	.inputValidator((message: string) => message)
+	.handler(async ({ data: message }) => {
+		const workspaceId = await resolveActiveWorkspace();
+		const hasTables = await hasImportedTables().catch(() => false);
+		const available = chatTypesFromState({ hasTables })
+			.filter((t) => t.available)
+			.map((t) => t.kind);
+		const kind = await classifyOpeningMessage(message, available);
+		return { conversationId: await createConversation(workspaceId, kind) };
 	});
 
 export const Route = createFileRoute("/(app)/workspace/$wsId/cockpit/")({
@@ -54,11 +71,29 @@ function CockpitIndex() {
 		}
 	};
 
+	// The "tell" path (DAT-534): classify → create a typed chat → open it with the
+	// message in router STATE, which CockpitProvider sends once on mount (the seed).
+	// router state is ephemeral (not the URL); the message is persisted by the first
+	// turn, so a reload doesn't re-seed.
+	const tell = async (message: string) => {
+		try {
+			const { conversationId } = await routeOpeningMessage({ data: message });
+			navigate({
+				to: "/workspace/$wsId/cockpit/$conversationId",
+				params: { wsId, conversationId },
+				state: { seed: message } as never,
+			});
+		} catch (err) {
+			console.error("[cockpit] nav-agent routing failed:", err);
+		}
+	};
+
 	return (
 		<CockpitHome
 			conversations={conversations}
 			onOpen={open}
 			onCreate={create}
+			onTell={tell}
 		/>
 	);
 }

--- a/packages/cockpit/src/tools/begin-session.test.ts
+++ b/packages/cockpit/src/tools/begin-session.test.ts
@@ -24,6 +24,7 @@ const h = vi.hoisted(() => ({
 		h.calls.push("record");
 	}),
 	attachRunId: vi.fn(async () => {}),
+	hasImportedTables: vi.fn(async () => true),
 }));
 
 vi.mock("#/config", () => ({
@@ -45,6 +46,11 @@ vi.mock("#/db/cockpit/registry", () => ({
 vi.mock("#/db/cockpit/runs", () => ({
 	recordRun: h.recordRun,
 	attachRunId: h.attachRunId,
+}));
+// The DAT-534 born-loud pre-check reads workspace state; mock it (default: data
+// present, so the existing record/start tests are unaffected).
+vi.mock("#/db/metadata/workspace-state", () => ({
+	hasImportedTables: h.hasImportedTables,
 }));
 
 const startMock = vi.fn(async (_name: string, _opts: unknown) => {
@@ -77,6 +83,8 @@ beforeEach(() => {
 	closeMock.mockClear();
 	h.recordRun.mockClear();
 	h.attachRunId.mockClear();
+	h.hasImportedTables.mockClear();
+	h.hasImportedTables.mockResolvedValue(true);
 });
 
 describe("beginSession (DAT-409, DAT-506)", () => {
@@ -88,6 +96,7 @@ describe("beginSession (DAT-409, DAT-506)", () => {
 	it("hands the workflow a FLAT input — workspace_id + table set + verticals — and returns the cockpit session", async () => {
 		h.vertical = "finance";
 		const result = await beginSession({ table_ids: ["t1", "t2"] });
+		if ("error" in result) throw new Error(`unexpected: ${result.error}`);
 
 		const opts = startMock.mock.calls[0][1] as Record<string, unknown>;
 		const args = opts.args as [
@@ -112,6 +121,7 @@ describe("beginSession (DAT-409, DAT-506)", () => {
 			table_ids: ["t1"],
 			session_id: "sess-reuse",
 		});
+		if ("error" in result) throw new Error(`unexpected: ${result.error}`);
 		expect(result.session_id).toBe("sess-reuse");
 		const opts = startMock.mock.calls[0][1] as Record<string, unknown>;
 		expect(opts.workflowId).toBe(`beginsession-${WS}-sess-reuse`);
@@ -126,8 +136,21 @@ describe("beginSession (DAT-409, DAT-506)", () => {
 		expect(h.recordRun).not.toHaveBeenCalled();
 	});
 
+	it("refuses with { error } before start when the workspace has no typed tables (DAT-534)", async () => {
+		// The engine errors late on an empty table set; the cockpit pre-flight turns
+		// that into an agent-actionable sentence — and must NOT record or start a run.
+		h.hasImportedTables.mockResolvedValue(false);
+		const result = await beginSession({ table_ids: ["t1"] });
+		expect(result).toMatchObject({
+			error: expect.stringContaining("import data in a Connect chat"),
+		});
+		expect(h.recordRun).not.toHaveBeenCalled();
+		expect(startMock).not.toHaveBeenCalled();
+	});
+
 	it("records the cockpit session + run before start, then attaches the runId", async () => {
 		const result = await beginSession({ table_ids: ["t1", "t2"] });
+		if ("error" in result) throw new Error(`unexpected: ${result.error}`);
 		expect(h.recordRun).toHaveBeenCalledTimes(1);
 		expect(h.recordedRun).toEqual({
 			workspaceId: WS,

--- a/packages/cockpit/src/tools/begin-session.ts
+++ b/packages/cockpit/src/tools/begin-session.ts
@@ -31,8 +31,10 @@ import { z } from "zod";
 import { config } from "../config";
 import { resolveActiveWorkspaceRow } from "../db/cockpit/registry";
 import { attachRunId, recordRun } from "../db/cockpit/runs";
+import { hasImportedTables } from "../db/metadata/workspace-state";
 import type { BeginSessionInput, BeginSessionResult } from "../temporal/types";
 import { beginSessionWorkflowId } from "../temporal/workflow-id";
+import { type AgentError, withAgentError } from "./agent-error";
 
 export interface BeginSessionToolInput {
 	table_ids: string[];
@@ -57,12 +59,26 @@ export interface BeginSessionToolResult {
  */
 export async function beginSession(
 	input: BeginSessionToolInput,
-): Promise<BeginSessionToolResult> {
+): Promise<BeginSessionToolResult | AgentError> {
 	if (!config.temporalHost || !config.temporalNamespace) {
 		throw new Error(
 			"Temporal client is not configured. Set TEMPORAL_HOST, " +
 				"TEMPORAL_NAMESPACE in the cockpit env.",
 		);
+	}
+
+	// Born-loud pre-check (DAT-534, mirrors DAT-511's hasRunningRun guard): a
+	// session needs ≥1 typed table to stage. Without imported data the engine
+	// errors LATE, mid-run; refuse BEFORE recording/starting a run so the agent
+	// gets a clean {error} and points the user at a Connect chat. `table_ids`
+	// already requires .min(1); this catches the workspace having no tables at all
+	// (stale/invented ids).
+	if (!(await hasImportedTables())) {
+		return {
+			error:
+				"No imported tables to stage yet — import data in a Connect chat " +
+				"first, then start a session.",
+		};
 	}
 
 	const sessionId = input.session_id ?? randomUUID();
@@ -158,10 +174,12 @@ export const beginSessionTool = toolDefinition({
 				"Optional session id; omit to start a fresh session, pass one to re-run it after teaching.",
 			),
 	}),
-	outputSchema: z.object({
-		workflow_id: z.string(),
-		run_id: z.string(),
-		session_id: z.string(),
-		table_ids: z.array(z.string()),
-	}),
+	outputSchema: withAgentError(
+		z.object({
+			workflow_id: z.string(),
+			run_id: z.string(),
+			session_id: z.string(),
+			table_ids: z.array(z.string()),
+		}),
+	),
 }).server((input) => beginSession(input));

--- a/packages/cockpit/src/ui/cockpit/chat-readiness-banner.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/chat-readiness-banner.test.tsx
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ChatReadinessBanner } from "#/ui/cockpit/chat-readiness-banner";
+
+afterEach(() => cleanup());
+
+describe("ChatReadinessBanner (DAT-534)", () => {
+	it("renders the message with its tone", () => {
+		render(
+			<MantineProvider env="test">
+				<ChatReadinessBanner
+					readiness={{ tone: "blocked", message: "Import data first." }}
+				/>
+			</MantineProvider>,
+		);
+		const banner = screen.getByTestId("chat-readiness");
+		expect(banner.dataset.tone).toBe("blocked");
+		expect(banner.textContent).toContain("Import data first.");
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/chat-readiness-banner.tsx
+++ b/packages/cockpit/src/ui/cockpit/chat-readiness-banner.tsx
@@ -1,0 +1,26 @@
+// In-chat readiness banner (DAT-534) — a greyed, NON-BLOCKING strip shown at the
+// top of a chat when its kind can't act yet (do-X-first / wait-for-Y). Advisory:
+// it never disables the composer. Rendered only when `chatReadiness` returns a
+// signal; a ready chat shows nothing.
+
+import { Alert } from "@mantine/core";
+import type { ChatReadiness } from "#/lib/chat-readiness";
+
+export function ChatReadinessBanner({
+	readiness,
+}: {
+	readiness: ChatReadiness;
+}) {
+	return (
+		<Alert
+			variant="light"
+			color="gray"
+			radius="sm"
+			py="xs"
+			data-testid="chat-readiness"
+			data-tone={readiness.tone}
+		>
+			{readiness.message}
+		</Alert>
+	);
+}

--- a/packages/cockpit/src/ui/cockpit/cockpit-home.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-home.test.tsx
@@ -14,20 +14,23 @@ function renderHome(
 	handlers?: {
 		onOpen?: (id: string) => void;
 		onCreate?: (kind: string) => void;
+		onTell?: (message: string) => void;
 	},
 ) {
 	const onOpen = vi.fn(handlers?.onOpen);
 	const onCreate = vi.fn(handlers?.onCreate);
+	const onTell = vi.fn(handlers?.onTell);
 	render(
 		<MantineProvider env="test">
 			<CockpitHome
 				conversations={conversations}
 				onOpen={onOpen}
 				onCreate={onCreate}
+				onTell={onTell}
 			/>
 		</MantineProvider>,
 	);
-	return { onOpen, onCreate };
+	return { onOpen, onCreate, onTell };
 }
 
 const conv = (
@@ -70,5 +73,25 @@ describe("CockpitHome", () => {
 		).toEqual(["Connect", "Analyse"]);
 		fireEvent.click(items[0]);
 		expect(onOpen).toHaveBeenCalledWith("c1");
+	});
+
+	it("routes a typed opening message through onTell (the 'tell' entry)", () => {
+		const { onTell } = renderHome([]);
+		const composer = screen.getByTestId("landing-composer");
+		fireEvent.change(composer, { target: { value: "import my orders csv" } });
+		fireEvent.click(screen.getByTestId("landing-send"));
+		expect(onTell).toHaveBeenCalledWith("import my orders csv");
+	});
+
+	it("Enter (without shift) sends the opening message; blank input does not", () => {
+		const { onTell } = renderHome([]);
+		const composer = screen.getByTestId("landing-composer");
+		// Blank → Send is disabled, no call.
+		fireEvent.click(screen.getByTestId("landing-send"));
+		expect(onTell).not.toHaveBeenCalled();
+		// Enter on non-blank sends (trimmed).
+		fireEvent.change(composer, { target: { value: "  what is revenue?  " } });
+		fireEvent.keyDown(composer, { key: "Enter" });
+		expect(onTell).toHaveBeenCalledWith("what is revenue?");
 	});
 });

--- a/packages/cockpit/src/ui/cockpit/cockpit-home.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-home.tsx
@@ -12,12 +12,15 @@
 
 import {
 	Badge,
+	Button,
 	Group,
 	Stack,
 	Text,
+	Textarea,
 	Title,
 	UnstyledButton,
 } from "@mantine/core";
+import { useState } from "react";
 import type {
 	ConversationKind,
 	ConversationSummary,
@@ -58,13 +61,24 @@ export function CockpitHome({
 	conversations,
 	onOpen,
 	onCreate,
+	onTell,
 }: {
 	conversations: ReadonlyArray<ConversationSummary>;
 	/** Open an existing chat by id. */
 	onOpen: (conversationId: string) => void;
-	/** Mint a new typed chat and open it. */
+	/** Mint a new typed chat and open it (the "click" path). */
 	onCreate: (kind: ConversationKind) => void;
+	/** Route a free-text opening message through the nav-agent (the "tell" path). */
+	onTell: (message: string) => void;
 }) {
+	const [draft, setDraft] = useState("");
+	const tell = () => {
+		const text = draft.trim();
+		if (!text) return;
+		setDraft("");
+		onTell(text);
+	};
+
 	return (
 		<Stack
 			align="center"
@@ -79,10 +93,43 @@ export function CockpitHome({
 					Start a chat
 				</Title>
 				<Text c="dimmed" ta="center" size="lg">
-					Pick what you want to do. Each chat is one focused thread — connect
-					data, stage a session, or analyse what's ready.
+					Tell me what you want to do and I'll open the right kind of chat — or
+					pick a type yourself below.
 				</Text>
 			</Stack>
+
+			{/* The "tell" entry — routed by the nav-agent (DAT-534). Enter sends; the
+			    chips below are the deterministic alternative. */}
+			<Stack w="100%" maw={680} gap="xs">
+				<Textarea
+					data-testid="landing-composer"
+					placeholder="e.g. import my orders CSV, or what's total revenue?"
+					value={draft}
+					onChange={(e) => setDraft(e.currentTarget.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter" && !e.shiftKey) {
+							e.preventDefault();
+							tell();
+						}
+					}}
+					autosize
+					minRows={1}
+					maxRows={4}
+				/>
+				<Group justify="flex-end">
+					<Button
+						data-testid="landing-send"
+						onClick={tell}
+						disabled={draft.trim().length === 0}
+					>
+						Send
+					</Button>
+				</Group>
+			</Stack>
+
+			<Text c="dimmed" size="sm">
+				or pick a type
+			</Text>
 
 			{/* Type chips — each mints a typed chat and navigates into it. */}
 			<Group gap="md" justify="center" wrap="wrap" maw={760}>

--- a/packages/cockpit/src/ui/cockpit/cockpit-state.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-state.tsx
@@ -27,7 +27,9 @@ import {
 	type ReactNode,
 	useCallback,
 	useContext,
+	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from "react";
 // Type-only: erased at build, so the cockpit_db (bun:sql) client never enters
@@ -125,6 +127,7 @@ export function CockpitProvider({
 	initialMessages,
 	initialUiState,
 	onPersistPin,
+	seedMessage,
 }: {
 	children: ReactNode;
 	// Server-owned conversation hydration (DAT-462): the persisted thread id +
@@ -136,6 +139,10 @@ export function CockpitProvider({
 	initialUiState?: UiState | null;
 	/** Persist a canvas-pin change (server fn from the route); fire-and-forget. */
 	onPersistPin?: (pinnedCallId: string | null) => void;
+	/** The landing nav-agent's opening message (DAT-534) — sent ONCE on mount into
+	 * a freshly-created, empty chat (the "tell" entry). Carried via router state,
+	 * so it's absent on reload (the message is persisted by then). */
+	seedMessage?: string;
 }) {
 	// The subscribe transport (Phase 2A) keys BOTH the long-lived subscribe channel
 	// (/api/chat-stream) and the send body off ONE conversation id, which MUST
@@ -216,6 +223,21 @@ export function CockpitProvider({
 		},
 		[sendMessage, refsHolder],
 	);
+
+	// Seed auto-send (DAT-534): the landing nav-agent classified the opening
+	// message + created this chat, then navigated here with the text in router
+	// state. Send it ONCE, on mount, into the still-empty transcript — that runs
+	// it through the normal /api/chat flow (persist + the agent's reply). Effect
+	// (convention 2: an external action, like the scroll-pin + NDJSON-fold) because
+	// it bridges router state → the chat send. Double-guarded against re-fire/reload:
+	// a ref makes it once-only, and `messages.length === 0` means a reload (seed
+	// gone from state, transcript already persisted) never re-sends.
+	const seededRef = useRef(false);
+	useEffect(() => {
+		if (seededRef.current || !seedMessage || messages.length > 0) return;
+		seededRef.current = true;
+		sendTurn(seedMessage);
+	}, [seedMessage, messages.length, sendTurn]);
 
 	// Pin/unpin also persists the canvas focus (DAT-462) so a reload returns to
 	// the same view. Fire-and-forget through the route's server fn — a failed


### PR DESCRIPTION
**Epic:** DAT-526 · **Design:** DD/36667393 · **Builds on:** DAT-528/532/533. The last P1 slice. Option B (the completion-handoff CTA was split to **DAT-541**).

## What's in
- **Haiku nav-agent — the "tell" entry.** The landing gains a free composer alongside the type chips. On submit, `routeOpeningMessage` runs a Haiku one-shot (`classifyOpeningMessage`: nested `chat()` + `outputSchema`, `NAV_MODEL="claude-haiku-4-5"`) that classifies the message into a kind, **biased by availability**, **best-effort** (any LLM error or unavailable pick → `connect`; chips always bypass). It creates the typed chat and navigates with the message in router **state**; `CockpitProvider` sends it **once** on mount (ref + `messages.length===0` double-guard — no re-fire on reload/abort).
- **Readiness banner.** `chatReadiness(kind, {hasTables, hasActiveRun})` (pure) → a **non-blocking greyed** advisory at the top of a chat: do-X-first ("import data first") or wait-for-Y ("a run is in progress"). Never disables the composer. The chat loader reads `hasImportedTables` + `listRunningStages` (both soft).
- **`begin_session` ≥1-typed-table pre-check.** Born-loud `{error}` (outputSchema now `withAgentError`) before `recordRun`/`workflow.start` when there are no imported tables (mirrors DAT-511). The union return is narrowed at the unit tests + 2 lane scripts.

## Tests / gates
`nav-agent` (classify availability-filter + fallback), `chat-readiness` (full state matrix), `chat-readiness-banner`, `cockpit-home` composer (Send/Enter/trim/blank), `begin-session` 0-tables→`{error}`-before-start. **1147 green**; biome + tsc + Nitro build clean. Cockpit-only, no engine, no eval.

## Reviewers
senior **APPROVE**, spec-compliance **COMPLIANT** (CTA correctly deferred to DAT-541; no scope creep; no engine change). Note: the nav-agent's async-rejection fallback is covered via a sync adapter-construction throw — a rejecting `@tanstack/ai` module-mock trips a vitest unhandled-rejection quirk despite the correct catch (documented inline).

## Acceptance
`/smoke` (real-LLM "tell" → typed-chat → seeded turn; the dimmed/banner states) — to run next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)