### PR TITLE
refactor(entropy): demote dimensional_entropy off the loss path → informative DirectSignal

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,28 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-16: refactor — dimensional_entropy DEMOTED off the loss path (informative DirectSignal)
+
+`dimensional_entropy` (cross-column NMI) was removed from `loss.yaml` (it had
+`query_intent: {score: 0.3}`, `aggregation_intent: {score: 0.4}`). It now falls
+through `_build_column_result` to a **DirectSignal** — the benford lane: the NMI
+score + `expected_dependency` teach still compute as context, but no longer drive
+intent readiness bands. The detector still runs (`temporal_slice_analysis` phase,
+in slice) and still emits its `table:` EntropyObject; only its loss row is gone.
+
+**Why** (eval Tier-1 falsification, `dataraum-eval` scripts/probes/dimensional-entropy):
+on the loss path the NMI band is *anti-predictive* of wrong answers — highest on
+CLEAN intrinsic structure (mutex/alias/FD, no wrong answer) and BLIND to the
+dependency violation that causes a bad join/rollup (a 5%-broken FD barely moves
+NMI, 0.862→0.799; the violation rate is owned by `derived_value` /
+`relationship_entropy`). Recorded: eval `entropy_eval_architecture.md`.
+
+### dataraum-eval
+- **Changed**: `loss.yaml` (row removed + rationale comment), `tests/unit/entropy/views/test_readiness_context.py` (`test_table_target_rolls_up` now uses `dimension_coverage`; added `test_dimensional_entropy_is_a_direct_signal_not_a_band_driver`).
+- **Affects**: any column×intent band that was driven *only* by dimensional_entropy now drops one band (it contributed query 0.3·NMI, agg 0.4·NMI). A `table:` whose only object is dimensional_entropy is no longer in `readiness.columns` — it's a `direct_signal`. Cockpit/readers that surface DirectSignals are unaffected; readers that assumed it banded need none, by design.
+- **Calibrate**: eval-side `detector_coverage.yaml` disposition flips `scalar → informative` (mirrors benford); no recall/precision change (the NMI statistic is unchanged).
+- **Status**: pending
+
 ## 2026-06-16: fix — operating_model_detect scored nothing (DAT-506 re-grain miss; surfaced by DAT-508)
 
 `operating_model_detect` was the lone OM phase wired with a bare `RunRef` instead

--- a/packages/dataraum-config/entropy/loss.yaml
+++ b/packages/dataraum-config/entropy/loss.yaml
@@ -160,10 +160,15 @@ measurements:
     # Cross-table reconciliation breaks: worst for aggregation + reporting.
     aggregation_intent: { score: 0.8 }
     reporting_intent: { score: 0.7 }
-  dimensional_entropy:
-    # Undocumented cross-column dependency (NMI). Context for query + aggregation.
-    query_intent: { score: 0.3 }
-    aggregation_intent: { score: 0.4 }
+  # dimensional_entropy is NOT in the loss table (DEMOTED 2026-06-16): an INFORMATIVE
+  # SIGNAL, not tunable entropy. Its NMI is anti-predictive on the loss path — a Tier-1
+  # eval falsification (eval scripts/probes/dimensional-entropy) showed the band runs the
+  # WRONG way vs wrong-answer risk: HIGHEST on clean intrinsic structure (mutex/alias/FD,
+  # no wrong answer), and BLIND to the dependency VIOLATION that causes a bad join/rollup
+  # (a 5%-broken FD barely moves NMI: 0.862 -> 0.799; the violation rate is owned by
+  # derived_value / relationship_entropy). The NMI score + expected_dependency teach still
+  # compute as a DirectSignal (context), but no longer drive intent readiness. Same lane as
+  # benford / outliers / drift / variance. (eval catalog: entropy_eval_architecture.md)
   dimension_coverage:
     # Fact-table dimension gaps affect query slicing + reporting completeness. (deferred)
     query_intent: { score: 0.5 }

