### PR TITLE
DAT-551 (slice 1): add_source + replay under the journey + unit teach type

### DIFF
--- a/packages/cockpit/src/temporal/journey-trigger.ts
+++ b/packages/cockpit/src/temporal/journey-trigger.ts
@@ -21,8 +21,10 @@ import {
 	journeyWorkflowId,
 	PAUSE_AUTO_MODE_SIGNAL,
 	RESUME_AUTO_MODE_SIGNAL,
+	RUN_ADD_SOURCE_SIGNAL,
 	RUN_BEGIN_SESSION_SIGNAL,
 	RUN_OPERATING_MODEL_SIGNAL,
+	type RunAddSource,
 	type RunBeginSession,
 	type RunOperatingModel,
 	VERTICAL_ESTABLISHED_SIGNAL,
@@ -79,6 +81,17 @@ export function signalVerticalEstablished(
 	return signalJourney(workspaceId, VERTICAL_ESTABLISHED_SIGNAL, [
 		{ vertical } satisfies VerticalEstablished,
 	]);
+}
+
+/** Signal `runAddSource` — the journey runs the engine add_source stage as a
+ * cross-language child (DAT-551). `select` (kind onboarding) and `replay` (kind
+ * replay) both route here. The tool passes the derived ids/queue + sources +
+ * conversationId so the journey (no request ALS) records + narrates correctly. */
+export function signalRunAddSource(
+	workspaceId: string,
+	req: RunAddSource,
+): Promise<string> {
+	return signalJourney(workspaceId, RUN_ADD_SOURCE_SIGNAL, [req]);
 }
 
 /** Signal `runBeginSession` — the journey runs the engine begin_session stage as

--- a/packages/cockpit/src/temporal/trigger-add-source.test.ts
+++ b/packages/cockpit/src/temporal/trigger-add-source.test.ts
@@ -1,23 +1,15 @@
-// Unit tests for the add_source TRIGGER (DAT-352; folded into the select call by
-// DAT-436 — `select.server` is the only caller. DAT-506: no engine seed; the run
-// is recorded in cockpit_db BEFORE the workflow starts, and the vertical is the
-// workspace property from the registry, not a trigger input).
-//
-// Mocked seams (units project — no DB, no Temporal): the cockpit registry (the
-// workspace + its vertical), the cockpit runs writer (recordRun/attachRunId), and
-// `@temporalio/client` (records the start call + returns a handle). We assert:
-// (1) recordRun runs BEFORE the workflow starts (an unrecorded run is orphaned),
-// (2) the start uses the right workflow id / queue / args with the workspace
-// vertical on the INPUT (non-blocking), and (3) it throws when Temporal is
-// unconfigured, recording nothing.
+// Unit tests for the add_source TRIGGER (DAT-352; one-call select DAT-436; routed
+// through the journey in DAT-551). The trigger no longer starts the workflow
+// directly — it signals the per-workspace JourneyWorkflow (`runAddSource`), which
+// records the run + starts the engine child. So the unit asserts the SIGNAL
+// payload, not a workflow.start. Mocked seams: #/config, the registry (workspace +
+// vertical + queue), the journey trigger (signalRunAddSource), and the ALS
+// conversation context.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const WS = "00000000-0000-0000-0000-000000000001";
 
-// Mutable config the tests flip to exercise the unconfigured guard. The default
-// config is inlined here (NOT via `WS`): `vi.hoisted` runs before module-level
-// `const WS`, so referencing it would hit the TDZ.
 const h = vi.hoisted(() => ({
 	config: {
 		dataraumWorkspaceId: "00000000-0000-0000-0000-000000000001",
@@ -25,54 +17,38 @@ const h = vi.hoisted(() => ({
 		temporalNamespace: "default",
 	} as Record<string, unknown>,
 	vertical: "_adhoc" as string,
-	// Records the order of side effects so we can assert record-before-start.
-	calls: [] as string[],
-	startArgs: null as unknown,
-	recordRun: vi.fn(async () => {
-		h.calls.push("record");
-	}),
-	attachRunId: vi.fn(async () => {}),
+	conversationId: "conv-1" as string | null,
+	signalled: null as {
+		workspaceId: string;
+		req: Record<string, unknown>;
+	} | null,
+	signalRunAddSource: vi.fn(
+		async (workspaceId: string, req: Record<string, unknown>) => {
+			h.signalled = { workspaceId, req };
+			return req.workflowId as string;
+		},
+	),
 }));
 
-// A live getter, not a snapshot: the unconfigured-guard test reassigns
-// `h.config`, so the module's `config` import must read the CURRENT object.
+// Live getter (the unconfigured-guard test reassigns h.config).
 vi.mock("#/config", () => ({
 	get config() {
 		return h.config;
 	},
 }));
-
-// cockpit_db control plane (DAT-461/505/506): workspace + its vertical via the
-// registry, run recorded BEFORE start — both mocked at the seam (no DB in units).
 vi.mock("#/db/cockpit/registry", () => ({
 	resolveActiveWorkspaceRow: vi.fn(async () => ({
 		id: h.config.dataraumWorkspaceId,
-		// Per-workspace queue (DAT-505) — the driver routes the workflow here.
+		// Per-workspace engine queue (DAT-505) — the journey runs the child here.
 		taskQueue: `engine-${h.config.dataraumWorkspaceId}`,
 		vertical: h.vertical,
 	})),
 }));
-vi.mock("#/db/cockpit/runs", () => ({
-	recordRun: h.recordRun,
-	attachRunId: h.attachRunId,
+vi.mock("#/temporal/journey-trigger", () => ({
+	signalRunAddSource: h.signalRunAddSource,
 }));
-
-// Temporal client: record the start args (after the record) + hand back a run id.
-const startMock = vi.fn(async (_name: string, opts: unknown) => {
-	h.calls.push("start");
-	h.startArgs = opts;
-	return { firstExecutionRunId: "run-abc" };
-});
-const closeMock = vi.fn(async () => {});
-vi.mock("@temporalio/client", () => ({
-	Connection: { connect: vi.fn(async () => ({ close: closeMock })) },
-	// Must be `new`-able — a regular function so `new Client(...)` works.
-	Client: vi.fn(function Client() {
-		return { workflow: { start: startMock } };
-	}),
-}));
-vi.mock("@temporalio/common", () => ({
-	WorkflowIdReusePolicy: { ALLOW_DUPLICATE: "ALLOW_DUPLICATE" },
+vi.mock("#/lib/run-context", () => ({
+	currentConversationId: () => h.conversationId,
 }));
 
 import { triggerAddSource } from "./trigger-add-source";
@@ -84,91 +60,48 @@ beforeEach(() => {
 		temporalNamespace: "default",
 	};
 	h.vertical = "_adhoc";
-	h.calls = [];
-	h.startArgs = null;
-	startMock.mockClear();
-	closeMock.mockClear();
-	h.recordRun.mockClear();
-	h.attachRunId.mockClear();
+	h.conversationId = "conv-1";
+	h.signalled = null;
+	h.signalRunAddSource.mockClear();
 });
 
-describe("triggerAddSource (DAT-352, one-call DAT-436, DAT-506)", () => {
-	it("records the run BEFORE starting the workflow (no orphaned run)", async () => {
-		await triggerAddSource({ sources: ["src-1"] });
-		// Order is the whole point (Q4): an unrecorded run is orphaned, so the
-		// cockpit_db record is authoritative and precedes the start.
-		expect(h.calls).toEqual(["record", "start"]);
-	});
-
-	it("starts addSourceWorkflow with the right id / queue / FLAT args (non-blocking)", async () => {
+describe("triggerAddSource (DAT-352, one-call DAT-436, routed via the journey — DAT-551)", () => {
+	it("signals the journey with the source SET / queue / verticals + kind onboarding", async () => {
+		h.vertical = "financial_reporting";
 		const result = await triggerAddSource({ sources: ["src-1"] });
 		const cockpitSessionId = result.cockpit_session_id;
 
-		expect(startMock).toHaveBeenCalledTimes(1);
-		const [name, opts] = startMock.mock.calls[0] as [
-			string,
-			Record<string, unknown>,
-		];
-		expect(name).toBe("addSourceWorkflow");
-		// Workflow id is keyed by the cockpit session id (DAT-422), not a source.
-		expect(opts.workflowId).toBe(`addsource-${WS}-${cockpitSessionId}`);
-		// Routed to the workspace's OWN queue (DAT-505), not the bare env queue.
-		expect(opts.taskQueue).toBe(`engine-${WS}`);
-		expect(opts.workflowIdReusePolicy).toBe("ALLOW_DUPLICATE");
-
-		// FLAT input (DAT-506): no identity envelope — workspace_id + the source SET
-		// + verticals (one-element array) at the top level, nothing else.
-		const args = opts.args as [
-			{ workspace_id: string; sources: string[]; verticals: string[] },
-		];
-		expect(args[0]).toEqual({
-			workspace_id: WS,
+		expect(h.signalled?.workspaceId).toBe(WS);
+		expect(h.signalled?.req).toEqual({
+			sessionId: cockpitSessionId,
+			workflowId: `addsource-${WS}-${cockpitSessionId}`,
+			engineTaskQueue: `engine-${WS}`,
 			sources: ["src-1"],
-			verticals: ["_adhoc"],
+			verticals: ["financial_reporting"],
+			kind: "onboarding",
+			conversationId: "conv-1",
 		});
-
+		// The trigger returns the deterministic workflow id (run_id mirrors it — the
+		// journey owns the real execution id; progress resolves latest by id).
 		expect(result).toEqual({
 			workflow_id: `addsource-${WS}-${cockpitSessionId}`,
-			run_id: "run-abc",
+			run_id: `addsource-${WS}-${cockpitSessionId}`,
 			sources: ["src-1"],
 			cockpit_session_id: cockpitSessionId,
 		});
-		// Connection is always closed.
-		expect(closeMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("threads the WORKSPACE vertical (from the registry) onto the input as a one-element array", async () => {
-		h.vertical = "financial_reporting";
-		await triggerAddSource({ sources: ["src-2"] });
-		const opts = startMock.mock.calls[0][1] as Record<string, unknown>;
-		const args = opts.args as [{ verticals: string[] }];
-		expect(args[0].verticals).toEqual(["financial_reporting"]);
+	it("threads a NULL conversationId when outside a chat turn (non-narrating run)", async () => {
+		h.conversationId = null;
+		await triggerAddSource({ sources: ["src-1"] });
+		expect(h.signalled?.req.conversationId).toBeNull();
 	});
 
-	it("records the cockpit session + run before start, then attaches the runId", async () => {
-		const result = await triggerAddSource({ sources: ["src-1"] });
-		const cockpitSessionId = result.cockpit_session_id;
-		expect(h.recordRun).toHaveBeenCalledTimes(1);
-		expect(h.recordRun).toHaveBeenCalledWith({
-			workspaceId: WS,
-			engineSessionId: cockpitSessionId,
-			kind: "onboarding",
-			stage: "add_source",
-			workflowId: `addsource-${WS}-${cockpitSessionId}`,
-		});
-		expect(h.attachRunId).toHaveBeenCalledWith(
-			`addsource-${WS}-${cockpitSessionId}`,
-			"run-abc",
-		);
-	});
-
-	it("throws when Temporal is unconfigured and records nothing", async () => {
+	it("throws when Temporal is unconfigured and signals nothing", async () => {
 		h.config = { dataraumWorkspaceId: WS };
 		await expect(triggerAddSource({ sources: ["src-1"] })).rejects.toThrow(
 			/Temporal client is not configured/,
 		);
-		// The guard runs first — no recorded run, no workflow start.
-		expect(h.recordRun).not.toHaveBeenCalled();
-		expect(startMock).not.toHaveBeenCalled();
+		expect(h.signalRunAddSource).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cockpit/src/temporal/trigger-add-source.ts
+++ b/packages/cockpit/src/temporal/trigger-add-source.ts
@@ -24,13 +24,11 @@
 // is no identity envelope and no session/source id on the wire.
 
 import { randomUUID } from "node:crypto";
-import { Client, Connection } from "@temporalio/client";
-import { WorkflowIdReusePolicy } from "@temporalio/common";
 
 import { config } from "../config";
 import { resolveActiveWorkspaceRow } from "../db/cockpit/registry";
-import { attachRunId, recordRun } from "../db/cockpit/runs";
-import type { AddSourceInput, AddSourceResult } from "./types";
+import { currentConversationId } from "../lib/run-context";
+import { signalRunAddSource } from "./journey-trigger";
 import { addSourceWorkflowId } from "./workflow-id";
 
 export interface TriggerAddSourceInput {
@@ -49,117 +47,66 @@ export interface TriggerAddSourceResult {
 	cockpit_session_id: string;
 }
 
-/** The Temporal-unconfigured guard, identical to replay.ts: Temporal config is
- * OPTIONAL in config.ts, so the trigger fails loud (not silently) when it isn't
- * wired. Narrows host + namespace to non-undefined for the start call. The TASK
- * QUEUE is NOT read from config anymore (DAT-505): a workflow routes to the
- * workspace's own queue (`engine-<id>`), resolved from the registry row at the
- * call site — not the bare `TEMPORAL_TASK_QUEUE` env. */
-function requireTemporalConfig(): {
-	host: string;
-	namespace: string;
-} {
+/** The Temporal-unconfigured guard, mirroring begin-session.ts: Temporal config is
+ * OPTIONAL in config.ts, so the trigger fails loud (not silently) BEFORE signalling
+ * the journey — so an unconfigured trigger signals nothing. (signalRunAddSource
+ * guards again downstream; this keeps the throw at the tool boundary.) */
+function requireTemporalConfig(): void {
 	if (!config.temporalHost || !config.temporalNamespace) {
 		throw new Error(
 			"Temporal client is not configured. Set TEMPORAL_HOST, " +
 				"TEMPORAL_NAMESPACE in the cockpit env.",
 		);
 	}
-	return {
-		host: config.temporalHost,
-		namespace: config.temporalNamespace,
-	};
 }
 
 /**
- * Start addSourceWorkflow NON-blocking. Returns the workflow + run id (and the
- * minted session id) immediately — the caller polls `get_progress`.
+ * Signal the workspace's JourneyWorkflow to run an add_source stage (DAT-551).
+ * Returns the deterministic workflow + minted session id immediately; the journey
+ * records the run (authoritative, before start) and starts + awaits the engine
+ * child, narrating completion into the originating chat. The caller does NOT poll a
+ * run id — progress resolves the latest execution by workflow id.
  *
- * No engine seed (DAT-506): sessions live in cockpit_db, and the run's table set
- * is anchored by `run_tables` (keyed by `run_id`), not `session_tables`. The
- * `vertical` is the workspace property, sourced from the registry. The run is
- * recorded in cockpit_db AUTHORITATIVELY (`recordRun` throws) BEFORE the workflow
- * starts — an unrecorded run is orphaned, so the breadcrumb is a precondition, not
- * a best-effort afterthought.
+ * No engine seed (DAT-506): sessions live in cockpit_db, the run's table set is
+ * anchored by `run_tables` (keyed by `run_id`), and the `vertical` is the workspace
+ * property from the registry.
  */
 export async function triggerAddSource(
 	input: TriggerAddSourceInput,
 ): Promise<TriggerAddSourceResult> {
-	const { host, namespace } = requireTemporalConfig();
+	requireTemporalConfig();
 
 	const cockpitSessionId = randomUUID();
 
 	// The active workspace ROW, from the cockpit_db registry (DAT-461/505/506):
-	// the source of truth for the recorded run, the per-workspace task queue the
-	// workflow routes to, AND the frame `vertical` (a workspace property chosen
-	// once — DAT-506 retired the per-add_source pick).
+	// the source of truth for the per-workspace task queue the child routes to AND
+	// the frame `vertical` (a workspace property chosen once — DAT-506 retired the
+	// per-add_source pick).
 	const workspace = await resolveActiveWorkspaceRow();
-	const workspaceId = workspace.id;
-	const vertical = workspace.vertical;
+	const workflowId = addSourceWorkflowId(workspace.id, cockpitSessionId);
 
-	const workflowId = addSourceWorkflowId(workspaceId, cockpitSessionId);
-
-	// Record the cockpit-side session + run BEFORE starting the workflow (Q4): an
-	// unrecorded run is orphaned (the reload-recovery substrate can't re-attach to
-	// it), so recordRun is AUTHORITATIVE here — it THROWS on failure, aborting the
-	// start. Idempotent upserts keep a retried start safe.
-	await recordRun({
-		workspaceId,
-		engineSessionId: cockpitSessionId,
-		kind: "onboarding",
-		stage: "add_source",
+	// Signal the journey to run the stage (DAT-551). The tool passes the derived
+	// ids/queue + the source SET + verticals + the originating conversationId
+	// (captured from the request-scoped ALS HERE, while we're still in the chat turn
+	// — the journey has none). The journey records the run authoritatively and starts
+	// the engine child on the workspace's OWN queue (DAT-505). `kind: onboarding`
+	// marks the session origin (a fresh import, vs replay's "replay").
+	await signalRunAddSource(workspace.id, {
+		sessionId: cockpitSessionId,
 		workflowId,
+		engineTaskQueue: workspace.taskQueue,
+		sources: input.sources,
+		verticals: [workspace.vertical],
+		kind: "onboarding",
+		conversationId: currentConversationId(),
 	});
 
-	// FLAT, source-free input (DAT-506): no identity envelope, no session/source id
-	// on the wire. The per-source ids ride in `sources` (DAT-422); the engine scopes
-	// each `import` to one and resolves provenance relationally (`tables.source_id`)
-	// past import. `verticals` is a one-element array of the workspace ontology (the
-	// engine raises born-loud on >1); the array is forward-compat.
-	const payload: AddSourceInput = {
-		workspace_id: workspaceId,
+	return {
+		// The deterministic workflow id; run_id mirrors it (the journey owns the real
+		// execution id — progress resolves the latest run by workflow_id, DAT-530).
+		workflow_id: workflowId,
+		run_id: workflowId,
 		sources: input.sources,
-		verticals: [vertical],
+		cockpit_session_id: cockpitSessionId,
 	};
-
-	const connection = await Connection.connect({ address: host });
-	try {
-		const client = new Client({ connection, namespace });
-		const handle = await client.workflow.start<
-			(p: AddSourceInput) => Promise<AddSourceResult>
-		>("addSourceWorkflow", {
-			// Route to the workspace's OWN queue (DAT-505) — the engine worker for
-			// this workspace polls `engine-<id>` and a payload for another workspace
-			// never reaches it.
-			taskQueue: workspace.taskQueue,
-			workflowId,
-			args: [payload],
-			// Reused per run (keyed by the cockpit session) across replays so Temporal
-			// UI groups iterations under one id — same policy the replay tool uses.
-			//
-			// DUPLICATE RUNS ARE BY DESIGN (decision pinned in the PR #231 review):
-			// every select call mints a fresh cockpit session id, so a re-called select
-			// starts an INDEPENDENT full run. Under the versioned-snapshot model
-			// (DAT-412) runs coexist — each writes its own run_id-stamped metadata,
-			// none clobbers another — so there is nothing to guard. The human control
-			// is the explicit select request itself: a re-called select is a
-			// deliberate user action (they re-issued it), not an accidental retry.
-			// Deliberately NO idempotency key and NO in-flight check here.
-			workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
-		});
-
-		// Finalize the provisional Temporal execution runId on the pre-recorded run
-		// (best-effort — the orphan-critical rows already exist). The engine mints its
-		// own internal metadata run_id; the cockpit does not store it (DAT-506).
-		await attachRunId(workflowId, handle.firstExecutionRunId);
-
-		return {
-			workflow_id: workflowId,
-			run_id: handle.firstExecutionRunId,
-			sources: input.sources,
-			cockpit_session_id: cockpitSessionId,
-		};
-	} finally {
-		await connection.close();
-	}
 }

--- a/packages/cockpit/src/temporal/trigger-add-source.ts
+++ b/packages/cockpit/src/temporal/trigger-add-source.ts
@@ -1,27 +1,30 @@
-// add_source TRIGGER (DAT-352, folded into the select tool by DAT-436)
-// — starts the engine's addSourceWorkflow for the source set `select` just
-// persisted, and records the cockpit-side run in cockpit_db (DAT-506).
+// add_source TRIGGER (DAT-352, folded into the select tool by DAT-436; routed
+// through the JourneyWorkflow in DAT-551 slice 1) — SIGNALS the per-workspace
+// journey to run the engine's addSourceWorkflow for the source set `select` just
+// persisted.
 //
 // Since DAT-436 the ONLY caller is `select.server` (tools/select.ts): calling
 // the `select` tool registers the source(s) AND starts the import in one step —
 // there is no separate "Add source" button or `/api/add-source` route, and no
 // approval hop.
 //
-// Sessions live in cockpit_db (DAT-506) — the engine no longer has an
-// `investigation_sessions` table or a write grant for one, and `run_tables`
-// (anchored by `run_id`) replaces `session_tables`. So this trigger does NOT
-// seed any engine row: it records the run in cockpit_db (`recordRun`, authoritative
-// — an unrecorded run is orphaned, so it THROWS) then starts the workflow.
+// DAT-551: this trigger no longer starts the workflow directly. It SIGNALS the
+// per-workspace JourneyWorkflow (`runAddSource`); the journey records the run in
+// cockpit_db (authoritative, before start — an unrecorded run is orphaned) and
+// starts `addSourceWorkflow` as a cross-language CHILD on the workspace's
+// `engine-<id>` queue. So the journey is the single owner of all stage execution
+// (begin_session/operating_model already route this way). The journey advances
+// tab-independently; the tool captures the current conversationId and threads it
+// through so the run still narrates into THIS chat (the journey has no request
+// ALS — DAT-528).
 //
-// The start is NON-blocking (`workflow.start`, not `.execute`): it returns the
-// workflow + run id immediately so the cockpit polls progress via the
-// `get_progress` query (see `progress.ts`). A run ingests a SET of objects from
-// 1–N sources (DAT-422), so the workflow id is keyed by the cockpit session id
-// (addsource-<workspace_id>-<cockpitSessionId>), mirroring begin_session, and reused
-// under ALLOW_DUPLICATE so replays group under one id — callers MUST target the
-// precise `run_id` when querying. The `verticals` ride on the FLAT workflow INPUT,
-// sourced from the workspace registry (DAT-506), NOT picked per add_source — there
-// is no identity envelope and no session/source id on the wire.
+// The tool returns the DETERMINISTIC workflow id immediately (the cockpit polls
+// progress by workflow id — the latest execution; the real Temporal run id is owned
+// by the journey). A run ingests a SET of objects from 1–N sources (DAT-422), so the
+// workflow id is keyed by the cockpit session id (addsource-<workspace_id>-
+// <cockpitSessionId>), mirroring begin_session. The `verticals` ride on the FLAT
+// workflow INPUT, sourced from the workspace registry (DAT-506), NOT picked per
+// add_source — no identity envelope, no session/source id on the wire.
 
 import { randomUUID } from "node:crypto";
 

--- a/packages/cockpit/src/tools/replay.test.ts
+++ b/packages/cockpit/src/tools/replay.test.ts
@@ -1,17 +1,16 @@
-// Unit tests for the replay tool (DAT-343, DAT-413, DAT-422, DAT-506).
+// Unit tests for the replay tool (DAT-343, DAT-413, DAT-422, DAT-506; routed
+// through the journey in DAT-551).
 //
 // Replay takes a SESSION (the named analytical unit the agent thinks in),
 // resolves the workspace's currently-imported sources, and re-runs add_source over
-// them as a NEW session. DAT-506: the engine mints its own run_id the cockpit never
-// sees, so a per-session join is impossible at the cockpit edge — replay resolves
-// the sources from the live per-table GENERATION heads (metadata_snapshot_head →
-// run_tables → tables → source), which in single-active-workspace are the session's
-// sources. There is NO engine seed; the new replay session/run is recorded in
-// cockpit_db BEFORE the workflow starts, and the vertical is the workspace property
-// from the registry (no per-session pick).
+// them as a NEW session. DAT-551: it no longer starts the workflow directly — it
+// signals the per-workspace JourneyWorkflow (`runAddSource`, kind "replay"), which
+// records the run + starts the engine child. So the unit asserts the SIGNAL
+// payload. The source resolution + "nothing to replay" guards stay request-side.
 //
-// Mocks: `#/config`, the cockpit registry + runs writer, the Drizzle metadata
-// client (generation-head → source ids), and `@temporalio/client`.
+// Mocks: `#/config`, the cockpit registry, the Drizzle metadata client
+// (generation-head → source ids), the journey trigger (signalRunAddSource), the ALS
+// conversation context, and the current-session resolver.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -24,19 +23,25 @@ const h = vi.hoisted(() => ({
 		temporalNamespace: "default",
 	} as Record<string, unknown>,
 	vertical: "_adhoc" as string,
-	// Records the order of side effects so we can assert resolve-then-record-then-start.
+	conversationId: "conv-1" as string | null,
+	// Records the order of side effects so we can assert resolve-then-signal.
 	calls: [] as string[],
-	recordedRun: null as Record<string, unknown> | null,
+	signalled: null as {
+		workspaceId: string;
+		req: Record<string, unknown>;
+	} | null,
 	// Rows the generation-head → run_tables → tables source query returns
 	// (empty = nothing imported = nothing to replay).
 	sourceRows: [] as Array<{ sourceId: string | null }>,
 	// The current session currentSessionId() resolves (null = none — replay rejects).
 	currentSession: null as string | null,
-	recordRun: vi.fn(async (input: Record<string, unknown>) => {
-		h.recordedRun = input;
-		h.calls.push("record");
-	}),
-	attachRunId: vi.fn(async () => {}),
+	signalRunAddSource: vi.fn(
+		async (workspaceId: string, req: Record<string, unknown>) => {
+			h.signalled = { workspaceId, req };
+			h.calls.push("signal");
+			return req.workflowId as string;
+		},
+	),
 }));
 
 // Live getter (the unconfigured-guard test reassigns h.config).
@@ -46,18 +51,12 @@ vi.mock("#/config", () => ({
 	},
 }));
 
