### PR TITLE
fix(cockpit): make "pending teaches" warning run-relative

### DIFF
--- a/packages/cockpit/src/db/metadata/pending-overlays.ts
+++ b/packages/cockpit/src/db/metadata/pending-overlays.ts
@@ -1,24 +1,41 @@
-// Helper for read tools: list the un-superseded teach rows that affect the
+// Helper for read tools: list the un-applied teach rows that affect the
 // active workspace's view (DAT-343).
 //
-// The consumers — look_table (DAT-350), why_column (DAT-351) — will surface
+// The consumers — look_table (DAT-350), why_column (DAT-351) — surface
 // "N pending teaches affect this view — consider replay first" hints in
 // their chat responses, so the agent knows to call `replay` before
-// believing what it sees. Slice-1 lands the helper here; the consumers
-// import it once they exist.
+// believing what it sees.
 //
-// Returns every active row in the workspace's `ws_<id>` schema (the
-// metadata client's connection already scopes to it via pgSchema — no
-// per-row workspace filter needed post-DAT-343). The caller decides what
-// counts as "affects this view" — some types are source-wide (null_value
-// affects every table), others are table-scoped (type_pattern targets the
-// typed table you're looking at). Pushing that scoping into the helper
-// would bake one consumer's notion of "relevance" in for everyone.
+// "Pending" is run-RELATIVE, not just "not undone": an overlay is pending only
+// when it was created AFTER the most recent metadata-snapshot promotion (the
+// latest `metadata_snapshot_head.promoted_at`). The engine re-reads the active
+// overlays LIVE at the start of every phase (server/overlay_resolver.py — there is
+// no run-start snapshot), then promotes the run's snapshot at the end, so a teach
+// created before that promotion was almost certainly re-read and applied by a
+// later phase; once a run promotes past a teach it IS reflected in the `current_*`
+// views and a replay would NOT change it — surfacing it as pending then is the bug
+// this guards against (the warning was otherwise permanent, since `superseded_at`
+// is only ever set by an explicit undo, never by a replay). The one accepted gap:
+// a teach created in the narrow window after the last phase's overlay read and
+// before promotion is dropped from pending though no phase applied it. With no
+// promoted snapshot yet the anchor is null and every active overlay is pending —
+// nothing has applied them.
+//
+// Returns the active rows in the workspace's `ws_<id>` schema (the metadata
+// client's connection already scopes to it via pgSchema — no per-row workspace
+// filter needed post-DAT-343). The caller decides what counts as "affects this
+// view" — some types are source-wide (null_value affects every table), others are
+// table-scoped (type_pattern targets the typed table you're looking at). Pushing
+// that scoping into the helper would bake one consumer's notion of "relevance" in
+// for everyone; this helper owns only the time axis. (The residual cross-stage gap
+// — a teach only one stage applies, when a different stage has promoted since — is
+// left to that per-type scoping; the anchor is the single latest promotion,
+// workspace-wide across stages.)
 
-import { asc, isNull } from "drizzle-orm";
+import { and, asc, desc, gt, isNull } from "drizzle-orm";
 
 import { metadataDb } from "./client";
