### PR TITLE
DAT-589: opt-in MS SQL + Wide World Importers sample source in the dev stack

### DIFF
--- a/packages/cockpit/.env.example
+++ b/packages/cockpit/.env.example
@@ -68,3 +68,17 @@ ANTHROPIC_API_KEY=
 # Temporal Web UI, linked by the /workflows section. Defaults to the
 # docker-compose dev address (CORS already allows :3000).
 # TEMPORAL_UI_URL=http://localhost:8080
+
+# --- Sample database sources (optional; DAT-589) ---
+# A configured DB source the agent/connect/probe can read. The NAME in the var is
+# the source name: DATARAUM_<NAME>_URL → a source called <name> (lowercased), which
+# list_sources surfaces and probe/connect resolve. The VALUE is passed VERBATIM into
+# DuckDB's mssql-extension ATTACH, so it is the EXTENSION's connection-string form
+# (NOT a JDBC/ADO url). The self-signed dev cert needs TrustServerCertificate=true.
+# Host dev reaches the container at Server=localhost,1433; an in-container cockpit
+# would use Server=mssql,1433. Bring the DB up first:
+#   docker compose -f packages/infra/docker-compose.yml \
+#                  -f packages/infra/docker-compose.sources.yml --profile mssql up -d --wait
+# Leave commented unless the sample DB is running (an unreachable source only fails
+# when actually probed, but there's no point advertising it otherwise).
+# DATARAUM_WWI_URL=Server=localhost,1433;Database=WideWorldImporters;UID=sa;PWD=Dataraum!Dev1;TrustServerCertificate=true

--- a/packages/infra/.env.example
+++ b/packages/infra/.env.example
@@ -84,3 +84,10 @@ S3_REGION=us-east-1
 S3_USE_SSL=false
 S3_ACCESS_KEY_ID=dataraum
 S3_SECRET_ACCESS_KEY=dataraum-s3-secret
+
+# ── Sample source backends (DAT-589) — OPT-IN via docker-compose.sources.yml ──
+# Only read by the `mssql` profile in docker-compose.sources.yml; the core stack
+# never touches these. SA password for the dev SQL Server (SQL Server enforces
+# 8+ chars with upper/lower/digit/symbol). Local-dev default, committed like
+# POSTGRES_PASSWORD — override for anything non-local.
+MSSQL_SA_PASSWORD=Dataraum!Dev1

