### PR TITLE
DAT-551 (slice 2): agentic grounding-teach loop

### DIFF
--- a/packages/cockpit/drizzle/cockpit/20260617135211_amused_violations/migration.sql
+++ b/packages/cockpit/drizzle/cockpit/20260617135211_amused_violations/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "session_runs" ADD COLUMN "awaiting_note" text;

--- a/packages/cockpit/drizzle/cockpit/20260617135211_amused_violations/snapshot.json
+++ b/packages/cockpit/drizzle/cockpit/20260617135211_amused_violations/snapshot.json
@@ -1,0 +1,975 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "0f26ec20-b131-4225-9beb-8435ea4ccbd5",
+  "prevIds": [
+    "fac629e5-a882-48df-9e1b-f4b2d310b8b5"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "actors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "conversation_messages",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "conversations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "session_runs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "ui_state",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "workspaces",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "actors"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "actors"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "actors"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seq",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "model_only",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_active_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stage",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workflow_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "run_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'running'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completion_narrated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "awaiting_note",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "engine_session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "pinned_call_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "engine_schema",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'_adhoc'",
+      "generated": null,
+      "identity": null,
+      "name": "vertical",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "conversation_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "seq",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "conversation_messages_conversation_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "conversations_workspace_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workflow_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "run_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "session_runs_workflow_run_uq",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "session_runs_session_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "conversation_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "session_runs_conversation_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "engine_session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_engine_session_uq",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_workspace_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "conversation_messages_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "workspace_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "workspaces",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "conversations_workspace_id_workspaces_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "session_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "sessions",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "session_runs_session_id_sessions_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "session_runs_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "session_runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "workspace_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "workspaces",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sessions_workspace_id_workspaces_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "created_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "actors",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sessions_created_by_actors_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "ui_state_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "actors_pkey",
+      "schema": "public",
+      "table": "actors",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "conversation_messages_pkey",
+      "schema": "public",
+      "table": "conversation_messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "conversations_pkey",
+      "schema": "public",
+      "table": "conversations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "session_runs_pkey",
+      "schema": "public",
+      "table": "session_runs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "conversation_id"
+      ],
+      "nameExplicit": false,
+      "name": "ui_state_pkey",
+      "schema": "public",
+      "table": "ui_state",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "workspaces_pkey",
+      "schema": "public",
+      "table": "workspaces",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/cockpit/src/db/cockpit/runs.test.ts
+++ b/packages/cockpit/src/db/cockpit/runs.test.ts
@@ -22,14 +22,19 @@ vi.mock("#/db/cockpit/schema", () => ({
 	sessions: { _t: "sessions", id: "id", engineSessionId: "engine_session_id" },
 	sessionRuns: {
 		_t: "session_runs",
+		id: "id",
 		sessionId: "session_id",
 		workflowId: "workflow_id",
 		runId: "run_id",
+		status: "status",
+		awaitingNote: "awaiting_note",
+		startedAt: "started_at",
 	},
 }));
 vi.mock("drizzle-orm", () => ({
 	eq: (...a: unknown[]) => a,
 	and: (...a: unknown[]) => a,
+	desc: (x: unknown) => x,
 }));
 
 const limitMock = vi.fn(async () => h.sessionRows);
