### PR TITLE
DAT-531: whole-stage impacted routing — teach → affected stage + derived staleness

### DIFF
--- a/packages/cockpit/src/db/metadata/stage-staleness-read.ts
+++ b/packages/cockpit/src/db/metadata/stage-staleness-read.ts
@@ -1,0 +1,54 @@
+// The DB read that feeds the pure stage-staleness logic (DAT-531). Split from
+// `stage-staleness.ts` so the pure module stays client-free (a unit test importing
+// the logic must not drag in the postgres client — the at-import hang trap). Both
+// reads are over engine metadata (read-only); the SQL is smoke-verified per the
+// metadata-read convention (`grounding-readiness.ts` precedent).
+
+import { isNull } from "drizzle-orm";
+import { metadataDb } from "#/db/metadata/client";
+import { metadataSnapshotHead } from "#/db/metadata/schema";
+import {
+	collapseHeads,
+	deriveStaleness,
+	type RawHead,
+	type StageStaleness,
+} from "#/db/metadata/stage-staleness";
+import { configOverlayWrite } from "#/db/metadata/write-surface";
+
+/**
+ * Read the workspace's per-stage staleness (DAT-531): fetch the generation-head log
+ * + the un-superseded teach overlays, collapse, derive. Workspace-scoped via the
+ * `ws_<id>` metadata schema the read client binds (DAT-505). Degrades to "nothing
+ * stale" on a read blip — a missing staleness hint is a soft advisory, it must
+ * never break the monitor.
+ */
+export async function readStageStaleness(): Promise<StageStaleness[]> {
+	try {
+		const [rawHeads, overlays] = await Promise.all([
+			metadataDb
+				.select({
+					target: metadataSnapshotHead.target,
+					stage: metadataSnapshotHead.stage,
+					promotedAt: metadataSnapshotHead.promotedAt,
+				})
+				.from(metadataSnapshotHead),
+			metadataDb
+				.select({
+					type: configOverlayWrite.type,
+					createdAt: configOverlayWrite.createdAt,
+				})
+				.from(configOverlayWrite)
+				.where(isNull(configOverlayWrite.supersededAt)),
+		]);
+		// The head view's columns are nullable; keep only complete rows.
+		const heads: RawHead[] = rawHeads.flatMap((h) =>
+			h.target && h.stage && h.promotedAt
+				? [{ target: h.target, stage: h.stage, promotedAt: h.promotedAt }]
+				: [],
+		);
+		return deriveStaleness(collapseHeads(heads), overlays);
+	} catch (err) {
+		console.warn(`[stage-staleness] read failed, assuming fresh: ${err}`);
+		return [];
+	}
+}