-// cockpit_db control plane (DAT-461/505/506): workspace + its vertical via the
-// registry, run recorded BEFORE start — both mocked at the seam (no DB in units).
 vi.mock("#/db/cockpit/registry", () => ({
 	resolveActiveWorkspaceRow: vi.fn(async () => ({
 		id: h.config.dataraumWorkspaceId,
 		taskQueue: `engine-${h.config.dataraumWorkspaceId}`,
 		vertical: h.vertical,
 	})),
-}));
-vi.mock("#/db/cockpit/runs", () => ({
-	recordRun: h.recordRun,
-	attachRunId: h.attachRunId,
 }));
 
 // Metadata client: generation-head → run_tables → tables source ids via
@@ -86,20 +85,11 @@ vi.mock("drizzle-orm", () => ({
 	eq: (...a: unknown[]) => a,
 }));
 
-// Temporal client: record the start args (after the record) + hand back a run id.
-const startMock = vi.fn(async (_name: string, _opts: unknown) => {
-	h.calls.push("start");
-	return { firstExecutionRunId: "run-xyz" };
-});
-const closeMock = vi.fn(async () => {});
-vi.mock("@temporalio/client", () => ({
-	Connection: { connect: vi.fn(async () => ({ close: closeMock })) },
-	Client: vi.fn(function Client() {
-		return { workflow: { start: startMock } };
-	}),
+vi.mock("#/temporal/journey-trigger", () => ({
+	signalRunAddSource: h.signalRunAddSource,
 }));
-vi.mock("@temporalio/common", () => ({
-	WorkflowIdReusePolicy: { ALLOW_DUPLICATE: "ALLOW_DUPLICATE" },
+vi.mock("#/lib/run-context", () => ({
+	currentConversationId: () => h.conversationId,
 }));
 // The current-session resolver replay falls back to when no session_id is given.
 vi.mock("#/prompts/workspace-context", () => ({
@@ -115,66 +105,62 @@ beforeEach(() => {
 		temporalNamespace: "default",
 	};
 	h.vertical = "_adhoc";
+	h.conversationId = "conv-1";
 	h.calls = [];
-	h.recordedRun = null;
+	h.signalled = null;
 	h.sourceRows = [{ sourceId: "src-1" }];
 	h.currentSession = null;
-	startMock.mockClear();
-	closeMock.mockClear();
-	h.recordRun.mockClear();
-	h.attachRunId.mockClear();
+	h.signalRunAddSource.mockClear();
 });
 
-describe("replay (DAT-422, DAT-506)", () => {
-	it("resolves the workspace sources, then records a FRESH run BEFORE start", async () => {
+describe("replay (DAT-422, routed via the journey — DAT-551)", () => {
+	it("resolves the workspace sources, then signals the journey for a FRESH session", async () => {
 		const result = await replay({ session_id: "old-sess" });
 
-		// Order: resolve the workspace's imported sources (generation heads), record
-		// the NEW run (authoritative, no orphan), then start.
-		expect(h.calls).toEqual(["resolveSources", "record", "start"]);
+		// Order: resolve the workspace's imported sources (generation heads), then
+		// signal the journey to run the NEW add_source.
+		expect(h.calls).toEqual(["resolveSources", "signal"]);
 		// A FRESH session — not the one being replayed.
 		expect(result.session_id).not.toBe("old-sess");
 	});
 
-	it("re-runs the session's source SET as a new run keyed by the new session", async () => {
+	it("signals the journey with the resolved source SET + kind replay + verticals", async () => {
 		h.sourceRows = [{ sourceId: "src-1" }, { sourceId: "src-2" }];
 		h.vertical = "finance";
 		const result = await replay({ session_id: "old-sess" });
 		const newSessionId = result.session_id;
 
-		const opts = startMock.mock.calls[0][1] as Record<string, unknown>;
-		const args = opts.args as [
-			{ workspace_id: string; sources: string[]; verticals: string[] },
-		];
-		// FLAT input (DAT-506): no identity envelope, no session/source id on the
-		// wire — workspace_id + the resolved source SET (DAT-422) + verticals.
-		expect(args[0]).toEqual({
-			workspace_id: WS,
+		expect(h.signalled?.workspaceId).toBe(WS);
+		expect(h.signalled?.req).toEqual({
+			sessionId: newSessionId,
+			workflowId: `addsource-${WS}-${newSessionId}`,
+			engineTaskQueue: `engine-${WS}`,
 			sources: ["src-1", "src-2"],
 			verticals: ["finance"],
+			kind: "replay",
+			conversationId: "conv-1",
 		});
-		expect(result.sources).toEqual(["src-1", "src-2"]);
-		// Workflow id is keyed by the NEW run's cockpit session (DAT-422).
-		expect(opts.workflowId).toBe(`addsource-${WS}-${newSessionId}`);
-		expect(opts.workflowIdReusePolicy).toBe("ALLOW_DUPLICATE");
-		expect(closeMock).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({
+			workflow_id: `addsource-${WS}-${newSessionId}`,
+			run_id: `addsource-${WS}-${newSessionId}`,
+			sources: ["src-1", "src-2"],
+			session_id: newSessionId,
+		});
 	});
 
-	it("rejects when the workspace has no imported sources (nothing to replay) — no record, no start", async () => {
+	it("rejects when the workspace has no imported sources (nothing to replay) — no signal", async () => {
 		h.sourceRows = [];
 		await expect(replay({ session_id: "empty-sess" })).rejects.toThrow(
 			/no imported sources/,
 		);
-		expect(h.recordRun).not.toHaveBeenCalled();
-		expect(startMock).not.toHaveBeenCalled();
+		expect(h.signalRunAddSource).not.toHaveBeenCalled();
 	});
 
 	it("defaults to the CURRENT session when no session_id is given (bare 'replay')", async () => {
 		h.currentSession = "current-sess";
 		h.sourceRows = [{ sourceId: "src-1" }];
 		const result = await replay({});
-		expect(h.calls).toContain("resolveSources");
-		expect(h.calls).toContain("start");
+		expect(h.calls).toEqual(["resolveSources", "signal"]);
 		expect(result.sources).toEqual(["src-1"]);
 		// It re-ran the current session into a FRESH one (replay is non-destructive).
 		expect(result.session_id).not.toBe("current-sess");
@@ -183,42 +169,27 @@ describe("replay (DAT-422, DAT-506)", () => {
 	it("rejects when there is no current session to replay", async () => {
 		h.currentSession = null;
 		await expect(replay({})).rejects.toThrow(/No session to replay/);
-		expect(h.recordRun).not.toHaveBeenCalled();
-		expect(startMock).not.toHaveBeenCalled();
+		expect(h.signalRunAddSource).not.toHaveBeenCalled();
 	});
 
-	it("throws when Temporal is unconfigured and does NOT read, record, or start", async () => {
+	it("throws when Temporal is unconfigured and does NOT read or signal", async () => {
 		h.config = { dataraumWorkspaceId: WS };
 		await expect(replay({ session_id: "old-sess" })).rejects.toThrow(
 			/Temporal client is not configured/,
 		);
 		expect(h.calls).toEqual([]); // the guard is first — nothing ran
-		expect(h.recordRun).not.toHaveBeenCalled();
-		expect(startMock).not.toHaveBeenCalled();
+		expect(h.signalRunAddSource).not.toHaveBeenCalled();
 	});
 
-	it("records the new replay session + run before start, then attaches the runId", async () => {
-		const result = await replay({ session_id: "old-sess" });
-		const newSessionId = result.session_id;
-		expect(h.recordRun).toHaveBeenCalledTimes(1);
-		expect(h.recordedRun).toEqual({
-			workspaceId: WS,
-			engineSessionId: newSessionId,
-			kind: "replay",
-			stage: "add_source",
-			workflowId: `addsource-${WS}-${newSessionId}`,
-		});
-		expect(h.attachRunId).toHaveBeenCalledWith(
-			`addsource-${WS}-${newSessionId}`,
-			"run-xyz",
-		);
+	it("threads a NULL conversationId when outside a chat turn", async () => {
+		h.conversationId = null;
+		await replay({ session_id: "old-sess" });
+		expect(h.signalled?.req.conversationId).toBeNull();
 	});
 
 	it("re-runs on the WORKSPACE vertical (from the registry) as a one-element array", async () => {
 		h.vertical = "marketing";
 		await replay({ session_id: "old-sess" });
-		const opts = startMock.mock.calls[0][1] as Record<string, unknown>;
-		const args = opts.args as [{ verticals: string[] }];
-		expect(args[0].verticals).toEqual(["marketing"]);
+		expect(h.signalled?.req.verticals).toEqual(["marketing"]);
 	});
 });

--- a/packages/cockpit/src/tools/replay.ts
+++ b/packages/cockpit/src/tools/replay.ts
@@ -96,13 +96,13 @@ export interface ReplayResult {
 }
 
 /**
- * Start an `addSourceWorkflow` execution to re-apply pending teaches as a full
- * re-run of a session's sources. Returns immediately with the workflow + run id
- * (and the new session id); the caller polls Temporal for progress.
+ * Signal the journey to run a fresh `addSourceWorkflow` that re-applies pending
+ * teaches as a full re-run of a session's sources (DAT-551). Returns immediately
+ * with the workflow + session id; the journey records the run + starts the child,
+ * and progress resolves the latest execution by workflow id (run_id mirrors it).
  *
  * The new run is keyed by the fresh session (`addsource-<workspace_id>-<session_id>`,
- * DAT-422). `ALLOW_DUPLICATE` is kept for parity with triggerAddSource; each replay
- * is its own session, so it is a distinct workflow id (no accidental reuse).
+ * DAT-422) — each replay is its own session, so it is a distinct workflow id.
  */
 export async function replay(input: ReplayInput): Promise<ReplayResult> {
 	if (!config.temporalHost || !config.temporalNamespace) {

--- a/packages/cockpit/src/tools/replay.ts
+++ b/packages/cockpit/src/tools/replay.ts
@@ -13,7 +13,9 @@
 // choose — a replay is always a full, non-destructive re-run that re-reads the
 // durable teach overlays.
 //
-// Pure compute kick: starts a fresh `addSourceWorkflow` keyed by the NEW session
+// Pure compute kick (DAT-551: routed through the JourneyWorkflow — it SIGNALS the
+// per-workspace journey, which records the run + starts the child): a fresh
+// `addSourceWorkflow` keyed by the NEW session
 // (`addsource-<workspace_id>-<session_id>`; see workflow-id.ts, DAT-422 — a run
 // is keyed by its session) and returns the workflow id + run id immediately; the
 // caller polls / queries Temporal for progress. End-to-end "replay actually
@@ -22,25 +24,23 @@
 //
 // No engine seed (DAT-506): sessions live in cockpit_db, and the run's table set
 // is anchored by `run_tables` (keyed by `run_id`), not `session_tables`. The new
-// replay session + run are recorded in cockpit_db AUTHORITATIVELY (`recordRun`
-// throws) BEFORE the workflow starts. The `vertical` is the workspace property,
+// replay session + run are recorded by the JOURNEY in cockpit_db AUTHORITATIVELY
+// BEFORE the child starts (DAT-551). The `vertical` is the workspace property,
 // sourced from the registry (DAT-506 retired the per-session vertical pick).
 
 import { randomUUID } from "node:crypto";
 import { toolDefinition } from "@tanstack/ai";
-import { Client, Connection } from "@temporalio/client";
-import { WorkflowIdReusePolicy } from "@temporalio/common";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { config } from "../config";
 import { resolveActiveWorkspaceRow } from "../db/cockpit/registry";
-import { attachRunId, recordRun } from "../db/cockpit/runs";
 import { metadataDb } from "../db/metadata/client";
 import { GENERATION_STAGE } from "../db/metadata/relationship-target";
 import { metadataSnapshotHead, runTables, tables } from "../db/metadata/schema";
+import { currentConversationId } from "../lib/run-context";
 import { currentSessionId } from "../prompts/workspace-context";
-import type { AddSourceInput, AddSourceResult } from "../temporal/types";
+import { signalRunAddSource } from "../temporal/journey-trigger";
 import { addSourceWorkflowId } from "../temporal/workflow-id";
 import {
 	AgentActionableError,
@@ -134,65 +134,36 @@ export async function replay(input: ReplayInput): Promise<ReplayResult> {
 	}
 
 	const workspace = await resolveActiveWorkspaceRow();
-	const workspaceId = workspace.id;
-	// The workspace vertical (DAT-506) — a replay re-runs against the workspace's
-	// chosen ontology, not a per-session pick.
-	const vertical = workspace.vertical;
-
 	// A replay generates a NEW session — a fresh analytical pass over the same
-	// sources. The id is fresh, so the cockpit_db record is a clean insert.
+	// sources. The id is fresh, so the journey records a clean insert.
 	const newSessionId = randomUUID();
-	const workflowId = addSourceWorkflowId(workspaceId, newSessionId);
+	const workflowId = addSourceWorkflowId(workspace.id, newSessionId);
 
-	// Record the new replay session + run BEFORE starting (Q4): an unrecorded run
-	// is orphaned, so recordRun is AUTHORITATIVE — it throws on failure.
-	await recordRun({
-		workspaceId,
-		engineSessionId: newSessionId,
-		kind: "replay",
-		stage: "add_source",
+	// Signal the journey to run the stage (DAT-551). kind:"replay" marks the session
+	// origin; the journey records the run authoritatively + starts the engine child
+	// on the workspace's OWN queue (DAT-505), re-reading the durable teach overlays.
+	// The conversationId is captured HERE (request ALS) so the run narrates into THIS
+	// chat — the journey has none. `verticals` is the workspace ontology (born-loud
+	// on >1); the engine scopes each `import` to one source + resolves provenance
+	// relationally past import.
+	await signalRunAddSource(workspace.id, {
+		sessionId: newSessionId,
 		workflowId,
+		engineTaskQueue: workspace.taskQueue,
+		sources: replaySources,
+		verticals: [workspace.vertical],
+		kind: "replay",
+		conversationId: currentConversationId(),
 	});
 
-	// FLAT, source-free input (DAT-506): no identity envelope, no session/source id
-	// on the wire. The resolved sources ride in `sources`; the engine scopes each
-	// `import` to one and resolves provenance relationally past import. `verticals`
-	// is a one-element array of the workspace ontology (born-loud on >1).
-	const payload: AddSourceInput = {
-		workspace_id: workspaceId,
+	return {
+		// Deterministic workflow id; run_id mirrors it (the journey owns the real
+		// execution id — progress resolves the latest run by workflow_id, DAT-530).
+		workflow_id: workflowId,
+		run_id: workflowId,
 		sources: replaySources,
-		verticals: [vertical],
+		session_id: newSessionId,
 	};
-
-	const connection = await Connection.connect({ address: config.temporalHost });
-	try {
-		const client = new Client({
-			connection,
-			namespace: config.temporalNamespace,
-		});
-		const handle = await client.workflow.start<
-			(p: AddSourceInput) => Promise<AddSourceResult>
-		>("addSourceWorkflow", {
-			// Route to the workspace's OWN queue (DAT-505).
-			taskQueue: workspace.taskQueue,
-			workflowId,
-			args: [payload],
-			workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
-		});
-
-		// Finalize the provisional Temporal execution runId (best-effort); the
-		// engine-minted metadata run_id lands on the completion edge.
-		await attachRunId(workflowId, handle.firstExecutionRunId);
-
-		return {
-			workflow_id: workflowId,
-			run_id: handle.firstExecutionRunId,
-			sources: replaySources,
-			session_id: newSessionId,
-		};
-	} finally {
-		await connection.close();
-	}
 }
 
 /**

--- a/packages/cockpit/src/tools/teach.test.ts
+++ b/packages/cockpit/src/tools/teach.test.ts
@@ -110,6 +110,39 @@ describe("validateTeach", () => {
 		});
 	});
 
+	describe("unit", () => {
+		it("accepts {table, column, unit} (DAT-428 column-scoped unit teach)", () => {
+			// Engine consumer: _apply_unit keys EXACTLY on payload.{table, column} →
+			// overrides.units."<table>.<column>". Identify by NAME, not a column id.
+			const out = validateTeach({
+				type: "unit",
+				payload: { table: "trades", column: "amount", unit: "EUR" },
+			});
+			expect(out).toEqual({ table: "trades", column: "amount", unit: "EUR" });
+		});
+
+		it.each(["table", "column", "unit"])("rejects missing %s", (field) => {
+			const payload: Record<string, string> = {
+				table: "trades",
+				column: "amount",
+				unit: "EUR",
+			};
+			delete payload[field];
+			expect(() => validateTeach({ type: "unit", payload })).toThrow(
+				TeachValidationError,
+			);
+		});
+
+		it("rejects an empty column (string of length 0)", () => {
+			expect(() =>
+				validateTeach({
+					type: "unit",
+					payload: { table: "trades", column: "", unit: "EUR" },
+				}),
+			).toThrow(TeachValidationError);
+		});
+	});
+
 	describe("concept", () => {
 		it("accepts vertical+name (minimal)", () => {
 			const out = validateTeach({
@@ -341,6 +374,7 @@ describe("validateTeach", () => {
 				new Set([
 					"type_pattern",
 					"null_value",
+					"unit",
 					"concept_property",
 					"relationship",
 					"hierarchy",
@@ -360,6 +394,7 @@ describe("validateTeach", () => {
 				new Set([
 					"type_pattern",
 					"null_value",
+					"unit",
 					"concept",
 					"concept_property",
 					"relationship",

--- a/packages/cockpit/src/tools/teach.ts
+++ b/packages/cockpit/src/tools/teach.ts
@@ -95,8 +95,8 @@ export const teachTool = toolDefinition({
 	name: "teach",
 	description:
 		"Record a grounding-layer correction about the data — a typing pattern, " +
-		"null token, ontology concept/property, or a column relationship. Writes a " +
-		"config_overlay row; follow with `replay` to apply " +
+		"null token, column unit, ontology concept/property, or a column " +
+		"relationship. Writes a config_overlay row; follow with `replay` to apply " +
 		"it to the source. For operating-model declarations use the dedicated tools " +
 		"instead: teach_validation, teach_cycle, teach_metric.",
 	inputSchema: z.object({

--- a/packages/cockpit/src/tools/teach.validation.ts
+++ b/packages/cockpit/src/tools/teach.validation.ts
@@ -80,6 +80,32 @@ const NullValuePayload = z
 	})
 	.passthrough();
 
+// `unit` overlays are column-scoped unit teaches (DAT-428): they land a unit on an
+// already-typed numeric column without having to win a type pattern. The engine
+// (_apply_unit) keys EXACTLY on payload.{table, column} → patches that column's best
+// type candidate's `detected_unit` (forcing unit_confidence → 1.0) under
+// phases/typing.yaml::overrides.units."<table>.<column>". Identify the column by
+// NAME (table + column), not a column id — the override is read in typing, before
+// column ids are stable.
+const UnitPayload = z
+	.object({
+		table: z
+			.string()
+			.min(1)
+			.describe("The typed table NAME the column lives in (not a column id)."),
+		column: z
+			.string()
+			.min(1)
+			.describe("The column NAME to assign the unit to (not a column id)."),
+		unit: z
+			.string()
+			.min(1)
+			.describe(
+				"The unit the column's values carry, e.g. 'EUR', 'kg', 'percent'.",
+			),
+	})
+	.passthrough();
+
 const ConceptPropertyPayload = z
 	.object({
 		vertical: z
@@ -244,6 +270,7 @@ const HierarchyPayload = z
 const TYPE_SCHEMAS = {
 	type_pattern: TypePatternPayload,
 	null_value: NullValuePayload,
+	unit: UnitPayload,
 	concept: ConceptPayload,
 	concept_property: ConceptPropertyPayload,
 	relationship: RelationshipPayload,
@@ -272,6 +299,7 @@ export const TEACH_TYPES = Object.keys(TYPE_SCHEMAS) as readonly TeachType[];
 export const AGENT_TEACH_TYPES = [
 	"type_pattern",
 	"null_value",
+	"unit",
 	"concept",
 	"concept_property",
 	"relationship",
@@ -289,6 +317,7 @@ export const TeachPayloadSchema = z
 	.union([
 		TypePatternPayload,
 		NullValuePayload,
+		UnitPayload,
 		ConceptPayload,
 		ConceptPropertyPayload,
 		RelationshipPayload,
@@ -298,6 +327,7 @@ export const TeachPayloadSchema = z
 		"The teach payload; required fields depend on `type` — " +
 			"type_pattern: {name, pattern, inferred_type?, …}; " +
 			"null_value: {category, value}; " +
+			"unit: {table, column, unit} (column identified by NAME); " +
 			"concept: {vertical, name, indicators?, …}; " +
 			"concept_property: {vertical, concept, property, value}; " +
 			"relationship: {action: confirm|reject|add, from_column_id, to_column_id} " +

--- a/packages/cockpit/src/worker/contracts.ts
+++ b/packages/cockpit/src/worker/contracts.ts
@@ -27,6 +27,32 @@ export interface VerticalEstablished {
 	vertical: string;
 }
 
+/** The add_source trigger (DAT-551 slice 1): `select` (a fresh import) or `replay`
+ * (re-run a session's sources to apply teaches) signals the journey, which runs
+ * `addSourceWorkflow` as a cross-language child. The journey is the single owner of
+ * stage execution; the agentic grounding-teach loop (slice 2) rides on this. */
+export const RUN_ADD_SOURCE_SIGNAL = "runAddSource";
+
+/** Payload of `runAddSource`. Carries `kind` because add_source originates two ways
+ * — `onboarding` (select) and `replay` — unlike begin_session (always one kind);
+ * the journey threads it to `recordRun`. */
+export interface RunAddSource {
+	/** Cockpit-minted session id (run-correlation key + workflow-id segment). */
+	sessionId: string;
+	/** The deterministic engine workflow id (tool-computed via addSourceWorkflowId). */
+	workflowId: string;
+	/** The workspace's engine task queue (`engine-<id>`) the child runs on. */
+	engineTaskQueue: string;
+	/** The source ids this run imports — a run is over a SET of objects (DAT-422). */
+	sources: string[];
+	/** The workspace verticals (one today; born-loud on >1). */
+	verticals: string[];
+	/** How the session originated: `onboarding` (select) or `replay` (re-run). */
+	kind: "onboarding" | "replay";
+	/** The originating chat (DAT-528) for narration routing. Null = none. */
+	conversationId: string | null;
+}
+
 /** The INTENTIONAL begin_session trigger (DAT-530): the user chose a table set,
  * so the journey runs `beginSessionWorkflow` as a cross-language child. */
 export const RUN_BEGIN_SESSION_SIGNAL = "runBeginSession";

--- a/packages/cockpit/src/worker/workflows/index.ts
+++ b/packages/cockpit/src/worker/workflows/index.ts
@@ -4,6 +4,7 @@
 
 export type {
 	JourneyState,
+	RunAddSource,
 	RunBeginSession,
 	RunOperatingModel,
 	VerticalEstablished,
@@ -13,6 +14,7 @@ export {
 	journeyWorkflow,
 	pauseAutoMode,
 	resumeAutoMode,
+	runAddSource,
 	runBeginSession,
 	runOperatingModel,
 	verticalEstablished,

--- a/packages/cockpit/src/worker/workflows/journey.ts
+++ b/packages/cockpit/src/worker/workflows/journey.ts
@@ -47,8 +47,10 @@ import {
 	type JourneyState,
 	PAUSE_AUTO_MODE_SIGNAL,
 	RESUME_AUTO_MODE_SIGNAL,
+	RUN_ADD_SOURCE_SIGNAL,
 	RUN_BEGIN_SESSION_SIGNAL,
 	RUN_OPERATING_MODEL_SIGNAL,
+	type RunAddSource,
 	type RunBeginSession,
 	type RunOperatingModel,
 	VERTICAL_ESTABLISHED_SIGNAL,
@@ -68,6 +70,7 @@ const { recordRun, attachRunId, markRunStatus } = proxyActivities<
 export const verticalEstablished = defineSignal<[VerticalEstablished]>(
 	VERTICAL_ESTABLISHED_SIGNAL,
 );
+export const runAddSource = defineSignal<[RunAddSource]>(RUN_ADD_SOURCE_SIGNAL);
 export const runBeginSession = defineSignal<[RunBeginSession]>(
 	RUN_BEGIN_SESSION_SIGNAL,
 );
@@ -88,10 +91,11 @@ const EVENTS_BEFORE_CONTINUE = 500;
 // predate it; it's established here as the discipline for future incremental edits.
 const CASCADE_PATCH = "journey-cascade-operating-model";
 
-/** A queued, user-intentional stage trigger (begin_session always; operating_model
- * as a manual re-trigger). The auto-cascade is NOT queued — it runs inline right
- * after its begin_session, so a session's two stages stay an atomic pair. */
+/** A queued, user-intentional stage trigger (add_source / begin_session always;
+ * operating_model as a manual re-trigger). The auto-cascade is NOT queued — it runs
+ * inline right after its begin_session, so a session's two stages stay an atomic pair. */
 type PendingStage =
+	| { kind: "add_source"; req: RunAddSource }
 	| { kind: "begin_session"; req: RunBeginSession }
 	| { kind: "operating_model"; req: RunOperatingModel };
 
@@ -108,7 +112,11 @@ async function runChildStage(
 		workflowType: string;
 		workflowId: string;
 		taskQueue: string;
-		stage: "begin_session" | "operating_model";
+		stage: "add_source" | "begin_session" | "operating_model";
+		// The session origin for recordRun (ignored on conflict — operating_model
+		// reuses begin_session's row): add_source carries onboarding|replay; the
+		// later stages reuse "begin_session".
+		kind: "onboarding" | "begin_session" | "replay";
 		engineSessionId: string;
 		conversationId: string | null;
 		args: unknown[];
@@ -121,12 +129,10 @@ async function runChildStage(
 		// Authoritative record BEFORE start (throws → caught below, child not
 		// started). EXPLICIT conversationId — the worker has no request ALS, so this
 		// is what keeps the completion narrating into the originating chat (DAT-528).
-		// `kind` is always begin_session: the session was born from begin_session and
-		// operating_model reuses its row (recordRun ignores kind on conflict).
 		await recordRun({
 			workspaceId,
 			engineSessionId: spec.engineSessionId,
-			kind: "begin_session",
+			kind: spec.kind,
 			stage: spec.stage,
 			workflowId: spec.workflowId,
 			conversationId: spec.conversationId,
@@ -159,6 +165,29 @@ async function runChildStage(
 	}
 }
 
+/** Run an add_source stage from its trigger (a fresh import or a replay). */
+function runAddSourceStage(
+	workspaceId: string,
+	req: RunAddSource,
+): Promise<boolean> {
+	return runChildStage(workspaceId, {
+		workflowType: "addSourceWorkflow",
+		workflowId: req.workflowId,
+		taskQueue: req.engineTaskQueue,
+		stage: "add_source",
+		kind: req.kind,
+		engineSessionId: req.sessionId,
+		conversationId: req.conversationId,
+		args: [
+			{
+				workspace_id: workspaceId,
+				sources: req.sources,
+				verticals: req.verticals,
+			},
+		],
+	});
+}
+
 /** Run a begin_session stage from its trigger. */
 function runBeginSessionStage(
 	workspaceId: string,
@@ -169,6 +198,7 @@ function runBeginSessionStage(
 		workflowId: req.workflowId,
 		taskQueue: req.engineTaskQueue,
 		stage: "begin_session",
+		kind: "begin_session",
 		engineSessionId: req.sessionId,
 		conversationId: req.conversationId,
 		args: [
@@ -193,6 +223,8 @@ function runOperatingModelStage(
 		workflowId: om.workflowId,
 		taskQueue: om.engineTaskQueue,
 		stage: "operating_model",
+		// Reuses begin_session's session row (recordRun ignores kind on conflict).
+		kind: "begin_session",
 		engineSessionId: om.sessionId,
 		conversationId: om.conversationId,
 		args: [{ workspace_id: workspaceId, verticals: om.verticals }],
@@ -221,6 +253,9 @@ export async function journeyWorkflow(
 	setHandler(verticalEstablished, () => {});
 
 	const pending: PendingStage[] = [];
+	setHandler(runAddSource, (req) => {
+		pending.push({ kind: "add_source", req });
+	});
 	setHandler(runBeginSession, (req) => {
 		pending.push({ kind: "begin_session", req });
 	});
@@ -256,6 +291,17 @@ export async function journeyWorkflow(
 	while (!(handled >= EVENTS_BEFORE_CONTINUE && pending.length === 0)) {
 		await condition(() => pending.length > 0);
 		const next = pending.shift() as PendingStage;
+
+		if (next.kind === "add_source") {
+			// A fresh import or a replay — always user-triggered (select / replay),
+			// never autonomous in this slice, so it does NOT fold into the breaker:
+			// the breaker is scoped to the begin_session → operating_model cascade
+			// (ADR-0014). runChildStage still records + marks the run. No cascade
+			// follows add_source here (the agentic grounding-teach loop is slice 2).
+			await runAddSourceStage(workspaceId, next.req);
+			handled += 1;
+			continue;
+		}
 
 		if (next.kind === "operating_model") {
 			// A manual re-trigger is user-intentional — it runs regardless of the


### PR DESCRIPTION
## DAT-551 slice 1 — `add_source` + `replay` under the journey, and the `unit` teach type

Part of the Cockpit Autonomy epic (DAT-526, P3c). The prerequisite slice for the agentic grounding-teach loop: finish "the journey owns ALL stages," and add the one missing grounding teach type the loop will auto-apply. **No engine change.** The agentic loop itself is slice 2.

### pt1 — the `unit` cockpit teach type (`751154b5`)
The auto-apply grounding set is `{type_pattern, null_value, unit}`, but `unit` wasn't a cockpit teach type. The engine already has the applier (`core/overlay.py` `_apply_unit`, DAT-428; payload `{table, column, unit}` → `phases/typing.yaml::overrides.units`), so this is cockpit-only: a `UnitPayload` Zod schema (column identified by NAME, not id) wired into `TYPE_SCHEMAS` + `AGENT_TEACH_TYPES` (so it's manually teachable too) + the teach tool's payload union/description. The auto-apply classification const lands in slice 2 (no consumer until the agent).

### pt2 — `add_source` + `replay` under the journey (`6cd5c7d3`)
`add_source` was the last stage NOT journey-owned (P3b already routed begin_session + operating_model). Now `select`→`triggerAddSource` (kind `onboarding`) and `replay` (kind `replay`) **signal the per-workspace JourneyWorkflow** (`runAddSource`); the journey records the run authoritatively and starts `addSourceWorkflow` as a cross-language child on `engine-<id>`. The conversationId is captured at the tool boundary and threaded through (the journey has no request ALS), so the run still narrates into the originating chat (DAT-528). The tools return the deterministic workflow id (`run_id` mirrors it — the journey owns the real execution id; progress resolves the latest run by workflow id, DAT-530).

`RunAddSource` carries `kind` (onboarding|replay) since add_source originates two ways; `runChildStage` generalized to thread it to `recordRun`. add_source runs as a user-intentional stage that does **not** fold into the breaker (scoped to the begin_session→operating_model cascade, ADR-0014) and does **not** cascade.

### pt3 — review fixups (`ad5c74e1`)
Two stale header comments corrected.

### Verification
- tsc clean · biome clean · **1173 unit tests** pass · offline determinism replay passes.
- **Live smoke (real engine + LLM):** Connect chat → adopt `finance` → upload `payments.csv` (2,585 rows) → `select` → the **journey-owned add_source** ran the full pipeline with a live progress widget, **narrated completion back into the originating chat** ("imported … ready with zero issues"), recorded **completed** in the native Runs monitor, and landed `payments` Ready in the inventory. Zero console errors. (The cross-language add_source child + signal routing + narration was the previously-unexercised seam — now proven end-to-end.)
- Reviewers: senior **APPROVE**, spec-compliance **COMPLIANT** (no critical findings).

### Not in this PR
- Slice 2: the agentic grounding-teach loop (LLM-in-worker assessment, auto-apply `{type_pattern, null_value, unit}`, attempt-bounded replay, `awaiting_input` surface). Unblocked by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
