### PR TITLE
DAT-570: tolerate the trigger poll-race on /api/workflow-progress

### DIFF
--- a/packages/cockpit/src/temporal/progress.test.ts
+++ b/packages/cockpit/src/temporal/progress.test.ts
@@ -3,8 +3,10 @@
 // Mocked seams: `#/config` (Temporal config) + `@temporalio/client` (a handle
 // whose query/describe the test scripts). We assert: getWorkflowProgress queries
 // `get_progress` on getHandle(id, runId) and maps to the mirrored snake_case
-// shape; `done` is true on phase==="done" OR a terminal describe() status; and
-// the unconfigured guard throws like replay.ts.
+// shape; `done` is true on phase==="done" OR a terminal describe() status; the
+// unconfigured guard throws like replay.ts; and the two trigger poll-races
+// (DAT-570) — no execution yet (describe → NotFound → PENDING) and a not-yet-
+// queryable execution (query fails → describe()-only) — degrade, never 500.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -39,6 +41,9 @@ const h = vi.hoisted(() => ({
 	queryName: null as string | null,
 	// When set, the mocked get_progress query rejects with this (the fallback path).
 	queryError: null as Error | null,
+	// When set, the mocked describe() rejects with this (the no-execution-yet
+	// poll-race — WorkflowNotFoundError, DAT-570).
+	describeError: null as Error | null,
 }));
 
 // A live getter, not a snapshot: the tests reassign `h.config`, so the module's
@@ -75,7 +80,10 @@ const queryMock = vi.fn(async (name: string) => {
 	if (h.queryError) throw h.queryError;
 	return h.snapshot;
 });
