### PR TITLE
DAT-571: bound driver-discovery load via bottom-k-by-hash sampling

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,30 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-18: DAT-571 — driver-discovery in-memory load is bounded by sampling
+
+`discover_drivers` now caps the row-grain frame it materializes. A `max_rows` gate
+(`DEFAULT_MAX_ROWS = 800_000`): at/below the cap the view loads in full (validated path,
+byte-for-byte unchanged — the COUNT(*) is the only added work); above it, the view is
+deterministically sub-sampled to `max_rows` rows via a bottom-k-by-hash sketch
+(`ORDER BY hash(<cols>) LIMIT max_rows`) and a `driver_rankings_view_sampled` log fires.
+Engine core (`tree.py`/`targets.py`/`criterion.py`) untouched.
+
+### dataraum-eval
+- **Two regimes for the DAT-546 "n_rows stable across reruns" assertion.** On views ≤ 800k
+  rows nothing changes. On views **> 800k rows**, `DriverRanking.n_rows` now reports the
+  **sample size (800k)**, not the full view size — and the bottom-k sketch is a total order
+  (deterministic regardless of DuckDB thread count), so the rerun-stability assertion still
+  holds in BOTH regimes (same corpus → same sample → same ranking). If a large-view
+  calibration fixture exists, expect `n_rows == 800_000` and a `driver_rankings_view_sampled`
+  log, not the raw row count.
+- **Sampling is fail-safe, not power-neutral.** The permutation null is recomputed on the
+  sample, so FDR/precision hold; the entity-grain family loses some power on *weak* drivers
+  under sampling (degrades to a miss, never a fabricated driver). A large-view recall fixture
+  should treat a missed *weak* entity-grain driver as expected, not a regression; a missed
+  *strong* driver (or any false positive) is a real bug. DAT-580 (arrow-backed load) will
+  raise the ceiling so sampling becomes a rare fallback.
+
 ## 2026-06-18: DAT-546 — driver_rankings begin_session artifact
 
 Driver discovery is now PERSISTED, not just an in-memory engine. A new begin_session

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -68,6 +68,12 @@ DEFAULT_ICC_THRESHOLD = 0.10
 # At entity grain a candidate group is evaluated only with at least this many ENTITIES
 # (the min_support analogue — power scales with entity count, not rows).
 DEFAULT_MIN_ENTITIES = 10
+# Above this row count the enriched view is sub-sampled before the in-memory load
+# (DAT-571). The bound is the pandas frame, NOT DuckDB's scan (which is memory_limit-
+# capped): ``.df()`` materializes string dims as Python objects (~50–80 B/value), so
+# ~800k rows × the (already pruned) candidate dims is the comfortable per-frame size
+# under the worker's concurrent activities. DAT-580 (arrow-backed load) will raise it.
+DEFAULT_MAX_ROWS = 800_000
 
 _TEMPORAL_TO_TARGET = {"additive": "flow", "point_in_time": "stock"}
 