@@ -47,7 +52,12 @@ vi.mock("#/db/cockpit/client", () => ({
 			},
 		}),
 		select: () => ({
-			from: () => ({ where: () => ({ limit: limitMock }) }),
+			from: () => ({
+				where: () => ({
+					limit: limitMock,
+					orderBy: () => ({ limit: limitMock }),
+				}),
+			}),
 		}),
 		update: (table: { _t: string }) => ({
 			set: (s: Record<string, unknown>) => ({
@@ -60,7 +70,12 @@ vi.mock("#/db/cockpit/client", () => ({
 }));
 
 import { runWithConversation } from "#/lib/run-context";
-import { attachRunId, markRunStatus, recordRun } from "./runs";
+import {
+	attachRunId,
+	markRunAwaitingInput,
+	markRunStatus,
+	recordRun,
+} from "./runs";
 
 const BASE = {
 	workspaceId: "ws-1",
@@ -176,6 +191,45 @@ describe("markRunStatus (DAT-461)", () => {
 		await expect(
 			markRunStatus("wf-1", "run-1", "failed"),
 		).resolves.toBeUndefined();
+		expect(warn).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("markRunAwaitingInput (DAT-551)", () => {
+	it("parks the LATEST run for the workflow in awaiting_input with the note", async () => {
+		h.sessionRows = [{ id: "run-row-latest" }];
+		await markRunAwaitingInput("wf-1", "payments.method needs a concept");
+		expect(limitMock).toHaveBeenCalled(); // resolved the latest run first
+		expect(h.updates).toHaveLength(1);
+		expect(h.updates[0].table).toBe("session_runs");
+		expect(h.updates[0].set).toEqual({
+			status: "awaiting_input",
+			awaitingNote: "payments.method needs a concept",
+		});
+	});
+
+	it("no-ops when the workflow has no recorded run (nothing to park)", async () => {
+		h.sessionRows = [];
+		await markRunAwaitingInput("wf-unknown", "x");
+		expect(h.updates).toHaveLength(0);
+	});
+
+	it("accepts a null note", async () => {
+		h.sessionRows = [{ id: "run-row-latest" }];
+		await markRunAwaitingInput("wf-1", null);
+		expect(h.updates[0].set).toEqual({
+			status: "awaiting_input",
+			awaitingNote: null,
+		});
+	});
+
+	it("is best-effort: swallows a db error", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const boom = await import("./client");
+		vi.spyOn(boom.cockpitDb, "select").mockImplementation(() => {
+			throw new Error("db down");
+		});
+		await expect(markRunAwaitingInput("wf-1", "x")).resolves.toBeUndefined();
 		expect(warn).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/cockpit/src/db/cockpit/runs.ts
+++ b/packages/cockpit/src/db/cockpit/runs.ts
@@ -375,6 +375,9 @@ export interface WorkspaceRun {
 	status: string;
 	startedAt: Date;
 	kind: SessionKind;
+	/** When status is `awaiting_input`, why the grounding loop parked it (DAT-551) —
+	 * the monitor shows it as the "needs you" detail. Null otherwise. */
+	awaitingNote: string | null;
 }
 
 /**
@@ -396,6 +399,7 @@ export async function listRunsByWorkspace(
 			status: sessionRuns.status,
 			startedAt: sessionRuns.startedAt,
 			kind: sessions.kind,
+			awaitingNote: sessionRuns.awaitingNote,
 		})
 		.from(sessionRuns)
 		.innerJoin(sessions, eq(sessionRuns.sessionId, sessions.id))

--- a/packages/cockpit/src/db/cockpit/runs.ts
+++ b/packages/cockpit/src/db/cockpit/runs.ts
@@ -172,6 +172,38 @@ export async function markRunStatus(
 }
 
 /**
+ * Park the LATEST run for a workflow in `awaiting_input` with a human-facing note
+ * (DAT-551 P3c). The grounding-teach loop calls this when it has applied every
+ * mechanical teach it can and a judgement gap remains (or it hit its attempt
+ * limit): the run isn't failed — it's waiting for a human teach. Targets the most
+ * recent execution for the workflow id (the current state), since a session's
+ * add_source has one run row per replay execution. Best-effort (mirrors
+ * markRunStatus): a write error is logged, not thrown — the journey must not crash.
+ */
+export async function markRunAwaitingInput(
+	workflowId: string,
+	note: string | null,
+): Promise<void> {
+	try {
+		const [latest] = await cockpitDb
+			.select({ id: sessionRuns.id })
+			.from(sessionRuns)
+			.where(eq(sessionRuns.workflowId, workflowId))
+			.orderBy(desc(sessionRuns.startedAt))
+			.limit(1);
+		if (!latest) return;
+		await cockpitDb
+			.update(sessionRuns)
+			.set({ status: "awaiting_input", awaitingNote: note })
+			.where(eq(sessionRuns.id, latest.id));
+	} catch (err) {
+		console.warn(
+			`[cockpit] markRunAwaitingInput failed for ${workflowId}: ${err}`,
+		);
+	}
+}
+
+/**
  * Atomically claim a run's completion narration (Phase 2A). The conditional
  * UPDATE sets `completion_narrated_at` only when it's still NULL and RETURNs the
  * row — so the FIRST caller wins (returns true) and every later one (another

--- a/packages/cockpit/src/db/cockpit/schema.ts
+++ b/packages/cockpit/src/db/cockpit/schema.ts
@@ -22,6 +22,7 @@ import {
 	integer,
 	jsonb,
 	pgTable,
+	text,
 	timestamp,
 	uniqueIndex,
 	varchar,
@@ -143,6 +144,12 @@ export const sessionRuns = pgTable(
 		// terminal-status writers (the progress poll / reconcile) don't touch it, so
 		// the claim never races them. NULL = not yet narrated.
 		completionNarratedAt: timestamp("completion_narrated_at", { mode: "date" }),
+		// Why the run is parked in `status='awaiting_input'` (DAT-551 P3c): the
+		// grounding-teach agent fixed what it mechanically could and a human-judgement
+		// gap remains (a concept/relationship the agent must not auto-apply), or it hit
+		// its attempt limit. One sentence the surface shows + deep-links a Stage chat
+		// from. NULL for every other run. Written by the journey's markRunAwaitingInput.
+		awaitingNote: text("awaiting_note"),
 	},
 	(t) => [
 		uniqueIndex("session_runs_workflow_run_uq").on(t.workflowId, t.runId),

--- a/packages/cockpit/src/db/metadata/grounding-readiness.ts
+++ b/packages/cockpit/src/db/metadata/grounding-readiness.ts
@@ -1,0 +1,61 @@
+// Grounding-readiness oracle (DAT-551 P3c) — the agent's self-check.
+//
+// Reads the head-joined `current_entropy_readiness` view (latest snapshot per
+// target) for a run's typed tables: per (column/table) target, its readiness
+// `band`, `worst_intent_risk`, and the ranked `top_drivers`. The grounding-teach
+// agent reads this to (a) decide whether a measurable gap remains and (b) verify a
+// teach helped — re-reading after a replay tells it if the band improved. The
+// `target` string ("column:<table>.<col>") carries the human names the agent needs
+// to formulate a `unit` teach; `top_drivers` (e.g. type_fidelity / null_semantics /
+// unit_entropy) tell it WHICH mechanical grounding teach a gap calls for.
+
+import { inArray } from "drizzle-orm";
+import { metadataDb } from "./client";
+import { currentEntropyReadiness } from "./schema";
+
+/** One target's latest readiness — the agent's per-column gap signal. */
+export interface GroundingReadinessRow {
+	/** The readiness target, e.g. "column:payments.amount" or "table:payments" —
+	 * carries the table + column NAMES the agent teaches a `unit` by. */
+	target: string;
+	tableId: string | null;
+	columnId: string | null;
+	/** "ready" | "investigate" | "blocked" (defaults to "unknown" if the view row
+	 * carried no band). */
+	band: string;
+	/** Worst per-intent risk in [0,1]; higher = more disagreement/ignorance. */
+	worstIntentRisk: number;
+	/** Ranked drivers [{node, state, impact_delta}] — the detectors driving the
+	 * risk; the agent maps these to the grounding teach that addresses them. */
+	topDrivers: unknown;
+}
+
+/**
+ * The latest readiness for the run's typed tables (DAT-551). Empty when nothing is
+ * measured yet. The agent compares this across replays to know if its teaches moved
+ * the band; the workflow loop uses "all ready" as the clean-exit signal.
+ */
+export async function readGroundingReadiness(
+	tableIds: string[],
+): Promise<GroundingReadinessRow[]> {
+	if (tableIds.length === 0) return [];
+	const rows = await metadataDb
+		.select({
+			target: currentEntropyReadiness.target,
+			tableId: currentEntropyReadiness.tableId,
+			columnId: currentEntropyReadiness.columnId,
+			band: currentEntropyReadiness.band,
+			worstIntentRisk: currentEntropyReadiness.worstIntentRisk,
+			topDrivers: currentEntropyReadiness.topDrivers,
+		})
+		.from(currentEntropyReadiness)
+		.where(inArray(currentEntropyReadiness.tableId, tableIds));
+	return rows.map((r) => ({
+		target: r.target ?? "",
+		tableId: r.tableId,
+		columnId: r.columnId,
+		band: r.band ?? "unknown",
+		worstIntentRisk: r.worstIntentRisk ?? 0,
+		topDrivers: r.topDrivers,
+	}));
+}

--- a/packages/cockpit/src/tools/teach.test.ts
+++ b/packages/cockpit/src/tools/teach.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	AGENT_AUTOAPPLY_TEACH_TYPES,
 	AGENT_TEACH_TYPES,
 	TEACH_TYPES,
 	TeachValidationError,
@@ -403,6 +404,30 @@ describe("validateTeach", () => {
 			);
 			for (const t of ["validation", "cycle", "metric", "explanation"]) {
 				expect(AGENT_TEACH_TYPES as readonly string[]).not.toContain(t);
+			}
+		});
+
+		it("AGENT_AUTOAPPLY_TEACH_TYPES is the mechanical grounding subset only (DAT-551)", () => {
+			// The agent may AUTO-APPLY only mechanical grounding teaches it can
+			// self-verify by re-measuring. Judgement-family types (concept/
+			// relationship/hierarchy) are entropy-measurable but stay human-surfaced.
+			expect(new Set(AGENT_AUTOAPPLY_TEACH_TYPES)).toEqual(
+				new Set(["type_pattern", "null_value", "unit"]),
+			);
+			// It is a strict subset of what the teach tool advertises.
+			for (const t of AGENT_AUTOAPPLY_TEACH_TYPES) {
+				expect(AGENT_TEACH_TYPES as readonly string[]).toContain(t);
+			}
+			// Judgement-family types are NEVER auto-appliable.
+			for (const t of [
+				"concept",
+				"concept_property",
+				"relationship",
+				"hierarchy",
+			]) {
+				expect(AGENT_AUTOAPPLY_TEACH_TYPES as readonly string[]).not.toContain(
+					t,
+				);
 			}
 		});
 

--- a/packages/cockpit/src/tools/teach.validation.ts
+++ b/packages/cockpit/src/tools/teach.validation.ts
@@ -306,6 +306,28 @@ export const AGENT_TEACH_TYPES = [
 	"hierarchy",
 ] as const satisfies readonly TeachType[];
 
+// The teach types an AGENT may AUTO-APPLY unattended (DAT-551 P3c — the grounding
+// loop). The authoritative, single source of truth for "the agent can fix this
+// without a human", NOT derived from the engine's loss table: by that definition
+// `relationship` (join_path_determinism) and `concept` grounding (business_meaning)
+// are entropy-measurable too, but they are JUDGEMENT (what a column means / how
+// tables relate) and must surface to a human. The gate is narrower — MECHANICAL
+// grounding the agent can both formulate without semantic judgement AND self-verify
+// by re-measuring readiness after a replay:
+//   type_pattern → type_fidelity   (a value-format regex)
+//   null_value   → null_semantics   (a null token)
+//   unit         → unit_entropy      (a column's unit)
+// Everything else (concept/concept_property/relationship/hierarchy + the
+// operating-model declarations) stays human-surfaced. The grounding-teach activity
+// offers the agent ONLY these via the constrained grounding-teach tool.
+export const AGENT_AUTOAPPLY_TEACH_TYPES = [
+	"type_pattern",
+	"null_value",
+	"unit",
+] as const satisfies readonly TeachType[];
+
+export type AutoApplyTeachType = (typeof AGENT_AUTOAPPLY_TEACH_TYPES)[number];
+
 // The payload shape surfaced in the teach TOOL's input schema — a union of ONLY
 // the agent-advertised (AGENT_TEACH_TYPES) payloads, so `toJSONSchema` dumps each
 // type's exact fields into the schema the model sees. Anthropic's tool
@@ -333,6 +355,19 @@ export const TeachPayloadSchema = z
 			"relationship: {action: confirm|reject|add, from_column_id, to_column_id} " +
 			"(keep is engine-internal, not a user action); " +
 			"hierarchy: {action: add|reject|alias, table_id, members}.",
+	);
+
+// The payload union for the AGENT-AUTOAPPLY teach types only (DAT-551) — the
+// constrained schema the grounding-teach agent's tool uses, so the model can ONLY
+// express a mechanical grounding teach (type_pattern / null_value / unit), never a
+// judgement-family one. The narrow gate is the type enum + this union together.
+export const AutoApplyTeachPayloadSchema = z
+	.union([TypePatternPayload, NullValuePayload, UnitPayload])
+	.describe(
+		"The grounding teach payload; required fields depend on type. " +
+			"type_pattern: {name, pattern, inferred_type?}; " +
+			"null_value: {category, value}; " +
+			"unit: {table, column, unit} (column identified by NAME).",
 	);
 
 export interface TeachInput {

--- a/packages/cockpit/src/ui/runs/run-monitor.test.tsx
+++ b/packages/cockpit/src/ui/runs/run-monitor.test.tsx
@@ -14,6 +14,7 @@ function run(over: Partial<WorkspaceRun> = {}): WorkspaceRun {
 		status: "completed",
 		startedAt: new Date("2026-06-17T06:58:27.925Z"),
 		kind: "onboarding",
+		awaitingNote: null,
 		...over,
 	};
 }
@@ -47,6 +48,21 @@ describe("RunMonitor (DAT-550)", () => {
 			.getAllByTestId("run-status")
 			.map((b) => b.textContent);
 		expect(statuses).toEqual(["completed", "running"]);
+	});
+
+	it("shows an awaiting_input run as 'Needs input' with its note (DAT-551)", () => {
+		renderMonitor({
+			runs: [
+				run({
+					status: "awaiting_input",
+					awaitingNote: "payments.method needs a concept mapping",
+				}),
+			],
+		});
+		expect(screen.getByTestId("run-status").textContent).toBe("Needs input");
+		expect(screen.getByTestId("run-awaiting-note").textContent).toContain(
+			"payments.method needs a concept",
+		);
 	});
 
 	it("shows an empty state with no runs", () => {

--- a/packages/cockpit/src/ui/runs/run-monitor.test.tsx
+++ b/packages/cockpit/src/ui/runs/run-monitor.test.tsx
@@ -65,6 +65,20 @@ describe("RunMonitor (DAT-550)", () => {
 		);
 	});
 
+	it("shows 'Needs input' from the note even if status was re-marked completed (race-proof, DAT-551)", () => {
+		// The completion-watcher can re-mark a run `completed`; awaitingNote is the
+		// durable signal, so the surface drives off it, not the status badge alone.
+		renderMonitor({
+			runs: [
+				run({
+					status: "completed",
+					awaitingNote: "needs a relationship teach",
+				}),
+			],
+		});
+		expect(screen.getByTestId("run-status").textContent).toBe("Needs input");
+	});
+
 	it("shows an empty state with no runs", () => {
 		renderMonitor({ runs: [] });
 		expect(screen.getByTestId("run-monitor-empty")).toBeTruthy();

--- a/packages/cockpit/src/ui/runs/run-monitor.tsx
+++ b/packages/cockpit/src/ui/runs/run-monitor.tsx
@@ -6,7 +6,12 @@
 
 import { Anchor, Badge, Group, Stack, Table, Text, Title } from "@mantine/core";
 import type { WorkspaceRun } from "#/db/cockpit/runs";
-import { formatStartedAt, stageLabel, statusTone } from "#/ui/runs/run-row";
+import {
+	formatStartedAt,
+	stageLabel,
+	statusLabel,
+	statusTone,
+} from "#/ui/runs/run-row";
 
 export interface RunMonitorProps {
 	runs: ReadonlyArray<WorkspaceRun>;
@@ -61,8 +66,18 @@ export function RunMonitor({ runs, limit, temporalUiUrl }: RunMonitorProps) {
 											color={statusTone(run.status)}
 											data-testid="run-status"
 										>
-											{run.status}
+											{statusLabel(run.status)}
 										</Badge>
+										{run.awaitingNote && (
+											<Text
+												size="xs"
+												c="dimmed"
+												mt={4}
+												data-testid="run-awaiting-note"
+											>
+												{run.awaitingNote}
+											</Text>
+										)}
 									</Table.Td>
 									<Table.Td>
 										<Text size="sm" c="dimmed">

--- a/packages/cockpit/src/ui/runs/run-monitor.tsx
+++ b/packages/cockpit/src/ui/runs/run-monitor.tsx
@@ -53,46 +53,56 @@ export function RunMonitor({ runs, limit, temporalUiUrl }: RunMonitorProps) {
 							</Table.Tr>
 						</Table.Thead>
 						<Table.Tbody>
-							{runs.map((run) => (
-								<Table.Tr
-									key={`${run.workflowId}:${run.runId}`}
-									data-testid="run-monitor-row"
-								>
-									<Table.Td>{stageLabel(run.stage)}</Table.Td>
-									<Table.Td>
-										<Badge
-											size="sm"
-											variant="light"
-											color={statusTone(run.status)}
-											data-testid="run-status"
-										>
-											{statusLabel(run.status)}
-										</Badge>
-										{run.awaitingNote && (
-											<Text
-												size="xs"
-												c="dimmed"
-												mt={4}
-												data-testid="run-awaiting-note"
+							{runs.map((run) => {
+								// `awaitingNote` is the durable "needs you" signal — only the
+								// grounding loop ever writes it, so it can't be clobbered the
+								// way `status` can (the completion-watcher may re-mark a run
+								// `completed` on its terminal poll). Drive the badge off the note
+								// when present so the surface is race-proof (DAT-551 review).
+								const effectiveStatus = run.awaitingNote
+									? "awaiting_input"
+									: run.status;
+								return (
+									<Table.Tr
+										key={`${run.workflowId}:${run.runId}`}
+										data-testid="run-monitor-row"
+									>
+										<Table.Td>{stageLabel(run.stage)}</Table.Td>
+										<Table.Td>
+											<Badge
+												size="sm"
+												variant="light"
+												color={statusTone(effectiveStatus)}
+												data-testid="run-status"
 											>
-												{run.awaitingNote}
+												{statusLabel(effectiveStatus)}
+											</Badge>
+											{run.awaitingNote && (
+												<Text
+													size="xs"
+													c="dimmed"
+													mt={4}
+													data-testid="run-awaiting-note"
+												>
+													{run.awaitingNote}
+												</Text>
+											)}
+										</Table.Td>
+										<Table.Td>
+											<Text size="sm" c="dimmed">
+												{formatStartedAt(run.startedAt)}
 											</Text>
-										)}
-									</Table.Td>
-									<Table.Td>
-										<Text size="sm" c="dimmed">
-											{formatStartedAt(run.startedAt)}
-										</Text>
-									</Table.Td>
-									{/* maxWidth so `truncate` actually clips (Mantine truncate needs a
+										</Table.Td>
+										{/* maxWidth so `truncate` actually clips (Mantine truncate needs a
 									    width constraint) instead of the column growing to the id. */}
-									<Table.Td style={{ maxWidth: 220 }}>
-										<Text size="xs" c="dimmed" ff="monospace" truncate="end">
-											{run.workflowId}
-										</Text>
-									</Table.Td>
-								</Table.Tr>
-							))}
+										<Table.Td style={{ maxWidth: 220 }}>
+											<Text size="xs" c="dimmed" ff="monospace" truncate="end">
+												{run.workflowId}
+											</Text>
+										</Table.Td>
+									</Table.Tr>
+								);
+							})}
 						</Table.Tbody>
 					</Table>
 					{runs.length >= limit && (

--- a/packages/cockpit/src/ui/runs/run-row.test.ts
+++ b/packages/cockpit/src/ui/runs/run-row.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatStartedAt, stageLabel, statusTone } from "#/ui/runs/run-row";
+import {
+	formatStartedAt,
+	stageLabel,
+	statusLabel,
+	statusTone,
+} from "#/ui/runs/run-row";
 
 describe("run-row presentation (DAT-550)", () => {
 	it("labels known stages and passes unknown ones through", () => {
@@ -13,7 +18,15 @@ describe("run-row presentation (DAT-550)", () => {
 		expect(statusTone("running")).toBe("blue");
 		expect(statusTone("completed")).toBe("green");
 		expect(statusTone("failed")).toBe("red");
-		expect(statusTone("awaiting_input")).toBe("gray");
+		// The grounding loop's human-handoff state (DAT-551) — amber, not gray.
+		expect(statusTone("awaiting_input")).toBe("yellow");
+		expect(statusTone("future_status")).toBe("gray");
+	});
+
+	it("labels awaiting_input as a call to action, others verbatim (DAT-551)", () => {
+		expect(statusLabel("awaiting_input")).toBe("Needs input");
+		expect(statusLabel("running")).toBe("running");
+		expect(statusLabel("completed")).toBe("completed");
 	});
 
 	it("formats startedAt as stable UTC from a Date or its wire string", () => {

--- a/packages/cockpit/src/ui/runs/run-row.ts
+++ b/packages/cockpit/src/ui/runs/run-row.ts
@@ -13,7 +13,7 @@ export function stageLabel(stage: string): string {
 }
 
 /** Mantine color for a run status badge. */
-export type RunStatusTone = "blue" | "green" | "red" | "gray";
+export type RunStatusTone = "blue" | "green" | "red" | "gray" | "yellow";
 export function statusTone(status: string): RunStatusTone {
 	switch (status) {
 		case "running":
@@ -22,9 +22,18 @@ export function statusTone(status: string): RunStatusTone {
 			return "green";
 		case "failed":
 			return "red";
+		// The grounding-teach loop parked it for a human judgement teach (DAT-551).
+		case "awaiting_input":
+			return "yellow";
 		default:
 			return "gray";
 	}
+}
+
+/** Human label for a run status — most are shown verbatim; awaiting_input reads as
+ * a call to action ("Needs input") rather than the raw enum. */
+export function statusLabel(status: string): string {
+	return status === "awaiting_input" ? "Needs input" : status;
 }
 
 /**

--- a/packages/cockpit/src/worker/activities.ts
+++ b/packages/cockpit/src/worker/activities.ts
@@ -13,5 +13,11 @@
 // it (DAT-528). These are thin re-exports — the SQL + idempotency are tested in
 // db/cockpit/runs.test; the journey's orchestration is tested via the Replayer +
 // compose-smoke.
+//
+// DAT-551 P3c adds `assessAndGround` — a heavier activity that reads the run's
+// readiness and runs an LLM to auto-apply mechanical grounding teaches. It is the
+// non-deterministic half of the post-add_source grounding loop; the journey's
+// deterministic loop drives the replays around it.
 
 export { attachRunId, markRunStatus, recordRun } from "#/db/cockpit/runs";
+export { assessAndGround } from "#/worker/grounding-agent";

--- a/packages/cockpit/src/worker/activities.ts
+++ b/packages/cockpit/src/worker/activities.ts
@@ -19,5 +19,11 @@
 // non-deterministic half of the post-add_source grounding loop; the journey's
 // deterministic loop drives the replays around it.
 
-export { attachRunId, markRunStatus, recordRun } from "#/db/cockpit/runs";
+export {
+	attachRunId,
+	markRunAwaitingInput,
+	markRunStatus,
+	recordRun,
+} from "#/db/cockpit/runs";
+export type { AssessAndGroundResult } from "#/worker/grounding-agent";
 export { assessAndGround } from "#/worker/grounding-agent";

--- a/packages/cockpit/src/worker/contracts.ts
+++ b/packages/cockpit/src/worker/contracts.ts
@@ -51,6 +51,10 @@ export interface RunAddSource {
 	kind: "onboarding" | "replay";
 	/** The originating chat (DAT-528) for narration routing. Null = none. */
 	conversationId: string | null;
+	/** How many grounding-teach replay attempts the autonomous loop may make after
+	 * this import (DAT-551 P3c). Optional — the journey defaults it; a future UI can
+	 * carry a user-chosen bound on the trigger. */
+	numberOfAttempts?: number;
 }
 
 /** The INTENTIONAL begin_session trigger (DAT-530): the user chose a table set,

--- a/packages/cockpit/src/worker/grounding-agent.test.ts
+++ b/packages/cockpit/src/worker/grounding-agent.test.ts
@@ -1,0 +1,141 @@
+// Unit tests for the grounding-teach agent activity (DAT-551 P3c). Mocks the
+// readiness oracle, `@tanstack/ai` chat, and the teach write at the seam (no DB, no
+// real LLM). Asserts the DECISION paths: the all-ready fast path skips the LLM; a
+// missing key surfaces for judgement without an LLM call; and a real verdict maps
+// through. The actual tool-loop (capture-cell applied-count) is exercised by the
+// compose smoke, like why-table's synthesizeAnalysis.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+	apiKey: "test-key" as string | undefined,
+	readiness: [] as Array<Record<string, unknown>>,
+	chat: vi.fn(async (_opts: unknown) => ({
+		needs_judgement: false,
+		judgement_note: null as string | null,
+	})),
+}));
+
+vi.mock("#/config", () => ({
+	get config() {
+		return { anthropicApiKey: h.apiKey };
+	},
+}));
+vi.mock("#/db/metadata/grounding-readiness", () => ({
+	readGroundingReadiness: vi.fn(async () => h.readiness),
+}));
+vi.mock("@tanstack/ai", () => ({
+	chat: (opts: unknown) => h.chat(opts),
+	maxIterations: (n: number) => ({ maxIterations: n }),
+	// The constrained tool is built at call time; the mock chat never invokes it,
+	// so a stub with a no-op server is enough.
+	toolDefinition: () => ({ server: () => ({ __tool: true }) }),
+}));
+vi.mock("@tanstack/ai-anthropic", () => ({
+	createAnthropicChat: () => ({ __adapter: true }),
+}));
+vi.mock("#/tools/teach", () => ({
+	teach: vi.fn(async () => ({ overlay_id: "ov-1", type: "type_pattern" })),
+}));
+
+import { assessAndGround } from "./grounding-agent";
+
+function row(
+	target: string,
+	band: string,
+	risk = 0.5,
+): Record<string, unknown> {
+	return {
+		target,
+		tableId: "t1",
+		columnId: null,
+		band,
+		worstIntentRisk: risk,
+		topDrivers: [
+			{ node: "type_fidelity", state: "conflict", impact_delta: 0.4 },
+		],
+	};
+}
+
+beforeEach(() => {
+	h.apiKey = "test-key";
+	h.readiness = [];
+	h.chat.mockClear();
+	h.chat.mockResolvedValue({ needs_judgement: false, judgement_note: null });
+});
+
+describe("assessAndGround (DAT-551)", () => {
+	it("fast-paths to a clean no-op when every target is ready (no LLM call)", async () => {
+		h.readiness = [row("column:payments.amount", "ready")];
+		const res = await assessAndGround({
+			tableIds: ["t1"],
+			attemptsRemaining: 3,
+		});
+		expect(res).toEqual({
+			appliedCount: 0,
+			needsJudgement: false,
+			judgementNote: null,
+		});
+		expect(h.chat).not.toHaveBeenCalled();
+	});
+
+	it("fast-paths when nothing is measured yet (empty readiness, no LLM call)", async () => {
+		h.readiness = [];
+		const res = await assessAndGround({
+			tableIds: ["t1"],
+			attemptsRemaining: 3,
+		});
+		expect(res.appliedCount).toBe(0);
+		expect(res.needsJudgement).toBe(false);
+		expect(h.chat).not.toHaveBeenCalled();
+	});
+
+	it("surfaces for judgement WITHOUT an LLM call when there is no API key", async () => {
+		h.apiKey = undefined;
+		h.readiness = [row("column:payments.amount", "investigate")];
+		const res = await assessAndGround({
+			tableIds: ["t1"],
+			attemptsRemaining: 3,
+		});
+		expect(res.needsJudgement).toBe(true);
+		expect(res.judgementNote).toMatch(/no ANTHROPIC_API_KEY/i);
+		expect(h.chat).not.toHaveBeenCalled();
+	});
+
+	it("runs the agent on a gap and maps its verdict through", async () => {
+		h.readiness = [
+			row("column:payments.amount", "investigate"),
+			row("column:payments.method", "ready"), // ready ones are filtered out
+		];
+		h.chat.mockResolvedValue({
+			needs_judgement: true,
+			judgement_note: "payments.method needs a concept mapping",
+		});
+		const res = await assessAndGround({
+			tableIds: ["t1"],
+			attemptsRemaining: 2,
+		});
+		expect(h.chat).toHaveBeenCalledTimes(1);
+		// appliedCount is 0 here because the mock chat doesn't invoke the tool — the
+		// real applied-count wiring is smoke-covered.
+		expect(res).toEqual({
+			appliedCount: 0,
+			needsJudgement: true,
+			judgementNote: "payments.method needs a concept mapping",
+		});
+	});
+
+	it("only sends NON-ready targets to the agent", async () => {
+		h.readiness = [
+			row("column:payments.amount", "blocked"),
+			row("column:payments.id", "ready"),
+		];
+		await assessAndGround({ tableIds: ["t1"], attemptsRemaining: 3 });
+		const opts = h.chat.mock.calls[0][0] as {
+			messages: Array<{ content: string }>;
+		};
+		const userMsg = opts.messages[0].content;
+		expect(userMsg).toContain("column:payments.amount");
+		expect(userMsg).not.toContain("column:payments.id");
+	});
+});

--- a/packages/cockpit/src/worker/grounding-agent.ts
+++ b/packages/cockpit/src/worker/grounding-agent.ts
@@ -1,0 +1,180 @@
+// Grounding-teach agent (DAT-551 P3c) — the LLM activity the journey runs after an
+// add_source completes. It reads the run's readiness oracle and, via a nested
+// chat(), auto-applies ONLY mechanical grounding teaches (type_pattern / null_value
+// / unit) for the gaps a detector can verify, reporting whether a human-judgement
+// gap remains.
+//
+// MAIN-THREAD activity (NOT workflow-sandboxed): it does IO (metadata read +
+// config_overlay writes via `teach`) and a real LLM call. This is the FIRST chat()
+// from the worker process — the cockpit's request-scoped tools (answer/why) are the
+// pattern, and `config.anthropicApiKey` is available here too. Non-deterministic →
+// correctly an ACTIVITY; the journey's deterministic loop drives the replays around
+// it (it never replays itself).
+//
+// The gate is authoritative + structural: the agent is handed ONLY the constrained
+// `ground_teach` tool, whose input enum is AGENT_AUTOAPPLY_TEACH_TYPES and whose
+// payload is AutoApplyTeachPayloadSchema — so the model literally cannot express a
+// judgement-family teach (concept/relationship/hierarchy/validation). A non-mechanical
+// gap is REPORTED (needs_judgement), never auto-applied.
+
+import { chat, maxIterations, toolDefinition } from "@tanstack/ai";
+import { createAnthropicChat } from "@tanstack/ai-anthropic";
+import { z } from "zod";
+
+import { config } from "#/config";
+import {
+	type GroundingReadinessRow,
+	readGroundingReadiness,
+} from "#/db/metadata/grounding-readiness";
+import { MAX_OUTPUT_TOKENS, MODEL } from "#/llm";
+import { teach } from "#/tools/teach";
+import {
+	AGENT_AUTOAPPLY_TEACH_TYPES,
+	AutoApplyTeachPayloadSchema,
+	type AutoApplyTeachType,
+} from "#/tools/teach.validation";
+
+// Runaway ceiling for the grounding agent's own tool loop (read gaps → apply N
+// teaches → emit verdict). A normal round applies a handful of teaches in 2–4
+// iterations; this is a backstop, not a budget (mirrors QUERY_SUBAGENT_MAX_ITERATIONS).
+const GROUNDING_LOOP_MAX_ITERATIONS = 12;
+
+const GROUNDING_INSTRUCTIONS = `You are the grounding-teach agent. After a data import, you fix MECHANICAL grounding gaps so the data types cleanly — nothing more.
+
+You are given the readiness of each column (band + worst-intent risk + the top drivers behind the risk). For each NON-ready target, decide if it is a MECHANICAL grounding gap you can fix, and if so apply ONE teach via the ground_teach tool:
+- driver about TYPE / type_fidelity (e.g. a date or number read as text) → type_pattern: a regex matching the values + the inferred_type.
+- driver about NULLS / null_semantics (an unrecognized null token like "N/A", "-", "TBD") → null_value: the token + its category.
+- driver about UNITS / unit_entropy (a measure with a missing/ambiguous unit) → unit: {table, column, unit}, identifying the column by NAME (parse it from the target "column:<table>.<col>").
+
+You MUST NOT attempt anything else. Concept meaning (business_meaning), relationships (join_path_determinism), hierarchies, and validations are HUMAN JUDGEMENT — you cannot teach them and the tool will not let you. If a remaining gap is one of those, do NOT apply a teach for it; instead set needs_judgement=true and describe it briefly in judgement_note for the human.
+
+Do NOT replay or re-measure — the system re-runs the import and re-measures after your teaches; you only apply teaches this round. When done, emit your verdict: needs_judgement (is there a non-mechanical gap a human must address?) and judgement_note (one sentence naming it, or null).`;
+
+/** The agent's structured verdict (the tool-applied teaches are counted separately
+ * via the capture cell, not self-reported). */
+const VerdictSchema = z.object({
+	needs_judgement: z
+		.boolean()
+		.describe(
+			"True if a NON-mechanical gap remains that a human must address (a concept/relationship/hierarchy/validation), false otherwise.",
+		),
+	judgement_note: z
+		.string()
+		.nullable()
+		.describe(
+			"One sentence naming the human-judgement gap (the target + what's needed), or null when none.",
+		),
+});
+
+export interface AssessAndGroundInput {
+	/** The run's typed table ids — the readiness scope to assess + ground. */
+	tableIds: string[];
+	/** How many grounding attempts remain (for the agent's context; the journey
+	 * owns the actual loop bound). */
+	attemptsRemaining: number;
+}
+
+export interface AssessAndGroundResult {
+	/** Mechanical grounding teaches applied this round (captured from the tool, not
+	 * self-reported) — the journey replays iff this is > 0 and attempts remain. */
+	appliedCount: number;
+	/** A non-mechanical gap remains → the journey surfaces it (awaiting_input). */
+	needsJudgement: boolean;
+	/** What to tell the human, when needsJudgement. */
+	judgementNote: string | null;
+}
+
+/** Build the user message: the non-ready targets with their drivers, for the agent
+ * to ground. */
+function buildReadinessMessage(
+	gaps: GroundingReadinessRow[],
+	attemptsRemaining: number,
+): string {
+	const lines = gaps.map((g) => {
+		const drivers = JSON.stringify(g.topDrivers ?? []);
+		return `- ${g.target} — band=${g.band}, worst_intent_risk=${g.worstIntentRisk.toFixed(2)}, top_drivers=${drivers}`;
+	});
+	return `<grounding_attempts_remaining>${attemptsRemaining}</grounding_attempts_remaining>\n<non_ready_targets>\n${lines.join("\n")}\n</non_ready_targets>`;
+}
+
+/** The constrained grounding-teach tool — the authoritative gate. Its input can
+ * ONLY name an auto-apply type; the write goes through the same `teach` primitive,
+ * and each success bumps the capture cell so the journey gets a real applied-count. */
+function makeGroundTeachTool(captured: { count: number }) {
+	return toolDefinition({
+		name: "ground_teach",
+		description:
+			"Apply ONE mechanical grounding teach — type_pattern, null_value, or unit. " +
+			"Writes a config_overlay row the next import re-run applies. Use only for " +
+			"a gap a detector can verify; never for concept/relationship/hierarchy/validation.",
+		inputSchema: z.object({
+			type: z.enum(AGENT_AUTOAPPLY_TEACH_TYPES),
+			payload: AutoApplyTeachPayloadSchema,
+		}),
+		outputSchema: z.union([
+			z.object({ overlay_id: z.string(), type: z.string() }),
+			z.object({ error: z.string() }),
+		]),
+	}).server(async (input) => {
+		try {
+			const res = await teach({
+				type: input.type as AutoApplyTeachType,
+				payload: input.payload,
+			});
+			captured.count += 1;
+			return res;
+		} catch (err) {
+			// Surface a validation error as data so the agent can retry, not crash.
+			return { error: err instanceof Error ? err.message : String(err) };
+		}
+	});
+}
+
+/**
+ * Assess the run's grounding readiness and auto-apply the mechanical teaches a
+ * detector can verify. Returns the applied count + whether a human-judgement gap
+ * remains. Fast-paths to a no-op (no LLM call) when every target is already ready.
+ */
+export async function assessAndGround(
+	input: AssessAndGroundInput,
+): Promise<AssessAndGroundResult> {
+	const readiness = await readGroundingReadiness(input.tableIds);
+	const gaps = readiness.filter((r) => r.band !== "ready");
+	// Fast path: nothing to ground → no LLM call, the loop exits clean.
+	if (gaps.length === 0) {
+		return { appliedCount: 0, needsJudgement: false, judgementNote: null };
+	}
+	// No key → can't run the agent. Don't crash the journey; surface for a human
+	// (mirrors the api-key-required contract — the engine treats the key as hard,
+	// but the journey must stay alive).
+	if (!config.anthropicApiKey) {
+		return {
+			appliedCount: 0,
+			needsJudgement: true,
+			judgementNote:
+				"Grounding agent unavailable (no ANTHROPIC_API_KEY) — review readiness manually.",
+		};
+	}
+
+	const captured = { count: 0 };
+	const verdict = await chat({
+		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
+		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
+		agentLoopStrategy: maxIterations(GROUNDING_LOOP_MAX_ITERATIONS),
+		systemPrompts: [GROUNDING_INSTRUCTIONS],
+		messages: [
+			{
+				role: "user",
+				content: buildReadinessMessage(gaps, input.attemptsRemaining),
+			},
+		],
+		tools: [makeGroundTeachTool(captured)],
+		outputSchema: VerdictSchema,
+	});
+
+	return {
+		appliedCount: captured.count,
+		needsJudgement: verdict.needs_judgement,
+		judgementNote: verdict.judgement_note,
+	};
+}

--- a/packages/cockpit/src/worker/workflows/grounding-step.test.ts
+++ b/packages/cockpit/src/worker/workflows/grounding-step.test.ts
@@ -1,0 +1,62 @@
+// Unit tests for the pure grounding-loop decision (DAT-551 P3c). The loop's wiring
+// is replay-fixture/smoke covered; this pins the branch logic.
+
+import { describe, expect, it } from "vitest";
+import { decideGroundingStep } from "./grounding-step";
+
+describe("decideGroundingStep (DAT-551)", () => {
+	it("replays when teaches were applied and attempts remain", () => {
+		expect(
+			decideGroundingStep(
+				{ appliedCount: 2, needsJudgement: false, judgementNote: null },
+				2,
+			),
+		).toEqual({ action: "replay" });
+	});
+
+	it("surfaces 'exhausted' when teaches were applied but no attempts remain", () => {
+		expect(
+			decideGroundingStep(
+				{ appliedCount: 1, needsJudgement: false, judgementNote: "x" },
+				0,
+			),
+		).toEqual({ action: "surface", reason: "exhausted", note: "x" });
+	});
+
+	it("is done when nothing was applied and no judgement is needed (clean)", () => {
+		expect(
+			decideGroundingStep(
+				{ appliedCount: 0, needsJudgement: false, judgementNote: null },
+				3,
+			),
+		).toEqual({ action: "done" });
+	});
+
+	it("surfaces 'judgement' when nothing mechanical was applied but a human gap remains", () => {
+		expect(
+			decideGroundingStep(
+				{
+					appliedCount: 0,
+					needsJudgement: true,
+					judgementNote: "payments.method needs a concept",
+				},
+				3,
+			),
+		).toEqual({
+			action: "surface",
+			reason: "judgement",
+			note: "payments.method needs a concept",
+		});
+	});
+
+	it("prioritises replay over a judgement note while attempts remain (re-measure first)", () => {
+		// Applied teaches + a flagged judgement gap + attempts left → replay; the
+		// judgement is re-evaluated next round on fresh readiness.
+		expect(
+			decideGroundingStep(
+				{ appliedCount: 1, needsJudgement: true, judgementNote: "later" },
+				1,
+			),
+		).toEqual({ action: "replay" });
+	});
+});

--- a/packages/cockpit/src/worker/workflows/grounding-step.ts
+++ b/packages/cockpit/src/worker/workflows/grounding-step.ts
@@ -1,0 +1,55 @@
+// Pure decision for one grounding-loop round (DAT-551 P3c).
+//
+// Pure + zero-import so it is (a) sandbox-safe to import into the journey workflow
+// and (b) unit-testable WITHOUT a Temporal test server — the loop's control flow is
+// otherwise replay-fixture/smoke covered, like the breaker reducer. Given the
+// agent's verdict for a round and how many replay attempts remain, decide whether to
+// replay (re-measure after teaches), finish clean, or surface for a human.
+
+/** What the journey does after one assessAndGround round. */
+export type GroundingStep =
+	| { action: "replay" }
+	| {
+			action: "surface";
+			reason: "judgement" | "exhausted";
+			note: string | null;
+	  }
+	| { action: "done" };
+
+export interface GroundingVerdict {
+	/** Mechanical grounding teaches applied this round. */
+	appliedCount: number;
+	/** A non-mechanical gap remains that a human must address. */
+	needsJudgement: boolean;
+	/** What to tell the human (when surfacing). */
+	judgementNote: string | null;
+}
+
+/**
+ * Decide the next step. `attemptsRemaining` is the number of replays still allowed.
+ * - Applied teaches AND attempts left → replay (re-run add_source to re-measure).
+ * - Applied teaches BUT out of attempts → surface (couldn't converge in budget).
+ * - No teaches applied → nothing mechanical left: surface if a judgement gap
+ *   remains, else done (clean).
+ */
+export function decideGroundingStep(
+	verdict: GroundingVerdict,
+	attemptsRemaining: number,
+): GroundingStep {
+	if (verdict.appliedCount > 0) {
+		if (attemptsRemaining > 0) return { action: "replay" };
+		return {
+			action: "surface",
+			reason: "exhausted",
+			note: verdict.judgementNote,
+		};
+	}
+	if (verdict.needsJudgement) {
+		return {
+			action: "surface",
+			reason: "judgement",
+			note: verdict.judgementNote,
+		};
+	}
+	return { action: "done" };
+}

--- a/packages/cockpit/src/worker/workflows/journey.ts
+++ b/packages/cockpit/src/worker/workflows/journey.ts
@@ -2,9 +2,10 @@
 //
 // SANDBOXED: this module runs inside the worker's deterministic vm isolate, NOT
 // the main thread. It may import ONLY `@temporalio/workflow`, the pure shared
-// `../contracts`, the pure `./breaker` reducer, the pure `../../temporal/workflow-id`
-// helpers, and activity *types* — no db client, no config, no node/bun IO. All
-// side effects live in `../activities`, dispatched through the proxy below.
+// `../contracts`, the pure `./breaker` + `./grounding-step` reducers, the pure
+// `../../temporal/workflow-id` helpers, and *types* (contracts + AddSourceResult +
+// activities) — no db client, no config, no node/bun IO. All side effects live in
+// `../activities`, dispatched through the proxies below.
 //
 // Grain: ONE long-lived workflow PER WORKSPACE (`journey-<workspaceId>`), bounded
 // by continue-as-new. The worker is a process singleton, so it hosts N workspaces'
@@ -27,6 +28,14 @@
 // change onto the Phase-1 structure. The operating_model TOOL stays as a manual
 // re-trigger (a teach re-run, P3c) — it signals the journey too, so the journey is
 // the single owner of all stage execution.
+//
+// P3c — GROUNDING AUTONOMY (DAT-551): a clean add_source AUTO-CASCADES into the
+// grounding-teach loop (`runGroundingLoop`): the `assessAndGround` activity
+// auto-applies the mechanical grounding teaches a detector can verify, the journey
+// replays (re-runs add_source) to re-measure, bounded by `numberOfAttempts`. A
+// human-judgement gap or exhaustion parks the run `awaiting_input` (the human
+// teaches + replays — a fresh loop); it NEVER blocks the shared journey on human
+// input. Gated by its own `patched()` + autoMode (the master autonomy switch).
 
 import {
 	condition,
@@ -40,6 +49,7 @@ import {
 	setHandler,
 	startChild,
 } from "@temporalio/workflow";
+import type { AddSourceResult } from "../../temporal/types";
 import { operatingModelWorkflowId } from "../../temporal/workflow-id";
 import type * as activities from "../activities";
 import {
@@ -57,14 +67,22 @@ import {
 	type VerticalEstablished,
 } from "../contracts";
 import { applyOutcome } from "./breaker";
+import { decideGroundingStep } from "./grounding-step";
 
 // The control-plane writers (cockpit_db) the journey brackets each child with.
 // Short timeout — these are quick local writes, not the (long) engine stage.
-const { recordRun, attachRunId, markRunStatus } = proxyActivities<
-	typeof activities
->({
-	startToCloseTimeout: "1 minute",
-	retry: { maximumAttempts: 3 },
+const { recordRun, attachRunId, markRunStatus, markRunAwaitingInput } =
+	proxyActivities<typeof activities>({
+		startToCloseTimeout: "1 minute",
+		retry: { maximumAttempts: 3 },
+	});
+
+// The grounding-teach agent (DAT-551 P3c) — an LLM tool-loop, so a much longer
+// timeout than the cockpit_db writes, and only one retry (a re-run is expensive +
+// the loop tolerates a failed round by stopping, never crashing the journey).
+const { assessAndGround } = proxyActivities<typeof activities>({
+	startToCloseTimeout: "10 minutes",
+	retry: { maximumAttempts: 2 },
 });
 
 export const verticalEstablished = defineSignal<[VerticalEstablished]>(
@@ -91,6 +109,12 @@ const EVENTS_BEFORE_CONTINUE = 500;
 // predate it; it's established here as the discipline for future incremental edits.
 const CASCADE_PATCH = "journey-cascade-operating-model";
 
+// Gates the post-add_source grounding-teach loop (DAT-551 P3c).
+const GROUNDING_PATCH = "journey-grounding-loop";
+
+// Default replay budget for the grounding loop when the trigger carries none.
+const DEFAULT_GROUNDING_ATTEMPTS = 3;
+
 /** A queued, user-intentional stage trigger (add_source / begin_session always;
  * operating_model as a manual re-trigger). The auto-cascade is NOT queued — it runs
  * inline right after its begin_session, so a session's two stages stay an atomic pair. */
@@ -99,11 +123,19 @@ type PendingStage =
 	| { kind: "begin_session"; req: RunBeginSession }
 	| { kind: "operating_model"; req: RunOperatingModel };
 
+/** A finished stage: whether it succeeded + the engine child's result (null on
+ * failure). The breaker folds `ok`; the grounding loop reads `result` (the
+ * AddSourceResult) for the typed table ids to assess. */
+interface StageOutcome {
+	ok: boolean;
+	result: unknown;
+}
+
 /**
  * Run one engine stage as a cross-language child of the journey. Records the run
  * authoritatively before start, attaches the child's real execution id, marks it
- * terminal on completion. Returns whether it succeeded — the caller folds that into
- * the breaker and decides whether to cascade. A failure NEVER crashes the
+ * terminal on completion. Returns {ok, result} — the caller folds `ok` into the
+ * breaker and reads `result` to drive a cascade. A failure NEVER crashes the
  * long-lived journey: the run is marked failed and the loop continues.
  */
 async function runChildStage(
@@ -121,7 +153,7 @@ async function runChildStage(
 		conversationId: string | null;
 		args: unknown[];
 	},
-): Promise<boolean> {
+): Promise<StageOutcome> {
 	// runId is the deterministic workflowId placeholder until the child mints its
 	// execution id (so a failure before start still has a key to mark).
 	let runId = spec.workflowId;
@@ -142,16 +174,18 @@ async function runChildStage(
 			taskQueue: spec.taskQueue,
 			workflowId: spec.workflowId,
 			// The journey's continue-as-new (or restart) must NOT kill a running
-			// engine stage — let it complete independently.
+			// engine stage — let it complete independently. A grounding REPLAY reuses
+			// this same workflowId; the prior execution is already closed by then, so
+			// the child default (allow-duplicate-when-closed) permits it.
 			parentClosePolicy: ParentClosePolicy.ABANDON,
 			args: spec.args,
 		});
 		runId = child.firstExecutionRunId;
 		await attachRunId(spec.workflowId, runId);
 
-		await child.result();
+		const result = await child.result();
 		await markRunStatus(spec.workflowId, runId, "completed");
-		return true;
+		return { ok: true, result };
 	} catch (err) {
 		log.warn("journey stage failed", {
 			stage: spec.stage,
@@ -161,7 +195,7 @@ async function runChildStage(
 		// Mark failed best-effort (markRunStatus is a no-op if the run wasn't
 		// recorded). Don't rethrow — one bad stage must not crash the journey.
 		await markRunStatus(spec.workflowId, runId, "failed").catch(() => {});
-		return false;
+		return { ok: false, result: null };
 	}
 }
 
@@ -169,7 +203,7 @@ async function runChildStage(
 function runAddSourceStage(
 	workspaceId: string,
 	req: RunAddSource,
-): Promise<boolean> {
+): Promise<StageOutcome> {
 	return runChildStage(workspaceId, {
 		workflowType: "addSourceWorkflow",
 		workflowId: req.workflowId,
@@ -192,7 +226,7 @@ function runAddSourceStage(
 function runBeginSessionStage(
 	workspaceId: string,
 	req: RunBeginSession,
-): Promise<boolean> {
+): Promise<StageOutcome> {
 	return runChildStage(workspaceId, {
 		workflowType: "beginSessionWorkflow",
 		workflowId: req.workflowId,
@@ -217,7 +251,7 @@ function runBeginSessionStage(
 function runOperatingModelStage(
 	workspaceId: string,
 	om: RunOperatingModel,
-): Promise<boolean> {
+): Promise<StageOutcome> {
 	return runChildStage(workspaceId, {
 		workflowType: "operatingModelWorkflow",
 		workflowId: om.workflowId,
@@ -229,6 +263,71 @@ function runOperatingModelStage(
 		conversationId: om.conversationId,
 		args: [{ workspace_id: workspaceId, verticals: om.verticals }],
 	});
+}
+
+/** The typed table ids from an add_source result — the readiness scope the
+ * grounding agent assesses. Narrows the child's `unknown` result defensively. */
+function typedTableIds(result: unknown): string[] {
+	const r = result as Partial<AddSourceResult> | null;
+	if (!r?.tables) return [];
+	return r.tables
+		.map((t) => t.typed_table_id)
+		.filter((id): id is string => typeof id === "string");
+}
+
+/**
+ * The post-add_source grounding-teach loop (DAT-551 P3c) — the autonomy step.
+ * Bounded by `numberOfAttempts`: assess the run's readiness, auto-apply the
+ * mechanical grounding teaches a detector can verify, replay (re-run add_source to
+ * re-measure), repeat — until readiness is clean, nothing mechanical is left, or the
+ * attempt budget runs out. On a human-judgement gap or exhaustion it parks the run
+ * in `awaiting_input` (a human resolves by teaching + replaying — a fresh loop) and
+ * RETURNS: it NEVER blocks the shared journey on human input (B1). Returns the
+ * number of replays it ran (for the continue-as-new event bound).
+ */
+async function runGroundingLoop(
+	workspaceId: string,
+	req: RunAddSource,
+	firstResult: unknown,
+): Promise<number> {
+	let tableIds = typedTableIds(firstResult);
+	if (tableIds.length === 0) return 0;
+	let attemptsRemaining = req.numberOfAttempts ?? DEFAULT_GROUNDING_ATTEMPTS;
+	let replays = 0;
+	while (true) {
+		let verdict: activities.AssessAndGroundResult;
+		try {
+			verdict = await assessAndGround({ tableIds, attemptsRemaining });
+		} catch (err) {
+			// The assessment died (LLM error after retries) — stop grounding, don't
+			// crash the journey. The import itself is already recorded complete.
+			log.warn("journey grounding assess failed", {
+				workflowId: req.workflowId,
+				err: String(err),
+			});
+			return replays;
+		}
+
+		const step = decideGroundingStep(verdict, attemptsRemaining);
+		if (step.action === "done") return replays;
+		if (step.action === "surface") {
+			await markRunAwaitingInput(req.workflowId, step.note).catch(() => {});
+			log.info("journey grounding surfaced for input", {
+				workflowId: req.workflowId,
+				reason: step.reason,
+			});
+			return replays;
+		}
+
+		// action === "replay": re-run add_source for the SAME session to apply the
+		// teaches + re-measure. A failed replay stops the loop (the run is marked).
+		attemptsRemaining -= 1;
+		const { ok, result } = await runAddSourceStage(workspaceId, req);
+		replays += 1;
+		if (!ok) return replays;
+		tableIds = typedTableIds(result);
+		if (tableIds.length === 0) return replays;
+	}
 }
 
 /**
@@ -293,13 +392,20 @@ export async function journeyWorkflow(
 		const next = pending.shift() as PendingStage;
 
 		if (next.kind === "add_source") {
-			// A fresh import or a replay — always user-triggered (select / replay),
-			// never autonomous in this slice, so it does NOT fold into the breaker:
-			// the breaker is scoped to the begin_session → operating_model cascade
-			// (ADR-0014). runChildStage still records + marks the run. No cascade
-			// follows add_source here (the agentic grounding-teach loop is slice 2).
-			await runAddSourceStage(workspaceId, next.req);
+			// A fresh import or a replay — always user-triggered (select / replay), so
+			// it does NOT fold into the breaker (scoped to the begin_session →
+			// operating_model cascade, ADR-0014). On a clean import it AUTO-CASCADES
+			// into the grounding-teach loop (DAT-551 P3c): auto-apply mechanical
+			// grounding teaches + replay until ready or attempts run out. Gated by
+			// patched() (the control-flow change) + autoMode (the master autonomy
+			// switch — a paused/tripped journey skips auto-grounding). The loop never
+			// blocks on human input; it parks awaiting_input + returns.
+			const req = next.req;
+			const { ok, result } = await runAddSourceStage(workspaceId, req);
 			handled += 1;
+			if (patched(GROUNDING_PATCH) && ok && breaker.autoMode) {
+				handled += await runGroundingLoop(workspaceId, req, result);
+			}
 			continue;
 		}
 
@@ -308,12 +414,12 @@ export async function journeyWorkflow(
 			// breaker (the breaker only gates the AUTONOMOUS follow-on). It STILL
 			// folds into the tally: a stage that keeps failing is a bad engine
 			// whoever triggered it, so repeated manual failures trip the breaker too.
-			fold(await runOperatingModelStage(workspaceId, next.req));
+			fold((await runOperatingModelStage(workspaceId, next.req)).ok);
 			handled += 1;
 			continue;
 		}
 
-		const beganOk = await runBeginSessionStage(workspaceId, next.req);
+		const beganOk = (await runBeginSessionStage(workspaceId, next.req)).ok;
 		fold(beganOk);
 		handled += 1;
 
@@ -328,13 +434,15 @@ export async function journeyWorkflow(
 		if (cascadeEnabled && beganOk && breaker.autoMode) {
 			const req = next.req;
 			fold(
-				await runOperatingModelStage(workspaceId, {
-					sessionId: req.sessionId,
-					workflowId: operatingModelWorkflowId(workspaceId, req.sessionId),
-					engineTaskQueue: req.engineTaskQueue,
-					verticals: req.verticals,
-					conversationId: req.conversationId,
-				}),
+				(
+					await runOperatingModelStage(workspaceId, {
+						sessionId: req.sessionId,
+						workflowId: operatingModelWorkflowId(workspaceId, req.sessionId),
+						engineTaskQueue: req.engineTaskQueue,
+						verticals: req.verticals,
+						conversationId: req.conversationId,
+					})
+				).ok,
 			);
 			handled += 1;
 		}

--- a/packages/cockpit/src/worker/workflows/journey.ts
+++ b/packages/cockpit/src/worker/workflows/journey.ts
@@ -321,8 +321,15 @@ async function runGroundingLoop(
 
 		// action === "replay": re-run add_source for the SAME session to apply the
 		// teaches + re-measure. A failed replay stops the loop (the run is marked).
+		// conversationId=null: these are INTERNAL autonomous re-runs — they must NOT
+		// each fire the completion-watcher's "import finished" narration (the user
+		// already heard the import landed; the loop's outcome surfaces via the run
+		// monitor / awaiting_input, not N chat messages).
 		attemptsRemaining -= 1;
-		const { ok, result } = await runAddSourceStage(workspaceId, req);
+		const { ok, result } = await runAddSourceStage(workspaceId, {
+			...req,
+			conversationId: null,
+		});
 		replays += 1;
 		if (!ok) return replays;
 		tableIds = typedTableIds(result);


### PR DESCRIPTION
## DAT-551 slice 2 — the agentic grounding-teach loop

The autonomy payoff of the Cockpit Autonomy epic (DAT-526, P3c): after a clean `add_source`, the journey **auto-applies the mechanical grounding teaches it can self-verify, and replays until the data is ready** — surfacing only what needs human judgement. Builds on slice 1 (journey owns all stages) and the `unit` teach type. **No engine change.**

### pt1 (7475514c) — the grounding-teach agent activity + the auto-apply gate
- `AGENT_AUTOAPPLY_TEACH_TYPES = {type_pattern, null_value, unit}` + `AutoApplyTeachPayloadSchema` — the authoritative, in-code classification of what an agent may auto-apply. **Not** derived from the engine loss table (by that definition `relationship`/`concept` are entropy-measurable too, but they're *judgement*); the gate is "mechanical grounding the agent can self-verify by re-measuring".
- `readGroundingReadiness(tableIds)` — the self-check oracle, reading the head-joined `current_entropy_readiness` view (band / worst_intent_risk / top_drivers).
- `assessAndGround` activity (`src/worker/grounding-agent.ts`) — the **first `chat()` from the worker process**. All-ready → no-op (no LLM); no key → surface; else a nested `chat()` handed **only** the constrained `ground_teach` tool (type enum = the 3, payload = the constrained union) so the model *cannot* express a judgement teach. Applies mechanical teaches (counted via a capture cell), returns `{appliedCount, needsJudgement, judgementNote}`.

### pt2 (f97ae328) — the journey loop + cascade + awaiting_input
- A clean `add_source` auto-cascades into `runGroundingLoop`, gated by `patched()` + `autoMode` (the master autonomy switch). Bounded by `numberOfAttempts` (journey-defaulted to 3): assess → apply → replay (re-run add_source for the same session) → re-measure, until ready / nothing mechanical left / budget exhausted.
- The per-round decision is a pure reducer (`decideGroundingStep`, unit-tested like the breaker); the loop wiring is smoke-covered.
- **B1 — park + nudge:** on a judgement gap or exhaustion the run is parked in a new `awaiting_input` status (+ `awaitingNote` column + migration) and the loop **returns** — it never blocks the shared per-workspace journey on human input (the human resolves by teaching + replaying — a fresh loop).
- `runChildStage` now returns `{ok, result}` so the loop reads the add_source result's typed table ids (the readiness scope); a grounding replay reuses the same workflow id (the prior execution is closed, so the child default permits it). `assessAndGround` gets a 10-min proxy (LLM tool-loop) vs the 1-min cockpit_db writers.

### pt3 (8a3cbee3) — surface awaiting_input + silence internal replays
- The loop's replays record `conversationId=null` — internal autonomous re-runs must **not** each fire the completion-watcher's "import finished" narration.
- The native run monitor (DAT-550) shows an `awaiting_input` run as a yellow **"Needs input"** badge with its note — the durable, tab-independent surface.
- **Deliberately deferred (follow-up):** the in-chat `awaiting_input` narration + Stage deep-link (the completion-watcher narrates on Temporal *completion* of running runs; surfacing a journey-set terminal-ish state in-chat is a more involved watcher change). The monitor "Needs input" + note is the surface for now.

### review fix (a7e58006)
Both reviewers APPROVE/COMPLIANT. Race-proofed the surface: the monitor drives "Needs input" off `awaitingNote` presence (the durable signal), not `status` (which the completion-watcher can re-mark `completed`).

### Verification
- tsc clean · biome clean · **1196 unit tests** · offline determinism replay passes (the begin_session fixture is unaffected — grounding is `patched`-gated).
- Reviewers: senior **APPROVE**, spec-compliance **COMPLIANT** (no blockers).
- **Compose smoke still pending** (a real engine + LLM run with gap-injected data to exercise the loop) — running next.

### Not in this PR
- The in-chat `awaiting_input` narration + Stage deep-link (deferred, above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