-const describeMock = vi.fn(async () => ({ status: { name: h.status } }));
+const describeMock = vi.fn(async () => {
+	if (h.describeError) throw h.describeError;
+	return { status: { name: h.status } };
+});
 const getHandleMock = vi.fn((...args: unknown[]) => {
 	h.getHandleArgs = args;
 	return { query: queryMock, describe: describeMock };
@@ -113,6 +121,7 @@ beforeEach(() => {
 	h.getHandleArgs = null;
 	h.queryName = null;
 	h.queryError = null;
+	h.describeError = null;
 	queryMock.mockClear();
 	describeMock.mockClear();
 	getHandleMock.mockClear();
@@ -232,11 +241,11 @@ describe("getWorkflowProgress (DAT-352)", () => {
 	});
 
 	it("falls back to describe()-only when the workflow has no get_progress query (operating_model)", async () => {
-		// operatingModelWorkflow registers no get_progress (begin_session does
-		// since DAT-435) — the query raises WorkflowQueryFailedError; the poll
-		// degrades to status + done, no phase detail.
+		// A workflow that registers no get_progress raises QueryNotRegisteredError;
+		// the poll degrades to status + done, no phase detail (no 500). All three
+		// parent workflows serve the query today — this is the forward-compat path.
 		const err = new Error("query not registered: get_progress");
-		err.name = "WorkflowQueryFailedError";
+		err.name = "QueryNotRegisteredError";
 		h.queryError = err;
 		h.status = "RUNNING";
 
@@ -257,7 +266,7 @@ describe("getWorkflowProgress (DAT-352)", () => {
 
 	it("fallback reports done with the terminal 'done' phase on a COMPLETED run", async () => {
 		const err = new Error("query not registered: get_progress");
-		err.name = "WorkflowQueryFailedError";
+		err.name = "QueryNotRegisteredError";
 		h.queryError = err;
 		h.status = "COMPLETED";
 
@@ -270,11 +279,63 @@ describe("getWorkflowProgress (DAT-352)", () => {
 		expect(result.status).toBe("COMPLETED");
 	});
 
-	it("rethrows a non-query-handler query failure (a real error is not swallowed)", async () => {
-		h.queryError = new Error("connection reset"); // name !== WorkflowQueryFailedError
+	it("returns a PENDING snapshot when the workflow has no execution yet (DAT-570)", async () => {
+		// The trigger returns the deterministic workflow id before the journey starts
+		// the engine child, so an eager poll finds no execution: describe() throws
+		// WorkflowNotFoundError. The poll must report PENDING (done:false) so the
+		// widget keeps polling — NOT 500.
+		const err = new Error("workflow not found");
+		err.name = "WorkflowNotFoundError";
+		h.describeError = err;
+
+		const result = await getWorkflowProgress({
+			workflow_id: "beginsession-ws",
+			run_id: "beginsession-ws",
+		});
+		expect(result).toEqual({
+			phase: "pending",
+			tables_total: 0,
+			tables_completed: 0,
+			tables: [],
+			failure: null,
+			status: "PENDING",
+			done: false,
+		});
+		// describe() failed before the query — never queried.
+		expect(queryMock).not.toHaveBeenCalled();
+	});
+
+	it("rethrows a non-NotFound describe() failure (a real error is not swallowed)", async () => {
+		// A connection/config failure on describe() is NOT the poll-race — surface it.
+		h.describeError = new Error("connection reset"); // name !== WorkflowNotFoundError
 		await expect(
 			getWorkflowProgress({ workflow_id: "w", run_id: "r" }),
 		).rejects.toThrow(/connection reset/);
+	});
+
+	it("degrades to describe()-only when the query can't be served yet — sibling poll-race (DAT-570)", async () => {
+		// The execution exists (describe() returns RUNNING) but its first workflow
+		// task hasn't completed, so get_progress can't be served (QueryRejectedError
+		// / a transient query RPC error). The poll degrades to the run's authoritative
+		// status instead of 500ing, so the widget keeps polling.
+		const err = new Error("query rejected: workflow task not completed");
+		err.name = "QueryRejectedError";
+		h.queryError = err;
+		h.status = "RUNNING";
+
+		const result = await getWorkflowProgress({
+			workflow_id: "beginsession-ws",
+			run_id: "beginsession-ws",
+		});
+		expect(result).toEqual({
+			phase: "running",
+			tables_total: 0,
+			tables_completed: 0,
+			tables: [],
+			failure: null,
+			status: "RUNNING",
+			done: false,
+		});
 	});
 
 	it("throws when Temporal is unconfigured (like replay.ts)", async () => {

--- a/packages/cockpit/src/temporal/progress.ts
+++ b/packages/cockpit/src/temporal/progress.ts
@@ -141,6 +141,24 @@ export function isProgressDone(phase: string, status: string): boolean {
 }
 
 /**
+ * The snapshot returned while a triggered run isn't queryable yet (DAT-570). A
+ * stage trigger returns the deterministic workflow id immediately, but the
+ * per-workspace journey starts the engine child a beat later (DAT-530/562) — so an
+ * eager poll can land before any execution exists. Report PENDING (done:false) so
+ * the widget keeps polling, rather than letting the poll 500 on a
+ * `WorkflowNotFoundError`.
+ */
+const PENDING_PROGRESS: WorkflowProgress = {
+	phase: "pending",
+	tables_total: 0,
+	tables_completed: 0,
+	tables: [],
+	failure: null,
+	status: "PENDING",
+	done: false,
+};
+
+/**
  * The terminal cockpit `runs.status` for a DONE run. "completed" covers
  * the clean exits — phase=="done" (the workflow finished even if describe()
  * hasn't flipped yet), an actual COMPLETED, and CONTINUED_AS_NEW (a handoff, not
@@ -165,11 +183,16 @@ export function terminalRunStatus(
  * Works for any cockpit-triggered workflow. `addSourceWorkflow` (DAT-406) and
  * `beginSessionWorkflow` (DAT-435) both register a `get_progress`
  * @workflow.query serving the same snapshot shape (add_source with per-table
- * fan-out detail, begin_session sequential with empty fan-out fields). A
- * workflow without the query (none today; forward-compat) raises
- * `WorkflowQueryFailedError` — caught here to fall back to a `describe()`-only
- * status (no phase detail, but the authoritative run status + `done`). Any
- * OTHER query error is a real failure and rethrows.
+ * fan-out detail, begin_session sequential with empty fan-out fields).
+ *
+ * Tolerant of the two poll-races a stage trigger opens (DAT-570): the trigger
+ * returns the deterministic workflow id before the journey starts the engine
+ * child, so an eager poll can (a) find NO execution yet — `describe()` throws
+ * `WorkflowNotFoundError`, reported as PENDING; or (b) reach a brand-new execution
+ * whose first workflow task hasn't completed, so the query can't be served — the
+ * query failure degrades to a `describe()`-only snapshot. Same describe()-only
+ * fallback also covers a workflow that registers no `get_progress` handler (none
+ * today; forward-compat). Neither race 500s the poll.
  */
 export async function getWorkflowProgress(
 	input: WorkflowProgressInput,
@@ -181,20 +204,45 @@ export async function getWorkflowProgress(
 	// execution. `run_id` is still accepted in the input (the poll body sends it)
 	// but no longer pins the iteration.
 	const handle = client.workflow.getHandle(input.workflow_id);
-	const description = await handle.describe();
+
+	// describe() throws WorkflowNotFoundError when the workflow id has no execution
+	// yet — the poll-race the trigger opens (DAT-570). Report PENDING (not a 500) so
+	// the widget keeps polling; any OTHER describe() failure (config/connection) is
+	// a real error and surfaces. Match on `.name` (the SDK sets it on the prototype)
+	// to avoid coupling to the class export.
+	let description: Awaited<ReturnType<typeof handle.describe>>;
+	try {
+		description = await handle.describe();
+	} catch (err) {
+		if (err instanceof Error && err.name === "WorkflowNotFoundError") {
+			return PENDING_PROGRESS;
+		}
+		throw err;
+	}
 	const status = description.status.name;
 
 	let snapshot: ProgressSnapshot | null = null;
 	try {
 		snapshot = await handle.query<ProgressSnapshot, []>("get_progress");
 	} catch (err) {
-		// A workflow with no get_progress handler (none today; kept for
-		// forward-compat — all three parent workflows serve the query) raises
-		// WorkflowQueryFailedError — degrade to describe()-only. Match on the
-		// error name to avoid coupling to the SDK's class export.
-		if (!(err instanceof Error) || err.name !== "WorkflowQueryFailedError") {
-			throw err;
-		}
+		// describe() already gave the authoritative status; the query only adds the
+		// phase + per-table detail, so a query that can't be served must NOT 500 the
+		// poll — degrade to the describe()-only snapshot below. Covers the sibling
+		// poll-race to describe()'s NotFound (DAT-570): a brand-new execution whose
+		// first workflow task hasn't completed yet can't serve `get_progress`
+		// (QueryRejectedError / a transient query RPC error), and also a workflow
+		// with no `get_progress` handler (QueryNotRegisteredError; forward-compat).
+		// Logged so a genuinely broken query stays visible while the run keeps
+		// polling on its authoritative describe() status.
+		console.warn("get_progress query failed; degrading to describe()-only", {
+			workflow_id: input.workflow_id,
+			status,
+			// `error_name` makes log triage trivial: QueryRejectedError =
+			// first-task-not-ready race, QueryNotRegisteredError = no handler, anything
+			// else = a real query RPC failure degraded on purpose (DAT-570).
+			error_name: err instanceof Error ? err.name : undefined,
+			error: err instanceof Error ? err.message : String(err),
+		});
 	}
 
 	if (!snapshot) {


### PR DESCRIPTION
**Ticket:** DAT-570 (bug, epic DAT-526) · **Size:** S · cockpit-only

## Problem

The run-monitor poll (`/api/workflow-progress`) intermittently **500s** right when a stage is triggered. Since DAT-530/562 the cockpit returns the deterministic workflow id immediately and the widget starts polling it, but the per-workspace `JourneyWorkflow` starts the engine child a beat later. So an eager poll hits a workflow id with **no execution yet** → `getWorkflowProgress`'s unguarded `handle.describe()` threw `WorkflowNotFoundError` → propagated to the route's catch → 500. (Confirmed by reading `temporal/progress.ts`; matches the single-occurrence-at-trigger symptom in the ticket.)

## Fix (both poll-races, `temporal/progress.ts`)

1. **No execution yet:** guard `describe()` — on `WorkflowNotFoundError` return a synthetic **PENDING** snapshot (`done:false`) so the widget keeps polling; any other describe() error (connection/config) still surfaces. Matched by `err.name` (the SDK sets it on the prototype via `SymbolBasedInstanceOfError`).
2. **Sibling race:** a brand-new execution whose first workflow task hasn't completed can't serve `get_progress`. The query catch now **degrades to the existing describe()-only fallback** on any query error (logged with `error_name` for triage) instead of rethrowing.

This also fixes a **latent bug**: the old catch matched `err.name === "WorkflowQueryFailedError"` — a name the live SDK never throws (it throws `QueryNotRegisteredError` / `QueryRejectedError`), so the forward-compat "degrade" path was dead code and a missing handler would have 500'd.

## Why PENDING is safe end-to-end

`done:false` → the route never calls `markRunStatus`; `"PENDING"` isn't in `TERMINAL_STATUSES`; `reconcile.ts` leaves the run running for the next sweep. Route handler and `reconcile.ts` need no change (confirmed by spec review).

## Tests

NotFound→PENDING (asserts the query is never reached), sibling query-degrade (`QueryRejectedError` → describe()-only RUNNING), rethrow of a non-NotFound describe() error; corrected stale `WorkflowQueryFailedError` names to the real SDK classes. Full vitest **1223 pass**, tsc + biome clean.

## Review

senior-code-reviewer **APPROVE**, spec-compliance-reviewer **COMPLIANT**. Applied the one non-blocking suggestion (`error_name` in the degrade log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)