@@ -242,6 +248,7 @@ def discover_drivers(
     top_k_slices: int = DEFAULT_TOP_K_SLICES,
     icc_threshold: float = DEFAULT_ICC_THRESHOLD,
     min_entities: int = DEFAULT_MIN_ENTITIES,
+    max_rows: int = DEFAULT_MAX_ROWS,
 ) -> DriverRanking:
     """Rank the catalog's dimensions as drivers of ``measure`` over the enriched view.
 
@@ -290,9 +297,18 @@ def discover_drivers(
     (``measure − entity_mean``); ratio de-means the per-row ratio by its entity's
     volume-weighted mean (its pooled ``Σnum/Σden``).
 
-    NOTE: the ``(present_dims + measure)`` columns are read into memory at row grain
-    in one pass. At ~1M rows × ~15 dims that is several hundred MB; DAT-546 should add
-    a row-count gate before calling on very large views.
+    **Bounded load (DAT-571):** the ``(present_dims + measure)`` columns are read into
+    memory at row grain in one pass — at ~1M rows × ~15 dims that pandas frame is several
+    hundred MB. Above ``max_rows`` the view is deterministically sub-sampled to ``max_rows``
+    rows via a bottom-k-by-hash sketch (the N smallest row-hashes are a uniform sample
+    without replacement) rather than dropping the analysis: large finance/logistics facts
+    are exactly where drivers matter most. The sketch is deterministic regardless of DuckDB
+    thread count (``ORDER BY`` is a total order — ``REPEATABLE()`` only holds single-threaded,
+    which the shared multi-thread worker connection can't guarantee), and uniform PER ROW, so
+    unlike ``SYSTEM``/block sampling it does not shred the entity grain. Cost: the entity-grain
+    family loses power on weak drivers under sampling (the permutation null is recomputed on
+    the sample, so FDR holds — it degrades to a miss, never a fabricated driver). DAT-580
+    (arrow-backed load) will raise the ceiling so sampling becomes a rare fallback.
     """
     empty = DriverRanking(measure=measure.label, target_type=measure.target_type, n_rows=0)
 
