### PR TITLE
DAT-546: driver rankings as a begin_session artifact + look_drivers

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,34 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-18: DAT-546 — driver_rankings begin_session artifact
+
+Driver discovery is now PERSISTED, not just an in-memory engine. A new begin_session
+value-layer phase `driver_rankings` (runs last in `_SESSION_VALUE_PHASE_ORDER`, after
+`correlations`, before `session_detect`) enumerates each session fact's
+`semantic_role='measure'` columns, runs the unchanged `discover_drivers` over each (it
+self-resolves cluster keys from `identity_columns`), and writes one run-versioned
+`DriverRankingArtifact` per `(measure_column_id, run_id)`. The grain-labeled output is
+stored GRANULARLY (primary `grain`/`entity` + the `secondary_dimensions` list, each item
+keeping its own `grain`/`entity`) — never merged into one cross-grain ranking.
+
+- New table `driver_rankings` + read view `current_driver_rankings` (catalog grain, in
+  `schema.sql`/`schema_read.sql`). The proven engine core is untouched.
+- Run-scoping: measure role + temporal_behavior read unscoped-by-run (the `slicing_phase`
+  convention; role is generation-stable); `discover_drivers`' substrate reads stay on the
+  begin_session run.
+- v1 = measure-role columns only (flow/stock). Declared-metric ratios + genuinely-ad-hoc
+  question ratios are deferred (the on-demand `discover_drivers` tool, same result contract).
+
+### dataraum-eval
+- **Ranking-stability across reruns:** the artifact must be rerun-stable (DAT-563's
+  home-grain routing is what makes it deterministic). Run begin_session twice on the same
+  corpus and assert each measure's persisted `ranked_dimensions` + `secondary_dimensions`
+  (dimension, grain, entity) are identical run-to-run; n_rows stable. A drift here is a
+  determinism regression in the engine, not a calibration knob.
+- The phase persists EVERY measure-role column, including empty rankings (`n_rows` records
+  the power) — assert "no significant driver" is a stored row, not an absent one.
+
 ## 2026-06-18: DAT-563 — N-entity home-grain driver routing + ICC-verification resolver
 
 Makes the cluster-aware driver path actually fire end to end, generalized to N recurring

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -147,6 +147,27 @@ export const currentDimensionHierarchies = metadataSchema
 		sql`SELECT hierarchy_id, run_id, table_id, kind, members, canonical_label, signature, score, detection_source, needs_confirmation, created_at FROM ws_00000000_0000_0000_0000_000000000001.dimension_hierarchies r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
 	);
 
+export const currentDriverRankings = metadataSchema
+	.view("current_driver_rankings", {
+		rankingId: varchar("ranking_id"),
+		runId: varchar("run_id"),
+		measureTableId: varchar("measure_table_id"),
+		measureColumnId: varchar("measure_column_id"),
+		measureLabel: varchar("measure_label"),
+		targetType: varchar("target_type"),
+		grain: varchar(),
+		entity: varchar(),
+		nRows: integer("n_rows"),
+		rankedDimensions: json("ranked_dimensions"),
+		driverPaths: json("driver_paths"),
+		interestingSlices: json("interesting_slices"),
+		secondaryDimensions: json("secondary_dimensions"),
+		createdAt: timestamp("created_at", { withTimezone: true }),
+	})
+	.as(
+		sql`SELECT ranking_id, run_id, measure_table_id, measure_column_id, measure_label, target_type, grain, entity, n_rows, ranked_dimensions, driver_paths, interesting_slices, secondary_dimensions, created_at FROM ws_00000000_0000_0000_0000_000000000001.driver_rankings r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
+	);
+
 export const currentEnrichedViews = metadataSchema
 	.view("current_enriched_views", {
 		viewId: varchar("view_id"),

--- a/packages/cockpit/src/tools/look-drivers.test.ts
+++ b/packages/cockpit/src/tools/look-drivers.test.ts
@@ -1,0 +1,113 @@
+// Unit tests for the look_drivers projection (DAT-546). Pure — no DB; the live
+// read path (begin_session head check + view read) is integration-smoke-covered.
+//
+// What this guards: grain labels are surfaced GRANULARLY (the primary family's
+// grain/entity plus each secondary's OWN grain/entity — never flattened), the
+// persisted JSON is narrowed at the boundary (a malformed blob degrades to []
+// rather than throwing), and enriched dimension names carrying a content-keyed
+// `src_<digest>__` prefix are sanitized.
+
+import { describe, expect, it, vi } from "vitest";
+
+// Importing the tool pulls config.ts + the Postgres metadata client; mock both
+// (with the `#/` alias — relative specifiers silently don't intercept) so the
+// pure projection runs with no env and no connection.
+vi.mock("#/config", () => ({ config: {} }));
+vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
+
+import { type DriverRankingRow, projectDriverRanking } from "./look-drivers";
+
+const D1 = "204bc8e118543a6c35654c1f68c43539a2e226f2";
+
+describe("projectDriverRanking (DAT-546)", () => {
+	it("preserves per-family grain labels — primary + secondaries never merged", () => {
+		const row: DriverRankingRow = {
+			measureLabel: "revenue",
+			targetType: "flow",
+			grain: "entity",
+			entity: "customer",
+			nRows: 200,
+			rankedDimensions: [
+				{ dimension: "region", gain: 0.42 },
+				{ dimension: "channel", gain: 0.19 },
+			],
+			driverPaths: [["region", "channel"]],
+			interestingSlices: [
+				{ dimension: "region", value: "CH", effect: 0.5, support: 120 },
+			],
+			secondaryDimensions: [
+				{ dimension: "sku", gain: 0.22, grain: "entity", entity: "product" },
+				{ dimension: "hour", gain: 0.11, grain: "row", entity: null },
+			],
+		};
+		expect(projectDriverRanking(row)).toEqual({
+			measure: "revenue",
+			target_type: "flow",
+			grain: "entity",
+			entity: "customer",
+			n_rows: 200,
+			ranked_dimensions: [
+				{ dimension: "region", gain: 0.42 },
+				{ dimension: "channel", gain: 0.19 },
+			],
+			driver_paths: [["region", "channel"]],
+			interesting_slices: [
+				{ dimension: "region", value: "CH", effect: 0.5, support: 120 },
+			],
+			// Each secondary keeps its own grain + entity — the product-entity family and
+			// the row family stay distinct, neither merged into the primary.
+			secondary_dimensions: [
+				{ dimension: "sku", gain: 0.22, grain: "entity", entity: "product" },
+				{ dimension: "hour", gain: 0.11, grain: "row", entity: null },
+			],
+		});
+	});
+
+	it("sanitizes content-keyed src_<digest>__ prefixes on dimension names", () => {
+		const row: DriverRankingRow = {
+			measureLabel: "amount",
+			targetType: "flow",
+			grain: "row",
+			entity: null,
+			nRows: 10_000,
+			rankedDimensions: [{ dimension: `src_${D1}__region`, gain: 0.3 }],
+			driverPaths: [[`src_${D1}__region`, "channel"]],
+			interestingSlices: [
+				{
+					dimension: `src_${D1}__region`,
+					value: "CH",
+					effect: 0.4,
+					support: 90,
+				},
+			],
+			secondaryDimensions: [],
+		};
+		const out = projectDriverRanking(row);
+		expect(out.ranked_dimensions[0].dimension).toBe("region");
+		expect(out.driver_paths[0]).toEqual(["region", "channel"]);
+		expect(out.interesting_slices[0].dimension).toBe("region");
+	});
+
+	it("degrades a malformed/empty ranking to a born-loud zero, not a crash", () => {
+		const row: DriverRankingRow = {
+			measureLabel: "qty",
+			targetType: "flow",
+			grain: "row",
+			entity: null,
+			nRows: 0, // no power / no enriched view — an honest empty ranking
+			rankedDimensions: null, // malformed JSON blob
+			driverPaths: "not-an-array",
+			interestingSlices: undefined,
+			secondaryDimensions: [{ wrong: "shape" }],
+		};
+		const out = projectDriverRanking(row);
+		expect(out).toMatchObject({
+			measure: "qty",
+			n_rows: 0,
+			ranked_dimensions: [],
+			driver_paths: [],
+			interesting_slices: [],
+			secondary_dimensions: [],
+		});
+	});
+});

--- a/packages/cockpit/src/tools/look-drivers.ts
+++ b/packages/cockpit/src/tools/look-drivers.ts
@@ -1,0 +1,209 @@
+// look_drivers tool (DAT-546) — the persisted driver rankings for the workspace's
+// promoted begin_session run. For a measure, which dimensions and slices most
+// explain its variation: a ranked, significance-gated answer the engine pre-computed
+// (the variance-reduction tree + within-dataset permutation null, DAT-545/561/563),
+// so the answer agent narrates a real driver story instead of guessing a GROUP BY.
+//
+// Pure read of the `current_driver_rankings` view: catalog-grain, so the view already
+// resolves to the single promoted begin_session catalog head (one row per measure
+// column — no session axis, no TS-side latest pick needed). The grain labels are
+// surfaced, NOT flattened: the primary family's `grain`/`entity` plus a
+// `secondary_dimensions` list where each item keeps its OWN grain + entity (the
+// per-entity families are not cross-comparable — DAT-563). Read-only → no approval.
+//
+// The DB read is integration-smoke-covered; the pure row→shape projection (JSON
+// narrowing + digest sanitization, grain labels preserved) is unit-tested via
+// `projectDriverRanking`.
+
+import { toolDefinition } from "@tanstack/ai";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { metadataDb } from "../db/metadata/client";
+import { catalogHeadTarget } from "../db/metadata/relationship-target";
+import {
+	currentDriverRankings,
+	metadataSnapshotHead,
+} from "../db/metadata/schema";
+import { stripSrcDigests } from "../lib/display-names";
+
+// --- The persisted JSON shapes (narrowed at the boundary; fail soft to []). ---
+
+const RankedDim = z.object({ dimension: z.string(), gain: z.number() });
+const Slice = z.object({
+	dimension: z.string(),
+	value: z.string(),
+	effect: z.number(),
+	support: z.number(),
+});
+const Secondary = z.object({
+	dimension: z.string(),
+	gain: z.number(),
+	// "entity" or "row" — the exchangeable unit this dim's null used.
+	grain: z.string(),
+	// Which identity column the entity grain belongs to; null for the row family.
+	entity: z.string().nullable(),
+});
+
+// --- The tool's output: one entry per ranked measure. ---
+
+const DriverRanking = z.object({
+	// The measure the ranking explains (the column / ratio label).
+	measure: z.string(),
+	target_type: z.string(), // flow | stock | ratio
+	// The PRIMARY family's exchangeable grain: "row", or "entity" when the measure
+	// clusters within an identity; `entity` then names WHICH identity (else null).
+	grain: z.string(),
+	entity: z.string().nullable(),
+	// Effective sample size the power scales with (rows, or entities at entity grain)
+	// — so "no significant driver" on few entities is honestly attributable.
+	n_rows: z.number(),
+	// The primary family's significant dims, strongest first.
+	ranked_dimensions: z.array(RankedDim),
+	// Surviving drill vectors (e.g. ["region","channel"]) of the primary tree.
+	driver_paths: z.array(z.array(z.string())),
+	// Sharp-deviation slices across the tree, strongest first.
+	interesting_slices: z.array(Slice),
+	// Every NON-primary grain family's significant dims, each labeled with its own
+	// grain + entity — never merged into ranked_dimensions (the grains aren't comparable).
+	secondary_dimensions: z.array(Secondary),
+});
+export type DriverRanking = z.infer<typeof DriverRanking>;
+
+const LookDriversResult = z.object({
+	// False when the workspace has no promoted begin_session run yet — the widget
+	// should say "not run" rather than imply zero measures.
+	analyzed: z.boolean(),
+	rankings: z.array(DriverRanking),
+});
+export type LookDriversResult = z.infer<typeof LookDriversResult>;
+
+/** A raw `current_driver_rankings` row (JSON columns are `unknown` from Drizzle). */
+export interface DriverRankingRow {
+	measureLabel: string | null;
+	targetType: string | null;
+	grain: string | null;
+	entity: string | null;
+	nRows: number | null;
+	rankedDimensions: unknown;
+	driverPaths: unknown;
+	interestingSlices: unknown;
+	secondaryDimensions: unknown;
+}
+
+/**
+ * Project one persisted ranking row to the tool's shape. Pure (no DB) so the JSON
+ * narrowing + sanitization is unit-testable. Every dimension/entity string is run
+ * through the digest backstop (an enriched dimension can carry a raw
+ * `src_<digest>__` physical prefix); a malformed JSON blob degrades to `[]` rather
+ * than throwing — born-loud absence, never a crash. Grain labels are preserved
+ * verbatim, per family.
+ */
+export function projectDriverRanking(row: DriverRankingRow): DriverRanking {
+	const ranked = RankedDim.array().safeParse(row.rankedDimensions);
+	const paths = z.array(z.array(z.string())).safeParse(row.driverPaths);
+	const slices = Slice.array().safeParse(row.interestingSlices);
+	const secondary = Secondary.array().safeParse(row.secondaryDimensions);
+	return {
+		measure: stripSrcDigests(row.measureLabel ?? ""),
+		target_type: row.targetType ?? "",
+		grain: row.grain ?? "row",
+		entity: row.entity === null ? null : stripSrcDigests(row.entity),
+		n_rows: row.nRows ?? 0,
+		ranked_dimensions: ranked.success
+			? ranked.data.map((d) => ({
+					dimension: stripSrcDigests(d.dimension),
+					gain: d.gain,
+				}))
+			: [],
+		driver_paths: paths.success
+			? paths.data.map((p) => p.map(stripSrcDigests))
+			: [],
+		interesting_slices: slices.success
+			? slices.data.map((s) => ({
+					...s,
+					dimension: stripSrcDigests(s.dimension),
+				}))
+			: [],
+		secondary_dimensions: secondary.success
+			? secondary.data.map((s) => ({
+					...s,
+					dimension: stripSrcDigests(s.dimension),
+					entity: s.entity === null ? null : stripSrcDigests(s.entity),
+				}))
+			: [],
+	};
+}
+
+/** The promoted begin_session catalog run, or null when none is promoted yet. */
+async function readBeginSessionHead(): Promise<string | null> {
+	const [head] = await metadataDb
+		.select({ runId: metadataSnapshotHead.runId })
+		.from(metadataSnapshotHead)
+		.where(
+			and(
+				eq(metadataSnapshotHead.target, catalogHeadTarget()),
+				eq(metadataSnapshotHead.stage, "catalog"),
+			),
+		)
+		.limit(1);
+	return head?.runId ?? null;
+}
+
+/** Persisted driver rankings for the promoted begin_session run, optionally filtered. */
+export async function lookDrivers(input: {
+	measure?: string;
+}): Promise<LookDriversResult> {
+	// `analyzed` = a begin_session run is promoted — distinct from "promoted but zero
+	// measure columns" (a fact with no measures), which must not read as never-ran.
+	const head = await readBeginSessionHead();
+	if (!head) {
+		return { analyzed: false, rankings: [] };
+	}
+
+	// The view IS the promoted run (one row per measure column, catalog head). The set
+	// is small (a handful of measures per fact), so the optional measure filter is a
+	// case-insensitive substring match in JS — no brittle SQL name resolution.
+	const rows = await metadataDb
+		.select({
+			measureLabel: currentDriverRankings.measureLabel,
+			targetType: currentDriverRankings.targetType,
+			grain: currentDriverRankings.grain,
+			entity: currentDriverRankings.entity,
+			nRows: currentDriverRankings.nRows,
+			rankedDimensions: currentDriverRankings.rankedDimensions,
+			driverPaths: currentDriverRankings.driverPaths,
+			interestingSlices: currentDriverRankings.interestingSlices,
+			secondaryDimensions: currentDriverRankings.secondaryDimensions,
+		})
+		.from(currentDriverRankings);
+
+	const needle = input.measure?.trim().toLowerCase();
+	const rankings = rows
+		.map(projectDriverRanking)
+		.filter((r) => !needle || r.measure.toLowerCase().includes(needle));
+
+	return { analyzed: true, rankings };
+}
+
+export const lookDriversTool = toolDefinition({
+	name: "look_drivers",
+	description:
+		"Show which dimensions and slices most explain a measure's variation — the " +
+		"pre-computed driver rankings for the workspace's begin_session run. For each " +
+		"measure: ranked_dimensions (the dims that best explain it, significance-gated), " +
+		"driver_paths (drill vectors like region→channel), and interesting_slices (where " +
+		"the measure deviates sharply, with effect + support). grain/entity say at what " +
+		"level the story holds (row-level, or clustered within an identity like customer); " +
+		"n_rows is the effective sample size. secondary_dimensions are drivers found at a " +
+		"DIFFERENT grain (e.g. a second identity) — kept separate, not comparable to the " +
+		"primary ranking. Pass `measure` to filter to one (substring match); omit it for " +
+		"all. Read-only; reflects the promoted begin_session run (run begin_session first).",
+	inputSchema: z.object({
+		measure: z.string().optional().meta({
+			description:
+				"Filter to measures whose name contains this (case-insensitive).",
+		}),
+	}),
+	outputSchema: LookDriversResult,
+}).server((input) => lookDrivers(input));

--- a/packages/cockpit/src/tools/registry.test.ts
+++ b/packages/cockpit/src/tools/registry.test.ts
@@ -79,6 +79,7 @@ describe("tool registry (DAT-353)", () => {
 				"why_cycle",
 				"look_metric",
 				"why_metric",
+				"look_drivers",
 				"replay",
 				"upload",
 			]),

--- a/packages/cockpit/src/tools/registry.ts
+++ b/packages/cockpit/src/tools/registry.ts
@@ -22,6 +22,7 @@ import { listSourcesTool } from "./list-sources";
 import { listTablesTool } from "./list-tables";
 import { listVerticalsTool } from "./list-verticals";
 import { lookCycleTool } from "./look-cycle";
+import { lookDriversTool } from "./look-drivers";
 import { lookMetricTool } from "./look-metric";
 import { lookProfileTool } from "./look-profile";
 import { lookRelationshipsTool } from "./look-relationships";
@@ -55,6 +56,7 @@ const inspectTools = [
 	lookValidationTool,
 	lookCycleTool,
 	lookMetricTool,
+	lookDriversTool,
 	whyColumnTool,
 	whyTableTool,
 	whyRelationshipTool,

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -337,6 +337,7 @@ export const CHIP_ONLY: ReadonlySet<string> = new Set([
 	"list_verticals", // catalogue → chip summary, no widget
 	"use_vertical", // adopt = control-plane write, no renderable surface (DAT-523)
 	"probe", // quick data check, summarized in the chip
+	"look_drivers", // driver rankings → chip summary; a dedicated widget is a fast-follow (DAT-546)
 	"teach", // writes an overlay row; outcome surfaces after a re-run, not a widget
 	"teach_validation",
 	"teach_cycle",

--- a/packages/dataraum-config/pipeline.yaml
+++ b/packages/dataraum-config/pipeline.yaml
@@ -89,6 +89,13 @@ phases:
     description: Within-table correlation analysis
     detectors: [derived_value]
 
+  driver_rankings:
+    description: Per-measure driver discovery, persisted run-versioned over the enriched views
+    # DAT-546: no detectors and no LLM — runs the validated driver-discovery engine
+    # (DAT-545/561/563) over each measure-role column and writes one grain-labeled
+    # DriverRankingArtifact per (measure_column_id, run_id). Read by the answer agent
+    # (look_drivers, DAT-538).
+
   # =========================================================================
   # Zone 3: Interpretation
   # =========================================================================

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -373,6 +373,31 @@ CREATE INDEX idx_derived_table ON derived_columns (table_id);
 
 CREATE INDEX ix_derived_columns_run_id ON derived_columns (run_id);
 
+CREATE TABLE driver_rankings (
+	ranking_id VARCHAR NOT NULL, 
+	run_id VARCHAR NOT NULL, 
+	measure_table_id VARCHAR NOT NULL, 
+	measure_column_id VARCHAR NOT NULL, 
+	measure_label VARCHAR NOT NULL, 
+	target_type VARCHAR NOT NULL, 
+	grain VARCHAR NOT NULL, 
+	entity VARCHAR, 
+	n_rows INTEGER NOT NULL, 
+	ranked_dimensions JSON NOT NULL, 
+	driver_paths JSON NOT NULL, 
+	interesting_slices JSON NOT NULL, 
+	secondary_dimensions JSON NOT NULL, 
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL, 
+	CONSTRAINT pk_driver_rankings PRIMARY KEY (ranking_id), 
+	CONSTRAINT uq_driver_rankings_column_run UNIQUE (measure_column_id, run_id), 
+	CONSTRAINT fk_driver_rankings_measure_table_id_tables FOREIGN KEY(measure_table_id) REFERENCES tables (table_id), 
+	CONSTRAINT fk_driver_rankings_measure_column_id_columns FOREIGN KEY(measure_column_id) REFERENCES columns (column_id)
+);
+
+CREATE INDEX ix_driver_rankings_measure_column_id ON driver_rankings (measure_column_id);
+
+CREATE INDEX ix_driver_rankings_run_id ON driver_rankings (run_id);
+
 CREATE TABLE entropy_objects (
 	object_id VARCHAR NOT NULL, 
 	layer VARCHAR NOT NULL, 

--- a/packages/engine/schema_read.sql
+++ b/packages/engine/schema_read.sql
@@ -81,6 +81,16 @@ WHERE EXISTS (
     AND h.run_id = r.run_id
 );
 
+DROP VIEW IF EXISTS __READ__.current_driver_rankings;
+CREATE VIEW __READ__.current_driver_rankings AS
+SELECT r.* FROM __WS__.driver_rankings r
+WHERE EXISTS (
+  SELECT 1 FROM __WS__.metadata_snapshot_head h
+  WHERE h.target = 'catalog'
+    AND h.stage = 'catalog'
+    AND h.run_id = r.run_id
+);
+
 DROP VIEW IF EXISTS __READ__.current_enriched_views;
 CREATE VIEW __READ__.current_enriched_views AS
 SELECT r.* FROM __WS__.enriched_views r

--- a/packages/engine/src/dataraum/analysis/drivers/db_models.py
+++ b/packages/engine/src/dataraum/analysis/drivers/db_models.py
@@ -1,0 +1,85 @@
+"""SQLAlchemy model for the persisted driver-rankings artifact (DAT-546).
+
+The pure driver-discovery engine (:mod:`dataraum.analysis.drivers.processor`,
+DAT-545/561/563) returns an in-memory :class:`~dataraum.analysis.drivers.models.DriverRanking`
+per measure. This is its durable form: one run-versioned row per
+``(measure_column_id, run_id)``, written by the ``driver_rankings`` begin_session
+phase. Persisting it (rather than recomputing on demand) is the engine's
+pre-computed-context thesis — expensive numpy/permutation work, computed once,
+read many times by the answer agent (``look_drivers``).
+
+Run-versioned like ``MeasureAggregationLineage``: the version axis is the
+begin_session ``run_id``; a row becomes current once that run is promoted under
+the workspace catalog head (``current_driver_rankings``, DAT-506 read-view
+machinery). The grain-labeled findings (DAT-563) persist GRANULARLY — the
+primary family's ``grain``/``entity`` plus the ``secondary_dimensions`` list of
+non-primary grain families — never merged into one cross-grain ranking; the
+grains are not comparable and downstream consumers decide how to combine them.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from dataraum.storage import Base
+
+
+class DriverRankingArtifact(Base):
+    """One measure's driver ranking, run-versioned (DAT-546).
+
+    Keyed ``(measure_column_id, run_id)``: the measure is a ``semantic_role='measure'``
+    fact column, so its ``column_id`` is the stable artifact id. The grain-labeled
+    output is stored faithfully to :class:`DriverRanking` — ``grain``/``entity`` name
+    the primary family's exchangeable unit (row, or which identity's entity grain),
+    ``n_rows`` is the effective sample size (so a "no significant driver" result is
+    honestly attributable), and ``secondary_dimensions`` carries every non-primary
+    grain family's significant dims as a flat labeled list.
+    """
+
+    __tablename__ = "driver_rankings"
+    __table_args__ = (
+        UniqueConstraint("measure_column_id", "run_id", name="uq_driver_rankings_column_run"),
+    )
+
+    ranking_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    # Snapshot version axis (DAT-413): the begin_session run that discovered this.
+    run_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+
+    measure_table_id: Mapped[str] = mapped_column(ForeignKey("tables.table_id"), nullable=False)
+    measure_column_id: Mapped[str] = mapped_column(
+        ForeignKey("columns.column_id"), nullable=False, index=True
+    )
+    # A human label for the measure (the column name / ratio label) — what the
+    # ranking was computed FOR, denormalized for the read surface.
+    measure_label: Mapped[str] = mapped_column(String, nullable=False)
+    target_type: Mapped[str] = mapped_column(String, nullable=False)  # flow | stock | ratio
+
+    # The PRIMARY family's exchangeable grain (DAT-552/561/563): "row", or "entity"
+    # when the cluster-aware path made an entity-grain family primary; ``entity`` then
+    # names which identity column that grain belongs to (None at row grain).
+    grain: Mapped[str] = mapped_column(String, nullable=False)
+    entity: Mapped[str | None] = mapped_column(String)
+    n_rows: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # Grain-labeled findings, stored granularly (never merged across grains):
+    ranked_dimensions: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSON, nullable=False, default=list
+    )  # [{dimension, gain}] — the primary family's significant dims, strongest first
+    driver_paths: Mapped[list[list[str]]] = mapped_column(
+        JSON, nullable=False, default=list
+    )  # [[dim, ...]] — surviving drill vectors of the primary tree
+    interesting_slices: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSON, nullable=False, default=list
+    )  # [{dimension, value, effect, support}] — sharp-deviation slices, strongest first
+    secondary_dimensions: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSON, nullable=False, default=list
+    )  # [{dimension, gain, grain, entity}] — non-primary grain families' dims
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )

--- a/packages/engine/src/dataraum/analysis/drivers/persistence.py
+++ b/packages/engine/src/dataraum/analysis/drivers/persistence.py
@@ -81,8 +81,14 @@ def _measure_columns(
 
     Read by ``column_id`` without a run filter (the ``slicing_phase`` convention):
     ``semantic_role`` is stable from add_source generation. Deduped to one row per
-    column (a deterministic pick by ``column_id``) so a re-adjudicated annotation can
-    never run discovery twice for the same measure.
+    column so a re-adjudicated annotation can never run discovery twice. UNLIKE
+    slicing (which only reads the stable role), the ``temporal_behavior`` picked here
+    drives ``discover_drivers``' target function — so when a column carries annotations
+    from multiple coexisting runs the pick MUST be deterministic, or a Temporal
+    redelivery could persist a different ranking than the promoted head. The
+    ``run_id`` desc tiebreak makes it stable (a deterministic pick, not a recency
+    claim — ``run_id`` isn't time-ordered; resolving the true per-table semantic head
+    is the value layer's shared gap with slicing, out of scope here).
     """
     rows = session.execute(
         select(
@@ -96,7 +102,7 @@ def _measure_columns(
             Column.table_id.in_(table_ids),
             SemanticAnnotation.semantic_role == "measure",
         )
-        .order_by(Column.column_id)
+        .order_by(Column.column_id, SemanticAnnotation.run_id.desc())
     ).all()
     by_column: dict[str, tuple[str, str, str, str | None]] = {}
     for column_id, table_id, column_name, behavior in rows:

--- a/packages/engine/src/dataraum/analysis/drivers/persistence.py
+++ b/packages/engine/src/dataraum/analysis/drivers/persistence.py
@@ -1,0 +1,163 @@
+"""Persist driver rankings as a run-versioned begin_session artifact (DAT-546).
+
+Bridges the pure engine (:func:`discover_drivers`) to the durable store: enumerate
+the session's measure-role fact columns, run the validated discovery over each, and
+write one run-versioned :class:`DriverRankingArtifact` per ``(measure_column_id,
+run_id)``. The engine and ``resolve_target_type`` are NOT touched here — this module
+only orchestrates + serializes.
+
+Run-scoping follows the shipped begin_session convention (``slicing_phase``): the
+measure role + temporal behavior are read by ``column_id`` without a run filter —
+``semantic_role`` is generation-stable, and the value layer has no base-run pinning
+(that is operating_model's concern). ``discover_drivers``' own substrate reads
+(enriched view, slice catalog, ``identity_columns``) ARE scoped to the begin_session
+``run_id`` passed through, because those artifacts are written this run.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import select
+
+from dataraum.analysis.drivers.db_models import DriverRankingArtifact
+from dataraum.analysis.drivers.models import DriverRanking, Measure
+from dataraum.analysis.drivers.processor import discover_drivers
+from dataraum.analysis.semantic.db_models import SemanticAnnotation
+from dataraum.core.logging import get_logger
+from dataraum.storage import Column
+from dataraum.storage.upsert import upsert
+
+if TYPE_CHECKING:
+    import duckdb
+    from sqlalchemy.orm import Session
+
+logger = get_logger(__name__)
+
+# temporal_behavior → driver target type (mirrors processor.resolve_target_type's
+# mapping; inlined so the validated module stays untouched). Anything else → flow,
+# the additive reading. Ratio measures are not enumerated here (v1 = measure-role
+# columns); they arrive via the deferred on-demand path.
+_TEMPORAL_TO_TARGET = {"additive": "flow", "point_in_time": "stock"}
+
+
+def ranking_to_row(
+    ranking: DriverRanking, *, run_id: str, measure_table_id: str, measure_column_id: str
+) -> dict[str, Any]:
+    """Serialize a :class:`DriverRanking` into a ``DriverRankingArtifact`` row dict.
+
+    Grain labels are preserved verbatim: the primary family's ``grain``/``entity``
+    plus every ``SecondaryDriver``'s own ``grain``/``entity`` — never flattened into
+    one ranking. The PK + ``created_at`` are omitted so their model defaults apply.
+    """
+    return {
+        "run_id": run_id,
+        "measure_table_id": measure_table_id,
+        "measure_column_id": measure_column_id,
+        "measure_label": ranking.measure,
+        "target_type": ranking.target_type,
+        "grain": ranking.grain,
+        "entity": ranking.entity,
+        "n_rows": ranking.n_rows,
+        "ranked_dimensions": [
+            {"dimension": dim, "gain": gain} for dim, gain in ranking.ranked_dimensions
+        ],
+        "driver_paths": [list(path) for path in ranking.driver_paths],
+        "interesting_slices": [
+            {"dimension": s.dimension, "value": s.value, "effect": s.effect, "support": s.support}
+            for s in ranking.interesting_slices
+        ],
+        "secondary_dimensions": [
+            {"dimension": sd.dimension, "gain": sd.gain, "grain": sd.grain, "entity": sd.entity}
+            for sd in ranking.secondary_dimensions
+        ],
+    }
+
+
+def _measure_columns(
+    session: Session, table_ids: list[str]
+) -> list[tuple[str, str, str, str | None]]:
+    """The session's measure-role columns: ``(column_id, table_id, name, behavior)``.
+
+    Read by ``column_id`` without a run filter (the ``slicing_phase`` convention):
+    ``semantic_role`` is stable from add_source generation. Deduped to one row per
+    column (a deterministic pick by ``column_id``) so a re-adjudicated annotation can
+    never run discovery twice for the same measure.
+    """
+    rows = session.execute(
+        select(
+            Column.column_id,
+            Column.table_id,
+            Column.column_name,
+            SemanticAnnotation.temporal_behavior,
+        )
+        .join(SemanticAnnotation, SemanticAnnotation.column_id == Column.column_id)
+        .where(
+            Column.table_id.in_(table_ids),
+            SemanticAnnotation.semantic_role == "measure",
+        )
+        .order_by(Column.column_id)
+    ).all()
+    by_column: dict[str, tuple[str, str, str, str | None]] = {}
+    for column_id, table_id, column_name, behavior in rows:
+        by_column.setdefault(column_id, (column_id, table_id, column_name, behavior))
+    return list(by_column.values())
+
+
+def persist_driver_rankings(
+    session: Session,
+    *,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    table_ids: list[str],
+    run_id: str,
+) -> int:
+    """Run driver discovery over each measure-role fact column and persist the rankings.
+
+    Idempotent per run — one row per ``(measure_column_id, run_id)`` UPSERTed on
+    ``uq_driver_rankings_column_run``; a Temporal success-redelivery converges in place
+    (the engine is deterministic per ``(seed, candidate set)``). EVERY measure-role
+    column gets a row, including an empty ranking (``n_rows`` records the power) —
+    born loud, never silently absent.
+
+    Returns:
+        The number of driver-ranking rows persisted.
+    """
+    if not table_ids:
+        return 0
+    measures = _measure_columns(session, table_ids)
+    if not measures:
+        logger.info("driver_rankings_no_measures", table_ids=table_ids)
+        return 0
+
+    rows: list[dict[str, Any]] = []
+    for column_id, table_id, column_name, behavior in measures:
+        target_type = _TEMPORAL_TO_TARGET.get(behavior or "", "flow")
+        measure = Measure(target_type=target_type, column=column_name)
+        ranking = discover_drivers(
+            session,
+            duckdb_conn=duckdb_conn,
+            fact_table_id=table_id,
+            run_id=run_id,
+            measure=measure,
+        )
+        rows.append(
+            ranking_to_row(
+                ranking,
+                run_id=run_id,
+                measure_table_id=table_id,
+                measure_column_id=column_id,
+            )
+        )
+        logger.info(
+            "driver_ranking_persisted",
+            measure=column_name,
+            target_type=target_type,
+            grain=ranking.grain,
+            entity=ranking.entity,
+            n_rows=ranking.n_rows,
+            ranked=len(ranking.ranked_dimensions),
+            secondary=len(ranking.secondary_dimensions),
+        )
+
+    upsert(session, DriverRankingArtifact, rows, index_elements=["measure_column_id", "run_id"])
+    return len(rows)

--- a/packages/engine/src/dataraum/pipeline/phases/drivers_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/drivers_phase.py
@@ -1,0 +1,61 @@
+"""Driver-rankings phase (DAT-546) — persist driver discovery per measure.
+
+Session value phase, mirroring ``aggregation_lineage``: source-free, session-scoped,
+no LLM call. For each ``semantic_role='measure'`` column on the session's tables it
+runs the validated driver-discovery engine (DAT-545/561/563) over the fact's enriched
+view and persists the grain-labeled ranking run-versioned. Runs after the value layer
+(``slicing`` → ``dimension_hierarchies`` → ``aggregation_lineage`` → ``correlations``)
+so its inputs — enriched views, the slice catalog, dimension hierarchies, and
+``identity_columns`` — are all present this run.
+
+Persisting (not recomputing on demand) is the pre-computed-context thesis: the answer
+agent reads the stored ranking via ``look_drivers``. The genuinely ad-hoc tail (a ratio
+a question invents that no measure column backs) is the deferred on-demand path.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+from dataraum.analysis.drivers.persistence import persist_driver_rankings
+from dataraum.core.logging import get_logger
+from dataraum.pipeline.base import PhaseContext, PhaseResult
+from dataraum.pipeline.phases.base import BasePhase
+from dataraum.pipeline.registry import analysis_phase
+
+logger = get_logger(__name__)
+
+
+@analysis_phase
+class DriversPhase(BasePhase):
+    """Persist per-measure driver rankings over the begin_session substrate (DAT-546)."""
+
+    @property
+    def name(self) -> str:
+        return "driver_rankings"
+
+    @property
+    def db_models(self) -> list[ModuleType]:
+        from dataraum.analysis.drivers import db_models
+
+        return [db_models]
+
+    def should_skip(self, ctx: PhaseContext) -> str | None:
+        """Skip only with no session scope; zero measures is a loud success in ``_run``."""
+        if not ctx.table_ids:
+            return "No tables in session scope"
+        return None
+
+    def _run(self, ctx: PhaseContext) -> PhaseResult:
+        run_id = ctx.require_run_id()
+        persisted = persist_driver_rankings(
+            ctx.session,
+            duckdb_conn=ctx.duckdb_conn,
+            table_ids=ctx.table_ids or [],
+            run_id=run_id,
+        )
+        return PhaseResult.success(
+            outputs={"rankings": persisted},
+            records_created=persisted,
+            summary=f"{persisted} measure(s) ranked for drivers",
+        )

--- a/packages/engine/src/dataraum/storage/read_views.py
+++ b/packages/engine/src/dataraum/storage/read_views.py
@@ -78,6 +78,7 @@ _CATALOG_GRAIN: dict[str, str] = {
     "dimension_hierarchies": "catalog",  # begin_session dimension_hierarchies (DAT-537)
     "derived_columns": "catalog",
     "measure_aggregation_lineage": "catalog",  # begin_session aggregation_lineage (DAT-491)
+    "driver_rankings": "catalog",  # begin_session driver_rankings (DAT-546)
     "lifecycle_artifacts": "operating_model",
     "validation_results": "operating_model",
     "detected_business_cycles": "operating_model",

--- a/packages/engine/src/dataraum/worker/activities.py
+++ b/packages/engine/src/dataraum/worker/activities.py
@@ -367,6 +367,19 @@ class PhaseActivities:
             "correlations", payload.run, payload.table_ids, payload.vertical
         )
 
+    @activity.defn(name="driver_rankings")
+    def run_driver_rankings(self, payload: SessionScopedInput) -> PhaseOutcome:
+        """Driver-rankings activity — persist per-measure driver discovery (DAT-546).
+
+        Runs the validated driver-discovery engine over each measure-role fact
+        column's enriched view and persists the grain-labeled ranking run-versioned
+        (one row per ``(measure_column_id, run_id)``). Deterministic, NO LLM call.
+        Read by the answer agent via ``look_drivers``.
+        """
+        return self._run_session_or_raise(
+            "driver_rankings", payload.run, payload.table_ids, payload.vertical
+        )
+
     @activity.defn(name="session_materialize_overlays")
     def run_session_materialize_overlays(self, run: RunRef) -> PhaseOutcome:
         """Materialize durable relationship overlays into this run (DAT-409).

--- a/packages/engine/src/dataraum/worker/main.py
+++ b/packages/engine/src/dataraum/worker/main.py
@@ -81,6 +81,8 @@ def worker_activities(phase_activities: PhaseActivities) -> list[object]:
         # DAT-537 g3 drill-down / alias discovery over the slice catalog.
         phase_activities.run_dimension_hierarchies,
         phase_activities.run_correlations,
+        # DAT-546: per-measure driver rankings persisted run-versioned (last value phase).
+        phase_activities.run_driver_rankings,
         # DAT-408/409 begin_session: materialize durable overlays →
         # terminal detect → silent-accept keepers → promote.
         phase_activities.run_session_materialize_overlays,

--- a/packages/engine/src/dataraum/worker/workflows.py
+++ b/packages/engine/src/dataraum/worker/workflows.py
@@ -479,6 +479,11 @@ _SESSION_VALUE_PHASE_ORDER = (
     # and reconciles the per-period sums across facts sharing a catalog dimension.
     "aggregation_lineage",
     "correlations",
+    # DAT-546: rank each measure-role column's drivers over the enriched view and
+    # persist run-versioned (read by the answer agent via look_drivers). Last in the
+    # value layer — needs slicing's catalog, dimension_hierarchies, and the enriched
+    # views all present this run. Deterministic, no LLM.
+    "driver_rankings",
 )
 
 

--- a/packages/engine/tests/integration/worker/test_begin_session_progress_query.py
+++ b/packages/engine/tests/integration/worker/test_begin_session_progress_query.py
@@ -64,6 +64,7 @@ _PHASE_ORDER = [
     "dimension_hierarchies",
     "aggregation_lineage",
     "correlations",
+    "driver_rankings",
     "session_detect",
     "session_write_keepers",
     "session_promote_to_latest",

--- a/packages/engine/tests/unit/analysis/drivers/test_persistence.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_persistence.py
@@ -118,6 +118,18 @@ def _write_view(duck: duckdb.DuckDBPyConnection, df, view_name: str = VIEW) -> N
     duck.unregister("seed_df")
 
 
+# --- target-type mapping is pinned to the validated engine's --------------------
+
+
+def test_temporal_to_target_matches_processor() -> None:
+    # persistence inlines the temporal_behavior→target map so the validated processor
+    # stays untouched; pin it to processor's so a future vocabulary change can't
+    # silently diverge the two (the only thing this duplication risks).
+    from dataraum.analysis.drivers import persistence, processor
+
+    assert persistence._TEMPORAL_TO_TARGET == processor._TEMPORAL_TO_TARGET
+
+
 # --- the serializer: grain labels preserved, never flattened ----------------------
 
 

--- a/packages/engine/tests/unit/analysis/drivers/test_persistence.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_persistence.py
@@ -1,0 +1,249 @@
+"""DAT-546 — persist driver rankings as a run-versioned begin_session artifact.
+
+Covers the serializer (grain labels preserved, never flattened), the orchestrator
+over a seeded session (one grain-labeled row per measure-role column), idempotent
+re-run (UPSERT converges), born-loud zero-measures, and session-table scoping. The
+statistical behavior of the engine itself is proven in ``test_grain_e2e``.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import duckdb
+import numpy as np
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from dataraum.analysis.drivers.db_models import DriverRankingArtifact
+from dataraum.analysis.drivers.models import DriverRanking, DriverSlice, SecondaryDriver
+from dataraum.analysis.drivers.persistence import persist_driver_rankings, ranking_to_row
+from dataraum.analysis.semantic.db_models import SemanticAnnotation, TableEntity
+from dataraum.analysis.slicing.db_models import SliceDefinition
+from dataraum.analysis.views.db_models import EnrichedView
+from dataraum.storage import Column, Table
+
+from .conftest import (
+    CL_DIMS,
+    CL_ENTITY,
+    TE_CUST,
+    TE_CUST_DRIVER,
+    TE_DIMS,
+    TE_PROD,
+    TE_PROD_DRIVER,
+    make_clustered_corpus,
+    make_two_entity_corpus,
+)
+
+RUN = "session-run-1"
+VIEW = "sales_enriched"
+N_PERM = 200
+
+
+def _seed(
+    session: Session,
+    *,
+    dims: list[str],
+    identities: list[str] | None = None,
+    measure_role: str = "measure",
+    behavior: str = "additive",
+    table_name: str = "sales",
+    view_name: str = VIEW,
+) -> tuple[str, str]:
+    """Seed a fact + catalog with a ``semantic_role`` column the orchestrator enumerates.
+
+    Returns ``(fact_table_id, measure_column_id)``. ``dims`` become grain-safe slice
+    definitions; ``measure`` gets a ``SemanticAnnotation`` with ``measure_role`` (set
+    to a non-measure role to exercise the born-loud zero path); identities (if given)
+    are persisted as ``TableEntity.identity_columns`` for the resolver to read.
+    """
+    fact = Table(
+        table_id=str(uuid4()),
+        source_id="s",
+        table_name=table_name,
+        layer="typed",
+        duckdb_path=view_name,
+    )
+    session.add(fact)
+    measure_col_id = ""
+    for pos, name in enumerate([*dims, "measure"]):
+        col = Column(
+            column_id=str(uuid4()), table_id=fact.table_id, column_name=name, column_position=pos
+        )
+        session.add(col)
+        if name in dims:
+            session.add(
+                SliceDefinition(
+                    run_id=RUN,
+                    table_id=fact.table_id,
+                    column_id=col.column_id,
+                    column_name=name,
+                    slice_priority=1,
+                    grain_safe=True,
+                    detection_source="llm",
+                )
+            )
+        else:  # the measure column
+            measure_col_id = col.column_id
+            session.add(
+                SemanticAnnotation(
+                    column_id=col.column_id,
+                    run_id=RUN,
+                    semantic_role=measure_role,
+                    temporal_behavior=behavior,
+                )
+            )
+    session.add(
+        EnrichedView(
+            run_id=RUN, fact_table_id=fact.table_id, view_name=view_name, is_grain_verified=True
+        )
+    )
+    if identities:
+        session.add(
+            TableEntity(
+                run_id=RUN,
+                table_id=fact.table_id,
+                detected_entity_type="orders",
+                identity_columns=[{"column": c, "note": "seed"} for c in identities],
+            )
+        )
+    session.flush()
+    return fact.table_id, measure_col_id
+
+
+def _write_view(duck: duckdb.DuckDBPyConnection, df, view_name: str = VIEW) -> None:
+    duck.execute(f'DROP TABLE IF EXISTS "{view_name}"')
+    duck.register("seed_df", df)
+    duck.execute(f'CREATE TABLE "{view_name}" AS SELECT * FROM seed_df')
+    duck.unregister("seed_df")
+
+
+# --- the serializer: grain labels preserved, never flattened ----------------------
+
+
+def test_ranking_to_row_preserves_per_item_grain_labels() -> None:
+    ranking = DriverRanking(
+        measure="revenue",
+        target_type="flow",
+        n_rows=200,
+        grain="entity",
+        entity="customer",
+        ranked_dimensions=[("region", 0.42), ("channel", 0.19)],
+        driver_paths=[["region", "channel"]],
+        interesting_slices=[DriverSlice(dimension="region", value="CH", effect=0.5, support=120)],
+        secondary_dimensions=[
+            SecondaryDriver(dimension="sku", gain=0.22, grain="entity", entity="product"),
+            SecondaryDriver(dimension="hour", gain=0.11, grain="row", entity=None),
+        ],
+    )
+    row = ranking_to_row(ranking, run_id=RUN, measure_table_id="t1", measure_column_id="c1")
+
+    assert row["grain"] == "entity"
+    assert row["entity"] == "customer"
+    assert row["n_rows"] == 200
+    assert row["ranked_dimensions"] == [
+        {"dimension": "region", "gain": 0.42},
+        {"dimension": "channel", "gain": 0.19},
+    ]
+    assert row["driver_paths"] == [["region", "channel"]]
+    assert row["interesting_slices"] == [
+        {"dimension": "region", "value": "CH", "effect": 0.5, "support": 120}
+    ]
+    # The crux: each secondary keeps ITS OWN grain + entity — the product-entity family
+    # and the row family are not merged into the primary or into one another.
+    assert row["secondary_dimensions"] == [
+        {"dimension": "sku", "gain": 0.22, "grain": "entity", "entity": "product"},
+        {"dimension": "hour", "gain": 0.11, "grain": "row", "entity": None},
+    ]
+
+
+# --- the orchestrator over a seeded session ---------------------------------------
+
+
+def test_persist_writes_one_grain_labeled_row_per_measure(
+    real_session: Session, duck: duckdb.DuckDBPyConnection
+) -> None:
+    # Two named identities on a clustered corpus → the engine resolves customer as the
+    # primary entity grain and product as a labeled-entity secondary. The persisted row
+    # must carry that structure GRANULARLY (DAT-563), not a flattened cross-grain list.
+    tid, measure_col_id = _seed(real_session, dims=TE_DIMS, identities=[TE_CUST, TE_PROD])
+    _write_view(duck, make_two_entity_corpus(np.random.default_rng(0)))
+
+    n = persist_driver_rankings(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+    assert n == 1
+
+    row = real_session.execute(
+        select(DriverRankingArtifact).where(
+            DriverRankingArtifact.measure_column_id == measure_col_id,
+            DriverRankingArtifact.run_id == RUN,
+        )
+    ).scalar_one()
+    assert row.measure_table_id == tid
+    assert row.measure_label == "measure"
+    assert row.target_type == "flow"
+    assert row.grain == "entity"
+    assert row.entity == TE_CUST
+    assert row.n_rows > 0
+    primary = {d["dimension"] for d in row.ranked_dimensions}
+    assert TE_CUST_DRIVER in primary
+    # The product family persisted at its OWN entity grain, labeled — never merged.
+    prod = [s for s in row.secondary_dimensions if s["entity"] == TE_PROD]
+    assert any(s["dimension"] == TE_PROD_DRIVER for s in prod)
+    assert all(s["grain"] == "entity" for s in prod)
+    assert TE_PROD_DRIVER not in primary
+
+
+def test_persist_is_idempotent_on_rerun(
+    real_session: Session, duck: duckdb.DuckDBPyConnection
+) -> None:
+    # Same run_id + deterministic engine → a Temporal success-redelivery converges in
+    # place: still exactly one row per (measure_column_id, run_id), identical content.
+    tid, measure_col_id = _seed(real_session, dims=TE_DIMS, identities=[TE_CUST, TE_PROD])
+    _write_view(duck, make_two_entity_corpus(np.random.default_rng(0)))
+
+    persist_driver_rankings(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+    first = real_session.execute(select(DriverRankingArtifact)).scalar_one()
+    first_dims = list(first.ranked_dimensions)
+
+    _write_view(duck, make_two_entity_corpus(np.random.default_rng(0)))
+    persist_driver_rankings(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+
+    rows = real_session.execute(select(DriverRankingArtifact)).scalars().all()
+    assert len(rows) == 1  # UPSERT converged, no duplicate
+    assert rows[0].ranked_dimensions == first_dims
+
+
+def test_no_measure_role_persists_nothing(
+    real_session: Session, duck: duckdb.DuckDBPyConnection
+) -> None:
+    # Born-loud zero: a fact whose only annotated column is NOT a measure role yields no
+    # rows (and no crash) — nothing to rank, surfaced as an explicit 0.
+    tid, _ = _seed(real_session, dims=CL_DIMS, measure_role="attribute")
+    _write_view(duck, make_clustered_corpus(np.random.default_rng(0)))
+
+    n = persist_driver_rankings(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+    assert n == 0
+    assert real_session.execute(select(DriverRankingArtifact)).first() is None
+
+
+def test_only_session_tables_are_enumerated(
+    real_session: Session, duck: duckdb.DuckDBPyConnection
+) -> None:
+    # Two facts in the catalog; only one is in session scope → only its measure is ranked.
+    in_scope, in_col = _seed(
+        real_session, dims=CL_DIMS, identities=[CL_ENTITY], table_name="in_scope", view_name=VIEW
+    )
+    _seed(
+        real_session,
+        dims=CL_DIMS,
+        identities=[CL_ENTITY],
+        table_name="out_of_scope",
+        view_name="other_enriched",
+    )
+    _write_view(duck, make_clustered_corpus(np.random.default_rng(0)))
+
+    n = persist_driver_rankings(real_session, duckdb_conn=duck, table_ids=[in_scope], run_id=RUN)
+    assert n == 1
+    rows = real_session.execute(select(DriverRankingArtifact)).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].measure_column_id == in_col

--- a/packages/engine/tests/unit/worker/test_session_value_phases.py
+++ b/packages/engine/tests/unit/worker/test_session_value_phases.py
@@ -30,6 +30,9 @@ def test_value_phase_order_is_the_agreed_chain() -> None:
         # reconciles the per-period sums — no slice-materialization phases precede it.
         "aggregation_lineage",
         "correlations",
+        # DAT-546: per-measure driver rankings, run-versioned. Last in the chain —
+        # needs slicing's catalog + dimension_hierarchies + the enriched views.
+        "driver_rankings",
     )
 
 


### PR DESCRIPTION
## DAT-546 — DAT-543 P2: persist driver discovery + cockpit read surface

Turns the validated driver-discovery engine (DAT-545/561/563) from an in-memory function into **pre-computed context**: a run-versioned begin_session artifact the answer agent reads. This deliberately reframes the stale ticket AC's "compute on-demand, don't persist" — driver rankings are exactly the kind of expensive-once / read-many output the engine exists to pre-compute.

### Engine (P1)
- **`driver_rankings` value-layer phase** (last in `_SESSION_VALUE_PHASE_ORDER`, after `correlations`, before `session_detect`): enumerates each session fact's `semantic_role='measure'` columns and runs the **untouched** `discover_drivers` over each, persisting one `DriverRankingArtifact` per `(measure_column_id, run_id)`.
- **Grain-labeled findings persist GRANULARLY** (DAT-563): the primary family's `grain`/`entity` plus a `secondary_dimensions` list where each item keeps its own `grain`/`entity` — never merged into one cross-grain ranking.
- `current_driver_rankings` read view via the catalog-grain generator; `schema.sql`/`schema_read.sql` regenerated. Fully wired: phase → activity → `worker_activities()` → workflow → `pipeline.yaml`.
- Born-loud: every measure column gets a row, including empty rankings (`n_rows` records the power).

### Cockpit (P2)
- **`look_drivers`** tool reads `current_driver_rankings` (catalog head → one row per measure, no TS latest-pick), JSON narrowed at the boundary with fail-soft, digest-sanitized, optional `measure` filter; `analyzed:false` distinguishes "never ran" from "no measures". Registered in `inspectTools` (stage + analyse); chip-only (widget is a fast-follow).
- `db:pull:metadata` regen mirrors the view in `schema.ts`.

### Review fixes
- Deterministic measure-annotation tiebreak (the pick drives the target function; non-determinism would undermine rerun-stability).
- Test pinning the inlined `_TEMPORAL_TO_TARGET` to the processor's (drift guard).

### Scope (agreed deferrals)
- **DAT-571** — row-count gate before the in-memory view load (engine core).
- **DAT-572** — precompute declared-metric *ratio* measures.
- **DAT-573** — on-demand `discover_drivers` tool for ad-hoc question ratios (same result contract).
- The validated engine core (`discover_drivers`/`tree`/`targets`/`criterion`) is untouched.

### Tests / verification
- 60 engine driver unit tests (incl. serializer multi-grain, orchestrator, idempotent rerun, born-loud zero, scoping) + 144 worker/pipeline + 1224 cockpit; tsc + biome + ruff + mypy clean.
- Reviewers: spec-compliance **COMPLIANT**, senior **APPROVE** (no blockers).
- Handoff entry for eval (ranking-stability across reruns).
- **Live smoke (full round-trip):** fresh stack rebuilt from branch → add_source(invoices.csv) → begin_session ran the `driver_rankings` phase: enumerated the `amount` measure, the DAT-563 ICC-verification resolver dropped mis-named identities (`vid` icc 0.01, `entry_id` icc 0) on real data, and persisted a grain-labeled row (`amount`, row grain, n_rows=3000, no significant driver = born-loud empty). `look_drivers` in the Analyse chat then read it back (`analyzed:true`, measure/target_type/grain/n_rows rendered faithfully). Only console error = the known DAT-570 `/api/workflow-progress` poll race (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)