### PR TITLE
DAT-563: N-entity home-grain driver routing + ICC-verification resolver

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,47 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-18: DAT-563 — N-entity home-grain driver routing + ICC-verification resolver
+
+Makes the cluster-aware driver path actually fire end to end, generalized to N recurring
+identities. `discover_drivers` now:
+- takes `cluster_keys: list[str] | None` (was `cluster_key: str | None`);
+- when `cluster_keys` is None, **resolves** them from the fact's persisted
+  `TableEntity.identity_columns` (DAT-565) and **ICC-verifies** each — keeps only identities
+  the measure clusters within (ICC > 0.10), drops the rest (no heuristic). An explicit list
+  is used verbatim;
+- routes each candidate dim to ONE home grain (the entity it's constant within; finest-entity
+  tiebreak) and ranks per entity via the unchanged `_entity_grain_ranking`, row-level dims via
+  the unchanged `_row_wise_ranking` (de-meaned against the highest-ICC entity);
+- result shape: `DriverRanking.entity` (which identity the primary entity grain belongs to) +
+  `SecondaryDriver.entity` (per non-primary family) added; N=1 is bit-for-bit DAT-561.
+
+The proven core (`_entity_grain_ranking` / `_row_wise_ranking` / `tree.py` / de-mean) is
+untouched.
+
+### dataraum-eval
+- **Graduate the dat-544 probes from a HARDCODED `entity_col` to the resolver path:** call
+  `discover_drivers` WITHOUT `cluster_keys` so it reads persisted `identity_columns` and
+  ICC-verifies. The probe must first run `semantic_per_table` (DAT-565) so the identities are
+  persisted; then assert the resolver picks the right cluster keys (not a hand-fed string).
+- **Add a multi-entity fixture** (≥2 recurring identities, each with attributes + a
+  within-entity row-level dim) and assert **FDR controlled PER GRAIN** (each entity's nulls +
+  the row null stay ≤ ~2α at their own grain — never pooled across families) and that the
+  primary is the highest-ICC entity. The engine guard is `make_two_entity_corpus` +
+  `TestIdentityResolver.test_fdr_controlled_per_grain_multi_entity`.
+- **Flat-denormalized fixture:** a named identity on a clustered flat table must resolve +
+  cluster (grain `entity`), NOT fall through to the broken row-wise null. And a **mis-named
+  low-ICC "identity"** must be dropped by verification (no heuristic) → plain row-wise.
+- New result fields to consume: `DriverRanking.entity` and `SecondaryDriver.entity` (the
+  identity each grain belongs to). DAT-546's artifact carries `grain`/entity per ranked dim.
+
+### dataraum-testdata
+- A **multi-entity denormalized** fixture: several recurring identities (e.g. customer,
+  product, vendor) that each functionally determine some attributes, plus a genuinely
+  row-level dimension — matches `make_two_entity_corpus`. Asymmetric clustering strength
+  (one identity should cluster the measure harder than the others) exercises the
+  primary-vs-secondary entity selection.
+
 ## 2026-06-18: DAT-565 — multi-role semantic_per_table (all time axes + identity columns)
 
 `semantic_per_table` now emits **every** event-time axis and the table's recurring

--- a/packages/engine/src/dataraum/analysis/drivers/models.py
+++ b/packages/engine/src/dataraum/analysis/drivers/models.py
@@ -69,7 +69,9 @@ class SecondaryDriver:
     other family's significant dims land here instead of in ``ranked_dimensions``: their
     gains were computed at a different exchangeable grain (``grain``), so they are NOT
     comparable to the primary tree's gains and must not be folded into the same ranking.
-    A flat labeled list, strongest first.
+    A flat labeled list — strongest-first WITHIN each family's block, the family blocks in
+    primary-precedence order (gains are not comparable across grains, so there is no global
+    sort).
 
     ``entity`` names the identity column whose grain this dim was ranked at (DAT-563
     N-entity routing) — ``None`` for the row-level family. It disambiguates the now-many

--- a/packages/engine/src/dataraum/analysis/drivers/models.py
+++ b/packages/engine/src/dataraum/analysis/drivers/models.py
@@ -61,19 +61,25 @@ class DriverSlice:
 
 @dataclass(frozen=True)
 class SecondaryDriver:
-    """A significant dim from the NON-primary grain family (DAT-561).
+    """A significant dim from a NON-primary grain family (DAT-561/563).
 