--- a/packages/cockpit/src/db/metadata/stage-staleness.test.ts
+++ b/packages/cockpit/src/db/metadata/stage-staleness.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+	collapseHeads,
+	deriveStaleness,
+	type RawHead,
+	type StageHead,
+} from "#/db/metadata/stage-staleness";
+
+const t = (iso: string) => new Date(iso);
+
+describe("collapseHeads (DAT-531)", () => {
+	it("collapses add_source to the MAX of its per-table generation heads", () => {
+		const heads: RawHead[] = [
+			{
+				target: "table:a",
+				stage: "generation",
+				promotedAt: t("2026-06-17T10:00:00Z"),
+			},
+			{
+				target: "table:b",
+				stage: "generation",
+				promotedAt: t("2026-06-17T12:00:00Z"),
+			},
+		];
+		const add = collapseHeads(heads).find((h) => h.stage === "add_source");
+		expect(add?.promotedAt?.toISOString()).toBe("2026-06-17T12:00:00.000Z");
+	});
+
+	it("reads begin_session from the catalog head and operating_model from its own", () => {
+		const heads: RawHead[] = [
+			{
+				target: "catalog",
+				stage: "catalog",
+				promotedAt: t("2026-06-17T11:00:00Z"),
+			},
+			{
+				target: "catalog",
+				stage: "operating_model",
+				promotedAt: t("2026-06-17T11:30:00Z"),
+			},
+		];
+		const out = collapseHeads(heads);
+		expect(
+			out.find((h) => h.stage === "begin_session")?.promotedAt?.toISOString(),
+		).toBe("2026-06-17T11:00:00.000Z");
+		expect(
+			out.find((h) => h.stage === "operating_model")?.promotedAt?.toISOString(),
+		).toBe("2026-06-17T11:30:00.000Z");
+	});
+
+	it("reports a stage with no head as null (unrun)", () => {
+		expect(collapseHeads([]).every((h) => h.promotedAt === null)).toBe(true);
+	});
+});
+
+describe("deriveStaleness (DAT-531)", () => {
+	const heads = (
+		a: string | null,
+		b: string | null,
+		o: string | null,
+	): StageHead[] => [
+		{ stage: "add_source", promotedAt: a ? t(a) : null },
+		{ stage: "begin_session", promotedAt: b ? t(b) : null },
+		{ stage: "operating_model", promotedAt: o ? t(o) : null },
+	];
+	const stale = (r: ReturnType<typeof deriveStaleness>, s: string) =>
+		r.find((x) => x.stage === s);
+
+	it("flags nothing stale when every stage ran in upstream→downstream order", () => {
+		const r = deriveStaleness(
+			heads(
+				"2026-06-17T10:00:00Z",
+				"2026-06-17T11:00:00Z",
+				"2026-06-17T12:00:00Z",
+			),
+			[],
+		);
+		expect(r.every((x) => !x.stale)).toBe(true);
+	});
+
+	it("flags downstream stale when an upstream head is newer (upstream-newer)", () => {
+		// add_source re-ran at 13:00, after begin_session (11:00) + operating_model (12:00).
+		const r = deriveStaleness(
+			heads(
+				"2026-06-17T13:00:00Z",
+				"2026-06-17T11:00:00Z",
+				"2026-06-17T12:00:00Z",
+			),
+			[],
+		);
+		expect(stale(r, "add_source")?.stale).toBe(false);
+		expect(stale(r, "begin_session")).toMatchObject({
+			stale: true,
+			reason: "upstream-newer",
+		});
+		expect(stale(r, "operating_model")).toMatchObject({
+			stale: true,
+			reason: "upstream-newer",
+		});
+	});
+
+	it("flags a stage teach-pending when an overlay post-dates its head", () => {
+		// A metric teach (→ operating_model) written after operating_model last ran.
+		const r = deriveStaleness(
+			heads(
+				"2026-06-17T10:00:00Z",
+				"2026-06-17T11:00:00Z",
+				"2026-06-17T12:00:00Z",
+			),
+			[{ type: "metric", createdAt: t("2026-06-17T12:30:00Z") }],
+		);
+		expect(stale(r, "operating_model")).toMatchObject({
+			stale: true,
+			reason: "teach-pending",
+		});
+		// The unrelated stages stay fresh.
+		expect(stale(r, "add_source")?.stale).toBe(false);
+		expect(stale(r, "begin_session")?.stale).toBe(false);
+	});
+
+	it("ignores an overlay written BEFORE the stage ran (already applied)", () => {
+		const r = deriveStaleness(
+			heads(
+				"2026-06-17T10:00:00Z",
+				"2026-06-17T11:00:00Z",
+				"2026-06-17T12:00:00Z",
+			),
+			[{ type: "metric", createdAt: t("2026-06-17T09:00:00Z") }],
+		);
+		expect(r.every((x) => !x.stale)).toBe(true);
+	});
+
+	it("prefers teach-pending over upstream-newer when both hold", () => {
+		// begin_session is behind add_source AND has a pending relationship teach.
+		const r = deriveStaleness(
+			heads("2026-06-17T13:00:00Z", "2026-06-17T11:00:00Z", null),
+			[{ type: "relationship", createdAt: t("2026-06-17T14:00:00Z") }],
+		);
+		expect(stale(r, "begin_session")).toMatchObject({
+			stale: true,
+			reason: "teach-pending",
+		});
+	});
+
+	it("never flags an unrun stage stale", () => {
+		const r = deriveStaleness(heads("2026-06-17T10:00:00Z", null, null), []);
+		expect(stale(r, "begin_session")?.stale).toBe(false);
+		expect(stale(r, "operating_model")?.stale).toBe(false);
+	});
+});

--- a/packages/cockpit/src/db/metadata/stage-staleness.test.ts
+++ b/packages/cockpit/src/db/metadata/stage-staleness.test.ts
@@ -147,4 +147,14 @@ describe("deriveStaleness (DAT-531)", () => {
 		expect(stale(r, "begin_session")?.stale).toBe(false);
 		expect(stale(r, "operating_model")?.stale).toBe(false);
 	});
+
+	it("throws born-loud on an overlay with an unknown teach type (caught at the DB layer)", () => {
+		// The pure module's contract: an unmappable teach type surfaces loudly; the
+		// read layer (stage-staleness-read.ts) catches it and degrades to "fresh".
+		expect(() =>
+			deriveStaleness(heads("2026-06-17T10:00:00Z", null, null), [
+				{ type: "not_a_real_type", createdAt: t("2026-06-17T11:00:00Z") },
+			]),
+		).toThrow(/no stage mapped/);
+	});
 });

--- a/packages/cockpit/src/db/metadata/stage-staleness.ts
+++ b/packages/cockpit/src/db/metadata/stage-staleness.ts
@@ -13,19 +13,16 @@
 // reconcile. Conservative-correct: a newer upstream head always flags stale even if
 // the output wouldn't change (worst case: an offered no-op re-run, never a miss).
 //
-// The DB read lives below `deriveStaleness`/`collapseHeads`, which are PURE (the
-// real SQL is smoke-verified per the metadata-read convention; the logic is
-// unit-tested in isolation).
+// PURE module (no I/O) — the logic is unit-tested in isolation; the DB read that
+// feeds it lives in `stage-staleness-read.ts` (the real SQL is smoke-verified per
+// the metadata-read convention). Keeping this client-free is what lets the unit
+// test import it without dragging in the postgres client (the at-import hang trap).
 
-import { isNull } from "drizzle-orm";
 import type { RunStage } from "#/db/cockpit/runs";
-import { metadataDb } from "#/db/metadata/client";
 import {
 	CATALOG_HEAD_TARGET,
 	GENERATION_STAGE,
 } from "#/db/metadata/relationship-target";
-import { metadataSnapshotHead } from "#/db/metadata/schema";
-import { configOverlayWrite } from "#/db/metadata/write-surface";
 import { affectedStage } from "#/tools/teach-routing";
 
 /** Upstream → downstream. Staleness only ever looks LEFT of a stage. */
