### PR TITLE
DAT-537: g3 FD / drill-down / alias pass over the enriched views

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,34 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-17: DAT-537 — new `dimension_hierarchies` begin_session phase (g3 FD / drill-down / alias)
+
+A new **deterministic** value-layer phase, `dimension_hierarchies`, runs in the
+begin_session chain between `slicing` and `aggregation_lineage`
+(`slicing → dimension_hierarchies → aggregation_lineage → correlations`). It
+computes the g3 approximate-functional-dependency measure
+(`g3(A→B) = 1 − COUNT(DISTINCT A)/COUNT(DISTINCT(A,B))`) over each fact's
+grain-verified enriched view across the catalog's grain-safe `SliceDefinition`
+dimensions (DAT-536), and writes drill-down hierarchies (`zip → city → state`) +
+1:1 alias groups. **No LLM, no detectors** — it declares none in `pipeline.yaml`,
+so it does not feed `session_detect` and changes no entropy/readiness measurement.
+
+New run-versioned table **`dimension_hierarchies`** (form-a: `(signature, run_id)`
+UNIQUE + upsert), sealed under the begin_session `(catalog,"catalog")` head; read
+view `current_dimension_hierarchies` added (on `read_views._CATALOG_GRAIN`).
+Net-new **`hierarchy` teach** type (`config_overlay` type='hierarchy', actions
+add/reject/alias) — deterministic, so NO keeper-lift-up / witness pool (unlike
+relationship teaches). Exposed on `GraphExecutionContext.dimension_hierarchies`;
+the GraphAgent prompt does NOT yet consume it (that is **DAT-538**).
+
+### dataraum-eval
+- **Affects engine phases/tables**: new `dimension_hierarchies` phase + activity; new `dimension_hierarchies` table + `current_dimension_hierarchies` read view. Engine `schema.sql` + `schema_read.sql` regenerated; cockpit drizzle mirror regenerated. A begin_session run now persists hierarchy/alias rows for any fact whose grain-safe catalog has ≥2 related dimensions.
+- **No measurement/threshold change**: the phase declares no detectors and touches no entropy/readiness/witness path, so existing calibration verdicts are unchanged. New surface to calibrate is **hierarchy/alias correctness** (geo `zip→city→state`, product→category chains; bidirectional-g3 aliases; the guards: constant dropped, ≤2-distinct/near-key rejected as determinant, low-support flagged `needs_confirmation`).
+- **New teach surface**: `teach({type:"hierarchy", payload:{action, table_id, members}})` (cockpit `AGENT_TEACH_TYPES`).
+
+### dataraum-testdata
+- A fixture carrying a clean FD chain (`zip→city→state` or `product→subcategory→category`) plus a 1:1 alias pair (e.g. `state` ↔ `state_name`) and a violated/near-FD would exercise the discovery + guards directly.
+
 ## 2026-06-17: DAT-536 — slice materialization removed; witness substrate re-pointed inline; dimensional_entropy no longer runs
 
 The slice sprawl is gone (ADR-0013 one-view model). The

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -129,6 +129,24 @@ export const currentDetectedBusinessCycles = metadataSchema
 		sql`SELECT cycle_id, run_id, cycle_name, cycle_type, canonical_type, is_known_type, description, business_value, confidence, tables_involved, stages, entity_flows, status_table, status_column, completion_value, total_records, completed_cycles, completion_rate, evidence, detected_at FROM ws_00000000_0000_0000_0000_000000000001.detected_business_cycles r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'operating_model'::text AND h.run_id::text = r.run_id::text))`,
 	);
 
