### PR TITLE
DAT-550: native run monitor + rail liveness badge (P3a)

### DIFF
--- a/packages/cockpit/src/db/cockpit/runs.ts
+++ b/packages/cockpit/src/db/cockpit/runs.ts
@@ -25,7 +25,7 @@
 // stores it (DAT-506: nothing reads it back).
 
 import { randomUUID } from "node:crypto";
-import { and, desc, eq, isNull } from "drizzle-orm";
+import { and, count, desc, eq, isNull } from "drizzle-orm";
 import { currentConversationId } from "#/lib/run-context";
 import { cockpitDb } from "./client";
 import { DEFAULT_ACTOR_ID } from "./registry";
@@ -322,4 +322,66 @@ export async function hasRunningRun(
 		)
 		.limit(1);
 	return row !== undefined;
+}
+
+/** One run for the workspace-wide monitor (DAT-550). Joined to its session for
+ * the workspace filter + the session `kind`. */
+export interface WorkspaceRun {
+	workflowId: string;
+	runId: string;
+	stage: RunStage;
+	status: string;
+	startedAt: Date;
+	kind: SessionKind;
+}
+
+/**
+ * The workspace's runs, newest-first, BOUNDED — the native run monitor (DAT-550,
+ * replacing the `/workflows` Temporal-UI iframe). WORKSPACE-scoped (joins
+ * `sessions`), unlike the conversation-scoped queries above: the monitor is a
+ * workspace-wide view of every stage run, independent of any chat. Bounded so a
+ * long-lived workspace's run history can't dump an unbounded set into the page.
+ */
+export async function listRunsByWorkspace(
+	workspaceId: string,
+	limit: number,
+): Promise<Array<WorkspaceRun>> {
+	const rows = await cockpitDb
+		.select({
+			workflowId: sessionRuns.workflowId,
+			runId: sessionRuns.runId,
+			stage: sessionRuns.stage,
+			status: sessionRuns.status,
+			startedAt: sessionRuns.startedAt,
+			kind: sessions.kind,
+		})
+		.from(sessionRuns)
+		.innerJoin(sessions, eq(sessionRuns.sessionId, sessions.id))
+		.where(eq(sessions.workspaceId, workspaceId))
+		.orderBy(desc(sessionRuns.startedAt))
+		.limit(limit);
+	return rows.map((r) => ({
+		...r,
+		stage: r.stage as RunStage,
+		kind: r.kind as SessionKind,
+	}));
+}
+
+/**
+ * Count of the workspace's in-flight (`running`) runs — feeds the rail liveness
+ * badge (DAT-550), polled tab-independently (a cockpit_db read, no open chat
+ * stream). Cheap aggregate, workspace-scoped.
+ */
+export async function countRunningRuns(workspaceId: string): Promise<number> {
+	const [row] = await cockpitDb
+		.select({ n: count() })
+		.from(sessionRuns)
+		.innerJoin(sessions, eq(sessionRuns.sessionId, sessions.id))
+		.where(
+			and(
+				eq(sessions.workspaceId, workspaceId),
+				eq(sessionRuns.status, "running"),
+			),
+		);
+	return row?.n ?? 0;
 }

--- a/packages/cockpit/src/routeTree.gen.ts
+++ b/packages/cockpit/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as ApiWorkflowProgressRouteImport } from './routes/api/workflow-progress'
 import { Route as ApiUploadRouteImport } from './routes/api/upload'
 import { Route as ApiShippedMetricDagRouteImport } from './routes/api/shipped-metric-dag'
+import { Route as ApiRunningRunsRouteImport } from './routes/api/running-runs'
 import { Route as ApiRunSqlRouteImport } from './routes/api/run-sql'
 import { Route as ApiChatStreamRouteImport } from './routes/api/chat-stream'
 import { Route as ApiChatRouteImport } from './routes/api/chat'