@@ -129,44 +126,4 @@ export function deriveStaleness(
 			reason: upstreamNewer ? "upstream-newer" : null,
 		};
 	});
-}
-
-/**
- * Read the workspace's per-stage staleness (DAT-531) — the thin I/O shell over the
- * pure logic above: fetch the generation-head log + the un-superseded teach
- * overlays, collapse, derive. Workspace-scoped via the `ws_<id>` metadata schema
- * the read client binds (DAT-505). Both reads are over engine metadata (read-only);
- * the SQL is smoke-verified per convention (the logic is unit-tested). Degrades to
- * "nothing stale" on a read blip — a missing staleness hint is a soft advisory, it
- * must never break the monitor.
- */
-export async function readStageStaleness(): Promise<StageStaleness[]> {
-	try {
-		const [rawHeads, overlays] = await Promise.all([
-			metadataDb
-				.select({
-					target: metadataSnapshotHead.target,
-					stage: metadataSnapshotHead.stage,
-					promotedAt: metadataSnapshotHead.promotedAt,
-				})
-				.from(metadataSnapshotHead),
-			metadataDb
-				.select({
-					type: configOverlayWrite.type,
-					createdAt: configOverlayWrite.createdAt,
-				})
-				.from(configOverlayWrite)
-				.where(isNull(configOverlayWrite.supersededAt)),
-		]);
-		// The head view's columns are nullable; keep only complete rows.
-		const heads: RawHead[] = rawHeads.flatMap((h) =>
-			h.target && h.stage && h.promotedAt
-				? [{ target: h.target, stage: h.stage, promotedAt: h.promotedAt }]
-				: [],
-		);
-		return deriveStaleness(collapseHeads(heads), overlays);
-	} catch (err) {
-		console.warn(`[stage-staleness] read failed, assuming fresh: ${err}`);
-		return [];
-	}
 }

--- a/packages/cockpit/src/db/metadata/stage-staleness.ts
+++ b/packages/cockpit/src/db/metadata/stage-staleness.ts
@@ -17,11 +17,15 @@
 // real SQL is smoke-verified per the metadata-read convention; the logic is
 // unit-tested in isolation).
 
+import { isNull } from "drizzle-orm";
 import type { RunStage } from "#/db/cockpit/runs";
+import { metadataDb } from "#/db/metadata/client";
 import {
 	CATALOG_HEAD_TARGET,
 	GENERATION_STAGE,
 } from "#/db/metadata/relationship-target";
+import { metadataSnapshotHead } from "#/db/metadata/schema";
+import { configOverlayWrite } from "#/db/metadata/write-surface";
 import { affectedStage } from "#/tools/teach-routing";
 
 /** Upstream → downstream. Staleness only ever looks LEFT of a stage. */
@@ -125,4 +129,44 @@ export function deriveStaleness(
 			reason: upstreamNewer ? "upstream-newer" : null,
 		};
 	});
+}
+
+/**
+ * Read the workspace's per-stage staleness (DAT-531) — the thin I/O shell over the
+ * pure logic above: fetch the generation-head log + the un-superseded teach
+ * overlays, collapse, derive. Workspace-scoped via the `ws_<id>` metadata schema
+ * the read client binds (DAT-505). Both reads are over engine metadata (read-only);
+ * the SQL is smoke-verified per convention (the logic is unit-tested). Degrades to
+ * "nothing stale" on a read blip — a missing staleness hint is a soft advisory, it
+ * must never break the monitor.
+ */
+export async function readStageStaleness(): Promise<StageStaleness[]> {
+	try {
+		const [rawHeads, overlays] = await Promise.all([
+			metadataDb
+				.select({
+					target: metadataSnapshotHead.target,
+					stage: metadataSnapshotHead.stage,
+					promotedAt: metadataSnapshotHead.promotedAt,
+				})
+				.from(metadataSnapshotHead),
+			metadataDb
+				.select({
+					type: configOverlayWrite.type,
+					createdAt: configOverlayWrite.createdAt,
+				})
+				.from(configOverlayWrite)
+				.where(isNull(configOverlayWrite.supersededAt)),
+		]);
+		// The head view's columns are nullable; keep only complete rows.
+		const heads: RawHead[] = rawHeads.flatMap((h) =>
+			h.target && h.stage && h.promotedAt
+				? [{ target: h.target, stage: h.stage, promotedAt: h.promotedAt }]
+				: [],
+		);
+		return deriveStaleness(collapseHeads(heads), overlays);
+	} catch (err) {
+		console.warn(`[stage-staleness] read failed, assuming fresh: ${err}`);
+		return [];
+	}
 }

