### PR TITLE
DAT-561: candidate-grain routing — fix the low-ICC entity-level driver FP

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,36 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-17: DAT-561 — candidate-grain routing (fixes the low-ICC entity-level FP)
+
+Closes the DAT-552 eval-gate residual: at **ICC ≈ 0.03** a high-cardinality
+entity-LEVEL random dim still false-positived under the row-wise null. Root cause:
+the row-wise null is structurally invalid for an **entity-constant** candidate at
+ANY ICC > 0 (pseudoreplication — its groups are whole entities). The 0.10 threshold
+only masked it for high-ICC measures. `discover_drivers` now routes **per-candidate
+by within-entity constancy**, not by the measure's global ICC:
+- **Entity-constant** candidates (one value per entity) → entity-grain null ALWAYS.
+- **Row-level** candidates (vary within entity) → row-wise null (valid at any ICC).
+- The two families merge into ONE `DriverRanking`: the ICC-preferred family is the
+  primary tree; the other family's significant dims surface in the NEW
+  `DriverRanking.secondary_dimensions` field (a flat list of `SecondaryDriver(dimension,
+  gain, grain)` — grains are not cross-comparable, never folded into the primary).
+- **Power add-on:** under high ICC the row-level (secondary) family gates on the
+  within-entity **de-meaned residual** (`measure − entity_mean`, flow/stock) — valid
+  and powered for within-entity drivers. Ratio keeps raw row-wise there (deferred).
+
+`discover_drivers`' public signature is unchanged; `DriverRanking` gains one additive
+field. Still a pure engine (no schema/persistence).
+
+### dataraum-eval
+- **The arr_delay/tailnum (low-ICC, high-K entity-level) fixture is now the regression guard.** Verify the entity-level dim never enters the row-wise primary (`ranked_dimensions`) and is gated at the entity grain (≤ 2α). Reverting to global-ICC routing puts it back into the row-wise primary → the guard fails.
+- **New result field to consume: `DriverRanking.secondary_dimensions`** — the non-primary grain family's significant dims, each carrying its own `grain` (`"entity"`/`"row"`). The harness must read drivers from BOTH `ranked_dimensions` (primary) and `secondary_dimensions` (secondary), and must NOT compare gains across the two (different exchangeable grains).
+- **Add a clustered fixture carrying BOTH an entity-level and a within-entity row-level driver** (the synthetic reference is conftest `make_clustered_two_driver_corpus`, additive, ICC ≈ 0.86). Verify: the entity-level driver leads the entity-grain primary; the within-entity driver surfaces in the de-meaned row-wise secondary; the row-level null FDR ≤ 2α on the residual; no grain-mixing.
+- The DAT-552 entry's "open follow-up: row-level drivers skipped at entity grain" is now CLOSED by this routing — calibration CAN expect within-entity drivers from the de-meaned row-level family (flow/stock).
+
+### dataraum-testdata
+- The clustered family (DAT-552) should gain a **within-entity row-level driver** variant: a row-level column that shifts the measure within entity (independent of the entity level), alongside the existing entity-level driver — so the real fixture exercises BOTH grains in one dataset (matches `make_clustered_two_driver_corpus`).
+
 ## 2026-06-17: DAT-552 — grain-aware permutation null for driver discovery
 
 Fixes the DAT-545 engine's row-exchangeability flaw (eval residual probe E1: the