@@ -49,6 +50,11 @@ const ApiUploadRoute = ApiUploadRouteImport.update({
 const ApiShippedMetricDagRoute = ApiShippedMetricDagRouteImport.update({
   id: '/api/shipped-metric-dag',
   path: '/api/shipped-metric-dag',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiRunningRunsRoute = ApiRunningRunsRouteImport.update({
+  id: '/api/running-runs',
+  path: '/api/running-runs',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiRunSqlRoute = ApiRunSqlRouteImport.update({
@@ -124,6 +130,7 @@ export interface FileRoutesByFullPath {
   '/api/chat': typeof ApiChatRoute
   '/api/chat-stream': typeof ApiChatStreamRoute
   '/api/run-sql': typeof ApiRunSqlRoute
+  '/api/running-runs': typeof ApiRunningRunsRoute
   '/api/shipped-metric-dag': typeof ApiShippedMetricDagRoute
   '/api/upload': typeof ApiUploadRoute
   '/api/workflow-progress': typeof ApiWorkflowProgressRoute
@@ -142,6 +149,7 @@ export interface FileRoutesByTo {
   '/api/chat': typeof ApiChatRoute
   '/api/chat-stream': typeof ApiChatStreamRoute
   '/api/run-sql': typeof ApiRunSqlRoute
+  '/api/running-runs': typeof ApiRunningRunsRoute
   '/api/shipped-metric-dag': typeof ApiShippedMetricDagRoute
   '/api/upload': typeof ApiUploadRoute
   '/api/workflow-progress': typeof ApiWorkflowProgressRoute
@@ -161,6 +169,7 @@ export interface FileRoutesById {
   '/api/chat': typeof ApiChatRoute
   '/api/chat-stream': typeof ApiChatStreamRoute
   '/api/run-sql': typeof ApiRunSqlRoute
+  '/api/running-runs': typeof ApiRunningRunsRoute
   '/api/shipped-metric-dag': typeof ApiShippedMetricDagRoute
   '/api/upload': typeof ApiUploadRoute
   '/api/workflow-progress': typeof ApiWorkflowProgressRoute
@@ -181,6 +190,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/chat-stream'
     | '/api/run-sql'
+    | '/api/running-runs'
     | '/api/shipped-metric-dag'
     | '/api/upload'
     | '/api/workflow-progress'
@@ -199,6 +209,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/chat-stream'
     | '/api/run-sql'
+    | '/api/running-runs'
     | '/api/shipped-metric-dag'
     | '/api/upload'
     | '/api/workflow-progress'
@@ -217,6 +228,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/chat-stream'
     | '/api/run-sql'
+    | '/api/running-runs'
     | '/api/shipped-metric-dag'
     | '/api/upload'
     | '/api/workflow-progress'
@@ -236,6 +248,7 @@ export interface RootRouteChildren {
   ApiChatRoute: typeof ApiChatRoute
   ApiChatStreamRoute: typeof ApiChatStreamRoute
   ApiRunSqlRoute: typeof ApiRunSqlRoute
+  ApiRunningRunsRoute: typeof ApiRunningRunsRoute
   ApiShippedMetricDagRoute: typeof ApiShippedMetricDagRoute
   ApiUploadRoute: typeof ApiUploadRoute
   ApiWorkflowProgressRoute: typeof ApiWorkflowProgressRoute
@@ -276,6 +289,13 @@ declare module '@tanstack/react-router' {
       path: '/api/shipped-metric-dag'
       fullPath: '/api/shipped-metric-dag'
       preLoaderRoute: typeof ApiShippedMetricDagRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/running-runs': {
+      id: '/api/running-runs'
+      path: '/api/running-runs'
+      fullPath: '/api/running-runs'
+      preLoaderRoute: typeof ApiRunningRunsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/run-sql': {
@@ -424,6 +444,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiChatRoute: ApiChatRoute,
   ApiChatStreamRoute: ApiChatStreamRoute,
   ApiRunSqlRoute: ApiRunSqlRoute,
+  ApiRunningRunsRoute: ApiRunningRunsRoute,
   ApiShippedMetricDagRoute: ApiShippedMetricDagRoute,
   ApiUploadRoute: ApiUploadRoute,
   ApiWorkflowProgressRoute: ApiWorkflowProgressRoute,

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.tsx
@@ -1,44 +1,31 @@
-import { Anchor, Card, Stack, Text, Title } from "@mantine/core";
 import { createFileRoute } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { config } from "#/config";
+import { resolveActiveWorkspace } from "#/db/cockpit/registry";
+import { listRunsByWorkspace } from "#/db/cockpit/runs";
+import { RunMonitor } from "#/ui/runs/run-monitor";
 
-// The Temporal Web UI runs as its own service; we embed it rather than
-// reimplement workflow inspection. The URL is config-driven (TEMPORAL_UI_URL,
-// default http://localhost:8080) and read server-side so the server-only
-// config never leaks into the client bundle.
-const getTemporalUiUrl = createServerFn({ method: "GET" }).handler(
-	() => config.temporalUiUrl,
-);
+// The native run monitor (DAT-550) — replaces the external Temporal-UI iframe
+// with a workspace-wide view of stage runs read from cockpit_db. The Temporal UI
+// is kept as a deep-link for low-level debugging. Workspace resolved server-side
+// (mirrors loadHistory), not from the route param. Bounded to the latest N.
+const RUN_LIMIT = 100;
 
-export const Route = createFileRoute("/(app)/workspace/$wsId/workflows")({
-	loader: () => getTemporalUiUrl(),
-	component: WorkflowsSection,
+const loadRuns = createServerFn({ method: "GET" }).handler(async () => {
+	const workspaceId = await resolveActiveWorkspace();
+	return {
+		runs: await listRunsByWorkspace(workspaceId, RUN_LIMIT),
+		temporalUiUrl: config.temporalUiUrl,
+		limit: RUN_LIMIT,
+	};
 });
 
-function WorkflowsSection() {
-	const temporalUiUrl = Route.useLoaderData();
-	return (
-		<Stack gap="md" h="100%">
-			<Stack gap="xs">
-				<Title order={2}>Workflows</Title>
-				<Text c="dimmed" size="sm">
-					Durable execution runs in Temporal. Inspect workflows and activities
-					in the Temporal Web UI.
-				</Text>
-			</Stack>
-			<Card withBorder padding="md" flex={1}>
-				<Stack gap="sm" h="100%">
-					<Anchor href={temporalUiUrl} target="_blank" rel="noreferrer">
-						Open Temporal UI ({temporalUiUrl})
-					</Anchor>
-					<iframe
-						title="Temporal Web UI"
-						src={temporalUiUrl}
-						style={{ flex: 1, width: "100%", border: "none" }}
-					/>
-				</Stack>
-			</Card>
-		</Stack>
-	);
+export const Route = createFileRoute("/(app)/workspace/$wsId/workflows")({
+	loader: () => loadRuns(),
+	component: RunsSection,
+});
+
+function RunsSection() {
+	const { runs, temporalUiUrl, limit } = Route.useLoaderData();
+	return <RunMonitor runs={runs} limit={limit} temporalUiUrl={temporalUiUrl} />;
 }

--- a/packages/cockpit/src/routes/api/running-runs.ts
+++ b/packages/cockpit/src/routes/api/running-runs.ts
@@ -1,0 +1,21 @@
+// Running-runs count endpoint (DAT-550) — the read side the rail liveness badge
+// polls. A thin I/O shell over `countRunningRuns`: resolve the active workspace,
+// count its in-flight runs, return `{count}`. The badge polls here on a TanStack
+// Query `refetchInterval` rather than importing the server module — keeping the
+// cockpit_db client + config out of the client bundle (same pattern as
+// /api/workflow-progress). GET: no input, the workspace is resolved server-side.
+
+import { createFileRoute } from "@tanstack/react-router";
+import { resolveActiveWorkspace } from "../../db/cockpit/registry";
+import { countRunningRuns } from "../../db/cockpit/runs";
+
+export const Route = createFileRoute("/api/running-runs")({
+	server: {
+		handlers: {
+			GET: async () => {
+				const workspaceId = await resolveActiveWorkspace();
+				return Response.json({ count: await countRunningRuns(workspaceId) });
+			},
+		},
+	},
+});

--- a/packages/cockpit/src/ui/app-shell.test.tsx
+++ b/packages/cockpit/src/ui/app-shell.test.tsx
@@ -18,6 +18,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { CockpitShell } from "#/ui/app-shell";
+import { TestQueryProvider } from "#/ui/cockpit/test-query-provider";
 import { sections } from "#/ui/sections";
 import { theme } from "#/ui/theme";
 
@@ -56,9 +57,14 @@ function renderShellAt(path: string, activeWorkspaceId = "test-ws") {
 	});
 
 	render(
-		<MantineProvider theme={theme} env="test">
-			<RouterProvider router={router} />
-		</MantineProvider>,
+		// The Runs rail item mounts a liveness badge that useQuery-polls
+		// /api/running-runs — needs a QueryClient (the fetch is a no-op in jsdom;
+		// the badge just stays inactive, which is fine for the shell smoke).
+		<TestQueryProvider>
+			<MantineProvider theme={theme} env="test">
+				<RouterProvider router={router} />
+			</MantineProvider>
+		</TestQueryProvider>,
 	);
 }
 

--- a/packages/cockpit/src/ui/app-shell.tsx
+++ b/packages/cockpit/src/ui/app-shell.tsx
@@ -18,6 +18,7 @@ import { useDisclosure, useHotkeys } from "@mantine/hooks";
 import { Link, useParams } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { CommandPalette } from "#/ui/command-palette";
+import { RunLivenessBadge } from "#/ui/runs/run-liveness-badge";
 import { type Section, sections } from "#/ui/sections";
 import { tokens } from "#/ui/theme";
 
@@ -30,7 +31,15 @@ import { tokens } from "#/ui/theme";
  */
 function RailItem({ section, wsId }: { section: Section; wsId: string }) {
 	const Icon = section.icon;
-	const inner = <Icon size={20} aria-hidden />;
+	// The Runs rail icon carries a liveness badge — a processing dot while the
+	// workspace has in-flight runs (DAT-550), polled tab-independently.
+	const icon = <Icon size={20} aria-hidden />;
+	const inner =
+		section.id === "workflows" ? (
+			<RunLivenessBadge>{icon}</RunLivenessBadge>
+		) : (
+			icon
+		);
 	const common = {
 		variant: "subtle" as const,
 		size: "lg" as const,

--- a/packages/cockpit/src/ui/runs/run-liveness-badge.test.tsx
+++ b/packages/cockpit/src/ui/runs/run-liveness-badge.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock the query at the seam — the badge's real logic is count → active dot; the
+// poll/fetch is exercised by /smoke. (The badge imports no server-only modules,
+// so this needs no config/db mocks.)
+const h = vi.hoisted(() => ({ data: undefined as number | undefined }));
+vi.mock("@tanstack/react-query", () => ({
+	useQuery: () => ({ data: h.data }),
+}));
+
+import { RunLivenessBadge } from "#/ui/runs/run-liveness-badge";
+
+function renderBadge() {
+	render(
+		<MantineProvider env="test">
+			<RunLivenessBadge>
+				<span data-testid="icon" />
+			</RunLivenessBadge>
+		</MantineProvider>,
+	);
+	return screen.getByTestId("run-liveness").getAttribute("data-running");
+}
+
+afterEach(() => cleanup());
+
+describe("RunLivenessBadge (DAT-550)", () => {
+	it("is inactive when no runs are in flight", () => {
+		h.data = 0;
+		expect(renderBadge()).toBe("false");
+	});
+
+	it("activates when runs are in flight", () => {
+		h.data = 3;
+		expect(renderBadge()).toBe("true");
+	});
+
+	it("treats no-data-yet (undefined) as inactive", () => {
+		h.data = undefined;
+		expect(renderBadge()).toBe("false");
+	});
+});

--- a/packages/cockpit/src/ui/runs/run-liveness-badge.tsx
+++ b/packages/cockpit/src/ui/runs/run-liveness-badge.tsx
@@ -1,0 +1,44 @@
+// Rail liveness badge (DAT-550) — a small processing dot on the Runs rail icon
+// when the workspace has in-flight runs. Fed by a light cockpit_db count polled
+// on an interval, so it reflects work the orchestration worker is doing with NO
+// browser chat stream open (tab-independence). Polls the /api/running-runs route
+// rather than importing the server module, so the cockpit_db client + config
+// never enter the client bundle (same pattern as the progress widgets).
+
+import { Indicator } from "@mantine/core";
+import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+// A PERSISTENT liveness poll — deliberately NOT the one-shot "refetchInterval
+// returns false when done" progress pattern (cockpit React rule 3): the badge
+// reflects an ever-changing "anything running?" signal, so it polls steadily.
+const POLL_MS = 5000;
+
+async function fetchRunningCount(): Promise<number> {
+	const res = await fetch("/api/running-runs");
+	if (!res.ok) return 0;
+	const data = (await res.json()) as { count?: number };
+	return data.count ?? 0;
+}
+
+export function RunLivenessBadge({ children }: { children: ReactNode }) {
+	const { data } = useQuery({
+		queryKey: ["workspace-running-runs"],
+		queryFn: fetchRunningCount,
+		refetchInterval: POLL_MS,
+	});
+	const running = (data ?? 0) > 0;
+	return (
+		<Indicator
+			disabled={!running}
+			processing
+			color="blue"
+			size={9}
+			offset={3}
+			data-testid="run-liveness"
+			data-running={running ? "true" : "false"}
+		>
+			{children}
+		</Indicator>
+	);
+}

--- a/packages/cockpit/src/ui/runs/run-liveness-badge.tsx
+++ b/packages/cockpit/src/ui/runs/run-liveness-badge.tsx
@@ -23,9 +23,17 @@ async function fetchRunningCount(): Promise<number> {
 
 export function RunLivenessBadge({ children }: { children: ReactNode }) {
 	const { data } = useQuery({
+		// TODO(DAT-357): when multi-workspace switching lands, scope this key (and
+		// /api/running-runs) by workspace id — today the endpoint resolves the
+		// single active workspace server-side, so the bare key is correct.
 		queryKey: ["workspace-running-runs"],
 		queryFn: fetchRunningCount,
 		refetchInterval: POLL_MS,
+		// The badge mounts in the always-rendered shell, so the query would
+		// otherwise run during SSR — where a relative fetch has no host. Gate to
+		// the client; the badge renders inactive on the server, then polls once
+		// hydrated (the project's `typeof window` SSR-guard idiom).
+		enabled: typeof window !== "undefined",
 	});
 	const running = (data ?? 0) > 0;
 	return (

--- a/packages/cockpit/src/ui/runs/run-monitor.test.tsx
+++ b/packages/cockpit/src/ui/runs/run-monitor.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { WorkspaceRun } from "#/db/cockpit/runs";
+import { RunMonitor } from "#/ui/runs/run-monitor";
+
+function run(over: Partial<WorkspaceRun> = {}): WorkspaceRun {
+	return {
+		workflowId: "addsource-ws-1-abc",
+		runId: "run-1",
+		stage: "add_source",
+		status: "completed",
+		startedAt: new Date("2026-06-17T06:58:27.925Z"),
+		kind: "onboarding",
+		...over,
+	};
+}
+
+function renderMonitor(props: Partial<Parameters<typeof RunMonitor>[0]> = {}) {
+	render(
+		<MantineProvider env="test">
+			<RunMonitor
+				runs={props.runs ?? [run()]}
+				limit={props.limit ?? 100}
+				temporalUiUrl={props.temporalUiUrl ?? "http://localhost:8080"}
+			/>
+		</MantineProvider>,
+	);
+}
+
+afterEach(() => cleanup());
+
+describe("RunMonitor (DAT-550)", () => {
+	it("renders a row per run with stage + status", () => {
+		renderMonitor({
+			runs: [
+				run({ stage: "add_source", status: "completed" }),
+				run({ workflowId: "wf-2", stage: "begin_session", status: "running" }),
+			],
+		});
+		expect(screen.getAllByTestId("run-monitor-row")).toHaveLength(2);
+		expect(screen.getByText("Add source")).toBeTruthy();
+		expect(screen.getByText("Begin session")).toBeTruthy();
+		const statuses = screen
+			.getAllByTestId("run-status")
+			.map((b) => b.textContent);
+		expect(statuses).toEqual(["completed", "running"]);
+	});
+
+	it("shows an empty state with no runs", () => {
+		renderMonitor({ runs: [] });
+		expect(screen.getByTestId("run-monitor-empty")).toBeTruthy();
+		expect(screen.queryByTestId("run-monitor-row")).toBeNull();
+	});
+
+	it("discloses the cap when the run count hits the limit", () => {
+		renderMonitor({ runs: [run(), run({ workflowId: "wf-2" })], limit: 2 });
+		expect(screen.getByTestId("run-monitor-capped").textContent).toContain(
+			"latest 2",
+		);
+	});
+
+	it("does NOT show the cap note below the limit", () => {
+		renderMonitor({ runs: [run()], limit: 100 });
+		expect(screen.queryByTestId("run-monitor-capped")).toBeNull();
+	});
+});

--- a/packages/cockpit/src/ui/runs/run-monitor.tsx
+++ b/packages/cockpit/src/ui/runs/run-monitor.tsx
@@ -1,0 +1,90 @@
+// Native run monitor (DAT-550) — a workspace-wide view of stage runs, replacing
+// the external Temporal-UI iframe. Pure render over the loader's runs (cockpit
+// React rule 12: widgets render persisted values, they don't recompute). The
+// list is BOUNDED by the loader's `limit` (newest-first); a full page discloses
+// the cap rather than dumping an unbounded set into the DOM (the UI quality bar).
+
+import { Anchor, Badge, Group, Stack, Table, Text, Title } from "@mantine/core";
+import type { WorkspaceRun } from "#/db/cockpit/runs";
+import { formatStartedAt, stageLabel, statusTone } from "#/ui/runs/run-row";
+
+export interface RunMonitorProps {
+	runs: ReadonlyArray<WorkspaceRun>;
+	/** The query bound — when `runs.length === limit` the view discloses the cap. */
+	limit: number;
+	/** Deep-link to the raw Temporal Web UI (kept for debugging). */
+	temporalUiUrl: string;
+}
+
+export function RunMonitor({ runs, limit, temporalUiUrl }: RunMonitorProps) {
+	return (
+		<Stack gap="md" h="100%" data-testid="run-monitor">
+			<Group justify="space-between" align="flex-end">
+				<Stack gap="xs">
+					<Title order={2}>Runs</Title>
+					<Text c="dimmed" size="sm">
+						Stage runs across this workspace — onboarding, sessions, and the
+						operating model. Updates as the orchestration worker advances them.
+					</Text>
+				</Stack>
+				<Anchor href={temporalUiUrl} target="_blank" rel="noreferrer" size="sm">
+					Open Temporal UI
+				</Anchor>
+			</Group>
+
+			{runs.length === 0 ? (
+				<Text c="dimmed" size="sm" data-testid="run-monitor-empty">
+					No runs yet — onboard a source or start a session to see runs here.
+				</Text>
+			) : (
+				<>
+					<Table highlightOnHover stickyHeader>
+						<Table.Thead>
+							<Table.Tr>
+								<Table.Th>Stage</Table.Th>
+								<Table.Th>Status</Table.Th>
+								<Table.Th>Started</Table.Th>
+								<Table.Th>Workflow</Table.Th>
+							</Table.Tr>
+						</Table.Thead>
+						<Table.Tbody>
+							{runs.map((run) => (
+								<Table.Tr
+									key={`${run.workflowId}:${run.runId}`}
+									data-testid="run-monitor-row"
+								>
+									<Table.Td>{stageLabel(run.stage)}</Table.Td>
+									<Table.Td>
+										<Badge
+											size="sm"
+											variant="light"
+											color={statusTone(run.status)}
+											data-testid="run-status"
+										>
+											{run.status}
+										</Badge>
+									</Table.Td>
+									<Table.Td>
+										<Text size="sm" c="dimmed">
+											{formatStartedAt(run.startedAt)}
+										</Text>
+									</Table.Td>
+									<Table.Td>
+										<Text size="xs" c="dimmed" ff="monospace" truncate="end">
+											{run.workflowId}
+										</Text>
+									</Table.Td>
+								</Table.Tr>
+							))}
+						</Table.Tbody>
+					</Table>
+					{runs.length >= limit && (
+						<Text c="dimmed" size="xs" data-testid="run-monitor-capped">
+							Showing the latest {limit} runs.
+						</Text>
+					)}
+				</>
+			)}
+		</Stack>
+	);
+}

--- a/packages/cockpit/src/ui/runs/run-monitor.tsx
+++ b/packages/cockpit/src/ui/runs/run-monitor.tsx
@@ -69,7 +69,9 @@ export function RunMonitor({ runs, limit, temporalUiUrl }: RunMonitorProps) {
 											{formatStartedAt(run.startedAt)}
 										</Text>
 									</Table.Td>
-									<Table.Td>
+									{/* maxWidth so `truncate` actually clips (Mantine truncate needs a
+									    width constraint) instead of the column growing to the id. */}
+									<Table.Td style={{ maxWidth: 220 }}>
 										<Text size="xs" c="dimmed" ff="monospace" truncate="end">
 											{run.workflowId}
 										</Text>

--- a/packages/cockpit/src/ui/runs/run-row.test.ts
+++ b/packages/cockpit/src/ui/runs/run-row.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { formatStartedAt, stageLabel, statusTone } from "#/ui/runs/run-row";
+
+describe("run-row presentation (DAT-550)", () => {
+	it("labels known stages and passes unknown ones through", () => {
+		expect(stageLabel("add_source")).toBe("Add source");
+		expect(stageLabel("begin_session")).toBe("Begin session");
+		expect(stageLabel("operating_model")).toBe("Operating model");
+		expect(stageLabel("future_stage")).toBe("future_stage");
+	});
+
+	it("maps status to a tone, defaulting unknown to gray", () => {
+		expect(statusTone("running")).toBe("blue");
+		expect(statusTone("completed")).toBe("green");
+		expect(statusTone("failed")).toBe("red");
+		expect(statusTone("awaiting_input")).toBe("gray");
+	});
+
+	it("formats startedAt as stable UTC from a Date or its wire string", () => {
+		const iso = "2026-06-17T06:58:27.925Z";
+		expect(formatStartedAt(new Date(iso))).toBe("2026-06-17 06:58 UTC");
+		// Server-fn loader data may arrive as a string — same result (SSR-stable).
+		expect(formatStartedAt(iso)).toBe("2026-06-17 06:58 UTC");
+	});
+});

--- a/packages/cockpit/src/ui/runs/run-row.ts
+++ b/packages/cockpit/src/ui/runs/run-row.ts
@@ -1,0 +1,39 @@
+// Pure presentation logic for the run monitor (DAT-550) — stage/status labels +
+// a SSR-safe timestamp format. Extracted as a .ts module with its own tests
+// (cockpit React rule 10); the component stays a pure render over these.
+
+/** Human label for a run stage (the `session_runs.stage` varchar). */
+const STAGE_LABEL: Record<string, string> = {
+	add_source: "Add source",
+	begin_session: "Begin session",
+	operating_model: "Operating model",
+};
+export function stageLabel(stage: string): string {
+	return STAGE_LABEL[stage] ?? stage;
+}
+
+/** Mantine color for a run status badge. */
+export type RunStatusTone = "blue" | "green" | "red" | "gray";
+export function statusTone(status: string): RunStatusTone {
+	switch (status) {
+		case "running":
+			return "blue";
+		case "completed":
+			return "green";
+		case "failed":
+			return "red";
+		default:
+			return "gray";
+	}
+}
+
+/**
+ * Stable UTC timestamp (`YYYY-MM-DD HH:MM UTC`). Deliberately UTC + fixed format
+ * so it can't drift between the SSR render and the client hydration (a locale/
+ * timezone-dependent format would mismatch). Accepts a Date or its wire string
+ * (server-fn loader data may arrive as either).
+ */
+export function formatStartedAt(startedAt: Date | string): string {
+	const iso = new Date(startedAt).toISOString();
+	return `${iso.slice(0, 10)} ${iso.slice(11, 16)} UTC`;
+}

--- a/packages/cockpit/src/ui/sections.ts
+++ b/packages/cockpit/src/ui/sections.ts
@@ -50,8 +50,10 @@ export const sections: readonly Section[] = [
 		to: "/workspace/$wsId/library",
 	},
 	{
+		// Native run monitor (DAT-550). Route path stays `/workflows`; the label is
+		// "Runs" — it's a cockpit_db-backed view of stage runs, not the raw Temporal UI.
 		id: "workflows",
-		label: "Workflows",
+		label: "Runs",
 		icon: Workflow,
 		to: "/workspace/$wsId/workflows",
 	},


### PR DESCRIPTION
**Epic:** DAT-526 (Cockpit Autonomy) · **Phase:** P3a · **Design:** DD/36175874 §3

Replace the `/workflows` external-Temporal-UI iframe with a cockpit-native run monitor, plus a rail liveness badge. **Cockpit-only, zero engine change.** First slice of the re-decomposed P3 (P3b=DAT-530 cascade substrate, P3c=DAT-551 teach loop).

## What's here
- **Workspace-scoped run queries** (`listRunsByWorkspace` + `countRunningRuns`) — the first non-conversation-scoped run queries, joining `session_runs → sessions`.
- **Native monitor** at `/workflows` (section relabeled "Runs"): bounded table (stage/status/started/workflow) with empty + cap-disclosure states, SSR-stable UTC timestamps, a Temporal-UI deep-link kept for debugging. Loader resolves the active workspace server-side (mirrors `loadHistory`).
- **Rail liveness badge** — a processing dot polling `/api/running-runs`, tab-independent (a cockpit_db count, no open chat stream); SSR-guarded.

## Why an API route for the badge
The badge mounts in the always-rendered shell. A co-located server fn would pull config/cockpit_db into the client bundle (and the shell test); polling `/api/running-runs` keeps server deps out of the client — the sanctioned pattern (same as `/api/workflow-progress`).

## Verified
- `bun run check` + tsc + **1164** unit tests green.
- **Container build clean** (no server-only leak in the client bundle — the real check the local darwin build can't do).
- **Browser smoke:** both real cockpit_db runs render with correct UTC times; rail shows "Runs"; iframe gone; **0 console errors**.
- **Reviews:** spec-compliance COMPLIANT (4/4 ACs); senior-code-reviewer found one real bug (badge `useQuery` ran during SSR with a relative fetch) — fixed with the `typeof window` guard — plus a badge test + nits, applied.

## Deferred
Live auto-refresh of the monitor table (loader-fetched; badge gives liveness); workspace-scoping the badge query key (TODO(DAT-357)). Journey-owns-stages / cascade / breaker / teach loop are P3b/P3c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)