--- a/packages/cockpit/src/db/metadata/stage-staleness.ts
+++ b/packages/cockpit/src/db/metadata/stage-staleness.ts
@@ -1,0 +1,128 @@
+// Derived stage staleness (DAT-531) — "which stage's result is behind?" computed
+// from the generation-head LOG, never a stored flag (the WAL analogy: staleness is
+// just reading whether your head trails an upstream write). Two derived sources,
+// both reads:
+//
+//   teach-pending  — an un-superseded config_overlay of type T was written AFTER
+//                    stage(T)'s head was promoted ⇒ that stage hasn't applied the
+//                    teach yet (uses the teach→stage map).
+//   upstream-newer — a stage's head is older than an upstream stage's head ⇒ its
+//                    result predates fresher upstream data (the cascade).
+//
+// Self-healing: a re-run advances the stage's head, so the staleness clears with no
+// reconcile. Conservative-correct: a newer upstream head always flags stale even if
+// the output wouldn't change (worst case: an offered no-op re-run, never a miss).
+//
+// The DB read lives below `deriveStaleness`/`collapseHeads`, which are PURE (the
+// real SQL is smoke-verified per the metadata-read convention; the logic is
+// unit-tested in isolation).
+
+import type { RunStage } from "#/db/cockpit/runs";
+import {
+	CATALOG_HEAD_TARGET,
+	GENERATION_STAGE,
+} from "#/db/metadata/relationship-target";
+import { affectedStage } from "#/tools/teach-routing";
+
+/** Upstream → downstream. Staleness only ever looks LEFT of a stage. */
+const STAGE_ORDER: readonly RunStage[] = [
+	"add_source",
+	"begin_session",
+	"operating_model",
+];
+
+/** The `metadata_snapshot_head.stage` value each pipeline stage promotes under
+ * (`storage/snapshot_head.py`): add_source promotes per-table `generation` heads;
+ * begin_session the workspace `catalog` head; operating_model its own. */
+const HEAD_STAGE_FOR: Record<RunStage, string> = {
+	add_source: GENERATION_STAGE,
+	begin_session: "catalog",
+	operating_model: "operating_model",
+};
+
+/** One raw head row (a slice of `metadata_snapshot_head`). */
+export interface RawHead {
+	target: string;
+	stage: string;
+	promotedAt: Date;
+}
+
+/** A pipeline stage's effective head time — the latest moment it promoted output.
+ * `null` = the stage has never run (not stale, just unrun). */
+export interface StageHead {
+	stage: RunStage;
+	promotedAt: Date | null;
+}
+
+/** An un-superseded teach overlay — only `type` + `createdAt` matter to staleness. */
+export interface OverlayRow {
+	type: string;
+	createdAt: Date;
+}
+
+export type StaleReason = "teach-pending" | "upstream-newer";
+
+export interface StageStaleness {
+	stage: RunStage;
+	stale: boolean;
+	/** Why it's stale, or null when fresh / unrun. */
+	reason: StaleReason | null;
+}
+
+/**
+ * Collapse the raw per-(target,stage) heads into one effective head time per
+ * pipeline stage. add_source spans many per-table `generation` heads → the MAX
+ * promoted_at (the most recent re-ground); begin_session/operating_model are the
+ * single `catalog`-target heads. A stage with no head row is `null` (unrun).
+ */
+export function collapseHeads(heads: readonly RawHead[]): StageHead[] {
+	return STAGE_ORDER.map((stage) => {
+		const headStage = HEAD_STAGE_FOR[stage];
+		const times = heads
+			.filter((h) => {
+				if (h.stage !== headStage) return false;
+				// begin_session / operating_model are catalog-target; add_source's
+				// generation heads are per-table (target `table:<id>`), so don't filter
+				// those by target — any generation head counts toward the data's freshness.
+				if (stage === "add_source") return true;
+				return h.target === CATALOG_HEAD_TARGET;
+			})
+			.map((h) => h.promotedAt.getTime());
+		return {
+			stage,
+			promotedAt: times.length ? new Date(Math.max(...times)) : null,
+		};
+	});
+}
+
+/**
+ * Derive per-stage staleness from the collapsed heads + the un-superseded teach
+ * overlays. Pure — no I/O. An unrun stage (`promotedAt === null`) is never "stale"
+ * (it's simply not run yet; readiness/the monitor cover that). teach-pending wins
+ * over upstream-newer when both hold (the more actionable reason).
+ */
+export function deriveStaleness(
+	heads: readonly StageHead[],
+	overlays: readonly OverlayRow[],
+): StageStaleness[] {
+	const headBy = new Map(heads.map((h) => [h.stage, h.promotedAt]));
+	return STAGE_ORDER.map((stage, i) => {
+		const myHead = headBy.get(stage) ?? null;
+		if (myHead === null) return { stage, stale: false, reason: null };
+
+		const teachPending = overlays.some(
+			(o) => affectedStage(o.type) === stage && o.createdAt > myHead,
+		);
+		if (teachPending) return { stage, stale: true, reason: "teach-pending" };
+
+		const upstreamNewer = STAGE_ORDER.slice(0, i).some((up) => {
+			const upHead = headBy.get(up) ?? null;
+			return upHead !== null && upHead > myHead;
+		});
+		return {
+			stage,
+			stale: upstreamNewer,
+			reason: upstreamNewer ? "upstream-newer" : null,
+		};
+	});
+}

--- a/packages/cockpit/src/db/metadata/workspace-state.ts
+++ b/packages/cockpit/src/db/metadata/workspace-state.ts
@@ -26,3 +26,18 @@ export async function hasImportedTables(): Promise<boolean> {
 		.limit(1);
 	return row !== undefined;
 }
+
+/**
+ * The workspace's current typed table ids from non-archived sources (DAT-531) —
+ * the table set a begin_session re-run stages over (post-DAT-506 the set is
+ * workspace-current, not per-session). Same source-archival filter as
+ * `hasImportedTables` / the list_tables inventory.
+ */
+export async function currentTypedTableIds(): Promise<string[]> {
+	const rows = await metadataDb
+		.select({ tableId: tables.tableId })
+		.from(tables)
+		.innerJoin(sources, eq(sources.sourceId, tables.sourceId))
+		.where(isNull(sources.archivedAt));
+	return rows.flatMap((r) => (r.tableId ? [r.tableId] : []));
+}

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.tsx
@@ -71,16 +71,24 @@ const rerunStage = createServerFn({ method: "POST" })
 		if (!sessionId) {
 			throw new Error("No current session to re-run — import a source first.");
 		}