@@ -19,7 +49,7 @@ row-wise null (DAT-545) is unchanged. Still a pure engine (no schema/persistence
 - **The calibration harness must now condition on `DriverRanking.grain`.** When `grain == "entity"`, the effective sample size is the **entity count**, reported in `DriverRanking.n_rows` (NOT the row count) — power scales with entities, so recall bars at entity grain must be entity-count-aware, not row-count-aware.
 - **The real-fixture transfer check (DAT-545 handoff) MUST include repeated-entity / high-ICC fixtures** — that is exactly the case this fixes; an i.i.d.-only fixture would never exercise it. Verify: (a) row-wise null on a high-ICC fixture inflates FDR (the bug), (b) the `cluster_key` path holds FDR ≤ 2α, (c) the ICC switch fires at ~0.10. The eval probes `scripts/probes/dat-544/{exchangeability_and_measure_types,real_fixture}.py` are the validated reference; graduate them into the rig.
 - **Cluster-aware applies to ratio too:** a clustered ratio uses the entity grain on the same ICC condition (entity statistic = Σnum/Σden, weight = Σden) — so the real-fixture check should include a **clustered-ratio** fixture, not just clustered levels.
-- **Open follow-ups (documented gaps, not bugs):** row-level (within-entity) drivers under high ICC are skipped at entity grain — their proper analysis (entity-demeaned residuals) is **DAT-561**; entity grain is single-level (`max_depth=1`). Calibration should not expect drivers from those paths yet.
+- **Open follow-ups (documented gaps, not bugs):** ~~row-level (within-entity) drivers under high ICC are skipped at entity grain~~ — **CLOSED by DAT-561** (see the entry above: row-level dims now route to a de-meaned row-wise family, entity-constant dims always to the entity grain). Entity grain remains single-level (`max_depth=1`).
 
 ### dataraum-testdata
 - Add a **clustered / repeated-entity** generative family (per-entity random effect on the measure → high ICC; entity-level driver + entity-level nulls + a row-level null) — the conftest `make_clustered_corpus` (200 entities × 100 rows) is the synthetic reference; a real analogue (e.g. customer/account recurring across transactions) is the target.

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -19,8 +19,10 @@ by within-entity constancy**, not by the measure's global ICC:
   `DriverRanking.secondary_dimensions` field (a flat list of `SecondaryDriver(dimension,
   gain, grain)` — grains are not cross-comparable, never folded into the primary).
 - **Power add-on:** under high ICC the row-level (secondary) family gates on the
-  within-entity **de-meaned residual** (`measure − entity_mean`, flow/stock) — valid
-  and powered for within-entity drivers. Ratio keeps raw row-wise there (deferred).
+  within-entity **de-meaned residual** — valid and powered for within-entity drivers.
+  Flow/stock de-mean the measure (`measure − entity_mean`); ratio de-means the per-row
+  ratio by its entity's volume-weighted mean (pooled `Σnum/Σden`), weighted-VR on the
+  residual with the `den` weight.
 
 `discover_drivers`' public signature is unchanged; `DriverRanking` gains one additive
 field. Still a pure engine (no schema/persistence).
@@ -28,7 +30,7 @@ field. Still a pure engine (no schema/persistence).
 ### dataraum-eval
 - **The arr_delay/tailnum (low-ICC, high-K entity-level) fixture is now the regression guard.** Verify the entity-level dim never enters the row-wise primary (`ranked_dimensions`) and is gated at the entity grain (≤ 2α). Reverting to global-ICC routing puts it back into the row-wise primary → the guard fails.
 - **New result field to consume: `DriverRanking.secondary_dimensions`** — the non-primary grain family's significant dims, each carrying its own `grain` (`"entity"`/`"row"`). The harness must read drivers from BOTH `ranked_dimensions` (primary) and `secondary_dimensions` (secondary), and must NOT compare gains across the two (different exchangeable grains).
-- **Add a clustered fixture carrying BOTH an entity-level and a within-entity row-level driver** (the synthetic reference is conftest `make_clustered_two_driver_corpus`, additive, ICC ≈ 0.86). Verify: the entity-level driver leads the entity-grain primary; the within-entity driver surfaces in the de-meaned row-wise secondary; the row-level null FDR ≤ 2α on the residual; no grain-mixing.
+- **Add a clustered fixture carrying BOTH an entity-level and a within-entity row-level driver** — for FLOW/stock (`make_clustered_two_driver_corpus`, additive, ICC ≈ 0.86) AND for RATIO (`make_clustered_ratio_two_driver_corpus`, ICC ≈ 0.85). Verify: the entity-level driver leads the entity-grain primary; the within-entity driver surfaces in the de-meaned row-wise secondary; the row-level null FDR ≤ 2α on the residual; no grain-mixing. The ratio residual is the per-row ratio minus its entity's volume-weighted mean.
 - The DAT-552 entry's "open follow-up: row-level drivers skipped at entity grain" is now CLOSED by this routing — calibration CAN expect within-entity drivers from the de-meaned row-level family (flow/stock).
 
 ### dataraum-testdata

--- a/packages/engine/src/dataraum/analysis/drivers/models.py
+++ b/packages/engine/src/dataraum/analysis/drivers/models.py
@@ -60,6 +60,23 @@ class DriverSlice:
 
 
 @dataclass(frozen=True)
+class SecondaryDriver:
+    """A significant dim from the NON-primary grain family (DAT-561).
+
+    The cluster-aware search runs two families — entity-constant candidates at entity
+    grain, row-level candidates row-wise — and reports the one selected by ICC as the
+    primary tree. The other family's significant dims land here instead of in
+    ``ranked_dimensions``: their gains were computed at a different exchangeable grain
+    (``grain``), so they are NOT comparable to the primary tree's gains and must not be
+    folded into the same ranking. A flat labeled list, strongest first.
+    """
+
+    dimension: str
+    gain: float
+    grain: str  # the exchangeable unit this dim's null used: "entity" or "row"
+
+
+@dataclass(frozen=True)
 class DriverNode:
     """One surviving split: the dimension that best explains the node's measure.
 
@@ -86,11 +103,17 @@ class DriverRanking:
     surviving dimension drill vectors; ``interesting_slices`` = the sharp-deviation
     slices across the tree, strongest first.
 
-    ``grain`` is the exchangeable unit the null used: ``"row"`` (the default) or
-    ``"entity"`` when a high-ICC measure forced the cluster-aware path (DAT-552).
-    ``n_rows`` is the count of those units (rows, or entities at entity grain) — i.e.
-    the effective sample size the power scales with, so a "no significant driver"
-    result on few entities is honestly attributable.
+    ``grain`` is the exchangeable unit the PRIMARY family's null used: ``"row"`` (the
+    default) or ``"entity"`` when the cluster-aware path made the entity-grain family
+    primary (DAT-552/561). ``n_rows`` is the count of those units (rows, or entities at
+    entity grain) — i.e. the effective sample size the power scales with, so a "no
+    significant driver" result on few entities is honestly attributable.
+
+    ``secondary_dimensions`` carries the OTHER grain family's significant dims when a
+    ``cluster_key`` is present (DAT-561 candidate-grain routing): entity-constant
+    candidates always run at entity grain, row-level candidates row-wise, and the family
+    not chosen as primary (by ICC) surfaces here as a flat grain-labeled list — never
+    mixed into ``ranked_dimensions``/``root`` (the grains are not cross-comparable).
     """
 
     measure: str
@@ -101,3 +124,4 @@ class DriverRanking:
     root: DriverNode | None = None
     driver_paths: list[list[str]] = field(default_factory=list)
     interesting_slices: list[DriverSlice] = field(default_factory=list)
+    secondary_dimensions: list[SecondaryDriver] = field(default_factory=list)

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -379,16 +379,19 @@ def _within_entity_ratio_residual(
     """
     num = frame[numerator].to_numpy(dtype=float)
     den = frame[denominator].to_numpy(dtype=float)
-    valid = ~np.isnan(num) & ~np.isnan(den) & (den > 0)
     codes, uniques = pd.factorize(frame[cluster_key])
     codes = codes.astype(int)
     n_ent = len(uniques)
+    # A NaN cluster key factorizes to code -1 (no entity to de-mean against): exclude it
+    # — bincount rejects negative codes, and a -1 gather would wrap to the last entity.
+    valid = ~np.isnan(num) & ~np.isnan(den) & (den > 0) & (codes >= 0)
     sum_num = np.bincount(codes[valid], weights=num[valid], minlength=n_ent)
     sum_den = np.bincount(codes[valid], weights=den[valid], minlength=n_ent)
     with np.errstate(divide="ignore", invalid="ignore"):
         entity_ratio = np.where(sum_den > 0, sum_num / np.where(sum_den > 0, sum_den, 1.0), np.nan)
         r = np.where(valid, num / np.where(valid, den, 1.0), np.nan)
-    residual = r - entity_ratio[codes]  # NaN where r or the entity ratio is NaN
+    gather = np.where(codes >= 0, codes, 0)  # safe index; invalid rows masked to NaN below
+    residual = np.where(valid, r - entity_ratio[gather], np.nan)
     weight = np.where(valid, den, 0.0)
     return residual, weight
 

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -337,6 +337,9 @@ def _partition_by_entity_constancy(
     everything else varies within entity → the row-wise null (DAT-561). This is the
     routing decision: it is per-candidate, independent of the measure's global ICC.
     """
+    # ``nunique`` counts non-null distinct values, so ``<= 1`` also catches an all-null
+    # dim (nunique 0) as entity-constant — harmless: it contributes nothing (every row
+    # gated out by the (A) gate) wherever it lands, exactly as on the old row-wise path.
     nunique = frame.groupby(cluster_key)[dims].nunique().max()
     entity_constant = [d for d in dims if int(nunique[d]) <= 1]
     row_level = [d for d in dims if d not in entity_constant]
@@ -431,7 +434,7 @@ def _routed_ranking(
             frame,
             row_dims,
             measure,
-            seed=seed,
+            seed=seed + 1,  # an independent permutation stream from the entity family
             max_depth=max_depth,
             alpha=alpha,
             min_support=min_support,

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -18,6 +18,7 @@ On-demand and pure: returns a :class:`DriverRanking`, persists nothing (DAT-546)
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -29,7 +30,7 @@ from dataraum.analysis.drivers.criterion import (
     DEFAULT_MISSINGNESS_GATE,
     intraclass_correlation,
 )
-from dataraum.analysis.drivers.models import DriverRanking, Measure
+from dataraum.analysis.drivers.models import DriverRanking, Measure, SecondaryDriver
 from dataraum.analysis.drivers.targets import EntityMeanTarget, FlowTarget, RatioTarget, Target
 from dataraum.analysis.drivers.tree import (
     DEFAULT_ALPHA,
@@ -50,9 +51,13 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# Above this ICC (η² of the measure between entities), the row-wise permutation null
-# is invalid — the cluster is the exchangeable unit, so switch to the entity grain
-# (DAT-552 / DAT-544 E1). Conservative: even modest clustering flips it.
+# The measure's ICC (η² between entities) selects which grain family is PRIMARY
+# (DAT-561): above this, the entity-grain family leads (the measure clusters, so the
+# between-entity story is the headline); below, the row-wise family leads. It no longer
+# gates WHICH dims go to which grain — that is now decided per-candidate by within-
+# entity constancy (an entity-constant candidate takes the entity-grain null at ANY
+# ICC, since the row-wise null is structurally invalid for it). Conservative: even
+# modest clustering makes the entity story primary (DAT-552 / DAT-544 E1).
 DEFAULT_ICC_THRESHOLD = 0.10
 # At entity grain a candidate group is evaluated only with at least this many ENTITIES
 # (the min_support analogue — power scales with entity count, not rows).
@@ -189,18 +194,34 @@ def discover_drivers(
     two candidate dims survive in the view, or the measure columns are absent
     (a catalog/view skew is logged, not fatal).
 
-    **Cluster-aware (DAT-552):** when ``cluster_key`` names a repeated-entity column
-    and the measure's ICC within it exceeds ``icc_threshold``, the row-wise
-    permutation null is invalid (the entity, not the row, is exchangeable) — the
-    search switches to the **entity grain** (one row per entity, permute entities;
-    ``DriverRanking.grain == "entity"``, power scales with entity count). Below the
-    threshold, or with no ``cluster_key``, the row-wise null (DAT-545) is used. Only
-    entity-LEVEL candidates (constant within entity) participate at entity grain;
-    row-level dims are logged and skipped that pass (their within-entity analysis is
-    DAT-561). Ratio enters the cluster-aware path on the same ICC condition as
-    flow/stock (entity statistic = Σnum/Σden, weight = Σden). ``max_depth`` applies
-    only to the row-wise path; the entity grain always uses ``max_depth=1`` (recursion
-    at entity grain is low-power — a follow-up).
+    **Cluster-aware candidate-grain routing (DAT-552/561):** when ``cluster_key`` names
+    a repeated-entity column, candidates are routed by their **within-entity
+    constancy**, not by the measure's global ICC:
+
+    - **Entity-constant** candidates (one value per entity) take the **entity-grain**
+      null ALWAYS — collapse to one row per entity, permute entities. The row-wise null
+      is structurally invalid for them at any ICC > 0 (their groups are whole entities,
+      so correlated within-entity rows would be counted as independent — DAT-561).
+    - **Row-level** candidates (vary within entity) take the **row-wise** null, which is
+      valid for them at any ICC (it just loses power as the measure clusters — see the
+      de-mean power add-on below).
+
+    The two families are merged into one ranking: the **primary** family (its tree,
+    paths, slices, ``ranked_dimensions``, and ``grain``) is the one selected by the
+    measure's ICC — entity grain above ``icc_threshold`` (the between-entity story is
+    the headline), row-wise below; the **secondary** family's significant dims are
+    exposed as ``secondary_dimensions`` (a flat grain-labeled list, not folded into the
+    primary ranking — the grains are not cross-comparable). Ratio routes the same way
+    (entity statistic = Σnum/Σden, weight = Σden). With no ``cluster_key`` the plain
+    row-wise null (DAT-545) is used. ``max_depth`` applies to the row-wise family; the
+    entity grain always uses ``max_depth=1`` (recursion there is low-power).
+
+    **Power add-on (DAT-561):** under HIGH ICC the row-level (secondary) family's
+    row-wise null on the raw measure has little power — the between-entity variance is
+    noise. For flow/stock it gates on the **within-entity de-meaned residual** instead
+    (the fixed-effects "within" transform: ``measure − entity_mean``), which is row-
+    exchangeable and powered — this is the within-entity driver analysis. Ratio keeps
+    the raw row-wise null there (valid, lower power — a deferred power follow-up).
 
     NOTE: the ``(present_dims + measure)`` columns are read into memory at row grain
     in one pass. At ~1M rows × ~15 dims that is several hundred MB; DAT-546 should add
@@ -236,41 +257,32 @@ def discover_drivers(
     sql = f"SELECT {', '.join(quote(c) for c in select_cols)} FROM {quote(view)}"  # noqa: S608 — catalog identifiers
     frame = duckdb_conn.execute(sql).df()
 
-    # Cluster-aware switch: a high-ICC measure within the declared entity invalidates
-    # the row-wise null (DAT-552) — for flow/stock (the column) AND ratio (the per-row
-    # num/den, which can cluster within entity just as a level does).
+    # Cluster-aware candidate-grain routing (DAT-561): a declared entity column splits
+    # the candidates by within-entity constancy and runs two grain families; the
+    # measure's ICC only picks which is primary. With no cluster_key, the plain
+    # row-wise null (DAT-545) over all candidates.
     if cluster_col is not None:
-        ent_codes, ent_uniques = pd.factorize(frame[cluster_col])
-        icc = intraclass_correlation(
-            ent_codes.astype(int), len(ent_uniques), _icc_measure(frame, measure)
+        return _routed_ranking(
+            frame,
+            present_dims,
+            measure,
+            cluster_col,
+            seed=seed,
+            max_depth=max_depth,
+            alpha=alpha,
+            min_support=min_support,
+            missingness_gate=missingness_gate,
+            n_perm=n_perm,
+            top_k_slices=top_k_slices,
+            icc_threshold=icc_threshold,
+            min_entities=min_entities,
         )
-        if icc > icc_threshold:
-            logger.info(
-                "driver_cluster_aware_entity_grain",
-                cluster_key=cluster_col,
-                icc=round(icc, 3),
-                n_entities=len(ent_uniques),
-            )
-            return _entity_grain_ranking(
-                frame,
-                present_dims,
-                measure,
-                cluster_col,
-                seed=seed,
-                alpha=alpha,
-                n_perm=n_perm,
-                top_k_slices=top_k_slices,
-                min_entities=min_entities,
-            )
-        logger.info("driver_row_wise_low_icc", cluster_key=cluster_col, icc=round(icc, 3))
 
-    values_by_dim = {d: frame[d].astype(object).to_numpy() for d in present_dims}
-    return discover_tree(
-        values_by_dim,
-        _make_target(measure, frame),
-        measure_label=measure.label,
-        dims=present_dims,
-        rng=np.random.default_rng(seed),
+    return _row_wise_ranking(
+        frame,
+        present_dims,
+        measure,
+        seed=seed,
         max_depth=max_depth,
         alpha=alpha,
         min_support=min_support,
@@ -316,9 +328,172 @@ def _collapse_to_entity(
     return values, sizes, values_by_dim
 
 
-def _entity_grain_ranking(
+def _partition_by_entity_constancy(
+    frame: pd.DataFrame, cluster_key: str, dims: list[str]
+) -> tuple[list[str], list[str]]:
+    """Split candidates into ``(entity_constant, row_level)`` by within-entity nunique.
+
+    Entity-constant = one value per entity (nunique ≤ 1) → the entity-grain null;
+    everything else varies within entity → the row-wise null (DAT-561). This is the
+    routing decision: it is per-candidate, independent of the measure's global ICC.
+    """
+    nunique = frame.groupby(cluster_key)[dims].nunique().max()
+    entity_constant = [d for d in dims if int(nunique[d]) <= 1]
+    row_level = [d for d in dims if d not in entity_constant]
+    return entity_constant, row_level
+
+
+def _within_entity_residual(frame: pd.DataFrame, cluster_key: str, column: str) -> np.ndarray:
+    """The fixed-effects "within" transform: ``measure − entity_mean`` (DAT-561).
+
+    Removes the between-entity level so the row-wise null on the residual is both valid
+    (residuals are row-exchangeable within entity) and powered for a within-entity
+    row-level driver — the entity-mean subtraction strips the clustered variance that
+    would otherwise swamp it. NaN measure rows stay NaN (the (B) gate handles them).
+    """
+    measure = frame[column].to_numpy(dtype=float)
+    entity_mean = frame.groupby(cluster_key)[column].transform("mean").to_numpy(dtype=float)
+    return np.asarray(measure - entity_mean, dtype=float)
+
+
+def _merge_secondary(
+    primary: DriverRanking | None, secondary: DriverRanking | None
+) -> DriverRanking:
+    """Fold the secondary family's significant dims into ``primary`` as a labeled list.
+
+    The ICC-preferred family is primary; if it has no candidate dims the other becomes
+    primary (so a real driver in the only populated family is never hidden behind an
+    empty primary). The remaining family contributes ``secondary_dimensions`` only —
+    its gains are at a different grain, never mixed into the primary ranking.
+    """
+    if primary is None:
+        primary, secondary = secondary, None
+    if primary is None:  # neither family had candidate dims (caller guarantees ≥2 total)
+        raise AssertionError("candidate-grain routing produced no family")
+    if secondary is None:
+        return primary
+    labeled = [SecondaryDriver(d, g, secondary.grain) for d, g in secondary.ranked_dimensions]
+    return replace(primary, secondary_dimensions=labeled)
+
+
+def _routed_ranking(
     frame: pd.DataFrame,
     dims: list[str],
+    measure: Measure,
+    cluster_key: str,
+    *,
+    seed: int,
+    max_depth: int,
+    alpha: float,
+    min_support: int,
+    missingness_gate: float,
+    n_perm: int,
+    top_k_slices: int,
+    icc_threshold: float,
+    min_entities: int,
+) -> DriverRanking:
+    """Route candidates to two grain families and merge primary (by ICC) + secondary."""
+    ent_codes, ent_uniques = pd.factorize(frame[cluster_key])
+    icc = intraclass_correlation(
+        ent_codes.astype(int), len(ent_uniques), _icc_measure(frame, measure)
+    )
+    high_icc = icc > icc_threshold
+    entity_dims, row_dims = _partition_by_entity_constancy(frame, cluster_key, dims)
+    logger.info(
+        "driver_candidate_grain_routing",
+        cluster_key=cluster_key,
+        icc=round(icc, 3),
+        n_entities=len(ent_uniques),
+        primary="entity" if high_icc else "row",
+        entity_constant=entity_dims,
+        row_level=row_dims,
+    )
+
+    entity_ranking = (
+        _entity_grain_ranking(
+            frame,
+            entity_dims,
+            measure,
+            cluster_key,
+            seed=seed,
+            alpha=alpha,
+            n_perm=n_perm,
+            top_k_slices=top_k_slices,
+            min_entities=min_entities,
+        )
+        if entity_dims
+        else None
+    )
+    # The row-level family de-means within entity ONLY under high ICC (the power add-on);
+    # at low ICC the raw measure is already powered and stays the primary tree as-is.
+    row_ranking = (
+        _row_wise_ranking(
+            frame,
+            row_dims,
+            measure,
+            seed=seed,
+            max_depth=max_depth,
+            alpha=alpha,
+            min_support=min_support,
+            missingness_gate=missingness_gate,
+            n_perm=n_perm,
+            top_k_slices=top_k_slices,
+            cluster_key=cluster_key if high_icc else None,
+        )
+        if row_dims
+        else None
+    )
+
+    if high_icc:
+        return _merge_secondary(entity_ranking, row_ranking)
+    return _merge_secondary(row_ranking, entity_ranking)
+
+
+def _row_wise_ranking(
+    frame: pd.DataFrame,
+    dims: list[str],
+    measure: Measure,
+    *,
+    seed: int,
+    max_depth: int,
+    alpha: float,
+    min_support: int,
+    missingness_gate: float,
+    n_perm: int,
+    top_k_slices: int,
+    cluster_key: str | None = None,
+) -> DriverRanking:
+    """Rank ``dims`` row-wise. ``cluster_key`` set → de-mean the measure within entity.
+
+    The within-entity de-mean (flow/stock only) is the DAT-561 power add-on for the
+    row-level family under high ICC; ratio keeps the raw row-wise null (valid, lower
+    power). With ``cluster_key=None`` this is the plain DAT-545 row-wise search.
+    """
+    if cluster_key is not None and measure.target_type in ("flow", "stock"):
+        assert measure.column is not None
+        residual = _within_entity_residual(frame, cluster_key, measure.column)
+        target: Target = FlowTarget(residual, target_type=measure.target_type)
+    else:
+        target = _make_target(measure, frame)
+    values_by_dim = {d: frame[d].astype(object).to_numpy() for d in dims}
+    return discover_tree(
+        values_by_dim,
+        target,
+        measure_label=measure.label,
+        dims=dims,
+        rng=np.random.default_rng(seed),
+        max_depth=max_depth,
+        alpha=alpha,
+        min_support=min_support,
+        missingness_gate=missingness_gate,
+        n_perm=n_perm,
+        top_k_slices=top_k_slices,
+    )
+
+
+def _entity_grain_ranking(
+    frame: pd.DataFrame,
+    entity_dims: list[str],
     measure: Measure,
     cluster_key: str,
     *,
@@ -328,27 +503,17 @@ def _entity_grain_ranking(
     top_k_slices: int,
     min_entities: int,
 ) -> DriverRanking:
-    """Collapse to one row per entity and rank entity-level candidates at that grain.
+    """Collapse to one row per entity and rank the (pre-partitioned) entity-level dims.
 
-    Only candidates that are CONSTANT within entity participate (row-level dims can't
-    be collapsed without losing their within-entity variation — logged + skipped this
-    pass). The entity statistic is the mean measure weighted by observed-row count
-    (flow/stock) or Σnum/Σden weighted by Σden (ratio); entities with no usable
-    measure are dropped. Single-level (``max_depth=1``): recursion at entity grain is
-    low-power and a follow-up.
+    ``entity_dims`` are already constant within entity (the caller's routing). The
+    entity statistic is the mean measure weighted by observed-row count (flow/stock) or
+    Σnum/Σden weighted by Σden (ratio); entities with no usable measure are dropped.
+    Single-level (``max_depth=1``): recursion at entity grain is low-power and a
+    follow-up.
     """
     empty = DriverRanking(
         measure=measure.label, target_type=measure.target_type, n_rows=0, grain="entity"
     )
-    # Entity-level = constant within every entity (nunique ≤ 1).
-    nunique = frame.groupby(cluster_key)[dims].nunique().max()
-    entity_dims = [d for d in dims if int(nunique[d]) <= 1]
-    skipped = [d for d in dims if d not in entity_dims]
-    if skipped:
-        logger.info("driver_row_level_dims_skipped_at_entity_grain", dropped=skipped)
-    if len(entity_dims) < 2:
-        return empty
-
     values, sizes, values_by_dim = _collapse_to_entity(frame, cluster_key, measure, entity_dims)
     if values.size == 0:  # every entity has no usable measure — nothing to rank
         return empty

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -31,7 +31,13 @@ from dataraum.analysis.drivers.criterion import (
     intraclass_correlation,
 )
 from dataraum.analysis.drivers.models import DriverRanking, Measure, SecondaryDriver
-from dataraum.analysis.drivers.targets import EntityMeanTarget, FlowTarget, RatioTarget, Target
+from dataraum.analysis.drivers.targets import (
+    EntityDemeanedRatioTarget,
+    EntityMeanTarget,
+    FlowTarget,
+    RatioTarget,
+    Target,
+)
 from dataraum.analysis.drivers.tree import (
     DEFAULT_ALPHA,
     DEFAULT_MAX_DEPTH,
@@ -218,10 +224,11 @@ def discover_drivers(
 
     **Power add-on (DAT-561):** under HIGH ICC the row-level (secondary) family's
     row-wise null on the raw measure has little power — the between-entity variance is
-    noise. For flow/stock it gates on the **within-entity de-meaned residual** instead
-    (the fixed-effects "within" transform: ``measure − entity_mean``), which is row-
-    exchangeable and powered — this is the within-entity driver analysis. Ratio keeps
-    the raw row-wise null there (valid, lower power — a deferred power follow-up).
+    noise. It gates on the **within-entity de-meaned residual** instead (the
+    fixed-effects "within" transform), which is row-exchangeable and powered — this is
+    the within-entity driver analysis. Flow/stock de-mean the measure
+    (``measure − entity_mean``); ratio de-means the per-row ratio by its entity's
+    volume-weighted mean (its pooled ``Σnum/Σden``).
 
     NOTE: the ``(present_dims + measure)`` columns are read into memory at row grain
     in one pass. At ~1M rows × ~15 dims that is several hundred MB; DAT-546 should add
@@ -359,6 +366,33 @@ def _within_entity_residual(frame: pd.DataFrame, cluster_key: str, column: str) 
     return np.asarray(measure - entity_mean, dtype=float)
 
 
+def _within_entity_ratio_residual(
+    frame: pd.DataFrame, cluster_key: str, numerator: str, denominator: str
+) -> tuple[np.ndarray, np.ndarray]:
+    """``(residual_ratio, weight)`` for the within-entity de-meaned RATIO (DAT-561).
+
+    The per-row ratio ``r = num/den`` minus its entity's VOLUME-WEIGHTED mean — which is
+    the entity's pooled ratio ``Σnum/Σden`` (the weighted mean of ``r`` with weight
+    ``den``). Strips the between-entity ratio level so the row-wise null on the residual
+    is valid + powered for a within-entity ratio driver. NaN where the row has no usable
+    ratio (missing/≤0 denominator); ``weight`` is the denominator mass (0 where invalid).
+    """
+    num = frame[numerator].to_numpy(dtype=float)
+    den = frame[denominator].to_numpy(dtype=float)
+    valid = ~np.isnan(num) & ~np.isnan(den) & (den > 0)
+    codes, uniques = pd.factorize(frame[cluster_key])
+    codes = codes.astype(int)
+    n_ent = len(uniques)
+    sum_num = np.bincount(codes[valid], weights=num[valid], minlength=n_ent)
+    sum_den = np.bincount(codes[valid], weights=den[valid], minlength=n_ent)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        entity_ratio = np.where(sum_den > 0, sum_num / np.where(sum_den > 0, sum_den, 1.0), np.nan)
+        r = np.where(valid, num / np.where(valid, den, 1.0), np.nan)
+    residual = r - entity_ratio[codes]  # NaN where r or the entity ratio is NaN
+    weight = np.where(valid, den, 0.0)
+    return residual, weight
+
+
 def _merge_secondary(
     primary: DriverRanking | None, secondary: DriverRanking | None
 ) -> DriverRanking:
@@ -468,14 +502,23 @@ def _row_wise_ranking(
 ) -> DriverRanking:
     """Rank ``dims`` row-wise. ``cluster_key`` set → de-mean the measure within entity.
 
-    The within-entity de-mean (flow/stock only) is the DAT-561 power add-on for the
-    row-level family under high ICC; ratio keeps the raw row-wise null (valid, lower
-    power). With ``cluster_key=None`` this is the plain DAT-545 row-wise search.
+    The within-entity de-mean is the DAT-561 power add-on for the row-level family under
+    high ICC: flow/stock de-mean the measure (``FlowTarget`` on the residual), ratio
+    de-means the per-row ratio by its entity's volume-weighted mean
+    (``EntityDemeanedRatioTarget``). With ``cluster_key=None`` this is the plain DAT-545
+    row-wise search on the raw measure.
     """
-    if cluster_key is not None and measure.target_type in ("flow", "stock"):
-        assert measure.column is not None
-        residual = _within_entity_residual(frame, cluster_key, measure.column)
-        target: Target = FlowTarget(residual, target_type=measure.target_type)
+    if cluster_key is not None:
+        if measure.target_type in ("flow", "stock"):
+            assert measure.column is not None
+            residual = _within_entity_residual(frame, cluster_key, measure.column)
+            target: Target = FlowTarget(residual, target_type=measure.target_type)
+        else:  # ratio
+            assert measure.numerator and measure.denominator
+            res_ratio, weight = _within_entity_ratio_residual(
+                frame, cluster_key, measure.numerator, measure.denominator
+            )
+            target = EntityDemeanedRatioTarget(res_ratio, weight)
     else:
         target = _make_target(measure, frame)
     values_by_dim = {d: frame[d].astype(object).to_numpy() for d in dims}

--- a/packages/engine/src/dataraum/analysis/drivers/targets.py
+++ b/packages/engine/src/dataraum/analysis/drivers/targets.py
@@ -199,3 +199,49 @@ class EntityMeanTarget(Target):
             effect = (group_mean / baseline - 1.0) if baseline else 0.0
             out.append((c, effect, n_entities))  # support = ENTITY count
         return out
+
+
+class EntityDemeanedRatioTarget(Target):
+    """Row-wise null on a within-entity de-meaned RATIO — the DAT-561 ratio power add-on.
+
+    The ratio analogue of the flow/stock within-entity residual: the per-row ratio
+    ``r = num/den`` is de-meaned within entity by its **volume-weighted** entity mean
+    (``Σnum/Σden`` over the entity, since the weighted mean of ``r`` with weight ``den``
+    IS the pooled entity ratio). The residual carries only the within-entity ratio
+    variation, so the row-wise null is valid + powered for a within-entity (row-level)
+    ratio driver under high ICC — where the raw ``RatioTarget`` null is diluted by the
+    between-entity ratio level (and mildly inflated for partially-entity-correlated
+    dims). The gain is the support-weighted variance reduction of the residual with the
+    SAME ``den`` weight (Simpson-safe, consistent with the pooled-ratio de-mean); the
+    null permutes the ``(residual, weight)`` PAIRS jointly.
+
+    The processor builds this only under high ICC, where the entity-grain family is
+    primary — so this is always a SECONDARY family: its tree/slices are never surfaced
+    (only its ranked dims feed ``secondary_dimensions``), hence ``group_effects`` returns
+    ``[]`` (a residual deviation is not a comparable slice effect to report).
+    """
+
+    grain = "row"
+
+    def __init__(self, residual_ratio: np.ndarray, weight: np.ndarray) -> None:
+        self.target_type = "ratio"
+        self._residual = residual_ratio  # NaN where the row has no usable ratio
+        self._weight = weight  # denominator mass (0 where invalid)
+        self.observed = residual_ratio  # doubles as the (B)-gate observed mask
+
+    def gain(self, codes: np.ndarray, n_codes: int, *, min_support: int) -> float:
+        return weighted_variance_reduction(
+            codes, n_codes, self._residual, self._weight, min_support=min_support
+        )
+
+    def permuted(self, rng: np.random.Generator) -> EntityDemeanedRatioTarget:
+        idx = rng.permutation(self._residual.size)
+        return EntityDemeanedRatioTarget(self._residual[idx], self._weight[idx])
+
+    def subset(self, mask: np.ndarray) -> EntityDemeanedRatioTarget:
+        return EntityDemeanedRatioTarget(self._residual[mask], self._weight[mask])
+
+    def group_effects(
+        self, codes: np.ndarray, n_codes: int, *, min_support: int
+    ) -> list[tuple[int, float, int]]:
+        return []

--- a/packages/engine/tests/unit/analysis/drivers/conftest.py
+++ b/packages/engine/tests/unit/analysis/drivers/conftest.py
@@ -197,13 +197,23 @@ CL_ROW_DRIVER = "D_row_real"  # within-entity (row-level) driver
 TWO_DRIVER_DIMS = [CL_DRIVER, CL_ROW_DRIVER, CL_ENTITY_NULLS[1], CL_ROW_NULL]
 
 
-def make_clustered_two_driver_corpus(rng: np.random.Generator) -> pd.DataFrame:
-    """200 entities × 100 rows; high ICC, with an entity-level AND a row-level driver."""
+def make_clustered_two_driver_corpus(
+    rng: np.random.Generator, *, ent_scale: float = 1.0
+) -> pd.DataFrame:
+    """200 entities × 100 rows, with an entity-level AND a within-entity row-level driver.
+
+    ``ent_scale`` knobs the between-entity variance: ``1.0`` → high ICC (≈0.86, the
+    de-mean power case); a small value (e.g. ``0.08``) → low ICC (≈0.04), where the
+    row-level driver must surface in the row-wise PRIMARY on the raw measure (the
+    low-ICC row-level recall case — no de-mean needed there).
+    """
     ent = np.repeat(np.arange(CL_N_ENTITIES), CL_PER_ENTITY)
     n = CL_N_ENTITIES * CL_PER_ENTITY
-    # Between-entity (high ICC): driver shift + a large entity random effect (var ≈ 14).
+    # Between-entity (ICC set by ent_scale): driver shift + an entity random effect.
     drv_grp = rng.integers(0, 4, CL_N_ENTITIES)
-    ent_effect = np.array([-3.0, -1.0, 1.0, 3.0])[drv_grp] + rng.normal(0, 3.0, CL_N_ENTITIES)
+    ent_effect = ent_scale * (
+        np.array([-3.0, -1.0, 1.0, 3.0])[drv_grp] + rng.normal(0, 3.0, CL_N_ENTITIES)
+    )
     # Within-entity (row-level) driver shift (var ≈ 1.25) + row noise (var ≈ 1.0).
     row_grp = rng.integers(0, 4, n)
     row_shift = np.array([-1.5, -0.5, 0.5, 1.5])[row_grp]

--- a/packages/engine/tests/unit/analysis/drivers/conftest.py
+++ b/packages/engine/tests/unit/analysis/drivers/conftest.py
@@ -254,3 +254,38 @@ def make_clustered_ratio_corpus(
     df[CL_ENTITY_NULLS[0]] = [f"a{g}" for g in rng.integers(0, 6, CL_N_ENTITIES)[ent]]
     df[CL_ENTITY_NULLS[1]] = [f"b{g}" for g in rng.integers(0, 30, CL_N_ENTITIES)[ent]]
     return df
+
+
+# Two-driver clustered RATIO corpus (DAT-561): a HIGH-ICC ratio carrying BOTH a
+# between-entity (entity-level) ratio driver AND a within-entity (row-level) ratio
+# driver, plus a null at each grain — the ratio analogue of make_clustered_two_driver_
+# corpus. The within-entity de-mean (volume-weighted) must recover the row driver that
+# the between-entity ratio level dilutes in the raw row-wise null.
+CL_RATIO_ROW_DRIVER = "D_row_ratio"  # within-entity (row-level) ratio driver
+RATIO_TWO_DRIVER_DIMS = [CL_DRIVER, CL_RATIO_ROW_DRIVER, CL_ENTITY_NULLS[1], CL_ROW_NULL]
+
+
+def make_clustered_ratio_two_driver_corpus(rng: np.random.Generator) -> pd.DataFrame:
+    """200 entities × 100 rows; high-ICC ratio with an entity-level AND a row-level driver."""
+    ent = np.repeat(np.arange(CL_N_ENTITIES), CL_PER_ENTITY)
+    n = CL_N_ENTITIES * CL_PER_ENTITY
+    # Between-entity ratio level (high ICC): driver shift + a sizeable entity effect.
+    drv_grp = rng.integers(0, 4, CL_N_ENTITIES)
+    ent_ratio = (
+        0.30 + np.array([-0.10, -0.03, 0.03, 0.10])[drv_grp] + rng.normal(0, 0.08, CL_N_ENTITIES)
+    )
+    # Within-entity (row-level) ratio shift + small row noise.
+    row_grp = rng.integers(0, 4, n)
+    row_shift = np.array([-0.06, -0.02, 0.02, 0.06])[row_grp]
+    den = rng.lognormal(mean=5.0, sigma=0.8, size=n)  # volume, varies independently
+    row_ratio = ent_ratio[ent] + row_shift + rng.normal(0, 0.01, n)
+
+    df = pd.DataFrame(index=np.arange(n))
+    df[CL_ENTITY] = ent
+    df["numerator"] = den * row_ratio
+    df["denominator"] = den
+    df[CL_DRIVER] = [f"d{g}" for g in drv_grp[ent]]  # entity-level ratio driver
+    df[CL_RATIO_ROW_DRIVER] = [f"w{g}" for g in row_grp]  # within-entity ratio driver
+    df[CL_ENTITY_NULLS[1]] = [f"b{g}" for g in rng.integers(0, 30, CL_N_ENTITIES)[ent]]  # ent null
+    df[CL_ROW_NULL] = [f"r{g}" for g in rng.integers(0, 6, n)]  # row-level null
+    return df

--- a/packages/engine/tests/unit/analysis/drivers/conftest.py
+++ b/packages/engine/tests/unit/analysis/drivers/conftest.py
@@ -187,6 +187,37 @@ def make_clustered_corpus(
     return df
 
 
+# Two-driver clustered corpus (DAT-561): a HIGH-ICC measure carrying BOTH a
+# between-entity (entity-level) driver AND a within-entity (row-level) driver, plus one
+# null at each grain. Additive (not lognormal) so the within-entity de-mean cleanly
+# isolates the row driver: residual = measure − entity_mean strips the entity level, so
+# the row driver — diluted ~7× in the raw measure by the between-entity variance — is
+# recovered, while the entity driver correctly drops out of the row-level family.
+CL_ROW_DRIVER = "D_row_real"  # within-entity (row-level) driver
+TWO_DRIVER_DIMS = [CL_DRIVER, CL_ROW_DRIVER, CL_ENTITY_NULLS[1], CL_ROW_NULL]
+
+
+def make_clustered_two_driver_corpus(rng: np.random.Generator) -> pd.DataFrame:
+    """200 entities × 100 rows; high ICC, with an entity-level AND a row-level driver."""
+    ent = np.repeat(np.arange(CL_N_ENTITIES), CL_PER_ENTITY)
+    n = CL_N_ENTITIES * CL_PER_ENTITY
+    # Between-entity (high ICC): driver shift + a large entity random effect (var ≈ 14).
+    drv_grp = rng.integers(0, 4, CL_N_ENTITIES)
+    ent_effect = np.array([-3.0, -1.0, 1.0, 3.0])[drv_grp] + rng.normal(0, 3.0, CL_N_ENTITIES)
+    # Within-entity (row-level) driver shift (var ≈ 1.25) + row noise (var ≈ 1.0).
+    row_grp = rng.integers(0, 4, n)
+    row_shift = np.array([-1.5, -0.5, 0.5, 1.5])[row_grp]
+
+    df = pd.DataFrame(index=np.arange(n))
+    df[CL_ENTITY] = ent
+    df["measure"] = 100.0 + ent_effect[ent] + row_shift + rng.normal(0, 1.0, n)
+    df[CL_DRIVER] = [f"d{g}" for g in drv_grp[ent]]  # entity-level driver
+    df[CL_ROW_DRIVER] = [f"w{g}" for g in row_grp]  # row-level driver
+    df[CL_ENTITY_NULLS[1]] = [f"b{g}" for g in rng.integers(0, 30, CL_N_ENTITIES)[ent]]  # ent null
+    df[CL_ROW_NULL] = [f"r{g}" for g in rng.integers(0, 6, n)]  # row-level null
+    return df
+
+
 # Clustered RATIO corpus (DAT-552 #321 fold): the per-row ratio (num/den) carries a
 # per-entity level (high ICC on the ratio); an entity-level driver shifts that level;
 # the denominator (volume) varies independently. Tests cluster-aware ratio.

--- a/packages/engine/tests/unit/analysis/drivers/test_grain.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain.py
@@ -14,16 +14,22 @@ from dataraum.analysis.drivers.criterion import (
     build_codes,
     intraclass_correlation,
     variance_reduction,
+    weighted_variance_reduction,
 )
-from dataraum.analysis.drivers.processor import _within_entity_residual
+from dataraum.analysis.drivers.processor import (
+    _within_entity_ratio_residual,
+    _within_entity_residual,
+)
 from dataraum.analysis.drivers.targets import EntityMeanTarget
 
 from .conftest import (
     CL_DRIVER,
     CL_ENTITY,
     CL_ENTITY_NULLS,
+    CL_RATIO_ROW_DRIVER,
     CL_ROW_DRIVER,
     make_clustered_corpus,
+    make_clustered_ratio_two_driver_corpus,
     make_clustered_two_driver_corpus,
 )
 
@@ -113,3 +119,18 @@ class TestWithinEntityDemean:
         # de-meaned residual strips it, recovering a multiple-times larger gain.
         assert residual_gain > 3 * raw_gain
         assert residual_gain > 0.3, f"residual gain too weak: {residual_gain:.3f}"
+
+    def test_demean_recovers_within_entity_ratio_signal(self) -> None:
+        df = make_clustered_ratio_two_driver_corpus(np.random.default_rng(0))
+        num = df["numerator"].to_numpy(dtype=float)
+        den = df["denominator"].to_numpy(dtype=float)
+        ratio = num / den
+        residual, weight = _within_entity_ratio_residual(df, CL_ENTITY, "numerator", "denominator")
+        codes, n = build_codes(
+            df[CL_RATIO_ROW_DRIVER].astype(object).to_numpy(), ratio, handle_nulls=True
+        )
+        # Both gains are volume-weighted (weight = denominator); only the de-mean differs.
+        raw_gain = weighted_variance_reduction(codes, n, ratio, den, min_support=2)
+        residual_gain = weighted_variance_reduction(codes, n, residual, weight, min_support=2)
+        assert residual_gain > 3 * raw_gain
+        assert residual_gain > 0.3, f"residual ratio gain too weak: {residual_gain:.3f}"

--- a/packages/engine/tests/unit/analysis/drivers/test_grain.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain.py
@@ -10,14 +10,21 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from dataraum.analysis.drivers.criterion import intraclass_correlation
+from dataraum.analysis.drivers.criterion import (
+    build_codes,
+    intraclass_correlation,
+    variance_reduction,
+)
+from dataraum.analysis.drivers.processor import _within_entity_residual
 from dataraum.analysis.drivers.targets import EntityMeanTarget
 
 from .conftest import (
     CL_DRIVER,
     CL_ENTITY,
     CL_ENTITY_NULLS,
+    CL_ROW_DRIVER,
     make_clustered_corpus,
+    make_clustered_two_driver_corpus,
 )
 
 
@@ -86,3 +93,23 @@ class TestEntityMeanTarget:
         assert effects  # the driver's 4 groups deviate from baseline
         # support is an ENTITY count (≤ 200 entities), never a row count.
         assert all(0 < support <= 200 for _c, _e, support in effects)
+
+
+class TestWithinEntityDemean:
+    """DAT-561 power add-on: the within-entity de-mean recovers a row-level driver that
+    the raw (high-ICC) measure dilutes — the residual transform that powers the
+    row-level family's null under high ICC."""
+
+    def test_demean_recovers_within_entity_driver_signal(self) -> None:
+        df = make_clustered_two_driver_corpus(np.random.default_rng(0))
+        measure = df["measure"].to_numpy(dtype=float)
+        residual = _within_entity_residual(df, CL_ENTITY, "measure")
+        codes, n = build_codes(
+            df[CL_ROW_DRIVER].astype(object).to_numpy(), measure, handle_nulls=True
+        )
+        raw_gain = variance_reduction(codes, n, measure, min_support=2)
+        residual_gain = variance_reduction(codes, n, residual, min_support=2)
+        # The between-entity variance dilutes the row driver in the raw measure; the
+        # de-meaned residual strips it, recovering a multiple-times larger gain.
+        assert residual_gain > 3 * raw_gain
+        assert residual_gain > 0.3, f"residual gain too weak: {residual_gain:.3f}"

--- a/packages/engine/tests/unit/analysis/drivers/test_grain.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain.py
@@ -134,3 +134,14 @@ class TestWithinEntityDemean:
         residual_gain = weighted_variance_reduction(codes, n, residual, weight, min_support=2)
         assert residual_gain > 3 * raw_gain
         assert residual_gain > 0.3, f"residual ratio gain too weak: {residual_gain:.3f}"
+
+    def test_ratio_residual_handles_null_cluster_key(self) -> None:
+        # A NaN cluster key factorizes to code -1; the residual must not crash (bincount
+        # rejects negatives) and the row must be excluded (NaN residual, 0 weight).
+        df = make_clustered_ratio_two_driver_corpus(np.random.default_rng(0))
+        df[CL_ENTITY] = df[CL_ENTITY].astype("float")
+        df.loc[0, CL_ENTITY] = np.nan  # one row with no entity
+        residual, weight = _within_entity_ratio_residual(df, CL_ENTITY, "numerator", "denominator")
+        assert np.isnan(residual[0]) and weight[0] == 0.0
+        # the rest are unaffected (still produce finite residuals somewhere)
+        assert np.isfinite(residual[1:]).any()

--- a/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
@@ -27,11 +27,14 @@ from .conftest import (
     CL_ENTITY,
     CL_ENTITY_NULLS,
     CL_RATIO_DIMS,
+    CL_RATIO_ROW_DRIVER,
     CL_ROW_DRIVER,
     CL_ROW_NULL,
+    RATIO_TWO_DRIVER_DIMS,
     TWO_DRIVER_DIMS,
     make_clustered_corpus,
     make_clustered_ratio_corpus,
+    make_clustered_ratio_two_driver_corpus,
     make_clustered_two_driver_corpus,
 )
 
@@ -81,18 +84,18 @@ def _seed_catalog(session: Session, dims: list[str] = CL_DIMS) -> str:
     return fact.table_id
 
 
-def _seed_ratio_catalog(session: Session) -> str:
+def _seed_ratio_catalog(session: Session, dims: list[str] = CL_RATIO_DIMS) -> str:
     """Seed a fact whose measure is a ratio (numerator/denominator) over a clustered view."""
     fact = Table(
         table_id=str(uuid4()), source_id="s", table_name="sales", layer="typed", duckdb_path="sales"
     )
     session.add(fact)
-    for pos, name in enumerate([*CL_RATIO_DIMS, CL_ENTITY, "numerator", "denominator"]):
+    for pos, name in enumerate([*dims, CL_ENTITY, "numerator", "denominator"]):
         col = Column(
             column_id=str(uuid4()), table_id=fact.table_id, column_name=name, column_position=pos
         )
         session.add(col)
-        if name in CL_RATIO_DIMS:
+        if name in dims:
             session.add(
                 SliceDefinition(
                     run_id=RUN,
@@ -431,3 +434,57 @@ class TestClusterAwareRatio:
             assert c <= 2 * ALPHA * seeds, f"entity null {n} surfaced {c}/{seeds}"
         # …and the entity-level ratio driver surfaces in the majority.
         assert driver_found >= seeds // 2, f"ratio driver recall {driver_found}/{seeds}"
+
+
+class TestWithinEntityRatioPower:
+    """DAT-561 ratio power add-on: under high ICC the row-level (secondary) RATIO family
+    gates on the within-entity volume-weighted de-meaned ratio, so a within-entity ratio
+    driver surfaces and the row-level null stays gated — while the entity-level ratio
+    driver leads the entity-grain primary and the grains never mix.
+    """
+
+    def _run(self, session, duck, tid, seed):  # noqa: ANN001, ANN202
+        _write_view(duck, make_clustered_ratio_two_driver_corpus(np.random.default_rng(600 + seed)))
+        return discover_drivers(
+            session,
+            duckdb_conn=duck,
+            fact_table_id=tid,
+            run_id=RUN,
+            measure=RATIO_MEASURE,
+            cluster_key=CL_ENTITY,
+            n_perm=N_PERM,
+            seed=seed,
+        )
+
+    def test_entity_and_within_entity_ratio_drivers_cleanly_separated(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed_ratio_catalog(real_session, RATIO_TWO_DRIVER_DIMS)
+        rank = self._run(real_session, duck, tid, 0)
+        assert rank.grain == "entity" and rank.target_type == "ratio"
+        primary = {d for d, _ in rank.ranked_dimensions}
+        secondary = {d.dimension for d in rank.secondary_dimensions}
+        assert CL_DRIVER in primary
+        assert CL_RATIO_ROW_DRIVER in secondary
+        assert CL_DRIVER not in secondary
+        assert CL_RATIO_ROW_DRIVER not in primary
+        assert all(d.grain == "row" for d in rank.secondary_dimensions)
+
+    def test_within_entity_ratio_driver_found_and_residual_null_gated(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed_ratio_catalog(real_session, RATIO_TWO_DRIVER_DIMS)
+        seeds = 30
+        driver_found = 0
+        row_null_surfaced = 0
+        for s in range(seeds):
+            rank = self._run(real_session, duck, tid, s)
+            secondary = {d.dimension for d in rank.secondary_dimensions}
+            driver_found += CL_RATIO_ROW_DRIVER in secondary
+            row_null_surfaced += CL_ROW_NULL in secondary
+        assert driver_found >= seeds // 2, (
+            f"within-entity ratio driver recall {driver_found}/{seeds}"
+        )
+        assert row_null_surfaced <= 2 * ALPHA * seeds, (
+            f"row-level null surfaced {row_null_surfaced}/{seeds} on the ratio residual"
+        )

--- a/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
@@ -27,9 +27,12 @@ from .conftest import (
     CL_ENTITY,
     CL_ENTITY_NULLS,
     CL_RATIO_DIMS,
+    CL_ROW_DRIVER,
     CL_ROW_NULL,
+    TWO_DRIVER_DIMS,
     make_clustered_corpus,
     make_clustered_ratio_corpus,
+    make_clustered_two_driver_corpus,
 )
 
 RUN = "session-run-1"
@@ -40,18 +43,18 @@ MEASURE = Measure(target_type="flow", column="measure")
 RATIO_MEASURE = Measure(target_type="ratio", numerator="numerator", denominator="denominator")
 
 
-def _seed_catalog(session: Session) -> str:
+def _seed_catalog(session: Session, dims: list[str] = CL_DIMS) -> str:
     """Seed the fact + catalog (the candidate dims; the entity key is NOT a slice dim)."""
     fact = Table(
         table_id=str(uuid4()), source_id="s", table_name="sales", layer="typed", duckdb_path="sales"
     )
     session.add(fact)
-    for pos, name in enumerate([*CL_DIMS, CL_ENTITY, "measure"]):
+    for pos, name in enumerate([*dims, CL_ENTITY, "measure"]):
         col = Column(
             column_id=str(uuid4()), table_id=fact.table_id, column_name=name, column_position=pos
         )
         session.add(col)
-        if name in CL_DIMS:  # only real candidate dims are cataloged (not the entity id / measure)
+        if name in dims:  # only real candidate dims are cataloged (not the entity id / measure)
             session.add(
                 SliceDefinition(
                     run_id=RUN,
@@ -303,6 +306,62 @@ class TestCandidateGrainRouting:
         # mis-routed to the entity grain.
         assert all(d.grain == "entity" for d in rank.secondary_dimensions)
         assert CL_ROW_NULL not in {d.dimension for d in rank.secondary_dimensions}
+
+
+class TestWithinEntityPower:
+    """DAT-561 power add-on (AC4): under high ICC the row-level (secondary) family gates
+    on the within-entity de-meaned residual, so a planted within-entity driver surfaces
+    and the row-level null stays gated — while the entity-level driver leads the primary
+    tree and the two grains never mix.
+    """
+
+    def _run(self, session, duck, tid, seed):  # noqa: ANN001, ANN202
+        _write_view(duck, make_clustered_two_driver_corpus(np.random.default_rng(400 + seed)))
+        return discover_drivers(
+            session,
+            duckdb_conn=duck,
+            fact_table_id=tid,
+            run_id=RUN,
+            measure=MEASURE,
+            cluster_key=CL_ENTITY,
+            n_perm=N_PERM,
+            seed=seed,
+        )
+
+    def test_entity_and_within_entity_drivers_cleanly_separated(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed_catalog(real_session, TWO_DRIVER_DIMS)
+        rank = self._run(real_session, duck, tid, 0)
+        assert rank.grain == "entity"  # high ICC → the entity-grain family is primary
+        primary = {d for d, _ in rank.ranked_dimensions}
+        secondary = {d.dimension for d in rank.secondary_dimensions}
+        # The entity-level driver leads the primary; the within-entity driver surfaces in
+        # the de-meaned row-wise secondary — and NEITHER bleeds into the other grain.
+        assert CL_DRIVER in primary
+        assert CL_ROW_DRIVER in secondary
+        assert CL_DRIVER not in secondary
+        assert CL_ROW_DRIVER not in primary
+        assert all(d.grain == "row" for d in rank.secondary_dimensions)
+
+    def test_within_entity_driver_found_and_residual_null_gated(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed_catalog(real_session, TWO_DRIVER_DIMS)
+        seeds = 30
+        driver_found = 0
+        row_null_surfaced = 0
+        for s in range(seeds):
+            rank = self._run(real_session, duck, tid, s)
+            secondary = {d.dimension for d in rank.secondary_dimensions}
+            driver_found += CL_ROW_DRIVER in secondary
+            row_null_surfaced += CL_ROW_NULL in secondary
+        # The de-meaned residual gives the within-entity driver real power…
+        assert driver_found >= seeds // 2, f"within-entity driver recall {driver_found}/{seeds}"
+        # …and the residual null is gated at ≈α (FDR ≤ 2α).
+        assert row_null_surfaced <= 2 * ALPHA * seeds, (
+            f"row-level null surfaced {row_null_surfaced}/{seeds} on the residual"
+        )
 
 
 class TestClusterAwareRatio:

--- a/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
@@ -293,19 +293,34 @@ class TestCandidateGrainRouting:
             f"entity-level null surfaced {in_secondary}/{seeds} even at entity grain"
         )
 
-    def test_low_icc_row_level_recall_preserved(
+    def test_low_icc_row_level_driver_still_surfaces(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
-        # AC2: routing entity-constant dims out must not cost low-ICC row-level recall —
-        # the row-wise primary still finds a genuine row-level driver. CL_ROW_NULL is a
-        # null here, but it must remain EVALUABLE (present as a row-level candidate); the
-        # planted row-level driver case is covered by TestWithinEntityPower (high ICC).
-        tid = _seed_catalog(real_session)
-        rank = _run_low_icc(real_session, duck, tid, 0, cluster_key=CL_ENTITY)
-        # The row-level null is a row-wise candidate (could appear in the primary), never
-        # mis-routed to the entity grain.
-        assert all(d.grain == "entity" for d in rank.secondary_dimensions)
-        assert CL_ROW_NULL not in {d.dimension for d in rank.secondary_dimensions}
+        # AC2: routing entity-constant dims out to the entity grain must NOT cost
+        # low-ICC row-level recall — a genuine row-level driver still surfaces in the
+        # row-wise PRIMARY (raw measure, no de-mean at low ICC). The two-driver corpus
+        # at ent_scale=0.08 has ICC ≈ 0.04 and a planted within-entity row driver.
+        tid = _seed_catalog(real_session, TWO_DRIVER_DIMS)
+        seeds = 10
+        found = 0
+        for s in range(seeds):
+            _write_view(
+                duck,
+                make_clustered_two_driver_corpus(np.random.default_rng(500 + s), ent_scale=0.08),
+            )
+            rank = discover_drivers(
+                real_session,
+                duckdb_conn=duck,
+                fact_table_id=tid,
+                run_id=RUN,
+                measure=MEASURE,
+                cluster_key=CL_ENTITY,
+                n_perm=N_PERM,
+                seed=s,
+            )
+            assert rank.grain == "row"  # low ICC → row-wise family is primary
+            found += CL_ROW_DRIVER in {d for d, _ in rank.ranked_dimensions}
+        assert found >= seeds // 2, f"low-ICC row-level driver recall {found}/{seeds}"
 
 
 class TestWithinEntityPower:

--- a/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
@@ -175,14 +175,21 @@ class TestClusterAwareSwitch:
         # (the spike's "power scales with entity count" finding), so NOT a 0.9 bar.
         assert driver_found >= seeds // 2, f"driver recall {driver_found}/{seeds}"
 
-    def test_row_level_dim_skipped_at_entity_grain(
+    def test_row_level_dim_routed_to_row_wise_secondary(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
-        # The row-level null (varies within entity) can't be collapsed → not evaluated
-        # at entity grain (logged + skipped), so it never appears in the ranking.
+        # DAT-561: a row-level dim (varies within entity) is NOT in the entity-grain
+        # primary — it is routed to the row-wise (secondary) family instead. The
+        # entity primary carries only entity-constant dims; the grains never mix.
         tid = _seed_catalog(real_session)
         rank = _run(real_session, duck, tid, 0, cluster_key=CL_ENTITY)
-        assert CL_ROW_NULL not in {d for d, _ in rank.ranked_dimensions}
+        assert rank.grain == "entity"
+        primary = {d for d, _ in rank.ranked_dimensions}
+        assert CL_ROW_NULL not in primary
+        assert primary <= {CL_DRIVER, *CL_ENTITY_NULLS}  # only entity-constant dims
+        # CL_ROW_NULL is random → it won't be a significant secondary either, but every
+        # secondary that DID surface is labeled row grain (never entity).
+        assert all(s.grain == "row" for s in rank.secondary_dimensions)
 
     def test_low_icc_cluster_key_stays_row_wise(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
@@ -232,6 +239,70 @@ class TestClusterAwareSwitch:
             n_perm=N_PERM,
         )
         assert lo_rank.grain == "row"
+
+
+def _run_low_icc(session, duck, tid, seed, *, cluster_key):  # noqa: ANN001, ANN202
+    # row_sigma=6 drowns the between-entity signal → ICC ≈ 0.03, the DAT-552 residual
+    # regime where the row-wise null FALSELY surfaced a high-K entity-level dim.
+    _write_view(duck, make_clustered_corpus(np.random.default_rng(100 + seed), row_sigma=6.0))
+    return discover_drivers(
+        session,
+        duckdb_conn=duck,
+        fact_table_id=tid,
+        run_id=RUN,
+        measure=MEASURE,
+        cluster_key=cluster_key,
+        n_perm=N_PERM,
+        seed=seed,
+    )
+
+
+class TestCandidateGrainRouting:
+    """DAT-561 — route by candidate constancy, not the measure's global ICC.
+
+    The eval-gate residual: at ICC ≈ 0.03 a high-cardinality entity-LEVEL random dim
+    still false-positived under the row-wise null (pseudoreplication — the row-wise null
+    is structurally invalid for an entity-constant candidate at ANY ICC). The fix routes
+    every entity-constant candidate to the entity grain regardless of ICC.
+    """
+
+    def test_entity_constant_dim_never_enters_row_wise_primary(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed_catalog(real_session)
+        seeds = 30
+        in_secondary = 0
+        for s in range(seeds):
+            rank = _run_low_icc(real_session, duck, tid, s, cluster_key=CL_ENTITY)
+            # Low ICC → the row-wise family is primary…
+            assert rank.grain == "row"
+            primary = {d for d, _ in rank.ranked_dimensions}
+            # …and it can ONLY contain row-level dims — every entity-constant candidate
+            # was routed to the entity grain (the structural fix; reverting to global-ICC
+            # routing puts entity-level dims back into this row-wise primary → fails here).
+            assert primary.isdisjoint({CL_DRIVER, *CL_ENTITY_NULLS})
+            sec = {d.dimension for d in rank.secondary_dimensions}
+            assert all(d.grain == "entity" for d in rank.secondary_dimensions)
+            in_secondary += CL_ENTITY_NULLS[1] in sec
+        # At the CORRECT (entity) grain the high-K entity-level null is gated at ≈α —
+        # the false positive the row-wise null produced is gone.
+        assert in_secondary <= 2 * ALPHA * seeds, (
+            f"entity-level null surfaced {in_secondary}/{seeds} even at entity grain"
+        )
+
+    def test_low_icc_row_level_recall_preserved(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # AC2: routing entity-constant dims out must not cost low-ICC row-level recall —
+        # the row-wise primary still finds a genuine row-level driver. CL_ROW_NULL is a
+        # null here, but it must remain EVALUABLE (present as a row-level candidate); the
+        # planted row-level driver case is covered by TestWithinEntityPower (high ICC).
+        tid = _seed_catalog(real_session)
+        rank = _run_low_icc(real_session, duck, tid, 0, cluster_key=CL_ENTITY)
+        # The row-level null is a row-wise candidate (could appear in the primary), never
+        # mis-routed to the entity grain.
+        assert all(d.grain == "entity" for d in rank.secondary_dimensions)
+        assert CL_ROW_NULL not in {d.dimension for d in rank.secondary_dimensions}
 
 
 class TestClusterAwareRatio:

--- a/packages/engine/tests/unit/analysis/drivers/test_processor.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_processor.py
@@ -5,6 +5,11 @@ End-to-end: seed a fact's grain-verified enriched view in DuckDB (the spike corp
 (SliceDefinition grain_safe + a DimensionHierarchy alias group + SemanticAnnotation
 temporal_behavior), then assert discover_drivers ranks the planted drivers, collapses
 the alias out of the candidate set, and resolves the target type from the catalog.
+
+The cluster-aware ``cluster_key`` path of the public ``discover_drivers`` API (DAT-552
+entity grain + DAT-561 candidate-grain routing / ``secondary_dimensions``) is covered
+end-to-end in ``test_grain_e2e.py`` — those tests drive the same public entry point on
+clustered corpora.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes the DAT-552 eval-gate residual: at **ICC ≈ 0.03** a high-cardinality entity-LEVEL random dim still false-positived under the row-wise null. The row-wise permutation null is structurally invalid for an **entity-constant** candidate at *any* ICC > 0 (pseudoreplication — its groups are whole entities), and the 0.10 threshold only masked it for high-ICC measures.

## What changed
`discover_drivers` now routes **per-candidate by within-entity constancy**, not by the measure's global ICC:
- **Entity-constant** candidates (one value per entity) → entity-grain null **always**.
- **Row-level** candidates (vary within entity) → row-wise null (valid at any ICC; preserves low-ICC recall).
- The two families merge into one `DriverRanking`: the ICC-preferred family is the **primary tree**; the other family's significant dims surface in the new `DriverRanking.secondary_dimensions` (`SecondaryDriver(dimension, gain, grain)`) — a flat grain-labeled list, never folded into the primary (grains not cross-comparable).
- **Power add-on:** under high ICC the row-level (secondary) family gates on the within-entity **de-meaned residual** (`measure − entity_mean`, flow/stock) — valid and powered for within-entity drivers. Ratio keeps raw row-wise there (documented deferral).

ICC now only selects which family is primary, not which dims route where. `discover_drivers`' public signature is unchanged; `DriverRanking` gains one additive field. Still a pure engine (no schema/persistence).

## Acceptance criteria
- [x] Entity-constant candidates take the entity-grain null regardless of ICC; the low-ICC high-K entity-level FP no longer surfaces (`test_entity_constant_dim_never_enters_row_wise_primary`, 30 seeds).
- [x] Row-level candidates evaluated row-wise; low-ICC row-level recall preserved (`test_low_icc_row_level_driver_still_surfaces`, planted driver at ICC≈0.04).
- [x] Two-family result unambiguous; no silent grain-mixing (`test_entity_and_within_entity_drivers_cleanly_separated`).
- [x] High-ICC row-level power: de-meaned residual surfaces a planted within-entity driver; residual-null FDR ≤ 2α (`test_within_entity_driver_found_and_residual_null_gated`).
- [x] DAT-552 high-ICC headline cases stay green.
- [x] eval/testdata handoff updated.

## Tests
41 driver unit tests pass; ruff + format + mypy clean. Reviewers: senior-code APPROVE, spec-compliance COMPLIANT (both Low findings closed in the last commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)