--- a/packages/infra/docker-compose.sources.yml
+++ b/packages/infra/docker-compose.sources.yml
@@ -1,0 +1,101 @@
+# Sample external source backends for exercising connect/probe (DAT-589, epic DAT-574).
+#
+# OPT-IN and SEPARATE from the core stack (docker-compose.yml): bring these up only
+# when you want a real database source to connect/probe/ingest, so the platform stays
+# backend-neutral and `make up` stays fast. MS SQL is the FIRST sample backend, NOT a
+# privileged one — the engine/cockpit address sources generically (credentials by
+# name, ATTACH by TYPE; backends = mssql/postgres/mysql/sqlite). A mysql /
+# foreign-postgres / sqlite source slots in here symmetrically: its own service, its
+# own profile, its own DATARAUM_<NAME>_URL. This file is the menu; WWI is the first dish.
+#
+# Bring up MS SQL + Wide World Importers alongside the core stack:
+#   docker compose -f packages/infra/docker-compose.yml \
+#                  -f packages/infra/docker-compose.sources.yml \
+#                  --profile mssql up -d --wait
+#
+# Then point the cockpit at it (host dev, `bun --bun run dev`) by setting in the
+# cockpit .env:
+#   DATARAUM_WWI_URL=Server=localhost,1433;Database=WideWorldImporters;UID=sa;PWD=Dataraum!Dev1;TrustServerCertificate=true
+# An in-container cockpit would use Server=mssql,1433 instead.
+#
+# Apple Silicon: SQL Server images are amd64-only — `platform: linux/amd64` runs them
+# under Rosetta (verified on SQL Server 2025). The self-signed cert is why the
+# connection string needs `TrustServerCertificate=true`.
+
+services:
+  # SQL Server 2025 — a sample MS SQL source. Profile-gated so a default `up` (even
+  # with this file merged) never starts it.
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2025-latest
+    platform: linux/amd64
+    profiles: ["mssql"]
+    environment:
+      ACCEPT_EULA: "Y"
+      # Local-dev default, committed like POSTGRES_PASSWORD. Complexity-checked by
+      # SQL Server (8+ chars, upper/lower/digit/symbol). Override in .env.
+      MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD:-Dataraum!Dev1}
+      MSSQL_PID: Developer
+    ports:
+      # Bound 0.0.0.0 (no 127.0.0.1 prefix — compose-ports gotcha) so the host
+      # cockpit reaches it on localhost:1433.
+      - "1433:1433"
+    volumes:
+      - mssql_data:/var/opt/mssql
+      # Nested mount for the .bak the fetch one-shot downloads + the restore reads.
+      - mssql_backup:/var/opt/mssql/backup
+    healthcheck:
+      # The port opens BEFORE logins are ready, so probe a real login. sqlcmd ships
+      # at /opt/mssql-tools18/bin in the 2025 image; -C trusts the self-signed cert.
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$$MSSQL_SA_PASSWORD\" -C -Q 'SELECT 1' -b -o /dev/null"]
+      interval: 10s
+      timeout: 5s
+      start_period: 90s
+      retries: 30
+
+  # One-shot: download the Wide World Importers backup into the shared volume,
+  # idempotent (skipped if already present). Native arm64 alpine (busybox wget) —
+  # no platform pin, so the heavy download isn't emulated.
+  mssql-wwi-fetch:
+    image: alpine:3
+    profiles: ["mssql"]
+    restart: on-failure:3
+    volumes:
+      - mssql_backup:/var/opt/mssql/backup
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        BAK=/var/opt/mssql/backup/WideWorldImporters-Full.bak
+        if [ -s "$$BAK" ]; then echo "WWI backup already present ($$(wc -c < "$$BAK") bytes)"; exit 0; fi
+        echo "Downloading Wide World Importers backup…"
+        wget -q -O "$$BAK" https://github.com/Microsoft/sql-server-samples/releases/download/wide-world-importers-v1.0/WideWorldImporters-Full.bak
+        echo "Downloaded $$(wc -c < "$$BAK") bytes"
+
+  # One-shot: restore WWI once SQL Server accepts logins AND the .bak is present.
+  # Reuses the server image (sqlcmd guaranteed, already pulled) with the entrypoint
+  # overridden so it runs the restore script instead of starting a second server.
+  mssql-wwi-restore:
+    image: mcr.microsoft.com/mssql/server:2025-latest
+    platform: linux/amd64
+    profiles: ["mssql"]
+    restart: on-failure:5
+    depends_on:
+      mssql:
+        condition: service_healthy
+      mssql-wwi-fetch:
+        condition: service_completed_successfully
+    environment:
+      MSSQL_HOST: mssql
+      MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD:-Dataraum!Dev1}
+    volumes:
+      - ./scripts:/scripts:ro
+      - mssql_backup:/var/opt/mssql/backup:ro
+    entrypoint: ["/bin/bash"]
+    command: /scripts/restore-wwi.sh
+
+volumes:
+  # Persisted so subsequent `up`s skip the boot-restore (and re-download); `down -v`
+  # wipes them for a clean slate, same as the core stack's postgres_data.
+  mssql_data:
+  mssql_backup:

--- a/packages/infra/scripts/restore-wwi.sh
+++ b/packages/infra/scripts/restore-wwi.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Restore Wide World Importers into the `mssql` sample-source service (DAT-589,
+# epic DAT-574). One-shot, mirroring the create-bucket.sh / create-namespace.sh
+# idiom: wait until SQL Server accepts logins (the port opens BEFORE logins are
+# ready), then RESTORE. Idempotent — skips if the DB already exists, so it is a
+# no-op on every `up` after the first.
+#
+# The .bak is placed in the shared backup volume by the `mssql-wwi-fetch`
+# one-shot; the RESTORE runs server-side (the `mssql` service reads the file from
+# its own /var/opt/mssql/backup). Logical file names + the in-memory filegroup
+# (`WWI_InMemory_Data_1`) were confirmed against the v1.0 backup.
+set -eu
+
+SQLCMD=/opt/mssql-tools18/bin/sqlcmd
+SERVER=${MSSQL_HOST:-mssql}
+SA_PASS=${MSSQL_SA_PASSWORD:?MSSQL_SA_PASSWORD required}
+BAK=${WWI_BAK_PATH:-/var/opt/mssql/backup/WideWorldImporters-Full.bak}
+DB=WideWorldImporters
+MAX_ATTEMPTS=${MSSQL_INIT_MAX_ATTEMPTS:-60}
+SLEEP_SECONDS=${MSSQL_INIT_SLEEP_SECONDS:-5}
+
+# -C trusts the container's self-signed cert; -b makes sqlcmd exit non-zero on a
+# SQL error so `set -e` catches a failed restore.
+q() { "$SQLCMD" -S "$SERVER" -U sa -P "$SA_PASS" -C -b "$@"; }
+
+echo "Waiting for SQL Server ($SERVER) to accept logins…"
+attempt=1
+until q -Q "SELECT 1" -o /dev/null 2>/dev/null; do
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "SQL Server did not accept logins after $MAX_ATTEMPTS attempts"; exit 1
+  fi
+  echo "  not ready yet (attempt $attempt/$MAX_ATTEMPTS)…"
+  attempt=$((attempt + 1)); sleep "$SLEEP_SECONDS"
+done
+echo "SQL Server is accepting logins"
+
+exists=$(q -h -1 -W -Q "SET NOCOUNT ON; SELECT COUNT(*) FROM sys.databases WHERE name='$DB'" | tr -d '[:space:]')
+if [ "$exists" = "1" ]; then
+  echo "$DB already restored — nothing to do"
+  exit 0
+fi
+
+if [ ! -s "$BAK" ]; then
+  echo "Backup not found at $BAK (the mssql-wwi-fetch one-shot should place it)"
+  exit 1
+fi
+
+echo "Restoring $DB from $BAK …"
+q -Q "RESTORE DATABASE [$DB] FROM DISK='$BAK' WITH \
+  MOVE 'WWI_Primary'          TO '/var/opt/mssql/data/WideWorldImporters.mdf', \
+  MOVE 'WWI_UserData'         TO '/var/opt/mssql/data/WideWorldImporters_UserData.ndf', \
+  MOVE 'WWI_Log'              TO '/var/opt/mssql/data/WideWorldImporters.ldf', \
+  MOVE 'WWI_InMemory_Data_1'  TO '/var/opt/mssql/data/WideWorldImporters_InMemory_Data_1', \
+  REPLACE, RECOVERY"
+
+echo "Restore complete:"
+q -h -1 -Q "SET NOCOUNT ON; SELECT '  Sales.Orders rows = ' + CAST(COUNT(*) AS varchar) FROM $DB.Sales.Orders"


### PR DESCRIPTION
First task of the **Cockpit UI brilliance** epic (DAT-574) — the dev-stack fixture that the probe surface (DAT-576) builds + smokes against, and the streaming spike that de-risks its approach.

## What
- **`packages/infra/docker-compose.sources.yml`** — an **opt-in, backend-agnostic** "sample source backends" module, **separate** from `docker-compose.yml` so `make up` stays fast and the platform stays backend-neutral. MS SQL is the **first** sample backend behind a `mssql` profile, not a privileged one; a mysql / foreign-postgres / sqlite source slots in symmetrically (own service + profile + `DATARAUM_<NAME>_URL`).
- **SQL Server 2025** (`platform: linux/amd64`, runs under Rosetta) + **Wide World Importers** restored via a fetch + restore one-shot pair (mirrors the existing `seaweedfs-init` / `create-namespace` idiom). `scripts/restore-wwi.sh` is idempotent.
- **`.env.example`** wiring: `DATARAUM_WWI_URL` (cockpit) + `MSSQL_SA_PASSWORD` (infra), in the **DuckDB mssql-extension connection-string form** `probe.ts` passes verbatim into `ATTACH`.

## Spike result (de-risks DAT-576 / Option A)
DuckDB's `mssql` extension **streams** over the ATTACH: `conn.stream()` yields WWI `Sales.Orders` (73,595 rows) in **36 lazy 2048-row chunks** over `localhost:1433` — true backpressure, exactly like the lake. So the streaming `/api/probe-sql` planned for the probe widget is viable. Connection-string format + the `sys`-schema-not-surfaced gotcha recorded on DAT-589.

## Bring it up
```
docker compose -f packages/infra/docker-compose.yml \
               -f packages/infra/docker-compose.sources.yml \
               --profile mssql up -d --wait
```
Default `make up` is unchanged (no MS SQL in the core stack).

## Validated
- Compose merges/parses; `--profile mssql up --wait` → mssql healthy, WWI restored (73,595 orders).
- Re-run restore → idempotent ("already restored — nothing to do").
- DuckDB streams WWI over the ATTACH end-to-end via the compose-managed container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)