+		let result: unknown;
 		if (stage === "operating_model") {
-			await operatingModel({ session_id: sessionId });
+			result = await operatingModel({ session_id: sessionId });
 		} else if (stage === "begin_session") {
 			// begin_session stages over the workspace's current typed table set.
-			await beginSession({
+			result = await beginSession({
 				session_id: sessionId,
 				table_ids: await currentTypedTableIds(),
 			});
 		} else {
-			await replay({ session_id: sessionId });
+			// add_source — the DAT-551 full replay path.
+			result = await replay({ session_id: sessionId });
+		}
+		// The tool fns return an { error } envelope for their born-loud guards (e.g.
+		// operating_model's "begin_session still running"). Surface it as a throw so
+		// the client handler shows the failure instead of a silent no-op re-run.
+		if (result && typeof result === "object" && "error" in result) {
+			throw new Error(String((result as { error: unknown }).error));
 		}
 	});
 

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.tsx
@@ -1,5 +1,9 @@
 import { Box, Stack } from "@mantine/core";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import {
+	createFileRoute,
+	useNavigate,
+	useRouter,
+} from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { config } from "#/config";
 import { createConversation } from "#/db/cockpit/conversations";
@@ -8,10 +12,18 @@ import {
 	type AwaitingInputItem,
 	listAwaitingInput,
 	listRunsByWorkspace,
+	type RunStage,
 } from "#/db/cockpit/runs";
+import { readStageStaleness } from "#/db/metadata/stage-staleness-read";
+import { currentTypedTableIds } from "#/db/metadata/workspace-state";
+import { currentSessionId } from "#/prompts/workspace-context";
+import { beginSession } from "#/tools/begin-session";
+import { operatingModel } from "#/tools/operating-model";
+import { replay } from "#/tools/replay";
 import { resolveSeed } from "#/ui/runs/needs-you";
 import { NeedsYouPanel } from "#/ui/runs/needs-you-panel";
 import { RunMonitor } from "#/ui/runs/run-monitor";
+import { StaleStagesPanel } from "#/ui/runs/stale-stages-panel";
 
 // The native run monitor (DAT-550) — a workspace-wide view of stage runs read from
 // cockpit_db — with the "Needs you" inbox (DAT-553) above it: the ACTIVE worklist
