### PR TITLE
DAT-545: driver-tree engine (variance reduction + permutation null) over the enriched view

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,31 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-17: DAT-545 — driver-discovery engine (analysis/drivers/)
+
+New **pure, on-demand** engine `packages/engine/src/dataraum/analysis/drivers/`:
+ranks the catalog's grain-safe dimensions by how much they explain a numeric
+measure's variation (variance-reduction tree), gated by a **within-dataset
+permutation null** — no global threshold, vertical-agnostic. Productionizes the
+DAT-544 kill-gate spike. **No schema change, no pipeline phase, no persistence** —
+it returns an in-memory `DriverRanking`; it is not yet wired to any caller (DAT-546
+adds the artifact + cockpit read surface; an agent caller is later). So it does not
+run in add_source/begin_session and changes no existing measurement.
+
+Engine: candidate dims = `SliceDefinition.grain_safe` (DAT-536) with
+`DimensionHierarchy` 1:1 aliases collapsed (DAT-537); substrate = the fact's
+grain-verified enriched view read row-grain via DuckDB; target-type from
+`SemanticAnnotation.temporal_behavior` (additive→flow, point_in_time→stock); ratio =
+support-weighted Σnum/Σden.
+
+### dataraum-eval
+- **The real-fixture transfer check is eval's task** (agreed handoff — it needs a real enriched view with planted drivers, not a unit test). Build the FDR/recall calibration rig over the DAT-544 adversarial corpus + harness and verify separation holds on REAL data across ≥1 non-synthetic fixture (vertical-agnostic — not finance-specific).
+- **Acceptance bars the spike established** (match these): strong driver (±60%) recall ≥ 0.9; independent-null FDR ≤ 2α (α=0.05), including a participating high-card dim; marginal-driver (±25%) power ≥ ~0.6 (the documented ≈±20–25% floor — NOT 90%; weak effects miss safely). ratio + stock target types separate too.
+- **No threshold to calibrate across datasets** — both ranking (ordinal) and the noise gate (within-dataset permutation null) are self-calibrating. This is the structural difference from the cut `slice_variance`/`temporal_drift` detectors; the eval rig should confirm there is no global constant being tuned.
+
+### dataraum-testdata
+- The DAT-544 corpus (`make_corpus`: planted drivers at known effect sizes + independent nulls + a confounded proxy + measure-conditional missingness) seeds a generative family. Add **ratio** (numerator/denominator whose ratio depends on a driver, denominator varying independently) and **stock** fixtures, and a **confounded-dim** fixture (a proxy that is an 80% copy of the strongest driver) for the de-confounding check.
+
 ## 2026-06-17: DAT-537 — new `dimension_hierarchies` begin_session phase (g3 FD / drill-down / alias)
 
 A new **deterministic** value-layer phase, `dimension_hierarchies`, runs in the

--- a/packages/engine/src/dataraum/analysis/drivers/__init__.py
+++ b/packages/engine/src/dataraum/analysis/drivers/__init__.py
@@ -1,0 +1,15 @@
+"""Driver discovery (DAT-545) — rank dimensions by information gain for a measure.
+
+A deterministic, on-demand engine: given a numeric measure and the catalog's
+grain-safe candidate dimensions, a greedy variance-reduction tree finds which
+dimensions and which slices most explain the measure's variation — gated by a
+within-dataset permutation null so it surfaces real drivers, not noise.
+
+Vertical-agnostic by construction: the ranking is ordinal (within the dataset
+received) and the noise gate is built from the same data, so there is no global
+threshold and nothing finance-specific. Built on the DAT-536 dimension catalog +
+DAT-537 alias/hierarchy edges; validated by the DAT-544 kill-gate spike.
+
+This package is the ENGINE only (pure, in-memory result) — persistence, caching,
+and agent wiring are DAT-546+.
+"""