-    The cluster-aware search runs two families — entity-constant candidates at entity
-    grain, row-level candidates row-wise — and reports the one selected by ICC as the
-    primary tree. The other family's significant dims land here instead of in
-    ``ranked_dimensions``: their gains were computed at a different exchangeable grain
-    (``grain``), so they are NOT comparable to the primary tree's gains and must not be
-    folded into the same ranking. A flat labeled list, strongest first.
+    The cluster-aware search runs one family per resolved entity (entity-constant
+    candidates at that entity's grain) plus a row-level family, and reports ONE as the
+    primary tree (the highest-ICC entity, or row-wise when nothing clusters). Every
+    other family's significant dims land here instead of in ``ranked_dimensions``: their
+    gains were computed at a different exchangeable grain (``grain``), so they are NOT
+    comparable to the primary tree's gains and must not be folded into the same ranking.
+    A flat labeled list, strongest first.
+
+    ``entity`` names the identity column whose grain this dim was ranked at (DAT-563
+    N-entity routing) — ``None`` for the row-level family. It disambiguates the now-many
+    ``grain == "entity"`` families (one per resolved identity: customer, product, …).
     """
 
     dimension: str
     gain: float
     grain: str  # the exchangeable unit this dim's null used: "entity" or "row"
+    entity: str | None = None  # the identity column this dim's entity grain belongs to
 
 
 @dataclass(frozen=True)
@@ -104,22 +110,29 @@ class DriverRanking:
     slices across the tree, strongest first.
 
     ``grain`` is the exchangeable unit the PRIMARY family's null used: ``"row"`` (the
-    default) or ``"entity"`` when the cluster-aware path made the entity-grain family
-    primary (DAT-552/561). ``n_rows`` is the count of those units (rows, or entities at
-    entity grain) — i.e. the effective sample size the power scales with, so a "no
-    significant driver" result on few entities is honestly attributable.
+    default) or ``"entity"`` when the cluster-aware path made an entity-grain family
+    primary (DAT-552/561). ``entity`` names WHICH identity column that entity grain
+    belongs to (DAT-563) — ``None`` at row grain; with N resolved identities the primary
+    is the highest-ICC one, so the headline must say which. ``n_rows`` is the count of
+    those units (rows, or entities at entity grain) — i.e. the effective sample size the
+    power scales with, so a "no significant driver" result on few entities is honestly
+    attributable.
 
-    ``secondary_dimensions`` carries the OTHER grain family's significant dims when a
-    ``cluster_key`` is present (DAT-561 candidate-grain routing): entity-constant
-    candidates always run at entity grain, row-level candidates row-wise, and the family
-    not chosen as primary (by ICC) surfaces here as a flat grain-labeled list — never
-    mixed into ``ranked_dimensions``/``root`` (the grains are not cross-comparable).
+    ``secondary_dimensions`` carries every NON-primary grain family's significant dims
+    when cluster keys are present (DAT-561/563 home-grain routing): each candidate is
+    ranked at exactly one home grain — the entity it is constant within (entity grain) or
+    row-wise — and one family is chosen primary (the highest-ICC entity, or row-wise when
+    nothing clusters). All other families surface here as a flat list, each
+    ``SecondaryDriver`` labeled with its ``grain`` and ``entity`` — never mixed into
+    ``ranked_dimensions``/``root`` (the grains are not cross-comparable). With N=1 this is
+    exactly DAT-561's primary/secondary split.
     """
 
     measure: str
     target_type: str
     n_rows: int
     grain: str = "row"
+    entity: str | None = None  # which identity the primary entity grain belongs to (DAT-563)
     ranked_dimensions: list[tuple[str, float]] = field(default_factory=list)
     root: DriverNode | None = None
     driver_paths: list[list[str]] = field(default_factory=list)

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -46,7 +46,7 @@ from dataraum.analysis.drivers.tree import (
     discover_tree,
 )
 from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
-from dataraum.analysis.semantic.db_models import SemanticAnnotation
+from dataraum.analysis.semantic.db_models import SemanticAnnotation, TableEntity
 from dataraum.analysis.slicing.db_models import SliceDefinition
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.core.logging import get_logger
@@ -134,6 +134,25 @@ def _candidate_dims(session: Session, fact_table_id: str, run_id: str) -> list[s
     return sorted(candidates)
 
 
+def _identity_columns(session: Session, fact_table_id: str, run_id: str) -> list[str]:
+    """The fact's persisted recurring-identity column names (DAT-565), this run.
+
+    Read from ``TableEntity.identity_columns`` — the cluster-entity roles
+    ``semantic_per_table`` named (would-be foreign keys, distinct from grain). Empty when
+    none were named, so a fact with no identities falls back to the plain row-wise null.
+    These are PROPOSALS; :func:`_resolve_cluster_keys` ICC-verifies them before routing.
+    """
+    blob = session.execute(
+        select(TableEntity.identity_columns).where(
+            TableEntity.table_id == fact_table_id,
+            TableEntity.run_id == run_id,
+        )
+    ).scalar_one_or_none()
+    if not blob:
+        return []
+    return [c["column"] for c in blob if isinstance(c, dict) and c.get("column")]
+
+
 def _measure_columns(measure: Measure) -> list[str]:
     """The enriched-view columns a measure needs read."""
     if measure.target_type in ("flow", "stock"):
@@ -163,6 +182,30 @@ def _entity_icc(frame: pd.DataFrame, entity: str, measure: Measure) -> float:
     """The measure's ICC (η² between entities) for one identity column (DAT-563)."""
     codes, uniques = pd.factorize(frame[entity])
     return intraclass_correlation(codes.astype(int), len(uniques), _icc_measure(frame, measure))
+
+
+def _resolve_cluster_keys(
+    frame: pd.DataFrame, proposed: list[str], measure: Measure, *, icc_threshold: float
+) -> list[str]:
+    """ICC-verify the proposed identities — keep those the measure actually clusters within.
+
+    For each proposed identity present in ``frame``, compute the measure's ICC and keep it
+    only when ICC > ``icc_threshold`` (DAT-563). **No heuristic:** an identity and a
+    high-cardinality ATTRIBUTE are indistinguishable by cardinality/recurrence, so the only
+    sound test is whether the measure clusters within it. Dropping an unverified column is
+    load-bearing — routing a mis-named identity would de-mean a real row-level driver away.
+    Proposed order is preserved (deterministic).
+    """
+    verified: list[str] = []
+    for col in proposed:
+        if col not in frame.columns:
+            continue
+        icc = _entity_icc(frame, col, measure)
+        if icc > icc_threshold:
+            verified.append(col)
+        else:
+            logger.info("driver_identity_unverified", identity=col, icc=round(icc, 3))
+    return verified
 
 
 def _make_target(measure: Measure, frame: pd.DataFrame) -> Target:
@@ -272,25 +315,40 @@ def discover_drivers(
         logger.info("driver_view_skew", view=view, present=present_dims, measure_cols=measure_cols)
         return empty
 
-    # The resolved identity columns are read alongside, deduped, and filtered to those
-    # present in the view (DAT-552/563). Phase 2 resolves them from ``identity_columns``
-    # when the caller passes none; an explicit list (tests / override) is used verbatim.
-    present_cluster_keys = [k for k in (cluster_keys or []) if k in view_cols]
-    select_cols = list(dict.fromkeys(present_dims + measure_cols + present_cluster_keys))
+    # Resolve the clustering identities (DAT-563). An explicit ``cluster_keys`` list is a
+    # caller override (tests) used verbatim; otherwise read the fact's persisted
+    # ``identity_columns`` (DAT-565) — those are PROPOSALS, ICC-verified below. Read the
+    # proposed columns into the frame alongside the dims + measure.
+    explicit = cluster_keys is not None
+    proposed = (
+        cluster_keys
+        if cluster_keys is not None
+        else _identity_columns(session, fact_table_id, run_id)
+    )
+    present_proposed = [k for k in proposed if k in view_cols]
+    select_cols = list(dict.fromkeys(present_dims + measure_cols + present_proposed))
     sql = f"SELECT {', '.join(quote(c) for c in select_cols)} FROM {quote(view)}"  # noqa: S608 — catalog identifiers
     frame = duckdb_conn.execute(sql).df()
+
+    # The resolver path ICC-verifies the persisted identities (drop those the measure does
+    # not cluster within — no heuristic); an explicit override is asserted by the caller.
+    keys = (
+        present_proposed
+        if explicit
+        else _resolve_cluster_keys(frame, present_proposed, measure, icc_threshold=icc_threshold)
+    )
 
     # Cluster-aware home-grain routing (DAT-561/563): each resolved identity column is an
     # entity grain; candidates are routed to their home grain (the entity they are
     # constant within) and ranked there, row-level candidates row-wise; the highest-ICC
-    # entity (or row-wise when nothing clusters) is primary. With no identities, the
-    # plain row-wise null (DAT-545) over all candidates.
-    if present_cluster_keys:
+    # entity (or row-wise when nothing clusters) is primary. With no verified identities,
+    # the plain row-wise null (DAT-545) over all candidates.
+    if keys:
         return _routed_ranking(
             frame,
             present_dims,
             measure,
-            present_cluster_keys,
+            keys,
             seed=seed,
             max_depth=max_depth,
             alpha=alpha,

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -159,6 +159,12 @@ def _icc_measure(frame: pd.DataFrame, measure: Measure) -> np.ndarray:
         return np.where(valid, num / np.where(valid, den, 1.0), np.nan)
 
 
+def _entity_icc(frame: pd.DataFrame, entity: str, measure: Measure) -> float:
+    """The measure's ICC (η² between entities) for one identity column (DAT-563)."""
+    codes, uniques = pd.factorize(frame[entity])
+    return intraclass_correlation(codes.astype(int), len(uniques), _icc_measure(frame, measure))
+
+
 def _make_target(measure: Measure, frame: pd.DataFrame) -> Target:
     """Build the row-aligned target from the measure's columns in ``frame``."""
     if measure.target_type in ("flow", "stock"):
@@ -180,7 +186,7 @@ def discover_drivers(
     fact_table_id: str,
     run_id: str,
     measure: Measure,
-    cluster_key: str | None = None,
+    cluster_keys: list[str] | None = None,
     seed: int = 0,
     max_depth: int = DEFAULT_MAX_DEPTH,
     alpha: float = DEFAULT_ALPHA,
@@ -200,27 +206,35 @@ def discover_drivers(
     two candidate dims survive in the view, or the measure columns are absent
     (a catalog/view skew is logged, not fatal).
 
-    **Cluster-aware candidate-grain routing (DAT-552/561):** when ``cluster_key`` names
-    a repeated-entity column, candidates are routed by their **within-entity
-    constancy**, not by the measure's global ICC:
+    **Cluster-aware home-grain routing (DAT-552/561/563):** ``cluster_keys`` names the
+    fact's recurring identity columns (customer, product, …) — one entity grain each.
+    Each candidate is routed to its **home grain**, by within-entity constancy, not by
+    the measure's global ICC:
 
-    - **Entity-constant** candidates (one value per entity) take the **entity-grain**
-      null ALWAYS — collapse to one row per entity, permute entities. The row-wise null
-      is structurally invalid for them at any ICC > 0 (their groups are whole entities,
-      so correlated within-entity rows would be counted as independent — DAT-561).
-    - **Row-level** candidates (vary within entity) take the **row-wise** null, which is
-      valid for them at any ICC (it just loses power as the measure clusters — see the
-      de-mean power add-on below).
+    - A candidate **constant within entity E** (one value per E) takes E's **entity-grain**
+      null — collapse to one row per E, permute entities. The row-wise null is
+      structurally invalid for it at any ICC > 0 (its groups are whole entities, so
+      correlated within-entity rows would be counted as independent — DAT-561). Constant
+      within several entities → its home is the **finest** (highest-cardinality) one.
+    - A candidate **constant within none** is row-level and takes the **row-wise** null,
+      valid at any ICC (it just loses power as the measure clusters — see the de-mean
+      power add-on below).
 
-    The two families are merged into one ranking: the **primary** family (its tree,
-    paths, slices, ``ranked_dimensions``, and ``grain``) is the one selected by the
-    measure's ICC — entity grain above ``icc_threshold`` (the between-entity story is
-    the headline), row-wise below; the **secondary** family's significant dims are
-    exposed as ``secondary_dimensions`` (a flat grain-labeled list, not folded into the
-    primary ranking — the grains are not cross-comparable). Ratio routes the same way
-    (entity statistic = Σnum/Σden, weight = Σden). With no ``cluster_key`` the plain
-    row-wise null (DAT-545) is used. ``max_depth`` applies to the row-wise family; the
-    entity grain always uses ``max_depth=1`` (recursion there is low-power).
+    One family per entity-with-home-dims plus a row-level family are assembled into one
+    ranking: the **primary** (its tree, paths, slices, ``ranked_dimensions``, ``grain``)
+    is the highest-ICC entity above ``icc_threshold`` (the between-entity story is the
+    headline), else row-wise; every other family's significant dims are exposed as
+    ``secondary_dimensions`` — a flat list, each labeled with its ``grain`` and
+    ``entity`` (not folded into the primary ranking — the grains are not cross-comparable).
+    Ratio routes the same way (entity statistic = Σnum/Σden, weight = Σden). With no
+    ``cluster_keys`` the plain row-wise null (DAT-545) is used. ``max_depth`` applies to
+    the row-wise family; the entity grain always uses ``max_depth=1`` (recursion there is
+    low-power). N=1 reduces exactly to the DAT-561 primary/secondary split.
+
+    **v1 limit (crossed effects):** a candidate constant within NO single entity but
+    clustered on two at once cannot be fully de-clustered by a single-entity de-mean; it
+    is handled row-wise, de-meaned against the highest-ICC entity only. Per-entity
+    marginals are surfaced; there is no joint two-way model.
 
     **Power add-on (DAT-561):** under HIGH ICC the row-level (secondary) family's
     row-wise null on the raw measure has little power — the between-entity variance is
@@ -258,22 +272,25 @@ def discover_drivers(
         logger.info("driver_view_skew", view=view, present=present_dims, measure_cols=measure_cols)
         return empty
 
-    # The cluster key is read alongside if it exists in the view (DAT-552).
-    cluster_col = cluster_key if (cluster_key and cluster_key in view_cols) else None
-    select_cols = present_dims + measure_cols + ([cluster_col] if cluster_col else [])
+    # The resolved identity columns are read alongside, deduped, and filtered to those
+    # present in the view (DAT-552/563). Phase 2 resolves them from ``identity_columns``
+    # when the caller passes none; an explicit list (tests / override) is used verbatim.
+    present_cluster_keys = [k for k in (cluster_keys or []) if k in view_cols]
+    select_cols = list(dict.fromkeys(present_dims + measure_cols + present_cluster_keys))
     sql = f"SELECT {', '.join(quote(c) for c in select_cols)} FROM {quote(view)}"  # noqa: S608 — catalog identifiers
     frame = duckdb_conn.execute(sql).df()
 
-    # Cluster-aware candidate-grain routing (DAT-561): a declared entity column splits
-    # the candidates by within-entity constancy and runs two grain families; the
-    # measure's ICC only picks which is primary. With no cluster_key, the plain
-    # row-wise null (DAT-545) over all candidates.
-    if cluster_col is not None:
+    # Cluster-aware home-grain routing (DAT-561/563): each resolved identity column is an
+    # entity grain; candidates are routed to their home grain (the entity they are
+    # constant within) and ranked there, row-level candidates row-wise; the highest-ICC
+    # entity (or row-wise when nothing clusters) is primary. With no identities, the
+    # plain row-wise null (DAT-545) over all candidates.
+    if present_cluster_keys:
         return _routed_ranking(
             frame,
             present_dims,
             measure,
-            cluster_col,
+            present_cluster_keys,
             seed=seed,
             max_depth=max_depth,
             alpha=alpha,
@@ -396,31 +413,37 @@ def _within_entity_ratio_residual(
     return residual, weight
 
 
-def _merge_secondary(
-    primary: DriverRanking | None, secondary: DriverRanking | None
-) -> DriverRanking:
-    """Fold the secondary family's significant dims into ``primary`` as a labeled list.
+def _home_grain_partition(
+    frame: pd.DataFrame, cluster_keys: list[str], dims: list[str]
+) -> tuple[dict[str, list[str]], list[str]]:
+    """Assign each candidate its HOME grain — the entity it is constant within (DAT-563).
 
-    The ICC-preferred family is primary; if it has no candidate dims the other becomes
-    primary (so a real driver in the only populated family is never hidden behind an
-    empty primary). The remaining family contributes ``secondary_dimensions`` only —
-    its gains are at a different grain, never mixed into the primary ranking.
+    Per entity, reuse the validated :func:`_partition_by_entity_constancy` nunique logic
+    to find the dims constant within it. A dim constant within ONE entity homes there; a
+    dim constant within SEVERAL homes at the **finest** (highest-cardinality) one — the
+    most specific grain — with a deterministic name tiebreak; a dim constant within none
+    is row-level. Returns ``({entity: [home dims]}, row_dims)`` with empty entities dropped.
     """
-    if primary is None:
-        primary, secondary = secondary, None
-    if primary is None:  # neither family had candidate dims (caller guarantees ≥2 total)
-        raise AssertionError("candidate-grain routing produced no family")
-    if secondary is None:
-        return primary
-    labeled = [SecondaryDriver(d, g, secondary.grain) for d, g in secondary.ranked_dimensions]
-    return replace(primary, secondary_dimensions=labeled)
+    card = {e: int(frame[e].nunique()) for e in cluster_keys}
+    constant_within = {
+        e: set(_partition_by_entity_constancy(frame, e, dims)[0]) for e in cluster_keys
+    }
+    home_by_entity: dict[str, list[str]] = {e: [] for e in cluster_keys}
+    row_dims: list[str] = []
+    for d in dims:
+        homes = [e for e in cluster_keys if d in constant_within[e]]
+        if not homes:
+            row_dims.append(d)
+            continue
+        home_by_entity[max(homes, key=lambda e: (card[e], e))].append(d)
+    return {e: ds for e, ds in home_by_entity.items() if ds}, row_dims
 
 
 def _routed_ranking(
     frame: pd.DataFrame,
     dims: list[str],
     measure: Measure,
-    cluster_key: str,
+    cluster_keys: list[str],
     *,
     seed: int,
     max_depth: int,
@@ -432,61 +455,89 @@ def _routed_ranking(
     icc_threshold: float,
     min_entities: int,
 ) -> DriverRanking:
-    """Route candidates to two grain families and merge primary (by ICC) + secondary."""
-    ent_codes, ent_uniques = pd.factorize(frame[cluster_key])
-    icc = intraclass_correlation(
-        ent_codes.astype(int), len(ent_uniques), _icc_measure(frame, measure)
-    )
-    high_icc = icc > icc_threshold
-    entity_dims, row_dims = _partition_by_entity_constancy(frame, cluster_key, dims)
+    """Route candidates to per-entity home grains + row-wise; primary = highest-ICC entity.
+
+    Reuse-orchestrate (DAT-563): the validated :func:`_entity_grain_ranking` and
+    :func:`_row_wise_ranking` are called verbatim, once per family. N=1 reduces exactly to
+    the DAT-561 two-family split. Each family carries ``(ranking, grain, entity)``; the
+    primary is the highest-ICC entity family when the measure clusters, the row family
+    otherwise (with low-ICC entity families behind it as a deterministic fallback). Every
+    non-primary family's dims surface as grain+entity-labeled ``secondary_dimensions``.
+    """
+    icc_by_entity = {e: _entity_icc(frame, e, measure) for e in cluster_keys}
+    top_entity = max(cluster_keys, key=lambda e: (icc_by_entity[e], e))
+    high_icc = icc_by_entity[top_entity] > icc_threshold
+    home_by_entity, row_dims = _home_grain_partition(frame, cluster_keys, dims)
     logger.info(
-        "driver_candidate_grain_routing",
-        cluster_key=cluster_key,
-        icc=round(icc, 3),
-        n_entities=len(ent_uniques),
-        primary="entity" if high_icc else "row",
-        entity_constant=entity_dims,
+        "driver_home_grain_routing",
+        cluster_keys=cluster_keys,
+        icc={e: round(v, 3) for e, v in icc_by_entity.items()},
+        n_entities={e: int(frame[e].nunique()) for e in cluster_keys},
+        primary=f"entity:{top_entity}" if high_icc else "row",
+        home_dims=home_by_entity,
         row_level=row_dims,
     )
 
-    entity_ranking = (
-        _entity_grain_ranking(
-            frame,
-            entity_dims,
-            measure,
-            cluster_key,
-            seed=seed,
-            alpha=alpha,
-            n_perm=n_perm,
-            top_k_slices=top_k_slices,
-            min_entities=min_entities,
+    # One family per entity-with-home-dims (deterministic seed by sorted name), plus the
+    # row-level family. The row family de-means within the highest-ICC entity ONLY under
+    # high ICC (the DAT-561 power add-on; the v1 crossed-effects limit lives here).
+    families: list[tuple[DriverRanking, str, str | None]] = []
+    for i, e in enumerate(sorted(home_by_entity)):
+        families.append(
+            (
+                _entity_grain_ranking(
+                    frame,
+                    home_by_entity[e],
+                    measure,
+                    e,
+                    seed=seed + i,
+                    alpha=alpha,
+                    n_perm=n_perm,
+                    top_k_slices=top_k_slices,
+                    min_entities=min_entities,
+                ),
+                "entity",
+                e,
+            )
         )
-        if entity_dims
-        else None
-    )
-    # The row-level family de-means within entity ONLY under high ICC (the power add-on);
-    # at low ICC the raw measure is already powered and stays the primary tree as-is.
-    row_ranking = (
-        _row_wise_ranking(
-            frame,
-            row_dims,
-            measure,
-            seed=seed + 1,  # an independent permutation stream from the entity family
-            max_depth=max_depth,
-            alpha=alpha,
-            min_support=min_support,
-            missingness_gate=missingness_gate,
-            n_perm=n_perm,
-            top_k_slices=top_k_slices,
-            cluster_key=cluster_key if high_icc else None,
+    if row_dims:
+        families.append(
+            (
+                _row_wise_ranking(
+                    frame,
+                    row_dims,
+                    measure,
+                    seed=seed + len(cluster_keys),
+                    max_depth=max_depth,
+                    alpha=alpha,
+                    min_support=min_support,
+                    missingness_gate=missingness_gate,
+                    n_perm=n_perm,
+                    top_k_slices=top_k_slices,
+                    cluster_key=top_entity if high_icc else None,
+                ),
+                "row",
+                None,
+            )
         )
-        if row_dims
-        else None
-    )
 
-    if high_icc:
-        return _merge_secondary(entity_ranking, row_ranking)
-    return _merge_secondary(row_ranking, entity_ranking)
+    # Primary precedence: high-ICC entity families (by ICC desc) → row family → low-ICC
+    # entity families. The first is the headline; the rest become labeled secondaries.
+    def precedence(fam: tuple[DriverRanking, str, str | None]) -> tuple[int, float, str]:
+        _ranking, grain, entity = fam
+        if grain == "entity":
+            ic = icc_by_entity[entity]  # type: ignore[index]
+            return (0 if ic > icc_threshold else 2, -ic, entity or "")
+        return (1, 0.0, "")  # row family sits between high- and low-ICC entity families
+
+    families.sort(key=precedence)
+    primary, _primary_grain, primary_entity = families[0]
+    secondary = [
+        SecondaryDriver(d, g, grain, entity)
+        for ranking, grain, entity in families[1:]
+        for d, g in ranking.ranked_dimensions
+    ]
+    return replace(primary, secondary_dimensions=secondary, entity=primary_entity)
 
 
 def _row_wise_ranking(

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -196,9 +196,12 @@ def _resolve_cluster_keys(
     load-bearing — routing a mis-named identity would de-mean a real row-level driver away.
     Proposed order is preserved (deterministic).
     """
+    # Deferred (DAT-563, optional): a born-loud miss-audit — warn when a high-ICC recurring
+    # column was NOT proposed as an identity — would need scanning un-read high-cardinality
+    # columns (an extra view scan); it is a guardrail, never a routing fallback.
     verified: list[str] = []
     for col in proposed:
-        if col not in frame.columns:
+        if col not in frame.columns:  # defensive: callers pass view-filtered cols, so never fires
             continue
         icc = _entity_icc(frame, col, measure)
         if icc > icc_threshold:
@@ -326,6 +329,11 @@ def discover_drivers(
         else _identity_columns(session, fact_table_id, run_id)
     )
     present_proposed = [k for k in proposed if k in view_cols]
+    # Born-loud: a named identity missing from the view (LLM hallucination, or a column
+    # renamed between semantic_per_table and the enriched view) is dropped — say so.
+    for col in proposed:
+        if col not in view_cols:
+            logger.info("driver_identity_not_in_view", identity=col, view=view)
     select_cols = list(dict.fromkeys(present_dims + measure_cols + present_proposed))
     sql = f"SELECT {', '.join(quote(c) for c in select_cols)} FROM {quote(view)}"  # noqa: S608 — catalog identifiers
     frame = duckdb_conn.execute(sql).df()
@@ -583,9 +591,9 @@ def _routed_ranking(
     # entity families. The first is the headline; the rest become labeled secondaries.
     def precedence(fam: tuple[DriverRanking, str, str | None]) -> tuple[int, float, str]:
         _ranking, grain, entity = fam
-        if grain == "entity":
-            ic = icc_by_entity[entity]  # type: ignore[index]
-            return (0 if ic > icc_threshold else 2, -ic, entity or "")
+        if grain == "entity" and entity is not None:  # entity families always carry a name
+            ic = icc_by_entity[entity]
+            return (0 if ic > icc_threshold else 2, -ic, entity)
         return (1, 0.0, "")  # row family sits between high- and low-ICC entity families
 
     families.sort(key=precedence)

--- a/packages/engine/tests/unit/analysis/drivers/conftest.py
+++ b/packages/engine/tests/unit/analysis/drivers/conftest.py
@@ -228,6 +228,50 @@ def make_clustered_two_driver_corpus(
     return df
 
 
+# Two-ENTITY corpus (DAT-563): rows cross TWO recurring identities (customer, product),
+# each with its own entity-level driver + null, plus a row-level null. The measure carries
+# a LARGE customer random effect (higher ICC → customer is the primary entity grain) and a
+# smaller product random effect (lower ICC → product is an entity-grain SECONDARY). Every
+# candidate is constant within exactly one identity, so home-grain routing is unambiguous:
+# customer attrs → customer grain, product attrs → product grain, the row null → row-wise.
+TE_N_CUST = 120
+TE_N_PROD = 40
+TE_N_ROWS = 24_000
+TE_CUST = "customer"
+TE_PROD = "product"
+TE_CUST_DRIVER = "D_cust"
+TE_PROD_DRIVER = "D_prod"
+TE_CUST_NULL = "N_cust"
+TE_PROD_NULL = "N_prod"
+TE_ROW_NULL = "N_row"
+TE_DIMS = [TE_CUST_DRIVER, TE_PROD_DRIVER, TE_CUST_NULL, TE_PROD_NULL, TE_ROW_NULL]
+TE_ENTITIES = [TE_CUST, TE_PROD]
+
+
+def make_two_entity_corpus(rng: np.random.Generator) -> pd.DataFrame:
+    """24k rows over 120 customers × 40 products; measure clusters within BOTH (customer > product)."""
+    n = TE_N_ROWS
+    cust = rng.integers(0, TE_N_CUST, n)
+    prod = rng.integers(0, TE_N_PROD, n)
+    # Customer-level driver + a large entity effect (high ICC → customer primary).
+    cust_drv = rng.integers(0, 4, TE_N_CUST)
+    cust_effect = np.array([-3.0, -1.0, 1.0, 3.0])[cust_drv] + rng.normal(0, 3.0, TE_N_CUST)
+    # Product-level driver + a smaller entity effect (lower ICC → product secondary).
+    prod_drv = rng.integers(0, 4, TE_N_PROD)
+    prod_effect = np.array([-1.0, -0.3, 0.3, 1.0])[prod_drv] + rng.normal(0, 0.8, TE_N_PROD)
+
+    df = pd.DataFrame(index=np.arange(n))
+    df[TE_CUST] = cust
+    df[TE_PROD] = prod
+    df["measure"] = 100.0 + cust_effect[cust] + prod_effect[prod] + rng.normal(0, 1.0, n)
+    df[TE_CUST_DRIVER] = [f"cd{g}" for g in cust_drv[cust]]  # constant within customer
+    df[TE_PROD_DRIVER] = [f"pd{g}" for g in prod_drv[prod]]  # constant within product
+    df[TE_CUST_NULL] = [f"cn{g}" for g in rng.integers(0, 6, TE_N_CUST)[cust]]  # cust-level null
+    df[TE_PROD_NULL] = [f"pn{g}" for g in rng.integers(0, 6, TE_N_PROD)[prod]]  # prod-level null
+    df[TE_ROW_NULL] = [f"r{g}" for g in rng.integers(0, 6, n)]  # row-level null
+    return df
+
+
 # Clustered RATIO corpus (DAT-552 #321 fold): the per-row ratio (num/den) carries a
 # per-entity level (high ICC on the ratio); an entity-level driver shifts that level;
 # the denominator (volume) varies independently. Tests cluster-aware ratio.

--- a/packages/engine/tests/unit/analysis/drivers/conftest.py
+++ b/packages/engine/tests/unit/analysis/drivers/conftest.py
@@ -253,12 +253,16 @@ def make_two_entity_corpus(rng: np.random.Generator) -> pd.DataFrame:
     n = TE_N_ROWS
     cust = rng.integers(0, TE_N_CUST, n)
     prod = rng.integers(0, TE_N_PROD, n)
-    # Customer-level driver + a large entity effect (high ICC → customer primary).
+    # Customer-level driver + entity effect — the LARGER share (ICC ≈ 0.65 → customer is
+    # primary AND clears the resolver's verify threshold).
     cust_drv = rng.integers(0, 4, TE_N_CUST)
-    cust_effect = np.array([-3.0, -1.0, 1.0, 3.0])[cust_drv] + rng.normal(0, 3.0, TE_N_CUST)
-    # Product-level driver + a smaller entity effect (lower ICC → product secondary).
+    cust_effect = np.array([-3.0, -1.0, 1.0, 3.0])[cust_drv] + rng.normal(0, 2.5, TE_N_CUST)
+    # Product-level driver + a smaller-but-real entity effect (ICC ≈ 0.27 → a verified
+    # SECONDARY entity grain, below customer but above the 0.10 verify threshold). The
+    # driver dominates the between-product variance (low entity noise) so it recalls
+    # reliably at the 40-product entity grain.
     prod_drv = rng.integers(0, 4, TE_N_PROD)
-    prod_effect = np.array([-1.0, -0.3, 0.3, 1.0])[prod_drv] + rng.normal(0, 0.8, TE_N_PROD)
+    prod_effect = np.array([-2.5, -0.8, 0.8, 2.5])[prod_drv] + rng.normal(0, 1.0, TE_N_PROD)
 
     df = pd.DataFrame(index=np.arange(n))
     df[TE_CUST] = cust

--- a/packages/engine/tests/unit/analysis/drivers/test_grain.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain.py
@@ -17,6 +17,7 @@ from dataraum.analysis.drivers.criterion import (
     weighted_variance_reduction,
 )
 from dataraum.analysis.drivers.processor import (
+    _home_grain_partition,
     _within_entity_ratio_residual,
     _within_entity_residual,
 )
@@ -28,15 +29,53 @@ from .conftest import (
     CL_ENTITY_NULLS,
     CL_RATIO_ROW_DRIVER,
     CL_ROW_DRIVER,
+    TE_CUST,
+    TE_CUST_DRIVER,
+    TE_CUST_NULL,
+    TE_DIMS,
+    TE_PROD,
+    TE_PROD_DRIVER,
+    TE_PROD_NULL,
+    TE_ROW_NULL,
     make_clustered_corpus,
     make_clustered_ratio_two_driver_corpus,
     make_clustered_two_driver_corpus,
+    make_two_entity_corpus,
 )
 
 
 def _codes(series: pd.Series) -> tuple[np.ndarray, int]:
     codes, uniques = pd.factorize(series)
     return codes.astype(int), len(uniques)
+
+
+class TestHomeGrainPartition:
+    """DAT-563: each candidate is assigned to EXACTLY ONE home grain (entity or row)."""
+
+    def test_each_dim_homes_at_one_grain(self) -> None:
+        df = make_two_entity_corpus(np.random.default_rng(0))
+        home, row = _home_grain_partition(df, [TE_CUST, TE_PROD], TE_DIMS)
+        # Customer attrs are constant within customer; product attrs within product.
+        assert set(home[TE_CUST]) == {TE_CUST_DRIVER, TE_CUST_NULL}
+        assert set(home[TE_PROD]) == {TE_PROD_DRIVER, TE_PROD_NULL}
+        assert row == [TE_ROW_NULL]  # varies within both → row-level
+        # The partition is exhaustive AND disjoint — every dim lands once, nowhere twice.
+        assigned = [d for ds in home.values() for d in ds] + row
+        assert sorted(assigned) == sorted(TE_DIMS)
+
+    def test_constant_within_two_homes_at_the_finer_entity(self) -> None:
+        # ``region`` is constant within BOTH store and chain (a store sits in one region,
+        # a chain spans one region here) → it must home at the FINER (higher-card) entity.
+        df = pd.DataFrame(
+            {
+                "chain": [0, 0, 1, 1, 2, 2],  # 3 chains
+                "store": [0, 1, 2, 3, 4, 5],  # 6 stores (finer)
+                "region": ["W", "W", "E", "E", "S", "S"],  # constant within store AND chain
+            }
+        )
+        home, row = _home_grain_partition(df, ["chain", "store"], ["region"])
+        assert home == {"store": ["region"]}  # finer entity wins the tiebreak
+        assert row == []
 
 
 class TestICC:

--- a/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
@@ -31,11 +31,19 @@ from .conftest import (
     CL_ROW_DRIVER,
     CL_ROW_NULL,
     RATIO_TWO_DRIVER_DIMS,
+    TE_CUST,
+    TE_CUST_DRIVER,
+    TE_DIMS,
+    TE_PROD,
+    TE_PROD_DRIVER,
+    TE_PROD_NULL,
+    TE_ROW_NULL,
     TWO_DRIVER_DIMS,
     make_clustered_corpus,
     make_clustered_ratio_corpus,
     make_clustered_ratio_two_driver_corpus,
     make_clustered_two_driver_corpus,
+    make_two_entity_corpus,
 )
 
 RUN = "session-run-1"
@@ -131,7 +139,7 @@ def _run(session: Session, duck: duckdb.DuckDBPyConnection, tid: str, seed: int,
         fact_table_id=tid,
         run_id=RUN,
         measure=MEASURE,
-        cluster_key=cluster_key,
+        cluster_keys=[cluster_key] if cluster_key is not None else None,
         n_perm=N_PERM,
         seed=seed,
     )
@@ -225,7 +233,7 @@ class TestClusterAwareSwitch:
             fact_table_id=tid,
             run_id=RUN,
             measure=MEASURE,
-            cluster_key=CL_ENTITY,
+            cluster_keys=[CL_ENTITY],
             n_perm=N_PERM,
         )
         assert hi_rank.grain == "entity"
@@ -241,7 +249,7 @@ class TestClusterAwareSwitch:
             fact_table_id=tid,
             run_id=RUN,
             measure=MEASURE,
-            cluster_key=CL_ENTITY,
+            cluster_keys=[CL_ENTITY],
             n_perm=N_PERM,
         )
         assert lo_rank.grain == "row"
@@ -257,7 +265,7 @@ def _run_low_icc(session, duck, tid, seed, *, cluster_key):  # noqa: ANN001, ANN
         fact_table_id=tid,
         run_id=RUN,
         measure=MEASURE,
-        cluster_key=cluster_key,
+        cluster_keys=[cluster_key] if cluster_key is not None else None,
         n_perm=N_PERM,
         seed=seed,
     )
@@ -317,7 +325,7 @@ class TestCandidateGrainRouting:
                 fact_table_id=tid,
                 run_id=RUN,
                 measure=MEASURE,
-                cluster_key=CL_ENTITY,
+                cluster_keys=[CL_ENTITY],
                 n_perm=N_PERM,
                 seed=s,
             )
@@ -341,7 +349,7 @@ class TestWithinEntityPower:
             fact_table_id=tid,
             run_id=RUN,
             measure=MEASURE,
-            cluster_key=CL_ENTITY,
+            cluster_keys=[CL_ENTITY],
             n_perm=N_PERM,
             seed=seed,
         )
@@ -393,7 +401,7 @@ class TestClusterAwareRatio:
             fact_table_id=tid,
             run_id=RUN,
             measure=RATIO_MEASURE,
-            cluster_key=cluster_key,
+            cluster_keys=[cluster_key] if cluster_key is not None else None,
             n_perm=N_PERM,
             seed=seed,
         )
@@ -451,7 +459,7 @@ class TestWithinEntityRatioPower:
             fact_table_id=tid,
             run_id=RUN,
             measure=RATIO_MEASURE,
-            cluster_key=CL_ENTITY,
+            cluster_keys=[CL_ENTITY],
             n_perm=N_PERM,
             seed=seed,
         )
@@ -488,3 +496,50 @@ class TestWithinEntityRatioPower:
         assert row_null_surfaced <= 2 * ALPHA * seeds, (
             f"row-level null surfaced {row_null_surfaced}/{seeds} on the ratio residual"
         )
+
+
+class TestTwoEntityRouting:
+    """DAT-563: N=2 home-grain routing end to end — customer (higher ICC) is primary, the
+    product family runs at its own entity grain as a labeled secondary, no grain mixes."""
+
+    def _run(self, session: Session, duck: duckdb.DuckDBPyConnection, tid: str, seed: int):
+        _write_view(duck, make_two_entity_corpus(np.random.default_rng(700 + seed)))
+        return discover_drivers(
+            session,
+            duckdb_conn=duck,
+            fact_table_id=tid,
+            run_id=RUN,
+            measure=MEASURE,
+            cluster_keys=[TE_CUST, TE_PROD],
+            n_perm=N_PERM,
+            seed=seed,
+        )
+
+    def test_primary_is_highest_icc_entity_secondary_is_the_other(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed_catalog(real_session, dims=TE_DIMS)
+        rank = self._run(real_session, duck, tid, 0)
+
+        # Customer clusters harder than product → customer is the primary entity grain,
+        # and the headline says which (DAT-563 entity label).
+        assert rank.grain == "entity"
+        assert rank.entity == TE_CUST
+        primary = {d for d, _ in rank.ranked_dimensions}
+        assert TE_CUST_DRIVER in primary  # the strong customer driver leads the primary
+
+        # The product family ran at ITS OWN entity grain: the product driver surfaces as a
+        # secondary labeled (entity, product) — proof the second entity was routed, not
+        # collapsed into customer or row.
+        prod_secondary = [s for s in rank.secondary_dimensions if s.entity == TE_PROD]
+        assert any(s.dimension == TE_PROD_DRIVER for s in prod_secondary)
+        assert all(s.grain == "entity" for s in prod_secondary)
+
+        # No grain mixes: product-grain dims never in the customer primary; the row null is
+        # never ranked at an entity grain; every dim appears at exactly ONE grain.
+        assert TE_PROD_DRIVER not in primary and TE_PROD_NULL not in primary
+        assert all(
+            s.grain == "row" for s in rank.secondary_dimensions if s.dimension == TE_ROW_NULL
+        )
+        seen = list(primary) + [s.dimension for s in rank.secondary_dimensions]
+        assert len(seen) == len(set(seen)), f"a dim was ranked at two grains: {seen}"

--- a/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session
 
 from dataraum.analysis.drivers.models import Measure
 from dataraum.analysis.drivers.processor import discover_drivers
-from dataraum.analysis.semantic.db_models import SemanticAnnotation
+from dataraum.analysis.semantic.db_models import SemanticAnnotation, TableEntity
 from dataraum.analysis.slicing.db_models import SliceDefinition
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.storage import Column, Table
@@ -33,6 +33,7 @@ from .conftest import (
     RATIO_TWO_DRIVER_DIMS,
     TE_CUST,
     TE_CUST_DRIVER,
+    TE_CUST_NULL,
     TE_DIMS,
     TE_PROD,
     TE_PROD_DRIVER,
@@ -122,6 +123,19 @@ def _seed_ratio_catalog(session: Session, dims: list[str] = CL_RATIO_DIMS) -> st
     )
     session.flush()
     return fact.table_id
+
+
+def _seed_identities(session: Session, tid: str, cols: list[str]) -> None:
+    """Persist the fact's ``identity_columns`` (DAT-565) so the resolver can read them."""
+    session.add(
+        TableEntity(
+            run_id=RUN,
+            table_id=tid,
+            detected_entity_type="orders",
+            identity_columns=[{"column": c, "note": "seed identity"} for c in cols],
+        )
+    )
+    session.flush()
 
 
 def _write_view(duck: duckdb.DuckDBPyConnection, df) -> None:
@@ -543,3 +557,89 @@ class TestTwoEntityRouting:
         )
         seen = list(primary) + [s.dimension for s in rank.secondary_dimensions]
         assert len(seen) == len(set(seen)), f"a dim was ranked at two grains: {seen}"
+
+
+class TestIdentityResolver:
+    """DAT-563: cluster keys RESOLVED from persisted ``identity_columns`` (DAT-565) and
+    ICC-verified — ``discover_drivers`` is called with NO ``cluster_keys`` (the real path)."""
+
+    def _resolve(self, session: Session, duck: duckdb.DuckDBPyConnection, tid: str, seed: int = 0):
+        return discover_drivers(  # no cluster_keys → resolve from identity_columns
+            session,
+            duckdb_conn=duck,
+            fact_table_id=tid,
+            run_id=RUN,
+            measure=MEASURE,
+            n_perm=N_PERM,
+            seed=seed,
+        )
+
+    def test_resolves_named_identities_and_routes(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        tid = _seed_catalog(real_session, dims=TE_DIMS)
+        _seed_identities(real_session, tid, [TE_CUST, TE_PROD])
+        _write_view(duck, make_two_entity_corpus(np.random.default_rng(0)))
+        rank = self._resolve(real_session, duck, tid)
+        # Both identities resolved + ICC-verified → same routing as the explicit N=2 case.
+        assert rank.grain == "entity" and rank.entity == TE_CUST
+        assert TE_CUST_DRIVER in {d for d, _ in rank.ranked_dimensions}
+        assert any(
+            s.entity == TE_PROD and s.dimension == TE_PROD_DRIVER for s in rank.secondary_dimensions
+        )
+
+    def test_drops_mis_named_low_icc_identity_no_heuristic(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # The LLM mis-names a row-level RANDOM column as an identity. Cardinality alone
+        # can't tell it from a real identity — only ICC can: the measure does not cluster
+        # within it, so verification drops it → plain row-wise, no spurious de-mean.
+        tid = _seed_catalog(real_session, dims=TE_DIMS)
+        _seed_identities(real_session, tid, [TE_ROW_NULL])
+        _write_view(duck, make_two_entity_corpus(np.random.default_rng(0)))
+        rank = self._resolve(real_session, duck, tid)
+        assert rank.grain == "row" and rank.entity is None
+
+    def test_no_identities_falls_back_to_row_wise(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # No TableEntity / no identity_columns named → the N=0 arm: plain row-wise.
+        tid = _seed_catalog(real_session, dims=TE_DIMS)
+        _write_view(duck, make_two_entity_corpus(np.random.default_rng(0)))
+        rank = self._resolve(real_session, duck, tid)
+        assert rank.grain == "row"
+
+    def test_flat_denormalized_identity_resolved_not_row_wise(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # A single named identity on a clustered (high-ICC) flat table is resolved +
+        # clustered, NOT silently left to the broken row-wise null (the AC).
+        tid = _seed_catalog(real_session, dims=CL_DIMS)
+        _seed_identities(real_session, tid, [CL_ENTITY])
+        _write_view(duck, make_clustered_corpus(np.random.default_rng(0)))
+        rank = self._resolve(real_session, duck, tid)
+        assert rank.grain == "entity" and rank.entity == CL_ENTITY
+
+    def test_fdr_controlled_per_grain_multi_entity(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # The statistical AC: over many seeds, the null at EACH grain stays gated (≤ 2α)
+        # while the strong customer driver recalls — FDR controlled per grain, not pooled
+        # across the two entity families + the row family.
+        tid = _seed_catalog(real_session, dims=TE_DIMS)
+        _seed_identities(real_session, tid, [TE_CUST, TE_PROD])
+        seeds = 20
+        cust_driver = cust_null = prod_null = row_null = 0
+        for s in range(seeds):
+            _write_view(duck, make_two_entity_corpus(np.random.default_rng(900 + s)))
+            rank = self._resolve(real_session, duck, tid, seed=s)
+            primary = {d for d, _ in rank.ranked_dimensions}
+            sec = {(x.dimension, x.entity) for x in rank.secondary_dimensions}
+            cust_driver += TE_CUST_DRIVER in primary
+            cust_null += TE_CUST_NULL in primary  # customer-grain null (the customer primary)
+            prod_null += (TE_PROD_NULL, TE_PROD) in sec  # product-grain null
+            row_null += any(x.dimension == TE_ROW_NULL for x in rank.secondary_dimensions)
+        assert cust_driver >= seeds // 2, f"customer driver recall {cust_driver}/{seeds}"
+        assert cust_null <= 2 * ALPHA * seeds, f"customer null surfaced {cust_null}/{seeds}"
+        assert prod_null <= 2 * ALPHA * seeds, f"product null surfaced {prod_null}/{seeds}"
+        assert row_null <= 2 * ALPHA * seeds, f"row null surfaced {row_null}/{seeds}"

--- a/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
@@ -558,6 +558,20 @@ class TestTwoEntityRouting:
         seen = list(primary) + [s.dimension for s in rank.secondary_dimensions]
         assert len(seen) == len(set(seen)), f"a dim was ranked at two grains: {seen}"
 
+    def test_rerun_determinism(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # Identical data + identities + seed → identical routing + ranking (DAT-563 AC6),
+        # for N≥2 (the per-entity seed arithmetic + sorted iteration must be stable).
+        tid = _seed_catalog(real_session, dims=TE_DIMS)
+        a = self._run(real_session, duck, tid, 0)
+        b = self._run(real_session, duck, tid, 0)
+        assert (a.grain, a.entity) == (b.grain, b.entity)
+        assert a.ranked_dimensions == b.ranked_dimensions
+        a_sec = [(s.dimension, s.gain, s.grain, s.entity) for s in a.secondary_dimensions]
+        b_sec = [(s.dimension, s.gain, s.grain, s.entity) for s in b.secondary_dimensions]
+        assert a_sec == b_sec
+
 
 class TestIdentityResolver:
     """DAT-563: cluster keys RESOLVED from persisted ``identity_columns`` (DAT-565) and


### PR DESCRIPTION
## What

Makes the cluster-aware driver path actually fire, generalized to **N recurring identities** (customer, product, …), and adds the **resolver** that reads + verifies them. Consumes the `identity_columns` produced by DAT-565 (#326). Closes DAT-563.

## Changes

**P1 — N-entity routing** (`4cef67c`, `analysis/drivers/{models,processor}.py`)
- `discover_drivers`: `cluster_key: str | None` → `cluster_keys: list[str] | None`.
- `_home_grain_partition`: each candidate dim gets ONE home grain — the entity it's constant within (reuses `_partition_by_entity_constancy` per entity), finest-entity (highest-card) tiebreak; constant-within-none → row-level.
- `_routed_ranking` generalized: per entity-with-home-dims it calls the **validated** `_entity_grain_ranking` verbatim, row-level dims → `_row_wise_ranking` (de-meaned against the highest-ICC entity — documented v1 crossed-effects limit); precedence-based primary (highest-ICC entity → row → low-ICC entities); grain+entity-labeled secondary.
- Result shape: `SecondaryDriver.entity` + `DriverRanking.entity` added (which identity a grain belongs to). Both additive — **N=1 reduces bit-for-bit to DAT-561**.

**P2 — ICC-verification resolver** (`88e1316`)
- `_identity_columns` reads `TableEntity.identity_columns`; `_resolve_cluster_keys` keeps only identities the measure clusters within (ICC > threshold) — **no heuristic** (an identity and a high-card attribute are indistinguishable by cardinality; routing a mis-named one would de-mean a real driver away).
- Wired in: `cluster_keys=None` ⇒ resolve+verify; explicit list ⇒ verbatim. Verified-empty ⇒ plain row-wise (N=0 arm).

**Review fixes** (`<this commit>`): born-loud `driver_identity_not_in_view` log; precedence typing; docs; N≥2 determinism test; handoff.

## The validated core is untouched

`_entity_grain_ranking`, `_row_wise_ranking`, `tree.py`, and the de-mean transforms are **byte-for-byte identical** to `main` (the spec's "reuse-orchestrate, do not rewrite" constraint — confirmed by the spec reviewer).

## Testing

- 1590 engine unit tests, mypy + ruff green.
- New: `_home_grain_partition` units (one-grain-each + finest tiebreak); a 2-entity corpus; explicit N=2 routing; **5 resolver tests** (resolve+route, drop mis-named low-ICC identity, no-identities→row-wise, flat-denormalized resolved-not-row-wise, **per-grain FDR** over 20 seeds); N≥2 determinism.
- Reviewers: senior-code-reviewer **APPROVE**, spec-compliance-reviewer **COMPLIANT**.

## Follow-ups / cross-repo

- **eval**: graduate the dat-544 probes off the hardcoded `entity_col` to the resolver; multi-entity + flat-denormalized fixtures; per-grain FDR. See `.claude/handoff.md`.
- Deferred (optional, per AC): born-loud miss-audit on a high-ICC recurring column not proposed (needs an extra view scan).
- Unblocks **DAT-546** (driver artifact + `look_drivers`, carrying the grain/entity label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)