### PR TITLE
DAT-562: retire the cockpit session concept (group runs by workspace)

### DIFF
--- a/packages/cockpit/drizzle/cockpit/20260618054150_complex_vermin/migration.sql
+++ b/packages/cockpit/drizzle/cockpit/20260618054150_complex_vermin/migration.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "runs" (
+	"id" varchar PRIMARY KEY,
+	"workspace_id" varchar NOT NULL,
+	"kind" varchar NOT NULL,
+	"stage" varchar NOT NULL,
+	"workflow_id" varchar NOT NULL,
+	"run_id" varchar NOT NULL,
+	"conversation_id" varchar,
+	"status" varchar DEFAULT 'running' NOT NULL,
+	"started_at" timestamp DEFAULT now() NOT NULL,
+	"completion_narrated_at" timestamp,
+	"awaiting_note" text
+);
+--> statement-breakpoint
+ALTER TABLE "session_runs" DROP CONSTRAINT "session_runs_session_id_sessions_id_fkey";--> statement-breakpoint
+DROP TABLE "session_runs";--> statement-breakpoint
+DROP TABLE "sessions";--> statement-breakpoint
+CREATE UNIQUE INDEX "runs_workflow_run_uq" ON "runs" ("workflow_id","run_id");--> statement-breakpoint
+CREATE INDEX "runs_workspace_idx" ON "runs" ("workspace_id");--> statement-breakpoint
+CREATE INDEX "runs_conversation_idx" ON "runs" ("conversation_id");--> statement-breakpoint
+ALTER TABLE "runs" ADD CONSTRAINT "runs_workspace_id_workspaces_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id");--> statement-breakpoint
+ALTER TABLE "runs" ADD CONSTRAINT "runs_conversation_id_conversations_id_fkey" FOREIGN KEY ("conversation_id") REFERENCES "conversations"("id");