@@ -24,13 +36,15 @@ const AWAITING_LIMIT = 50;
 
 const loadRuns = createServerFn({ method: "GET" }).handler(async () => {
 	const workspaceId = await resolveActiveWorkspace();
-	const [runs, awaiting] = await Promise.all([
+	const [runs, awaiting, staleness] = await Promise.all([
 		listRunsByWorkspace(workspaceId, RUN_LIMIT),
 		listAwaitingInput(workspaceId, AWAITING_LIMIT),
+		readStageStaleness(),
 	]);
 	return {
 		runs,
 		awaiting,
+		staleness,
 		temporalUiUrl: config.temporalUiUrl,
 		limit: RUN_LIMIT,
 	};
@@ -44,15 +58,55 @@ const openStageChat = createServerFn({ method: "POST" }).handler(async () => {
 	return createConversation(workspaceId, "stage");
 });
 
+// One-click re-run of a stale stage (DAT-531) — routes to the affected stage via
+// the SAME journey signals the agent tools use (no new orchestration). Re-runs the
+// CURRENT session; the run records with a null conversationId (no originating chat),
+// so it surfaces in the monitor rather than narrating. `replay` is the DAT-551
+// add_source path for grounding-stale; begin_session / operating_model re-run
+// in-session (the cheap case).
+const rerunStage = createServerFn({ method: "POST" })
+	.inputValidator((stage: RunStage) => stage)
+	.handler(async ({ data: stage }) => {
+		const sessionId = await currentSessionId();
+		if (!sessionId) {
+			throw new Error("No current session to re-run — import a source first.");
+		}
+		if (stage === "operating_model") {
+			await operatingModel({ session_id: sessionId });
+		} else if (stage === "begin_session") {
+			// begin_session stages over the workspace's current typed table set.
+			await beginSession({
+				session_id: sessionId,
+				table_ids: await currentTypedTableIds(),
+			});
+		} else {
+			await replay({ session_id: sessionId });
+		}
+	});
+
 export const Route = createFileRoute("/(app)/workspace/$wsId/workflows")({
 	loader: () => loadRuns(),
 	component: RunsSection,
 });
 
 function RunsSection() {
-	const { runs, awaiting, temporalUiUrl, limit } = Route.useLoaderData();
+	const { runs, awaiting, staleness, temporalUiUrl, limit } =
+		Route.useLoaderData();
 	const { wsId } = Route.useParams();
 	const navigate = useNavigate();
+	const router = useRouter();
+
+	// Re-run a stale stage, then refresh the loader so the new running run shows
+	// (staleness itself clears once the re-run promotes a fresh head). A user event,
+	// so the mutation lives in the handler (React rule 4).
+	const onRerun = async (stage: RunStage) => {
+		try {
+			await rerunStage({ data: stage });
+			await router.invalidate();
+		} catch (err) {
+			console.error("[cockpit] re-run stage failed:", err);
+		}
+	};
 
 	// Open a fresh Stage chat seeded to resolve this item — the SAME mint→navigate→
 	// seed flow as the landing's "tell" entry (CockpitProvider sends the seed once
@@ -73,6 +127,7 @@ function RunsSection() {
 
 	return (
 		<Stack gap="md" h="100%">
+			<StaleStagesPanel stages={staleness} onRerun={onRerun} />
 			<NeedsYouPanel items={awaiting} onResolve={onResolve} />
 			{/* The monitor fills the remaining height + scrolls INTERNALLY so its
 			    sticky header sticks (overflowY:auto makes this Box the scroll

--- a/packages/cockpit/src/tools/teach-routing.test.ts
+++ b/packages/cockpit/src/tools/teach-routing.test.ts
@@ -3,14 +3,21 @@ import { TEACH_TYPES } from "#/tools/teach.validation";
 import { affectedStage } from "#/tools/teach-routing";
 
 describe("affectedStage (DAT-531 teach → stage map)", () => {
-	it("routes grounding teaches to add_source", () => {
-		for (const t of ["type_pattern", "null_value", "unit", "concept"]) {
+	it("routes grounding teaches (incl. concept_property) to add_source", () => {
+		for (const t of [
+			"type_pattern",
+			"null_value",
+			"unit",
+			"concept",
+			"concept_property",
+		]) {
 			expect(affectedStage(t)).toBe("add_source");
 		}
 	});
 
-	it("routes relationship to begin_session", () => {
+	it("routes relationship + hierarchy to begin_session", () => {
 		expect(affectedStage("relationship")).toBe("begin_session");
+		expect(affectedStage("hierarchy")).toBe("begin_session");
 	});
 
 	it("routes the operating-model families to operating_model", () => {

--- a/packages/cockpit/src/tools/teach-routing.test.ts
+++ b/packages/cockpit/src/tools/teach-routing.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { TEACH_TYPES } from "#/tools/teach.validation";
+import { affectedStage } from "#/tools/teach-routing";
+
+describe("affectedStage (DAT-531 teach → stage map)", () => {
+	it("routes grounding teaches to add_source", () => {
+		for (const t of ["type_pattern", "null_value", "unit", "concept"]) {
+			expect(affectedStage(t)).toBe("add_source");
+		}
+	});
+
+	it("routes relationship to begin_session", () => {
+		expect(affectedStage("relationship")).toBe("begin_session");
+	});
+
+	it("routes the operating-model families to operating_model", () => {
+		for (const t of ["validation", "cycle", "metric"]) {
+			expect(affectedStage(t)).toBe("operating_model");
+		}
+	});
+
+	it("maps EVERY current teach type (born-loud completeness)", () => {
+		// The enum changes over time; this proves no live type routes nowhere.
+		for (const t of TEACH_TYPES) {
+			expect(() => affectedStage(t)).not.toThrow();
+		}
+	});
+
+	it("throws born-loud on an unmapped type rather than misrouting", () => {
+		expect(() => affectedStage("not_a_teach_type")).toThrow(/no stage mapped/);
+	});
+});

--- a/packages/cockpit/src/tools/teach-routing.ts
+++ b/packages/cockpit/src/tools/teach-routing.ts
@@ -1,0 +1,53 @@
+// Teach → affected engine stage (DAT-531). A teach is a pure config_overlay
+// write; this map says WHICH whole stage must re-run to apply it — the ENTRY
+// stage. Downstream staleness then derives from the generation-head log
+// (stage-staleness.ts), so this map only names the shallowest stage a teach
+// touches, never the cascade.
+//
+// Born-loud, not a frozen switch: the teach-type enum changes over time, so every
+// `TeachType` MUST appear in `TEACH_STAGE` (a missing one is a COMPILE error via
+// the `Record<TeachType, …>`), and an unknown runtime string (overlay rows carry
+// `type` as varchar) THROWS rather than silently misrouting.
+
+import type { RunStage } from "#/db/cockpit/runs";
+import { TEACH_TYPES, type TeachType } from "#/tools/teach.validation";
+
+/** The engine stage each teach type's correction re-grounds at (DAT-531). The
+ * `Record<TeachType, …>` is the completeness guard — adding a teach type without a
+ * stage here fails to type-check. */
+const TEACH_STAGE: Record<TeachType, RunStage> = {
+	// Grounding teaches re-ground typed columns — applied by re-running add_source.
+	// (A concept change re-grounds here too; operating_model going stale off it
+	// falls out of the head log downstream, not this map.)
+	type_pattern: "add_source",
+	null_value: "add_source",
+	unit: "add_source",
+	concept: "add_source",
+	// A concept-property patch re-grounds the semantic binding too (add_source);
+	// operating_model going stale off a concept change derives downstream.
+	concept_property: "add_source",
+	// Relationships + dimension hierarchies are begin_session products
+	// (`run_relationships` / `run_dimension_hierarchies`).
+	relationship: "begin_session",
+	hierarchy: "begin_session",
+	// The operating-model families — the cheap case: re-run operating_model only.
+	validation: "operating_model",
+	cycle: "operating_model",
+	metric: "operating_model",
+};
+
+/**
+ * The stage that must re-run to apply a teach of `type`. Accepts a raw string
+ * (overlay rows are varchar-typed) and fails born-loud on an unmapped type — a new
+ * teach type can't silently route nowhere.
+ */
+export function affectedStage(type: string): RunStage {
+	const stage = (TEACH_STAGE as Record<string, RunStage | undefined>)[type];
+	if (!stage) {
+		throw new Error(
+			`[teach-routing] no stage mapped for teach type '${type}' — every teach ` +
+				`type must declare its affected stage (DAT-531). Known types: ${TEACH_TYPES.join(", ")}`,
+		);
+	}
+	return stage;
+}

--- a/packages/cockpit/src/ui/runs/stale-stages-panel.test.tsx
+++ b/packages/cockpit/src/ui/runs/stale-stages-panel.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { StageStaleness } from "#/db/metadata/stage-staleness";
+import { StaleStagesPanel } from "#/ui/runs/stale-stages-panel";
+
+function renderPanel(stages: StageStaleness[], onRerun = vi.fn()) {
+	render(
+		<MantineProvider env="test">
+			<StaleStagesPanel stages={stages} onRerun={onRerun} />
+		</MantineProvider>,
+	);
+	return onRerun;
+}
+
+afterEach(() => cleanup());
+
+describe("StaleStagesPanel (DAT-531)", () => {
+	it("renders nothing when no stage is stale", () => {
+		renderPanel([
+			{ stage: "add_source", stale: false, reason: null },
+			{ stage: "begin_session", stale: false, reason: null },
+		]);
+		expect(screen.queryByTestId("stale-stages-panel")).toBeNull();
+	});
+
+	it("lists only the stale stages with a reason + count", () => {
+		renderPanel([
+			{ stage: "add_source", stale: false, reason: null },
+			{ stage: "begin_session", stale: true, reason: "upstream-newer" },
+			{ stage: "operating_model", stale: true, reason: "teach-pending" },
+		]);
+		expect(screen.getByTestId("stale-stages-panel").textContent).toContain(
+			"Needs re-run (2)",
+		);
+		expect(screen.getAllByTestId("stale-stage-item")).toHaveLength(2);
+		expect(screen.getByText("Begin session")).toBeTruthy();
+		expect(screen.getByText("Operating model")).toBeTruthy();
+		const reasons = screen
+			.getAllByTestId("stale-stage-reason")
+			.map((n) => n.textContent);
+		expect(reasons.some((r) => r?.includes("Upstream data changed"))).toBe(
+			true,
+		);
+		expect(reasons.some((r) => r?.includes("teach is waiting"))).toBe(true);
+	});
+
+	it("calls onRerun with the stage when its button is clicked", () => {
+		const onRerun = renderPanel([
+			{ stage: "operating_model", stale: true, reason: "teach-pending" },
+		]);
+		fireEvent.click(screen.getByTestId("stale-stage-rerun"));
+		expect(onRerun).toHaveBeenCalledWith("operating_model");
+	});
+});

--- a/packages/cockpit/src/ui/runs/stale-stages-panel.tsx
+++ b/packages/cockpit/src/ui/runs/stale-stages-panel.tsx
@@ -7,11 +7,14 @@
 
 import { Alert, Button, Group, Stack, Text } from "@mantine/core";
 import type { RunStage } from "#/db/cockpit/runs";
-import type { StageStaleness } from "#/db/metadata/stage-staleness";
+import type {
+	StageStaleness,
+	StaleReason,
+} from "#/db/metadata/stage-staleness";
 import { stageLabel } from "#/ui/runs/run-row";
 
-/** Human "why it's behind" copy per derived reason. */
-const REASON_COPY: Record<string, string> = {
+/** Human "why it's behind" copy per derived reason (exhaustive over StaleReason). */
+const REASON_COPY: Record<StaleReason, string> = {
 	"teach-pending": "A teach is waiting — re-run to apply it.",
 	"upstream-newer": "Upstream data changed since this last ran.",
 };
@@ -49,7 +52,7 @@ export function StaleStagesPanel({ stages, onRerun }: StaleStagesPanelProps) {
 								{stageLabel(s.stage)}
 							</Text>
 							<Text size="xs" c="dimmed" data-testid="stale-stage-reason">
-								{s.reason ? (REASON_COPY[s.reason] ?? "") : ""}
+								{s.reason ? REASON_COPY[s.reason] : ""}
 							</Text>
 						</Stack>
 						<Button

--- a/packages/cockpit/src/ui/runs/stale-stages-panel.tsx
+++ b/packages/cockpit/src/ui/runs/stale-stages-panel.tsx
@@ -1,0 +1,69 @@
+// "Needs re-run" panel (DAT-531) — the stages whose result is behind the latest
+// teaches/data, derived from the generation-head log (stage-staleness.ts), with a
+// one-click re-run that routes to the affected stage via the existing journey
+// signals. Sibling of the DAT-553 "Needs you" inbox (both: "the workspace needs an
+// action"), sitting in the Runs route above the monitor. Pure render + dispatch
+// (React rule 12); renders nothing when nothing is stale.
+
+import { Alert, Button, Group, Stack, Text } from "@mantine/core";
+import type { RunStage } from "#/db/cockpit/runs";
+import type { StageStaleness } from "#/db/metadata/stage-staleness";
+import { stageLabel } from "#/ui/runs/run-row";
+
+/** Human "why it's behind" copy per derived reason. */
+const REASON_COPY: Record<string, string> = {
+	"teach-pending": "A teach is waiting — re-run to apply it.",
+	"upstream-newer": "Upstream data changed since this last ran.",
+};
+
+export interface StaleStagesPanelProps {
+	stages: ReadonlyArray<StageStaleness>;
+	/** Re-run the stage (the route signals the journey via the existing tool path). */
+	onRerun: (stage: RunStage) => void;
+}
+
+export function StaleStagesPanel({ stages, onRerun }: StaleStagesPanelProps) {
+	const stale = stages.filter((s) => s.stale);
+	if (stale.length === 0) return null;
+	return (
+		<Alert
+			color="orange"
+			variant="light"
+			title={`Needs re-run (${stale.length})`}
+			data-testid="stale-stages-panel"
+		>
+			<Stack gap="xs">
+				<Text size="sm" c="dimmed">
+					These stages are behind your latest teaches or data — re-run to bring
+					them up to date.
+				</Text>
+				{stale.map((s) => (
+					<Group
+						key={s.stage}
+						justify="space-between"
+						wrap="nowrap"
+						data-testid="stale-stage-item"
+					>
+						<Stack gap={0} style={{ minWidth: 0 }}>
+							<Text size="sm" fw={600}>
+								{stageLabel(s.stage)}
+							</Text>
+							<Text size="xs" c="dimmed" data-testid="stale-stage-reason">
+								{s.reason ? (REASON_COPY[s.reason] ?? "") : ""}
+							</Text>
+						</Stack>
+						<Button
+							size="xs"
+							variant="light"
+							color="orange"
+							onClick={() => onRerun(s.stage)}
+							data-testid="stale-stage-rerun"
+						>
+							Re-run {stageLabel(s.stage).toLowerCase()}
+						</Button>
+					</Group>
+				))}
+			</Stack>
+		</Alert>
+	);
+}


### PR DESCRIPTION
## What & why

Closes **DAT-531** (P4, epic DAT-526). When a teach happens, route a re-run to the affected engine stage and surface which stages are now **behind** — so a cheap `metric`/`validation` teach re-runs only `operating_model` in-session instead of forcing a full add_source replay. **No engine change**; reuses the journey signals from DAT-530/551.

## Design (refined)

- The engine has 3 journey-owned stages (add_source / begin_session / operating_model). Each teach type maps to the **entry** stage it re-grounds at — a born-loud registration (`Record<TeachType,RunStage>` makes completeness a *compile* error; an unknown type throws).
- **Staleness is DERIVED from the generation-head log, not stored** (the WAL analogy). `metadata_snapshot_head (target, stage) → promoted_at`: add_source promotes per-table `(table:{id}, generation)` heads; begin_session the `(catalog, catalog)` head; operating_model `(catalog, operating_model)`. Two derived sources:
  - **teach-pending** — an un-superseded `config_overlay` of type T post-dates `stage(T)`'s head.
  - **upstream-newer** — a stage's head trails an upstream head (the cascade).
  - **Self-healing**: a re-run advances the head and the staleness clears — no flag to maintain, no reconcile.

## What's in it

- `tools/teach-routing.ts` — pure `affectedStage(type)` map (+test). The completeness guard caught two live teach types the spec missed (`concept_property`, `hierarchy`).
- `db/metadata/stage-staleness.ts` (pure) + `stage-staleness-read.ts` (DB read) — `collapseHeads` + `deriveStaleness` (+test); split so the pure module stays client-free.
- `db/metadata/workspace-state.ts` — `currentTypedTableIds()` (the begin_session re-run's table set).
- `ui/runs/stale-stages-panel.tsx` — "Needs re-run" panel (sibling of the DAT-553 "Needs you" inbox) + one-click re-run (+test).
- `routes/(app)/workspace/$wsId/workflows.tsx` — loader reads staleness; `rerunStage` server fn resolves the current session and reuses the existing `operatingModel`/`beginSession`/`replay` tool fns (in-session for the cheap cases; `replay` = the DAT-551 add_source path). Surfaces the tools' `{error}` guards as a throw.

## Acceptance criteria

- [x] Each teach type routes to exactly the mapped stage; unmapped type fails born-loud (unit tests over every live type)
- [x] Downstream staleness derived from head `promoted_at` (no stored flag), rendered in the monitor, clears automatically on re-run
- [x] `validation`/`cycle`/`metric` → re-run `operating_model` only, in-session
- [x] grounding/vertical → re-run add_source via the existing DAT-551 `replay` path
- [x] `bun run check` + tsc + vitest green (1221 tests). No engine change.
- Out of scope: session-identity cleanup (**DAT-562**); no engine partial-replay.

## Testing

- Unit: the teach→stage map (born-loud completeness + explicit per-type stages), `deriveStaleness`/`collapseHeads` (teach-pending, upstream-newer, precedence, unrun-not-stale, born-loud throw), the panel render/dispatch. Join/aggregate reads are smoke-verified by convention.
- Reviewers: senior-code-reviewer **APPROVE**, spec-compliance-reviewer **COMPLIANT** (all ACs). Findings fixed (surface tool `{error}` envelopes; tighter typing; added tests).
- **Container smoke** (real onboarding): finance add_source → `unit` teach → "Needs re-run (Add source, teach-pending)" → one-click re-run (replay) → head advanced past the teach → panel self-cleared. Baseline correctly showed *nothing* stale (no false positive). Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)