--- a/packages/engine/src/dataraum/analysis/drivers/criterion.py
+++ b/packages/engine/src/dataraum/analysis/drivers/criterion.py
@@ -127,3 +127,45 @@ def variance_reduction(
         return 0.0
     within_var = (sq_big.sum() - np.sum(sum_big * sum_big / n_big)) / total_n
     return max(0.0, float((total_var - within_var) / total_var))
+
+
+def weighted_variance_reduction(
+    codes: np.ndarray,
+    n_codes: int,
+    ratio: np.ndarray,
+    weight: np.ndarray,
+    *,
+    min_support: int = DEFAULT_MIN_SUPPORT,
+) -> float:
+    """Support-weighted variance reduction for a RATIO measure (DAT-545 P4).
+
+    A ratio ``R = Σnum / Σden`` is the weight-``den`` mean of the per-row ratios
+    ``r = num/den`` — so the explained fraction is a *weighted* variance reduction of
+    ``r`` with weights ``w = den`` (averaging raw per-row ratios would weight a
+    ₂-row group like a ₂-million-row one; Simpson's paradox). Rows with a
+    non-positive or missing denominator carry no ratio and are dropped. Same shape as
+    :func:`variance_reduction` — groups clear ``min_support`` by ROW count, the result
+    is ``[0, 1]`` and only ever ranked / permutation-gated.
+    """
+    valid = (codes >= 0) & ~np.isnan(ratio) & (weight > 0)
+    if int(valid.sum()) < min_support:
+        return 0.0
+    c, r, w = codes[valid], ratio[valid], weight[valid]
+    counts = np.bincount(c, minlength=n_codes)
+    w_sum = np.bincount(c, weights=w, minlength=n_codes)
+    wr = np.bincount(c, weights=w * r, minlength=n_codes)
+    wrr = np.bincount(c, weights=w * r * r, minlength=n_codes)
+
+    big = counts >= min_support
+    if int(big.sum()) < 2:
+        return 0.0
+    w_big, wr_big, wrr_big = w_sum[big], wr[big], wrr[big]
+    total_w = w_big.sum()
+    if total_w <= 0:
+        return 0.0
+    grand = wr_big.sum() / total_w
+    total_var = wrr_big.sum() / total_w - grand**2
+    if total_var <= 0:
+        return 0.0
+    within_var = (wrr_big.sum() - np.sum(wr_big * wr_big / w_big)) / total_w
+    return max(0.0, float((total_var - within_var) / total_var))

--- a/packages/engine/src/dataraum/analysis/drivers/criterion.py
+++ b/packages/engine/src/dataraum/analysis/drivers/criterion.py
@@ -1,0 +1,129 @@
+"""The split criterion + null-handling gates (DAT-545, ported from the DAT-544 spike).
+
+Two numpy primitives the tree is built from:
+
+- :func:`build_codes` turns a dimension's raw values into integer group codes,
+  applying the two null gates the spike proved load-bearing:
+    **(A) dim-present** — rows whose dimension value is NULL get code ``-1`` and are
+    dropped from the gain (a column's own missingness is never read as a phantom
+    "null slice").
+    **(B) missingness-concentration** — a slice value where the MEASURE is
+    disproportionately missing (observed-rate < ``missingness_gate`` × the
+    dim-present baseline) is dropped too. Min-support alone leaked
+    measure-conditional missingness in the spike; this gate (the
+    ``slice_conditional_null`` contingency, reimplemented inline — NOT the
+    per-column entropy detector) closed it.
+
+- :func:`variance_reduction` is the FLOW gain: the fraction of the measure's
+  variance explained by the grouping, over groups that clear ``min_support``.
+  ``stock`` measures use the same row-grain reduction (additivity-respecting
+  because it never sums); ``ratio`` has its own support-weighted gain (DAT-545 P4).
+
+The magnitude is never compared to a global threshold — the tree RANKS by it and
+gates significance with a within-dataset permutation null (see ``tree.py``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+# A group must clear this row count to enter the variance computation — both the
+# determinant subset and each retained group. The spike calibrated it against
+# ~20k-row datasets; the engine passes it through so it can scale with the data.
+DEFAULT_MIN_SUPPORT = 200
+
+# A slice value is dropped (B-gate) when its measure-observed rate falls below this
+# fraction of the dim-present baseline — i.e. the measure goes disproportionately
+# missing inside that slice, which would otherwise manufacture a false driver.
+DEFAULT_MISSINGNESS_GATE = 0.5
+
+_DIM_NULL_CODE = -1
+
+
+def build_codes(
+    values: np.ndarray,
+    measure: np.ndarray,
+    *,
+    handle_nulls: bool,
+    missingness_gate: float = DEFAULT_MISSINGNESS_GATE,
+) -> tuple[np.ndarray, int]:
+    """Encode a dimension's values as integer group codes, applying the null gates.
+
+    Args:
+        values: object array of the dimension's raw values (``None``/NaN = missing).
+        measure: float array of the measure, row-aligned with ``values`` (NaN = missing).
+        handle_nulls: when True, apply (A) dim-present + (B) missingness gates; when
+            False, the ablation baseline — dim-NULL becomes its own ``"__NULL__"``
+            category and no missingness gate runs (this is what LEAKS, by design).
+        missingness_gate: the (B) threshold (fraction of the dim-present baseline).
+
+    Returns:
+        ``(codes, n_codes)`` — ``codes[i]`` is the group of row ``i`` or
+        ``_DIM_NULL_CODE`` (-1) if the row is gated out; ``n_codes`` is the number
+        of retained groups (the max code + 1).
+    """
+    dim_null = pd.isna(values)
+    measure_observed = ~np.isnan(measure)
+    codes = np.full(len(values), _DIM_NULL_CODE, dtype=int)
+
+    if not handle_nulls:
+        # Ablation: dim-null is its own category, no missingness gate.
+        labelled = np.where(dim_null, "__NULL__", values)
+        uniq = pd.unique(labelled)
+        for i, label in enumerate(uniq):
+            codes[labelled == label] = i
+        return codes, len(uniq)
+
+    # (A) dim-present: only rows that carry a slice label participate.
+    present = ~dim_null
+    baseline = measure_observed[present].mean() if present.any() else 0.0
+    next_code = 0
+    for label in pd.unique(values[present]):
+        in_slice = present & (values == label)
+        rate = measure_observed[in_slice].mean() if in_slice.any() else 0.0
+        # (B) missingness-concentration: drop a slice where the measure is
+        # disproportionately missing — its aggregate would be silently biased.
+        if rate < missingness_gate * baseline:
+            continue
+        codes[in_slice] = next_code
+        next_code += 1
+    return codes, next_code
+
+
+def variance_reduction(
+    codes: np.ndarray,
+    n_codes: int,
+    measure: np.ndarray,
+    *,
+    min_support: int = DEFAULT_MIN_SUPPORT,
+) -> float:
+    """Fraction of the measure's variance explained by the grouping (flow gain).
+
+    Computed over rows with a retained code (``>= 0``) and an observed measure,
+    restricted to groups that clear ``min_support`` (small groups are dropped from
+    BOTH the total and within terms, so a long tail of tiny slices can't inflate
+    the reduction). Returns ``0.0`` when there is too little support or no variance
+    to explain. Range ``[0, 1]``; higher = more explanatory. The value is only ever
+    RANKED and permutation-gated — never thresholded absolutely.
+    """
+    observed = ~np.isnan(measure)
+    keep = (codes >= 0) & observed
+    if int(keep.sum()) < min_support:
+        return 0.0
+    c, y = codes[keep], measure[keep]
+    counts = np.bincount(c, minlength=n_codes)
+    sums = np.bincount(c, weights=y, minlength=n_codes)
+    sq_sums = np.bincount(c, weights=y * y, minlength=n_codes)
+
+    big = counts >= min_support
+    if int(big.sum()) < 2:
+        return 0.0  # need ≥2 supported groups to speak of between-group variance
+    n_big, sum_big, sq_big = counts[big], sums[big], sq_sums[big]
+    total_n = n_big.sum()
+    grand_mean = sum_big.sum() / total_n
+    total_var = sq_big.sum() / total_n - grand_mean**2
+    if total_var <= 0:
+        return 0.0
+    within_var = (sq_big.sum() - np.sum(sum_big * sum_big / n_big)) / total_n
+    return max(0.0, float((total_var - within_var) / total_var))

--- a/packages/engine/src/dataraum/analysis/drivers/models.py
+++ b/packages/engine/src/dataraum/analysis/drivers/models.py
@@ -1,0 +1,88 @@
+"""Result types for the driver-discovery engine (DAT-545).
+
+In-memory only — DAT-545 is the engine, not the persisted artifact (that is
+DAT-546). ``Measure`` is the engine's input value object; the rest is its output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Measure:
+    """The numeric target a driver search explains.
+
+    ``target_type`` drives the criterion (DAT-545): ``flow`` (additive) and
+    ``stock`` (point_in_time) variance-reduce the row-grain value directly; ``ratio``
+    aggregates Σnumerator / Σdenominator per group, support-weighted (averaging
+    ratios is invalid). The type is read from the catalog's ``temporal_behavior``;
+    a ratio is a computed measure carrying both columns.
+    """
+
+    target_type: str  # 'flow' | 'stock' | 'ratio'
+    column: str | None = None  # flow / stock
+    numerator: str | None = None  # ratio
+    denominator: str | None = None  # ratio
+
+    def __post_init__(self) -> None:
+        if self.target_type in ("flow", "stock"):
+            if not self.column:
+                raise ValueError(f"{self.target_type} measure needs `column`")
+        elif self.target_type == "ratio":
+            if not (self.numerator and self.denominator):
+                raise ValueError("ratio measure needs `numerator` and `denominator`")
+        else:
+            raise ValueError(f"unknown target_type {self.target_type!r}")
+
+    @property
+    def label(self) -> str:
+        """A human label for logs/diagnostics."""
+        if self.target_type == "ratio":
+            return f"{self.numerator}/{self.denominator}"
+        return self.column or "?"
+
+
+@dataclass(frozen=True)
+class DriverSlice:
+    """A filter slice where the measure deviates sharply from the node baseline."""
+
+    dimension: str
+    value: str
+    effect: float  # group_mean / node_baseline − 1  (signed relative deviation)
+    support: int
+
+
+@dataclass(frozen=True)
+class DriverNode:
+    """One surviving split: the dimension that best explains the node's measure.
+
+    ``children`` are ``(slice_value, subtree)`` pairs — the deeper split found WITHIN
+    that slice value's rows (the drill path). Empty at a leaf / at ``max_depth``.
+    """
+
+    dimension: str
+    gain: float
+    p_value: float
+    support: int
+    slices: tuple[DriverSlice, ...]
+    children: tuple[tuple[str, DriverNode], ...] = ()
+
+
+@dataclass(frozen=True)
+class DriverRanking:
+    """The engine's output for one measure.
+
+    ``ranked_dimensions`` = the significant dims at the root by gain (the best
+    aggregation vectors); ``root`` = the greedy driver tree; ``driver_paths`` = the
+    surviving dimension drill vectors; ``interesting_slices`` = the sharp-deviation
+    slices across the tree, strongest first.
+    """
+
+    measure: str
+    target_type: str
+    n_rows: int
+    ranked_dimensions: list[tuple[str, float]] = field(default_factory=list)
+    root: DriverNode | None = None
+    driver_paths: list[list[str]] = field(default_factory=list)
+    interesting_slices: list[DriverSlice] = field(default_factory=list)

--- a/packages/engine/src/dataraum/analysis/drivers/models.py
+++ b/packages/engine/src/dataraum/analysis/drivers/models.py
@@ -45,11 +45,17 @@ class Measure:
 
 @dataclass(frozen=True)
 class DriverSlice:
-    """A filter slice where the measure deviates sharply from the node baseline."""
+    """A filter slice where the measure deviates sharply from the node baseline.
+
+    ``effect`` is the signed relative deviation of the slice's value from the node
+    baseline (``group / baseline − 1``); the baseline is the node's dim-present mean
+    (flow/stock) or pooled ratio (ratio). ``support`` is the slice's row count (it
+    cleared ``min_support``).
+    """
 
     dimension: str
     value: str
-    effect: float  # group_mean / node_baseline − 1  (signed relative deviation)
+    effect: float
     support: int
 
 
@@ -64,6 +70,8 @@ class DriverNode:
     dimension: str
     gain: float
     p_value: float
+    # Dim-present rows at this node (codes ≥ 0) — INCLUDES rows in sub-min_support
+    # groups that the gain itself excluded, so ``support`` ≥ Σ(slice.support).
     support: int
     slices: tuple[DriverSlice, ...]
     children: tuple[tuple[str, DriverNode], ...] = ()

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -1,0 +1,180 @@
+"""Driver discovery over the real catalog + enriched view (DAT-545 P3).
+
+Binds the engine (:mod:`tree`) to the begin_session substrate:
+
+- **Candidate dims** = this run's grain-safe ``SliceDefinition`` columns (DAT-536),
+  with ``DimensionHierarchy`` 1:1 alias groups collapsed to their canonical axis
+  (DAT-537) so a redundant dimension never competes in the permutation null.
+- **Substrate** = the fact's grain-verified enriched view, read at ROW grain via
+  DuckDB (required so the (B) missingness gate sees NULL structure). Columns are
+  pulled ONCE into memory; the permutation null runs in numpy (the design's "GROUP
+  BYs over aggregation views" is moot — ADR-0013 removed those, and 500 shuffles in
+  SQL would be hundreds of scans).
+- **Target type** = the measure's ``SemanticAnnotation.temporal_behavior``
+  (``additive`` → flow, ``point_in_time`` → stock) via :func:`resolve_target_type`.
+
+On-demand and pure: returns a :class:`DriverRanking`, persists nothing (DAT-546).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from sqlalchemy import select
+
+from dataraum.analysis.drivers.criterion import DEFAULT_MIN_SUPPORT, DEFAULT_MISSINGNESS_GATE
+from dataraum.analysis.drivers.models import DriverRanking, Measure
+from dataraum.analysis.drivers.tree import (
+    DEFAULT_ALPHA,
+    DEFAULT_MAX_DEPTH,
+    DEFAULT_N_PERM,
+    DEFAULT_TOP_K_SLICES,
+    discover_tree,
+)
+from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
+from dataraum.analysis.semantic.db_models import SemanticAnnotation
+from dataraum.analysis.slicing.db_models import SliceDefinition
+from dataraum.analysis.views.db_models import EnrichedView
+from dataraum.core.logging import get_logger
+
+if TYPE_CHECKING:
+    import duckdb
+    from sqlalchemy.orm import Session
+
+logger = get_logger(__name__)
+
+_TEMPORAL_TO_TARGET = {"additive": "flow", "point_in_time": "stock"}
+
+
+def resolve_target_type(session: Session, *, column_id: str, run_id: str) -> str:
+    """Map the measure column's ``temporal_behavior`` to a driver target type.
+
+    ``additive`` → ``flow``, ``point_in_time`` → ``stock``; anything else (or no
+    annotation) defaults to ``flow`` — the additive reading, logged. Ratio is not a
+    ``temporal_behavior`` value: a ratio measure is constructed explicitly by the
+    caller (computed metric), not resolved here.
+    """
+    behavior = session.execute(
+        select(SemanticAnnotation.temporal_behavior).where(
+            SemanticAnnotation.column_id == column_id,
+            SemanticAnnotation.run_id == run_id,
+        )
+    ).scalar_one_or_none()
+    target = _TEMPORAL_TO_TARGET.get(behavior or "", "flow")
+    if behavior not in _TEMPORAL_TO_TARGET:
+        logger.info("driver_target_type_defaulted", column_id=column_id, behavior=behavior)
+    return target
+
+
+def _enriched_view_name(session: Session, fact_table_id: str, run_id: str) -> str | None:
+    """The grain-verified enriched view for the fact this run (the split substrate)."""
+    return session.execute(
+        select(EnrichedView.view_name).where(
+            EnrichedView.fact_table_id == fact_table_id,
+            EnrichedView.run_id == run_id,
+            EnrichedView.is_grain_verified.is_(True),
+        )
+    ).scalar_one_or_none()
+
+
+def _candidate_dims(session: Session, fact_table_id: str, run_id: str) -> list[str]:
+    """This run's grain-safe slice dimensions, with alias groups collapsed to canonical.
+
+    A DAT-537 1:1 alias group is a redundant axis — keep only its canonical member so
+    it doesn't compete as a separate candidate (the de-confounding the spike deferred).
+    """
+    defs = session.execute(
+        select(SliceDefinition.column_name).where(
+            SliceDefinition.table_id == fact_table_id,
+            SliceDefinition.run_id == run_id,
+            SliceDefinition.grain_safe.is_(True),
+            SliceDefinition.column_name.isnot(None),
+        )
+    ).scalars()
+    candidates = {name for name in defs if name}
+
+    aliases = session.execute(
+        select(DimensionHierarchy).where(
+            DimensionHierarchy.table_id == fact_table_id,
+            DimensionHierarchy.run_id == run_id,
+            DimensionHierarchy.kind == "alias",
+        )
+    ).scalars()
+    for group in aliases:
+        for member in group.members:
+            name = member.get("column_name")
+            if name and name != group.canonical_label:
+                candidates.discard(name)
+    return sorted(candidates)
+
+
+def _measure_columns(measure: Measure) -> list[str]:
+    """The enriched-view columns a measure needs read."""
+    if measure.target_type in ("flow", "stock"):
+        return [measure.column] if measure.column else []
+    raise NotImplementedError(f"target_type {measure.target_type!r} arrives in DAT-545 P4")
+
+
+def discover_drivers(
+    session: Session,
+    *,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    fact_table_id: str,
+    run_id: str,
+    measure: Measure,
+    seed: int = 0,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    alpha: float = DEFAULT_ALPHA,
+    min_support: int = DEFAULT_MIN_SUPPORT,
+    missingness_gate: float = DEFAULT_MISSINGNESS_GATE,
+    n_perm: int = DEFAULT_N_PERM,
+    top_k_slices: int = DEFAULT_TOP_K_SLICES,
+) -> DriverRanking:
+    """Rank the catalog's dimensions as drivers of ``measure`` over the enriched view.
+
+    Pure + deterministic for a given ``seed`` (so a future cache keyed by
+    ``(measure, run)`` is stable). Returns an empty ranking — never an error — when
+    the fact has no grain-verified enriched view or fewer than two candidate dims.
+    """
+    empty = DriverRanking(measure=measure.label, target_type=measure.target_type, n_rows=0)
+
+    view = _enriched_view_name(session, fact_table_id, run_id)
+    if view is None:
+        logger.info("driver_no_enriched_view", fact_table_id=fact_table_id, run_id=run_id)
+        return empty
+    dims = _candidate_dims(session, fact_table_id, run_id)
+    if len(dims) < 2:
+        logger.info("driver_too_few_candidates", fact_table_id=fact_table_id, n=len(dims))
+        return empty
+
+    def quote(name: str) -> str:
+        return '"' + name.replace('"', '""') + '"'
+
+    select_cols = dims + _measure_columns(measure)
+    sql = f"SELECT {', '.join(quote(c) for c in select_cols)} FROM {quote(view)}"  # noqa: S608 — catalog identifiers
+    frame = duckdb_conn.execute(sql).df()
+
+    # Only dims actually present in the view participate (a catalog/view skew is
+    # logged, not fatal).
+    present_dims = [d for d in dims if d in frame.columns]
+    if len(present_dims) < 2:
+        logger.info("driver_dims_absent_from_view", view=view, present=present_dims)
+        return empty
+    values_by_dim = {d: frame[d].astype(object).to_numpy() for d in present_dims}
+    measure_array = frame[measure.column].to_numpy(dtype=float)
+
+    return discover_tree(
+        values_by_dim,
+        measure_array,
+        measure_label=measure.label,
+        target_type=measure.target_type,
+        dims=present_dims,
+        rng=np.random.default_rng(seed),
+        max_depth=max_depth,
+        alpha=alpha,
+        min_support=min_support,
+        missingness_gate=missingness_gate,
+        n_perm=n_perm,
+        top_k_slices=top_k_slices,
+    )

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -21,10 +21,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+import pandas as pd
 from sqlalchemy import select
 
 from dataraum.analysis.drivers.criterion import DEFAULT_MIN_SUPPORT, DEFAULT_MISSINGNESS_GATE
 from dataraum.analysis.drivers.models import DriverRanking, Measure
+from dataraum.analysis.drivers.targets import FlowTarget, RatioTarget, Target
 from dataraum.analysis.drivers.tree import (
     DEFAULT_ALPHA,
     DEFAULT_MAX_DEPTH,
@@ -113,7 +115,22 @@ def _measure_columns(measure: Measure) -> list[str]:
     """The enriched-view columns a measure needs read."""
     if measure.target_type in ("flow", "stock"):
         return [measure.column] if measure.column else []
-    raise NotImplementedError(f"target_type {measure.target_type!r} arrives in DAT-545 P4")
+    assert measure.numerator and measure.denominator  # guaranteed by Measure.__post_init__
+    return [measure.numerator, measure.denominator]
+
+
+def _make_target(measure: Measure, frame: pd.DataFrame) -> Target:
+    """Build the row-aligned target from the measure's columns in ``frame``."""
+    if measure.target_type in ("flow", "stock"):
+        assert measure.column  # guaranteed by Measure.__post_init__
+        return FlowTarget(
+            frame[measure.column].to_numpy(dtype=float), target_type=measure.target_type
+        )
+    assert measure.numerator and measure.denominator  # guaranteed by Measure.__post_init__
+    return RatioTarget(
+        frame[measure.numerator].to_numpy(dtype=float),
+        frame[measure.denominator].to_numpy(dtype=float),
+    )
 
 
 def discover_drivers(
@@ -162,13 +179,11 @@ def discover_drivers(
         logger.info("driver_dims_absent_from_view", view=view, present=present_dims)
         return empty
     values_by_dim = {d: frame[d].astype(object).to_numpy() for d in present_dims}
-    measure_array = frame[measure.column].to_numpy(dtype=float)
 
     return discover_tree(
         values_by_dim,
-        measure_array,
+        _make_target(measure, frame),
         measure_label=measure.label,
-        target_type=measure.target_type,
         dims=present_dims,
         rng=np.random.default_rng(seed),
         max_depth=max_depth,

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -150,9 +150,16 @@ def discover_drivers(
 ) -> DriverRanking:
     """Rank the catalog's dimensions as drivers of ``measure`` over the enriched view.
 
-    Pure + deterministic for a given ``seed`` (so a future cache keyed by
-    ``(measure, run)`` is stable). Returns an empty ranking — never an error — when
-    the fact has no grain-verified enriched view or fewer than two candidate dims.
+    Pure + deterministic for a given ``(seed, candidate-dim set)`` — the permutation
+    draw sequence depends on the dims, so a future cache (DAT-546) must key on the
+    candidate set too, not just ``(measure, run, seed)``. Returns an empty ranking —
+    never an error — when the fact has no grain-verified enriched view, fewer than
+    two candidate dims survive in the view, or the measure columns are absent
+    (a catalog/view skew is logged, not fatal).
+
+    NOTE: the ``(present_dims + measure)`` columns are read into memory at row grain
+    in one pass. At ~1M rows × ~15 dims that is several hundred MB; DAT-546 should add
+    a row-count gate before calling on very large views.
     """
     empty = DriverRanking(measure=measure.label, target_type=measure.target_type, n_rows=0)
 
@@ -168,16 +175,19 @@ def discover_drivers(
     def quote(name: str) -> str:
         return '"' + name.replace('"', '""') + '"'
 
-    select_cols = dims + _measure_columns(measure)
+    # Probe the view's columns first (LIMIT 0 — no scan) so a catalog/view skew is a
+    # logged empty result, not a DuckDB BinderException, AND we still read only the
+    # columns we need (no SELECT *). The measure columns must exist; dims intersect.
+    view_cols = set(duckdb_conn.execute(f"SELECT * FROM {quote(view)} LIMIT 0").df().columns)  # noqa: S608
+    present_dims = [d for d in dims if d in view_cols]
+    measure_cols = _measure_columns(measure)
+    if len(present_dims) < 2 or any(c not in view_cols for c in measure_cols):
+        logger.info("driver_view_skew", view=view, present=present_dims, measure_cols=measure_cols)
+        return empty
+
+    select_cols = present_dims + measure_cols
     sql = f"SELECT {', '.join(quote(c) for c in select_cols)} FROM {quote(view)}"  # noqa: S608 — catalog identifiers
     frame = duckdb_conn.execute(sql).df()
-
-    # Only dims actually present in the view participate (a catalog/view skew is
-    # logged, not fatal).
-    present_dims = [d for d in dims if d in frame.columns]
-    if len(present_dims) < 2:
-        logger.info("driver_dims_absent_from_view", view=view, present=present_dims)
-        return empty
     values_by_dim = {d: frame[d].astype(object).to_numpy() for d in present_dims}
 
     return discover_tree(

--- a/packages/engine/src/dataraum/analysis/drivers/targets.py
+++ b/packages/engine/src/dataraum/analysis/drivers/targets.py
@@ -1,0 +1,134 @@
+"""Target types for the driver tree (DAT-545 P4) — flow/stock vs ratio.
+
+The tree is target-agnostic: it asks a ``Target`` for the gain of a grouping, a
+shuffled copy of itself (the permutation null), and per-group effects (for the
+interesting slices). This is where flow/stock and ratio differ:
+
+- :class:`FlowTarget` serves both **flow** (additive) and **stock** (point_in_time):
+  row-grain variance reduction of the measure value. Stock is additivity-respecting
+  *because* it never sums — it reduces the raw snapshot value's variance.
+- :class:`RatioTarget` serves **ratio**: the group statistic is ``Σnum/Σden`` (never
+  the mean of per-row ratios), so it permutes the (num, den) PAIRS jointly and uses
+  the support-weighted gain.
+
+``observed`` is the array :func:`build_codes` reads for the (B) missingness gate —
+finite where the row contributes to the measure, NaN where it does not.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from dataraum.analysis.drivers.criterion import variance_reduction, weighted_variance_reduction
+
+
+class Target(ABC):
+    """A numeric target the driver tree explains. Immutable; ``permuted`` returns a copy."""
+
+    target_type: str
+    observed: np.ndarray
+
+    @abstractmethod
+    def gain(self, codes: np.ndarray, n_codes: int, *, min_support: int) -> float:
+        """Fraction of the target's variation explained by the grouping ``codes``."""
+
+    @abstractmethod
+    def permuted(self, rng: np.random.Generator) -> Target:
+        """A copy with the target shuffled across rows (the permutation null draw)."""
+
+    @abstractmethod
+    def subset(self, mask: np.ndarray) -> Target:
+        """A copy restricted to ``mask`` rows (a child node's row subset)."""
+
+    @abstractmethod
+    def group_effects(
+        self, codes: np.ndarray, n_codes: int, *, min_support: int
+    ) -> list[tuple[int, float, int]]:
+        """``(code, effect, support)`` per supported group; effect = group/baseline − 1."""
+
+
+class FlowTarget(Target):
+    """Flow (additive) or stock (point_in_time): row-grain variance reduction."""
+
+    def __init__(self, measure: np.ndarray, *, target_type: str = "flow") -> None:
+        self.target_type = target_type
+        self._measure = measure
+        self.observed = measure  # finite where measured (NaN = missing)
+
+    def gain(self, codes: np.ndarray, n_codes: int, *, min_support: int) -> float:
+        return variance_reduction(codes, n_codes, self._measure, min_support=min_support)
+
+    def permuted(self, rng: np.random.Generator) -> FlowTarget:
+        return FlowTarget(rng.permutation(self._measure), target_type=self.target_type)
+
+    def subset(self, mask: np.ndarray) -> FlowTarget:
+        return FlowTarget(self._measure[mask], target_type=self.target_type)
+
+    def group_effects(
+        self, codes: np.ndarray, n_codes: int, *, min_support: int
+    ) -> list[tuple[int, float, int]]:
+        observed = ~np.isnan(self._measure)
+        keep = (codes >= 0) & observed
+        if int(keep.sum()) < min_support or not self._measure[keep].size:
+            return []
+        baseline = float(self._measure[keep].mean())
+        out: list[tuple[int, float, int]] = []
+        for c in range(n_codes):
+            in_group = (codes == c) & observed
+            support = int(in_group.sum())
+            if support < min_support:
+                continue
+            group_mean = float(self._measure[in_group].mean())
+            effect = (group_mean / baseline - 1.0) if baseline else 0.0
+            out.append((c, effect, support))
+        return out
+
+
+class RatioTarget(Target):
+    """Ratio: the group statistic is Σnum/Σden, support-weighted by the denominator."""
+
+    def __init__(self, numerator: np.ndarray, denominator: np.ndarray) -> None:
+        self.target_type = "ratio"
+        self._num = numerator
+        self._den = denominator
+        valid = ~np.isnan(numerator) & ~np.isnan(denominator) & (denominator > 0)
+        # Per-row ratio (NaN where invalid) doubles as the (B)-gate observed mask;
+        # weight is the denominator mass (0 where invalid).
+        with np.errstate(divide="ignore", invalid="ignore"):
+            self._ratio = np.where(valid, numerator / np.where(valid, denominator, 1.0), np.nan)
+        self._weight = np.where(valid, denominator, 0.0)
+        self.observed = self._ratio
+
+    def gain(self, codes: np.ndarray, n_codes: int, *, min_support: int) -> float:
+        return weighted_variance_reduction(
+            codes, n_codes, self._ratio, self._weight, min_support=min_support
+        )
+
+    def permuted(self, rng: np.random.Generator) -> RatioTarget:
+        idx = rng.permutation(self._num.size)
+        return RatioTarget(self._num[idx], self._den[idx])
+
+    def subset(self, mask: np.ndarray) -> RatioTarget:
+        return RatioTarget(self._num[mask], self._den[mask])
+
+    def group_effects(
+        self, codes: np.ndarray, n_codes: int, *, min_support: int
+    ) -> list[tuple[int, float, int]]:
+        valid = (codes >= 0) & ~np.isnan(self._ratio) & (self._weight > 0)
+        if int(valid.sum()) < min_support:
+            return []
+        den_total = float(self._den[valid].sum())
+        baseline = float(self._num[valid].sum() / den_total) if den_total else 0.0
+        out: list[tuple[int, float, int]] = []
+        for c in range(n_codes):
+            in_group = (codes == c) & valid
+            support = int(in_group.sum())
+            if support < min_support:
+                continue
+            den_g = float(self._den[in_group].sum())
+            group_ratio = float(self._num[in_group].sum() / den_g) if den_g else 0.0
+            effect = (group_ratio / baseline - 1.0) if baseline else 0.0
+            out.append((c, effect, support))
+        return out

--- a/packages/engine/src/dataraum/analysis/drivers/tree.py
+++ b/packages/engine/src/dataraum/analysis/drivers/tree.py
@@ -1,0 +1,261 @@
+"""The greedy driver tree + within-dataset permutation null (DAT-545 P2).
+
+The engine's decision core, ported and generalized from the DAT-544 spike:
+
+- **Gate** — for every candidate dimension, the real gain, plus a p-value from a
+  **within-dataset permutation null**: shuffle the measure ``n_perm`` times and, each
+  shuffle, take the MAX gain over all candidates (free multiple-comparison control —
+  a dim's gain must beat the best a SHUFFLED measure produces across the whole
+  candidate set). Codes are built ONCE on the real measure (the (B) gate is part of a
+  dimension's encoding); only the measure is permuted.
+- **Greedy split** — keep the significant dim with the highest gain, recurse into each
+  of its slice values that has enough rows, on the remaining dims, up to ``max_depth``.
+- **Depth penalty** — the significance bar tightens with depth (``alpha / (depth+1)``)
+  and each node rebuilds its null on its own rows, so deeper, smaller splits face a
+  stricter, self-calibrated gate (the spike confirmed FDR doesn't compound at depth).
+
+Magnitudes are only ever RANKED and permutation-gated — no global threshold anywhere,
+which is what makes this vertical-agnostic (the noise floor is the dataset's own).
+
+Flow/stock targets variance-reduce the row-grain measure directly (this module);
+ratio gets its support-weighted gain in P4 via the same gate machinery.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from dataraum.analysis.drivers.criterion import (
+    DEFAULT_MIN_SUPPORT,
+    DEFAULT_MISSINGNESS_GATE,
+    build_codes,
+    variance_reduction,
+)
+from dataraum.analysis.drivers.models import DriverNode, DriverRanking, DriverSlice
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+DEFAULT_N_PERM = 500
+DEFAULT_ALPHA = 0.05
+DEFAULT_MAX_DEPTH = 2
+DEFAULT_TOP_K_SLICES = 5
+# A child subset must clear this multiple of min_support to be re-gated — too few
+# rows and the per-node null is meaningless (the spike's 4× rule).
+_RECURSE_SUPPORT_MULTIPLE = 4
+
+_Coded = tuple[np.ndarray, int]
+
+
+def _gate(
+    values_by_dim: Mapping[str, np.ndarray],
+    measure: np.ndarray,
+    *,
+    dims: list[str],
+    rng: np.random.Generator,
+    n_perm: int,
+    min_support: int,
+    missingness_gate: float,
+) -> tuple[dict[str, _Coded], dict[str, float], dict[str, float]]:
+    """Return per-dim ``(codes, n_codes)``, real gain, and permutation-null p-value."""
+    coded: dict[str, _Coded] = {
+        d: build_codes(
+            values_by_dim[d], measure, handle_nulls=True, missingness_gate=missingness_gate
+        )
+        for d in dims
+    }
+    real = {d: variance_reduction(*coded[d], measure, min_support=min_support) for d in dims}
+    perm_max = np.empty(n_perm)
+    for i in range(n_perm):
+        shuffled = rng.permutation(measure)
+        perm_max[i] = max(
+            (variance_reduction(*coded[d], shuffled, min_support=min_support) for d in dims),
+            default=0.0,
+        )
+    p = {d: (1 + int(np.sum(perm_max >= real[d]))) / (1 + n_perm) for d in dims}
+    return coded, real, p
+
+
+def _code_labels(values: np.ndarray, codes: np.ndarray, n_codes: int) -> list[str]:
+    """The representative raw label of each group code (one label per code)."""
+    labels = [""] * n_codes
+    for c in range(n_codes):
+        idx = np.flatnonzero(codes == c)
+        if idx.size:
+            labels[c] = str(values[idx[0]])
+    return labels
+
+
+def _slices(
+    dimension: str,
+    values: np.ndarray,
+    measure: np.ndarray,
+    coded: _Coded,
+    *,
+    min_support: int,
+    top_k: int,
+) -> tuple[DriverSlice, ...]:
+    """The supported slice values whose mean deviates most from the node baseline."""
+    codes, n_codes = coded
+    observed = ~np.isnan(measure)
+    keep = (codes >= 0) & observed
+    if int(keep.sum()) < min_support or not measure[keep].size:
+        return ()
+    baseline = float(measure[keep].mean())
+    labels = _code_labels(values, codes, n_codes)
+    out: list[DriverSlice] = []
+    for c in range(n_codes):
+        in_group = (codes == c) & observed
+        support = int(in_group.sum())
+        if support < min_support:
+            continue
+        group_mean = float(measure[in_group].mean())
+        effect = (group_mean / baseline - 1.0) if baseline else 0.0
+        out.append(DriverSlice(dimension, labels[c], effect, support))
+    out.sort(key=lambda s: abs(s.effect), reverse=True)
+    return tuple(out[:top_k])
+
+
+def _build_node(
+    values_by_dim: Mapping[str, np.ndarray],
+    measure: np.ndarray,
+    *,
+    dims: list[str],
+    depth: int,
+    max_depth: int,
+    alpha: float,
+    min_support: int,
+    missingness_gate: float,
+    n_perm: int,
+    top_k: int,
+    rng: np.random.Generator,
+) -> tuple[DriverNode | None, dict[str, float], dict[str, float]]:
+    """Build the best split for this subset; recurse into its slice values.
+
+    Returns ``(node, real_gain, p_value)`` — the gain/p maps are the node's gate
+    result (the caller uses the root's to rank dimensions).
+    """
+    coded, real, p = _gate(
+        values_by_dim,
+        measure,
+        dims=dims,
+        rng=rng,
+        n_perm=n_perm,
+        min_support=min_support,
+        missingness_gate=missingness_gate,
+    )
+    eff_alpha = alpha / (depth + 1)  # depth penalty: deeper splits face a stricter bar
+    significant = [d for d in dims if p[d] < eff_alpha and real[d] > 0.0]
+    if not significant:
+        return None, real, p
+
+    best = max(significant, key=lambda d: real[d])
+    codes, _ = coded[best]
+    observed = ~np.isnan(measure)
+    support = int(((codes >= 0) & observed).sum())
+    slices = _slices(
+        best, values_by_dim[best], measure, coded[best], min_support=min_support, top_k=top_k
+    )
+
+    children: list[tuple[str, DriverNode]] = []
+    if depth + 1 < max_depth and len(dims) > 1:
+        labels = _code_labels(values_by_dim[best], codes, coded[best][1])
+        remaining = [d for d in dims if d != best]
+        for c in range(coded[best][1]):
+            mask = codes == c
+            if int(mask.sum()) < _RECURSE_SUPPORT_MULTIPLE * min_support:
+                continue
+            sub_values = {d: values_by_dim[d][mask] for d in remaining}
+            child, _, _ = _build_node(
+                sub_values,
+                measure[mask],
+                dims=remaining,
+                depth=depth + 1,
+                max_depth=max_depth,
+                alpha=alpha,
+                min_support=min_support,
+                missingness_gate=missingness_gate,
+                n_perm=n_perm,
+                top_k=top_k,
+                rng=rng,
+            )
+            if child is not None:
+                children.append((labels[c], child))
+
+    return (
+        DriverNode(best, real[best], p[best], support, slices, tuple(children)),
+        real,
+        p,
+    )
+
+
+def _walk_paths(node: DriverNode, prefix: list[str]) -> list[list[str]]:
+    """Every root→leaf dimension path through the tree (drill vectors)."""
+    path = [*prefix, node.dimension]
+    if not node.children:
+        return [path]
+    paths: list[list[str]] = []
+    for _value, child in node.children:
+        paths.extend(_walk_paths(child, path))
+    return paths
+
+
+def _all_slices(node: DriverNode) -> list[DriverSlice]:
+    out = list(node.slices)
+    for _value, child in node.children:
+        out.extend(_all_slices(child))
+    return out
+
+
+def discover_tree(
+    values_by_dim: Mapping[str, np.ndarray],
+    measure: np.ndarray,
+    *,
+    measure_label: str,
+    target_type: str,
+    dims: list[str],
+    rng: np.random.Generator,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    alpha: float = DEFAULT_ALPHA,
+    min_support: int = DEFAULT_MIN_SUPPORT,
+    missingness_gate: float = DEFAULT_MISSINGNESS_GATE,
+    n_perm: int = DEFAULT_N_PERM,
+    top_k_slices: int = DEFAULT_TOP_K_SLICES,
+) -> DriverRanking:
+    """Rank ``dims`` by their permutation-gated gain on ``measure`` and build the tree.
+
+    ``measure`` is row-aligned with each array in ``values_by_dim`` (NaN = missing).
+    Returns a :class:`DriverRanking`; ``root`` is ``None`` when no dimension clears
+    the null (a clean "no significant driver" answer, not an error).
+    """
+    root, real, p = _build_node(
+        values_by_dim,
+        measure,
+        dims=dims,
+        depth=0,
+        max_depth=max_depth,
+        alpha=alpha,
+        min_support=min_support,
+        missingness_gate=missingness_gate,
+        n_perm=n_perm,
+        top_k=top_k_slices,
+        rng=rng,
+    )
+    ranked = sorted(
+        ((d, real[d]) for d in dims if p[d] < alpha and real[d] > 0.0),
+        key=lambda pair: pair[1],
+        reverse=True,
+    )
+    paths = _walk_paths(root, []) if root is not None else []
+    slices = sorted(_all_slices(root), key=lambda s: abs(s.effect), reverse=True) if root else []
+    return DriverRanking(
+        measure=measure_label,
+        target_type=target_type,
+        n_rows=int(measure.size),
+        ranked_dimensions=ranked,
+        root=root,
+        driver_paths=paths,
+        interesting_slices=slices,
+    )

--- a/packages/engine/src/dataraum/analysis/drivers/tree.py
+++ b/packages/engine/src/dataraum/analysis/drivers/tree.py
@@ -1,13 +1,13 @@
-"""The greedy driver tree + within-dataset permutation null (DAT-545 P2).
+"""The greedy driver tree + within-dataset permutation null (DAT-545 P2/P4).
 
 The engine's decision core, ported and generalized from the DAT-544 spike:
 
 - **Gate** — for every candidate dimension, the real gain, plus a p-value from a
-  **within-dataset permutation null**: shuffle the measure ``n_perm`` times and, each
+  **within-dataset permutation null**: shuffle the target ``n_perm`` times and, each
   shuffle, take the MAX gain over all candidates (free multiple-comparison control —
-  a dim's gain must beat the best a SHUFFLED measure produces across the whole
-  candidate set). Codes are built ONCE on the real measure (the (B) gate is part of a
-  dimension's encoding); only the measure is permuted.
+  a dim's gain must beat the best a SHUFFLED target produces across the whole
+  candidate set). Codes are built ONCE on the real target (the (B) gate is part of a
+  dimension's encoding); only the target is permuted.
 - **Greedy split** — keep the significant dim with the highest gain, recurse into each
   of its slice values that has enough rows, on the remaining dims, up to ``max_depth``.
 - **Depth penalty** — the significance bar tightens with depth (``alpha / (depth+1)``)
@@ -15,10 +15,8 @@ The engine's decision core, ported and generalized from the DAT-544 spike:
   stricter, self-calibrated gate (the spike confirmed FDR doesn't compound at depth).
 
 Magnitudes are only ever RANKED and permutation-gated — no global threshold anywhere,
-which is what makes this vertical-agnostic (the noise floor is the dataset's own).
-
-Flow/stock targets variance-reduce the row-grain measure directly (this module);
-ratio gets its support-weighted gain in P4 via the same gate machinery.
+which is what makes this vertical-agnostic (the noise floor is the dataset's own). The
+target type (flow/stock vs ratio) is abstracted behind :class:`Target` (``targets.py``).
 """
 
 from __future__ import annotations
@@ -31,12 +29,13 @@ from dataraum.analysis.drivers.criterion import (
     DEFAULT_MIN_SUPPORT,
     DEFAULT_MISSINGNESS_GATE,
     build_codes,
-    variance_reduction,
 )
 from dataraum.analysis.drivers.models import DriverNode, DriverRanking, DriverSlice
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+    from dataraum.analysis.drivers.targets import Target
 
 DEFAULT_N_PERM = 500
 DEFAULT_ALPHA = 0.05
@@ -51,7 +50,7 @@ _Coded = tuple[np.ndarray, int]
 
 def _gate(
     values_by_dim: Mapping[str, np.ndarray],
-    measure: np.ndarray,
+    target: Target,
     *,
     dims: list[str],
     rng: np.random.Generator,
@@ -62,17 +61,16 @@ def _gate(
     """Return per-dim ``(codes, n_codes)``, real gain, and permutation-null p-value."""
     coded: dict[str, _Coded] = {
         d: build_codes(
-            values_by_dim[d], measure, handle_nulls=True, missingness_gate=missingness_gate
+            values_by_dim[d], target.observed, handle_nulls=True, missingness_gate=missingness_gate
         )
         for d in dims
     }
-    real = {d: variance_reduction(*coded[d], measure, min_support=min_support) for d in dims}
+    real = {d: target.gain(*coded[d], min_support=min_support) for d in dims}
     perm_max = np.empty(n_perm)
     for i in range(n_perm):
-        shuffled = rng.permutation(measure)
+        shuffled = target.permuted(rng)
         perm_max[i] = max(
-            (variance_reduction(*coded[d], shuffled, min_support=min_support) for d in dims),
-            default=0.0,
+            (shuffled.gain(*coded[d], min_support=min_support) for d in dims), default=0.0
         )
     p = {d: (1 + int(np.sum(perm_max >= real[d]))) / (1 + n_perm) for d in dims}
     return coded, real, p
@@ -91,36 +89,26 @@ def _code_labels(values: np.ndarray, codes: np.ndarray, n_codes: int) -> list[st
 def _slices(
     dimension: str,
     values: np.ndarray,
-    measure: np.ndarray,
+    target: Target,
     coded: _Coded,
     *,
     min_support: int,
     top_k: int,
 ) -> tuple[DriverSlice, ...]:
-    """The supported slice values whose mean deviates most from the node baseline."""
+    """The supported slice values whose target deviates most from the node baseline."""
     codes, n_codes = coded
-    observed = ~np.isnan(measure)
-    keep = (codes >= 0) & observed
-    if int(keep.sum()) < min_support or not measure[keep].size:
-        return ()
-    baseline = float(measure[keep].mean())
     labels = _code_labels(values, codes, n_codes)
-    out: list[DriverSlice] = []
-    for c in range(n_codes):
-        in_group = (codes == c) & observed
-        support = int(in_group.sum())
-        if support < min_support:
-            continue
-        group_mean = float(measure[in_group].mean())
-        effect = (group_mean / baseline - 1.0) if baseline else 0.0
-        out.append(DriverSlice(dimension, labels[c], effect, support))
+    out = [
+        DriverSlice(dimension, labels[code], effect, support)
+        for code, effect, support in target.group_effects(codes, n_codes, min_support=min_support)
+    ]
     out.sort(key=lambda s: abs(s.effect), reverse=True)
     return tuple(out[:top_k])
 
 
 def _build_node(
     values_by_dim: Mapping[str, np.ndarray],
-    measure: np.ndarray,
+    target: Target,
     *,
     dims: list[str],
     depth: int,
@@ -134,12 +122,12 @@ def _build_node(
 ) -> tuple[DriverNode | None, dict[str, float], dict[str, float]]:
     """Build the best split for this subset; recurse into its slice values.
 
-    Returns ``(node, real_gain, p_value)`` — the gain/p maps are the node's gate
+    Returns ``(node, real_gain, p_value)`` — the gain/p maps are this node's gate
     result (the caller uses the root's to rank dimensions).
     """
     coded, real, p = _gate(
         values_by_dim,
-        measure,
+        target,
         dims=dims,
         rng=rng,
         n_perm=n_perm,
@@ -152,25 +140,24 @@ def _build_node(
         return None, real, p
 
     best = max(significant, key=lambda d: real[d])
-    codes, _ = coded[best]
-    observed = ~np.isnan(measure)
-    support = int(((codes >= 0) & observed).sum())
+    codes, n_codes = coded[best]
+    support = int((codes >= 0).sum())
     slices = _slices(
-        best, values_by_dim[best], measure, coded[best], min_support=min_support, top_k=top_k
+        best, values_by_dim[best], target, coded[best], min_support=min_support, top_k=top_k
     )
 
     children: list[tuple[str, DriverNode]] = []
     if depth + 1 < max_depth and len(dims) > 1:
-        labels = _code_labels(values_by_dim[best], codes, coded[best][1])
+        labels = _code_labels(values_by_dim[best], codes, n_codes)
         remaining = [d for d in dims if d != best]
-        for c in range(coded[best][1]):
+        for c in range(n_codes):
             mask = codes == c
             if int(mask.sum()) < _RECURSE_SUPPORT_MULTIPLE * min_support:
                 continue
             sub_values = {d: values_by_dim[d][mask] for d in remaining}
             child, _, _ = _build_node(
                 sub_values,
-                measure[mask],
+                target.subset(mask),
                 dims=remaining,
                 depth=depth + 1,
                 max_depth=max_depth,
@@ -184,11 +171,7 @@ def _build_node(
             if child is not None:
                 children.append((labels[c], child))
 
-    return (
-        DriverNode(best, real[best], p[best], support, slices, tuple(children)),
-        real,
-        p,
-    )
+    return DriverNode(best, real[best], p[best], support, slices, tuple(children)), real, p
 
 
 def _walk_paths(node: DriverNode, prefix: list[str]) -> list[list[str]]:
@@ -211,10 +194,9 @@ def _all_slices(node: DriverNode) -> list[DriverSlice]:
 
 def discover_tree(
     values_by_dim: Mapping[str, np.ndarray],
-    measure: np.ndarray,
+    target: Target,
     *,
     measure_label: str,
-    target_type: str,
     dims: list[str],
     rng: np.random.Generator,
     max_depth: int = DEFAULT_MAX_DEPTH,
@@ -224,15 +206,15 @@ def discover_tree(
     n_perm: int = DEFAULT_N_PERM,
     top_k_slices: int = DEFAULT_TOP_K_SLICES,
 ) -> DriverRanking:
-    """Rank ``dims`` by their permutation-gated gain on ``measure`` and build the tree.
+    """Rank ``dims`` by their permutation-gated gain on ``target`` and build the tree.
 
-    ``measure`` is row-aligned with each array in ``values_by_dim`` (NaN = missing).
-    Returns a :class:`DriverRanking`; ``root`` is ``None`` when no dimension clears
-    the null (a clean "no significant driver" answer, not an error).
+    Each array in ``values_by_dim`` is row-aligned with the target. Returns a
+    :class:`DriverRanking`; ``root`` is ``None`` when no dimension clears the null (a
+    clean "no significant driver" answer, not an error).
     """
     root, real, p = _build_node(
         values_by_dim,
-        measure,
+        target,
         dims=dims,
         depth=0,
         max_depth=max_depth,
@@ -252,8 +234,8 @@ def discover_tree(
     slices = sorted(_all_slices(root), key=lambda s: abs(s.effect), reverse=True) if root else []
     return DriverRanking(
         measure=measure_label,
-        target_type=target_type,
-        n_rows=int(measure.size),
+        target_type=target.target_type,
+        n_rows=int(target.observed.size),
         ranked_dimensions=ranked,
         root=root,
         driver_paths=paths,

--- a/packages/engine/tests/unit/analysis/drivers/conftest.py
+++ b/packages/engine/tests/unit/analysis/drivers/conftest.py
@@ -9,16 +9,58 @@ that calibration. The real-fixture transfer check lives in dataraum-eval (handof
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
+import duckdb
 import numpy as np
 import pandas as pd
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from dataraum.storage import init_database
 
 N_ROWS = 20_000
+
+
+@pytest.fixture
+def real_session() -> Iterator[Session]:
+    """In-memory SQLite catalog (FKs off, the resolve-test pattern)."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _pragma(dbapi_conn, _record):  # noqa: ANN001, ANN202
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=OFF")
+        cur.close()
+
+    init_database(engine)
+    factory = sessionmaker(bind=engine)
+    try:
+        with factory() as s:
+            yield s
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def duck() -> Iterator[duckdb.DuckDBPyConnection]:
+    conn = duckdb.connect(":memory:")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
 
 # Planted drivers: name → multiplicative effect size on the measure.
 EFFECTS = {"D_e60": 0.60, "D_e25": 0.25, "D_e15": 0.15, "D_e08": 0.08, "D_e04": 0.04}
 DRIVERS = list(EFFECTS)
-# The drivers a recall test requires to surface AND outrank every independent null.
-REQUIRED_DRIVERS = ["D_e60", "D_e25"]
 # Independent nulls — must stay gated (the FDR metric).
 INDEPENDENT_NULLS = ["N_lowcard", "N_midcard", "N_highcard", "N_mnar", "N_measure_missing"]
 # Confounded proxy: 80% a copy of the strongest driver → expected to surface (a real

--- a/packages/engine/tests/unit/analysis/drivers/conftest.py
+++ b/packages/engine/tests/unit/analysis/drivers/conftest.py
@@ -1,0 +1,75 @@
+"""Synthetic driver-discovery corpus (DAT-545) — ported from the DAT-544 kill-gate.
+
+Vertical-neutral by design: abstract dimension names (``D_e*`` = planted drivers at
+a known effect size, ``N_*`` = nulls that must stay gated) and a generic
+multiplicative ``measure`` — nothing finance-specific. This is the same generative
+family the spike's GREEN verdict rests on, so the engine's recall/FDR tests inherit
+that calibration. The real-fixture transfer check lives in dataraum-eval (handoff).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+N_ROWS = 20_000
+
+# Planted drivers: name → multiplicative effect size on the measure.
+EFFECTS = {"D_e60": 0.60, "D_e25": 0.25, "D_e15": 0.15, "D_e08": 0.08, "D_e04": 0.04}
+DRIVERS = list(EFFECTS)
+# The drivers a recall test requires to surface AND outrank every independent null.
+REQUIRED_DRIVERS = ["D_e60", "D_e25"]
+# Independent nulls — must stay gated (the FDR metric).
+INDEPENDENT_NULLS = ["N_lowcard", "N_midcard", "N_highcard", "N_mnar", "N_measure_missing"]
+# Confounded proxy: 80% a copy of the strongest driver → expected to surface (a real
+# proxy, fine for aggregation); the test is that INDEPENDENT nulls stay gated when it competes.
+PROXY = "N_proxy"
+ALL_DIMS = DRIVERS + INDEPENDENT_NULLS + [PROXY]
+
+
+def make_corpus(rng: np.random.Generator) -> pd.DataFrame:
+    """One synthetic dataset: planted drivers + independent nulls + a confounded proxy.
+
+    ``N_mnar`` is missing-dimension on half the rows (exercises the (A) gate);
+    ``N_measure_missing`` concentrates MEASURE missingness in one slice value
+    (exercises the (B) gate — the leak min-support alone can't close).
+    """
+    n = N_ROWS
+    measure = rng.lognormal(mean=6.0, sigma=1.1, size=n)
+    df = pd.DataFrame(index=np.arange(n))
+
+    v_e60 = None
+    for name, eps in EFFECTS.items():
+        v = rng.integers(0, 4, n)
+        if name == "D_e60":
+            v_e60 = v
+        measure *= 1.0 + eps * (v - 1.5) / 1.5
+        df[name] = [f"{name}:{x}" for x in v]
+
+    proxy_v = np.where(rng.random(n) < 0.8, v_e60, rng.integers(0, 4, n))
+    df[PROXY] = [f"px{x}" for x in proxy_v]
+
+    df["N_lowcard"] = [f"l{v}" for v in rng.integers(0, 6, n)]
+    df["N_midcard"] = [f"d{v}" for v in rng.integers(0, 90, n)]  # participates (inflation test)
+    df["N_highcard"] = [f"h{v}" for v in rng.integers(0, 400, n)]  # excised by min-support
+
+    present = rng.random(n) < 0.5
+    df["N_mnar"] = np.where(present, [f"p{v}" for v in rng.integers(0, 5, n)], None)
+    measure[~present] *= 1.5
+
+    df["measure"] = measure
+
+    # Measure-conditional missingness: in slice value 0 the measure is 85% dropped
+    # (and 3× inflated where present) — a flat null-ratio hides it; the (B) gate closes it.
+    n_mm = rng.integers(0, 5, n)
+    df["N_measure_missing"] = [f"x{v}" for v in n_mm]
+    bias = n_mm == 0
+    drop = bias & (rng.random(n) < 0.85)
+    df.loc[drop, "measure"] = np.nan
+    df.loc[bias & ~drop, "measure"] *= 3.0
+    return df
+
+
+def columns(df: pd.DataFrame, dim: str) -> tuple[np.ndarray, np.ndarray]:
+    """``(values, measure)`` numpy arrays for one dimension — the criterion's inputs."""
+    return df[dim].astype(object).to_numpy(), df["measure"].to_numpy(dtype=float)

--- a/packages/engine/tests/unit/analysis/drivers/conftest.py
+++ b/packages/engine/tests/unit/analysis/drivers/conftest.py
@@ -115,3 +115,31 @@ def make_corpus(rng: np.random.Generator) -> pd.DataFrame:
 def columns(df: pd.DataFrame, dim: str) -> tuple[np.ndarray, np.ndarray]:
     """``(values, measure)`` numpy arrays for one dimension — the criterion's inputs."""
     return df[dim].astype(object).to_numpy(), df["measure"].to_numpy(dtype=float)
+
+
+# Ratio corpus (DAT-545 P4): the RATIO numerator/denominator depends on the driver
+# dims, with the denominator (volume) varying independently — so a naive mean of
+# per-row ratios would misweight, but Σnum/Σden support-weighting recovers the driver.
+RATIO_EFFECTS = {"R_e60": 0.60, "R_e25": 0.25}
+RATIO_DRIVERS = list(RATIO_EFFECTS)
+RATIO_NULLS = ["N_lowcard", "N_midcard", "N_highcard"]
+RATIO_DIMS = RATIO_DRIVERS + RATIO_NULLS
+
+
+def make_ratio_corpus(rng: np.random.Generator) -> pd.DataFrame:
+    """A ratio (numerator/denominator) whose VALUE depends on the driver dims."""
+    n = N_ROWS
+    df = pd.DataFrame(index=np.arange(n))
+    denominator = rng.lognormal(mean=5.0, sigma=0.8, size=n)  # volume, varies independently
+    log_ratio = np.full(n, np.log(0.2))  # base ratio 0.2
+    for name, eps in RATIO_EFFECTS.items():
+        v = rng.integers(0, 4, n)
+        df[name] = [f"{name}:{x}" for x in v]
+        log_ratio += np.log1p(eps * (v - 1.5) / 1.5)
+    ratio = np.exp(log_ratio + rng.normal(0.0, 0.1, n))  # + per-row noise
+    df["N_lowcard"] = [f"l{v}" for v in rng.integers(0, 6, n)]
+    df["N_midcard"] = [f"d{v}" for v in rng.integers(0, 90, n)]
+    df["N_highcard"] = [f"h{v}" for v in rng.integers(0, 400, n)]
+    df["numerator"] = denominator * ratio
+    df["denominator"] = denominator
+    return df

--- a/packages/engine/tests/unit/analysis/drivers/test_criterion.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_criterion.py
@@ -1,0 +1,73 @@
+"""DAT-545 P1 — the split criterion + (A)/(B) null gates.
+
+Criterion-level only (no permutation null yet — that's the tree, P2): the gain
+ranks a planted driver above an independent null, the (A) gate drops dim-null rows,
+the (B) gate closes the measure-conditional-missingness leak, and min-support
+suppresses a tiny-group dimension.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from dataraum.analysis.drivers.criterion import build_codes, variance_reduction
+
+from .conftest import columns, make_corpus
+
+
+def _gain(df, dim: str, *, handle_nulls: bool) -> float:
+    values, measure = columns(df, dim)
+    codes, n_codes = build_codes(values, measure, handle_nulls=handle_nulls)
+    return variance_reduction(codes, n_codes, measure)
+
+
+class TestVarianceReduction:
+    def test_strong_driver_outranks_independent_null(self) -> None:
+        df = make_corpus(np.random.default_rng(0))
+        assert _gain(df, "D_e60", handle_nulls=True) > _gain(df, "N_lowcard", handle_nulls=True)
+        # The effect-size ladder is monotone in expectation: the ±60% driver explains
+        # more variance than the ±15% one.
+        assert _gain(df, "D_e60", handle_nulls=True) > _gain(df, "D_e15", handle_nulls=True)
+
+    def test_min_support_suppresses_tiny_groups(self) -> None:
+        # N_highcard (400 levels over 20k rows ⇒ ~50/group) has no group clearing
+        # min_support=200, so the gain collapses to 0 — the slice_variance wall avoided.
+        df = make_corpus(np.random.default_rng(0))
+        assert _gain(df, "N_highcard", handle_nulls=True) == 0.0
+
+    def test_min_support_threshold_is_honoured(self) -> None:
+        # Two clean groups below threshold → 0.0; above → positive.
+        measure = np.concatenate([np.zeros(150), np.ones(150)])
+        values = np.array(["a"] * 150 + ["b"] * 150, dtype=object)
+        codes, n = build_codes(values, measure, handle_nulls=True)
+        assert variance_reduction(codes, n, measure, min_support=200) == 0.0
+        assert variance_reduction(codes, n, measure, min_support=100) > 0.9
+
+
+class TestNullGates:
+    def test_dim_present_gate_drops_null_rows(self) -> None:
+        # (A): N_mnar is dim-null on ~half the rows — those must get code -1.
+        df = make_corpus(np.random.default_rng(0))
+        values, measure = columns(df, "N_mnar")
+        codes, _ = build_codes(values, measure, handle_nulls=True)
+        import pandas as pd
+
+        dim_null = pd.isna(values)
+        assert np.all(codes[dim_null] == -1)
+        assert np.any(codes[~dim_null] >= 0)
+
+    def test_missingness_gate_closes_measure_missing_leak(self) -> None:
+        # (B): N_measure_missing concentrates measure-missingness in one slice value.
+        # WITHOUT handling it manufactures a spurious gain; WITH the (B) gate the
+        # offending slice is dropped and the gain falls sharply. This is the
+        # load-bearing ablation from the spike.
+        df = make_corpus(np.random.default_rng(0))
+        leaked = _gain(df, "N_measure_missing", handle_nulls=False)
+        gated = _gain(df, "N_measure_missing", handle_nulls=True)
+        assert leaked > gated
+        # The gate drops at least the offending slice value (fewer retained codes
+        # than distinct present values).
+        values, measure = columns(df, "N_measure_missing")
+        _, n_handled = build_codes(values, measure, handle_nulls=True)
+        _, n_raw = build_codes(values, measure, handle_nulls=False)
+        assert n_handled < n_raw

--- a/packages/engine/tests/unit/analysis/drivers/test_processor.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_processor.py
@@ -1,0 +1,164 @@
+"""DAT-545 P3 — driver discovery over the real catalog + enriched view.
+
+End-to-end: seed a fact's grain-verified enriched view in DuckDB (the spike corpus
++ an exact 1:1 alias column) and the begin_session catalog in SQLite
+(SliceDefinition grain_safe + a DimensionHierarchy alias group + SemanticAnnotation
+temporal_behavior), then assert discover_drivers ranks the planted drivers, collapses
+the alias out of the candidate set, and resolves the target type from the catalog.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import duckdb
+import numpy as np
+from sqlalchemy.orm import Session
+
+from dataraum.analysis.drivers.models import Measure
+from dataraum.analysis.drivers.processor import (
+    _candidate_dims,
+    discover_drivers,
+    resolve_target_type,
+)
+from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
+from dataraum.analysis.semantic.db_models import SemanticAnnotation
+from dataraum.analysis.slicing.db_models import SliceDefinition
+from dataraum.analysis.views.db_models import EnrichedView
+from dataraum.storage import Column, Table
+
+from .conftest import ALL_DIMS, make_corpus
+
+RUN = "session-run-1"
+VIEW = "sales_enriched"
+ALIAS = "D_e25_alias"  # an exact 1:1 copy of D_e25 → must collapse to canonical D_e25
+
+
+def _seed(
+    session: Session, duck: duckdb.DuckDBPyConnection, *, temporal_behavior: str = "additive"
+) -> str:
+    """Seed the fact, enriched view (DuckDB), catalog, alias group, and annotation."""
+    df = make_corpus(np.random.default_rng(0))
+    df[ALIAS] = df["D_e25"]  # 1:1 alias of a driver
+
+    fact = Table(
+        table_id=str(uuid4()),
+        source_id="src-1",
+        table_name="sales",
+        layer="typed",
+        duckdb_path="sales",
+    )
+    session.add(fact)
+    col_id: dict[str, str] = {}
+    for pos, name in enumerate([*ALL_DIMS, ALIAS, "measure"]):
+        col = Column(
+            column_id=str(uuid4()), table_id=fact.table_id, column_name=name, column_position=pos
+        )
+        session.add(col)
+        col_id[name] = col.column_id
+
+    # Catalog: every dim (incl. the alias) is a grain-safe slice definition.
+    for name in [*ALL_DIMS, ALIAS]:
+        session.add(
+            SliceDefinition(
+                run_id=RUN,
+                table_id=fact.table_id,
+                column_id=col_id[name],
+                column_name=name,
+                slice_priority=1,
+                grain_safe=True,
+                detection_source="llm",
+            )
+        )
+    # DAT-537 alias group: {D_e25, D_e25_alias} canonical D_e25.
+    session.add(
+        DimensionHierarchy(
+            run_id=RUN,
+            table_id=fact.table_id,
+            kind="alias",
+            members=[
+                {"column_name": "D_e25", "column_id": col_id["D_e25"], "distinct_count": 4},
+                {"column_name": ALIAS, "column_id": col_id[ALIAS], "distinct_count": 4},
+            ],
+            canonical_label="D_e25",
+            signature=f"alias:{fact.table_id}:D_e25|{ALIAS}",
+            score=0.0,
+        )
+    )
+    session.add(
+        SemanticAnnotation(
+            column_id=col_id["measure"], run_id=RUN, temporal_behavior=temporal_behavior
+        )
+    )
+    session.add(
+        EnrichedView(
+            run_id=RUN, fact_table_id=fact.table_id, view_name=VIEW, is_grain_verified=True
+        )
+    )
+    session.flush()
+
+    duck.register("corpus_df", df)
+    duck.execute(f'CREATE TABLE "{VIEW}" AS SELECT * FROM corpus_df')
+    duck.unregister("corpus_df")
+    return fact.table_id
+
+
+class TestResolveTargetType:
+    def test_maps_temporal_behavior(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed(real_session, duck, temporal_behavior="point_in_time")
+        col = real_session.query(Column).filter_by(table_id=tid, column_name="measure").one()
+        assert resolve_target_type(real_session, column_id=col.column_id, run_id=RUN) == "stock"
+
+    def test_defaults_to_flow_when_unknown(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        _seed(real_session, duck, temporal_behavior="")
+        assert resolve_target_type(real_session, column_id="nope", run_id=RUN) == "flow"
+
+
+class TestDiscoverDrivers:
+    def test_alias_collapsed_from_candidates(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed(real_session, duck)
+        dims = _candidate_dims(real_session, tid, RUN)
+        assert "D_e25" in dims  # canonical kept
+        assert ALIAS not in dims  # redundant axis collapsed out (DAT-537)
+
+    def test_end_to_end_ranks_drivers(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed(real_session, duck)
+        ranking = discover_drivers(
+            real_session,
+            duckdb_conn=duck,
+            fact_table_id=tid,
+            run_id=RUN,
+            measure=Measure(target_type="flow", column="measure"),
+            n_perm=200,
+        )
+        assert ranking.n_rows == 20_000
+        assert ranking.root is not None
+        sig = {d for d, _ in ranking.ranked_dimensions}
+        assert "D_e60" in sig  # the strong driver surfaces
+        assert ALIAS not in sig  # the collapsed alias never even competed
+        assert ranking.driver_paths and ranking.driver_paths[0][0] == ranking.root.dimension
+
+    def test_no_enriched_view_returns_empty(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed(real_session, duck)
+        real_session.execute(EnrichedView.__table__.update().values(is_grain_verified=False))
+        real_session.flush()
+        ranking = discover_drivers(
+            real_session,
+            duckdb_conn=duck,
+            fact_table_id=tid,
+            run_id=RUN,
+            measure=Measure(target_type="flow", column="measure"),
+            n_perm=50,
+        )
+        assert ranking.root is None
+        assert ranking.n_rows == 0

--- a/packages/engine/tests/unit/analysis/drivers/test_processor.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_processor.py
@@ -117,6 +117,15 @@ class TestResolveTargetType:
         _seed(real_session, duck, temporal_behavior="")
         assert resolve_target_type(real_session, column_id="nope", run_id=RUN) == "flow"
 
+    def test_unrecognised_behavior_defaults_to_flow(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # An annotation present but with a value outside {additive, point_in_time}
+        # falls back to flow (logged), not an error.
+        tid = _seed(real_session, duck, temporal_behavior="periodic")
+        col = real_session.query(Column).filter_by(table_id=tid, column_name="measure").one()
+        assert resolve_target_type(real_session, column_id=col.column_id, run_id=RUN) == "flow"
+
 
 class TestDiscoverDrivers:
     def test_alias_collapsed_from_candidates(
@@ -126,6 +135,19 @@ class TestDiscoverDrivers:
         dims = _candidate_dims(real_session, tid, RUN)
         assert "D_e25" in dims  # canonical kept
         assert ALIAS not in dims  # redundant axis collapsed out (DAT-537)
+
+    def test_non_grain_safe_dims_excluded(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # A dimension flagged grain_safe=False is not a candidate (AC: grain-safety).
+        tid = _seed(real_session, duck)
+        real_session.execute(
+            SliceDefinition.__table__.update()
+            .where(SliceDefinition.column_name == "N_lowcard")
+            .values(grain_safe=False)
+        )
+        real_session.flush()
+        assert "N_lowcard" not in _candidate_dims(real_session, tid, RUN)
 
     def test_end_to_end_ranks_drivers(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection

--- a/packages/engine/tests/unit/analysis/drivers/test_ratio_stock.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_ratio_stock.py
@@ -1,0 +1,123 @@
+"""DAT-545 P4 — ratio (support-weighted) + stock (additivity-respecting) targets.
+
+Ratio is the genuinely new criterion (the spike validated flow only): the group
+statistic is Σnum/Σden, support-weighted by the denominator, never the mean of
+per-row ratios. Stock reuses the row-grain variance reduction — additivity-respecting
+*because* it never sums — so the test confirms reuse + the target-type label.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from dataraum.analysis.drivers.criterion import build_codes, weighted_variance_reduction
+from dataraum.analysis.drivers.targets import FlowTarget, RatioTarget
+from dataraum.analysis.drivers.tree import discover_tree
+
+from .conftest import (
+    ALL_DIMS,
+    RATIO_DIMS,
+    RATIO_NULLS,
+    make_corpus,
+    make_ratio_corpus,
+)
+
+ALPHA = 0.05
+FDR_BAR = 2 * ALPHA
+N_PERM = 200
+
+
+class TestWeightedCriterion:
+    def test_support_weighting_beats_naive_mean(self) -> None:
+        # Two groups, same per-row ratio spread, but group B carries 10× the
+        # denominator mass. The weighted reduction reflects the pooled ratio, not an
+        # unweighted average — a tiny group can't swing it.
+        rng = np.random.default_rng(0)
+        # group A: 300 rows, ratio ~0.5, small denominators; group B: 3000 rows,
+        # ratio ~0.5, large denominators. No between-group ratio difference → ~0 gain.
+        num = np.concatenate([rng.normal(0.5, 0.01, 300) * 1.0, rng.normal(0.5, 0.01, 3000) * 10.0])
+        den = np.concatenate([np.full(300, 1.0), np.full(3000, 10.0)])
+        codes = np.array([0] * 300 + [1] * 3000)
+        ratio = num / den
+        gain = weighted_variance_reduction(codes, 2, ratio, den, min_support=100)
+        assert gain < 0.05  # same ratio in both groups ⇒ no explanatory power
+
+    def test_distinct_group_ratios_give_high_gain(self) -> None:
+        rng = np.random.default_rng(0)
+        num = np.concatenate([rng.normal(0.2, 0.01, 1000), rng.normal(0.8, 0.01, 1000)])
+        den = np.ones(2000)
+        codes = np.array([0] * 1000 + [1] * 1000)
+        gain = weighted_variance_reduction(codes, 2, num / den, den, min_support=100)
+        assert gain > 0.9  # the grouping explains almost all the ratio's variance
+
+
+class TestRatioTarget:
+    def test_recall_and_fdr(self) -> None:
+        seeds = 15
+        strong = 0
+        null_total = 0
+        target_type = ""
+        for seed in range(seeds):
+            rng = np.random.default_rng(seed)
+            df = make_ratio_corpus(rng)
+            values_by_dim = {d: df[d].astype(object).to_numpy() for d in RATIO_DIMS}
+            target = RatioTarget(
+                df["numerator"].to_numpy(dtype=float), df["denominator"].to_numpy(dtype=float)
+            )
+            rank = discover_tree(
+                values_by_dim,
+                target,
+                measure_label="margin",
+                dims=RATIO_DIMS,
+                rng=rng,
+                max_depth=1,
+                alpha=ALPHA,
+                n_perm=N_PERM,
+            )
+            target_type = rank.target_type
+            sig = {d for d, _ in rank.ranked_dimensions}
+            strong += "R_e60" in sig
+            null_total += sum(n in sig for n in RATIO_NULLS)
+        assert target_type == "ratio"
+        assert strong >= int(0.9 * seeds), f"ratio strong-driver recall {strong}/{seeds}"
+        assert null_total <= FDR_BAR * len(RATIO_NULLS) * seeds
+
+    def test_invalid_denominator_rows_dropped(self) -> None:
+        # den ≤ 0 / NaN rows carry no ratio → excluded from the gain (no divide blow-up).
+        num = np.array([1.0, 2.0, 3.0, 4.0])
+        den = np.array([2.0, 0.0, np.nan, 8.0])
+        target = RatioTarget(num, den)
+        assert np.isnan(target.observed[1]) and np.isnan(target.observed[2])
+        assert not np.isnan(target.observed[0]) and not np.isnan(target.observed[3])
+
+
+class TestStockTarget:
+    def test_stock_reuses_row_grain_reduction(self) -> None:
+        # Stock = additivity-respecting because it never sums: the same row-grain
+        # variance reduction as flow, only the target_type label differs.
+        rng = np.random.default_rng(0)
+        df = make_corpus(rng)
+        values_by_dim = {d: df[d].astype(object).to_numpy() for d in ALL_DIMS}
+        target = FlowTarget(df["measure"].to_numpy(dtype=float), target_type="stock")
+        rank = discover_tree(
+            values_by_dim,
+            target,
+            measure_label="balance",
+            dims=ALL_DIMS,
+            rng=rng,
+            max_depth=1,
+            alpha=ALPHA,
+            n_perm=N_PERM,
+        )
+        assert rank.target_type == "stock"
+        assert "D_e60" in {d for d, _ in rank.ranked_dimensions}
+
+    def test_build_codes_is_target_agnostic(self) -> None:
+        # build_codes reads the target's `observed` array (NaN = unobserved) — same
+        # for a stock measure as a flow one.
+        rng = np.random.default_rng(0)
+        df = make_corpus(rng)
+        values = df["D_e60"].astype(object).to_numpy()
+        target = FlowTarget(df["measure"].to_numpy(dtype=float), target_type="stock")
+        codes, n_codes = build_codes(values, target.observed, handle_nulls=True)
+        assert n_codes >= 2

--- a/packages/engine/tests/unit/analysis/drivers/test_tree.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_tree.py
@@ -1,0 +1,138 @@
+"""DAT-545 P2 — the greedy tree + within-dataset permutation null.
+
+Inherits the DAT-544 kill-gate's claims, now over the engine: the STRONG driver
+surfaces ~always (≥0.9) while independent nulls stay gated at ≈α (FDR ≤ 2α) even
+with a confounded proxy competing; the marginal ±25% driver surfaces at the spike's
+documented power floor (majority, ≥0.6 — NOT 90%); recursion doesn't compound FDR at
+depth 2; and the tree yields drill paths + deviating slices. Fewer seeds /
+permutations than the spike for unit speed; the separation + FDR bars are the same.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from dataraum.analysis.drivers.models import DriverRanking
+from dataraum.analysis.drivers.tree import discover_tree
+
+from .conftest import ALL_DIMS, INDEPENDENT_NULLS, PROXY, make_corpus
+
+ALPHA = 0.05
+FDR_BAR = 2 * ALPHA
+N_PERM = 300
+
+
+def _run(seed: int, *, max_depth: int) -> DriverRanking:
+    rng = np.random.default_rng(seed)
+    df = make_corpus(rng)
+    values_by_dim = {d: df[d].astype(object).to_numpy() for d in ALL_DIMS}
+    measure = df["measure"].to_numpy(dtype=float)
+    return discover_tree(
+        values_by_dim,
+        measure,
+        measure_label="measure",
+        target_type="flow",
+        dims=ALL_DIMS,
+        rng=rng,
+        max_depth=max_depth,
+        alpha=ALPHA,
+        n_perm=N_PERM,
+    )
+
+
+class TestSingleNodeSeparation:
+    def test_separation_strong_driver_and_fdr(self) -> None:
+        # The GREEN kill-claim: the STRONG driver surfaces ~always AND every
+        # independent null stays gated at ≈α — separation, no global threshold.
+        seeds = 20
+        strong = 0
+        null_surfaced = dict.fromkeys(INDEPENDENT_NULLS, 0)
+        for seed in range(seeds):
+            sig = {d for d, _ in _run(seed, max_depth=1).ranked_dimensions}
+            strong += "D_e60" in sig
+            for n in INDEPENDENT_NULLS:
+                null_surfaced[n] += n in sig
+        assert strong >= int(0.9 * seeds), f"strong-driver recall {strong}/{seeds}"
+        for n, c in null_surfaced.items():
+            assert c <= FDR_BAR * seeds, f"null {n} surfaced {c}/{seeds}"
+
+    def test_marginal_driver_power_floor(self) -> None:
+        # Power is finite, not infinite (the spike's documented ≈±20–25% floor:
+        # ±25%→~30/40). A regression guard, NOT a 90% bar — the ±25% driver
+        # surfaces in the MAJORITY of datasets; weaker effects miss safely.
+        seeds = 20
+        marginal = sum(
+            "D_e25" in {d for d, _ in _run(s, max_depth=1).ranked_dimensions} for s in range(seeds)
+        )
+        assert marginal >= int(0.6 * seeds), f"marginal-driver power {marginal}/{seeds}"
+
+    def test_confounded_proxy_surfaces_without_breaking_fdr(self) -> None:
+        seeds = 15
+        proxy = 0
+        null_total = 0
+        for seed in range(seeds):
+            sig = {d for d, _ in _run(seed, max_depth=1).ranked_dimensions}
+            proxy += PROXY in sig
+            null_total += sum(n in sig for n in INDEPENDENT_NULLS)
+        # The 80%-copy proxy is a legitimate strong correlate — it should surface.
+        assert proxy >= int(0.5 * seeds), f"proxy surfaced only {proxy}/{seeds}"
+        # …yet the genuinely-independent nulls stay gated while it competes.
+        assert null_total <= FDR_BAR * len(INDEPENDENT_NULLS) * seeds
+
+
+class TestRecursion:
+    def test_depth2_does_not_compound_fdr(self) -> None:
+        seeds = 10
+        null_children = 0
+        total_children = 0
+        recursed = 0
+        for seed in range(seeds):
+            rank = _run(seed, max_depth=2)
+            if rank.root is None:
+                continue
+            for _value, child in rank.root.children:
+                total_children += 1
+                null_children += child.dimension in INDEPENDENT_NULLS
+            recursed += bool(rank.root.children)
+        # The tree actually recurses on some datasets (the test isn't vacuous)…
+        assert recursed > 0
+        # …and a pure independent null surfaces as a depth-2 split at ≤ 2α.
+        if total_children:
+            assert null_children <= FDR_BAR * total_children
+
+
+class TestTreeOutputs:
+    def test_paths_and_slices(self) -> None:
+        rank = _run(0, max_depth=2)
+        assert rank.root is not None
+        assert rank.n_rows == 20_000
+        # The top-ranked dimension is a real driver (or the legit proxy), never a null.
+        top = rank.ranked_dimensions[0][0]
+        assert top not in INDEPENDENT_NULLS
+        # Drill paths are non-empty and start at the root dimension.
+        assert rank.driver_paths and all(p[0] == rank.root.dimension for p in rank.driver_paths)
+        # Interesting slices carry the root's deviating values, sorted by |effect|.
+        assert rank.interesting_slices
+        effects = [abs(s.effect) for s in rank.interesting_slices]
+        assert effects == sorted(effects, reverse=True)
+
+    def test_no_significant_driver_returns_clean_empty(self) -> None:
+        # Pure noise: measure independent of every dim → root None, empty ranking.
+        rng = np.random.default_rng(7)
+        n = 5_000
+        values_by_dim = {
+            f"N{i}": np.array([f"v{v}" for v in rng.integers(0, 5, n)]) for i in range(4)
+        }
+        measure = rng.normal(size=n)
+        rank = discover_tree(
+            values_by_dim,
+            measure,
+            measure_label="m",
+            target_type="flow",
+            dims=list(values_by_dim),
+            rng=rng,
+            n_perm=N_PERM,
+        )
+        assert rank.root is None
+        assert rank.ranked_dimensions == []
+        assert rank.driver_paths == []

--- a/packages/engine/tests/unit/analysis/drivers/test_tree.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_tree.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import numpy as np
 
 from dataraum.analysis.drivers.models import DriverRanking
+from dataraum.analysis.drivers.targets import FlowTarget
 from dataraum.analysis.drivers.tree import discover_tree
 
 from .conftest import ALL_DIMS, INDEPENDENT_NULLS, PROXY, make_corpus
@@ -29,9 +30,8 @@ def _run(seed: int, *, max_depth: int) -> DriverRanking:
     measure = df["measure"].to_numpy(dtype=float)
     return discover_tree(
         values_by_dim,
-        measure,
+        FlowTarget(measure),
         measure_label="measure",
-        target_type="flow",
         dims=ALL_DIMS,
         rng=rng,
         max_depth=max_depth,
@@ -126,9 +126,8 @@ class TestTreeOutputs:
         measure = rng.normal(size=n)
         rank = discover_tree(
             values_by_dim,
-            measure,
+            FlowTarget(measure),
             measure_label="m",
-            target_type="flow",
             dims=list(values_by_dim),
             rng=rng,
             n_perm=N_PERM,


### PR DESCRIPTION
## DAT-545 — driver-discovery engine

DAT-543 P1. A pure, **on-demand** `analysis/drivers/` engine that ranks the catalog's grain-safe dimensions by how much they explain a numeric measure's variation — gated by a **within-dataset permutation null**, so there is **no global threshold anywhere** and nothing finance-specific (vertical-agnostic). Productionizes the GREEN DAT-544 kill-gate spike. Built on DAT-536 (catalog) + DAT-537 (alias de-confounding).

**Engine only** — returns an in-memory `DriverRanking`. No DB model, no pipeline phase, no persistence, no agent wiring (those are DAT-546+). No existing measurement changes.

### Phases
- **P1 criterion** — `variance_reduction` (flow gain, min-support gated) + (A) dim-present + (B) missingness-concentration gates (the `slice_conditional_null` mechanism, reimplemented inline).
- **P2 tree** — per-dim gain + max-over-candidates permutation null (free multiple-comparison control); depth-penalized greedy recursion (`alpha/(depth+1)` + per-node null + 4×min_support); driver-path + interesting-slice extraction.
- **P3 wiring** — `discover_drivers`: candidate dims from `SliceDefinition.grain_safe` with `DimensionHierarchy` 1:1 aliases collapsed; enriched view read row-grain via DuckDB into numpy (probed for skew, columns-only, no `SELECT *`); target-type from `SemanticAnnotation.temporal_behavior`.
- **P4 target types** — `Target` abstraction: `FlowTarget` (flow/stock, additivity-safe because it never sums) + `RatioTarget` (Σnum/Σden support-weighted, permutes num/den jointly — avoids the average-of-ratios trap).

### Compute model
Reads `(measure + candidate dims)` row-grain into numpy once; the 500-shuffle permutation null runs in numpy (not hundreds of DuckDB GROUP BYs). The design doc's "aggregation views" are moot — ADR-0013 removed them.

### Tests / honesty
24 unit tests over the spike's generative corpus: strong-driver recall ≥0.9 + independent-null FDR ≤2α (with a confounded proxy competing); **marginal ±25% driver at the spike's documented ~0.6 power floor — NOT a 90% over-claim** (the spike itself reframed GREEN to *separation*, not power); recursion doesn't compound FDR at depth 2; ratio support-weighting (beats naive mean) + recall/FDR; stock reuse; alias collapse; (B)-gate closes the measure-missing leak. Full engine unit suite **1556 passing**; ruff + mypy clean. Reviewers: senior **APPROVE**, spec **PASS** — all findings applied.

### Cross-repo (handoff, not merge-blocking)
Real-fixture transfer check + FDR/recall calibration → **dataraum-eval** (the agreed home; the engine merges on synthetic-corpus tests). The DAT-544 corpus seeds testdata's generative family + ratio/stock/confounded fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)