--- a/packages/cockpit/drizzle/cockpit/20260618054150_complex_vermin/snapshot.json
+++ b/packages/cockpit/drizzle/cockpit/20260618054150_complex_vermin/snapshot.json
@@ -1,0 +1,792 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "b29775e2-e5fe-4d46-8b18-15caa92e35dd",
+  "prevIds": [
+    "0f26ec20-b131-4225-9beb-8435ea4ccbd5"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "actors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "conversation_messages",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "conversations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "runs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "ui_state",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "workspaces",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "actors"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "actors"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "actors"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seq",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "model_only",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_active_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stage",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workflow_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "run_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'running'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completion_narrated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "awaiting_note",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "pinned_call_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "engine_schema",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'_adhoc'",
+      "generated": null,
+      "identity": null,
+      "name": "vertical",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "conversation_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "seq",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "conversation_messages_conversation_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "conversations_workspace_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workflow_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "run_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "runs_workflow_run_uq",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "runs_workspace_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "conversation_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "runs_conversation_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "conversation_messages_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "workspace_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "workspaces",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "conversations_workspace_id_workspaces_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "workspace_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "workspaces",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "runs_workspace_id_workspaces_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "runs_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "ui_state_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "actors_pkey",
+      "schema": "public",
+      "table": "actors",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "conversation_messages_pkey",
+      "schema": "public",
+      "table": "conversation_messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "conversations_pkey",
+      "schema": "public",
+      "table": "conversations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "runs_pkey",
+      "schema": "public",
+      "table": "runs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "conversation_id"
+      ],
+      "nameExplicit": false,
+      "name": "ui_state_pkey",
+      "schema": "public",
+      "table": "ui_state",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "workspaces_pkey",
+      "schema": "public",
+      "table": "workspaces",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/cockpit/scripts/smoke-add-source.ts
+++ b/packages/cockpit/scripts/smoke-add-source.ts
@@ -155,12 +155,29 @@ async function runInitial(
 async function awaitReplay(
 	client: Client,
 	workflowId: string,
-	runId: string,
-): Promise<AddSourceResult> {
-	// The replay reuses the workspace's add_source workflow id (DAT-562) — get the
-	// handle by that exact id + run the replay returned.
-	const handle = client.workflow.getHandle(workflowId, runId);
-	return (await handle.result()) as AddSourceResult;
+	initialRunId: string,
+): Promise<{ result: AddSourceResult; runId: string }> {
+	// Replay routes through the JOURNEY now (DAT-562): the tool SIGNALS the
+	// per-workspace journey and returns the workflow id with the run_id as a
+	// placeholder (the journey owns the real Temporal execution id). So we can't
+	// await by a run id from the result — instead wait for a FRESH execution of the
+	// workspace's `addsource-<ws>` id to appear (the journey starts it shortly after
+	// the signal), then await that execution's result. The replay reuses the
+	// constant workflow id, so a new execution = a new firstExecutionRunId.
+	for (let i = 0; i < 120; i++) {
+		const runId = (await client.workflow.getHandle(workflowId).describe())
+			.runId;
+		if (runId !== initialRunId) {
+			const result = (await client.workflow
+				.getHandle(workflowId, runId)
+				.result()) as AddSourceResult;
+			return { result, runId };
+		}
+		await new Promise((r) => setTimeout(r, 1000));
+	}
+	throw new Error(
+		`replay: no fresh execution of ${workflowId} appeared within 120s`,
+	);
 }
 
 async function main(): Promise<void> {
@@ -215,18 +232,25 @@ async function main(): Promise<void> {
 		// non-destructive re-run. The vertical is the workspace property (sourced
 		// from the registry, not passed here).
 		const replayResult = await replay({});
-		const replayed = await awaitReplay(
+		// The replay reuses the workspace's add_source workflow id (DAT-562).
+		if (replayResult.workflow_id !== addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID)) {
+			throw new Error(
+				`replay: expected the workspace add_source workflow id, got ${replayResult.workflow_id}`,
+			);
+		}
+		const { result: replayed, runId: replayRunId } = await awaitReplay(
 			client,
 			replayResult.workflow_id,
-			replayResult.run_id,
+			initialRunId,
 		);
 
-		// A replay is a fresh execution, so it carries a NEW run_id (≠ the
-		// initial run). The engine mints the version run_id internally; here we
-		// only assert the replay started its own Temporal run.
-		if (replayResult.run_id === initialRunId) {
+		// A replay is a fresh Temporal execution under the SAME (reused) workflow id,
+		// so it carries a NEW execution run id (≠ the initial run). The engine mints
+		// the version run_id internally; here we only assert the replay ran its own
+		// Temporal execution.
+		if (replayRunId === initialRunId) {
 			throw new Error(
-				`replay: expected a fresh run_id, got the initial run ${initialRunId}`,
+				`replay: expected a fresh execution, got the initial run ${initialRunId}`,
 			);
 		}
 
@@ -240,7 +264,7 @@ async function main(): Promise<void> {
 		}
 		console.log(
 			`✓ replay (full re-run): ${replayed.tables.length} table(s) re-processed ` +
-				`under fresh run ${replayResult.run_id}`,
+				`under fresh execution ${replayRunId} of ${replayResult.workflow_id}`,
 		);
 
 		// Sanity: the overlay rows are still active after replay (replay

--- a/packages/cockpit/scripts/smoke-add-source.ts
+++ b/packages/cockpit/scripts/smoke-add-source.ts
@@ -60,12 +60,11 @@ const fileUris = env.SOURCE_PATH.split(",")
 	.map((u) => u.trim())
 	.filter(Boolean);
 
-async function seed(sourceId: string, sessionId: string): Promise<void> {
+async function seed(sourceId: string): Promise<void> {
 	// Seed the `sources` row through the Drizzle metadata write seam (the one-gate
-	// `select` writes it the same way). No engine session seed (DAT-506): sessions
-	// live in cockpit_db. This driver seeds DIRECTLY (not through select), then
-	// records the run in cockpit_db so replay can resolve the session's sources
-	// (replay reads cockpit_db sessions/session_runs → engine run_tables).
+	// `select` writes it the same way). This driver seeds DIRECTLY (not through
+	// select), then records the run in cockpit_db so the workspace's run grouping
+	// (DAT-562) is populated; replay re-runs the workspace's current sources.
 	// Source.name is UNIQUE — keep it unique per run so the driver is repeatable.
 	const name = `source_${sourceId.slice(0, 8)}`;
 	const now = new Date();
@@ -81,14 +80,13 @@ async function seed(sourceId: string, sessionId: string): Promise<void> {
 			updatedAt: now,
 		})
 		.onConflictDoNothing({ target: sourcesWrite.sourceId });
-	// Record the cockpit session + run (DAT-506) keyed by this session id, so the
-	// replay step below resolves the session's sources from cockpit_db.
+	// Record the cockpit run (DAT-562: runs group by workspace, no session row);
+	// the run is keyed by the workspace's deterministic add_source workflow id.
 	await recordRun({
 		workspaceId: env.DATARAUM_WORKSPACE_ID,
-		engineSessionId: sessionId,
 		kind: "onboarding",
 		stage: "add_source",
-		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID, sessionId),
+		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
 	});
 }
 
@@ -108,7 +106,6 @@ async function countOverlays(): Promise<number> {
 async function runInitial(
 	client: Client,
 	sourceId: string,
-	sessionId: string,
 ): Promise<{ result: AddSourceResult; runId: string }> {
 	const input: AddSourceInput = {
 		// FLAT, source-free input (DAT-506): no identity, no session/source id on the
@@ -131,7 +128,7 @@ async function runInitial(
 		// TEMPORAL_TASK_QUEUE env (which predated per-workspace queues and stranded
 		// the workflow on a queue no worker polls).
 		taskQueue: engineTaskQueueFor(env.DATARAUM_WORKSPACE_ID),
-		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID, sessionId),
+		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
 		args: [input],
 	});
 	const result = (await handle.result()) as AddSourceResult;
@@ -160,16 +157,15 @@ async function awaitReplay(
 	workflowId: string,
 	runId: string,
 ): Promise<AddSourceResult> {
-	// The replay reuses the run's session, so its workflow id is the session-keyed
-	// one the replay returned (DAT-422) — get the handle by that exact id + run.
+	// The replay reuses the workspace's add_source workflow id (DAT-562) — get the
+	// handle by that exact id + run the replay returned.
 	const handle = client.workflow.getHandle(workflowId, runId);
 	return (await handle.result()) as AddSourceResult;
 }
 
 async function main(): Promise<void> {
 	const sourceId = randomUUID();
-	const sessionId = randomUUID();
-	await seed(sourceId, sessionId);
+	await seed(sourceId);
 
 	const connection = await Connection.connect({ address: env.TEMPORAL_HOST });
 	try {
@@ -182,7 +178,6 @@ async function main(): Promise<void> {
 		const { result: initial, runId: initialRunId } = await runInitial(
 			client,
 			sourceId,
-			sessionId,
 		);
 		console.log(
 			`✓ initial run: ${initial.tables.length} table(s) fanned out + typed via Temporal`,
@@ -213,13 +208,13 @@ async function main(): Promise<void> {
 			);
 		}
 
-		// ---- Replay: re-run the workspace's sources (DAT-422, DAT-506) ----
-		// Replay takes the session we just built (the named unit), resolves the
-		// workspace's imported sources (the generation heads), and re-runs add_source
-		// over them as a NEW session — the engine mints a fresh run_id internally. No
-		// scope/from_phase; a full, non-destructive re-run. The vertical is the
-		// workspace property (sourced from the registry, not passed here).
-		const replayResult = await replay({ session_id: sessionId });
+		// ---- Replay: re-run the workspace's sources (DAT-422, DAT-562) ----
+		// Replay takes NO args (DAT-562): it resolves the workspace's imported
+		// sources (the generation heads) and re-runs add_source over them — the
+		// engine mints a fresh run_id internally. No scope/from_phase; a full,
+		// non-destructive re-run. The vertical is the workspace property (sourced
+		// from the registry, not passed here).
+		const replayResult = await replay({});
 		const replayed = await awaitReplay(
 			client,
 			replayResult.workflow_id,

--- a/packages/cockpit/scripts/smoke-begin-session.ts
+++ b/packages/cockpit/scripts/smoke-begin-session.ts
@@ -60,7 +60,6 @@ const VERTICAL = "finance";
  * then run addSourceWorkflow to type the files. Returns the typed table ids. */
 async function ingest(client: Client): Promise<string[]> {
 	const sourceId = randomUUID();
-	const sessionId = randomUUID();
 	const now = new Date();
 
 	// The workspace registry carries the vertical (DAT-506): seed it = finance so
@@ -92,13 +91,13 @@ async function ingest(client: Client): Promise<string[]> {
 		})
 		.onConflictDoNothing({ target: sourcesWrite.sourceId });
 
-	// Record the add_source run in cockpit_db (DAT-506 — the session-of-record).
+	// Record the add_source run in cockpit_db (DAT-562 — runs group by workspace,
+	// no session row; keyed by the workspace's deterministic add_source workflow id).
 	await recordRun({
 		workspaceId: env.DATARAUM_WORKSPACE_ID,
-		engineSessionId: sessionId,
 		kind: "onboarding",
 		stage: "add_source",
-		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID, sessionId),
+		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
 	});
 
 	const input: AddSourceInput = {
@@ -117,7 +116,7 @@ async function ingest(client: Client): Promise<string[]> {
 		// the bare TEMPORAL_TASK_QUEUE env (which predated per-workspace queues and
 		// left the workflow stranded on a queue no worker polls).
 		taskQueue: engineTaskQueueFor(env.DATARAUM_WORKSPACE_ID),
-		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID, sessionId),
+		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
 		args: [input],
 	});
 	const result = (await handle.result()) as AddSourceResult;
@@ -146,9 +145,7 @@ async function main(): Promise<void> {
 		// beginSession returns a born-loud {error} when the workspace has no typed
 		// tables (DAT-534); the smoke ingested above, so it must have started.
 		if ("error" in begun) throw new Error(`begin_session refused: ${begun.error}`);
-		console.log(
-			`✓ begin_session started: workflow=${begun.workflow_id} session=${begun.session_id}`,
-		);
+		console.log(`✓ begin_session started: workflow=${begun.workflow_id}`);
 		// Await the workflow to completion (it seals + promotes the relationship heads).
 		await client.workflow.getHandle(begun.workflow_id, begun.run_id).result();
 		console.log("✓ begin_session workflow completed (sealed + promoted)");

--- a/packages/cockpit/scripts/smoke-dat-461.ts
+++ b/packages/cockpit/scripts/smoke-dat-461.ts
@@ -3,8 +3,13 @@
 // The cockpit client uses Bun's `SQL` (bun:sql), so this is a `bun run` script,
 // NOT a vitest test (vitest runs under Node, which can't import `bun`). The unit
 // tests cover the writer LOGIC with a mocked Drizzle client; this exercises the
-// actual SQL — registry seed, the session upsert + run append, idempotency, and
-// the terminal-status update — end to end.
+// actual SQL — registry seed, recordRun, idempotency, attachRunId, and the
+// terminal-status update — end to end.
+//
+// DAT-562: the `sessions` / `session_runs` tables are retired. Runs group by
+// WORKSPACE directly — recordRun writes one `runs` row keyed by its deterministic
+// `workflowId`, the `kind` (origin) lives on the run row, and `(workflowId, runId)`
+// is UNIQUE so a re-record is a no-op. There is no ENGINE_SESSION concept.
 //
 // Prereqs: compose postgres up + the migration applied:
 //   docker compose -f packages/infra/docker-compose.yml up -d --wait postgres
@@ -18,20 +23,15 @@ import { and, eq } from "drizzle-orm";
 import { cockpitDb } from "#/db/cockpit/client";
 import { DEFAULT_ACTOR_ID, resolveActiveWorkspace } from "#/db/cockpit/registry";
 import { attachRunId, markRunStatus, recordRun } from "#/db/cockpit/runs";
-import {
-	actors,
-	sessionRuns,
-	sessions,
-	workspaces,
-} from "#/db/cockpit/schema";
+import { actors, runs, workspaces } from "#/db/cockpit/schema";
 
-const ENGINE_SESSION = `smoke-461-${crypto.randomUUID()}`;
-// DAT-506: a run is recorded keyed by its deterministic workflowId; runId is the
-// workflowId placeholder until attachRunId. Two runs on one session → two distinct
-// workflowIds (the begin_session run + the operating_model run).
-const WF_1 = `beginsession-smoke-${ENGINE_SESSION}`;
-const WF_2 = `operatingmodel-smoke-${ENGINE_SESSION}`;
-const TEMPORAL_RUN = `${ENGINE_SESSION}-exec-1`;
+// DAT-562: a run is recorded keyed by its deterministic workflowId; runId is the
+// workflowId placeholder until attachRunId. Two stages on one workspace → two
+// distinct workflowIds (the begin_session run + the operating_model run).
+const SUFFIX = crypto.randomUUID();
+const WF_1 = `beginsession-smoke-${SUFFIX}`;
+const WF_2 = `operatingmodel-smoke-${SUFFIX}`;
+const TEMPORAL_RUN = `exec-1-${SUFFIX}`;
 
 async function main(): Promise<void> {
 	// 1. Registry seed + resolve.
@@ -54,69 +54,61 @@ async function main(): Promise<void> {
 		.limit(1);
 	assert.equal(actor?.id, DEFAULT_ACTOR_ID, "default actor seeded");
 
-	// 2. recordRun: creates a session + run; idempotent per (workflowId, runId);
-	//    a 2nd run on the same engine session appends + reuses the one session.
+	// 2. recordRun: writes one `runs` row (DAT-562) keyed by (workflowId, runId);
+	//    re-recording the same run is a UNIQUE no-op. The kind lives on the run row.
 	const base = {
 		workspaceId: wsId,
-		engineSessionId: ENGINE_SESSION,
 		kind: "begin_session",
 		stage: "begin_session",
 		workflowId: WF_1,
 	} as const;
 	await recordRun(base);
 	await recordRun(base); // re-record same run → UNIQUE no-op (runId=WF_1 placeholder)
-	const sess = await cockpitDb
-		.select({ id: sessions.id, kind: sessions.kind })
-		.from(sessions)
-		.where(eq(sessions.engineSessionId, ENGINE_SESSION));
-	assert.equal(sess.length, 1, "exactly one session row");
-	assert.equal(sess[0].kind, "begin_session", "session kind recorded");
-	const runsBefore = await cockpitDb
-		.select({ runId: sessionRuns.runId, status: sessionRuns.status })
-		.from(sessionRuns)
-		.where(eq(sessionRuns.sessionId, sess[0].id));
-	assert.equal(runsBefore.length, 1, "one run after idempotent re-record");
-	assert.equal(runsBefore[0].status, "running", "run starts running");
+	const wf1Rows = await cockpitDb
+		.select({ runId: runs.runId, status: runs.status, kind: runs.kind })
+		.from(runs)
+		.where(eq(runs.workflowId, WF_1));
+	assert.equal(wf1Rows.length, 1, "one run after idempotent re-record");
+	assert.equal(wf1Rows[0].kind, "begin_session", "run kind recorded on the row");
+	assert.equal(wf1Rows[0].status, "running", "run starts running");
 	// Provisional runId = the workflowId until attachRunId.
-	assert.equal(runsBefore[0].runId, WF_1, "runId is the workflowId placeholder");
+	assert.equal(wf1Rows[0].runId, WF_1, "runId is the workflowId placeholder");
 
 	// attachRunId rewrites the provisional runId to the Temporal execution id.
 	await attachRunId(WF_1, TEMPORAL_RUN);
 	const [attached] = await cockpitDb
-		.select({ runId: sessionRuns.runId })
-		.from(sessionRuns)
-		.where(eq(sessionRuns.workflowId, WF_1))
+		.select({ runId: runs.runId })
+		.from(runs)
+		.where(eq(runs.workflowId, WF_1))
 		.limit(1);
 	assert.equal(attached?.runId, TEMPORAL_RUN, "runId finalized to the exec id");
 
+	// A second stage with a DIFFERENT workflowId adds a second run row (same
+	// workspace) — runs group by workspace, not by a shared session.
 	await recordRun({ ...base, stage: "operating_model", workflowId: WF_2 });
-	const sessAfter = await cockpitDb
-		.select({ id: sessions.id })
-		.from(sessions)
-		.where(eq(sessions.engineSessionId, ENGINE_SESSION));
-	assert.equal(sessAfter.length, 1, "second run reuses the session");
-	const runsAfter = await cockpitDb
-		.select({ runId: sessionRuns.runId })
-		.from(sessionRuns)
-		.where(eq(sessionRuns.sessionId, sess[0].id));
-	assert.equal(runsAfter.length, 2, "second run appended");
+	const wsRuns = await cockpitDb
+		.select({ workflowId: runs.workflowId })
+		.from(runs)
+		.where(eq(runs.workspaceId, wsId));
+	assert.ok(
+		wsRuns.some((r) => r.workflowId === WF_1) &&
+			wsRuns.some((r) => r.workflowId === WF_2),
+		"second stage appended a second run row for the workspace",
+	);
 
 	// 3. markRunStatus: terminal transition (keyed by the finalized runId).
 	await markRunStatus(WF_1, TEMPORAL_RUN, "completed");
 	const [r] = await cockpitDb
-		.select({ status: sessionRuns.status })
-		.from(sessionRuns)
-		.where(
-			and(eq(sessionRuns.workflowId, WF_1), eq(sessionRuns.runId, TEMPORAL_RUN)),
-		)
+		.select({ status: runs.status })
+		.from(runs)
+		.where(and(eq(runs.workflowId, WF_1), eq(runs.runId, TEMPORAL_RUN)))
 		.limit(1);
 	assert.equal(r?.status, "completed", "run marked completed");
 
-	// Cleanup — leave the shared registry rows (workspace, default actor) intact.
-	await cockpitDb
-		.delete(sessionRuns)
-		.where(eq(sessionRuns.sessionId, sess[0].id));
-	await cockpitDb.delete(sessions).where(eq(sessions.id, sess[0].id));
+	// Cleanup — delete the test runs (by their workflow ids). Leave the shared
+	// registry rows (workspace, default actor) intact.
+	await cockpitDb.delete(runs).where(eq(runs.workflowId, WF_1));
+	await cockpitDb.delete(runs).where(eq(runs.workflowId, WF_2));
 
 	console.log("✓ DAT-461 lane smoke passed");
 }

--- a/packages/cockpit/scripts/smoke-dat-462.ts
+++ b/packages/cockpit/scripts/smoke-dat-462.ts
@@ -31,14 +31,12 @@ import { runWithConversation } from "#/lib/run-context";
 import {
 	conversationMessages,
 	conversations,
-	sessionRuns,
-	sessions,
+	runs,
 	uiState,
 } from "#/db/cockpit/schema";
 import { loadUiState, saveUiState } from "#/db/cockpit/ui-state";
 
-const ENGINE_SESSION = `smoke-462-${crypto.randomUUID()}`;
-const WF = `wf-${ENGINE_SESSION}`;
+const WF = `wf-${crypto.randomUUID()}`;
 // DAT-506: recordRun keys the run by its workflowId; the runId is the workflowId
 // placeholder until attachRunId, so the listed/marked runId is WF here.
 const RUN = WF;
@@ -107,7 +105,6 @@ async function main(): Promise<void> {
 	await runWithConversation(CONV, () =>
 		recordRun({
 			workspaceId: wsId,
-			engineSessionId: ENGINE_SESSION,
 			kind: "begin_session",
 			stage: "begin_session",
 			workflowId: WF,
@@ -133,24 +130,15 @@ async function main(): Promise<void> {
 		"terminal run no longer listed",
 	);
 
-	// Cleanup — the dedicated conversation + the test session/runs. Leaves the
-	// shared registry rows (workspace, default actor) intact.
+	// Cleanup — the test run (DAT-562: deleted by its workflow id), then the
+	// dedicated conversation. The run FKs the conversation, so delete it first.
+	// Leaves the shared registry rows (workspace, default actor) intact.
+	await cockpitDb.delete(runs).where(eq(runs.workflowId, WF));
 	await cockpitDb.delete(uiState).where(eq(uiState.conversationId, CONV));
 	await cockpitDb
 		.delete(conversationMessages)
 		.where(eq(conversationMessages.conversationId, CONV));
 	await cockpitDb.delete(conversations).where(eq(conversations.id, CONV));
-	const [sess] = await cockpitDb
-		.select({ id: sessions.id })
-		.from(sessions)
-		.where(eq(sessions.engineSessionId, ENGINE_SESSION))
-		.limit(1);
-	if (sess) {
-		await cockpitDb
-			.delete(sessionRuns)
-			.where(eq(sessionRuns.sessionId, sess.id));
-		await cockpitDb.delete(sessions).where(eq(sessions.id, sess.id));
-	}
 
 	console.log("✓ DAT-462 lane smoke passed");
 }

--- a/packages/cockpit/scripts/smoke-operating-model.ts
+++ b/packages/cockpit/scripts/smoke-operating-model.ts
@@ -71,7 +71,6 @@ const VERTICAL = "finance";
  * type the files. Returns the typed table ids (the begin_session selection). */
 async function ingest(client: Client): Promise<string[]> {
 	const sourceId = randomUUID();
-	const sessionId = randomUUID();
 	const now = new Date();
 
 	// The workspace registry carries the vertical (DAT-506): seed it = finance so
@@ -103,13 +102,13 @@ async function ingest(client: Client): Promise<string[]> {
 		})
 		.onConflictDoNothing({ target: sourcesWrite.sourceId });
 
-	// Record the add_source run in cockpit_db (DAT-506 — the session-of-record).
+	// Record the add_source run in cockpit_db (DAT-562 — runs group by workspace,
+	// no session row; keyed by the workspace's deterministic add_source workflow id).
 	await recordRun({
 		workspaceId: env.DATARAUM_WORKSPACE_ID,
-		engineSessionId: sessionId,
 		kind: "onboarding",
 		stage: "add_source",
-		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID, sessionId),
+		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
 	});
 
 	const input: AddSourceInput = {
@@ -122,7 +121,7 @@ async function ingest(client: Client): Promise<string[]> {
 		(p: AddSourceInput) => Promise<AddSourceResult>
 	>("addSourceWorkflow", {
 		taskQueue: env.TEMPORAL_TASK_QUEUE,
-		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID, sessionId),
+		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
 		args: [input],
 	});
 	const result = (await handle.result()) as AddSourceResult;
@@ -153,7 +152,7 @@ async function main(): Promise<void> {
 		// typed tables (DAT-534); the smoke ingested above, so it must have started.
 		if ("error" in begun) throw new Error(`begin_session refused: ${begun.error}`);
 		await client.workflow.getHandle(begun.workflow_id, begun.run_id).result();
-		console.log(`✓ begin_session completed: session=${begun.session_id}`);
+		console.log(`✓ begin_session completed: workflow=${begun.workflow_id}`);
 
 		// ---- operatingModelWorkflow: flat input (DAT-438, DAT-506) ----------------
 		// The stage re-reads the session's table set from the catalog head's
@@ -167,10 +166,7 @@ async function main(): Promise<void> {
 			(p: OperatingModelInput) => Promise<OperatingModelResult>
 		>("operatingModelWorkflow", {
 			taskQueue: env.TEMPORAL_TASK_QUEUE,
-			workflowId: operatingModelWorkflowId(
-				env.DATARAUM_WORKSPACE_ID,
-				begun.session_id,
-			),
+			workflowId: operatingModelWorkflowId(env.DATARAUM_WORKSPACE_ID),
 			args: [input],
 		});
 		const result = (await handle.result()) as OperatingModelResult;

--- a/packages/cockpit/src/db/cockpit/registry.ts
+++ b/packages/cockpit/src/db/cockpit/registry.ts
@@ -5,7 +5,7 @@
 // `DATARAUM_WORKSPACE_ID`, and `resolveActiveWorkspace()` returns it. The value
 // is still the env-designated workspace — what changes is that the cockpit_db
 // `workspaces` table is now the system of record (its row backs the FK on
-// `sessions.workspaceId`, and reads go through here). Per-request workspace
+// `runs.workspaceId`, and reads go through here). Per-request workspace
 // SELECTION (a switcher) is Phase 3 (DAT-357); tools have no per-request context
 // channel today (TanStack AI `.server((input)=>…)` passes only input), so a
 // single resolver is the correct seam now.
@@ -20,9 +20,10 @@ import { config } from "../../config";
 import { cockpitDb } from "./client";
 import { actors, workspaces } from "./schema";
 
-// The single coarse actor (DAT-460): no auth, no multi-user yet. `sessions`
-// stamp `createdBy` with this so attribution exists without engine-side actor_id
-// plumbing (the retired DAT-365). Real actors/auth are Phase 3 (DAT-357).
+// The single coarse actor (DAT-460): no auth, no multi-user yet. Seeded so the
+// attribution seam exists for when auth lands (DAT-357); run `createdBy` was carried
+// by the retired `sessions` table (DAT-562) and had no reader, so nothing stamps this
+// today. Real actors/auth are Phase 3 (DAT-357).
 export const DEFAULT_ACTOR_ID = "default";
 
 // The no-vertical placeholder a cold-start workspace is seeded with (DAT-505) —
@@ -80,7 +81,7 @@ async function ensureRegistry(workspaceId: string): Promise<void> {
  * The single seam the drivers use to route a workflow: it carries the per-workspace
  * task queue (`engine-<id>`) and the frame `vertical` alongside the id, so nothing
  * re-derives routing from the bare env var. Proven to exist as a `workspaces` row,
- * so `sessions.workspaceId` FKs resolve.
+ * so `runs.workspaceId` FKs resolve.
  */
 export async function resolveActiveWorkspaceRow(): Promise<ActiveWorkspace> {
 	const workspaceId = config.dataraumWorkspaceId;
@@ -107,7 +108,7 @@ export async function resolveActiveWorkspaceRow(): Promise<ActiveWorkspace> {
 /**
  * The active workspace id, read from the registry (seeding it on the cold path).
  * Returns the `DATARAUM_WORKSPACE_ID` value in Phase 1 — but proven to exist as
- * a `workspaces` row, so `sessions.workspaceId` FKs resolve. Thin wrapper over
+ * a `workspaces` row, so `runs.workspaceId` FKs resolve. Thin wrapper over
  * `resolveActiveWorkspaceRow` for call sites that need only the id.
  */
 export async function resolveActiveWorkspace(): Promise<string> {

--- a/packages/cockpit/src/db/cockpit/runs.test.ts
+++ b/packages/cockpit/src/db/cockpit/runs.test.ts
@@ -1,11 +1,10 @@
-// Unit tests for control-plane run recording (DAT-461, DAT-506). Mocks the
-// cockpit_db client at the `#/` boundary (no DB). Asserts recordRun upserts the
-// session (conflict target = engine session id), looks up its id, and appends the
-// run (conflict target = workflow+run) keyed by the workflowId placeholder runId;
-// that it is AUTHORITATIVE (Q4: a db error THROWS — an unrecorded run is orphaned,
-// so the caller must not start it); attachRunId finalizes the runId; and that
-// markRunStatus issues the terminal update (still best-effort). The real SQL +
-// idempotency/append are covered by the Bun lane smoke.
+// Unit tests for control-plane run recording (DAT-461, DAT-506, DAT-562). Mocks the
+// cockpit_db client at the `#/` boundary (no DB). Asserts recordRun inserts the run
+// row directly (workspace-grouped, conflict target = workflow+run) keyed by the
+// workflowId placeholder runId; that it is AUTHORITATIVE (Q4: a db error THROWS — an
+// unrecorded run is orphaned, so the caller must not start it); attachRunId finalizes
+// the runId; and that markRunStatus issues the terminal update (still best-effort).
+// The real SQL + idempotency/append are covered by the Bun lane smoke.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -13,17 +12,17 @@ const h = vi.hoisted(() => ({
 	inserts: [] as Array<{ table: string; row: Record<string, unknown> }>,
 	conflicts: [] as unknown[],
 	updates: [] as Array<{ table: string; set: Record<string, unknown> }>,
-	sessionRows: [{ id: "sess-row-1" }] as Array<{ id: string }>,
+	// Rows the latest-run lookup (markRunAwaitingInput) returns.
+	latestRows: [{ id: "run-row-latest" }] as Array<{ id: string }>,
 	throwOnInsert: false,
 }));
 
-vi.mock("#/db/cockpit/registry", () => ({ DEFAULT_ACTOR_ID: "default" }));
 vi.mock("#/db/cockpit/schema", () => ({
-	sessions: { _t: "sessions", id: "id", engineSessionId: "engine_session_id" },
-	sessionRuns: {
-		_t: "session_runs",
+	runs: {
+		_t: "runs",
 		id: "id",
-		sessionId: "session_id",
+		workspaceId: "workspace_id",
+		kind: "kind",
 		workflowId: "workflow_id",
 		runId: "run_id",
 		status: "status",
@@ -37,7 +36,7 @@ vi.mock("drizzle-orm", () => ({
 	desc: (x: unknown) => x,
 }));
 
-const limitMock = vi.fn(async () => h.sessionRows);
+const limitMock = vi.fn(async () => h.latestRows);
 vi.mock("#/db/cockpit/client", () => ({
 	cockpitDb: {
 		insert: (table: { _t: string }) => ({
@@ -79,7 +78,6 @@ import {
 
 const BASE = {
 	workspaceId: "ws-1",
-	engineSessionId: "eng-sess-1",
 	kind: "begin_session" as const,
 	stage: "begin_session" as const,
 	workflowId: "wf-1",
@@ -89,26 +87,21 @@ beforeEach(() => {
 	h.inserts = [];
 	h.conflicts = [];
 	h.updates = [];
-	h.sessionRows = [{ id: "sess-row-1" }];
+	h.latestRows = [{ id: "run-row-latest" }];
 	h.throwOnInsert = false;
 	limitMock.mockClear();
 });
 afterEach(() => vi.restoreAllMocks());
 
-describe("recordRun (DAT-461, DAT-506)", () => {
-	it("upserts the session then appends the run against the looked-up session id", async () => {
+describe("recordRun (DAT-461, DAT-506, DAT-562)", () => {
+	it("inserts the run row directly, workspace-grouped (no session row)", async () => {
 		await recordRun(BASE);
 
-		const sess = h.inserts.find((i) => i.table === "sessions");
-		expect(sess?.row.engineSessionId).toBe("eng-sess-1");
-		expect(sess?.row.workspaceId).toBe("ws-1");
-		expect(sess?.row.kind).toBe("begin_session");
-		expect(sess?.row.status).toBe("active");
-		expect(sess?.row.createdBy).toBe("default");
-
-		const run = h.inserts.find((i) => i.table === "session_runs");
-		// The run FKs to the looked-up session row id, NOT the engine session id.
-		expect(run?.row.sessionId).toBe("sess-row-1");
+		// One insert — the run — keyed to the WORKSPACE, with kind/stage on the row.
+		expect(h.inserts).toHaveLength(1);
+		const run = h.inserts.find((i) => i.table === "runs");
+		expect(run?.row.workspaceId).toBe("ws-1");
+		expect(run?.row.kind).toBe("begin_session");
 		expect(run?.row.stage).toBe("begin_session");
 		expect(run?.row.workflowId).toBe("wf-1");
 		// Provisional runId = the deterministic workflowId until attachRunId.
@@ -121,7 +114,7 @@ describe("recordRun (DAT-461, DAT-506)", () => {
 
 	it("stamps the originating conversationId from the ALS context (DAT-528)", async () => {
 		await runWithConversation("conv-9", () => recordRun(BASE));
-		const run = h.inserts.find((i) => i.table === "session_runs");
+		const run = h.inserts.find((i) => i.table === "runs");
 		expect(run?.row.conversationId).toBe("conv-9");
 	});
 
@@ -131,7 +124,7 @@ describe("recordRun (DAT-461, DAT-506)", () => {
 		await runWithConversation("conv-als", () =>
 			recordRun({ ...BASE, conversationId: "conv-explicit" }),
 		);
-		const run = h.inserts.find((i) => i.table === "session_runs");
+		const run = h.inserts.find((i) => i.table === "runs");
 		expect(run?.row.conversationId).toBe("conv-explicit");
 	});
 
@@ -139,7 +132,7 @@ describe("recordRun (DAT-461, DAT-506)", () => {
 		await runWithConversation("conv-als", () =>
 			recordRun({ ...BASE, conversationId: null }),
 		);
-		const run = h.inserts.find((i) => i.table === "session_runs");
+		const run = h.inserts.find((i) => i.table === "runs");
 		expect(run?.row.conversationId).toBeNull();
 	});
 
@@ -147,19 +140,13 @@ describe("recordRun (DAT-461, DAT-506)", () => {
 		h.throwOnInsert = true;
 		await expect(recordRun(BASE)).rejects.toThrow(/db down/);
 	});
-
-	it("THROWS when the session lookup returns nothing (refuses an orphaned run)", async () => {
-		h.sessionRows = [];
-		await expect(recordRun(BASE)).rejects.toThrow(/orphaned run/);
-		expect(h.inserts.find((i) => i.table === "session_runs")).toBeUndefined();
-	});
 });
 
 describe("attachRunId (DAT-506)", () => {
 	it("rewrites the provisional runId to the Temporal execution id", async () => {
 		await attachRunId("wf-1", "run-real");
 		expect(h.updates).toHaveLength(1);
-		expect(h.updates[0].table).toBe("session_runs");
+		expect(h.updates[0].table).toBe("runs");
 		expect(h.updates[0].set).toEqual({ runId: "run-real" });
 	});
 
@@ -178,7 +165,7 @@ describe("markRunStatus (DAT-461)", () => {
 	it("issues a terminal status update for the run", async () => {
 		await markRunStatus("wf-1", "run-1", "completed");
 		expect(h.updates).toHaveLength(1);
-		expect(h.updates[0].table).toBe("session_runs");
+		expect(h.updates[0].table).toBe("runs");
 		expect(h.updates[0].set).toEqual({ status: "completed" });
 	});
 
@@ -197,11 +184,11 @@ describe("markRunStatus (DAT-461)", () => {
 
 describe("markRunAwaitingInput (DAT-551)", () => {
 	it("parks the LATEST run for the workflow in awaiting_input with the note", async () => {
-		h.sessionRows = [{ id: "run-row-latest" }];
+		h.latestRows = [{ id: "run-row-latest" }];
 		await markRunAwaitingInput("wf-1", "payments.method needs a concept");
 		expect(limitMock).toHaveBeenCalled(); // resolved the latest run first
 		expect(h.updates).toHaveLength(1);
-		expect(h.updates[0].table).toBe("session_runs");
+		expect(h.updates[0].table).toBe("runs");
 		expect(h.updates[0].set).toEqual({
 			status: "awaiting_input",
 			awaitingNote: "payments.method needs a concept",
@@ -209,13 +196,13 @@ describe("markRunAwaitingInput (DAT-551)", () => {
 	});
 
 	it("no-ops when the workflow has no recorded run (nothing to park)", async () => {
-		h.sessionRows = [];
+		h.latestRows = [];
 		await markRunAwaitingInput("wf-unknown", "x");
 		expect(h.updates).toHaveLength(0);
 	});
 
 	it("accepts a null note", async () => {
-		h.sessionRows = [{ id: "run-row-latest" }];
+		h.latestRows = [{ id: "run-row-latest" }];
 		await markRunAwaitingInput("wf-1", null);
 		expect(h.updates[0].set).toEqual({
 			status: "awaiting_input",

--- a/packages/cockpit/src/db/cockpit/runs.ts
+++ b/packages/cockpit/src/db/cockpit/runs.ts
@@ -1,51 +1,45 @@
-// Control-plane run recording (DAT-461, DAT-506) — the driver tools call this
-// BEFORE a Temporal workflow starts to record the session + its run in cockpit_db.
+// Control-plane run recording (DAT-461, DAT-506, DAT-562) — the driver tools call
+// this BEFORE a Temporal workflow starts to record the run in cockpit_db.
 //
-// cockpit_db is the session-of-record now (DAT-506): the engine no longer has an
-// `investigation_sessions` table. This records the COCKPIT's view — which
-// workspace, who, and the `(workflowId, runId)` the reload-recovery substrate
-// (DAT-462) reads to re-attach progress.
+// Runs group by WORKSPACE (DAT-562 retired the `sessions` table — a cockpit session
+// scoped nothing post-DAT-506 and minting one per import only fragmented grouping).
+// This records the COCKPIT's view — which workspace, the run's origin/stage, and the
+// `(workflowId, runId)` the reload-recovery substrate (DAT-462) reads to re-attach
+// progress.
 //
 // AUTHORITATIVE, not best-effort (Q4 ruling, DAT-506): an unrecorded run is
-// orphaned — the reload-recovery substrate can't re-attach to it and there is no
-// session-of-record for it — so recordRun runs BEFORE `workflow.start` and THROWS
-// on failure, aborting the start. Idempotent so a retried start is safe: the
-// `sessions` upsert is conflict-safe (one row per engine session — operating_model
-// reuses begin_session's, re-runs reuse too), and `(workflowId, runId)` is UNIQUE
-// so a repeated record is a no-op. The COMPLETION-side writers (`markRunStatus` /
-// `claimRunNarration`) stay best-effort — by then the run is recorded and live.
+// orphaned — the reload-recovery substrate can't re-attach to it — so recordRun runs
+// BEFORE `workflow.start` and THROWS on failure, aborting the start. Idempotent so a
+// retried start is safe: `(workflowId, runId)` is UNIQUE so a repeated record is a
+// no-op. The COMPLETION-side writers (`markRunStatus` / `claimRunNarration`) stay
+// best-effort — by then the run is recorded and live.
 //
 // `runId` is Temporal's EXECUTION id (`firstExecutionRunId`, minted only at
 // `workflow.start`) — the poll/reconcile identity. The pre-start call records the
 // run keyed by its deterministic `workflowId` with `runId` left as the workflowId
 // placeholder; `attachRunId` rewrites it to the real execution id right after start.
-// That post-record writer is best-effort — the orphan-critical session + run rows
-// already exist by then. The engine mints its own internal metadata `run_id` (the
-// version axis) and resolves replay from the generation heads, so the cockpit never
-// stores it (DAT-506: nothing reads it back).
+// That post-record writer is best-effort — the orphan-critical run row already
+// exists by then. The engine mints its own internal metadata `run_id` (the version
+// axis) and resolves replay from the generation heads, so the cockpit never stores
+// it (DAT-506: nothing reads it back).
 
 import { randomUUID } from "node:crypto";
 import { and, count, desc, eq, gt, isNull, notExists } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { currentConversationId } from "#/lib/run-context";
 import { cockpitDb } from "./client";
-import { DEFAULT_ACTOR_ID } from "./registry";
-import { sessionRuns, sessions } from "./schema";
+import { runs } from "./schema";
 
-/** How a cockpit session originated — mirrors the run `kind`. */
-export type SessionKind = "onboarding" | "begin_session" | "replay";
+/** How a run originated (was the retired `sessions.kind`). */
+export type RunKind = "onboarding" | "begin_session" | "replay";
 /** Which workflow a run executed. */
 export type RunStage = "add_source" | "begin_session" | "operating_model";
 
 export interface RecordRunInput {
 	workspaceId: string;
-	// The engine's session-correlation id (the workflow-id segment + the value
-	// echoed back in results). The cockpit `sessions` row is keyed by it.
-	engineSessionId: string;
-	// The session's origin — used only when the session row is first created;
-	// ignored (onConflictDoNothing) when it already exists (operating_model /
-	// re-runs reuse the row).
-	kind: SessionKind;
+	// The run's origin — onboarding | begin_session | replay (DAT-562: stored on
+	// the run row itself; operating_model re-uses "begin_session", as before).
+	kind: RunKind;
 	stage: RunStage;
 	// The deterministic workflow id (known before start). The run row is keyed by
 	// it; `runId` is the workflowId placeholder until `attachRunId` finalizes it.
@@ -60,41 +54,18 @@ export interface RecordRunInput {
 }
 
 /**
- * Record the session + its run AUTHORITATIVELY, BEFORE `workflow.start`. Throws
- * on failure (the caller must not start an unrecorded — orphaned — run). The run
- * row's `runId` is the deterministic `workflowId` until `attachRunId` rewrites it
- * to the Temporal execution id post-start.
+ * Record the run AUTHORITATIVELY, BEFORE `workflow.start`. Throws on failure (the
+ * caller must not start an unrecorded — orphaned — run). The run row's `runId` is
+ * the deterministic `workflowId` until `attachRunId` rewrites it to the Temporal
+ * execution id post-start.
  */
 export async function recordRun(input: RecordRunInput): Promise<void> {
 	await cockpitDb
-		.insert(sessions)
+		.insert(runs)
 		.values({
 			id: randomUUID(),
 			workspaceId: input.workspaceId,
-			engineSessionId: input.engineSessionId,
 			kind: input.kind,
-			status: "active",
-			createdBy: DEFAULT_ACTOR_ID,
-		})
-		.onConflictDoNothing({ target: sessions.engineSessionId });
-
-	const [session] = await cockpitDb
-		.select({ id: sessions.id })
-		.from(sessions)
-		.where(eq(sessions.engineSessionId, input.engineSessionId))
-		.limit(1);
-	if (!session) {
-		throw new Error(
-			`[cockpit] recordRun could not resolve the session row for ` +
-				`${input.engineSessionId} — refusing to start an orphaned run`,
-		);
-	}
-
-	await cockpitDb
-		.insert(sessionRuns)
-		.values({
-			id: randomUUID(),
-			sessionId: session.id,
 			stage: input.stage,
 			workflowId: input.workflowId,
 			// Provisional until attachRunId: the Temporal execution runId isn't known
@@ -112,15 +83,21 @@ export async function recordRun(input: RecordRunInput): Promise<void> {
 					: currentConversationId(),
 			status: "running",
 		})
+		// Idempotent on the deterministic (workflowId, runId=workflowId) key. Workflow
+		// ids are constant-per-workspace now (DAT-562), so this also guards a second
+		// trigger for the same stage — but the per-workspace journey drains triggers
+		// SERIALLY (signal handling is FIFO; the next stage only starts after the
+		// prior child resolves + `attachRunId` has rewritten its provisional runId off
+		// the placeholder), so two adds never race for this one row in practice.
 		.onConflictDoNothing({
-			target: [sessionRuns.workflowId, sessionRuns.runId],
+			target: [runs.workflowId, runs.runId],
 		});
 }
 
 /**
  * Rewrite a recorded run's provisional `runId` (the workflowId placeholder) to
  * the real Temporal execution id, right after `workflow.start`. Best-effort: the
- * orphan-critical session + run rows already exist; this only refines the run's
+ * orphan-critical run row already exists; this only refines the run's
  * Temporal identity for the progress poll / reload-recovery.
  */
 export async function attachRunId(
@@ -129,14 +106,9 @@ export async function attachRunId(
 ): Promise<void> {
 	try {
 		await cockpitDb
-			.update(sessionRuns)
+			.update(runs)
 			.set({ runId })
-			.where(
-				and(
-					eq(sessionRuns.workflowId, workflowId),
-					eq(sessionRuns.runId, workflowId),
-				),
-			);
+			.where(and(eq(runs.workflowId, workflowId), eq(runs.runId, workflowId)));
 	} catch (err) {
 		console.warn(
 			`[cockpit] attachRunId failed for ${workflowId} (run ${runId}): ${err}`,
@@ -157,14 +129,9 @@ export async function markRunStatus(
 ): Promise<void> {
 	try {
 		await cockpitDb
-			.update(sessionRuns)
+			.update(runs)
 			.set({ status })
-			.where(
-				and(
-					eq(sessionRuns.workflowId, workflowId),
-					eq(sessionRuns.runId, runId),
-				),
-			);
+			.where(and(eq(runs.workflowId, workflowId), eq(runs.runId, runId)));
 	} catch (err) {
 		console.warn(
 			`[cockpit] markRunStatus failed for run ${runId} (${workflowId}): ${err}`,
@@ -177,7 +144,7 @@ export async function markRunStatus(
  * (DAT-551 P3c). The grounding-teach loop calls this when it has applied every
  * mechanical teach it can and a judgement gap remains (or it hit its attempt
  * limit): the run isn't failed — it's waiting for a human teach. Targets the most
- * recent execution for the workflow id (the current state), since a session's
+ * recent execution for the workflow id (the current state), since the workflow's
  * add_source has one run row per replay execution. Best-effort (mirrors
  * markRunStatus): a write error is logged, not thrown — the journey must not crash.
  */
@@ -187,16 +154,16 @@ export async function markRunAwaitingInput(
 ): Promise<void> {
 	try {
 		const [latest] = await cockpitDb
-			.select({ id: sessionRuns.id })
-			.from(sessionRuns)
-			.where(eq(sessionRuns.workflowId, workflowId))
-			.orderBy(desc(sessionRuns.startedAt))
+			.select({ id: runs.id })
+			.from(runs)
+			.where(eq(runs.workflowId, workflowId))
+			.orderBy(desc(runs.startedAt))
 			.limit(1);
 		if (!latest) return;
 		await cockpitDb
-			.update(sessionRuns)
+			.update(runs)
 			.set({ status: "awaiting_input", awaitingNote: note })
-			.where(eq(sessionRuns.id, latest.id));
+			.where(eq(runs.id, latest.id));
 	} catch (err) {
 		console.warn(
 			`[cockpit] markRunAwaitingInput failed for ${workflowId}: ${err}`,
@@ -219,16 +186,16 @@ export async function claimRunNarration(
 ): Promise<boolean> {
 	try {
 		const claimed = await cockpitDb
-			.update(sessionRuns)
+			.update(runs)
 			.set({ completionNarratedAt: new Date() })
 			.where(
 				and(
-					eq(sessionRuns.workflowId, workflowId),
-					eq(sessionRuns.runId, runId),
-					isNull(sessionRuns.completionNarratedAt),
+					eq(runs.workflowId, workflowId),
+					eq(runs.runId, runId),
+					isNull(runs.completionNarratedAt),
 				),
 			)
-			.returning({ id: sessionRuns.id });
+			.returning({ id: runs.id });
 		return claimed.length > 0;
 	} catch (err) {
 		console.warn(
@@ -258,17 +225,14 @@ export async function listNonTerminalRuns(
 ): Promise<Array<ActiveRun>> {
 	return cockpitDb
 		.select({
-			workflowId: sessionRuns.workflowId,
-			runId: sessionRuns.runId,
+			workflowId: runs.workflowId,
+			runId: runs.runId,
 		})
-		.from(sessionRuns)
+		.from(runs)
 		.where(
-			and(
-				eq(sessionRuns.conversationId, conversationId),
-				eq(sessionRuns.status, "running"),
-			),
+			and(eq(runs.conversationId, conversationId), eq(runs.status, "running")),
 		)
-		.orderBy(desc(sessionRuns.startedAt))
+		.orderBy(desc(runs.startedAt))
 		.limit(limit);
 }
 
@@ -283,13 +247,10 @@ export async function listRunningStages(
 	conversationId: string,
 ): Promise<Array<RunStage>> {
 	const rows = await cockpitDb
-		.selectDistinct({ stage: sessionRuns.stage })
-		.from(sessionRuns)
+		.selectDistinct({ stage: runs.stage })
+		.from(runs)
 		.where(
-			and(
-				eq(sessionRuns.conversationId, conversationId),
-				eq(sessionRuns.status, "running"),
-			),
+			and(eq(runs.conversationId, conversationId), eq(runs.status, "running")),
 		);
 	return rows.map((r) => r.stage as RunStage);
 }
@@ -321,61 +282,60 @@ export async function listWatchableRuns(
 ): Promise<Array<WatchableRun>> {
 	const rows = await cockpitDb
 		.select({
-			workflowId: sessionRuns.workflowId,
-			runId: sessionRuns.runId,
-			stage: sessionRuns.stage,
+			workflowId: runs.workflowId,
+			runId: runs.runId,
+			stage: runs.stage,
 		})
-		.from(sessionRuns)
+		.from(runs)
 		.where(
 			and(
-				eq(sessionRuns.conversationId, conversationId),
-				eq(sessionRuns.status, "running"),
-				isNull(sessionRuns.completionNarratedAt),
+				eq(runs.conversationId, conversationId),
+				eq(runs.status, "running"),
+				isNull(runs.completionNarratedAt),
 			),
 		)
-		.orderBy(desc(sessionRuns.startedAt))
+		.orderBy(desc(runs.startedAt))
 		.limit(limit);
 	return rows.map((r) => ({ ...r, stage: r.stage as RunStage }));
 }
 
 /**
- * Whether the engine session has an in-flight run at `stage` (DAT-511). The
+ * Whether the workspace has an in-flight run at `stage` (DAT-511, DAT-562). The
  * `operating_model` tool pre-checks `begin_session` here so a user (or the
  * agent, mis-narrated per DAT-510) can't start the operating model against a
- * session that hasn't promoted yet — the engine guards the same precondition
- * born-loud (`resolve_operating_model_scope`); this check just turns the
- * workflow failure into a friendly in-chat sentence. Conservative on staleness:
+ * workspace whose begin_session hasn't promoted yet — the engine guards the same
+ * precondition born-loud (`resolve_operating_model_scope`); this check just turns
+ * the workflow failure into a friendly in-chat sentence. Conservative on staleness:
  * a crashed run lingering as `running` blocks until the reload reconcile
  * (`reconcileActiveRuns`) sweeps it terminal.
  */
 export async function hasRunningRun(
-	engineSessionId: string,
+	workspaceId: string,
 	stage: RunStage,
 ): Promise<boolean> {
 	const [row] = await cockpitDb
-		.select({ id: sessionRuns.id })
-		.from(sessionRuns)
-		.innerJoin(sessions, eq(sessionRuns.sessionId, sessions.id))
+		.select({ id: runs.id })
+		.from(runs)
 		.where(
 			and(
-				eq(sessions.engineSessionId, engineSessionId),
-				eq(sessionRuns.stage, stage),
-				eq(sessionRuns.status, "running"),
+				eq(runs.workspaceId, workspaceId),
+				eq(runs.stage, stage),
+				eq(runs.status, "running"),
 			),
 		)
 		.limit(1);
 	return row !== undefined;
 }
 
-/** One run for the workspace-wide monitor (DAT-550). Joined to its session for
- * the workspace filter + the session `kind`. */
+/** One run for the workspace-wide monitor (DAT-550). `kind` is the run's own
+ * origin (DAT-562 — no session join). */
 export interface WorkspaceRun {
 	workflowId: string;
 	runId: string;
 	stage: RunStage;
 	status: string;
 	startedAt: Date;
-	kind: SessionKind;
+	kind: RunKind;
 	/** When status is `awaiting_input`, why the grounding loop parked it (DAT-551) —
 	 * the monitor shows it as the "needs you" detail. Null otherwise. */
 	awaitingNote: string | null;
@@ -383,10 +343,11 @@ export interface WorkspaceRun {
 
 /**
  * The workspace's runs, newest-first, BOUNDED — the native run monitor (DAT-550,
- * replacing the `/workflows` Temporal-UI iframe). WORKSPACE-scoped (joins
- * `sessions`), unlike the conversation-scoped queries above: the monitor is a
- * workspace-wide view of every stage run, independent of any chat. Bounded so a
- * long-lived workspace's run history can't dump an unbounded set into the page.
+ * replacing the `/workflows` Temporal-UI iframe). WORKSPACE-scoped directly
+ * (DAT-562 — runs carry `workspaceId`), unlike the conversation-scoped queries
+ * above: the monitor is a workspace-wide view of every stage run, independent of
+ * any chat. Bounded so a long-lived workspace's run history can't dump an unbounded
+ * set into the page.
  */
 export async function listRunsByWorkspace(
 	workspaceId: string,
@@ -394,23 +355,22 @@ export async function listRunsByWorkspace(
 ): Promise<Array<WorkspaceRun>> {
 	const rows = await cockpitDb
 		.select({
-			workflowId: sessionRuns.workflowId,
-			runId: sessionRuns.runId,
-			stage: sessionRuns.stage,
-			status: sessionRuns.status,
-			startedAt: sessionRuns.startedAt,
-			kind: sessions.kind,
-			awaitingNote: sessionRuns.awaitingNote,
+			workflowId: runs.workflowId,
+			runId: runs.runId,
+			stage: runs.stage,
+			status: runs.status,
+			startedAt: runs.startedAt,
+			kind: runs.kind,
+			awaitingNote: runs.awaitingNote,
 		})
-		.from(sessionRuns)
-		.innerJoin(sessions, eq(sessionRuns.sessionId, sessions.id))
-		.where(eq(sessions.workspaceId, workspaceId))
-		.orderBy(desc(sessionRuns.startedAt))
+		.from(runs)
+		.where(eq(runs.workspaceId, workspaceId))
+		.orderBy(desc(runs.startedAt))
 		.limit(limit);
 	return rows.map((r) => ({
 		...r,
 		stage: r.stage as RunStage,
-		kind: r.kind as SessionKind,
+		kind: r.kind as RunKind,
 	}));
 }
 
@@ -422,49 +382,46 @@ export async function listRunsByWorkspace(
 export async function countRunningRuns(workspaceId: string): Promise<number> {
 	const [row] = await cockpitDb
 		.select({ n: count() })
-		.from(sessionRuns)
-		.innerJoin(sessions, eq(sessionRuns.sessionId, sessions.id))
-		.where(
-			and(
-				eq(sessions.workspaceId, workspaceId),
-				eq(sessionRuns.status, "running"),
-			),
-		);
+		.from(runs)
+		.where(and(eq(runs.workspaceId, workspaceId), eq(runs.status, "running")));
 	return row?.n ?? 0;
 }
 
-/** One open "Needs you" item (DAT-553) — a session whose LATEST run is parked
+/** One open "Needs you" item (DAT-553) — a workflow whose LATEST run is parked
  * `awaiting_input` (the grounding loop hit a human-judgement gap or exhausted its
- * attempts). Carries the note (why it needs a human), the stage, and the engine
- * session id so the inbox can deep-link a resolve in a Stage chat. */
+ * attempts). Carries the note (why it needs a human) and the stage; `workflowId`
+ * keys the inbox row. */
 export interface AwaitingInputItem {
 	workflowId: string;
 	stage: RunStage;
 	awaitingNote: string | null;
-	engineSessionId: string;
 	startedAt: Date;
 }
 
 /**
- * The "open item" predicate (DAT-553): an `awaiting_input` run in this workspace
- * that is still its SESSION's LATEST run. The `NOT EXISTS` newer-run guard is what
- * makes the inbox SELF-CLEARING — a human teach + replay appends a newer run for
- * the session, so the parked item drops off automatically (no dismiss lifecycle).
- * Shared by the list + count so the two surfaces can never disagree on "open".
+ * The "open item" predicate (DAT-553, fixed by DAT-562): an `awaiting_input` run in
+ * this workspace that is still its WORKFLOW's LATEST run. The `NOT EXISTS` newer-run
+ * guard makes the inbox SELF-CLEARING — a human teach + replay reuses the parked
+ * import's workflow id (`addsource-<ws>`) and appends a newer run, so the parked
+ * item drops off automatically (no dismiss lifecycle). Keying on `workflowId` (not
+ * the retired per-import session) is what makes the HUMAN replay path clear it: under
+ * the old session-scoped predicate a replay minted a new session, so the parked item
+ * never saw a newer run and never cleared. Shared by the list + count so the two
+ * surfaces can never disagree on "open".
  */
 function openAwaitingItem(workspaceId: string) {
-	const newer = alias(sessionRuns, "newer_run");
+	const newer = alias(runs, "newer_run");
 	return and(
-		eq(sessions.workspaceId, workspaceId),
-		eq(sessionRuns.status, "awaiting_input"),
+		eq(runs.workspaceId, workspaceId),
+		eq(runs.status, "awaiting_input"),
 		notExists(
 			cockpitDb
 				.select({ id: newer.id })
 				.from(newer)
 				.where(
 					and(
-						eq(newer.sessionId, sessionRuns.sessionId),
-						gt(newer.startedAt, sessionRuns.startedAt),
+						eq(newer.workflowId, runs.workflowId),
+						gt(newer.startedAt, runs.startedAt),
 					),
 				),
 		),
@@ -473,7 +430,7 @@ function openAwaitingItem(workspaceId: string) {
 
 /**
  * The workspace's open "Needs you" items, newest-first, BOUNDED — the inbox panel
- * (DAT-553). Self-clearing via `openAwaitingItem` (latest-run-per-session). The run
+ * (DAT-553). Self-clearing via `openAwaitingItem` (latest-run-per-workflow). The run
  * monitor (DAT-550/551) still shows these PASSIVELY as "Needs input"; this is the
  * ACTIVE worklist read. Bounded so a long-lived workspace can't dump an unbounded
  * set into the page.
@@ -484,16 +441,14 @@ export async function listAwaitingInput(
 ): Promise<Array<AwaitingInputItem>> {
 	const rows = await cockpitDb
 		.select({
-			workflowId: sessionRuns.workflowId,
-			stage: sessionRuns.stage,
-			awaitingNote: sessionRuns.awaitingNote,
-			engineSessionId: sessions.engineSessionId,
-			startedAt: sessionRuns.startedAt,
+			workflowId: runs.workflowId,
+			stage: runs.stage,
+			awaitingNote: runs.awaitingNote,
+			startedAt: runs.startedAt,
 		})
-		.from(sessionRuns)
-		.innerJoin(sessions, eq(sessionRuns.sessionId, sessions.id))
+		.from(runs)
 		.where(openAwaitingItem(workspaceId))
-		.orderBy(desc(sessionRuns.startedAt))
+		.orderBy(desc(runs.startedAt))
 		.limit(limit);
 	return rows.map((r) => ({ ...r, stage: r.stage as RunStage }));
 }
@@ -506,8 +461,7 @@ export async function listAwaitingInput(
 export async function countAwaitingInput(workspaceId: string): Promise<number> {
 	const [row] = await cockpitDb
 		.select({ n: count() })
-		.from(sessionRuns)
-		.innerJoin(sessions, eq(sessionRuns.sessionId, sessions.id))
+		.from(runs)
 		.where(openAwaitingItem(workspaceId));
 	return row?.n ?? 0;
 }

--- a/packages/cockpit/src/db/cockpit/schema.ts
+++ b/packages/cockpit/src/db/cockpit/schema.ts
@@ -6,10 +6,14 @@
 // `ws_<id>` analytical schema (which the cockpit reads through ../metadata/).
 //
 // Control plane vs data plane (DD/32538626): the engine owns analytical data;
-// cockpit_db owns *who / which-workspace / which-session / which-runs*. Sessions
-// live HERE now (DAT-506) — the engine dropped `investigation_sessions`; the run's
-// table set is anchored engine-side by `run_tables` (keyed by `run_id`). `sessions`
-// is the session-of-record, keyed to a run-correlation id (`engineSessionId`).
+// cockpit_db owns *who / which-workspace / which-runs*. Post-DAT-506 the analytical
+// truth is the engine's per-table / catalog GENERATION heads; the cockpit's job is
+// purely run-grouping. DAT-562 RETIRED the `sessions` table: a cockpit "session" no
+// longer scoped anything (the id never went on the wire, no engine table carried it,
+// every stage resolves what it operates on from the heads — workspace-current), and
+// minting one per import only fragmented run-grouping. Runs now group by WORKSPACE
+// directly (`runs.workspaceId`), and workflow ids drop the session segment
+// (`addsource-<ws>` — see temporal/workflow-id.ts).
 //
 // Source of truth: this file. Migrations land in ../../../drizzle/cockpit/ via
 // `bun run db:generate:cockpit`, applied by `bun run db:migrate:cockpit` (the
@@ -31,10 +35,9 @@ import {
 /**
  * Who triggered control-plane work. A coarse identity seam (DAT-460): a single
  * seeded `default` row for now — NO auth, NO multi-user. Real actors/auth are
- * Phase 3 (DAT-357). `sessions.createdBy` references this so attribution exists
- * from day one without threading `actor_id` through the engine (the retired
- * DAT-365 approach — identity is a control-plane concern, kept out of the data
- * plane).
+ * Phase 3 (DAT-357). The registry seeds the `default` row; run attribution
+ * (`createdBy`) was carried by the retired `sessions` table (DAT-562) and had no
+ * reader, so it is reintroduced on `runs` only when auth lands.
  */
 export const actors = pgTable("actors", {
 	id: varchar("id").primaryKey(),
@@ -67,60 +70,33 @@ export const workspaces = pgTable("workspaces", {
 });
 
 /**
- * A control-plane session — the cockpit's record of an analytical session, the
- * session-of-record (DAT-506: the engine no longer has `investigation_sessions`).
- * `engineSessionId` (UNIQUE) is the run-correlation id the cockpit mints and keys
- * its workflow ids on (DAT-506 dropped the on-wire identity envelope — it is not
- * sent to the engine). begin_session/add_source/replay each create one;
- * operating_model REUSES begin_session's (looked up by `engineSessionId`). `kind`
- * is the run origin (onboarding | begin_session | replay); `status` carries the
- * lifecycle (active | ended | archived) that DAT-404 will drive.
- */
-export const sessions = pgTable(
-	"sessions",
-	{
-		id: varchar("id").primaryKey(),
-		workspaceId: varchar("workspace_id")
-			.notNull()
-			.references(() => workspaces.id),
-		engineSessionId: varchar("engine_session_id").notNull(),
-		kind: varchar("kind").notNull(),
-		status: varchar("status").notNull().default("active"),
-		createdBy: varchar("created_by")
-			.notNull()
-			.references(() => actors.id),
-		createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
-		endedAt: timestamp("ended_at", { mode: "date" }),
-	},
-	(t) => [
-		// One cockpit session per engine session — the upsert key the tools use so
-		// operating_model's append (and any re-run) reuses the row instead of
-		// duplicating it.
-		uniqueIndex("sessions_engine_session_uq").on(t.engineSessionId),
-		index("sessions_workspace_idx").on(t.workspaceId),
-	],
-);
-
-/**
- * One Temporal run under a session — the reload-recovery substrate (DAT-462
- * reads non-terminal rows to re-attach progress). A session has 1:N runs:
- * re-runs / teach-replays append a new row. `stage` is the workflow that ran
- * (add_source | begin_session | operating_model); `(workflowId, runId)` is the
- * Temporal identity the progress widget polls, UNIQUE so an idempotent record
- * call can't double-insert.
+ * One Temporal run in a workspace — the reload-recovery substrate (DAT-462 reads
+ * non-terminal rows to re-attach progress) and the native monitor's row (DAT-550).
+ * Runs group by WORKSPACE directly (DAT-562 retired the per-import `sessions` row):
+ * every add_source / begin_session / operating_model run — fresh or a teach-replay —
+ * is one row, attributed to its workspace.
+ *
+ * `kind` is the run's ORIGIN (onboarding | begin_session | replay) — formerly the
+ * `sessions` row's origin, now the run's own truth (a run has exactly one origin).
+ * `stage` is the workflow that ran (add_source | begin_session | operating_model);
+ * `(workflowId, runId)` is the Temporal identity the progress widget polls, UNIQUE
+ * so an idempotent record call can't double-insert.
  *
  * `runId` is Temporal's EXECUTION runId (`firstExecutionRunId`) — what
  * `getHandle(workflowId, runId)` pins for the progress poll / reconcile. The engine
  * mints its OWN internal metadata `run_id` (the version axis, DAT-413) and resolves
  * replay from the generation heads, so the cockpit does not store it (DAT-506).
  */
-export const sessionRuns = pgTable(
-	"session_runs",
+export const runs = pgTable(
+	"runs",
 	{
 		id: varchar("id").primaryKey(),
-		sessionId: varchar("session_id")
+		workspaceId: varchar("workspace_id")
 			.notNull()
-			.references(() => sessions.id),
+			.references(() => workspaces.id),
+		// The run's origin (onboarding | begin_session | replay) — drives the
+		// monitor's label. Was the retired `sessions.kind`; a run has one origin.
+		kind: varchar("kind").notNull(),
 		stage: varchar("stage").notNull(),
 		workflowId: varchar("workflow_id").notNull(),
 		runId: varchar("run_id").notNull(),
@@ -152,10 +128,10 @@ export const sessionRuns = pgTable(
 		awaitingNote: text("awaiting_note"),
 	},
 	(t) => [
-		uniqueIndex("session_runs_workflow_run_uq").on(t.workflowId, t.runId),
-		index("session_runs_session_idx").on(t.sessionId),
+		uniqueIndex("runs_workflow_run_uq").on(t.workflowId, t.runId),
+		index("runs_workspace_idx").on(t.workspaceId),
 		// The run-routing filter (DAT-528): the watcher/reconcile scope by it.
-		index("session_runs_conversation_idx").on(t.conversationId),
+		index("runs_conversation_idx").on(t.conversationId),
 	],
 );
 

--- a/packages/cockpit/src/db/metadata/write-surface.ts
+++ b/packages/cockpit/src/db/metadata/write-surface.ts
@@ -8,8 +8,8 @@
 //   config_overlay  — the teach vocabulary IS overlay rows
 //   sql_snippets    — save-on-clean grows the snippet library (DAT-486)
 //
-// (DAT-506 removed `investigation_sessions` — sessions live in cockpit_db now,
-// and the engine dropped the table + its write grant.)
+// (DAT-506 removed `investigation_sessions` — the engine dropped the table + its
+// write grant; run-grouping is the cockpit's concern, in cockpit_db.)
 //
 // The engine bootstrap grants the reader role exactly these verbs on exactly
 // these tables (storage/read_views.py::_CONTROL_WRITE_GRANTS); everything else

--- a/packages/cockpit/src/lib/agent-turn.ts
+++ b/packages/cockpit/src/lib/agent-turn.ts
@@ -55,13 +55,13 @@ type ChatStream = ReturnType<
  * prompt-cache hit for the chat's life (a chat's kind is immutable). It must stay
  * stateless — that's what is cached.
  *
- * `workspaceContext` (the current sessions — session-awareness for replay / teach
- * / look) is a SECOND system block placed AFTER the orchestrator. The cache
- * breakpoint is ON the orchestrator, so the cached prefix is exactly the
- * orchestrator; this dynamic block sits past the breakpoint and is never cached —
- * a small fresh suffix each turn. So the orchestrator keeps hitting even as the
- * session changes; the two don't thrash. The caller computes the block (a DB
- * read) and passes it; `buildChatOptions` stays pure for the unit wiring test.
+ * `workspaceContext` (the workspace's vertical + imported tables — workspace-
+ * awareness for replay / teach / look) is a SECOND system block placed AFTER the
+ * orchestrator. The cache breakpoint is ON the orchestrator, so the cached prefix is
+ * exactly the orchestrator; this dynamic block sits past the breakpoint and is never
+ * cached — a small fresh suffix each turn. So the orchestrator keeps hitting even as
+ * the imported tables change; the two don't thrash. The caller computes the block (a
+ * DB read) and passes it; `buildChatOptions` stays pure for the unit wiring test.
  *
  * `abortController` (when given) is threaded into the agentic loop so a cancelled
  * stream — the client calling useChat's `stop()`, or simply disconnecting —

--- a/packages/cockpit/src/prompts/workspace-context.integration.test.ts
+++ b/packages/cockpit/src/prompts/workspace-context.integration.test.ts
@@ -1,15 +1,15 @@
 // Real-Postgres integration test for the WORKSPACE CONTEXT reader
-// (session-awareness, DAT-506). The pure formatter is unit-tested; the DB readers
-// (`currentSessionId`, `buildWorkspaceContext`) — the cockpit_db sessions/session_runs
-// join, the engine `run_tables` → tables → sources de-prefix, and the "only
-// sessions WITH linked tables" filter — are validated HERE against real schemas, so
-// a column/join regression after `db:pull:metadata` is caught rather than shipped
-// (the reader runs on EVERY chat turn).
+// (workspace-awareness, DAT-506, DAT-562). The pure formatter is unit-tested; the DB
+// reader (`buildWorkspaceContext`) — the engine `run_tables` → tables → sources
+// de-prefix through the generation head + the workspace vertical — is validated HERE
+// against real schemas, so a column/join regression after `db:pull:metadata` is
+// caught rather than shipped (the reader runs on EVERY chat turn).
 //
-// DAT-506 grain: sessions live in cockpit_db (`sessions`/`session_runs`); the run's
-// table set is anchored engine-side by `run_tables(run_id, table_id)`. The fixture
-// seeds the engine source/table/run_tables via a raw (superuser) SQL connection
-// (cockpit_reader can't write run_tables) and the cockpit sessions/runs via cockpitDb.
+// DAT-562 grain: the cockpit "session" is retired — the context block names the
+// workspace's imported tables + vertical, not a session. The workspace's tables are
+// the live per-table GENERATION heads (DAT-506); the fixture seeds the engine
+// source/table/run_tables + head via a raw (superuser) SQL connection (cockpit_reader
+// can't write run_tables) and the workspace row via cockpitDb.
 //
 // Requires the compose stack (postgres on 127.0.0.1:5432). Self-skips when
 // METADATA_DATABASE_URL is unset so unit CI without the stack stays green.
@@ -45,14 +45,12 @@ const WS = (process.env.DATARAUM_WORKSPACE_ID as string) ?? "";
 const SCHEMA = STACK_AVAILABLE ? `ws_${WS.replaceAll("-", "_")}` : "";
 
 describe.skipIf(!STACK_AVAILABLE)(
-	"workspace-context reader (session-awareness, DAT-506)",
+	"workspace-context reader (workspace-awareness, DAT-562)",
 	() => {
 		/* biome-ignore-start lint/suspicious/noExplicitAny: dynamic-imported module shapes */
 		let cockpitDb: any;
 		let cockpitSchema: any;
-		let eq: any;
 		let sql: any;
-		let currentSessionId: any;
 		let buildWorkspaceContext: any;
 		/* biome-ignore-end lint/suspicious/noExplicitAny: dynamic-imported module shapes */
 
@@ -63,25 +61,15 @@ describe.skipIf(!STACK_AVAILABLE)(
 		const tableId = `wc_it_tbl_${u}`;
 		// `<source>__<stem>` so displayTableName de-prefixes to the filename "widgets".
 		const tableName = `${sourceName}__widgets`;
-		// The most-recent session — the CURRENT one. The workspace-current tables
-		// (the generation heads) attach to it (DAT-506: the table set is
-		// workspace-current, not per-session — see the module header).
-		const sessId = `wc_it_sess_${u}`;
 		const runId = `wc_it_run_${u}`;
-		// An OLDER session — listed but not CURRENT.
-		const olderSessId = `wc_it_older_${u}`;
-		const cockpitSessRowId = `wc_it_csess_${u}`;
-		const cockpitOlderRowId = `wc_it_colder_${u}`;
 
 		beforeAll(async () => {
 			cockpitDb = (await import("../db/cockpit/client")).cockpitDb;
 			cockpitSchema = await import("../db/cockpit/schema");
-			eq = (await import("drizzle-orm")).eq;
 			const { SQL } = await import("bun");
 			sql = new SQL(process.env.METADATA_DATABASE_URL as string);
-			const wc = await import("./workspace-context");
-			currentSessionId = wc.currentSessionId;
-			buildWorkspaceContext = wc.buildWorkspaceContext;
+			buildWorkspaceContext = (await import("./workspace-context"))
+				.buildWorkspaceContext;
 
 			// Engine side (raw superuser SQL — cockpit_reader can't write run_tables):
 			// source → table → run_tables. far-future created_at so this run's tables
@@ -112,21 +100,13 @@ describe.skipIf(!STACK_AVAILABLE)(
 				[`wc_it_head_${u}`, `table:${tableId}`, runId],
 			);
 
-			// cockpit_db side: the session-of-record rows (most-recent = CURRENT). The
-			// workspace's tables resolve via the engine GENERATION head above, not a
-			// per-session run join (DAT-506 — see the module header), so no
-			// session_runs seed is needed for the reader.
-			const { actors, workspaces, sessions } = cockpitSchema;
-			await cockpitDb
-				.insert(actors)
-				.values({ id: "default", displayName: "Default user" })
-				.onConflictDoNothing();
-			// UPSERT the vertical (not onConflictDoNothing): the cockpit registry
-			// self-seeds this same workspace row with the `_adhoc` cold-start default
-			// on first resolve (registry.ensureRegistry), and against the shared live
-			// stack that seed runs at container boot — before this suite. This test
-			// owns the `vertical finance` assertion, so it must SET the vertical, not
-			// silently no-op on the pre-existing `_adhoc` row.
+			// cockpit_db side: only the workspace row carries the vertical now (DAT-562
+			// retired the sessions table). UPSERT the vertical (not onConflictDoNothing):
+			// the cockpit registry self-seeds this same workspace row with the `_adhoc`
+			// cold-start default on first resolve, and against the shared live stack that
+			// seed runs at container boot — before this suite. This test owns the
+			// `vertical finance` assertion, so it must SET the vertical.
+			const { workspaces } = cockpitSchema;
 			await cockpitDb
 				.insert(workspaces)
 				.values({
@@ -139,44 +119,9 @@ describe.skipIf(!STACK_AVAILABLE)(
 					target: workspaces.id,
 					set: { vertical: "finance" },
 				});
-			await cockpitDb
-				.insert(sessions)
-				.values({
-					id: cockpitSessRowId,
-					workspaceId: WS,
-					engineSessionId: sessId,
-					kind: "begin_session",
-					status: "active",
-					createdBy: "default",
-					// The most recent — the CURRENT session.
-					createdAt: new Date("2100-01-01T00:00:00Z"),
-				})
-				.onConflictDoNothing();
-			await cockpitDb
-				.insert(sessions)
-				.values({
-					id: cockpitOlderRowId,
-					workspaceId: WS,
-					engineSessionId: olderSessId,
-					kind: "begin_session",
-					status: "active",
-					createdBy: "default",
-					// OLDER — listed but not CURRENT.
-					createdAt: new Date("2099-01-01T00:00:00Z"),
-				})
-				.onConflictDoNothing();
 		});
 
 		afterAll(async () => {
-			const { sessions } = cockpitSchema;
-			if (cockpitDb) {
-				await cockpitDb
-					.delete(sessions)
-					.where(eq(sessions.id, cockpitSessRowId));
-				await cockpitDb
-					.delete(sessions)
-					.where(eq(sessions.id, cockpitOlderRowId));
-			}
 			if (sql) {
 				await sql.unsafe(
 					`DELETE FROM "${SCHEMA}".metadata_snapshot_head WHERE run_id = $1`,
@@ -197,19 +142,13 @@ describe.skipIf(!STACK_AVAILABLE)(
 			}
 		});
 
-		it("currentSessionId returns the most-recent session when the workspace has tables", async () => {
-			expect(await currentSessionId()).toBe(sessId);
-		});
-
-		it("buildWorkspaceContext surfaces the current session by filename + workspace vertical + the CURRENT tag", async () => {
+		it("buildWorkspaceContext surfaces the imported tables by filename + the workspace vertical", async () => {
 			const block: string = await buildWorkspaceContext();
-			expect(block).toContain(sessId);
+			expect(block).toContain("Imported tables");
 			expect(block).toContain("widgets"); // de-prefixed table name, not the raw __ name
 			expect(block).toContain("vertical finance"); // the WORKSPACE vertical
-			expect(block).toContain("← CURRENT");
-			// The older session is listed too (most-recent-first), not tagged CURRENT.
-			expect(block).toContain(olderSessId);
-			expect(block.match(/← CURRENT/g)).toHaveLength(1);
+			// No session id to surface any more (DAT-562).
+			expect(block).toContain("never ask the user for a session id");
 		});
 	},
 );

--- a/packages/cockpit/src/prompts/workspace-context.test.ts
+++ b/packages/cockpit/src/prompts/workspace-context.test.ts
@@ -1,16 +1,14 @@
-// Unit tests for the WORKSPACE CONTEXT formatter (session-awareness). The DB read
-// lives in `buildWorkspaceContext` (smoke-covered); the wording + the CURRENT tag
-// are pure and tested here. Mock the metadata client so importing the module
-// (which imports it for the DB readers) opens no connection.
+// Unit tests for the WORKSPACE CONTEXT formatter (workspace-awareness, DAT-562).
+// The DB read lives in `buildWorkspaceContext` (smoke-covered); the wording is pure
+// and tested here. Mock the metadata client so importing the module (which imports
+// it for the DB readers) opens no connection.
 
 import { describe, expect, it, vi } from "vitest";
 
 // Mock every DB seam the module imports so a bare import opens no connection
 // (the DB readers themselves are smoke-covered; only the formatter is unit-tested).
 vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
-vi.mock("#/db/cockpit/client", () => ({ cockpitDb: {} }));
 vi.mock("#/db/cockpit/registry", () => ({
-	resolveActiveWorkspace: async () => "ws-test",
 	resolveActiveWorkspaceRow: async () => ({
 		id: "ws-test",
 		taskQueue: "engine-ws-test",
@@ -20,39 +18,27 @@ vi.mock("#/db/cockpit/registry", () => ({
 
 import { formatWorkspaceContext } from "#/prompts/workspace-context";
 
-describe("formatWorkspaceContext", () => {
-	it("returns null when there are no sessions (nothing to tell the agent)", () => {
-		expect(formatWorkspaceContext([])).toBeNull();
+describe("formatWorkspaceContext (DAT-562)", () => {
+	it("returns null when there are no imported tables (nothing to tell the agent)", () => {
+		expect(formatWorkspaceContext("finance", [])).toBeNull();
 	});
 
-	it("tags the most-recent session CURRENT and names what each spans", () => {
-		const text = formatWorkspaceContext([
-			{
-				sessionId: "s1",
-				vertical: "finance",
-				tableNames: ["invoices", "payments"],
-			},
-			{ sessionId: "s2", vertical: "_adhoc", tableNames: ["orders"] },
+	it("names the workspace's imported tables + vertical and tells the agent not to ask for a session id", () => {
+		const text = formatWorkspaceContext("finance", [
+			"invoices",
+			"payments",
 		]) as string;
 
 		expect(text).not.toBeNull();
-		// The first (most recent) carries the CURRENT tag with its tables + vertical.
-		expect(text).toContain(
-			"s1 — invoices, payments · vertical finance ← CURRENT",
-		);
-		// Older sessions are listed but NOT tagged current — only one ← CURRENT tag
-		// (the word "CURRENT" also appears in the instruction prose, hence the tag).
-		expect(text).toContain("s2 — orders · vertical _adhoc");
-		expect(text.match(/← CURRENT/g)).toHaveLength(1);
-		// And it tells the agent to stop asking for a session id.
+		expect(text).toContain("Imported tables: invoices, payments");
+		expect(text).toContain("vertical finance");
+		// There is no session id to ask for any more.
 		expect(text).toContain("never ask the user for a session id");
 	});
 
-	it("handles a session with no tables or vertical yet", () => {
-		const text = formatWorkspaceContext([
-			{ sessionId: "s1", vertical: null, tableNames: [] },
-		]) as string;
-		expect(text).toContain("no tables yet");
+	it("falls back to _adhoc when the workspace has no vertical", () => {
+		const text = formatWorkspaceContext(null, ["orders"]) as string;
+		expect(text).toContain("Imported tables: orders");
 		expect(text).toContain("vertical _adhoc");
 	});
 });

--- a/packages/cockpit/src/prompts/workspace-context.ts
+++ b/packages/cockpit/src/prompts/workspace-context.ts
@@ -1,26 +1,19 @@
-// Per-turn WORKSPACE CONTEXT for the agent — session-awareness (DAT-506).
+// Per-turn WORKSPACE CONTEXT for the agent — workspace-awareness (DAT-506, DAT-562).
 //
-// The agent learns state ONLY from what reaches its message context (tool
-// results + the structured handoff parts), and the chat messages are
-// in-memory, so a reload wipes them. Result: replay / teach / look_relationships
-// / why_relationship had no way to know which session the user is in, and asked
-// for an id.
+// The agent learns state ONLY from what reaches its message context (tool results +
+// the structured handoff parts), and the chat messages are in-memory, so a reload
+// wipes them. Without a hint, replay / teach / look_relationships had no idea whether
+// the workspace even has imported data, and asked the user for ids.
 //
-// Fix: each turn, read the workspace's sessions from cockpit_db (`sessions` — the
-// session-of-record post-DAT-506; the engine no longer has `investigation_sessions`)
-// and hand the agent the CURRENT session (most recent) plus the recent ones. The
-// workspace's imported tables come from the live per-table GENERATION heads (the
-// engine mints its own `run_id` the cockpit never sees, and no engine table carries
-// the cockpit `session_id`, so a session→run_tables join is impossible at the
-// cockpit edge — the generation heads ARE the workspace's current typed-table set,
-// which in single-active-workspace equals the session's tables). A session is
-// ambient state, like the workspace: the user is always in exactly one, and
-// add_source / begin_session are the transitions into a new one.
+// Fix: each turn, tell the agent what the workspace HAS — its framed vertical and the
+// imported tables — so session-scoped actions (replay / teach / look_relationships)
+// just work without asking. There is no session id to surface: DAT-562 retired the
+// cockpit "session" (it scoped nothing post-DAT-506 — the engine resolves every stage
+// from the workspace-current generation heads), so replay/operating_model take no id
+// and the context block names the workspace, not a session.
 
-import { desc, eq } from "drizzle-orm";
-import { cockpitDb } from "../db/cockpit/client";
+import { eq } from "drizzle-orm";
 import { resolveActiveWorkspaceRow } from "../db/cockpit/registry";
-import { sessions } from "../db/cockpit/schema";
 import { metadataDb } from "../db/metadata/client";
 import { GENERATION_STAGE } from "../db/metadata/relationship-target";
 import {
@@ -30,32 +23,6 @@ import {
 	tables,
 } from "../db/metadata/schema";
 import { displayTableName } from "../lib/display-names";
-
-const RECENT_LIMIT = 5;
-
-/** A session as the agent should see it: its (engine) id, framed vertical, and
- * the human-named tables the workspace spans (de-prefixed filenames). */
-export interface SessionSummary {
-	sessionId: string;
-	vertical: string | null;
-	tableNames: string[];
-}
-
-/** The engine session ids of a workspace's sessions, most recent first. cockpit_db
- * is the session-of-record (DAT-506); the engine session id is the value the tools
- * + workflow ids key on. */
-async function recentSessions(
-	workspaceId: string,
-	limit: number,
-): Promise<string[]> {
-	const rows = await cockpitDb
-		.select({ engineSessionId: sessions.engineSessionId })
-		.from(sessions)
-		.where(eq(sessions.workspaceId, workspaceId))
-		.orderBy(desc(sessions.createdAt))
-		.limit(limit);
-	return rows.map((r) => r.engineSessionId);
-}
 
 /** The workspace's currently-imported tables (de-prefixed display names) — the
  * tables at the live per-table GENERATION heads (DAT-506). Empty until an
@@ -76,72 +43,35 @@ async function workspaceTableNames(): Promise<string[]> {
 }
 
 /**
- * The most recent session — the CURRENT session the user is in — when the
- * workspace has imported tables to act on; null otherwise. The "with tables" gate
- * keeps a bare "replay" right after onboarding from running before anything is
- * imported. (DAT-506: the table set is workspace-current, not per-session — the
- * engine run_id the cockpit can't see makes a per-session join impossible.)
- *
- * `replay` defaults to this so "replay" re-runs without an id.
+ * Format the WORKSPACE CONTEXT block. Pure — the DB read lives in
+ * `buildWorkspaceContext`, so the wording is unit-testable. Null when the workspace
+ * has no imported tables (nothing the agent can act on yet).
  */
-export async function currentSessionId(): Promise<string | null> {
-	const workspaceId = (await resolveActiveWorkspaceRow()).id;
-	const recent = await recentSessions(workspaceId, 1);
-	if (recent.length === 0) return null;
-	const tableNames = await workspaceTableNames();
-	return tableNames.length > 0 ? recent[0] : null;
+export function formatWorkspaceContext(
+	vertical: string | null,
+	tableNames: string[],
+): string | null {
+	if (tableNames.length === 0) return null;
+	return (
+		"WORKSPACE CONTEXT — the user's current workspace. Imported tables: " +
+		`${tableNames.join(", ")} · vertical ${vertical ?? "_adhoc"}. For replay, ` +
+		"teach, look_relationships, why_relationship and any session-scoped action, " +
+		"operate on this workspace directly — never ask the user for a session id " +
+		"(there is none). `replay` re-runs the workspace's imported sources; " +
+		"`operating_model` re-runs over the workspace's begin_session result."
+	);
 }
 
 /**
- * Format the WORKSPACE CONTEXT block from the recent sessions (most-recent
- * first). Pure — the DB read lives in `buildWorkspaceContext`, so the wording +
- * the CURRENT tag are unit-testable. Null when there are no sessions (nothing to
- * tell the agent).
- */
-export function formatWorkspaceContext(
-	recent: SessionSummary[],
-): string | null {
-	if (recent.length === 0) return null;
-	const lines = recent.map((s, i) => {
-		const span =
-			s.tableNames.length > 0 ? s.tableNames.join(", ") : "no tables yet";
-		const tag = i === 0 ? " ← CURRENT (the session the user is in)" : "";
-		return `- ${s.sessionId} — ${span} · vertical ${s.vertical ?? "_adhoc"}${tag}`;
-	});
-	return (
-		"WORKSPACE CONTEXT — the analytical sessions in this workspace, most recent " +
-		"first. The user is always in ONE session; the most recent is the CURRENT " +
-		"one. For replay, teach, look_relationships, why_relationship and any " +
-		"session-scoped action, use the CURRENT session's id (or the one the user " +
-		"names) — never ask the user for a session id when this block has one. " +
-		"`replay` with no session_id re-runs the CURRENT session.\n" +
-		lines.join("\n")
-	);
-}
-
-/** Read the recent sessions + the workspace's imported tables, most-recent first.
- * Only emitted when the workspace HAS imported tables (a freshly-recorded session
+ * Read the workspace's vertical + imported tables and format the context block.
+ * Only emitted when the workspace HAS imported tables (a freshly-created workspace
  * with nothing imported isn't something the agent can act on). The vertical is the
- * WORKSPACE's (DAT-506: a workspace property, not a per-session pick); the table
- * set is the workspace-current set (the generation heads), shown against each
- * recent session. */
+ * WORKSPACE's (DAT-506: a workspace property); the table set is the workspace-current
+ * set (the generation heads).
+ */
 export async function buildWorkspaceContext(): Promise<string | null> {
 	const workspace = await resolveActiveWorkspaceRow();
-	const [recent, tableNames] = await Promise.all([
-		recentSessions(workspace.id, RECENT_LIMIT),
-		workspaceTableNames(),
-	]);
-	if (recent.length === 0 || tableNames.length === 0) return null;
-
-	return formatWorkspaceContext(
-		recent.map((sessionId, i) => ({
-			sessionId,
-			// Vertical is a workspace property now (DAT-506) — same on every session.
-			vertical: workspace.vertical,
-			// The workspace-current tables belong to the CURRENT session; older
-			// sessions list "no tables yet" (their own run's tables aren't separable
-			// at the cockpit edge — see the module header).
-			tableNames: i === 0 ? tableNames : [],
-		})),
-	);
+	const tableNames = await workspaceTableNames();
+	if (tableNames.length === 0) return null;
+	return formatWorkspaceContext(workspace.vertical, tableNames);
 }

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.tsx
@@ -16,7 +16,6 @@ import {
 } from "#/db/cockpit/runs";
 import { readStageStaleness } from "#/db/metadata/stage-staleness-read";
 import { currentTypedTableIds } from "#/db/metadata/workspace-state";
-import { currentSessionId } from "#/prompts/workspace-context";
 import { beginSession } from "#/tools/begin-session";
 import { operatingModel } from "#/tools/operating-model";
 import { replay } from "#/tools/replay";
@@ -67,22 +66,15 @@ const openStageChat = createServerFn({ method: "POST" }).handler(async () => {
 const rerunStage = createServerFn({ method: "POST" })
 	.inputValidator((stage: RunStage) => stage)
 	.handler(async ({ data: stage }) => {
-		const sessionId = await currentSessionId();
-		if (!sessionId) {
-			throw new Error("No current session to re-run — import a source first.");
-		}
 		let result: unknown;
 		if (stage === "operating_model") {
-			result = await operatingModel({ session_id: sessionId });
+			result = await operatingModel();
 		} else if (stage === "begin_session") {
 			// begin_session stages over the workspace's current typed table set.
-			result = await beginSession({
-				session_id: sessionId,
-				table_ids: await currentTypedTableIds(),
-			});
+			result = await beginSession({ table_ids: await currentTypedTableIds() });
 		} else {
-			// add_source — the DAT-551 full replay path.
-			result = await replay({ session_id: sessionId });
+			// add_source — the DAT-551 full replay path (re-runs the workspace sources).
+			result = await replay({});
 		}
 		// The tool fns return an { error } envelope for their born-loud guards (e.g.
 		// operating_model's "begin_session still running"). Surface it as a throw so

--- a/packages/cockpit/src/routes/api/chat.ts
+++ b/packages/cockpit/src/routes/api/chat.ts
@@ -219,12 +219,13 @@ export const Route = createFileRoute("/api/chat")({
 					persistTo = null;
 				}
 
-				// The current sessions, so the agent knows where the user is (replay /
-				// teach / look_relationships resolve against the session without asking).
+				// The workspace's vertical + imported tables, so the agent knows what it
+				// can act on (replay / teach / look_relationships resolve against the
+				// workspace without asking — DAT-562 retired the per-session id).
 				// A cheap DB read per turn — negligible beside the LLM call. It is
 				// OPPORTUNISTIC enrichment: a DB hiccup must NOT take down chat, so a
-				// throw degrades to no block (the agent falls back to asking for an id —
-				// the pre-fix behavior), never a dead turn.
+				// throw degrades to no block (the agent falls back to asking — the
+				// pre-fix behavior), never a dead turn.
 				const workspaceContext = await buildWorkspaceContext().catch(
 					(err: unknown) => {
 						console.error(

--- a/packages/cockpit/src/temporal/journey-trigger.test.ts
+++ b/packages/cockpit/src/temporal/journey-trigger.test.ts
@@ -73,8 +73,7 @@ describe("signalVerticalEstablished (DAT-529)", () => {
 describe("stage + breaker signals (DAT-530)", () => {
 	it("signals runBeginSession with the full payload on the per-workspace journey", async () => {
 		const req = {
-			sessionId: "sess-1",
-			workflowId: "beginsession-ws-1-sess-1",
+			workflowId: "beginsession-ws-1",
 			engineTaskQueue: "engine-ws-1",
 			tables: ["t1", "t2"],
 			verticals: ["finance"],
@@ -95,8 +94,7 @@ describe("stage + breaker signals (DAT-530)", () => {
 
 	it("signals runOperatingModel (the manual re-trigger) with its payload", async () => {
 		const req = {
-			sessionId: "sess-1",
-			workflowId: "operatingmodel-ws-1-sess-1",
+			workflowId: "operatingmodel-ws-1",
 			engineTaskQueue: "engine-ws-1",
 			verticals: ["finance"],
 			conversationId: null,

--- a/packages/cockpit/src/temporal/progress.ts
+++ b/packages/cockpit/src/temporal/progress.ts
@@ -141,7 +141,7 @@ export function isProgressDone(phase: string, status: string): boolean {
 }
 
 /**
- * The terminal cockpit `session_runs.status` for a DONE run. "completed" covers
+ * The terminal cockpit `runs.status` for a DONE run. "completed" covers
  * the clean exits — phase=="done" (the workflow finished even if describe()
  * hasn't flipped yet), an actual COMPLETED, and CONTINUED_AS_NEW (a handoff, not
  * a failure); everything else terminal (FAILED / TERMINATED / CANCELED /

--- a/packages/cockpit/src/temporal/reconcile.ts
+++ b/packages/cockpit/src/temporal/reconcile.ts
@@ -1,7 +1,7 @@
 // Reload reconcile (DAT-462) — bridge cockpit_db's in-flight runs to Temporal.
 //
 // On cockpit load, a run may have FINISHED while the tab was closed: its
-// `session_runs` row still reads "running" but the workflow is long done. This
+// `runs` row still reads "running" but the workflow is long done. This
 // chat's loader fires the sweep for ITS conversation (DAT-528: conversation-scoped
 // — a chat reconciles its own runs); a run in another chat is swept when that chat
 // opens. The progress widget's own re-poll also terminates runs whose conversation

--- a/packages/cockpit/src/temporal/trigger-add-source.test.ts
+++ b/packages/cockpit/src/temporal/trigger-add-source.test.ts
@@ -69,12 +69,11 @@ describe("triggerAddSource (DAT-352, one-call DAT-436, routed via the journey â€
 	it("signals the journey with the source SET / queue / verticals + kind onboarding", async () => {
 		h.vertical = "financial_reporting";
 		const result = await triggerAddSource({ sources: ["src-1"] });
-		const cockpitSessionId = result.cockpit_session_id;
 
+		// One workflow id per workspace (DAT-562) â€” no minted session segment.
 		expect(h.signalled?.workspaceId).toBe(WS);
 		expect(h.signalled?.req).toEqual({
-			sessionId: cockpitSessionId,
-			workflowId: `addsource-${WS}-${cockpitSessionId}`,
+			workflowId: `addsource-${WS}`,
 			engineTaskQueue: `engine-${WS}`,
 			sources: ["src-1"],
 			verticals: ["financial_reporting"],
@@ -84,10 +83,9 @@ describe("triggerAddSource (DAT-352, one-call DAT-436, routed via the journey â€
 		// The trigger returns the deterministic workflow id (run_id mirrors it â€” the
 		// journey owns the real execution id; progress resolves latest by id).
 		expect(result).toEqual({
-			workflow_id: `addsource-${WS}-${cockpitSessionId}`,
-			run_id: `addsource-${WS}-${cockpitSessionId}`,
+			workflow_id: `addsource-${WS}`,
+			run_id: `addsource-${WS}`,
 			sources: ["src-1"],
-			cockpit_session_id: cockpitSessionId,
 		});
 	});
 

--- a/packages/cockpit/src/temporal/trigger-add-source.ts
+++ b/packages/cockpit/src/temporal/trigger-add-source.ts
@@ -20,13 +20,11 @@
 //
 // The tool returns the DETERMINISTIC workflow id immediately (the cockpit polls
 // progress by workflow id — the latest execution; the real Temporal run id is owned
-// by the journey). A run ingests a SET of objects from 1–N sources (DAT-422), so the
-// workflow id is keyed by the cockpit session id (addsource-<workspace_id>-
-// <cockpitSessionId>), mirroring begin_session. The `verticals` ride on the FLAT
-// workflow INPUT, sourced from the workspace registry (DAT-506), NOT picked per
-// add_source — no identity envelope, no session/source id on the wire.
-
-import { randomUUID } from "node:crypto";
+// by the journey). The workflow id is `addsource-<workspace_id>` — one per workspace
+// (DAT-562 retired the per-import session segment); the serial per-workspace journey
+// makes re-runs reuse it safely. The `verticals` ride on the FLAT workflow INPUT,
+// sourced from the workspace registry (DAT-506), NOT picked per add_source — no
+// identity envelope, no session/source id on the wire.
 
 import { config } from "../config";
 import { resolveActiveWorkspaceRow } from "../db/cockpit/registry";
@@ -45,9 +43,6 @@ export interface TriggerAddSourceResult {
 	workflow_id: string;
 	run_id: string;
 	sources: string[];
-	// The cockpit-side session-of-record id (cockpit_db `sessions`), NOT a wire
-	// field — the run's correlation key + the workflow-id segment.
-	cockpit_session_id: string;
 }
 
 /** The Temporal-unconfigured guard, mirroring begin-session.ts: Temporal config is
@@ -70,23 +65,20 @@ function requireTemporalConfig(): void {
  * child, narrating completion into the originating chat. The caller does NOT poll a
  * run id — progress resolves the latest execution by workflow id.
  *
- * No engine seed (DAT-506): sessions live in cockpit_db, the run's table set is
- * anchored by `run_tables` (keyed by `run_id`), and the `vertical` is the workspace
- * property from the registry.
+ * No engine seed (DAT-506): the run's table set is anchored by `run_tables` (keyed
+ * by `run_id`), and the `vertical` is the workspace property from the registry.
  */
 export async function triggerAddSource(
 	input: TriggerAddSourceInput,
 ): Promise<TriggerAddSourceResult> {
 	requireTemporalConfig();
 
-	const cockpitSessionId = randomUUID();
-
 	// The active workspace ROW, from the cockpit_db registry (DAT-461/505/506):
 	// the source of truth for the per-workspace task queue the child routes to AND
 	// the frame `vertical` (a workspace property chosen once — DAT-506 retired the
 	// per-add_source pick).
 	const workspace = await resolveActiveWorkspaceRow();
-	const workflowId = addSourceWorkflowId(workspace.id, cockpitSessionId);
+	const workflowId = addSourceWorkflowId(workspace.id);
 
 	// Signal the journey to run the stage (DAT-551). The tool passes the derived
 	// ids/queue + the source SET + verticals + the originating conversationId
@@ -95,7 +87,6 @@ export async function triggerAddSource(
 	// the engine child on the workspace's OWN queue (DAT-505). `kind: onboarding`
 	// marks the session origin (a fresh import, vs replay's "replay").
 	await signalRunAddSource(workspace.id, {
-		sessionId: cockpitSessionId,
 		workflowId,
 		engineTaskQueue: workspace.taskQueue,
 		sources: input.sources,
@@ -110,6 +101,5 @@ export async function triggerAddSource(
 		workflow_id: workflowId,
 		run_id: workflowId,
 		sources: input.sources,
-		cockpit_session_id: cockpitSessionId,
 	};
 }

--- a/packages/cockpit/src/temporal/workflow-id.test.ts
+++ b/packages/cockpit/src/temporal/workflow-id.test.ts
@@ -1,42 +1,55 @@
 import { describe, expect, it } from "vitest";
 
-import { addSourceWorkflowId, operatingModelWorkflowId } from "./workflow-id";
+import {
+	addSourceWorkflowId,
+	beginSessionWorkflowId,
+	operatingModelWorkflowId,
+} from "./workflow-id";
 
-// The parent workflow ID encodes workspace_id as its first segment (DAT-364) and
-// is keyed by the run's session_id (DAT-422 — a run is over a SET of objects from
-// 1–N sources, not one source). It MUST agree with the Python worker's
-// `add_source_workflow_id` (the worker builds child IDs off the same prefix).
-// These pin the format + the cross-workspace distinctness the convention exists
-// to guarantee.
+// The parent workflow ID is `<stage>-<workspace_id>` — ONE id per stage per
+// workspace (DAT-562 retired the per-import session segment). It MUST agree with the
+// Python worker's prefix convention (the worker builds child IDs off the same
+// prefix). These pin the format + the cross-workspace distinctness the convention
+// exists to guarantee.
 
 const WS_A = "12345678-1234-1234-1234-123456789abc";
 const WS_B = "00000000-0000-0000-0000-000000000001";
-const SESSION = "sess-7";
 
-describe("addSourceWorkflowId (DAT-364, DAT-422)", () => {
-	it("encodes workspace then session", () => {
-		expect(addSourceWorkflowId(WS_A, SESSION)).toBe(
-			`addsource-${WS_A}-${SESSION}`,
-		);
+describe("addSourceWorkflowId (DAT-364, DAT-562)", () => {
+	it("encodes the stage then the workspace", () => {
+		expect(addSourceWorkflowId(WS_A)).toBe(`addsource-${WS_A}`);
 	});
 
-	it("does not collide across workspaces sharing a session_id", () => {
-		expect(addSourceWorkflowId(WS_A, SESSION)).not.toBe(
-			addSourceWorkflowId(WS_B, SESSION),
+	it("does not collide across workspaces", () => {
+		expect(addSourceWorkflowId(WS_A)).not.toBe(addSourceWorkflowId(WS_B));
+	});
+});
+
+describe("beginSessionWorkflowId (DAT-409, DAT-562)", () => {
+	it("encodes the stage then the workspace", () => {
+		expect(beginSessionWorkflowId(WS_A)).toBe(`beginsession-${WS_A}`);
+	});
+});
+
+describe("operatingModelWorkflowId (DAT-438, DAT-562)", () => {
+	it("encodes the stage then the workspace", () => {
+		expect(operatingModelWorkflowId(WS_A)).toBe(`operatingmodel-${WS_A}`);
+	});
+
+	it("does not collide across workspaces", () => {
+		expect(operatingModelWorkflowId(WS_A)).not.toBe(
+			operatingModelWorkflowId(WS_B),
 		);
 	});
 });
 
-describe("operatingModelWorkflowId (DAT-438)", () => {
-	it("encodes workspace then session", () => {
-		expect(operatingModelWorkflowId(WS_A, SESSION)).toBe(
-			`operatingmodel-${WS_A}-${SESSION}`,
-		);
-	});
-
-	it("does not collide across workspaces sharing a session_id", () => {
-		expect(operatingModelWorkflowId(WS_A, SESSION)).not.toBe(
-			operatingModelWorkflowId(WS_B, SESSION),
-		);
+describe("stage ids are distinct within one workspace", () => {
+	it("never collide across stages", () => {
+		const ids = new Set([
+			addSourceWorkflowId(WS_A),
+			beginSessionWorkflowId(WS_A),
+			operatingModelWorkflowId(WS_A),
+		]);
+		expect(ids.size).toBe(3);
 	});
 });

--- a/packages/cockpit/src/temporal/workflow-id.ts
+++ b/packages/cockpit/src/temporal/workflow-id.ts
@@ -5,55 +5,42 @@
 // and builds the child (`processTableWorkflow`) IDs off the same prefix (see
 // `dataraum.worker.contracts.{add_source_workflow_id,process_table_workflow_id}`).
 //
-// Every workflow ID encodes `workspace_id` as its first segment. Slice 1 runs
-// single-workspace so it's constant today, but threading it through now makes
-// slice 2+ multi-workspace routing a no-op and guarantees two workspaces sharing
-// a `session_id` never collide on a workflow ID. `workspace_id` is kept verbatim
-// (raw UUID with dashes) — Temporal IDs have no charset restriction, so we favour
-// grep-able IDs over the underscored `ws_<id>` schema form.
+// A workflow ID is `<stage>-<workspace_id>` — ONE id per stage per workspace
+// (DAT-562 retired the per-import `session_id` segment). `workspace_id` is kept
+// verbatim (raw UUID with dashes) — Temporal IDs have no charset restriction, so we
+// favour grep-able IDs over the underscored `ws_<id>` schema form — and guarantees
+// two workspaces never collide on an id.
 //
-// The `session_id` segment is COCKPIT-MINTED (DAT-506: sessions live in cockpit_db,
-// the engine no longer owns them and the id is not sent on the wire) — the cockpit's
-// own session-of-record id, used purely to make the workflow ID deterministic and
-// re-run-stable.
+// Why constant-per-workspace is correct (not too coarse): the per-workspace
+// JourneyWorkflow drains its triggers SERIALLY (one stage child at a time), so two
+// executions of the same stage are never open simultaneously — Temporal's
+// allow-duplicate-when-closed policy lets each re-run / replay reuse the id, and the
+// SDK groups the iterations under it. Distinct executions still record as distinct
+// `(workflowId, runId)` rows, so the monitor never loses a run. The engine builds
+// its child ids as `<parent_id>-table-<raw_id>` (an opaque prefix it never
+// re-parses), so the shorter parent id is engine-safe.
 
 /**
- * Workflow ID for the parent `addSourceWorkflow` of one run. A run ingests a SET
- * of objects from 1–N sources (DAT-422), so it is keyed by its cockpit-minted
- * `session_id` — the cockpit's session-of-record id — NOT a source, mirroring
- * `beginSessionWorkflowId`. Reused across teach replays of the same run (with
- * `ALLOW_DUPLICATE`) so Temporal groups the iterations under one ID.
+ * Workflow ID for the parent `addSourceWorkflow` of an import run (a fresh import
+ * or a replay). One id per workspace; re-runs / replays reuse it (the SDK groups
+ * the iterations, and the grounding-teach loop's replays already do).
  */
-export function addSourceWorkflowId(
-	workspaceId: string,
-	sessionId: string,
-): string {
-	return `addsource-${workspaceId}-${sessionId}`;
+export function addSourceWorkflowId(workspaceId: string): string {
+	return `addsource-${workspaceId}`;
 }
 
 /**
- * Workflow ID for the parent `beginSessionWorkflow` of one analytical session
- * (DAT-409). Keyed by the cockpit-minted `session_id` (begin_session is
- * source-free); reused across teach re-runs of the same session (with
- * `ALLOW_DUPLICATE`) so Temporal groups the iterations under one ID.
+ * Workflow ID for the parent `beginSessionWorkflow` (DAT-409). One id per
+ * workspace; re-running begin_session after a teach reuses it.
  */
-export function beginSessionWorkflowId(
-	workspaceId: string,
-	sessionId: string,
-): string {
-	return `beginsession-${workspaceId}-${sessionId}`;
+export function beginSessionWorkflowId(workspaceId: string): string {
+	return `beginsession-${workspaceId}`;
 }
 
 /**
- * Workflow ID for the `operatingModelWorkflow` of one analytical session
- * (DAT-438). Keyed by the cockpit-minted `session_id` like
- * `beginSessionWorkflowId` — the stage operates on the session's anchored table
- * set; reused across re-runs of the same session (with `ALLOW_DUPLICATE`) so
- * Temporal groups the iterations under one ID.
+ * Workflow ID for the `operatingModelWorkflow` (DAT-438). One id per workspace;
+ * the auto-cascade and the manual re-trigger share it.
  */
-export function operatingModelWorkflowId(
-	workspaceId: string,
-	sessionId: string,
-): string {
-	return `operatingmodel-${workspaceId}-${sessionId}`;
+export function operatingModelWorkflowId(workspaceId: string): string {
+	return `operatingmodel-${workspaceId}`;
 }

--- a/packages/cockpit/src/tools/begin-session.test.ts
+++ b/packages/cockpit/src/tools/begin-session.test.ts
@@ -76,10 +76,10 @@ describe("beginSession (DAT-409, routed via the journey — DAT-530)", () => {
 		const result = await beginSession({ table_ids: ["t1", "t2"] });
 		if ("error" in result) throw new Error(`unexpected: ${result.error}`);
 
+		// One workflow id per workspace (DAT-562) — no minted session segment.
 		expect(h.signalled?.workspaceId).toBe(WS);
 		expect(h.signalled?.req).toEqual({
-			sessionId: result.session_id,
-			workflowId: `beginsession-${WS}-${result.session_id}`,
+			workflowId: `beginsession-${WS}`,
 			engineTaskQueue: `engine-${WS}`,
 			tables: ["t1", "t2"],
 			verticals: ["finance"],
@@ -87,7 +87,7 @@ describe("beginSession (DAT-409, routed via the journey — DAT-530)", () => {
 		});
 		// The tool returns the deterministic workflow id (run_id mirrors it — the
 		// journey owns the real execution id; progress resolves latest by id).
-		expect(result.workflow_id).toBe(`beginsession-${WS}-${result.session_id}`);
+		expect(result.workflow_id).toBe(`beginsession-${WS}`);
 		expect(result.run_id).toBe(result.workflow_id);
 		expect(result.table_ids).toEqual(["t1", "t2"]);
 	});
@@ -97,16 +97,6 @@ describe("beginSession (DAT-409, routed via the journey — DAT-530)", () => {
 		const result = await beginSession({ table_ids: ["t1"] });
 		if ("error" in result) throw new Error(`unexpected: ${result.error}`);
 		expect(h.signalled?.req.conversationId).toBeNull();
-	});
-
-	it("reuses a caller-supplied session id for the workflow id", async () => {
-		const result = await beginSession({
-			table_ids: ["t1"],
-			session_id: "sess-reuse",
-		});
-		if ("error" in result) throw new Error(`unexpected: ${result.error}`);
-		expect(result.session_id).toBe("sess-reuse");
-		expect(h.signalled?.req.workflowId).toBe(`beginsession-${WS}-sess-reuse`);
 	});
 
 	it("throws when Temporal is unconfigured and signals nothing", async () => {

--- a/packages/cockpit/src/tools/begin-session.ts
+++ b/packages/cockpit/src/tools/begin-session.ts
@@ -19,10 +19,9 @@
 //
 // The tool returns the DETERMINISTIC workflow id immediately (the cockpit polls
 // progress by workflow id — the latest execution; the real Temporal run id is
-// owned by the journey). The workflow id is reused per session
-// (`beginsession-<workspace_id>-<session_id>`) so teach re-runs group under one id.
+// owned by the journey). The workflow id is `beginsession-<workspace_id>` — one per
+// workspace (DAT-562) so teach re-runs group under one id.
 
-import { randomUUID } from "node:crypto";
 import { toolDefinition } from "@tanstack/ai";
 import { z } from "zod";
 
@@ -36,21 +35,17 @@ import { type AgentError, withAgentError } from "./agent-error";
 
 export interface BeginSessionToolInput {
 	table_ids: string[];
-	// Per-session id — the cockpit's run-correlation key. Optional: omit to start a
-	// fresh session; pass an existing one to re-run that session (teach → re-run),
-	// reusing the recorded row conflict-safely.
-	session_id?: string;
 }
 
 export interface BeginSessionToolResult {
-	// The deterministic engine workflow id (`beginsession-<ws>-<session>`). Progress
-	// is polled by this id (the latest execution); the journey owns the real run id.
+	// The deterministic engine workflow id (`beginsession-<ws>`). Progress is polled
+	// by this id (the latest execution); the journey owns the real run id. One id per
+	// workspace (DAT-562) — re-running begin_session after a teach reuses it.
 	workflow_id: string;
 	// Kept for the result contract; equals workflow_id (the journey starts the run,
 	// so no Temporal execution id is known at tool-return time — progress resolves
 	// the latest run by workflow_id, DAT-530).
 	run_id: string;
-	session_id: string;
 	table_ids: string[];
 }
 
@@ -82,20 +77,17 @@ export async function beginSession(
 		};
 	}
 
-	const sessionId = input.session_id ?? randomUUID();
-
 	// The active workspace ROW (DAT-461/505/506): the source of truth for the
 	// engine task queue (`engine-<id>`) and the frame `vertical` (a workspace
 	// property chosen once — DAT-506 retired the per-session pick).
 	const workspace = await resolveActiveWorkspaceRow();
-	const workflowId = beginSessionWorkflowId(workspace.id, sessionId);
+	const workflowId = beginSessionWorkflowId(workspace.id);
 
 	// Signal the journey to run the stage. The tool passes the derived ids/queue +
 	// verticals + the originating conversationId (captured from the request-scoped
 	// ALS HERE, while we're still in the chat turn — the journey has none). The
 	// journey records the run authoritatively and starts the engine child.
 	await signalRunBeginSession(workspace.id, {
-		sessionId,
 		workflowId,
 		engineTaskQueue: workspace.taskQueue,
 		tables: input.table_ids,
@@ -106,7 +98,6 @@ export async function beginSession(
 	return {
 		workflow_id: workflowId,
 		run_id: workflowId,
-		session_id: sessionId,
 		table_ids: input.table_ids,
 	};
 }
@@ -125,9 +116,9 @@ export const beginSessionTool = toolDefinition({
 		"look_relationships / why_relationship and refine with teach. Runs engine " +
 		"processing + LLM calls. Returns the workflow_id; the run proceeds in the " +
 		"background and its progress shows live in the canvas — you'll be told " +
-		"automatically when it finishes, so don't poll for status. Pass an existing " +
-		"session_id to re-run a session after teaching. Runs on the WORKSPACE's " +
-		"vertical (set once for the workspace — not chosen per session).",
+		"automatically when it finishes, so don't poll for status. To re-run after " +
+		"teaching, just call begin_session again with the table set. Runs on the " +
+		"WORKSPACE's vertical (set once for the workspace — not chosen per session).",
 	inputSchema: z.object({
 		table_ids: z
 			.array(z.string())
@@ -135,18 +126,11 @@ export const beginSessionTool = toolDefinition({
 			.describe(
 				"The typed table ids to compose into the session (from list_tables).",
 			),
-		session_id: z
-			.string()
-			.optional()
-			.describe(
-				"Optional session id; omit to start a fresh session, pass one to re-run it after teaching.",
-			),
 	}),
 	outputSchema: withAgentError(
 		z.object({
 			workflow_id: z.string(),
 			run_id: z.string(),
-			session_id: z.string(),
 			table_ids: z.array(z.string()),
 		}),
 	),

--- a/packages/cockpit/src/tools/operating-model.test.ts
+++ b/packages/cockpit/src/tools/operating-model.test.ts
@@ -74,15 +74,15 @@ beforeEach(() => {
 });
 
 describe("operatingModel (DAT-440, routed via the journey — DAT-530)", () => {
-	it("signals the journey with the derived ids/queue + verticals + the session", async () => {
+	it("signals the journey with the derived ids/queue + verticals", async () => {
 		h.vertical = "finance";
-		const result = await operatingModel({ session_id: "sess-1" });
+		const result = await operatingModel();
 		if ("error" in result) throw new Error(`unexpected: ${result.error}`);
 
+		// One workflow id per workspace (DAT-562) — no session arg.
 		expect(h.signalled?.workspaceId).toBe(WS);
 		expect(h.signalled?.req).toEqual({
-			sessionId: "sess-1",
-			workflowId: `operatingmodel-${WS}-sess-1`,
+			workflowId: `operatingmodel-${WS}`,
 			engineTaskQueue: `engine-${WS}`,
 			verticals: ["finance"],
 			conversationId: "conv-1",
@@ -90,22 +90,21 @@ describe("operatingModel (DAT-440, routed via the journey — DAT-530)", () => {
 		// The tool returns the deterministic workflow id (run_id mirrors it — the
 		// journey owns the real execution id; progress resolves latest by id).
 		expect(result).toEqual({
-			workflow_id: `operatingmodel-${WS}-sess-1`,
-			run_id: `operatingmodel-${WS}-sess-1`,
-			session_id: "sess-1",
+			workflow_id: `operatingmodel-${WS}`,
+			run_id: `operatingmodel-${WS}`,
 		});
 	});
 
 	it("threads a NULL conversationId when outside a chat turn (non-narrating run)", async () => {
 		h.conversationId = null;
-		const result = await operatingModel({ session_id: "sess-1" });
+		const result = await operatingModel();
 		if ("error" in result) throw new Error(`unexpected: ${result.error}`);
 		expect(h.signalled?.req.conversationId).toBeNull();
 	});
 
 	it("throws when Temporal is unconfigured and signals nothing", async () => {
 		h.config = { dataraumWorkspaceId: WS };
-		await expect(operatingModel({ session_id: "sess-1" })).rejects.toThrow(
+		await expect(operatingModel()).rejects.toThrow(
 			/Temporal client is not configured/,
 		);
 		expect(h.signalRunOperatingModel).not.toHaveBeenCalled();
@@ -116,15 +115,15 @@ describe("operatingModel (DAT-440, routed via the journey — DAT-530)", () => {
 		// would-be workflow failure into an agent-actionable sentence — and must
 		// NOT signal the journey.
 		h.hasRunningRun.mockResolvedValueOnce(true);
-		const result = await operatingModel({ session_id: "sess-1" });
+		const result = await operatingModel();
 		expect(result).toMatchObject({
 			error: expect.stringContaining("begin_session is still running"),
 		});
 		expect(h.signalRunOperatingModel).not.toHaveBeenCalled();
 	});
 
-	it("checks the begin_session stage for the requested session", async () => {
-		await operatingModel({ session_id: "sess-1" });
-		expect(h.hasRunningRun).toHaveBeenCalledWith("sess-1", "begin_session");
+	it("checks the begin_session stage for the workspace", async () => {
+		await operatingModel();
+		expect(h.hasRunningRun).toHaveBeenCalledWith(WS, "begin_session");
 	});
 });

--- a/packages/cockpit/src/tools/operating-model.ts
+++ b/packages/cockpit/src/tools/operating-model.ts
@@ -34,34 +34,32 @@ import { signalRunOperatingModel } from "../temporal/journey-trigger";
 import { operatingModelWorkflowId } from "../temporal/workflow-id";
 import { type AgentError, withAgentError } from "./agent-error";
 
-export interface OperatingModelToolInput {
-	// The begin_session session to run the stage over — its table set anchors
-	// the run; the engine re-reads it from the catalog head's run_tables (DAT-506).
-	session_id: string;
-}
+// No input: operating_model re-runs the WORKSPACE's begin_session result (DAT-562
+// retired the session id — the engine re-reads the table set from the catalog head's
+// run_tables, DAT-506). The tool is the manual re-trigger; the autonomous cascade
+// runs it automatically after a clean begin_session.
+export type OperatingModelToolInput = Record<string, never>;
 
 export interface OperatingModelToolResult {
-	// The deterministic engine workflow id (`operatingmodel-<ws>-<session>`).
-	// Progress is polled by this id (the latest execution); the journey owns the
-	// real run id.
+	// The deterministic engine workflow id (`operatingmodel-<ws>`). Progress is
+	// polled by this id (the latest execution); the journey owns the real run id.
 	workflow_id: string;
 	// Kept for the result contract; equals workflow_id (the journey starts the run,
 	// so no Temporal execution id is known at tool-return time — progress resolves
 	// the latest run by workflow_id, DAT-530).
 	run_id: string;
-	session_id: string;
 }
 
 /**
  * Signal the workspace's JourneyWorkflow to run an operating_model stage (the
- * manual re-trigger). Returns the deterministic workflow + session id immediately;
+ * manual re-trigger). Returns the deterministic workflow id immediately;
  * the journey records the run (authoritative) and starts + awaits the engine child,
  * narrating completion into this chat. The caller does NOT poll. Read the outcome
  * via `look_validation`.
  */
-export async function operatingModel(
-	input: OperatingModelToolInput,
-): Promise<OperatingModelToolResult | AgentError> {
+export async function operatingModel(): Promise<
+	OperatingModelToolResult | AgentError
+> {
 	if (!config.temporalHost || !config.temporalNamespace) {
 		throw new Error(
 			"Temporal client is not configured. Set TEMPORAL_HOST, " +
@@ -69,31 +67,30 @@ export async function operatingModel(
 		);
 	}
 
+	// The active workspace ROW (DAT-461/505/506): the source of truth for the engine
+	// task queue (`engine-<id>`) and the frame `vertical` (a workspace property).
+	const workspace = await resolveActiveWorkspaceRow();
+
 	// Sequencing pre-check (DAT-511): the operating model grounds on the
 	// promoted begin_session workspace — starting it mid-session pins an empty
 	// relationship context (the engine refuses born-loud; this check turns
 	// that workflow failure into an agent-actionable sentence instead).
-	if (await hasRunningRun(input.session_id, "begin_session")) {
+	if (await hasRunningRun(workspace.id, "begin_session")) {
 		return {
 			error:
-				`begin_session is still running for session '${input.session_id}' — ` +
-				"the operating model grounds on the session's promoted workspace. " +
-				"Wait for the session to finish (you'll be told when it does), " +
-				"then run operating_model again.",
+				"begin_session is still running — the operating model grounds on the " +
+				"session's promoted workspace. Wait for it to finish (you'll be told " +
+				"when it does), then run operating_model again.",
 		};
 	}
 
-	// The active workspace ROW (DAT-461/505/506): the source of truth for the engine
-	// task queue (`engine-<id>`) and the frame `vertical` (a workspace property).
-	const workspace = await resolveActiveWorkspaceRow();
-	const workflowId = operatingModelWorkflowId(workspace.id, input.session_id);
+	const workflowId = operatingModelWorkflowId(workspace.id);
 
 	// Signal the journey to run the stage. The tool passes the derived ids/queue +
 	// verticals + the originating conversationId (captured from the request-scoped
 	// ALS HERE, while we're still in the chat turn — the journey has none). The
 	// journey records the run authoritatively and starts the engine child.
 	await signalRunOperatingModel(workspace.id, {
-		sessionId: input.session_id,
 		workflowId,
 		engineTaskQueue: workspace.taskQueue,
 		verticals: [workspace.vertical],
@@ -103,7 +100,6 @@ export async function operatingModel(
 	return {
 		workflow_id: workflowId,
 		run_id: workflowId,
-		session_id: input.session_id,
 	};
 }
 
@@ -116,31 +112,23 @@ export async function operatingModel(
 export const operatingModelTool = toolDefinition({
 	name: "operating_model",
 	description:
-		"Re-run the operating-model stage over a begin_session session: take the " +
-		"vertical's declared validations through their lifecycle — ground each " +
-		"against the session's tables and execute the ones that bind; a " +
+		"Re-run the operating-model stage over the workspace's begin_session result: " +
+		"take the vertical's declared validations through their lifecycle — ground " +
+		"each against the workspace's tables and execute the ones that bind; a " +
 		"validation that cannot run stays visible with the reason. NOTE: a " +
 		"successful begin_session AUTOMATICALLY runs operating_model — only call " +
-		"this to RE-run after teaching. Runs engine processing + LLM calls. " +
-		"Returns the workflow_id + " +
-		"run_id; the run proceeds in the background and its progress shows live " +
-		"in the canvas — you'll be told automatically when it finishes, so don't " +
-		"poll for status; then use look_validation to see the outcomes. " +
-		"Re-running the same session_id re-evaluates its validations. " +
-		"Precondition: the session's begin_session run must have FINISHED — " +
-		"while it is still running this returns { error } instead of starting.",
-	inputSchema: z.object({
-		session_id: z
-			.string()
-			.describe(
-				"The begin_session session to run the stage over (its session_id; the engine re-reads the session's table set).",
-			),
-	}),
+		"this to RE-run after teaching (no arguments). Runs engine processing + LLM " +
+		"calls. Returns the workflow_id + run_id; the run proceeds in the background " +
+		"and its progress shows live in the canvas — you'll be told automatically " +
+		"when it finishes, so don't poll for status; then use look_validation to see " +
+		"the outcomes. Precondition: the workspace's begin_session run must have " +
+		"FINISHED — while it is still running this returns { error } instead of " +
+		"starting.",
+	inputSchema: z.object({}),
 	outputSchema: withAgentError(
 		z.object({
 			workflow_id: z.string(),
 			run_id: z.string(),
-			session_id: z.string(),
 		}),
 	),
-}).server((input) => operatingModel(input));
+}).server(() => operatingModel());

--- a/packages/cockpit/src/tools/replay.test.ts
+++ b/packages/cockpit/src/tools/replay.test.ts
@@ -1,16 +1,17 @@
 // Unit tests for the replay tool (DAT-343, DAT-413, DAT-422, DAT-506; routed
-// through the journey in DAT-551).
+// through the journey in DAT-551; session retired in DAT-562).
 //
-// Replay takes a SESSION (the named analytical unit the agent thinks in),
-// resolves the workspace's currently-imported sources, and re-runs add_source over
-// them as a NEW session. DAT-551: it no longer starts the workflow directly — it
-// signals the per-workspace JourneyWorkflow (`runAddSource`, kind "replay"), which
-// records the run + starts the engine child. So the unit asserts the SIGNAL
-// payload. The source resolution + "nothing to replay" guards stay request-side.
+// Replay takes NO input: it resolves the workspace's currently-imported sources and
+// re-runs add_source over them to apply pending teaches. DAT-551: it signals the
+// per-workspace JourneyWorkflow (`runAddSource`, kind "replay"), which records the
+// run + starts the engine child. DAT-562: the run REUSES the workspace's
+// `addsource-<ws>` workflow id (so a replay that resolves a parked grounding gap
+// self-clears the inbox). So the unit asserts the SIGNAL payload. The source
+// resolution + "nothing to replay" guard stay request-side.
 //
 // Mocks: `#/config`, the cockpit registry, the Drizzle metadata client
-// (generation-head → source ids), the journey trigger (signalRunAddSource), the ALS
-// conversation context, and the current-session resolver.
+// (generation-head → source ids), the journey trigger (signalRunAddSource), and the
+// ALS conversation context.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -33,8 +34,6 @@ const h = vi.hoisted(() => ({
 	// Rows the generation-head → run_tables → tables source query returns
 	// (empty = nothing imported = nothing to replay).
 	sourceRows: [] as Array<{ sourceId: string | null }>,
-	// The current session currentSessionId() resolves (null = none — replay rejects).
-	currentSession: null as string | null,
 	signalRunAddSource: vi.fn(
 		async (workspaceId: string, req: Record<string, unknown>) => {
 			h.signalled = { workspaceId, req };
@@ -91,10 +90,6 @@ vi.mock("#/temporal/journey-trigger", () => ({
 vi.mock("#/lib/run-context", () => ({
 	currentConversationId: () => h.conversationId,
 }));
-// The current-session resolver replay falls back to when no session_id is given.
-vi.mock("#/prompts/workspace-context", () => ({
-	currentSessionId: async () => h.currentSession,
-}));
 
 import { replay } from "./replay";
 
@@ -109,31 +104,29 @@ beforeEach(() => {
 	h.calls = [];
 	h.signalled = null;
 	h.sourceRows = [{ sourceId: "src-1" }];
-	h.currentSession = null;
 	h.signalRunAddSource.mockClear();
 });
 
-describe("replay (DAT-422, routed via the journey — DAT-551)", () => {
-	it("resolves the workspace sources, then signals the journey for a FRESH session", async () => {
-		const result = await replay({ session_id: "old-sess" });
+describe("replay (DAT-422, routed via the journey — DAT-551, DAT-562)", () => {
+	it("resolves the workspace sources, then signals the journey", async () => {
+		const result = await replay({});
 
 		// Order: resolve the workspace's imported sources (generation heads), then
-		// signal the journey to run the NEW add_source.
+		// signal the journey to run add_source.
 		expect(h.calls).toEqual(["resolveSources", "signal"]);
-		// A FRESH session — not the one being replayed.
-		expect(result.session_id).not.toBe("old-sess");
+		expect(result.sources).toEqual(["src-1"]);
 	});
 
 	it("signals the journey with the resolved source SET + kind replay + verticals", async () => {
 		h.sourceRows = [{ sourceId: "src-1" }, { sourceId: "src-2" }];
 		h.vertical = "finance";
-		const result = await replay({ session_id: "old-sess" });
-		const newSessionId = result.session_id;
+		const result = await replay({});
 
+		// One workflow id per workspace (DAT-562) — reused across imports/replays so a
+		// replay that resolves a parked grounding gap self-clears the inbox.
 		expect(h.signalled?.workspaceId).toBe(WS);
 		expect(h.signalled?.req).toEqual({
-			sessionId: newSessionId,
-			workflowId: `addsource-${WS}-${newSessionId}`,
+			workflowId: `addsource-${WS}`,
 			engineTaskQueue: `engine-${WS}`,
 			sources: ["src-1", "src-2"],
 			verticals: ["finance"],
@@ -141,40 +134,21 @@ describe("replay (DAT-422, routed via the journey — DAT-551)", () => {
 			conversationId: "conv-1",
 		});
 		expect(result).toEqual({
-			workflow_id: `addsource-${WS}-${newSessionId}`,
-			run_id: `addsource-${WS}-${newSessionId}`,
+			workflow_id: `addsource-${WS}`,
+			run_id: `addsource-${WS}`,
 			sources: ["src-1", "src-2"],
-			session_id: newSessionId,
 		});
 	});
 
 	it("rejects when the workspace has no imported sources (nothing to replay) — no signal", async () => {
 		h.sourceRows = [];
-		await expect(replay({ session_id: "empty-sess" })).rejects.toThrow(
-			/no imported sources/,
-		);
-		expect(h.signalRunAddSource).not.toHaveBeenCalled();
-	});
-
-	it("defaults to the CURRENT session when no session_id is given (bare 'replay')", async () => {
-		h.currentSession = "current-sess";
-		h.sourceRows = [{ sourceId: "src-1" }];
-		const result = await replay({});
-		expect(h.calls).toEqual(["resolveSources", "signal"]);
-		expect(result.sources).toEqual(["src-1"]);
-		// It re-ran the current session into a FRESH one (replay is non-destructive).
-		expect(result.session_id).not.toBe("current-sess");
-	});
-
-	it("rejects when there is no current session to replay", async () => {
-		h.currentSession = null;
-		await expect(replay({})).rejects.toThrow(/No session to replay/);
+		await expect(replay({})).rejects.toThrow(/no imported sources/);
 		expect(h.signalRunAddSource).not.toHaveBeenCalled();
 	});
 
 	it("throws when Temporal is unconfigured and does NOT read or signal", async () => {
 		h.config = { dataraumWorkspaceId: WS };
-		await expect(replay({ session_id: "old-sess" })).rejects.toThrow(
+		await expect(replay({})).rejects.toThrow(
 			/Temporal client is not configured/,
 		);
 		expect(h.calls).toEqual([]); // the guard is first — nothing ran
@@ -183,13 +157,13 @@ describe("replay (DAT-422, routed via the journey — DAT-551)", () => {
 
 	it("threads a NULL conversationId when outside a chat turn", async () => {
 		h.conversationId = null;
-		await replay({ session_id: "old-sess" });
+		await replay({});
 		expect(h.signalled?.req.conversationId).toBeNull();
 	});
 
 	it("re-runs on the WORKSPACE vertical (from the registry) as a one-element array", async () => {
 		h.vertical = "marketing";
-		await replay({ session_id: "old-sess" });
+		await replay({});
 		expect(h.signalled?.req.verticals).toEqual(["marketing"]);
 	});
 });

--- a/packages/cockpit/src/tools/replay.ts
+++ b/packages/cockpit/src/tools/replay.ts
@@ -1,34 +1,28 @@
-// Replay tool (DAT-343, DAT-413, DAT-422) — re-run a SESSION to apply pending
-// teaches as a full add_source re-run under a fresh run_id.
+// Replay tool (DAT-343, DAT-413, DAT-422, DAT-562) — re-run the workspace's
+// imported sources through add_source to apply pending teaches.
 //
-// The agent thinks in SESSIONS (the only named analytical unit), not sources —
-// so replay takes a `session_id` (the user's replay intent), and re-runs
-// add_source over the workspace's CURRENT imported source set as a NEW session.
-// In single-active-workspace (Phase 1) that set IS the named session's sources;
-// resolving a per-session source set (an older session, not the current one) is
-// DAT-357 — see workspaceSources. A replay generates a NEW session: a fresh
-// analytical pass over the same data (transparent — the agent replays the session
-// it knows and gets a new one back). The engine mints a fresh `run_id` internally
-// (versioned metadata, append-only snapshots); there is no scope or from_phase to
-// choose — a replay is always a full, non-destructive re-run that re-reads the
-// durable teach overlays.
+// Replay takes NO input (DAT-562 retired the cockpit session): it resolves the
+// workspace's CURRENT imported source set (the generation heads) and re-runs
+// add_source over it. The engine mints a fresh `run_id` internally (versioned
+// metadata, append-only snapshots); there is no scope or from_phase to choose — a
+// replay is always a full, non-destructive re-run that re-reads the durable teach
+// overlays.
 //
 // Pure compute kick (DAT-551: routed through the JourneyWorkflow — it SIGNALS the
-// per-workspace journey, which records the run + starts the child): a fresh
-// `addSourceWorkflow` keyed by the NEW session
-// (`addsource-<workspace_id>-<session_id>`; see workflow-id.ts, DAT-422 — a run
-// is keyed by its session) and returns the workflow id + run id immediately; the
-// caller polls / queries Temporal for progress. End-to-end "replay actually
-// produces clean output" coverage lives in the integration smoke that drives the
-// running stack.
+// per-workspace journey, which records the run + starts the child): it REUSES the
+// workspace's `addsource-<workspace_id>` workflow id (see workflow-id.ts — one id
+// per workspace) and returns the workflow id + run id immediately; the caller polls
+// / queries Temporal for progress. Reusing the id is what makes a replay that
+// resolves a parked grounding gap self-clear the "Needs you" inbox (the parked
+// run's workflow gets a newer run — see openAwaitingItem). End-to-end "replay
+// actually produces clean output" coverage lives in the integration smoke that
+// drives the running stack.
 //
-// No engine seed (DAT-506): sessions live in cockpit_db, and the run's table set
-// is anchored by `run_tables` (keyed by `run_id`), not `session_tables`. The new
-// replay session + run are recorded by the JOURNEY in cockpit_db AUTHORITATIVELY
+// No engine seed (DAT-506): the run's table set is anchored by `run_tables` (keyed
+// by `run_id`). The run is recorded by the JOURNEY in cockpit_db AUTHORITATIVELY
 // BEFORE the child starts (DAT-551). The `vertical` is the workspace property,
 // sourced from the registry (DAT-506 retired the per-session vertical pick).
 
-import { randomUUID } from "node:crypto";
 import { toolDefinition } from "@tanstack/ai";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -39,7 +33,6 @@ import { metadataDb } from "../db/metadata/client";
 import { GENERATION_STAGE } from "../db/metadata/relationship-target";
 import { metadataSnapshotHead, runTables, tables } from "../db/metadata/schema";
 import { currentConversationId } from "../lib/run-context";
-import { currentSessionId } from "../prompts/workspace-context";
 import { signalRunAddSource } from "../temporal/journey-trigger";
 import { addSourceWorkflowId } from "../temporal/workflow-id";
 import {
@@ -54,17 +47,10 @@ import {
  * of objects from 1–N sources (DAT-422); replay re-runs add_source over exactly
  * the workspace's current set.
  *
- * Why the generation heads, not a per-session join: post-DAT-506 the engine mints
- * its own internal `run_id` (the version axis) and persists `run_tables` keyed by
- * it — the cockpit never sees that id (it only holds the Temporal execution runId),
- * and no engine table carries the cockpit `session_id`. So a session→run_tables
- * join is impossible at the cockpit edge. The live generation heads ARE the
- * workspace's current typed-table set (one head per table → its run_id → run_tables
- * → tables → source), which in single-active-workspace (Phase 1) is exactly the
- * replayed session's sources. True per-session scoping (replaying an OLDER session's
- * source set, not the workspace's current one) waits on the multi-workspace switcher
- * (DAT-357); until then the resolution is workspace-current.
- * Empty when nothing is imported yet (the caller rejects that — nothing to replay).
+ * The live generation heads ARE the workspace's current typed-table set (one head
+ * per table → its run_id → run_tables → tables → source), so replay re-runs over
+ * exactly that set. Empty when nothing is imported yet (the caller rejects that —
+ * nothing to replay).
  */
 async function workspaceSources(): Promise<string[]> {
 	const rows = await metadataDb
@@ -78,33 +64,29 @@ async function workspaceSources(): Promise<string[]> {
 		.filter((id): id is string => id !== null && id !== undefined);
 }
 
-export interface ReplayInput {
-	// The session to replay. OPTIONAL: omitted, replay re-runs the CURRENT session
-	// (the most recent — the one the user has been teaching). Replay resolves the
-	// session's sources and re-runs add_source over them as a NEW session, applying
-	// any pending teaches.
-	session_id?: string;
-}
+// Replay takes no input (DAT-562): it re-runs add_source over the workspace's
+// current imported sources to apply pending teaches. There is no session to name —
+// the workspace's generation heads ARE what gets re-run.
+export type ReplayInput = Record<string, never>;
 
 export interface ReplayResult {
 	workflow_id: string;
 	run_id: string;
-	// The sources the new run re-ingested (resolved from the replayed session).
+	// The sources the run re-ingested (the workspace's current imported set).
 	sources: string[];
-	// The NEW session the replay created (≠ the replayed session_id).
-	session_id: string;
 }
 
 /**
  * Signal the journey to run a fresh `addSourceWorkflow` that re-applies pending
- * teaches as a full re-run of a session's sources (DAT-551). Returns immediately
- * with the workflow + session id; the journey records the run + starts the child,
+ * teaches as a full re-run of the workspace's current sources (DAT-551). Returns
+ * immediately with the workflow id; the journey records the run + starts the child,
  * and progress resolves the latest execution by workflow id (run_id mirrors it).
  *
- * The new run is keyed by the fresh session (`addsource-<workspace_id>-<session_id>`,
- * DAT-422) — each replay is its own session, so it is a distinct workflow id.
+ * The run REUSES the workspace's `addsource-<ws>` workflow id (DAT-562) — so a
+ * replay that resolves a parked grounding gap appends a newer run under the SAME id,
+ * which is exactly what self-clears the "Needs you" inbox (openAwaitingItem).
  */
-export async function replay(input: ReplayInput): Promise<ReplayResult> {
+export async function replay(_input: ReplayInput): Promise<ReplayResult> {
 	if (!config.temporalHost || !config.temporalNamespace) {
 		throw new Error(
 			"Temporal client is not configured. Set TEMPORAL_HOST, " +
@@ -112,19 +94,8 @@ export async function replay(input: ReplayInput): Promise<ReplayResult> {
 		);
 	}
 
-	// The session to replay: the one named, else the CURRENT session (most recent —
-	// the one the user is in / has been teaching). So a bare "replay" just works.
-	const sessionId = input.session_id ?? (await currentSessionId());
-	if (!sessionId) {
-		throw new AgentActionableError(
-			"No session to replay — add a source or begin a session first.",
-		);
-	}
-
-	// Resolve what to replay — the workspace's current source set (DAT-506: no
-	// per-session join exists at the cockpit edge; true per-session scoping is
-	// DAT-357). `sessionId` gates the user's intent + names the run; it does not
-	// scope the resolution.
+	// Resolve what to replay — the workspace's current source set (the generation
+	// heads). Empty ⇒ nothing has been imported yet, so there is nothing to replay.
 	const replaySources = await workspaceSources();
 	if (replaySources.length === 0) {
 		throw new AgentActionableError(
@@ -134,12 +105,9 @@ export async function replay(input: ReplayInput): Promise<ReplayResult> {
 	}
 
 	const workspace = await resolveActiveWorkspaceRow();
-	// A replay generates a NEW session — a fresh analytical pass over the same
-	// sources. The id is fresh, so the journey records a clean insert.
-	const newSessionId = randomUUID();
-	const workflowId = addSourceWorkflowId(workspace.id, newSessionId);
+	const workflowId = addSourceWorkflowId(workspace.id);
 
-	// Signal the journey to run the stage (DAT-551). kind:"replay" marks the session
+	// Signal the journey to run the stage (DAT-551). kind:"replay" marks the run
 	// origin; the journey records the run authoritatively + starts the engine child
 	// on the workspace's OWN queue (DAT-505), re-reading the durable teach overlays.
 	// The conversationId is captured HERE (request ALS) so the run narrates into THIS
@@ -147,7 +115,6 @@ export async function replay(input: ReplayInput): Promise<ReplayResult> {
 	// on >1); the engine scopes each `import` to one source + resolves provenance
 	// relationally past import.
 	await signalRunAddSource(workspace.id, {
-		sessionId: newSessionId,
 		workflowId,
 		engineTaskQueue: workspace.taskQueue,
 		sources: replaySources,
@@ -162,7 +129,6 @@ export async function replay(input: ReplayInput): Promise<ReplayResult> {
 		workflow_id: workflowId,
 		run_id: workflowId,
 		sources: replaySources,
-		session_id: newSessionId,
 	};
 }
 
@@ -174,24 +140,16 @@ export async function replay(input: ReplayInput): Promise<ReplayResult> {
 export const replayTool = toolDefinition({
 	name: "replay",
 	description:
-		"Replay a session — re-run the sources it was built from through add_source as a NEW session to apply pending teaches. A full, non-destructive re-run under a fresh run_id (no scope to choose). Omit session_id to replay the CURRENT session (from the WORKSPACE CONTEXT) — a bare 'replay' re-runs the session the user has been teaching. Returns the workflow_id + run_id; the run proceeds durably in the background and its progress renders live in the canvas — you'll be told automatically when it finishes, so don't poll for status.",
-	inputSchema: z.object({
-		session_id: z
-			.string()
-			.optional()
-			.describe(
-				"Optional. The session to replay (a session_id, e.g. from the WORKSPACE CONTEXT block or a prior add_source / begin_session). Omit to replay the CURRENT (most recent) session.",
-			),
-	}),
-	// Success OR `{ error }`: "no session to replay" / "session has no sources"
-	// are the agent's to fix (add a source / begin a session first), so they come
-	// back as data. A missing Temporal config is infra → still throws (pass 2b).
+		"Replay — re-run the workspace's current imported sources through add_source to apply pending teaches. A full, non-destructive re-run under a fresh run_id (no scope or session to choose; takes no arguments). Returns the workflow_id + run_id; the run proceeds durably in the background and its progress renders live in the canvas — you'll be told automatically when it finishes, so don't poll for status.",
+	inputSchema: z.object({}),
+	// Success OR `{ error }`: "nothing to replay" (no imported sources yet) is the
+	// agent's to fix (add a source first), so it comes back as data. A missing
+	// Temporal config is infra → still throws (pass 2b).
 	outputSchema: withAgentError(
 		z.object({
 			workflow_id: z.string(),
 			run_id: z.string(),
 			sources: z.array(z.string()),
-			session_id: z.string(),
 		}),
 	),
 }).server((input) => catchActionable(() => replay(input)));

--- a/packages/cockpit/src/tools/select.test.ts
+++ b/packages/cockpit/src/tools/select.test.ts
@@ -442,16 +442,15 @@ describe("select — upsert", () => {
 
 describe("select — one call (DAT-436)", () => {
 	// The injected trigger stub: records its input + the call order and hands
-	// back a fixed run identity (the real triggerAddSource seeds the session +
+	// back a fixed run identity (the real triggerAddSource signals the journey +
 	// starts addSourceWorkflow — its own unit test covers that).
 	function makeTrigger() {
 		return vi.fn(async (input: { sources: string[] }) => {
 			preflight.calls.push("trigger");
 			return {
-				workflow_id: "addsource-ws-sess",
+				workflow_id: "addsource-ws",
 				run_id: "run-1",
 				sources: input.sources,
-				cockpit_session_id: "sess-1",
 			};
 		});
 	}
@@ -473,9 +472,8 @@ describe("select — one call (DAT-436)", () => {
 
 		// The result merges the persisted descriptor with the run identity — the
 		// canvas keys its progress poll on these ids.
-		expect(result.workflow_id).toBe("addsource-ws-sess");
+		expect(result.workflow_id).toBe("addsource-ws");
 		expect(result.run_id).toBe("run-1");
-		expect(result.session_id).toBe("sess-1");
 		expect(result.name).toBe("orders.csv");
 	});
 
@@ -521,7 +519,7 @@ describe("select — one call (DAT-436)", () => {
 		expect(trigger).toHaveBeenCalledWith({
 			sources: result.sources,
 		});
-		expect(result.workflow_id).toBe("addsource-ws-sess");
+		expect(result.workflow_id).toBe("addsource-ws");
 		expect(result.run_id).toBe("run-1");
 	});
 });

--- a/packages/cockpit/src/tools/select.ts
+++ b/packages/cockpit/src/tools/select.ts
@@ -18,8 +18,8 @@
 //
 // Order inside the call: the source upsert(s); then the trigger (records the run
 // in cockpit_db, then the non-blocking workflow.start — temporal/trigger-add-
-// source.ts). The result carries the workflow/run/session ids so the progress
-// canvas member follows immediately. The vertical is a workspace property now
+// source.ts). The result carries the workflow/run ids so the progress canvas member
+// follows immediately. The vertical is a workspace property now
 // (DAT-506) — sourced by the trigger from the registry, NOT a select input, so
 // there is no per-add_source concept pre-flight.
 //
@@ -86,8 +86,8 @@ const STAGE_AFTER_SELECT = "add_source";
 const INITIAL_STATUS = "configured";
 
 /** The persisted Source descriptor + the started run's identity. The
- * workflow/run/session ids are what the progress canvas member keys its
- * `get_progress` poll on (tool-result-to-canvas.ts, replay precedent). */
+ * workflow/run ids are what the progress canvas member keys its `get_progress`
+ * poll on (tool-result-to-canvas.ts, replay precedent). */
 export const SelectResult = z.object({
 	// Every source `select` minted/UPSERTed for this selection — the SET the
 	// add_source run ingests (DAT-422). N for a file selection (one content-keyed
@@ -111,10 +111,10 @@ export const SelectResult = z.object({
 		.nullable(),
 	// The started addSourceWorkflow run (DAT-436: calling select STARTS the
 	// import). workflow_id + run_id pin the precise execution the progress
-	// canvas polls; session_id is the run's cockpit_db session.
+	// canvas polls (DAT-562 retired the cockpit session id — runs group by
+	// workspace, the workflow id is `addsource-<ws>`).
 	workflow_id: z.string(),
 	run_id: z.string(),
-	session_id: z.string(),
 });
 export type SelectResult = z.infer<typeof SelectResult>;
 
@@ -123,10 +123,7 @@ export type SelectResult = z.infer<typeof SelectResult>;
  * integration smoke drives `persistSelection` directly (row-shape contract
  * against a real Postgres; starting a real workflow is the compose smoke's
  * job). */
-export type PersistedSelection = Omit<
-	SelectResult,
-	"workflow_id" | "run_id" | "session_id"
->;
+export type PersistedSelection = Omit<SelectResult, "workflow_id" | "run_id">;
 
 export interface SelectInput {
 	// Database source only: the unique source name (lowercase, starts with a
@@ -414,7 +411,6 @@ export async function select(
 		...selection,
 		workflow_id: run.workflow_id,
 		run_id: run.run_id,
-		session_id: run.cockpit_session_id,
 	};
 }
 

--- a/packages/cockpit/src/ui/runs/needs-you-panel.test.tsx
+++ b/packages/cockpit/src/ui/runs/needs-you-panel.test.tsx
@@ -8,10 +8,9 @@ import { NeedsYouPanel } from "#/ui/runs/needs-you-panel";
 
 function item(over: Partial<AwaitingInputItem> = {}): AwaitingInputItem {
 	return {
-		workflowId: "addsource-ws-1-abc",
+		workflowId: "addsource-ws-1",
 		stage: "add_source",
 		awaitingNote: "columns 'vid' and 'pt' have unclear meaning",
-		engineSessionId: "eng-sess-1",
 		startedAt: new Date("2026-06-17T06:58:27.925Z"),
 		...over,
 	};
@@ -38,7 +37,7 @@ describe("NeedsYouPanel (DAT-553)", () => {
 		renderPanel([
 			item(),
 			item({
-				engineSessionId: "eng-sess-2",
+				workflowId: "beginsession-ws-1",
 				stage: "begin_session",
 				awaitingNote: "needs a concept",
 			}),

--- a/packages/cockpit/src/ui/runs/needs-you-panel.tsx
+++ b/packages/cockpit/src/ui/runs/needs-you-panel.tsx
@@ -36,7 +36,7 @@ export function NeedsYouPanel({ items, onResolve }: NeedsYouPanelProps) {
 				</Text>
 				{items.map((item) => (
 					<Group
-						key={item.engineSessionId}
+						key={item.workflowId}
 						justify="space-between"
 						wrap="nowrap"
 						data-testid="needs-you-item"

--- a/packages/cockpit/src/ui/runs/run-row.ts
+++ b/packages/cockpit/src/ui/runs/run-row.ts
@@ -2,7 +2,7 @@
 // a SSR-safe timestamp format. Extracted as a .ts module with its own tests
 // (cockpit React rule 10); the component stays a pure render over these.
 
-/** Human label for a run stage (the `session_runs.stage` varchar). */
+/** Human label for a run stage (the `runs.stage` varchar). */
 const STAGE_LABEL: Record<string, string> = {
 	add_source: "Add source",
 	begin_session: "Begin session",

--- a/packages/cockpit/src/worker/contracts.ts
+++ b/packages/cockpit/src/worker/contracts.ts
@@ -37,9 +37,8 @@ export const RUN_ADD_SOURCE_SIGNAL = "runAddSource";
  * — `onboarding` (select) and `replay` — unlike begin_session (always one kind);
  * the journey threads it to `recordRun`. */
 export interface RunAddSource {
-	/** Cockpit-minted session id (run-correlation key + workflow-id segment). */
-	sessionId: string;
-	/** The deterministic engine workflow id (tool-computed via addSourceWorkflowId). */
+	/** The deterministic engine workflow id (`addsource-<ws>`, tool-computed via
+	 * addSourceWorkflowId). One per workspace — DAT-562 retired the session segment. */
 	workflowId: string;
 	/** The workspace's engine task queue (`engine-<id>`) the child runs on. */
 	engineTaskQueue: string;
@@ -65,10 +64,9 @@ export const RUN_BEGIN_SESSION_SIGNAL = "runBeginSession";
  * the derived values and passes them, so the sandboxed journey stays free of any
  * workspace IO — it just orchestrates the child + records the run. */
 export interface RunBeginSession {
-	/** Cockpit-minted session id (the run-correlation key + workflow-id segment). */
-	sessionId: string;
-	/** The deterministic engine workflow id (tool-computed via beginSessionWorkflowId);
-	 * the journey starts the child + records the run under it. Stable across re-runs. */
+	/** The deterministic engine workflow id (`beginsession-<ws>`, tool-computed via
+	 * beginSessionWorkflowId); the journey starts the child + records the run under
+	 * it. One per workspace, stable across re-runs (DAT-562). */
 	workflowId: string;
 	/** The workspace's engine task queue (`engine-<id>`) the child runs on. */
 	engineTaskQueue: string;
@@ -88,13 +86,12 @@ export interface RunBeginSession {
 export const RUN_OPERATING_MODEL_SIGNAL = "runOperatingModel";
 
 /** Payload of `runOperatingModel`. Like {@link RunBeginSession} but for the third
- * stage — no `tables` (the engine re-reads the session's table set from the catalog
- * head; DAT-506). A manual re-trigger always runs (it is user-intentional, like
+ * stage — no `tables` (the engine re-reads the table set from the catalog head;
+ * DAT-506). A manual re-trigger always runs (it is user-intentional, like
  * begin_session — the breaker / auto-mode gate only the AUTONOMOUS cascade). */
 export interface RunOperatingModel {
-	/** The begin_session session to run the stage over (run-correlation key). */
-	sessionId: string;
-	/** The deterministic engine workflow id (tool-computed via operatingModelWorkflowId). */
+	/** The deterministic engine workflow id (`operatingmodel-<ws>`, tool-computed via
+	 * operatingModelWorkflowId). One per workspace (DAT-562). */
 	workflowId: string;
 	/** The workspace's engine task queue (`engine-<id>`) the child runs on. */
 	engineTaskQueue: string;

--- a/packages/cockpit/src/worker/workflows/journey.ts
+++ b/packages/cockpit/src/worker/workflows/journey.ts
@@ -145,11 +145,9 @@ async function runChildStage(
 		workflowId: string;
 		taskQueue: string;
 		stage: "add_source" | "begin_session" | "operating_model";
-		// The session origin for recordRun (ignored on conflict — operating_model
-		// reuses begin_session's row): add_source carries onboarding|replay; the
-		// later stages reuse "begin_session".
+		// The run's origin for recordRun (DAT-562 — stored on the run row): add_source
+		// carries onboarding|replay; the later stages use "begin_session".
 		kind: "onboarding" | "begin_session" | "replay";
-		engineSessionId: string;
 		conversationId: string | null;
 		args: unknown[];
 	},
@@ -163,7 +161,6 @@ async function runChildStage(
 		// is what keeps the completion narrating into the originating chat (DAT-528).
 		await recordRun({
 			workspaceId,
-			engineSessionId: spec.engineSessionId,
 			kind: spec.kind,
 			stage: spec.stage,
 			workflowId: spec.workflowId,
@@ -210,7 +207,6 @@ function runAddSourceStage(
 		taskQueue: req.engineTaskQueue,
 		stage: "add_source",
 		kind: req.kind,
-		engineSessionId: req.sessionId,
 		conversationId: req.conversationId,
 		args: [
 			{
@@ -233,7 +229,6 @@ function runBeginSessionStage(
 		taskQueue: req.engineTaskQueue,
 		stage: "begin_session",
 		kind: "begin_session",
-		engineSessionId: req.sessionId,
 		conversationId: req.conversationId,
 		args: [
 			{
@@ -257,9 +252,8 @@ function runOperatingModelStage(
 		workflowId: om.workflowId,
 		taskQueue: om.engineTaskQueue,
 		stage: "operating_model",
-		// Reuses begin_session's session row (recordRun ignores kind on conflict).
+		// The OM run's origin (DAT-562 — stored on the run row, like begin_session's).
 		kind: "begin_session",
-		engineSessionId: om.sessionId,
 		conversationId: om.conversationId,
 		args: [{ workspace_id: workspaceId, verticals: om.verticals }],
 	});
@@ -319,7 +313,7 @@ async function runGroundingLoop(
 			return replays;
 		}
 
-		// action === "replay": re-run add_source for the SAME session to apply the
+		// action === "replay": re-run add_source for the SAME workspace to apply the
 		// teaches + re-measure. A failed replay stops the loop (the run is marked).
 		// conversationId=null: these are INTERNAL autonomous re-runs — they must NOT
 		// each fire the completion-watcher's "import finished" narration (the user
@@ -443,8 +437,7 @@ export async function journeyWorkflow(
 			fold(
 				(
 					await runOperatingModelStage(workspaceId, {
-						sessionId: req.sessionId,
-						workflowId: operatingModelWorkflowId(workspaceId, req.sessionId),
+						workflowId: operatingModelWorkflowId(workspaceId),
 						engineTaskQueue: req.engineTaskQueue,
 						verticals: req.verticals,
 						conversationId: req.conversationId,


### PR DESCRIPTION
## What

Retires the cockpit **`sessions`** concept (epic DAT-526). Post-DAT-506 a cockpit "session" scoped nothing analytical — its id never went on the wire, no engine table carried it, and every stage resolves from the workspace-current generation heads. Yet `triggerAddSource` minted a fresh session UUID **per import** (and `replay` per replay), fragmenting run-grouping and breaking the DAT-553 "Needs you" inbox self-clear on the human-replay path.

Resolved as **Option 3** (refine): retire the concept entirely. Cockpit-only, **no engine change**.

## The cut

- **Schema**: drop `sessions` + `session_runs`; one **`runs`** table FKing `workspaceId` directly, with `kind` (the run's origin) moved onto the row. Migration drops both + creates `runs` (dev-only DB, fresh-on-boot — no data preservation).
- **Workflow ids**: constant-per-workspace `<stage>-<ws>` (1-arg helpers). Safe because the per-workspace `JourneyWorkflow` drains triggers **serially** (two same-stage executions never open at once; Temporal allow-duplicate-when-closed lets re-runs/replays reuse the id; distinct executions still record as distinct `(workflowId, runId)` rows). The engine builds child ids as an opaque `<parent>-table-<id>` prefix and receives no session id on the wire.
- **Contracts**: `sessionId` dropped from the 3 journey signal payloads + journey plumbing + the begin_session→operating_model cascade; `session_id`/minting dropped from `replay` (now takes `{}`), `operating_model` (no args), `begin_session`, `select`, `trigger-add-source`. `recordRun` inserts the run directly (no session upsert/lookup).
- **Prompt**: `currentSessionId`/`recentSessions` deleted; WORKSPACE CONTEXT now names the workspace vertical + imported tables (no churning ids).
- **Bug fix folded in (DAT-553)**: `openAwaitingItem` self-clears on **`workflowId`** — a human replay reuses `addsource-<ws>`, appends a newer run for that workflow, and clears the parked `awaiting_input` item. The old session-scoped predicate never cleared it (replay minted a new session).

## Verification

- `bunx tsc --noEmit` clean · `bunx biome check src` clean · **1219 tests pass**
- **No `packages/engine/` files touched** (cockpit-only)
- Reviewers: senior-code-reviewer **APPROVE**, spec-compliance-reviewer **COMPLIANT**

## Deploy caveat

A *running* per-workspace journey won't adopt the new signal contract until continue-as-new/restart — deploying to active workspaces needs a deliberate journey restart (documented in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)