+export const currentDimensionHierarchies = metadataSchema
+	.view("current_dimension_hierarchies", {
+		hierarchyId: varchar("hierarchy_id"),
+		runId: varchar("run_id"),
+		tableId: varchar("table_id"),
+		kind: varchar(),
+		members: json(),
+		canonicalLabel: varchar("canonical_label"),
+		signature: varchar(),
+		score: doublePrecision(),
+		detectionSource: varchar("detection_source"),
+		needsConfirmation: boolean("needs_confirmation"),
+		createdAt: timestamp("created_at", { withTimezone: true }),
+	})
+	.as(
+		sql`SELECT hierarchy_id, run_id, table_id, kind, members, canonical_label, signature, score, detection_source, needs_confirmation, created_at FROM ws_00000000_0000_0000_0000_000000000001.dimension_hierarchies r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
+	);
+
 export const currentEnrichedViews = metadataSchema
 	.view("current_enriched_views", {
 		viewId: varchar("view_id"),

--- a/packages/cockpit/src/tools/teach.test.ts
+++ b/packages/cockpit/src/tools/teach.test.ts
@@ -280,6 +280,44 @@ describe("validateTeach", () => {
 		});
 	});
 
+	describe("hierarchy", () => {
+		it.each([
+			"add",
+			"reject",
+			"alias",
+		] as const)("accepts {action, table_id, members} for the %s action (DAT-537)", (action) => {
+			const out = validateTeach({
+				type: "hierarchy",
+				payload: {
+					action,
+					table_id: "tbl-1",
+					members: ["zip", "city", "state"],
+				},
+			});
+			expect(out.action).toBe(action);
+			expect(out.table_id).toBe("tbl-1");
+			expect(out.members).toEqual(["zip", "city", "state"]);
+		});
+
+		it("rejects an unknown action (confirm is relationship-only)", () => {
+			expect(() =>
+				validateTeach({
+					type: "hierarchy",
+					payload: { action: "confirm", table_id: "t", members: ["a", "b"] },
+				}),
+			).toThrow(TeachValidationError);
+		});
+
+		it("rejects an empty members list", () => {
+			expect(() =>
+				validateTeach({
+					type: "hierarchy",
+					payload: { action: "add", table_id: "t", members: [] },
+				}),
+			).toThrow(TeachValidationError);
+		});
+	});
+
 	// validation/cycle/metric are internal-only dispatch targets (the typed
 	// teach_validation/teach_cycle/teach_metric tools write through them with an
 	// already-validated payload), so the primitive still passthrough-accepts them.
@@ -305,6 +343,7 @@ describe("validateTeach", () => {
 					"null_value",
 					"concept_property",
 					"relationship",
+					"hierarchy",
 					"concept",
 					"validation",
 					"cycle",
@@ -324,6 +363,7 @@ describe("validateTeach", () => {
 					"concept",
 					"concept_property",
 					"relationship",
+					"hierarchy",
 				]),
 			);
 			for (const t of ["validation", "cycle", "metric", "explanation"]) {

--- a/packages/cockpit/src/tools/teach.validation.ts
+++ b/packages/cockpit/src/tools/teach.validation.ts
@@ -206,12 +206,48 @@ const RelationshipPayload = z
 	})
 	.passthrough();
 
+// `hierarchy` overlays are durable drill-down / alias teaches over a fact's
+// enriched view (DAT-537). The engine keys on {action, table_id, members}: `add`
+// asserts a drill-down chain g3 missed (materialized as a `manual` drilldown),
+// `alias` asserts that two columns are 1:1 redundant axes (a `manual` alias), and
+// `reject` suppresses a g3-discovered structure this run (matched by member-set).
+// `members` are the enriched-view column NAMES surfaced from the look tools —
+// ordered finest → coarsest for a drill-down add. g3 discovery is deterministic, so
+// there is no `confirm`/silent-accept here (unlike relationship teaches).
+const HIERARCHY_ACTIONS = ["add", "reject", "alias"] as const;
+const HierarchyPayload = z
+	.object({
+		action: z
+			.enum(HIERARCHY_ACTIONS)
+			.describe(
+				"add = assert a drill-down chain the g3 pass missed (finest→coarsest members); " +
+					"alias = assert two+ columns are 1:1 redundant axes; " +
+					"reject = drop a discovered hierarchy/alias (matched by its member set).",
+			),
+		table_id: z
+			.string()
+			.min(1)
+			.describe(
+				"The fact table whose enriched view the hierarchy is on (from look_table).",
+			),
+		members: z
+			.array(z.string().min(1))
+			.min(1)
+			.describe(
+				"Enriched-view column names: ordered finest→coarsest for a drill-down add " +
+					"(e.g. ['zip','city','state']), the equivalent group for an alias, or the " +
+					"target structure's members for a reject.",
+			),
+	})
+	.passthrough();
+
 const TYPE_SCHEMAS = {
 	type_pattern: TypePatternPayload,
 	null_value: NullValuePayload,
 	concept: ConceptPayload,
 	concept_property: ConceptPropertyPayload,
 	relationship: RelationshipPayload,
+	hierarchy: HierarchyPayload,
 	// validation/cycle/metric are NOT advertised to the agent (see
 	// AGENT_TEACH_TYPES). The typed teach_validation/teach_cycle/teach_metric
 	// tools own that surface — they validate the rich spec at the SDK boundary,
@@ -239,6 +275,7 @@ export const AGENT_TEACH_TYPES = [
 	"concept",
 	"concept_property",
 	"relationship",
+	"hierarchy",
 ] as const satisfies readonly TeachType[];
 
 // The payload shape surfaced in the teach TOOL's input schema — a union of ONLY
@@ -255,6 +292,7 @@ export const TeachPayloadSchema = z
 		ConceptPayload,
 		ConceptPropertyPayload,
 		RelationshipPayload,
+		HierarchyPayload,
 	])
 	.describe(
 		"The teach payload; required fields depend on `type` — " +
@@ -263,7 +301,8 @@ export const TeachPayloadSchema = z
 			"concept: {vertical, name, indicators?, …}; " +
 			"concept_property: {vertical, concept, property, value}; " +
 			"relationship: {action: confirm|reject|add, from_column_id, to_column_id} " +
-			"(keep is engine-internal, not a user action).",
+			"(keep is engine-internal, not a user action); " +
+			"hierarchy: {action: add|reject|alias, table_id, members}.",
 	);
 
 export interface TeachInput {

--- a/packages/dataraum-config/pipeline.yaml
+++ b/packages/dataraum-config/pipeline.yaml
@@ -69,6 +69,13 @@ phases:
     # now aggregated inline over the enriched views in aggregation_lineage.
     # dimensional_entropy lost its run site here; its formal cut is DAT-539.
 
+  dimension_hierarchies:
+    description: Deterministic g3 FD pass — drill-down hierarchies + 1:1 aliases over the slice catalog
+    # DAT-537: no detectors and no LLM — reads slicing's grain-safe dimension catalog
+    # and the grain-verified enriched views, writes run-versioned drill-down chains
+    # (zip → city → state) + alias groups. Consumed by the answer agent (DAT-538) and
+    # the driver tree (DAT-545, which uses alias collapse to de-confound its ranking).
+
   aggregation_lineage:
     description: Events→measure rollup discovery, inline-aggregated over enriched views
     # temporal_behavior is declared HERE (DAT-491/536): at the session detect the

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -239,6 +239,27 @@ CREATE TABLE columns (
 
 CREATE INDEX idx_columns_table ON columns (table_id);
 
+CREATE TABLE dimension_hierarchies (
+	hierarchy_id VARCHAR NOT NULL, 
+	run_id VARCHAR NOT NULL, 
+	table_id VARCHAR NOT NULL, 
+	kind VARCHAR NOT NULL, 
+	members JSON NOT NULL, 
+	canonical_label VARCHAR NOT NULL, 
+	signature VARCHAR NOT NULL, 
+	score FLOAT NOT NULL, 
+	detection_source VARCHAR NOT NULL, 
+	needs_confirmation BOOLEAN NOT NULL, 
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL, 
+	CONSTRAINT pk_dimension_hierarchies PRIMARY KEY (hierarchy_id), 
+	CONSTRAINT uq_dimension_hierarchy_signature_run UNIQUE (signature, run_id), 
+	CONSTRAINT fk_dimension_hierarchies_table_id_tables FOREIGN KEY(table_id) REFERENCES tables (table_id)
+);
+
+CREATE INDEX idx_dimension_hierarchies_run ON dimension_hierarchies (run_id);
+
+CREATE INDEX idx_dimension_hierarchies_table ON dimension_hierarchies (table_id);
+
 CREATE TABLE enriched_views (
 	view_id VARCHAR NOT NULL, 
 	fact_table_id VARCHAR NOT NULL, 

--- a/packages/engine/schema_read.sql
+++ b/packages/engine/schema_read.sql
@@ -71,6 +71,16 @@ WHERE EXISTS (
     AND h.run_id = r.run_id
 );
 
+DROP VIEW IF EXISTS __READ__.current_dimension_hierarchies;
+CREATE VIEW __READ__.current_dimension_hierarchies AS
+SELECT r.* FROM __WS__.dimension_hierarchies r
+WHERE EXISTS (
+  SELECT 1 FROM __WS__.metadata_snapshot_head h
+  WHERE h.target = 'catalog'
+    AND h.stage = 'catalog'
+    AND h.run_id = r.run_id
+);
+
 DROP VIEW IF EXISTS __READ__.current_enriched_views;
 CREATE VIEW __READ__.current_enriched_views AS
 SELECT r.* FROM __WS__.enriched_views r

--- a/packages/engine/src/dataraum/analysis/hierarchies/__init__.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/__init__.py
@@ -1,0 +1,9 @@
+"""Dimension hierarchy / functional-dependency discovery (DAT-537).
+
+A deterministic g3 functional-dependency pass over each fact's grain-verified
+enriched view: it finds drill-down hierarchies (``zip → city → state``) and 1:1
+aliases among the catalog's grain-safe slice dimensions, with no LLM and no NMI.
+Built on the DAT-536 dimension catalog; consumed downstream by the answer agent
+(DAT-538) and the driver-tree engine (DAT-545, which uses alias collapse to
+de-confound its ranking).
+"""

--- a/packages/engine/src/dataraum/analysis/hierarchies/db_models.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/db_models.py
@@ -75,9 +75,10 @@ class DimensionHierarchy(Base):
     # JSON ``members`` column cannot be a conflict target.
     signature: Mapped[str] = mapped_column(String, nullable=False)
 
-    # The g3 evidence: the WEAKEST edge's g3 for a drilldown (max over edges), or
-    # the bidirectional g3 for an alias. Lower = stronger (0 = exact FD). Audit +
-    # the support/confidence ordering for downstream consumers.
+    # The g3 evidence: the highest edge g3 in a drilldown chain (the weakest link;
+    # max over edges), or the bidirectional g3 for an alias. Lower = stronger
+    # (0 = every edge is an exact FD). Audit + the support/confidence ordering for
+    # downstream consumers.
     score: Mapped[float] = mapped_column(Float, nullable=False)
 
     # 'g3' (auto-discovered) | 'manual' (a teach add/alias assertion).

--- a/packages/engine/src/dataraum/analysis/hierarchies/db_models.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/db_models.py
@@ -1,0 +1,91 @@
+"""SQLAlchemy model for dimension-hierarchy discovery (DAT-537)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from dataraum.storage import Base
+
+
+class DimensionHierarchy(Base):
+    """One drill-down chain or 1:1 alias group over a fact's enriched view, per run.
+
+    The deterministic g3 functional-dependency pass (DAT-537) writes one row per
+    discovered structure. Two kinds share the table via the ``kind`` discriminator:
+
+    - ``kind='drilldown'``: an ordered drill-down hierarchy. ``members`` lists the
+      levels **finest → coarsest** (each FD-determines the next, e.g. ``zip → city
+      → state``); ``canonical_label`` renders the chain.
+    - ``kind='alias'``: a 1:1 redundant-axis group (bidirectional ``g3 ≈ 0``).
+      ``members`` lists the equivalent columns; ``canonical_label`` is the chosen
+      canonical axis name.
+
+    Run-versioned like ``MeasureAggregationLineage`` (DAT-491): form-(a) writer —
+    one row per ``(signature, run_id)``, UPSERTed, so a Temporal success-redelivery
+    (same ``run_id``, deterministic g3) converges in place and prior runs' rows
+    coexist. ``signature`` is the run-grain dedup key:
+    ``"{kind}:{table_id}:" + "|".join(sorted(member column_names))``.
+
+    Sealed under the begin_session ``(catalog, "catalog")`` head: it is on
+    ``read_views._CATALOG_GRAIN``, so ``current_dimension_hierarchies`` resolves
+    the promoted run and ``session_promote_to_latest`` flips it with the rest of
+    the catalog — no separate promote.
+    """
+
+    __tablename__ = "dimension_hierarchies"
+    __table_args__ = (
+        UniqueConstraint("signature", "run_id", name="uq_dimension_hierarchy_signature_run"),
+        Index("idx_dimension_hierarchies_table", "table_id"),
+        Index("idx_dimension_hierarchies_run", "run_id"),
+    )
+
+    hierarchy_id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=lambda: str(uuid4())
+    )
+    # Snapshot version axis (DAT-448): the begin_session run that derived this.
+    run_id: Mapped[str] = mapped_column(String, nullable=False)
+    # The fact whose grain-verified enriched view the chain was computed over
+    # (cross-table levels surface for free on the denormalized view).
+    table_id: Mapped[str] = mapped_column(ForeignKey("tables.table_id"), nullable=False)
+
+    kind: Mapped[str] = mapped_column(String, nullable=False)  # 'drilldown' | 'alias'
+
+    # Ordered member columns. Each entry: {column_name, column_id, distinct_count}.
+    # drilldown: finest → coarsest (the drill path). alias: the equivalent group,
+    # canonical first. ``column_id`` is the catalog SliceDefinition's underlying
+    # column (provenance); ``column_name`` is the enriched-view column the g3 pass
+    # measured (may be an FK-prefixed dim col) and is the member identity.
+    members: Mapped[list[dict[str, object]]] = mapped_column(JSON, nullable=False)
+    canonical_label: Mapped[str] = mapped_column(String, nullable=False)
+
+    # Run-grain dedup key (see class docstring); the UNIQUE rides on it because a
+    # JSON ``members`` column cannot be a conflict target.
+    signature: Mapped[str] = mapped_column(String, nullable=False)
+
+    # The g3 evidence: the WEAKEST edge's g3 for a drilldown (max over edges), or
+    # the bidirectional g3 for an alias. Lower = stronger (0 = exact FD). Audit +
+    # the support/confidence ordering for downstream consumers.
+    score: Mapped[float] = mapped_column(Float, nullable=False)
+
+    # 'g3' (auto-discovered) | 'manual' (a teach add/alias assertion).
+    detection_source: Mapped[str] = mapped_column(String, nullable=False, default="g3")
+    # Low-support / borderline edges are surfaced for confirmation, not silently
+    # auto-asserted (DAT-537 guard). A manual teach clears it.
+    needs_confirmation: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )

--- a/packages/engine/src/dataraum/analysis/hierarchies/overlay.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/overlay.py
@@ -1,0 +1,74 @@
+"""Durable hierarchy/alias teaches as config overlays (DAT-537).
+
+Mirrors the relationship-overlay pattern (``analysis/relationships/utils.py``) with
+direct reads (NO YAML applier): a ``ConfigOverlay(type='hierarchy')`` row carries
+
+    {action, table_id, kind, members}
+
+where ``action`` is ``add`` (assert a drill-down chain g3 missed → a durable
+``manual`` drilldown), ``alias`` (assert A ≡ B → a ``manual`` alias group), or
+``reject`` (suppress a g3-discovered structure this run). ``members`` is the ordered
+list of enriched-view column NAMES (finest → coarsest for a drilldown; the group for
+an alias) — the member identity the g3 pass and the ``signature`` key use.
+
+The heavy half of the relationship apparatus is ELIDED on purpose: g3 is
+DETERMINISTIC, so there is no silent-accept ``keeper`` lift-up and no witness/detect
+pool (those exist to adjudicate non-deterministic LLM discovery). A teach here is a
+plain assert/suppress folded into the run that recomputes the same g3 set every time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+@dataclass(frozen=True)
+class HierarchyTeach:
+    """One parsed, well-formed hierarchy/alias overlay (DAT-537)."""
+
+    action: str  # 'add' | 'reject' | 'alias'
+    table_id: str
+    members: list[str]  # ordered enriched-view column names (finest→coarsest for add)
+
+
+def hierarchy_overlay_specs(session: Session, action: str) -> list[HierarchyTeach]:
+    """Active ``ConfigOverlay(type='hierarchy')`` teaches for one ``action``.
+
+    Every engine reader of hierarchy teaches goes through this one parser so they
+    agree on the shape; ``superseded_at IS NULL`` filters undone teaches out. A
+    payload missing ``table_id`` or a non-empty string ``members`` list is skipped
+    (malformed) — the parser never emits a half-formed spec.
+    """
+    from dataraum.storage import ConfigOverlay
+
+    rows = list(
+        session.execute(
+            select(ConfigOverlay).where(
+                ConfigOverlay.type == "hierarchy",
+                ConfigOverlay.superseded_at.is_(None),
+            )
+        ).scalars()
+    )
+    out: list[HierarchyTeach] = []
+    for row in rows:
+        payload = row.payload or {}
+        if payload.get("action") != action:
+            continue
+        table_id = payload.get("table_id")
+        members = payload.get("members")
+        if not isinstance(table_id, str) or not table_id:
+            continue
+        if (
+            not isinstance(members, list)
+            or not members
+            or not all(isinstance(m, str) for m in members)
+        ):
+            continue
+        out.append(HierarchyTeach(action=action, table_id=table_id, members=list(members)))
+    return out

--- a/packages/engine/src/dataraum/analysis/hierarchies/processor.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/processor.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, cast
 from sqlalchemy import select
 
 from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
+from dataraum.analysis.hierarchies.overlay import hierarchy_overlay_specs
 from dataraum.analysis.slicing.db_models import SliceDefinition
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.core.logging import get_logger
@@ -350,18 +351,19 @@ def _apply_teaches(
     g3 row (clears ``needs_confirmation``). Keyed by signature so the result stays
     one row per ``(signature, run_id)``.
     """
-    from dataraum.analysis.hierarchies.overlay import hierarchy_overlay_specs
-
     by_sig: dict[str, dict[str, object]] = {str(r["signature"]): r for r in rows}
 
     def _row_member_names(r: dict[str, object]) -> frozenset[str]:
         members = cast("list[dict[str, object]]", r["members"])
         return frozenset(str(m["column_name"]) for m in members)
 
+    # One read of the active hierarchy teaches, grouped by action (the parser
+    # re-queries per action, so load each once).
+    specs = {a: hierarchy_overlay_specs(session, a) for a in ("reject", "add", "alias")}
+
     # reject: drop any g3 structure whose table + member-set matches.
     rejected: set[tuple[str, frozenset[str]]] = {
-        (spec.table_id, frozenset(spec.members))
-        for spec in hierarchy_overlay_specs(session, "reject")
+        (spec.table_id, frozenset(spec.members)) for spec in specs["reject"]
     }
     if rejected:
         by_sig = {
@@ -373,7 +375,7 @@ def _apply_teaches(
     # add → manual drilldown, alias → manual alias (ordered members preserved).
     col_ids = _member_column_ids(session, table_ids, run_id)
     for action, kind in (("add", "drilldown"), ("alias", "alias")):
-        for spec in hierarchy_overlay_specs(session, action):
+        for spec in specs[action]:
             members = spec.members
             if kind == "drilldown" and len(members) < 2:
                 logger.info("hierarchy_teach_skipped", reason="drilldown_needs_2_levels", spec=spec)
@@ -476,6 +478,10 @@ def _view_structures(
     reduced = _transitive_reduction(edges)
 
     # Per-edge g3 (on the original measured columns behind each rep) for scoring.
+    # ``pairs`` keys are always (lex-smaller, lex-larger) because
+    # ``cand_names = sorted(by_name)`` — so ``forward=(a, b) in pairs`` resolves
+    # which endpoint is ``d_a`` in the stored ``_Pair``. (If cand_names ever stops
+    # being lexicographically sorted, this direction test must be revisited.)
     def _edge_g3(a: str, b: str) -> float:
         pair = pairs.get((a, b)) or pairs.get((b, a))
         if pair is None:
@@ -511,6 +517,9 @@ def _view_structures(
         logger.info("hierarchy_drilldown", view=view_name, chain=chain, score=round(score, 4))
 
     for group in groups:
+        # Representative-pair score. For a 3+ member group every pair already passed
+        # the alias threshold in union-find, so the first pair's g3 bounds the group
+        # (≤ FD_MAX_G3) — a faithful, conservative score.
         gpair = pairs.get((group[0], group[1])) or pairs.get((group[1], group[0]))
         score = max(gpair.g3(forward=True), gpair.g3(forward=False)) if gpair else 0.0
         out.append(

--- a/packages/engine/src/dataraum/analysis/hierarchies/processor.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/processor.py
@@ -33,7 +33,7 @@ signal, never a silent cut.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from sqlalchemy import select
 
@@ -300,8 +300,105 @@ def discover_dimension_hierarchies(
             )
         )
 
+    # Fold the user's durable hierarchy/alias teaches into this run (DAT-537),
+    # mirroring relationship-overlay materialization minus keeper-lift-up + witness
+    # (g3 is deterministic). reject suppresses a g3 structure; add/alias assert one.
+    rows = _apply_teaches(session, rows, table_ids=table_ids, run_id=run_id)
+
     upsert(session, DimensionHierarchy, rows, index_elements=["signature", "run_id"])
     return len(rows)
+
+
+def _member_column_ids(
+    session: Session, table_ids: list[str], run_id: str
+) -> dict[str, dict[str, str]]:
+    """``table_id -> {column_name: column_id}`` from this run's slice catalog.
+
+    Resolves a manual teach's member columns to their catalog column ids; a member
+    the catalog doesn't carry (a forced edge on an excluded/unknown column) resolves
+    to ``""`` rather than failing the teach.
+    """
+    out: dict[str, dict[str, str]] = {}
+    for sd in (
+        session.execute(
+            select(SliceDefinition).where(
+                SliceDefinition.table_id.in_(table_ids),
+                SliceDefinition.run_id == run_id,
+                SliceDefinition.column_name.isnot(None),
+            )
+        )
+        .scalars()
+        .all()
+    ):
+        if sd.column_name:
+            out.setdefault(sd.table_id, {})[sd.column_name] = sd.column_id
+    return out
+
+
+def _apply_teaches(
+    session: Session,
+    rows: list[dict[str, object]],
+    *,
+    table_ids: list[str],
+    run_id: str,
+) -> list[dict[str, object]]:
+    """Apply reject / add / alias hierarchy overlays to the g3 row set.
+
+    reject drops the g3 structure with a matching ``(table_id, member-set)``
+    (kind-agnostic — a member-set is one structure); add asserts a ``manual``
+    drilldown, alias a ``manual`` alias. A manual assert overrides a same-signature
+    g3 row (clears ``needs_confirmation``). Keyed by signature so the result stays
+    one row per ``(signature, run_id)``.
+    """
+    from dataraum.analysis.hierarchies.overlay import hierarchy_overlay_specs
+
+    by_sig: dict[str, dict[str, object]] = {str(r["signature"]): r for r in rows}
+
+    def _row_member_names(r: dict[str, object]) -> frozenset[str]:
+        members = cast("list[dict[str, object]]", r["members"])
+        return frozenset(str(m["column_name"]) for m in members)
+
+    # reject: drop any g3 structure whose table + member-set matches.
+    rejected: set[tuple[str, frozenset[str]]] = {
+        (spec.table_id, frozenset(spec.members))
+        for spec in hierarchy_overlay_specs(session, "reject")
+    }
+    if rejected:
+        by_sig = {
+            sig: r
+            for sig, r in by_sig.items()
+            if (str(r["table_id"]), _row_member_names(r)) not in rejected
+        }
+
+    # add → manual drilldown, alias → manual alias (ordered members preserved).
+    col_ids = _member_column_ids(session, table_ids, run_id)
+    for action, kind in (("add", "drilldown"), ("alias", "alias")):
+        for spec in hierarchy_overlay_specs(session, action):
+            members = spec.members
+            if kind == "drilldown" and len(members) < 2:
+                logger.info("hierarchy_teach_skipped", reason="drilldown_needs_2_levels", spec=spec)
+                continue
+            names = col_ids.get(spec.table_id, {})
+            sig = f"{kind}:{spec.table_id}:" + "|".join(sorted(members))
+            by_sig[sig] = {
+                "run_id": run_id,
+                "table_id": spec.table_id,
+                "kind": kind,
+                "members": [
+                    {"column_name": n, "column_id": names.get(n, ""), "distinct_count": None}
+                    for n in members
+                ],
+                "canonical_label": " → ".join(members) if kind == "drilldown" else members[0],
+                "signature": sig,
+                "score": 0.0,
+                "detection_source": "manual",
+                "needs_confirmation": False,
+            }
+            logger.info(
+                "hierarchy_teach_applied", action=action, table_id=spec.table_id, members=members
+            )
+
+    return list(by_sig.values())
 
 
 def _view_structures(

--- a/packages/engine/src/dataraum/analysis/hierarchies/processor.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/processor.py
@@ -1,0 +1,434 @@
+"""g3 functional-dependency / hierarchy discovery over the enriched views (DAT-537).
+
+Deterministic, no LLM. For each fact's grain-verified enriched view, the catalog's
+grain-safe slice dimensions (DAT-536) are the candidate axes. One DuckDB scan per
+view computes every column's distinct count and every unordered pair's joint
+distinct count; from those the **approximate functional dependency** measure
+
+    g3(A → B) = 1 − COUNT(DISTINCT A) / COUNT(DISTINCT (A, B))
+
+is read for both directions of every pair (g3 = 0 ⇔ A determines B exactly). Edges
+become drill-down hierarchies (``zip → city → state``) after transitive reduction;
+bidirectional ``g3 ≈ 0`` pairs collapse into 1:1 alias groups (the redundant-axis
+dedup the DAT-545 driver tree needs to de-confound its ranking).
+
+Null semantics (documented bias): the per-column distinct counts ignore NULLs
+(SQL ``COUNT(DISTINCT)``) while the joint distinct count over a row literal counts
+``(a, NULL)`` as a present pair, so a column with NULLs inflates its joint count and
+its g3 — biasing toward MISSED dependencies (false negatives), never spurious ones.
+A missed edge is recoverable via teach; a spurious asserted hierarchy is not. Slice
+dimensions are categorical and typically non-null, so for the common case g3 is exact.
+
+Candidate set = ALL this-run grain-safe catalog dims (deterministic; no priority
+cap — a cap would be arbitrary across runs and would drop axes DAT-545 must rank).
+Pruning is only by data-grounded guards: a constant column (< ``MIN_DISTINCT_DIMENSION``)
+is not an axis at all and is dropped from both roles; a too-coarse determinant
+(≤ 2 distinct) determines anything vacuously and a near-key determinant
+(≥ ``NEAR_KEY_FRAC`` of the rows distinct) manufactures a spurious FD, so both are
+rejected as DETERMINANTS (still allowed as a coarsest level). The candidate count and
+every guard exclusion are logged (born-loud): a pathologically wide view is a measured
+signal, never a silent cut.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
+from dataraum.analysis.slicing.db_models import SliceDefinition
+from dataraum.analysis.views.db_models import EnrichedView
+from dataraum.core.logging import get_logger
+from dataraum.storage import Table
+from dataraum.storage.upsert import upsert
+
+if TYPE_CHECKING:
+    import duckdb
+    from sqlalchemy.orm import Session
+
+logger = get_logger(__name__)
+
+# g3 at or below this is treated as an exact functional dependency (allows a
+# small fraction of dirty-data violations). A true FD over clean data is g3 = 0.
+FD_MAX_G3 = 0.01
+
+# A constant column (1 distinct) is not a usable axis at all: useless as a level
+# and trivially determined by everything (junk ``X → constant`` edges) — dropped
+# from BOTH roles. A 2-value column is a legitimate low-cardinality level (e.g. a
+# binary dimension, or the coarsest level when the data spans 2 states), so the
+# floor for being a candidate is 2.
+MIN_DISTINCT_DIMENSION = 2
+# A DETERMINANT must distinguish enough values that the FD isn't trivial — a
+# ≤2-distinct determinant "determines" anything coarser vacuously (ticket guard) —
+# and at most ``NEAR_KEY_FRAC`` of the rows: a near-unique column is a key, every
+# value maps to one of anything, a spurious FD.
+MIN_DISTINCT_DETERMINANT = 3
+NEAR_KEY_FRAC = 0.9
+
+# Edges resting on fewer than this many rows are surfaced for confirmation
+# (``needs_confirmation``) rather than auto-asserted — too little support to trust.
+MIN_SUPPORT_ROWS = 100
+
+
+@dataclass(frozen=True)
+class _Pair:
+    """The g3 evidence for one unordered column pair over the enriched view."""
+
+    d_a: int  # distinct values of column a (NULLs ignored)
+    d_b: int  # distinct values of column b
+    d_ab: int  # distinct (a, b) pairs (row literal; NULL field counts as present)
+
+    def g3(self, *, forward: bool) -> float:
+        """The g3 of a → b (``forward``) or b → a. Empty pair → 1.0 (no FD)."""
+        if self.d_ab == 0:
+            return 1.0
+        return 1.0 - (self.d_a if forward else self.d_b) / self.d_ab
+
+
+def _g3_scan(
+    duckdb_conn: duckdb.DuckDBPyConnection, view_name: str, cols: list[str]
+) -> tuple[int, dict[str, int], dict[tuple[int, int], int]] | None:
+    """One scan: row count, per-column distinct counts, per-pair joint distincts.
+
+    Returns ``(n_rows, {col: d_col}, {(i, j): d_ij})`` for ``i < j``, or ``None``
+    if the scan fails (logged) — the view is then skipped, a visible abstention.
+    """
+    parts = ["COUNT(*) AS n"]
+    parts += [f'COUNT(DISTINCT "{c}") AS d{i}' for i, c in enumerate(cols)]
+    pair_alias: dict[tuple[int, int], str] = {}
+    for i in range(len(cols)):
+        for j in range(i + 1, len(cols)):
+            alias = f"j_{i}_{j}"
+            pair_alias[(i, j)] = alias
+            parts.append(f'COUNT(DISTINCT ("{cols[i]}", "{cols[j]}")) AS {alias}')
+    sql = f'SELECT {", ".join(parts)} FROM "{view_name}"'  # noqa: S608 — names are catalog dims
+    try:
+        row = duckdb_conn.execute(sql).fetchone()
+    except Exception as e:  # noqa: BLE001 — any DuckDB error → skip this view, logged
+        logger.warning("hierarchy_g3_scan_failed", view=view_name, error=str(e))
+        return None
+    if row is None:
+        return None
+    n = int(row[0])
+    singles = {c: int(row[1 + i]) for i, c in enumerate(cols)}
+    # ``parts`` is n, then the k singles, then the joints in ``pair_alias`` order —
+    # so the j-th joint sits at offset ``1 + k + j`` (pair_alias is insertion-ordered).
+    offset = 1 + len(cols)
+    joints = {pair: int(row[offset + k]) for k, pair in enumerate(pair_alias)}
+    return n, singles, joints
+
+
+def _transitive_reduction(edges: set[tuple[str, str]]) -> set[tuple[str, str]]:
+    """Remove edges implied by a longer path (DAG; ``a → b`` = a determines b).
+
+    Drops ``a → c`` whenever ``a → … → c`` exists through an intermediate, so a
+    chain ``zip → city → state`` keeps only the adjacent links. Determination is a
+    partial order (acyclic once aliases are collapsed), so a simple reachability
+    test per edge suffices.
+    """
+    succ: dict[str, set[str]] = {}
+    for a, b in edges:
+        succ.setdefault(a, set()).add(b)
+
+    def reaches(start: str, target: str, skip: tuple[str, str]) -> bool:
+        stack = [start]
+        seen = {start}
+        while stack:
+            node = stack.pop()
+            for nxt in succ.get(node, ()):
+                if (node, nxt) == skip:
+                    continue
+                if nxt == target:
+                    return True
+                if nxt not in seen:
+                    seen.add(nxt)
+                    stack.append(nxt)
+        return False
+
+    return {(a, b) for (a, b) in edges if not reaches(a, b, skip=(a, b))}
+
+
+def _maximal_chains(edges: set[tuple[str, str]]) -> list[list[str]]:
+    """Every maximal path (length ≥ 2 nodes) through the reduced DAG, finest→coarsest.
+
+    A node with no incoming reduced edge is a chain start (the finest level); a
+    node with no outgoing edge is the end (coarsest). Branching yields multiple
+    chains. Deterministic: starts and successors are sorted.
+    """
+    succ: dict[str, list[str]] = {}
+    has_incoming: set[str] = set()
+    for a, b in sorted(edges):
+        succ.setdefault(a, []).append(b)
+        has_incoming.add(b)
+    starts = sorted({a for a, _ in edges} - has_incoming)
+
+    chains: list[list[str]] = []
+
+    def walk(path: list[str]) -> None:
+        tail = path[-1]
+        nexts = succ.get(tail)
+        if not nexts:
+            if len(path) >= 2:
+                chains.append(path)
+            return
+        for nxt in nexts:
+            walk([*path, nxt])
+
+    for start in starts:
+        walk([start])
+    return chains
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    """A resolved candidate dimension column on one enriched view."""
+
+    column_name: str  # the enriched-view column the g3 pass measures (member identity)
+    column_id: str  # the catalog SliceDefinition's underlying column (provenance)
+
+
+def _alias_groups(
+    names: list[str], pairs: dict[tuple[str, str], _Pair]
+) -> tuple[list[list[str]], dict[str, str]]:
+    """Union-find 1:1 aliases (bidirectional g3 ≈ 0) into groups.
+
+    Returns ``(groups, representative)``: ``groups`` lists each alias set (size ≥ 2,
+    sorted, canonical = first); ``representative`` maps every column to its canonical
+    so hierarchy detection runs on collapsed axes (a redundant axis never appears as
+    its own level).
+    """
+    parent = {n: n for n in names}
+
+    def find(x: str) -> str:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(x: str, y: str) -> None:
+        rx, ry = find(x), find(y)
+        if rx != ry:
+            # Point the lexicographically smaller root at the larger; the group's
+            # canonical is recomputed as ``sorted(group)[0]`` below, so the exact
+            # link direction here is not load-bearing — only connectivity is.
+            parent[min(rx, ry)] = max(rx, ry)
+
+    for (a, b), pair in pairs.items():
+        if pair.g3(forward=True) <= FD_MAX_G3 and pair.g3(forward=False) <= FD_MAX_G3:
+            union(a, b)
+
+    members: dict[str, list[str]] = {}
+    for n in names:
+        members.setdefault(find(n), []).append(n)
+    groups = [sorted(g) for g in members.values() if len(g) >= 2]
+    representative = {n: sorted(g)[0] for g in members.values() for n in g}
+    return groups, representative
+
+
+def discover_dimension_hierarchies(
+    session: Session,
+    *,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    table_ids: list[str],
+    run_id: str,
+) -> int:
+    """Compute g3 hierarchies + aliases over each enriched view; persist run-versioned.
+
+    Form-(a) writer (DAT-502): one row per ``(signature, run_id)``, UPSERTed;
+    deterministic, so a redelivered run converges. Returns the rows persisted.
+    """
+    enriched = (
+        session.execute(
+            select(EnrichedView).where(
+                EnrichedView.fact_table_id.in_(table_ids),
+                EnrichedView.is_grain_verified.is_(True),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    table_by_id = {
+        t.table_id: t
+        for t in session.execute(select(Table).where(Table.table_id.in_(table_ids))).scalars()
+    }
+
+    rows: list[dict[str, object]] = []
+    for ev in enriched:
+        defs = (
+            session.execute(
+                select(SliceDefinition).where(
+                    SliceDefinition.table_id == ev.fact_table_id,
+                    SliceDefinition.run_id == run_id,
+                    SliceDefinition.grain_safe.is_(True),
+                    SliceDefinition.column_name.isnot(None),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        # Dedup by enriched column name (the propagation pass can emit a dim twice).
+        by_name: dict[str, _Candidate] = {}
+        for sd in defs:
+            name = sd.column_name or ""
+            if name and name not in by_name:
+                by_name[name] = _Candidate(column_name=name, column_id=sd.column_id)
+        cand_names = sorted(by_name)
+        if len(cand_names) < 2:
+            continue
+        logger.info(
+            "hierarchy_candidates",
+            table=table_by_id[ev.fact_table_id].table_name
+            if ev.fact_table_id in table_by_id
+            else ev.fact_table_id,
+            view=ev.view_name,
+            n_candidates=len(cand_names),
+        )
+
+        scan = _g3_scan(duckdb_conn, ev.view_name, cand_names)
+        if scan is None:
+            continue
+        rows.extend(
+            _view_structures(
+                fact_table_id=ev.fact_table_id,
+                view_name=ev.view_name,
+                run_id=run_id,
+                by_name=by_name,
+                cand_names=cand_names,
+                scan=scan,
+            )
+        )
+
+    upsert(session, DimensionHierarchy, rows, index_elements=["signature", "run_id"])
+    return len(rows)
+
+
+def _view_structures(
+    *,
+    fact_table_id: str,
+    view_name: str,
+    run_id: str,
+    by_name: dict[str, _Candidate],
+    cand_names: list[str],
+    scan: tuple[int, dict[str, int], dict[tuple[int, int], int]],
+) -> list[dict[str, object]]:
+    """The drill-down + alias row dicts for one enriched view from its g3 scan.
+
+    A module-level helper (not a closure in the per-view loop) so its inner
+    functions bind these parameters, not loop variables.
+    """
+    n_rows, singles, joints = scan
+    pairs: dict[tuple[str, str], _Pair] = {
+        (cand_names[i], cand_names[j]): _Pair(
+            d_a=singles[cand_names[i]], d_b=singles[cand_names[j]], d_ab=d_ij
+        )
+        for (i, j), d_ij in joints.items()
+    }
+
+    # Constant columns (< MIN_DISTINCT_DIMENSION distinct) are dropped from BOTH
+    # roles: not a meaningful axis, and as a DEPENDENT a constant is trivially
+    # determined by everything, manufacturing junk edges. Born-loud on each drop.
+    eligible = [c for c in cand_names if singles[c] >= MIN_DISTINCT_DIMENSION]
+    for c in cand_names:
+        if singles[c] < MIN_DISTINCT_DIMENSION:
+            logger.info(
+                "hierarchy_column_excluded", column=c, reason="constant", distinct=singles[c]
+            )
+    if len(eligible) < 2:
+        return []
+    elig_pairs = {(a, b): p for (a, b), p in pairs.items() if a in eligible and b in eligible}
+
+    # Collapse 1:1 aliases first, then detect hierarchies on canonical axes.
+    groups, rep = _alias_groups(eligible, elig_pairs)
+
+    # A column is rejected as a DETERMINANT (it may still be a dependent/coarsest
+    # level) when it is too coarse to determine non-trivially (≤2 distinct) or
+    # near-key (each value ~unique → spurious FD). Born-loud on every exclusion.
+    def _bad_determinant(col: str) -> bool:
+        d = singles[col]
+        if d < MIN_DISTINCT_DETERMINANT:
+            logger.info(
+                "hierarchy_determinant_excluded", column=col, reason="too_coarse", distinct=d
+            )
+            return True
+        if n_rows and d >= NEAR_KEY_FRAC * n_rows:
+            logger.info(
+                "hierarchy_determinant_excluded",
+                column=col,
+                reason="near_key",
+                distinct=d,
+                rows=n_rows,
+            )
+            return True
+        return False
+
+    # Directed FD edges on canonical reps: a → b when a determines b (g3 ≈ 0)
+    # AND a is strictly finer (more distinct) — finest → coarsest drill direction.
+    edges: set[tuple[str, str]] = set()
+    for (a, b), pair in elig_pairs.items():
+        ra, rb = rep[a], rep[b]
+        if ra == rb:  # same alias group — not a level relationship
+            continue
+        fwd, bwd = pair.g3(forward=True), pair.g3(forward=False)
+        if fwd <= FD_MAX_G3 and pair.d_a > pair.d_b and not _bad_determinant(a):
+            edges.add((ra, rb))
+        elif bwd <= FD_MAX_G3 and pair.d_b > pair.d_a and not _bad_determinant(b):
+            edges.add((rb, ra))
+
+    reduced = _transitive_reduction(edges)
+
+    # Per-edge g3 (on the original measured columns behind each rep) for scoring.
+    def _edge_g3(a: str, b: str) -> float:
+        pair = pairs.get((a, b)) or pairs.get((b, a))
+        if pair is None:
+            return 0.0
+        return pair.g3(forward=(a, b) in pairs)
+
+    def _member(col: str) -> dict[str, object]:
+        c = by_name[col]
+        return {
+            "column_name": c.column_name,
+            "column_id": c.column_id,
+            "distinct_count": singles[col],
+        }
+
+    needs_conf = n_rows < MIN_SUPPORT_ROWS
+    out: list[dict[str, object]] = []
+
+    for chain in _maximal_chains(reduced):
+        score = max(_edge_g3(chain[k], chain[k + 1]) for k in range(len(chain) - 1))
+        out.append(
+            {
+                "run_id": run_id,
+                "table_id": fact_table_id,
+                "kind": "drilldown",
+                "members": [_member(c) for c in chain],
+                "canonical_label": " → ".join(chain),
+                "signature": f"drilldown:{fact_table_id}:" + "|".join(sorted(chain)),
+                "score": score,
+                "detection_source": "g3",
+                "needs_confirmation": needs_conf,
+            }
+        )
+        logger.info("hierarchy_drilldown", view=view_name, chain=chain, score=round(score, 4))
+
+    for group in groups:
+        gpair = pairs.get((group[0], group[1])) or pairs.get((group[1], group[0]))
+        score = max(gpair.g3(forward=True), gpair.g3(forward=False)) if gpair else 0.0
+        out.append(
+            {
+                "run_id": run_id,
+                "table_id": fact_table_id,
+                "kind": "alias",
+                "members": [_member(c) for c in group],
+                "canonical_label": group[0],
+                "signature": f"alias:{fact_table_id}:" + "|".join(sorted(group)),
+                "score": score,
+                "detection_source": "g3",
+                "needs_confirmation": needs_conf,
+            }
+        )
+        logger.info("hierarchy_alias", view=view_name, group=group, score=round(score, 4))
+
+    return out

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -141,6 +141,24 @@ class SliceContext:
 
 
 @dataclass
+class HierarchyContext:
+    """A discovered drill-down hierarchy or 1:1 alias group (DAT-537).
+
+    The g3 functional-dependency pass surfaces these over a fact's enriched view:
+    a ``drilldown`` carries ordered levels finest → coarsest (``zip → city →
+    state``), an ``alias`` a redundant-axis group collapsed to one canonical label.
+    Exposed for the answer agent / GraphAgent to drill and de-duplicate axes; the
+    prompt CONSUMPTION lands in DAT-538 (this is the expose seam, not the use).
+    """
+
+    kind: str  # 'drilldown' | 'alias'
+    table_name: str
+    members: list[str]  # ordered level names (drilldown) or the group (alias)
+    canonical_label: str
+    needs_confirmation: bool = False
+
+
+@dataclass
 class CycleStageContext:
     """A stage within a business cycle."""
 
@@ -250,6 +268,10 @@ class GraphExecutionContext:
     # Available slice dimensions (from slicing analysis)
     available_slices: list[SliceContext] = field(default_factory=list)
 
+    # Drill-down hierarchies + 1:1 aliases (from the g3 pass, DAT-537). Exposed for
+    # the answer agent to drill / de-duplicate axes; prompt use lands in DAT-538.
+    dimension_hierarchies: list[HierarchyContext] = field(default_factory=list)
+
     # Business cycles (from cycles analysis)
     business_cycles: list[BusinessCycleContext] = field(default_factory=list)
 
@@ -311,6 +333,7 @@ def build_execution_context(
     # Lazy imports to avoid circular dependencies
     from dataraum.analysis.correlation.db_models import DerivedColumn
     from dataraum.analysis.cycles.db_models import DetectedBusinessCycle
+    from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
     from dataraum.analysis.relationships.graph_topology import (
         analyze_graph_topology,
     )
@@ -505,6 +528,33 @@ def build_execution_context(
             )
     # Sort by priority descending
     slice_contexts.sort(key=lambda s: s.priority, reverse=True)
+
+    # 10b. Load dimension hierarchies + aliases (DAT-537) — run-versioned, same
+    # fail-closed discipline as the slices (scoped to the resolved catalog run;
+    # empty when none resolves). The expose seam for the answer agent; the GraphAgent
+    # prompt consumes them in DAT-538.
+    hierarchy_contexts: list[HierarchyContext] = []
+    if run_id is not None:
+        hier_stmt = (
+            select(DimensionHierarchy)
+            .where(
+                DimensionHierarchy.table_id.in_(table_ids),
+                DimensionHierarchy.run_id == run_id,
+            )
+            .order_by(DimensionHierarchy.score)  # strongest (lowest g3) first
+        )
+        for hier in session.execute(hier_stmt).scalars().all():
+            hier_tbl = table_map.get(hier.table_id)
+            if hier_tbl:
+                hierarchy_contexts.append(
+                    HierarchyContext(
+                        kind=hier.kind,
+                        table_name=hier_tbl.table_name,
+                        members=[str(m.get("column_name", "")) for m in hier.members],
+                        canonical_label=hier.canonical_label,
+                        needs_confirmation=hier.needs_confirmation,
+                    )
+                )
 
     # 11. Load derived columns from correlation analysis — run-versioned since
     # DAT-448, same fail-closed discipline as the slices above (scoped to the
@@ -886,6 +936,7 @@ def build_execution_context(
         slice_column=slice_column,
         slice_value=slice_value,
         available_slices=slice_contexts,
+        dimension_hierarchies=hierarchy_contexts,
         business_cycles=business_cycle_contexts,
         cycle_health=cycle_health_report,
         validations=validation_contexts,
@@ -1386,6 +1437,7 @@ __all__ = [
     "TableContext",
     "RelationshipContext",
     "SliceContext",
+    "HierarchyContext",
     "CycleStageContext",
     "EntityFlowContext",
     "BusinessCycleContext",

--- a/packages/engine/src/dataraum/pipeline/phases/dimension_hierarchies_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/dimension_hierarchies_phase.py
@@ -1,0 +1,75 @@
+"""Dimension-hierarchies phase (DAT-537) — g3 FD / drill-down / alias discovery.
+
+Session value phase, deterministic and source-free: over each fact's grain-verified
+enriched view it computes the g3 functional-dependency measure across the catalog's
+grain-safe slice dimensions (DAT-536), surfacing drill-down hierarchies and 1:1
+aliases. No LLM — the judgments it builds on (which columns are slice dimensions,
+the enriched joins) were made upstream.
+
+Runs after ``slicing`` and before ``aggregation_lineage`` (it reads the slice
+catalog; nothing in the value layer depends on it yet — the answer agent consumes
+the hierarchies in DAT-538, the driver tree in DAT-545). It also folds the user's
+durable hierarchy/alias teaches into this run (DAT-537), mirroring the relationship
+overlay materialization minus keeper-lift-up + witness (g3 is deterministic, so
+there is no silent-accept and no detect pool).
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+from sqlalchemy import select
+
+from dataraum.analysis.hierarchies.processor import discover_dimension_hierarchies
+from dataraum.analysis.slicing.db_models import SliceDefinition
+from dataraum.core.logging import get_logger
+from dataraum.pipeline.base import PhaseContext, PhaseResult
+from dataraum.pipeline.phases.base import BasePhase
+from dataraum.pipeline.registry import analysis_phase
+
+logger = get_logger(__name__)
+
+
+@analysis_phase
+class DimensionHierarchiesPhase(BasePhase):
+    """Discover g3 drill-down hierarchies + aliases over the slice substrate."""
+
+    @property
+    def name(self) -> str:
+        return "dimension_hierarchies"
+
+    @property
+    def db_models(self) -> list[ModuleType]:
+        from dataraum.analysis.hierarchies import db_models
+
+        return [db_models]
+
+    def should_skip(self, ctx: PhaseContext) -> str | None:
+        """Skip on genuine preconditions only (a re-run must re-derive, DAT-408)."""
+        if not ctx.table_ids:
+            return "No tables in session scope"
+        has_defs = ctx.session.execute(
+            select(SliceDefinition.slice_id)
+            .where(
+                SliceDefinition.table_id.in_(ctx.table_ids),
+                SliceDefinition.run_id == ctx.run_id,
+            )
+            .limit(1)
+        ).first()
+        if has_defs is None:
+            return "No slice definitions this run (slicing skipped) — no dimensions to relate"
+        return None
+
+    def _run(self, ctx: PhaseContext) -> PhaseResult:
+        run_id = ctx.require_run_id()
+        persisted = discover_dimension_hierarchies(
+            ctx.session,
+            duckdb_conn=ctx.duckdb_conn,
+            table_ids=ctx.table_ids or [],
+            run_id=run_id,
+        )
+        return PhaseResult.success(
+            outputs={"hierarchies": persisted},
+            records_created=persisted,
+            summary=f"{persisted} dimension hierarchy/alias structure(s) discovered",
+        )

--- a/packages/engine/src/dataraum/storage/read_views.py
+++ b/packages/engine/src/dataraum/storage/read_views.py
@@ -75,6 +75,7 @@ _CATALOG_GRAIN: dict[str, str] = {
     "table_entities": "catalog",
     "enriched_views": "catalog",
     "slice_definitions": "catalog",
+    "dimension_hierarchies": "catalog",  # begin_session dimension_hierarchies (DAT-537)
     "derived_columns": "catalog",
     "measure_aggregation_lineage": "catalog",  # begin_session aggregation_lineage (DAT-491)
     "lifecycle_artifacts": "operating_model",

--- a/packages/engine/src/dataraum/worker/activities.py
+++ b/packages/engine/src/dataraum/worker/activities.py
@@ -342,6 +342,20 @@ class PhaseActivities:
             "slicing", payload.run, payload.table_ids, payload.vertical
         )
 
+    @activity.defn(name="dimension_hierarchies")
+    def run_dimension_hierarchies(self, payload: SessionScopedInput) -> PhaseOutcome:
+        """Dimension-hierarchies activity — g3 FD / drill-down / alias discovery (DAT-537).
+
+        Deterministic g3 functional-dependency pass over each fact's grain-verified
+        enriched view across the catalog's grain-safe slice dimensions — NO LLM call.
+        Drill-down chains + 1:1 aliases persist run-versioned (also folding the user's
+        durable hierarchy/alias teaches into this run); consumed by the answer agent
+        (DAT-538) and the driver tree (DAT-545).
+        """
+        return self._run_session_or_raise(
+            "dimension_hierarchies", payload.run, payload.table_ids, payload.vertical
+        )
+
     @activity.defn(name="correlations")
     def run_correlations(self, payload: SessionScopedInput) -> PhaseOutcome:
         """Correlations activity — detect derived columns over the enriched views.

--- a/packages/engine/src/dataraum/worker/main.py
+++ b/packages/engine/src/dataraum/worker/main.py
@@ -78,6 +78,8 @@ def worker_activities(phase_activities: PhaseActivities) -> list[object]:
         phase_activities.run_enriched_views,
         # DAT-403 value layer — runs after enriched_views.
         phase_activities.run_slicing,
+        # DAT-537 g3 drill-down / alias discovery over the slice catalog.
+        phase_activities.run_dimension_hierarchies,
         phase_activities.run_correlations,
         # DAT-408/409 begin_session: materialize durable overlays →
         # terminal detect → silent-accept keepers → promote.

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -471,6 +471,10 @@ def _retry_for(phase: str) -> RetryPolicy:
 # by the session's table set (``scoped``), source-free like the spine above.
 _SESSION_VALUE_PHASE_ORDER = (
     "slicing",
+    # DAT-537: deterministic g3 FD pass over the slice catalog — drill-down
+    # hierarchies + 1:1 aliases (no LLM). Reads slicing's catalog; nothing in the
+    # value layer depends on it yet (answer agent consumes it in DAT-538).
+    "dimension_hierarchies",
     # DAT-491/536: aggregates each fact's enriched view inline (GROUP BY dim, period)
     # and reconciles the per-period sums across facts sharing a catalog dimension.
     "aggregation_lineage",

--- a/packages/engine/tests/integration/worker/test_begin_session_progress_query.py
+++ b/packages/engine/tests/integration/worker/test_begin_session_progress_query.py
@@ -61,6 +61,7 @@ _PHASE_ORDER = [
     "session_materialize_overlays",
     "enriched_views",
     "slicing",
+    "dimension_hierarchies",
     "aggregation_lineage",
     "correlations",
     "session_detect",

--- a/packages/engine/tests/unit/analysis/hierarchies/conftest.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/conftest.py
@@ -1,0 +1,132 @@
+"""Shared fixtures for the hierarchy-discovery tests (DAT-537).
+
+Metadata lives in in-memory SQLite (FKs off, the resolve-test pattern); the
+queryable enriched view is an in-memory DuckDB table seeded by ``seed_sales`` so a
+known ``zip → city → state`` chain, two 1:1 aliases, a constant, and a near-key id
+are present for both the g3 and the teach tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from uuid import uuid4
+
+import duckdb
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from dataraum.analysis.slicing.db_models import SliceDefinition
+from dataraum.analysis.views.db_models import EnrichedView
+from dataraum.storage import Column, Table, init_database
+
+RUN = "session-run-1"
+VIEW = "sales_enriched"
+
+# zip → (city, state): multiple zips per city, multiple cities per state — a real
+# FD chain (not a 1:1 bijection, which would read as an alias instead).
+ZIP_MAP = {
+    "07001": ("newark", "nj"),
+    "07002": ("newark", "nj"),
+    "07003": ("jersey", "nj"),
+    "10001": ("nyc", "ny"),
+    "10002": ("nyc", "ny"),
+    "10003": ("albany", "ny"),
+}
+STATE_NAME = {"nj": "New Jersey", "ny": "New York"}
+DIMS = ["zip", "zip_code", "city", "state", "state_name", "country", "order_id"]
+
+
+@pytest.fixture
+def real_session() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _pragma(dbapi_conn, _record):  # noqa: ANN001, ANN202
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=OFF")
+        cur.close()
+
+    init_database(engine)
+    factory = sessionmaker(bind=engine)
+    try:
+        with factory() as s:
+            yield s
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def duck() -> Iterator[duckdb.DuckDBPyConnection]:
+    conn = duckdb.connect(":memory:")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def seed_sales(session: Session, duck: duckdb.DuckDBPyConnection, *, rows_per_zip: int = 20) -> str:
+    """Seed the fact, its grain-verified enriched view, the catalog, and DuckDB rows.
+
+    ``zip_code`` is a 1:1 copy of ``zip`` and ``state_name`` of ``state`` (alias
+    groups); ``country`` is constant; ``order_id`` is unique (near-key). Returns the
+    fact ``table_id``.
+    """
+    table = Table(
+        table_id=str(uuid4()),
+        source_id="src-1",
+        table_name="sales",
+        layer="typed",
+        duckdb_path="sales",
+    )
+    session.add(table)
+    for pos, name in enumerate(DIMS):
+        column = Column(
+            column_id=str(uuid4()),
+            table_id=table.table_id,
+            column_name=name,
+            column_position=pos,
+            resolved_type="VARCHAR",
+        )
+        session.add(column)
+        session.add(
+            SliceDefinition(
+                run_id=RUN,
+                table_id=table.table_id,
+                column_id=column.column_id,
+                column_name=name,
+                slice_priority=1,
+                slice_type="categorical",
+                grain_safe=True,
+                detection_source="llm",
+            )
+        )
+    session.add(
+        EnrichedView(
+            run_id=RUN, fact_table_id=table.table_id, view_name=VIEW, is_grain_verified=True
+        )
+    )
+    session.flush()
+
+    duck.execute(
+        f"CREATE TABLE {VIEW} ("
+        "zip VARCHAR, zip_code VARCHAR, city VARCHAR, state VARCHAR, "
+        "state_name VARCHAR, country VARCHAR, order_id BIGINT)"
+    )
+    values: list[str] = []
+    oid = 0
+    for _ in range(rows_per_zip):
+        for zip_code, (city, state) in ZIP_MAP.items():
+            oid += 1
+            values.append(
+                f"('{zip_code}', '{zip_code}', '{city}', '{state}', "
+                f"'{STATE_NAME[state]}', 'us', {oid})"
+            )
+    duck.execute(f"INSERT INTO {VIEW} VALUES {', '.join(values)}")  # noqa: S608 — test data
+    return table.table_id

--- a/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
@@ -1,0 +1,246 @@
+"""g3 dimension-hierarchy / alias discovery — DAT-537.
+
+Deterministic FD pass over a fact's grain-verified enriched view. The fixture
+seeds metadata in in-memory SQLite (FKs off, the resolve-test pattern) and the
+queryable enriched view as an in-memory DuckDB table whose rows encode a known
+``zip → city → state`` chain, two 1:1 aliases, a degenerate constant, and a
+near-key id — so the verdicts (chain, alias collapse, guards) are checkable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from uuid import uuid4
+
+import duckdb
+import pytest
+from sqlalchemy import create_engine, event, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
+from dataraum.analysis.hierarchies.processor import discover_dimension_hierarchies
+from dataraum.analysis.slicing.db_models import SliceDefinition
+from dataraum.analysis.views.db_models import EnrichedView
+from dataraum.storage import Column, Table, init_database
+
+_RUN = "session-run-1"
+_VIEW = "sales_enriched"
+
+# zip → (city, state): multiple zips per city, multiple cities per state — a real
+# FD chain (not a 1:1 bijection, which would read as an alias instead).
+_ZIP_MAP = {
+    "07001": ("newark", "nj"),
+    "07002": ("newark", "nj"),
+    "07003": ("jersey", "nj"),
+    "10001": ("nyc", "ny"),
+    "10002": ("nyc", "ny"),
+    "10003": ("albany", "ny"),
+}
+_STATE_NAME = {"nj": "New Jersey", "ny": "New York"}
+# The catalog's grain-safe slice dimensions on the enriched view.
+_DIMS = ["zip", "zip_code", "city", "state", "state_name", "country", "order_id"]
+
+
+@pytest.fixture
+def real_session() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _pragma(dbapi_conn, _record):  # noqa: ANN001, ANN202
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=OFF")
+        cur.close()
+
+    init_database(engine)
+    factory = sessionmaker(bind=engine)
+    try:
+        with factory() as s:
+            yield s
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def duck() -> Iterator[duckdb.DuckDBPyConnection]:
+    conn = duckdb.connect(":memory:")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _seed(session: Session, duck: duckdb.DuckDBPyConnection, *, rows_per_zip: int = 20) -> str:
+    """Seed the fact, its grain-verified enriched view, the catalog, and DuckDB rows.
+
+    ``zip_code`` is a 1:1 copy of ``zip`` and ``state_name`` of ``state`` (alias
+    groups); ``country`` is constant (degenerate); ``order_id`` is unique (near-key).
+    Returns the fact ``table_id``.
+    """
+    table = Table(
+        table_id=str(uuid4()),
+        source_id="src-1",
+        table_name="sales",
+        layer="typed",
+        duckdb_path="sales",
+    )
+    session.add(table)
+    col_ids: dict[str, str] = {}
+    for pos, name in enumerate(_DIMS):
+        column = Column(
+            column_id=str(uuid4()),
+            table_id=table.table_id,
+            column_name=name,
+            column_position=pos,
+            resolved_type="VARCHAR",
+        )
+        session.add(column)
+        col_ids[name] = column.column_id
+        session.add(
+            SliceDefinition(
+                run_id=_RUN,
+                table_id=table.table_id,
+                column_id=column.column_id,
+                column_name=name,
+                slice_priority=1,
+                slice_type="categorical",
+                grain_safe=True,
+                detection_source="llm",
+            )
+        )
+    session.add(
+        EnrichedView(
+            run_id=_RUN,
+            fact_table_id=table.table_id,
+            view_name=_VIEW,
+            is_grain_verified=True,
+        )
+    )
+    session.flush()
+
+    duck.execute(
+        f"CREATE TABLE {_VIEW} ("
+        "zip VARCHAR, zip_code VARCHAR, city VARCHAR, state VARCHAR, "
+        "state_name VARCHAR, country VARCHAR, order_id BIGINT)"
+    )
+    values: list[str] = []
+    oid = 0
+    for _ in range(rows_per_zip):
+        for zip_code, (city, state) in _ZIP_MAP.items():
+            oid += 1
+            values.append(
+                f"('{zip_code}', '{zip_code}', '{city}', '{state}', "
+                f"'{_STATE_NAME[state]}', 'us', {oid})"
+            )
+    duck.execute(f"INSERT INTO {_VIEW} VALUES {', '.join(values)}")  # noqa: S608 — test data
+    return table.table_id
+
+
+def _rows(session: Session, table_id: str, kind: str) -> list[DimensionHierarchy]:
+    return list(
+        session.execute(
+            select(DimensionHierarchy).where(
+                DimensionHierarchy.table_id == table_id,
+                DimensionHierarchy.kind == kind,
+            )
+        ).scalars()
+    )
+
+
+def _members(row: DimensionHierarchy) -> list[str]:
+    return [m["column_name"] for m in row.members]
+
+
+class TestDiscoverDimensionHierarchies:
+    def test_drilldown_chain_finest_to_coarsest(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed(real_session, duck)
+        assert (
+            discover_dimension_hierarchies(
+                real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN
+            )
+            > 0
+        )
+        drills = _rows(real_session, tid, "drilldown")
+        assert len(drills) == 1
+        row = drills[0]
+        # Aliases collapse to canonical (zip < zip_code, state < state_name); the
+        # chain is finest → coarsest with the transitive zip → state edge reduced out.
+        assert _members(row) == ["zip", "city", "state"]
+        assert row.canonical_label == "zip → city → state"
+        assert row.score <= 0.01
+        assert row.run_id == _RUN
+        assert row.needs_confirmation is False
+
+    def test_one_to_one_aliases_collapse(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed(real_session, duck)
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN)
+        aliases = {tuple(_members(r)): r for r in _rows(real_session, tid, "alias")}
+        assert ("zip", "zip_code") in aliases
+        assert ("state", "state_name") in aliases
+        # Canonical = lexicographically first member.
+        assert aliases[("zip", "zip_code")].canonical_label == "zip"
+        assert aliases[("state", "state_name")].canonical_label == "state"
+
+    def test_degenerate_and_near_key_excluded(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed(real_session, duck)
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN)
+        all_members = {
+            m
+            for r in _rows(real_session, tid, "drilldown") + _rows(real_session, tid, "alias")
+            for m in _members(r)
+        }
+        # 'country' is a constant (degenerate, dropped both roles); 'order_id' is
+        # unique (near-key, never a determinant) — neither appears in any structure.
+        assert "country" not in all_members
+        assert "order_id" not in all_members
+
+    def test_low_support_flags_needs_confirmation(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # Below MIN_SUPPORT_ROWS (100): the chain is found but flagged, not asserted.
+        tid = _seed(real_session, duck, rows_per_zip=2)  # 12 rows
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN)
+        drills = _rows(real_session, tid, "drilldown")
+        assert drills and all(r.needs_confirmation for r in drills)
+
+    def test_rerun_is_idempotent(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """Success-redelivery (same run_id) converges by upsert on (signature, run_id)."""
+        tid = _seed(real_session, duck)
+        first = discover_dimension_hierarchies(
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN
+        )
+        real_session.commit()
+        second = discover_dimension_hierarchies(
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN
+        )
+        real_session.commit()
+        assert first == second
+        rows = real_session.execute(select(DimensionHierarchy)).scalars().all()
+        assert len(rows) == first
+
+    def test_no_enriched_view_no_rows(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # Without a grain-verified enriched view there is no queryable substrate.
+        tid = _seed(real_session, duck)
+        real_session.execute(EnrichedView.__table__.update().values(is_grain_verified=False))
+        real_session.flush()
+        assert (
+            discover_dimension_hierarchies(
+                real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN
+            )
+            == 0
+        )

--- a/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
@@ -1,144 +1,22 @@
 """g3 dimension-hierarchy / alias discovery — DAT-537.
 
-Deterministic FD pass over a fact's grain-verified enriched view. The fixture
-seeds metadata in in-memory SQLite (FKs off, the resolve-test pattern) and the
-queryable enriched view as an in-memory DuckDB table whose rows encode a known
-``zip → city → state`` chain, two 1:1 aliases, a degenerate constant, and a
-near-key id — so the verdicts (chain, alias collapse, guards) are checkable.
+Deterministic FD pass over a fact's grain-verified enriched view. The shared
+``seed_sales`` fixture (conftest) encodes a known ``zip → city → state`` chain, two
+1:1 aliases, a constant, and a near-key id, so the verdicts (chain, alias collapse,
+guards) are checkable.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from uuid import uuid4
-
 import duckdb
-import pytest
-from sqlalchemy import create_engine, event, select
-from sqlalchemy.orm import Session, sessionmaker
-from sqlalchemy.pool import StaticPool
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
 from dataraum.analysis.hierarchies.processor import discover_dimension_hierarchies
-from dataraum.analysis.slicing.db_models import SliceDefinition
 from dataraum.analysis.views.db_models import EnrichedView
-from dataraum.storage import Column, Table, init_database
 
-_RUN = "session-run-1"
-_VIEW = "sales_enriched"
-
-# zip → (city, state): multiple zips per city, multiple cities per state — a real
-# FD chain (not a 1:1 bijection, which would read as an alias instead).
-_ZIP_MAP = {
-    "07001": ("newark", "nj"),
-    "07002": ("newark", "nj"),
-    "07003": ("jersey", "nj"),
-    "10001": ("nyc", "ny"),
-    "10002": ("nyc", "ny"),
-    "10003": ("albany", "ny"),
-}
-_STATE_NAME = {"nj": "New Jersey", "ny": "New York"}
-# The catalog's grain-safe slice dimensions on the enriched view.
-_DIMS = ["zip", "zip_code", "city", "state", "state_name", "country", "order_id"]
-
-
-@pytest.fixture
-def real_session() -> Iterator[Session]:
-    engine = create_engine(
-        "sqlite:///:memory:",
-        echo=False,
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-
-    @event.listens_for(engine, "connect")
-    def _pragma(dbapi_conn, _record):  # noqa: ANN001, ANN202
-        cur = dbapi_conn.cursor()
-        cur.execute("PRAGMA foreign_keys=OFF")
-        cur.close()
-
-    init_database(engine)
-    factory = sessionmaker(bind=engine)
-    try:
-        with factory() as s:
-            yield s
-    finally:
-        engine.dispose()
-
-
-@pytest.fixture
-def duck() -> Iterator[duckdb.DuckDBPyConnection]:
-    conn = duckdb.connect(":memory:")
-    try:
-        yield conn
-    finally:
-        conn.close()
-
-
-def _seed(session: Session, duck: duckdb.DuckDBPyConnection, *, rows_per_zip: int = 20) -> str:
-    """Seed the fact, its grain-verified enriched view, the catalog, and DuckDB rows.
-
-    ``zip_code`` is a 1:1 copy of ``zip`` and ``state_name`` of ``state`` (alias
-    groups); ``country`` is constant (degenerate); ``order_id`` is unique (near-key).
-    Returns the fact ``table_id``.
-    """
-    table = Table(
-        table_id=str(uuid4()),
-        source_id="src-1",
-        table_name="sales",
-        layer="typed",
-        duckdb_path="sales",
-    )
-    session.add(table)
-    col_ids: dict[str, str] = {}
-    for pos, name in enumerate(_DIMS):
-        column = Column(
-            column_id=str(uuid4()),
-            table_id=table.table_id,
-            column_name=name,
-            column_position=pos,
-            resolved_type="VARCHAR",
-        )
-        session.add(column)
-        col_ids[name] = column.column_id
-        session.add(
-            SliceDefinition(
-                run_id=_RUN,
-                table_id=table.table_id,
-                column_id=column.column_id,
-                column_name=name,
-                slice_priority=1,
-                slice_type="categorical",
-                grain_safe=True,
-                detection_source="llm",
-            )
-        )
-    session.add(
-        EnrichedView(
-            run_id=_RUN,
-            fact_table_id=table.table_id,
-            view_name=_VIEW,
-            is_grain_verified=True,
-        )
-    )
-    session.flush()
-
-    duck.execute(
-        f"CREATE TABLE {_VIEW} ("
-        "zip VARCHAR, zip_code VARCHAR, city VARCHAR, state VARCHAR, "
-        "state_name VARCHAR, country VARCHAR, order_id BIGINT)"
-    )
-    values: list[str] = []
-    oid = 0
-    for _ in range(rows_per_zip):
-        for zip_code, (city, state) in _ZIP_MAP.items():
-            oid += 1
-            values.append(
-                f"('{zip_code}', '{zip_code}', '{city}', '{state}', "
-                f"'{_STATE_NAME[state]}', 'us', {oid})"
-            )
-    duck.execute(f"INSERT INTO {_VIEW} VALUES {', '.join(values)}")  # noqa: S608 — test data
-    return table.table_id
+from .conftest import RUN, seed_sales
 
 
 def _rows(session: Session, table_id: str, kind: str) -> list[DimensionHierarchy]:
@@ -160,10 +38,10 @@ class TestDiscoverDimensionHierarchies:
     def test_drilldown_chain_finest_to_coarsest(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
-        tid = _seed(real_session, duck)
+        tid = seed_sales(real_session, duck)
         assert (
             discover_dimension_hierarchies(
-                real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN
+                real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN
             )
             > 0
         )
@@ -175,14 +53,14 @@ class TestDiscoverDimensionHierarchies:
         assert _members(row) == ["zip", "city", "state"]
         assert row.canonical_label == "zip → city → state"
         assert row.score <= 0.01
-        assert row.run_id == _RUN
+        assert row.run_id == RUN
         assert row.needs_confirmation is False
 
     def test_one_to_one_aliases_collapse(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
-        tid = _seed(real_session, duck)
-        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN)
+        tid = seed_sales(real_session, duck)
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
         aliases = {tuple(_members(r)): r for r in _rows(real_session, tid, "alias")}
         assert ("zip", "zip_code") in aliases
         assert ("state", "state_name") in aliases
@@ -193,15 +71,15 @@ class TestDiscoverDimensionHierarchies:
     def test_degenerate_and_near_key_excluded(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
-        tid = _seed(real_session, duck)
-        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN)
+        tid = seed_sales(real_session, duck)
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
         all_members = {
             m
             for r in _rows(real_session, tid, "drilldown") + _rows(real_session, tid, "alias")
             for m in _members(r)
         }
-        # 'country' is a constant (degenerate, dropped both roles); 'order_id' is
-        # unique (near-key, never a determinant) — neither appears in any structure.
+        # 'country' is a constant (dropped both roles); 'order_id' is unique (near-key,
+        # never a determinant) — neither appears in any structure.
         assert "country" not in all_members
         assert "order_id" not in all_members
 
@@ -209,8 +87,8 @@ class TestDiscoverDimensionHierarchies:
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
         # Below MIN_SUPPORT_ROWS (100): the chain is found but flagged, not asserted.
-        tid = _seed(real_session, duck, rows_per_zip=2)  # 12 rows
-        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN)
+        tid = seed_sales(real_session, duck, rows_per_zip=2)  # 12 rows
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
         drills = _rows(real_session, tid, "drilldown")
         assert drills and all(r.needs_confirmation for r in drills)
 
@@ -218,13 +96,13 @@ class TestDiscoverDimensionHierarchies:
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
         """Success-redelivery (same run_id) converges by upsert on (signature, run_id)."""
-        tid = _seed(real_session, duck)
+        tid = seed_sales(real_session, duck)
         first = discover_dimension_hierarchies(
-            real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN
         )
         real_session.commit()
         second = discover_dimension_hierarchies(
-            real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN
         )
         real_session.commit()
         assert first == second
@@ -235,12 +113,12 @@ class TestDiscoverDimensionHierarchies:
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
         # Without a grain-verified enriched view there is no queryable substrate.
-        tid = _seed(real_session, duck)
+        tid = seed_sales(real_session, duck)
         real_session.execute(EnrichedView.__table__.update().values(is_grain_verified=False))
         real_session.flush()
         assert (
             discover_dimension_hierarchies(
-                real_session, duckdb_conn=duck, table_ids=[tid], run_id=_RUN
+                real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN
             )
             == 0
         )

--- a/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
@@ -122,3 +122,35 @@ class TestDiscoverDimensionHierarchies:
             )
             == 0
         )
+
+
+class TestDimensionHierarchiesPhaseSkip:
+    """The phase's should_skip preconditions (deterministic re-run discipline)."""
+
+    def _ctx(self, session: Session, duck: duckdb.DuckDBPyConnection, table_ids: list[str]):
+        from dataraum.pipeline.base import PhaseContext
+
+        return PhaseContext(
+            session=session,
+            duckdb_conn=duck,
+            table_ids=table_ids,
+            run_id=RUN,
+            config={},
+        )
+
+    def test_skips_when_no_slice_definitions(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        from dataraum.pipeline.phases.dimension_hierarchies_phase import DimensionHierarchiesPhase
+
+        # A table id with no SliceDefinition rows for this run → nothing to relate.
+        reason = DimensionHierarchiesPhase().should_skip(self._ctx(real_session, duck, ["nope"]))
+        assert reason is not None and "slice definitions" in reason
+
+    def test_does_not_skip_with_catalog(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        from dataraum.pipeline.phases.dimension_hierarchies_phase import DimensionHierarchiesPhase
+
+        tid = seed_sales(real_session, duck)
+        assert DimensionHierarchiesPhase().should_skip(self._ctx(real_session, duck, [tid])) is None

--- a/packages/engine/tests/unit/analysis/hierarchies/test_teach.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_teach.py
@@ -1,0 +1,94 @@
+"""Hierarchy/alias teach materialization — DAT-537.
+
+The teach mirrors the relationship-overlay pattern minus keeper-lift-up + witness
+(g3 is deterministic). A ``ConfigOverlay(type='hierarchy')`` reject suppresses a
+g3 structure; add asserts a ``manual`` drilldown; alias asserts a ``manual`` alias.
+These run inside ``discover_dimension_hierarchies`` against the shared fixture.
+"""
+
+from __future__ import annotations
+
+import duckdb
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
+from dataraum.analysis.hierarchies.processor import discover_dimension_hierarchies
+from dataraum.storage import ConfigOverlay
+
+from .conftest import RUN, seed_sales
+
+
+def _teach(session: Session, action: str, table_id: str, members: list[str]) -> None:
+    session.add(
+        ConfigOverlay(
+            type="hierarchy",
+            payload={"action": action, "table_id": table_id, "members": members},
+        )
+    )
+    session.flush()
+
+
+def _discover(session: Session, duck: duckdb.DuckDBPyConnection, tid: str) -> int:
+    return discover_dimension_hierarchies(session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+
+
+def _by_members(session: Session, kind: str) -> dict[tuple[str, ...], DimensionHierarchy]:
+    rows = session.execute(
+        select(DimensionHierarchy).where(DimensionHierarchy.kind == kind)
+    ).scalars()
+    return {tuple(m["column_name"] for m in r.members): r for r in rows}
+
+
+class TestHierarchyTeach:
+    def test_reject_suppresses_g3_drilldown(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = seed_sales(real_session, duck)
+        # The g3 pass finds zip → city → state; rejecting it (by member set, any
+        # order) drops the structure this run.
+        _teach(real_session, "reject", tid, ["state", "zip", "city"])
+        _discover(real_session, duck, tid)
+        assert ("zip", "city", "state") not in _by_members(real_session, "drilldown")
+
+    def test_add_materializes_manual_drilldown(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = seed_sales(real_session, duck)
+        # Assert a chain the g3 pass would not surface on its own (city alone → state
+        # is found, but an explicit add of a 2-level chain lands as a manual row).
+        _teach(real_session, "add", tid, ["city", "state"])
+        _discover(real_session, duck, tid)
+        row = _by_members(real_session, "drilldown")[("city", "state")]
+        assert row.detection_source == "manual"
+        assert row.needs_confirmation is False
+        assert row.canonical_label == "city → state"
+        # The catalog resolves the member column ids (provenance), not left blank.
+        assert all(m["column_id"] for m in row.members)
+
+    def test_alias_materializes_manual_alias(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = seed_sales(real_session, duck)
+        _teach(real_session, "alias", tid, ["city", "state_name"])
+        _discover(real_session, duck, tid)
+        row = _by_members(real_session, "alias")[("city", "state_name")]
+        assert row.detection_source == "manual"
+        assert row.canonical_label == "city"
+
+    def test_superseded_teach_is_ignored(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        from datetime import UTC, datetime
+
+        tid = seed_sales(real_session, duck)
+        overlay = ConfigOverlay(
+            type="hierarchy",
+            payload={"action": "reject", "table_id": tid, "members": ["zip", "city", "state"]},
+            superseded_at=datetime.now(UTC),
+        )
+        real_session.add(overlay)
+        real_session.flush()
+        _discover(real_session, duck, tid)
+        # The reject was undone (superseded) → the g3 chain survives.
+        assert ("zip", "city", "state") in _by_members(real_session, "drilldown")

--- a/packages/engine/tests/unit/graphs/test_context_builder.py
+++ b/packages/engine/tests/unit/graphs/test_context_builder.py
@@ -386,3 +386,54 @@ class TestBuilderOmRunIdOverride:
         ctx_override = build_execution_context(session, [table_id], om_run_id="run-current")
         assert len(ctx_override.business_cycles) == 1
         assert ctx_override.business_cycles[0].cycle_name == "Order to Cash"
+
+
+class TestBuilderExtractsDimensionHierarchies:
+    """Verify the builder exposes DimensionHierarchy rows (DAT-537), run-scoped.
+
+    Run-versioned, sealed at the begin_session catalog head: the builder reads only
+    the promoted run, exactly like the slice read — an unpromoted run's rows must
+    not bleed in (fail-closed).
+    """
+
+    def test_hierarchies_exposed_at_promoted_head(self, session: Session) -> None:
+        from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
+        from dataraum.storage.snapshot_head import (
+            MetadataSnapshotHead,
+            catalog_head_target,
+        )
+
+        _source_id, table_id, column_id = _insert_source_table_column(session)
+        session.add(
+            DimensionHierarchy(
+                run_id="run-1",
+                table_id=table_id,
+                kind="drilldown",
+                members=[
+                    {"column_name": "zip", "column_id": column_id, "distinct_count": 6},
+                    {"column_name": "city", "column_id": "", "distinct_count": 4},
+                    {"column_name": "state", "column_id": "", "distinct_count": 2},
+                ],
+                canonical_label="zip → city → state",
+                signature="drilldown:t:city|state|zip",
+                score=0.0,
+            )
+        )
+        head = MetadataSnapshotHead(
+            head_id=_id(), target=catalog_head_target(), stage="catalog", run_id="run-1"
+        )
+        session.add(head)
+        session.flush()
+
+        ctx = build_execution_context(session, [table_id])
+        assert len(ctx.dimension_hierarchies) == 1
+        hier = ctx.dimension_hierarchies[0]
+        assert hier.kind == "drilldown"
+        assert hier.members == ["zip", "city", "state"]
+        assert hier.canonical_label == "zip → city → state"
+        assert hier.table_name == "invoices"
+
+        # Flip the head to a run with no hierarchy rows → fail-closed empty.
+        head.run_id = "run-2"
+        session.flush()
+        assert build_execution_context(session, [table_id]).dimension_hierarchies == []

--- a/packages/engine/tests/unit/worker/test_session_value_phases.py
+++ b/packages/engine/tests/unit/worker/test_session_value_phases.py
@@ -23,6 +23,9 @@ from dataraum.worker.workflows import _SESSION_VALUE_PHASE_ORDER
 def test_value_phase_order_is_the_agreed_chain() -> None:
     assert _SESSION_VALUE_PHASE_ORDER == (
         "slicing",
+        # DAT-537: deterministic g3 FD pass over slicing's catalog — drill-down
+        # hierarchies + aliases. Reads slicing; consumed by the answer agent (DAT-538).
+        "dimension_hierarchies",
         # DAT-491/536: lineage aggregates each fact's enriched view inline and
         # reconciles the per-period sums — no slice-materialization phases precede it.
         "aggregation_lineage",


### PR DESCRIPTION
## DAT-537 — deterministic g3 functional-dependency / hierarchy pass

DAT-514 P2. A new begin_session value-layer phase that discovers **drill-down hierarchies** (`zip → city → state`) and **1:1 alias groups** among the catalog's grain-safe slice dimensions (DAT-536), per fact's grain-verified enriched view — deterministic, **no LLM**. Built on DAT-536 (PR #315); on the DAT-545 driver-tree critical path (alias collapse = the de-confounding input).

### What's here (3 phases)
- **P1 — g3 core + storage:** `analysis/hierarchies/{db_models,processor}.py`. `g3(A→B)=1−COUNT(DISTINCT A)/COUNT(DISTINCT(A,B))` in one DuckDB scan per view (single + pairwise distinct counts via the `(a,b)` row literal); direction by `|A|>|B|`; transitive reduction → chains; union-find aliases. Run-versioned `DimensionHierarchy` table (form-a `(signature, run_id)` UNIQUE + upsert), sealed under the begin_session `(catalog,"catalog")` head via `read_views._CATALOG_GRAIN`. New `dimension_hierarchies` phase wired `slicing → dimension_hierarchies → aggregation_lineage → correlations`; worker activity + `pipeline.yaml`. Schema + cockpit drizzle mirror regenerated.
- **P2 — teach:** `analysis/hierarchies/overlay.py` + in-phase materialize of `add`/`reject`/`alias`, mirroring the relationship-overlay pattern **minus keeper-lift-up + witness pool** (g3 is deterministic). Cockpit `hierarchy` teach type.
- **P3 — expose:** `HierarchyContext` + `GraphExecutionContext.dimension_hierarchies`, populated run-scoped + fail-closed. **GraphAgent prompt untouched — consumption is DAT-538.**

### Candidate set: no arbitrary cap
The candidate-dim priority cap was deliberately **dropped** — it would be arbitrary across runs (unstable FD edges) and lossy for DAT-545's alias de-confounding. Candidate set = all grain-safe catalog dims; only **data-grounded guards** prune (constant dropped both roles; ≤2-distinct / near-key rejected as determinant; low-support → `needs_confirmation`), every exclusion logged born-loud.

### Tests / gates
- 11 new engine unit tests (g3 chain, alias collapse, guards, idempotent re-run, teach add/reject/alias/supersede, phase skip) + context-builder run-scoped/fail-closed test + cockpit hierarchy validation tests. Full engine unit suite **1534 passing**; ruff + mypy clean; schema-drift clean; cockpit teach tests + tsc pass.
- Reviewers: senior **APPROVE**, spec-compliance **PASS** — all should-fix improvements applied.

### Cross-repo
Handoff entry added: new phase/table, deterministic (no detectors → no measurement change); new calibration surface = hierarchy/alias correctness + guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)