@@ -335,7 +351,19 @@ def discover_drivers(
         if col not in view_cols:
             logger.info("driver_identity_not_in_view", identity=col, view=view)
     select_cols = list(dict.fromkeys(present_dims + measure_cols + present_proposed))
-    sql = f"SELECT {', '.join(quote(c) for c in select_cols)} FROM {quote(view)}"  # noqa: S608 — catalog identifiers
+    cols_sql = ", ".join(quote(c) for c in select_cols)
+    # Bound the in-memory frame (DAT-571): a cheap COUNT(*) keeps normal-size views on
+    # the validated full-load path byte-for-byte; above max_rows, deterministically
+    # sub-sample to max_rows rows via a bottom-k-by-hash sketch instead of dropping the
+    # analysis. hash() is variadic over the selected columns, so identical rows hash
+    # alike and the cutoff is stable across runs and thread counts.
+    count_row = duckdb_conn.execute(f"SELECT COUNT(*) FROM {quote(view)}").fetchone()  # noqa: S608
+    n_full = int(count_row[0]) if count_row else 0
+    if n_full > max_rows:
+        logger.info("driver_rankings_view_sampled", view=view, full_n=n_full, sample_n=max_rows)
+        sql = f"SELECT {cols_sql} FROM {quote(view)} ORDER BY hash({cols_sql}) LIMIT {max_rows}"  # noqa: S608 — catalog identifiers
+    else:
+        sql = f"SELECT {cols_sql} FROM {quote(view)}"  # noqa: S608 — catalog identifiers
     frame = duckdb_conn.execute(sql).df()
 
     # The resolver path ICC-verifies the persisted identities (drop those the measure does

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -352,13 +352,17 @@ def discover_drivers(
             logger.info("driver_identity_not_in_view", identity=col, view=view)
     select_cols = list(dict.fromkeys(present_dims + measure_cols + present_proposed))
     cols_sql = ", ".join(quote(c) for c in select_cols)
-    # Bound the in-memory frame (DAT-571): a cheap COUNT(*) keeps normal-size views on
-    # the validated full-load path byte-for-byte; above max_rows, deterministically
-    # sub-sample to max_rows rows via a bottom-k-by-hash sketch instead of dropping the
-    # analysis. hash() is variadic over the selected columns, so identical rows hash
-    # alike and the cutoff is stable across runs and thread counts.
+    # Bound the in-memory frame (DAT-571): a COUNT(*) keeps normal-size views — the common
+    # case — on the validated full-load path byte-for-byte (a single plain SELECT); above
+    # max_rows, deterministically sub-sample to max_rows rows via a bottom-k-by-hash sketch
+    # instead of dropping the analysis. hash() is variadic over the selected columns, so
+    # identical rows hash alike and the cutoff is stable across runs and thread counts. The
+    # oversized branch deliberately scans twice (COUNT, then the ORDER BY) — fusing them via
+    # COUNT(*) OVER () would force the sort + a reload onto the common small-view path; that
+    # path is hot, the oversized path is rare, and memory (not scan time) is what we bound.
     count_row = duckdb_conn.execute(f"SELECT COUNT(*) FROM {quote(view)}").fetchone()  # noqa: S608
-    n_full = int(count_row[0]) if count_row else 0
+    assert count_row is not None  # COUNT(*) on an existing view always returns one row
+    n_full = int(count_row[0])
     if n_full > max_rows:
         logger.info("driver_rankings_view_sampled", view=view, full_n=n_full, sample_n=max_rows)
         sql = f"SELECT {cols_sql} FROM {quote(view)} ORDER BY hash({cols_sql}) LIMIT {max_rows}"  # noqa: S608 — catalog identifiers

--- a/packages/engine/tests/unit/analysis/drivers/test_processor.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_processor.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 import duckdb
 import numpy as np
 from sqlalchemy.orm import Session
+from structlog.testing import capture_logs
 
 from dataraum.analysis.drivers.models import Measure
 from dataraum.analysis.drivers.processor import (
@@ -189,3 +190,76 @@ class TestDiscoverDrivers:
         )
         assert ranking.root is None
         assert ranking.n_rows == 0
+
+
+class TestRowCountGate:
+    """DAT-571: bound the in-memory frame by bottom-k-by-hash sampling over-large views."""
+
+    def test_oversized_view_is_sampled_and_logged(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # The 20k-row corpus with a 5k cap → exactly 5k rows analyzed, and a loud log
+        # naming the full + sampled counts (the cheap COUNT(*) drives the gate).
+        tid = _seed(real_session, duck)
+        with capture_logs() as logs:
+            ranking = discover_drivers(
+                real_session,
+                duckdb_conn=duck,
+                fact_table_id=tid,
+                run_id=RUN,
+                measure=Measure(target_type="flow", column="measure"),
+                n_perm=200,
+                max_rows=5_000,
+            )
+        assert ranking.n_rows == 5_000
+        sampled = [e for e in logs if e["event"] == "driver_rankings_view_sampled"]
+        assert sampled and sampled[0]["full_n"] == 20_000 and sampled[0]["sample_n"] == 5_000
+
+    def test_normal_view_takes_full_load_path(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # At/below the cap → the validated full-load path, untouched: every row, no log.
+        tid = _seed(real_session, duck)
+        with capture_logs() as logs:
+            ranking = discover_drivers(
+                real_session,
+                duckdb_conn=duck,
+                fact_table_id=tid,
+                run_id=RUN,
+                measure=Measure(target_type="flow", column="measure"),
+                n_perm=50,
+                max_rows=1_000_000,
+            )
+        assert ranking.n_rows == 20_000
+        assert not [e for e in logs if e["event"] == "driver_rankings_view_sampled"]
+
+    def test_sampled_ranking_is_deterministic_and_keeps_strong_driver(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # Bottom-k-by-hash is a total order → identical ranking across runs (no REPEATABLE
+        # or thread dependence). And the sample preserves the ordinal signal: the strong
+        # driver still surfaces (recall) while independent nulls stay gated (precision).
+        tid = _seed(real_session, duck)
+        measure = Measure(target_type="flow", column="measure")
+        first = discover_drivers(
+            real_session,
+            duckdb_conn=duck,
+            fact_table_id=tid,
+            run_id=RUN,
+            measure=measure,
+            n_perm=200,
+            max_rows=5_000,
+        )
+        second = discover_drivers(
+            real_session,
+            duckdb_conn=duck,
+            fact_table_id=tid,
+            run_id=RUN,
+            measure=measure,
+            n_perm=200,
+            max_rows=5_000,
+        )
+        assert first.ranked_dimensions == second.ranked_dimensions  # deterministic sample
+        sig = {d for d, _ in first.ranked_dimensions}
+        assert "D_e60" in sig  # strong driver survives sampling (recall)
+        assert "N_lowcard" not in sig and "N_highcard" not in sig  # nulls gated (precision)

--- a/packages/engine/tests/unit/analysis/drivers/test_processor.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_processor.py
@@ -198,8 +198,10 @@ class TestRowCountGate:
     def test_oversized_view_is_sampled_and_logged(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
-        # The 20k-row corpus with a 5k cap → exactly 5k rows analyzed, and a loud log
-        # naming the full + sampled counts (the cheap COUNT(*) drives the gate).
+        # The 20k-row corpus with a 5k cap → the materialized frame is capped at 5k rows,
+        # and a loud log names the full + sampled counts (the COUNT(*) drives the gate).
+        # n_rows == frame length (NaN measure rows included — FlowTarget.observed keeps the
+        # raw array), so this pins the bottom-k LIMIT, not a finite-value count.
         tid = _seed(real_session, duck)
         with capture_logs() as logs:
             ranking = discover_drivers(


### PR DESCRIPTION
## What & why

`discover_drivers` materializes `(present_dims + measure + identity)` columns into a pandas frame in one pass. At ~1M rows that frame is several hundred MB, and the `driver_rankings` begin_session phase (DAT-546) now runs it for **every** measure-role column on **every** session fact — a large finance/logistics fact can OOM the worker (8 concurrent activities; the pandas frame lives *outside* DuckDB's `memory_limit`).

This adds a `max_rows` gate (default `DEFAULT_MAX_ROWS = 800_000`):
- **≤ cap (common case):** a cheap `COUNT(*)`, then the validated full-load `SELECT` — byte-for-byte unchanged.
- **> cap:** the view is deterministically sub-sampled to `max_rows` rows via a **bottom-k-by-hash** sketch (`ORDER BY hash(<cols>) LIMIT max_rows` — the N smallest row-hashes are a uniform sample without replacement), plus a loud `driver_rankings_view_sampled` log. The analysis runs on the sample rather than being dropped — large facts are exactly where drivers matter most.

## Design notes (refined with @phas02)

- **Sample, not drop.** The original Jira AC ("return empty above the threshold") was rejected: it denies drivers to the largest, most valuable facts. AC amended to sample.
- **Bottom-k-by-hash over reservoir+`REPEATABLE`.** `REPEATABLE` is deterministic only single-threaded, but the worker's DuckDB connection is shared multi-threaded across activities and `threads` is instance-global (can't be pinned per-query). `ORDER BY hash(...)` is a total order → deterministic regardless of thread count, and uniform **per row** — so unlike `SYSTEM`/block sampling it doesn't shred the entity grain (DAT-561/563).
- **Fail-safe entity-grain limit (accepted v1).** The permutation null is recomputed on the sample, so FDR/precision hold; the entity-grain family loses power only on *weak* drivers (degrades to a miss, never a fabricated driver).
- **Follow-up DAT-580** (zero-copy pyarrow load) raises the ceiling so sampling becomes a rare fallback.

Engine core (`tree.py` / `targets.py` / `criterion.py`) untouched.

## Tests

`TestRowCountGate` (3 tests, real DuckDB + real catalog, no mocks):
- oversized view → sampled to the cap + `driver_rankings_view_sampled` logged with `full_n`/`sample_n`
- normal view → full-load path untouched, no log
- sampled ranking is deterministic across reruns + strong driver survives (recall) + independent nulls stay gated (precision)

Full 63-test drivers suite green; ruff + mypy clean.

## Reviewers
senior-code-reviewer: no critical/blocking (one perf note + two nits, all addressed). spec-compliance-reviewer: PASS.

## Eval handoff
`.claude/handoff.md` updated: the DAT-546 "n_rows stable across reruns" assertion now has two regimes (>800k → `n_rows == 800_000` + sampled log), still rerun-stable in both; sampling is fail-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)