--- a/packages/engine/tests/unit/entropy/views/test_readiness_context.py
+++ b/packages/engine/tests/unit/entropy/views/test_readiness_context.py
@@ -255,12 +255,25 @@ class TestPerColumnAssembly:
     def test_table_target_rolls_up(self):
         """A ``table:`` target rolls up like a column (DAT-415)."""
         objects = [
-            make_entropy_object(detector_id="dimensional_entropy", score=0.8, target="table:sales"),
+            make_entropy_object(detector_id="dimension_coverage", score=0.8, target="table:sales"),
         ]
         result = assemble_readiness_context(objects)
         assert result.total_columns == 1
         assert "table:sales" in result.columns
         assert all(ds.target != "table:sales" for ds in result.direct_signals)
+
+    def test_dimensional_entropy_is_a_direct_signal_not_a_band_driver(self):
+        """Demoted (2026-06-16): dimensional_entropy is informative — excluded from the
+        loss rollup, surfaced as a DirectSignal, never banding a table (benford lane)."""
+        objects = [
+            make_entropy_object(detector_id="dimensional_entropy", score=1.0, target="table:sales"),
+        ]
+        result = assemble_readiness_context(objects)
+        assert "table:sales" not in result.columns  # no loss row → nothing to band
+        assert any(
+            ds.target == "table:sales" and ds.detector_id == "dimensional_entropy"
+            for ds in result.direct_signals
+        )
 
     def test_node_evidence_carries_raw_data(self):
         """ColumnNodeEvidence carries score, evidence, detector_id from the object."""


### PR DESCRIPTION
## What

Removes `dimensional_entropy` (cross-column NMI) from `loss.yaml` (it had `query_intent: {score: 0.3}`, `aggregation_intent: {score: 0.4}`). It now falls through `_build_column_result` to a **DirectSignal** — the benford lane: the NMI score + `expected_dependency` teach still compute as context, but no longer drive intent readiness bands. The detector is unchanged — it still runs in `temporal_slice_analysis` (in slice) and emits its `table:` EntropyObject; only its loss row is gone.

## Why — a Tier-1 eval falsification

`dimensional_entropy` sits on the loss path, so its bands must predict **wrong answers**, not association (ADR-0009/0011). A millisecond kill-gate probe on the loss-path bar (eval `scripts/probes/dimensional-entropy`, engine `stats.nmi`) falsifies that two ways, both pure-math-robust:

1. **Blind to the violation that causes the wrong answer.** A 5%-broken zip→city FD — the thing that yields a bad join/rollup — barely moves NMI (clean **0.862 → 0.799**, same `investigate` agg band). NMI measures association *strength*; the *violation rate* is owned by `derived_value` / `relationship_entropy` / orphan_rate.
2. **The band is monotone the WRONG way.** Worse data → lower NMI → *readier* band: clean mutex/alias/FD (NMI 1.0/1.0/0.862, **no** wrong answer) all band `agg=investigate`, while a 20%-violated FD (NMI 0.608, worst wrong answer) bands `agg=ready`.

A loss signal highest on safe data and lowest on unsafe data is anti-predictive — the **benford/DEMOTE signature** (`loss.yaml` already excludes benford as an "INFORMATIVE SIGNAL, not tunable entropy").

## Changes

- `dataraum-config/entropy/loss.yaml` — row removed + rationale comment.
- `engine/tests/.../test_readiness_context.py` — `test_table_target_rolls_up` now proves the DAT-415 table-rollup via `dimension_coverage` (still a table-scoped loss detector); added `test_dimensional_entropy_is_a_direct_signal_not_a_band_driver`.
- `.claude/handoff.md` — eval-side note (`detector_coverage.yaml` disposition `scalar → informative`).

## Test

484/484 entropy unit tests pass (`uv run pytest tests/unit/entropy/ -q`).

## Notes / follow-ups

- **Behaviour change:** a column×intent band driven *only* by dimensional_entropy drops one band; a `table:` whose only object is dimensional_entropy is no longer in `readiness.columns` — it's a `direct_signal` (cockpit/readers that surface DirectSignals are unaffected by design).
- The "g3 FD pass" that could give a directional/hierarchy role does **not** exist today (NMI is symmetric), so a future "reframe as a directional FD detector" would be new work, not a salvage.
- Eval records the verdict in `entropy_eval_architecture.md` + `detector_coverage.yaml`; the eval engine-pointer bump follows on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)