-import { configOverlay } from "./schema";
+import { configOverlay, metadataSnapshotHead } from "./schema";
 
 export interface PendingOverlay {
 	overlay_id: string;
@@ -28,11 +45,28 @@ export interface PendingOverlay {
 }
 
 /**
- * Return every active (non-superseded) overlay row for the active workspace,
- * ordered by `created_at` ASC (the order the engine's per-type appliers
- * consume them — last-write-wins for keyed payloads).
+ * Return the PENDING overlay rows for the active workspace — active
+ * (non-superseded) AND created after the most recent snapshot promotion (so a
+ * teach a prior run already applied no longer counts), ordered by `created_at` ASC
+ * (the order the engine's per-type appliers consume them — last-write-wins for
+ * keyed payloads).
  */
 export async function getPendingOverlays(): Promise<PendingOverlay[]> {
+	// The promotion that produced the current view: a teach predating it is already
+	// applied; only teaches created after it are pending a replay. null (no run has
+	// promoted yet) ⇒ every active overlay is pending. Read the latest `promoted_at`
+	// as a plain COLUMN (orderBy + limit), NOT `max()`: drizzle applies the column's
+	// timestamp codec to a column but passes an aggregate expression through the
+	// driver's default decode, which misreads our `timestamp WITHOUT time zone` as
+	// local — a silent skew against `config_overlay.created_at` (decoded by the same
+	// column codec) that would push the anchor hours early.
+	const [head] = await metadataDb
+		.select({ promotedAt: metadataSnapshotHead.promotedAt })
+		.from(metadataSnapshotHead)
+		.orderBy(desc(metadataSnapshotHead.promotedAt))
+		.limit(1);
+	const appliedThrough = head?.promotedAt ?? null;
+
 	const rows = await metadataDb
 		.select({
 			overlayId: configOverlay.overlayId,
@@ -41,7 +75,14 @@ export async function getPendingOverlays(): Promise<PendingOverlay[]> {
 			createdAt: configOverlay.createdAt,
 		})
 		.from(configOverlay)
-		.where(isNull(configOverlay.supersededAt))
+		.where(
+			appliedThrough === null
+				? isNull(configOverlay.supersededAt)
+				: and(
+						isNull(configOverlay.supersededAt),
+						gt(configOverlay.createdAt, appliedThrough),
+					),
+		)
 		.orderBy(asc(configOverlay.createdAt));
 
 	// View columns type as nullable (Postgres views carry no NOT NULL) —

--- a/packages/cockpit/src/tools/teach.integration.test.ts
+++ b/packages/cockpit/src/tools/teach.integration.test.ts
@@ -12,6 +12,10 @@
 //   3. After undo, getPendingOverlays no longer surfaces the row
 //   4. Calling undoTeach on the same row twice is idempotent (no error,
 //      superseded_at unchanged)
+//   5. A teach predating a COMPLETED run is no longer pending — "pending" is
+//      run-relative, not just "not undone" (the permanent-warning fix). Without
+//      this, an applied teach surfaced forever because superseded_at is only set
+//      by undo, never by a replay.
 //
 // Requires a running compose stack (postgres on 127.0.0.1:5432 with the
 // engine-created ws_<id>.config_overlay table). Skipped automatically when
@@ -55,6 +59,8 @@ describe.skipIf(!STACK_AVAILABLE)(
 		let undoTeach: any;
 		// biome-ignore lint/suspicious/noExplicitAny: dynamic-imported module shapes
 		let getPendingOverlays: any;
+		// biome-ignore lint/suspicious/noExplicitAny: dynamic-imported module shapes
+		let metadataDb: any;
 
 		beforeAll(async () => {
 			// Dynamic imports so the missing-env skip works — top-level imports
@@ -64,6 +70,11 @@ describe.skipIf(!STACK_AVAILABLE)(
 			undoTeach = teachMod.undoTeach;
 			const helperMod = await import("../db/metadata/pending-overlays");
 			getPendingOverlays = helperMod.getPendingOverlays;
+			// The promotion anchor lives in the metadata schema (ws_<id>), reachable
+			// via the same postgres-js client the helper uses — not the cockpit_db
+			// (bun:sql) client, which can't load under vitest.
+			const clientMod = await import("../db/metadata/client");
+			metadataDb = clientMod.metadataDb;
 		});
 
 		afterAll(async () => {
@@ -124,6 +135,67 @@ describe.skipIf(!STACK_AVAILABLE)(
 					(r: { overlay_id: string }) => r.overlay_id === result.overlay_id,
 				),
 			).toBe(false);
+		});
+
+		it("a teach is no longer pending once a later snapshot is promoted — pending is run-relative", async () => {
+			const { sql } = await import("drizzle-orm");
+			const stamp = Date.now();
+			const headId = `dat343_run_relative_head_${stamp}`;
+			// The metadata client sets no search_path (its generated SQL is
+			// schema-qualified via pgSchema), so raw DML must name the ws_<id> schema.
+			// REQUIRED_DEFAULTS already populated this; fall back to the same default
+			// rather than "" so the schema name can't silently truncate to `ws_`.
+			const wsId =
+				process.env.DATARAUM_WORKSPACE_ID ??
+				"00000000-0000-0000-0000-000000000001";
+			const wsSchema = sql.identifier(`ws_${wsId.replaceAll("-", "_")}`);
+
+			// Teach FIRST (created_at = now), so a promotion stamped after it is later.
+			const result = await teach({
+				type: "type_pattern",
+				payload: {
+					name: `dat343_run_relative_${stamp}`,
+					pattern: "^y$",
+					inferred_type: "VARCHAR",
+				},
+			});
+
+			// Still pending before any snapshot promotes past it.
+			const beforeRun = await getPendingOverlays();
+			expect(
+				beforeRun.some(
+					(r: { overlay_id: string }) => r.overlay_id === result.overlay_id,
+				),
+			).toBe(true);
+
+			// Promote a snapshot head with promoted_at AFTER the teach — the run that
+			// promoted it would have applied the teach, so it must drop out of the
+			// pending set. Bind a JS Date (not SQL now()) so it round-trips through the
+			// same client as the teach's created_at: `promoted_at` is `timestamp
+			// WITHOUT time zone`, and now() would store LOCAL wall-clock while the
+			// client writes Dates as UTC — a tz skew the engine never has (it writes
+			// both columns as UTC). A unique target avoids the (target, stage) UNIQUE.
+			const promotedAt = new Date();
+			await metadataDb.execute(sql`
+				INSERT INTO ${wsSchema}.metadata_snapshot_head (head_id, target, stage, run_id, promoted_at)
+				VALUES (${headId}, ${`test:${stamp}`}, 'generation', ${`run_${stamp}`}, ${promotedAt})
+			`);
+
+			try {
+				const afterRun = await getPendingOverlays();
+				expect(
+					afterRun.some(
+						(r: { overlay_id: string }) => r.overlay_id === result.overlay_id,
+					),
+				).toBe(false);
+			} finally {
+				// Drop the synthetic head so the anchor doesn't linger for other suites,
+				// and supersede the teach we left active.
+				await metadataDb.execute(
+					sql`DELETE FROM ${wsSchema}.metadata_snapshot_head WHERE head_id = ${headId}`,
+				);
+				await undoTeach(result.overlay_id);
+			}
 		});
 	},
 );


### PR DESCRIPTION
## The bug

The cockpit hint **"N pending teaches may affect this view — consider a replay before trusting it"** fired *permanently*. `getPendingOverlays` counted every `config_overlay` row with `superseded_at IS NULL` ("not undone"), but `superseded_at` is **only ever set by an explicit undo, never by a replay**. So once a user taught anything, the warning never cleared — even right after a replay that already applied the teach. "Pending" had no time axis; it conflated "not undone" with "not yet applied."

## The fix

Anchor "pending" to the run that produced the view: an overlay is pending only when its `created_at` is **after the latest `metadata_snapshot_head.promoted_at`** (the version-axis head). A replay promotes a newer snapshot past the teach, so it correctly drops out of the count. No promotion yet ⇒ null anchor ⇒ all active overlays pending (nothing has applied them).

- Lives entirely on the **metadata** client (`ws_<id>` schema) — no cross-boundary into the bun-only cockpit_db client — so all 14 `look_*`/`why_*` callers are fixed at once with **no signature changes**.
- Scope deliberately limited to the **time axis**; per-type "does this teach affect *this* view" scoping stays with the read tools (separate, smaller concern, noted in the comment).

## Decode subtlety (caught against live Postgres)

Reads `promoted_at` as a **plain column** via `orderBy(desc).limit(1)`, *not* `max()`. drizzle+bun-sql applies the column timestamp codec to a plain column but decodes an **aggregate** expression via the driver default, which misread the `timestamp WITHOUT time zone` as local — a −2h skew vs `config_overlay.created_at` that would have pushed the anchor hours early. Same family as the run-versioned-model decode gotchas.

## Accepted approximation

The engine re-reads active overlays **live at each phase start** (`overlay_resolver.py`), not via a run-start snapshot, so a teach created before a promotion was almost certainly applied. The one accepted gap (documented in-code): a teach created in the narrow window after the last phase's overlay read and before promotion is dropped from pending though no phase applied it — a single spurious dismissal, no data effect.

## Tests

Adds a **live-Postgres** regression case to `teach.integration.test.ts` proving a teach drops out of pending once a later snapshot promotes (binds a JS `Date` rather than SQL `now()` to stay tz-consistent with how the teach's `created_at` is written).

- biome clean · tsc 0 errors · unit 1220 pass · integration 3/3 against the live stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)