### PR TITLE
DAT-576: Probe surface — editable SQL against a configured DB source (streaming)

### DIFF
--- a/packages/cockpit/.env.example
+++ b/packages/cockpit/.env.example
@@ -72,13 +72,17 @@ ANTHROPIC_API_KEY=
 # --- Sample database sources (optional; DAT-589) ---
 # A configured DB source the agent/connect/probe can read. The NAME in the var is
 # the source name: DATARAUM_<NAME>_URL → a source called <name> (lowercased), which
-# list_sources surfaces and probe/connect resolve. The VALUE is passed VERBATIM into
-# DuckDB's mssql-extension ATTACH, so it is the EXTENSION's connection-string form
-# (NOT a JDBC/ADO url). The self-signed dev cert needs TrustServerCertificate=true.
-# Host dev reaches the container at Server=localhost,1433; an in-container cockpit
-# would use Server=mssql,1433. Bring the DB up first:
+# list_sources surfaces and the probe source-picker offers.
+#
+# MUST be a `scheme://` URL — the backend is inferred from the SCHEME (mssql /
+# sqlserver → mssql, postgres/postgresql, mysql/mariadb, sqlite). A bare keyword
+# DSN (`Server=host,1433;Database=…`) ATTACHes fine but has no scheme, so the
+# source can't be classified and won't appear in the picker (DAT-576 smoke). The
+# value is passed verbatim into DuckDB's ATTACH; the self-signed dev cert needs
+# `?TrustServerCertificate=true`. Host dev uses @localhost:1433; an in-container
+# cockpit uses @mssql:1433. Bring the DB up first:
 #   docker compose -f packages/infra/docker-compose.yml \
 #                  -f packages/infra/docker-compose.sources.yml --profile mssql up -d --wait
 # Leave commented unless the sample DB is running (an unreachable source only fails
 # when actually probed, but there's no point advertising it otherwise).
-# DATARAUM_WWI_URL=Server=localhost,1433;Database=WideWorldImporters;UID=sa;PWD=Dataraum!Dev1;TrustServerCertificate=true
+# DATARAUM_WWI_URL=mssql://sa:Dataraum!Dev1@localhost:1433/WideWorldImporters?TrustServerCertificate=true

--- a/packages/cockpit/bun.lock
+++ b/packages/cockpit/bun.lock
@@ -6,6 +6,11 @@
       "name": "dataraum-cockpit",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.97.1",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-sql": "^6.10.0",
+        "@codemirror/language": "^6.12.3",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.43.1",
         "@duckdb/node-api": "^1.5.3-r.3",
         "@mantine/core": "^9.3.0",
         "@mantine/hooks": "^9.3.0",
@@ -136,6 +141,18 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.10.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.6.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q=="],
+
+    "@codemirror/lang-sql": ["@codemirror/lang-sql@6.10.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.3", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
+
+    "@codemirror/state": ["@codemirror/state@6.6.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ=="],
+
+    "@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
@@ -289,9 +306,17 @@
 
     "@jsonjoy.com/util": ["@jsonjoy.com/util@1.9.0", "", { "dependencies": { "@jsonjoy.com/buffers": "^1.0.0", "@jsonjoy.com/codegen": "^1.0.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ=="],
 
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
+
     "@mantine/core": ["@mantine/core@9.3.0", "", { "dependencies": { "@floating-ui/react": "^0.27.19", "clsx": "^2.1.1", "react-number-format": "^5.4.5", "react-remove-scroll": "^2.7.2", "type-fest": "^5.6.0" }, "peerDependencies": { "@mantine/hooks": "9.3.0", "react": "^19.2.0", "react-dom": "^19.2.0" } }, "sha512-mHVCm61YVW9ipy9eHiKMqsRUm3TkOErbdw7zHs0HRw5g403nf7tSTqNGvaYE+aX1Py874qMkrUzeQfj4bjiiBA=="],
 
     "@mantine/hooks": ["@mantine/hooks@9.3.0", "", { "peerDependencies": { "react": "^19.2.0" } }, "sha512-QoSr9WI4WsKWrM3qFYYizHUn3+n+CVcFMYe4sdlnmFPStvs6BacPODKJSbFlYl73Z20t82JIy0eKqt4noHQI2g=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -707,6 +732,8 @@
 
     "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
 
+    "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
+
     "crossws": ["crossws@0.4.5", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
@@ -1027,6 +1054,8 @@
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
+
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "swc-loader": ["swc-loader@0.2.7", "", { "dependencies": { "@swc/counter": "^0.1.3" }, "peerDependencies": { "@swc/core": "^1.2.147", "webpack": ">=2" } }, "sha512-nwYWw3Fh9ame3Rtm7StS9SBLpHRRnYcK7bnpF3UKZmesAK0gw2/ADvlURFAINmPvKtDLzp+GBiP9yLoEjg6S9w=="],
@@ -1102,6 +1131,8 @@
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
     "vitest": ["vitest@5.0.0-beta.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/mocker": "5.0.0-beta.4", "@vitest/pretty-format": "5.0.0-beta.4", "@vitest/runner": "5.0.0-beta.4", "@vitest/spy": "5.0.0-beta.4", "@vitest/utils": "5.0.0-beta.4", "chai": "^6.2.2", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^6.0.1", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "5.0.0-beta.4", "@vitest/browser-preview": "5.0.0-beta.4", "@vitest/browser-webdriverio": "5.0.0-beta.4", "@vitest/coverage-istanbul": "5.0.0-beta.4", "@vitest/coverage-v8": "5.0.0-beta.4", "@vitest/ui": "5.0.0-beta.4", "happy-dom": "*", "jsdom": "*", "vite": "^6.4.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-YrZcX7kcwHmc7ko5Riu7YnoTREUzAUc4JEsteRmJ5IjdwU166EElX6ZogLBWtutNUDX+Ksa6kk76VKSM1bkWNA=="],
+
+    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 

--- a/packages/cockpit/package.json
+++ b/packages/cockpit/package.json
@@ -27,6 +27,11 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.97.1",
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-sql": "^6.10.0",
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.43.1",
     "@duckdb/node-api": "^1.5.3-r.3",
     "@mantine/core": "^9.3.0",
     "@mantine/hooks": "^9.3.0",

--- a/packages/cockpit/src/duckdb/probe-stream.integration.test.ts
+++ b/packages/cockpit/src/duckdb/probe-stream.integration.test.ts
@@ -1,0 +1,164 @@
+// Real in-process DuckDB integration for the STREAMING probe path (DAT-576).
+//
+// The human-grid analog of probe.integration: instead of materializing a sample,
+// it drives openProbeConnection() → buildGridQuery() → conn.stream() → streamNdjson
+// and asserts the columnar-NDJSON frames — proving the full streaming-over-ATTACH
+// path (the same one /api/probe-sql is a thin shell over) against a real sqlite
+// source. sqlite is the cheapest backend to stand up hermetically (a file, no
+// server); the ATTACH + stream machinery is shared across all four backends.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DuckDBInstance } from "@duckdb/node-api";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+	buildGridQuery,
+	type StreamableResult,
+	streamNdjson,
+} from "./stream-sql";
+
+const REQUIRED_DEFAULTS: Record<string, string> = {
+	COCKPIT_DATABASE_URL:
+		process.env.COCKPIT_DATABASE_URL ??
+		"postgresql://dataraum:dataraum@127.0.0.1:5432/cockpit_db",
+	METADATA_DATABASE_URL:
+		process.env.METADATA_DATABASE_URL ??
+		"postgresql://dataraum:dataraum@127.0.0.1:5432/dataraum",
+	DATARAUM_WORKSPACE_ID:
+		process.env.DATARAUM_WORKSPACE_ID ?? "00000000-0000-0000-0000-000000000001",
+	DATARAUM_CONFIG_PATH:
+		process.env.DATARAUM_CONFIG_PATH ?? "/opt/dataraum/config",
+	DATARAUM_LAKE_PATH:
+		process.env.DATARAUM_LAKE_PATH ?? "s3://dataraum-lake/lake",
+	DUCKLAKE_CATALOG_URL:
+		process.env.DUCKLAKE_CATALOG_URL ??
+		"postgresql://dataraum:dataraum@127.0.0.1:5432/lake_catalog",
+	ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? "sk-ant-test-placeholder",
+	S3_ENDPOINT: process.env.S3_ENDPOINT ?? "127.0.0.1:8333",
+	S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID ?? "dataraum",
+	S3_SECRET_ACCESS_KEY:
+		process.env.S3_SECRET_ACCESS_KEY ?? "dataraum-s3-secret",
+	S3_BUCKET: process.env.S3_BUCKET ?? "dataraum-lake",
+};
+for (const [k, v] of Object.entries(REQUIRED_DEFAULTS)) {
+	if (!process.env[k]) process.env[k] = v;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic-imported module shape
+let openProbeConnection: any;
+
+let dir: string;
+let dbfile: string;
+
+/** Drive streamNdjson to completion, returning the parsed frames. */
+async function collectFrames(
+	result: StreamableResult,
+	cap = 50_000,
+): Promise<{ t: string; [k: string]: unknown }[]> {
+	const frames: { t: string; [k: string]: unknown }[] = [];
+	for await (const line of streamNdjson(result, cap, "test", {
+		aborted: false,
+	})) {
+		const trimmed = line.trim();
+		if (trimmed) frames.push(JSON.parse(trimmed));
+	}
+	return frames;
+}
+
+beforeAll(async () => {
+	({ openProbeConnection } = await import("./probe"));
+
+	dir = mkdtempSync(join(tmpdir(), "probe-stream-it-"));
+	dbfile = join(dir, "src.sqlite");
+
+	// Build a real sqlite source with 5000 rows (> one 2048-row DuckDB chunk, so
+	// the stream genuinely produces multiple batch frames).
+	const inst = await DuckDBInstance.create(":memory:");
+	const c = await inst.connect();
+	await c.run("INSTALL sqlite");
+	await c.run("LOAD sqlite");
+	await c.run(`ATTACH '${dbfile}' AS s (TYPE SQLITE)`);
+	await c.run("CREATE TABLE s.main.events(id INTEGER, label VARCHAR)");
+	await c.run(
+		"INSERT INTO s.main.events SELECT i, 'e' || i FROM range(5000) AS t(i)",
+	);
+	await c.run("DETACH s");
+	c.closeSync();
+	inst.closeSync();
+
+	vi.stubEnv("DATARAUM_EVENTS_URL", dbfile);
+});
+
+afterAll(() => {
+	vi.unstubAllEnvs();
+	if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("streaming probe over a real sqlite source (DAT-576)", () => {
+	it("streams columnar NDJSON frames over the ATTACH and disposes the connection", async () => {
+		const { conn, dispose } = await openProbeConnection({
+			source_name: "events",
+			backend: "sqlite",
+		});
+		const result = (await conn.stream(
+			buildGridQuery("SELECT id, label FROM events ORDER BY id"),
+		)) as unknown as StreamableResult;
+		const frames = await collectFrames(result);
+		dispose();
+
+		const header = frames.find((f) => f.t === "h");
+		const batches = frames.filter((f) => f.t === "b");
+		const footer = frames.find((f) => f.t === "f");
+
+		expect(header?.columns).toEqual(["id", "label"]);
+		// 5000 rows > 2048 vector size → more than one batch (genuine streaming).
+		expect(batches.length).toBeGreaterThan(1);
+		expect(footer?.rows).toBe(5000);
+		expect(footer?.truncated).toBeFalsy();
+	});
+
+	it("caps + flags truncated, ordering the FULL result before the cap", async () => {
+		const { conn, dispose } = await openProbeConnection({
+			source_name: "events",
+			backend: "sqlite",
+		});
+		const result = (await conn.stream(
+			buildGridQuery("SELECT id FROM events", { column: "id", dir: "desc" }),
+		)) as unknown as StreamableResult;
+		const frames = await collectFrames(result, 3);
+		dispose();
+
+		const footer = frames.find((f) => f.t === "f");
+		const firstBatch = frames.find((f) => f.t === "b");
+		expect(footer?.truncated).toBe(true);
+		expect(footer?.cap).toBe(3);
+		// DESC over the full result → top id is 4999, not an arbitrary first-N slice.
+		// sqlite surfaces INTEGER as BIGINT, serialized losslessly as a string.
+		expect((firstBatch?.cols as unknown[][])[0][0]).toBe("4999");
+	});
+
+	it("surfaces a bad-SQL prepare error from conn.stream() (no leak of the source URL)", async () => {
+		const { conn, dispose, redact } = await openProbeConnection({
+			source_name: "events",
+			backend: "sqlite",
+		});
+		await expect(
+			conn.stream(buildGridQuery("SELECT * FROM does_not_exist")),
+		).rejects.toThrow();
+		// redact is a no-op for a sqlite file path, but the contract holds.
+		expect(redact("plain message")).toBe("plain message");
+		dispose();
+	});
+
+	it("rejects an unsupported backend and a missing credential (loud)", async () => {
+		await expect(
+			openProbeConnection({ source_name: "events", backend: "oracle" }),
+		).rejects.toThrow(/Unsupported backend/);
+		await expect(
+			openProbeConnection({ source_name: "no_such_src", backend: "sqlite" }),
+		).rejects.toThrow(/DATARAUM_NO_SUCH_SRC_URL/);
+	});
+});

--- a/packages/cockpit/src/duckdb/probe.ts
+++ b/packages/cockpit/src/duckdb/probe.ts
@@ -11,7 +11,7 @@
 // and DETACHes/closes in a finally. It never touches the long-lived lake reader
 // connection, so an external ATTACH can't leak into lake-catalog state.
 
-import { DuckDBInstance } from "@duckdb/node-api";
+import { type DuckDBConnection, DuckDBInstance } from "@duckdb/node-api";
 
 import { config } from "../config";
 import { resolveCredential } from "./credentials";
@@ -67,18 +67,33 @@ export interface ProbeInput {
 	limit?: number;
 }
 
+/** An open probe connection: a throwaway in-memory DuckDB with the source
+ * ATTACHed READ_ONLY and its default schema selected. The caller MUST `dispose()`
+ * it — the materialize path ({@link probe}) in a `finally`, the streaming path
+ * (`/api/probe-sql`) when the stream ends or is cancelled. */
+export interface ProbeConnection {
+	/** Ready for a read-only query against the attached source (`src.*`). */
+	readonly conn: DuckDBConnection;
+	/** Close the connection + its throwaway instance (releases the ATTACH). */
+	readonly dispose: () => void;
+	/** Strip the resolved source URL from a message before it leaves the process
+	 * — a driver error can echo the credential-bearing DSN (the agent result + the
+	 * persisted transcript must never carry it). */
+	readonly redact: (message: string) => string;
+}
+
 /**
- * Run read-only SQL against an external database source.
- *
- * Resolves credentials by source name, ATTACHes the source READ_ONLY in a
- * throwaway connection, `USE`s the backend's default schema, runs the SQL
- * (wrapped in a `LIMIT`), and DETACHes. Fails loud — unknown backend, missing
- * credential, or a failed ATTACH/SELECT all throw with an actionable message.
- *
- * The returned {@link QueryResult} contains only column metadata + JSON-safe
- * rows; the connection URL is never included.
+ * Open a throwaway in-memory DuckDB connection with the source ATTACHed READ_ONLY
+ * and the backend's default schema selected — the shared setup behind BOTH the
+ * agent's materialized {@link probe} (a bounded sample) and the human grid's
+ * streaming `/api/probe-sql` (the full result). Fails loud with a
+ * CREDENTIAL-REDACTED message on unknown backend, missing credential, or a failed
+ * ATTACH; on a setup failure the connection is disposed before throwing.
  */
-export async function probe(input: ProbeInput): Promise<QueryResult> {
+export async function openProbeConnection(input: {
+	source_name: string;
+	backend: string;
+}): Promise<ProbeConnection> {
 	const backend = input.backend.toLowerCase();
 	if (!(backend in BACKEND_EXTENSIONS)) {
 		throw new Error(
@@ -97,15 +112,27 @@ export async function probe(input: ProbeInput): Promise<QueryResult> {
 	const extension = BACKEND_EXTENSIONS[backend];
 	const attachType = BACKEND_ATTACH_TYPES[backend];
 	const defaultSchema = BACKEND_DEFAULT_SCHEMA[backend];
-	const limit = clampRowLimit(input.limit);
 
 	const instance = await DuckDBInstance.create(":memory:");
 	const conn = await instance.connect();
+	// Closing the throwaway instance releases the ATTACH — no explicit DETACH.
+	const dispose = () => {
+		conn.closeSync();
+		instance.closeSync();
+	};
+	// SECURITY: a failed ATTACH/query can echo the connection DSN (which carries
+	// the credential) in the driver message; redact the resolved URL before it
+	// leaves the process.
+	const redact = (message: string): string =>
+		credential.url
+			? message.split(credential.url).join("<source url redacted>")
+			: message;
+
 	try {
 		// Same extension-cache contract as the lake reader (lake.ts): the image
-		// pre-bakes all four backend extensions and sets DUCKLAKE_SKIP_INSTALL=1,
-		// so a probe never hits extensions.duckdb.org at runtime. Host dev has
-		// neither var set and installs on demand into ~/.duckdb.
+		// pre-bakes all four backend extensions and sets DUCKLAKE_SKIP_INSTALL=1, so
+		// a probe never hits extensions.duckdb.org at runtime. Host dev has neither
+		// var set and installs on demand into ~/.duckdb.
 		if (config.duckdbExtensionDirectory) {
 			await conn.run(
 				`SET extension_directory = '${escapeSqlLiteral(config.duckdbExtensionDirectory)}'`,
@@ -119,41 +146,48 @@ export async function probe(input: ProbeInput): Promise<QueryResult> {
 			}
 		}
 		await conn.run(`LOAD ${extension}`);
-
-		const safeUrl = escapeSqlLiteral(credential.url);
 		await conn.run(
-			`ATTACH '${safeUrl}' AS ${ATTACH_ALIAS} (TYPE ${attachType}, READ_ONLY)`,
+			`ATTACH '${escapeSqlLiteral(credential.url)}' AS ${ATTACH_ALIAS} (TYPE ${attachType}, READ_ONLY)`,
 		);
-		try {
-			await conn.run(`USE ${ATTACH_ALIAS}.${defaultSchema}`);
-			// Wrap the user SQL in a subquery + LIMIT so a probe can never pull an
-			// unbounded result into the chat context. READ_ONLY already blocks
-			// writes at the engine level.
-			const reader = await conn.runAndReadAll(
-				`SELECT * FROM (${input.sql}) AS _probe LIMIT ${limit}`,
-			);
-			return readerToResult(reader);
-		} finally {
-			try {
-				await conn.run(`DETACH ${ATTACH_ALIAS}`);
-			} catch {
-				// Best-effort cleanup; the connection is closed below regardless.
-			}
-		}
+		// USE the default schema so user SQL referencing `schema.table` resolves
+		// without the `src.` alias prefix (mirrors the engine's map).
+		await conn.run(`USE ${ATTACH_ALIAS}.${defaultSchema}`);
 	} catch (err) {
-		// SECURITY: a failed ATTACH can echo the connection DSN (which carries the
-		// credential) in the driver message. Redact the resolved URL before the
-		// message leaves this function — it reaches the agent (now as a `{ error }`
-		// result) and the persisted transcript.
 		const raw = err instanceof Error ? err.message : String(err);
-		const safe = credential.url
-			? raw.split(credential.url).join("<source url redacted>")
-			: raw;
+		dispose();
 		throw new Error(
-			`Probe of source '${input.source_name}' (${backend}) failed: ${safe}`,
+			`Probe of source '${input.source_name}' (${backend}) failed: ${redact(raw)}`,
+		);
+	}
+
+	return { conn, dispose, redact };
+}
+
+/**
+ * Run read-only SQL against an external database source and MATERIALIZE a bounded
+ * sample — the AGENT path (the LLM must never get an unbounded result dumped into
+ * context; the full result for the human grid streams via `/api/probe-sql`).
+ *
+ * The returned {@link QueryResult} contains only column metadata + JSON-safe rows;
+ * the connection URL is never included.
+ */
+export async function probe(input: ProbeInput): Promise<QueryResult> {
+	const { conn, dispose, redact } = await openProbeConnection(input);
+	const limit = clampRowLimit(input.limit);
+	try {
+		// Wrap the user SQL in a subquery + LIMIT so a probe can never pull an
+		// unbounded result into the chat context. READ_ONLY already blocks writes
+		// at the engine level.
+		const reader = await conn.runAndReadAll(
+			`SELECT * FROM (${input.sql}) AS _probe LIMIT ${limit}`,
+		);
+		return readerToResult(reader);
+	} catch (err) {
+		const raw = err instanceof Error ? err.message : String(err);
+		throw new Error(
+			`Probe of source '${input.source_name}' (${input.backend.toLowerCase()}) failed: ${redact(raw)}`,
 		);
 	} finally {
-		conn.closeSync();
-		instance.closeSync();
+		dispose();
 	}
 }

--- a/packages/cockpit/src/duckdb/stream-sql.test.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.test.ts
@@ -284,6 +284,38 @@ describe("streamNdjson cap + truncation", () => {
 		});
 	});
 
+	it("redacts the source URL from a mid-stream error footer (probe path, DAT-576)", async () => {
+		// An external-ATTACH driver error can echo the credential-bearing DSN; the
+		// probe route passes its `redact` so the secret never lands in the footer.
+		const secret = "Server=db,1433;UID=sa;PWD=hunter2";
+		const result: StreamableResult = {
+			columnNames: () => ["id"],
+			columnTypesJson: () => ["INTEGER"],
+			fetchChunk: async () => {
+				throw new Error(`ATTACH driver error for '${secret}'`);
+			},
+		};
+		const redact = (m: string) => m.split(secret).join("<source url redacted>");
+		const lines: string[] = [];
+		for await (const line of streamNdjson(
+			result,
+			1000,
+			"q",
+			{ aborted: false },
+			redact,
+		)) {
+			const trimmed = line.trim();
+			if (trimmed) lines.push(trimmed);
+		}
+		const footer = lines
+			.map((l) => JSON.parse(l) as { t: string; error?: string })
+			.find((f) => f.t === "f");
+		expect(footer?.error).toBe(
+			"ATTACH driver error for '<source url redacted>'",
+		);
+		expect(footer?.error).not.toContain(secret);
+	});
+
 	it("reports rows emitted before a mid-stream failure in the error footer", async () => {
 		let i = 0;
 		const result: StreamableResult = {

--- a/packages/cockpit/src/duckdb/stream-sql.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.ts
@@ -96,6 +96,37 @@ export function buildGridQuery(sql: string, sort?: GridSort | null): string {
 	return `${base} ORDER BY ${quoteIdentifier(sort.column)} ${dir}`;
 }
 
+/**
+ * Validate an optional grid `sort` field off a request body. Shared by every grid
+ * stream route (`/api/run-sql`, `/api/probe-sql`): returns the sort, `null` when
+ * absent, or an `{ error }` the route turns into a 400. Bounds the column-name
+ * length so a validated field can't balloon the SQL handed to DuckDB.
+ */
+export function parseSort(
+	raw: unknown,
+): { sort: GridSort | null } | { error: string } {
+	if (raw === undefined || raw === null) return { sort: null };
+	// `typeof [] === "object"`, so reject arrays explicitly — otherwise a JSON
+	// array falls through to the column check and yields a misleading error.
+	if (typeof raw !== "object" || Array.isArray(raw))
+		return { error: "Field 'sort' must be an object." };
+	const { column, dir } = raw as { column?: unknown; dir?: unknown };
+	if (
+		typeof column !== "string" ||
+		column.length === 0 ||
+		column.length > 256
+	) {
+		return {
+			error:
+				"Field 'sort.column' is required and must be a non-empty string (max 256 chars).",
+		};
+	}
+	if (dir !== "asc" && dir !== "desc") {
+		return { error: "Field 'sort.dir' must be 'asc' or 'desc'." };
+	}
+	return { sort: { column, dir } };
+}
+
 // --- Wire protocol (design §4) -----------------------------------------------
 
 /**

--- a/packages/cockpit/src/duckdb/stream-sql.ts
+++ b/packages/cockpit/src/duckdb/stream-sql.ts
@@ -242,6 +242,11 @@ export async function* streamNdjson(
 	cap: number,
 	queryId: string,
 	signal?: AbortSignalLike,
+	// Redact a credential-bearing source URL from a mid-stream DuckDB error before
+	// it lands in the footer frame: a probe streams over an external ATTACH whose
+	// driver error can echo the DSN. The probe route passes this; lake queries
+	// (run_sql) have no URL to redact, so it defaults to identity.
+	redact: (message: string) => string = (m) => m,
 ): AsyncGenerator<string> {
 	yield encodeFrame({
 		t: "h",
@@ -298,7 +303,7 @@ export async function* streamNdjson(
 		yield encodeFrame({
 			t: "f",
 			rows,
-			error: err instanceof Error ? err.message : String(err),
+			error: redact(err instanceof Error ? err.message : String(err)),
 		});
 	}
 }

--- a/packages/cockpit/src/routeTree.gen.ts
+++ b/packages/cockpit/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as ApiUploadRouteImport } from './routes/api/upload'
 import { Route as ApiShippedMetricDagRouteImport } from './routes/api/shipped-metric-dag'
 import { Route as ApiRunningRunsRouteImport } from './routes/api/running-runs'
 import { Route as ApiRunSqlRouteImport } from './routes/api/run-sql'
+import { Route as ApiProbeSqlRouteImport } from './routes/api/probe-sql'
 import { Route as ApiChatStreamRouteImport } from './routes/api/chat-stream'
 import { Route as ApiChatRouteImport } from './routes/api/chat'
 import { Route as ApiAwaitingInputRouteImport } from './routes/api/awaiting-input'
@@ -61,6 +62,11 @@ const ApiRunningRunsRoute = ApiRunningRunsRouteImport.update({
 const ApiRunSqlRoute = ApiRunSqlRouteImport.update({
   id: '/api/run-sql',
   path: '/api/run-sql',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiProbeSqlRoute = ApiProbeSqlRouteImport.update({
+  id: '/api/probe-sql',
+  path: '/api/probe-sql',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiChatStreamRoute = ApiChatStreamRouteImport.update({
@@ -136,6 +142,7 @@ export interface FileRoutesByFullPath {
   '/api/awaiting-input': typeof ApiAwaitingInputRoute
   '/api/chat': typeof ApiChatRoute
   '/api/chat-stream': typeof ApiChatStreamRoute
+  '/api/probe-sql': typeof ApiProbeSqlRoute
   '/api/run-sql': typeof ApiRunSqlRoute
   '/api/running-runs': typeof ApiRunningRunsRoute
   '/api/shipped-metric-dag': typeof ApiShippedMetricDagRoute
@@ -156,6 +163,7 @@ export interface FileRoutesByTo {
   '/api/awaiting-input': typeof ApiAwaitingInputRoute
   '/api/chat': typeof ApiChatRoute
   '/api/chat-stream': typeof ApiChatStreamRoute
+  '/api/probe-sql': typeof ApiProbeSqlRoute
   '/api/run-sql': typeof ApiRunSqlRoute
   '/api/running-runs': typeof ApiRunningRunsRoute
   '/api/shipped-metric-dag': typeof ApiShippedMetricDagRoute
@@ -177,6 +185,7 @@ export interface FileRoutesById {
   '/api/awaiting-input': typeof ApiAwaitingInputRoute
   '/api/chat': typeof ApiChatRoute
   '/api/chat-stream': typeof ApiChatStreamRoute
+  '/api/probe-sql': typeof ApiProbeSqlRoute
   '/api/run-sql': typeof ApiRunSqlRoute
   '/api/running-runs': typeof ApiRunningRunsRoute
   '/api/shipped-metric-dag': typeof ApiShippedMetricDagRoute
@@ -199,6 +208,7 @@ export interface FileRouteTypes {
     | '/api/awaiting-input'
     | '/api/chat'
     | '/api/chat-stream'
+    | '/api/probe-sql'
     | '/api/run-sql'
     | '/api/running-runs'
     | '/api/shipped-metric-dag'
@@ -219,6 +229,7 @@ export interface FileRouteTypes {
     | '/api/awaiting-input'
     | '/api/chat'
     | '/api/chat-stream'
+    | '/api/probe-sql'
     | '/api/run-sql'
     | '/api/running-runs'
     | '/api/shipped-metric-dag'
@@ -239,6 +250,7 @@ export interface FileRouteTypes {
     | '/api/awaiting-input'
     | '/api/chat'
     | '/api/chat-stream'
+    | '/api/probe-sql'
     | '/api/run-sql'
     | '/api/running-runs'
     | '/api/shipped-metric-dag'
@@ -260,6 +272,7 @@ export interface RootRouteChildren {
   ApiAwaitingInputRoute: typeof ApiAwaitingInputRoute
   ApiChatRoute: typeof ApiChatRoute
   ApiChatStreamRoute: typeof ApiChatStreamRoute
+  ApiProbeSqlRoute: typeof ApiProbeSqlRoute
   ApiRunSqlRoute: typeof ApiRunSqlRoute
   ApiRunningRunsRoute: typeof ApiRunningRunsRoute
   ApiShippedMetricDagRoute: typeof ApiShippedMetricDagRoute
@@ -316,6 +329,13 @@ declare module '@tanstack/react-router' {
       path: '/api/run-sql'
       fullPath: '/api/run-sql'
       preLoaderRoute: typeof ApiRunSqlRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/probe-sql': {
+      id: '/api/probe-sql'
+      path: '/api/probe-sql'
+      fullPath: '/api/probe-sql'
+      preLoaderRoute: typeof ApiProbeSqlRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/chat-stream': {
@@ -464,6 +484,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAwaitingInputRoute: ApiAwaitingInputRoute,
   ApiChatRoute: ApiChatRoute,
   ApiChatStreamRoute: ApiChatStreamRoute,
+  ApiProbeSqlRoute: ApiProbeSqlRoute,
   ApiRunSqlRoute: ApiRunSqlRoute,
   ApiRunningRunsRoute: ApiRunningRunsRoute,
   ApiShippedMetricDagRoute: ApiShippedMetricDagRoute,
@@ -473,3 +494,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}

--- a/packages/cockpit/src/routes/api/probe-sql.ts
+++ b/packages/cockpit/src/routes/api/probe-sql.ts
@@ -1,0 +1,190 @@
+// Streaming `probe` endpoint for the human/grid consumer (DAT-576).
+//
+// The probe analog of `/api/run-sql`: the SAME columnar-NDJSON wire protocol and
+// the SAME `duckdb/stream-sql.ts` framing/cap/sort core, but the rows come from an
+// external DB source ATTACHed READ_ONLY (`duckdb/probe.ts`) instead of the lake.
+// The agent's `probe` tool still materializes a bounded in-context SAMPLE; this is
+// the separate full-result channel the editable probe widget streams.
+//
+// Connection lifecycle is the one real difference from run-sql: that route reuses
+// the long-lived SHARED lake connection (never closes it), whereas a probe opens a
+// THROWAWAY connection per request — so this route disposes it when the stream
+// ends OR is cancelled (the `finally` in `start`, reached on both paths).
+
+import { createFileRoute } from "@tanstack/react-router";
+import { openProbeConnection, SUPPORTED_BACKENDS } from "../../duckdb/probe";
+import {
+	buildGridQuery,
+	clampGridCap,
+	encodeFrame,
+	type GridSort,
+	parseSort,
+	type StreamableResult,
+	streamNdjson,
+} from "../../duckdb/stream-sql";
+import { disableBunIdleTimeout } from "../../lib/bun-request-timeout";
+
+/** Request body for `POST /api/probe-sql`. */
+interface ProbeSqlStreamBody {
+	/** Configured DB source name (the `DATARAUM_<NAME>_URL` key). */
+	source_name: string;
+	/** Backend kind — one of {@link SUPPORTED_BACKENDS}. */
+	backend: string;
+	/** Read-only SQL to run against the attached source (`src.*`). */
+	sql: string;
+	/**
+	 * Optional positional bind values for `$1`, `$2`, … — same rule as run-sql:
+	 * pass any user-derived literal here, never string-concatenated into `sql`.
+	 */
+	params?: (string | number | boolean | null)[];
+	/** Optional row cap, clamped server-side to `[1, 200_000]` (clampGridCap). */
+	cap?: number;
+	/** Optional server-side single-column sort, applied before the cap. */
+	sort?: GridSort;
+}
+
+let queryCounter = 0;
+
+/** Short, monotonic per-process handle for correlating logs/frames. */
+function nextQueryId(): string {
+	queryCounter += 1;
+	return `p_${queryCounter.toString(36)}_${Date.now().toString(36)}`;
+}
+
+function badRequest(message: string): Response {
+	return new Response(JSON.stringify({ error: message }), {
+		status: 400,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+export const Route = createFileRoute("/api/probe-sql")({
+	server: {
+		handlers: {
+			POST: async ({ request }) => {
+				// External sources are remote — a batch can stall >10s; exempt this
+				// request from Bun's idle timeout (see lib/bun-request-timeout).
+				disableBunIdleTimeout(request);
+
+				let body: ProbeSqlStreamBody;
+				try {
+					body = (await request.json()) as ProbeSqlStreamBody;
+				} catch {
+					return badRequest("Request body must be JSON.");
+				}
+				if (typeof body.sql !== "string" || body.sql.trim() === "") {
+					return badRequest("Field 'sql' is required and must be a string.");
+				}
+				if (
+					typeof body.source_name !== "string" ||
+					body.source_name.trim() === ""
+				) {
+					return badRequest("Field 'source_name' is required.");
+				}
+				if (
+					typeof body.backend !== "string" ||
+					!SUPPORTED_BACKENDS.includes(body.backend.toLowerCase())
+				) {
+					return badRequest(
+						`Field 'backend' must be one of: ${SUPPORTED_BACKENDS.join(", ")}.`,
+					);
+				}
+
+				const sortResult = parseSort(body.sort);
+				if ("error" in sortResult) return badRequest(sortResult.error);
+
+				const cap = clampGridCap(body.cap);
+				const queryId = nextQueryId();
+				const params = body.params;
+
+				// Open the throwaway ATTACH. A setup failure (bad/missing credential,
+				// unreachable DB, failed ATTACH) is already CREDENTIAL-REDACTED by
+				// openProbeConnection — surface it to the user as a 400.
+				let probeConn: Awaited<ReturnType<typeof openProbeConnection>>;
+				try {
+					probeConn = await openProbeConnection({
+						source_name: body.source_name,
+						backend: body.backend,
+					});
+				} catch (err) {
+					return badRequest(
+						err instanceof Error ? err.message : "Probe connection failed.",
+					);
+				}
+				const { conn, dispose, redact } = probeConn;
+
+				// Prepare BEFORE the first byte: a bind/parse error (bad SQL, unknown
+				// table) surfaces here as a 400 with the actual message — the user is
+				// writing this SQL and needs the detail. Once the stream flushes, the
+				// status is locked at 200 and mid-stream errors go in the footer.
+				let result: StreamableResult;
+				try {
+					const wrapped = buildGridQuery(body.sql, sortResult.sort);
+					result = (await (params
+						? conn.stream(wrapped, params)
+						: conn.stream(wrapped))) as unknown as StreamableResult;
+				} catch (err) {
+					dispose();
+					const raw = err instanceof Error ? err.message : String(err);
+					return badRequest(redact(raw));
+				}
+
+				const enc = new TextEncoder();
+				// Flipped by cancel() (grid closed / navigated away). streamNdjson
+				// checks it at each chunk boundary, so it stops within one chunk; the
+				// `finally` then disposes the per-request connection.
+				const aborted = { aborted: false };
+
+				const stream = new ReadableStream<Uint8Array>({
+					async start(controller) {
+						try {
+							for await (const line of streamNdjson(
+								result,
+								cap,
+								queryId,
+								aborted,
+							)) {
+								controller.enqueue(enc.encode(line));
+							}
+						} catch (err) {
+							// streamNdjson handles DuckDB errors in-band (footer frame);
+							// this guard only catches an enqueue/controller failure. Emit a
+							// best-effort, redacted footer.
+							try {
+								controller.enqueue(
+									enc.encode(
+										encodeFrame({
+											t: "f",
+											rows: 0,
+											error: redact(
+												err instanceof Error ? err.message : String(err),
+											),
+										}),
+									),
+								);
+							} catch {
+								// Controller already closed — nothing more we can do.
+							}
+						} finally {
+							controller.close();
+							// Per-request connection — unlike run-sql's shared lake reader,
+							// this MUST be disposed on BOTH natural end and cancel.
+							dispose();
+						}
+					},
+					cancel() {
+						aborted.aborted = true;
+					},
+				});
+
+				return new Response(stream, {
+					status: 200,
+					headers: {
+						"Content-Type": "application/x-ndjson",
+						"Cache-Control": "no-cache, no-transform",
+					},
+				});
+			},
+		},
+	},
+});

--- a/packages/cockpit/src/routes/api/probe-sql.ts
+++ b/packages/cockpit/src/routes/api/probe-sql.ts
@@ -43,6 +43,8 @@ interface ProbeSqlStreamBody {
 	sort?: GridSort;
 }
 
+// Per-process monotonic handle (singleton in the Bun/Nitro server process), same
+// as run-sql.ts — for correlating logs/frames, not security-sensitive.
 let queryCounter = 0;
 
 /** Short, monotonic per-process handle for correlating logs/frames. */
@@ -143,6 +145,9 @@ export const Route = createFileRoute("/api/probe-sql")({
 								cap,
 								queryId,
 								aborted,
+								// Redact the source URL from any mid-stream DuckDB error
+								// footer — an external-ATTACH driver error can echo the DSN.
+								redact,
 							)) {
 								controller.enqueue(enc.encode(line));
 							}

--- a/packages/cockpit/src/routes/api/run-sql.ts
+++ b/packages/cockpit/src/routes/api/run-sql.ts
@@ -18,6 +18,7 @@ import {
 	clampGridCap,
 	encodeFrame,
 	type GridSort,
+	parseSort,
 	type StreamableResult,
 	streamNdjson,
 } from "../../duckdb/stream-sql";
@@ -46,35 +47,6 @@ interface RunSqlStreamBody {
 	 * it as an identifier, so a bad name yields a binder error, never injection.
 	 */
 	sort?: GridSort;
-}
-
-/** Validate an optional sort field; returns the sort, null (absent), or an error. */
-function parseSort(
-	raw: unknown,
-): { sort: GridSort | null } | { error: string } {
-	if (raw === undefined || raw === null) return { sort: null };
-	// `typeof [] === "object"`, so reject arrays explicitly — otherwise a JSON
-	// array falls through to the column check and yields a misleading error.
-	if (typeof raw !== "object" || Array.isArray(raw))
-		return { error: "Field 'sort' must be an object." };
-	const { column, dir } = raw as { column?: unknown; dir?: unknown };
-	// Bound the length: a validated field must not accept an arbitrarily large
-	// string that would balloon the SQL handed to DuckDB (a column name this long
-	// is never a real output column anyway).
-	if (
-		typeof column !== "string" ||
-		column.length === 0 ||
-		column.length > 256
-	) {
-		return {
-			error:
-				"Field 'sort.column' is required and must be a non-empty string (max 256 chars).",
-		};
-	}
-	if (dir !== "asc" && dir !== "desc") {
-		return { error: "Field 'sort.dir' must be 'asc' or 'desc'." };
-	}
-	return { sort: { column, dir } };
 }
 
 let queryCounter = 0;

--- a/packages/cockpit/src/server/configured-databases.ts
+++ b/packages/cockpit/src/server/configured-databases.ts
@@ -1,0 +1,32 @@
+// Server fn: the configured DB sources the probe surface can offer (DAT-576).
+//
+// `list_sources` already enumerates configured databases for the AGENT; this is
+// the analog the editable probe WIDGET needs directly (so it doesn't depend on the
+// agent having called a tool first). Env-scanned (`DATARAUM_<NAME>_URL`), filtered
+// to a known/supported backend, the connection URL NEVER serialized — the handler
+// runs server-side and is stripped from the client bundle.
+
+import { createServerFn } from "@tanstack/react-start";
+import { listConfiguredDatabases } from "#/duckdb/credentials";
+
+/** A configured DB source the probe surface can query — a known, supported backend. */
+export interface ProbeSource {
+	/** Source name (the `<NAME>` in `DATARAUM_<NAME>_URL`, lowercased). */
+	name: string;
+	/** Backend kind (postgres/mysql/sqlite/mssql). */
+	backend: string;
+}
+
+/**
+ * The configured DB sources the probe surface can offer: every `DATARAUM_<NAME>_URL`
+ * whose scheme maps to a supported backend. `listConfiguredDatabases` infers the
+ * backend from the URL scheme via the SAME map as probe's supported backends, so a
+ * non-null backend IS a supported one; an unrecognized scheme (`backend === null`)
+ * is dropped — probe can't ATTACH it. The URL is never exposed (server-only handler).
+ */
+export const getConfiguredDatabases = createServerFn({ method: "GET" }).handler(
+	(): ProbeSource[] =>
+		listConfiguredDatabases().filter(
+			(d): d is ProbeSource => d.backend !== null,
+		),
+);

--- a/packages/cockpit/src/tools/open-probe.ts
+++ b/packages/cockpit/src/tools/open-probe.ts
@@ -1,0 +1,24 @@
+// open_probe tool (DAT-576) — a UI tool: it opens an editable SQL probe panel in
+// the workspace canvas so the user can pick a configured database source and write
+// + run read-only SQL against it BEFORE importing. It does no server work; the
+// result projects the probe widget (tool-result-to-canvas), and the panel runs
+// queries on its own streaming channel (/api/probe-sql).
+//
+// Mirrors `upload`: a no-arg opener. To pre-fill the panel with a specific query,
+// the agent uses `probe` instead (it runs a sample AND seeds the same panel).
+
+import { toolDefinition } from "@tanstack/ai";
+import { z } from "zod";
+
+export const openProbeTool = toolDefinition({
+	name: "open_probe",
+	description:
+		"Open an editable SQL probe panel so the user can write and run read-only SQL " +
+		"against a configured database source BEFORE importing it. Call this whenever the " +
+		"user wants to explore or query a connected database directly, or write SQL " +
+		"themselves. The user picks the source and writes the query in the panel — you " +
+		"don't run it here. To pre-fill a specific query for them, use `probe` instead " +
+		"(it seeds the same panel).",
+	inputSchema: z.object({}),
+	outputSchema: z.object({ ready: z.boolean() }),
+}).server(() => ({ ready: true }));

--- a/packages/cockpit/src/tools/registry.test.ts
+++ b/packages/cockpit/src/tools/registry.test.ts
@@ -82,6 +82,7 @@ describe("tool registry (DAT-353)", () => {
 				"look_drivers",
 				"replay",
 				"upload",
+				"open_probe",
 			]),
 		);
 	});

--- a/packages/cockpit/src/tools/registry.ts
+++ b/packages/cockpit/src/tools/registry.ts
@@ -28,6 +28,7 @@ import { lookProfileTool } from "./look-profile";
 import { lookRelationshipsTool } from "./look-relationships";
 import { lookTableTool } from "./look-table";
 import { lookValidationTool } from "./look-validation";
+import { openProbeTool } from "./open-probe";
 import { operatingModelTool } from "./operating-model";
 import { probeTool } from "./probe";
 import { answerTool } from "./query";
@@ -81,6 +82,7 @@ export const toolsByKind = {
 		listVerticalsTool,
 		connectTool,
 		probeTool,
+		openProbeTool,
 		useVerticalTool,
 		frameTool,
 		selectTool,

--- a/packages/cockpit/src/ui/cockpit/canvas-registry.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-registry.ts
@@ -20,6 +20,7 @@ import { MetricShadowWidget } from "#/ui/cockpit/widgets/metric-shadow";
 import { MetricWhyWidget } from "#/ui/cockpit/widgets/metric-why";
 import { ModelFrameWidget } from "#/ui/cockpit/widgets/model-frame";
 import { OperatingModelProgressWidget } from "#/ui/cockpit/widgets/operating-model-progress";
+import { ProbeWidget } from "#/ui/cockpit/widgets/probe";
 import { RelationshipListWidget } from "#/ui/cockpit/widgets/relationship-list";
 import { RelationshipWhyWidget } from "#/ui/cockpit/widgets/relationship-why";
 import { ResultGridWidget } from "#/ui/cockpit/widgets/result-grid";
@@ -65,4 +66,5 @@ export const canvasRegistry = new WidgetRegistry()
 		kind: "operating-model-progress",
 		component: OperatingModelProgressWidget,
 	})
-	.register({ kind: "upload-area", component: UploadAreaWidget });
+	.register({ kind: "upload-area", component: UploadAreaWidget })
+	.register({ kind: "probe", component: ProbeWidget });

--- a/packages/cockpit/src/ui/cockpit/canvas-state.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-state.ts
@@ -124,7 +124,17 @@ export type CanvasState =
 	// A file-upload area (redesign) — projected by the `upload` UI tool so the user
 	// can drop local files; NOT a permanent chat fixture. Carries nothing; the
 	// widget owns the dropzone + drives connect on upload.
-	| { kind: "upload-area" };
+	| { kind: "upload-area" }
+	// DAT-576: the editable probe surface — the user picks a configured DB source,
+	// writes/edits read-only SQL, and runs it against the external DB BEFORE ingest
+	// (streamed via /api/probe-sql into the same result grid). Projected EMPTY by the
+	// `open_probe` UI tool, or SEEDED with the agent's `probe` call input (source +
+	// sql) so a generated query lands in the editor for the user to edit + re-run.
+	| {
+			kind: "probe";
+			source?: { name: string; backend: string };
+			sql?: string;
+	  };
 
 /** Every `kind` a canvas member can have — handy for registry/test exhaustion. */
 export type CanvasKind = CanvasState["kind"];

--- a/packages/cockpit/src/ui/cockpit/chat-rail.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/chat-rail.test.tsx
@@ -319,7 +319,7 @@ describe("ChatRail tool-result chips (DAT-354)", () => {
 	});
 
 	it.each([
-		"probe",
+		// probe is NO LONGER here — it now seeds the editable probe canvas (DAT-576).
 		"teach",
 	])("renders %s as a display-only chip (no rehydrate target)", (name) => {
 		h.messages = [

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -49,8 +49,8 @@ describe("toolLabel", () => {
 });
 
 describe("isCanvasTool", () => {
-	it("marks the 24 canvas-producing tools clickable", () => {
-		expect(CANVAS_TOOLS.size).toBe(24);
+	it("marks the 26 canvas-producing tools clickable", () => {
+		expect(CANVAS_TOOLS.size).toBe(26);
 		for (const name of [
 			"list_sources",
 			"list_tables",
@@ -78,12 +78,15 @@ describe("isCanvasTool", () => {
 			"answer",
 			"replay",
 			"upload",
+			// probe SEEDS the editable probe canvas + open_probe opens it empty (DAT-576).
+			"probe",
+			"open_probe",
 		]) {
 			expect(isCanvasTool(name)).toBe(true);
 		}
 	});
 
-	it("marks probe / teach / teach_validation / teach_cycle display-only", () => {
+	it("marks teach / teach_validation / teach_cycle display-only", () => {
 		// These return no renderable surface — their chips must not be clickable.
 		// (operating_model LEFT this list with the DAT-435 follow-on: its driver
 		// projects the live progress canvas, like begin_session.) teach_validation
@@ -92,7 +95,7 @@ describe("isCanvasTool", () => {
 		// teach_metric LEFT this list (DAT-482): an OVERRIDE projects the shipped
 		// DAG it replaces (metric-shadow), so its chip is clickable.
 		for (const name of [
-			"probe",
+			// probe LEFT this list (DAT-576): it now seeds the editable probe canvas.
 			"teach",
 			"teach_validation",
 			"teach_cycle",

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -80,6 +80,7 @@ const TOOL_LABELS: Record<string, string> = {
 	begin_session: "Starting session",
 	run_sql: "Query",
 	probe: "Data check",
+	open_probe: "Probe editor",
 	teach: "Teaching",
 	teach_validation: "Declaring validation",
 	teach_cycle: "Declaring cycle",
@@ -363,6 +364,8 @@ export function toolChipSummary(
 		}
 		case "upload":
 			return "drop files to import";
+		case "open_probe":
+			return "write SQL to probe a source";
 		default:
 			// Never surface a raw snake_case verb as the summary — humanize unmapped
 			// tools the same way the title does (look_relationships → "Look relationships").

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
@@ -431,6 +431,44 @@ describe("toolResultToCanvas", () => {
 		});
 	});
 
+	it("maps open_probe to an empty probe canvas (the UI tool just opens the editor)", () => {
+		expect(toolResultToCanvas("open_probe", { ready: true })).toEqual({
+			kind: "probe",
+		});
+	});
+
+	it("seeds the probe canvas from the probe call arguments (source + sql)", () => {
+		expect(
+			toolResultToCanvas(
+				"probe",
+				{ columns: [], rows: [], rowCount: 0 },
+				{
+					source_name: "wwi",
+					backend: "mssql",
+					sql: "SELECT TOP 10 * FROM Sales.Orders",
+				},
+			),
+		).toEqual({
+			kind: "probe",
+			source: { name: "wwi", backend: "mssql" },
+			sql: "SELECT TOP 10 * FROM Sales.Orders",
+		});
+	});
+
+	it("returns null for probe with no sql/source on the wire, or an agent error", () => {
+		expect(
+			toolResultToCanvas("probe", {}, { source_name: "wwi", backend: "mssql" }),
+		).toBeNull();
+		expect(toolResultToCanvas("probe", {}, { sql: "SELECT 1" })).toBeNull();
+		expect(
+			toolResultToCanvas(
+				"probe",
+				{ error: "bad SQL" },
+				{ source_name: "wwi", backend: "mssql", sql: "SELECT 1" },
+			),
+		).toBeNull();
+	});
+
 	it("maps select to the add-source-progress canvas (DAT-436: calling select starts the import)", () => {
 		const selection = {
 			sources: ["s1"],

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -315,6 +315,34 @@ const PROJECTORS: Record<string, CanvasProjector> = {
 	// The `upload` UI tool carries no data — it just opens the upload area so the
 	// user can drop local files.
 	upload: () => ({ kind: "upload-area" }),
+	// The `open_probe` UI tool carries no data — it opens an EMPTY editable probe
+	// panel for the user to pick a source + write SQL.
+	open_probe: () => ({ kind: "probe" }),
+	// The agent's `probe` ran a sample for ITS context; the human grid re-streams the
+	// FULL result. Like run_sql, the query is in the CALL INPUT (source + sql), not the
+	// result — so it SEEDS the editable panel (probe is OUT of CHIP_ONLY now): the user
+	// sees the agent's query, can edit it, and re-runs it as a stream. An errored probe
+	// (`{ error }`) or a call missing source/sql leaves the canvas unchanged.
+	probe: (result, input) => {
+		if (isAgentError(result)) return null;
+		const args = (input ?? {}) as {
+			source_name?: unknown;
+			backend?: unknown;
+			sql?: unknown;
+		};
+		if (typeof args.sql !== "string" || args.sql.length === 0) return null;
+		if (
+			typeof args.source_name !== "string" ||
+			typeof args.backend !== "string"
+		) {
+			return null;
+		}
+		return {
+			kind: "probe",
+			source: { name: args.source_name, backend: args.backend },
+			sql: args.sql,
+		};
+	},
 };
 
 /**
@@ -336,7 +364,6 @@ export const CANVAS_TOOLS: ReadonlySet<string> = new Set(
 export const CHIP_ONLY: ReadonlySet<string> = new Set([
 	"list_verticals", // catalogue → chip summary, no widget
 	"use_vertical", // adopt = control-plane write, no renderable surface (DAT-523)
-	"probe", // quick data check, summarized in the chip
 	"look_drivers", // driver rankings → chip summary; a dedicated widget is a fast-follow (DAT-546)
 	"teach", // writes an overlay row; outcome surfaces after a re-run, not a widget
 	"teach_validation",

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+// Behavior tests for ProbeWidget (DAT-576). The boundaries are stubbed — they are
+// external systems verified elsewhere: the server fn (env/RPC), the CodeMirror
+// editor (a DOM widget, smoke-verified), and the streaming grid (network I/O). What
+// we assert here is the widget's OWN logic: the no-sources state, run-gating (needs
+// a configured source AND non-empty SQL), and that a Run streams /api/probe-sql with
+// the right request body — including the agent-seed (source + sql) path.
+
+import { MantineProvider } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const getConfiguredDatabasesMock = vi.fn();
+vi.mock("#/server/configured-databases", () => ({
+	getConfiguredDatabases: () => getConfiguredDatabasesMock(),
+}));
+vi.mock("#/ui/cockpit/widgets/sql-editor", () => ({
+	SqlEditor: ({
+		value,
+		onChange,
+	}: {
+		value: string;
+		onChange: (s: string) => void;
+	}) => (
+		<textarea
+			data-testid="sql-editor"
+			value={value}
+			onChange={(e) => onChange(e.target.value)}
+		/>
+	),
+}));
+vi.mock("#/ui/cockpit/widgets/result-grid", () => ({
+	StreamingGrid: ({
+		endpoint,
+		body,
+	}: {
+		endpoint: string;
+		body: Record<string, unknown>;
+	}) => (
+		<div
+			data-testid="streaming-grid"
+			data-endpoint={endpoint}
+			data-body={JSON.stringify(body)}
+		/>
+	),
+}));
+
+import type { CanvasState } from "#/ui/cockpit/canvas-state";
+import { ProbeWidget } from "#/ui/cockpit/widgets/probe";
+import { theme } from "#/ui/theme";
+
+function renderProbe(
+	state: Extract<CanvasState, { kind: "probe" }> = { kind: "probe" },
+) {
+	const qc = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return render(
+		<QueryClientProvider client={qc}>
+			<MantineProvider theme={theme} env="test">
+				<ProbeWidget state={state} />
+			</MantineProvider>
+		</QueryClientProvider>,
+	);
+}
+
+const runBtn = () => screen.getByTestId("probe-run") as HTMLButtonElement;
+
+describe("ProbeWidget (DAT-576)", () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("shows the no-sources alert and disables run when none are configured", async () => {
+		getConfiguredDatabasesMock.mockResolvedValue([]);
+		renderProbe();
+		await waitFor(() =>
+			expect(screen.getByTestId("probe-no-sources")).toBeTruthy(),
+		);
+		expect(runBtn().disabled).toBe(true);
+		expect(screen.queryByTestId("streaming-grid")).toBeNull();
+	});
+
+	it("gates run on a source AND non-empty SQL", async () => {
+		getConfiguredDatabasesMock.mockResolvedValue([
+			{ name: "wwi", backend: "mssql" },
+		]);
+		// Seed the source (agent-generate path) but no SQL → still disabled.
+		renderProbe({ kind: "probe", source: { name: "wwi", backend: "mssql" } });
+		await waitFor(() => expect(getConfiguredDatabasesMock).toHaveBeenCalled());
+		expect(runBtn().disabled).toBe(true);
+
+		// Typing SQL enables it.
+		fireEvent.change(screen.getByTestId("sql-editor"), {
+			target: { value: "SELECT 1" },
+		});
+		await waitFor(() => expect(runBtn().disabled).toBe(false));
+	});
+
+	it("streams /api/probe-sql with the seeded source + sql on Run", async () => {
+		getConfiguredDatabasesMock.mockResolvedValue([
+			{ name: "wwi", backend: "mssql" },
+		]);
+		renderProbe({
+			kind: "probe",
+			source: { name: "wwi", backend: "mssql" },
+			sql: "SELECT TOP 10 * FROM Sales.Orders",
+		});
+		await waitFor(() => expect(runBtn().disabled).toBe(false));
+		fireEvent.click(runBtn());
+
+		const grid = await screen.findByTestId("streaming-grid");
+		expect(grid.getAttribute("data-endpoint")).toBe("/api/probe-sql");
+		expect(JSON.parse(grid.getAttribute("data-body") ?? "{}")).toEqual({
+			source_name: "wwi",
+			backend: "mssql",
+			sql: "SELECT TOP 10 * FROM Sales.Orders",
+		});
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
@@ -37,6 +37,20 @@ export function ProbeWidget({
 }: {
 	state: Extract<CanvasState, { kind: "probe" }>;
 }) {
+	// Remount the panel whenever the agent SEED (the source + sql projected onto the
+	// canvas) changes, so a repeated probe / open_probe in a later turn re-seeds the
+	// editor + picker via fresh state init — never a reset effect (idiom rule 5, the
+	// ResultGridWidget → StreamingGrid pattern). User edits don't touch the seed, so
+	// typing never remounts.
+	const seedKey = `${state.source?.name ?? ""}|${state.sql ?? ""}`;
+	return <ProbePanel key={seedKey} state={state} />;
+}
+
+function ProbePanel({
+	state,
+}: {
+	state: Extract<CanvasState, { kind: "probe" }>;
+}) {
 	const sources = useQuery({
 		queryKey: ["configured-databases"],
 		queryFn: () => getConfiguredDatabases(),

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
@@ -99,8 +99,8 @@ function ProbePanel({
 				)}
 			</Group>
 			<Text size="xs" c="dimmed">
-				Read-only SQL against a configured source — no data is imported.
-				⌘/Ctrl+Enter to run.
+				Read-only DuckDB SQL against a configured source (use LIMIT, not TOP) —
+				no data is imported. ⌘/Ctrl+Enter to run.
 			</Text>
 
 			<Select
@@ -140,7 +140,7 @@ function ProbePanel({
 				value={sqlText}
 				onChange={setSqlText}
 				onRun={run}
-				placeholder="SELECT TOP 100 * FROM Sales.Orders"
+				placeholder="SELECT * FROM my_schema.my_table LIMIT 100"
 			/>
 
 			<Group>

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
@@ -1,0 +1,148 @@
+// Probe widget (DAT-576) — the editable Connect-phase surface: pick a configured
+// DB source, write/edit read-only SQL, and run it against the external DB BEFORE
+// ingest. Runs stream through /api/probe-sql into the SAME virtualized result grid
+// the lake uses (StreamingGrid), so a large external result never floods the DOM.
+//
+// The agent only SEEDS this surface: a `probe` tool call projects its source + sql
+// into the editor (out of CHIP_ONLY, Phase 3) for the user to edit and re-run. The
+// run itself is a direct fetch — no agent round-trip — exactly like the run_sql
+// result grid.
+
+import {
+	Alert,
+	Badge,
+	Button,
+	Group,
+	Select,
+	Stack,
+	Text,
+} from "@mantine/core";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { getConfiguredDatabases } from "#/server/configured-databases";
+import type { CanvasState } from "#/ui/cockpit/canvas-state";
+import { StreamingGrid } from "#/ui/cockpit/widgets/result-grid";
+import { SqlEditor } from "#/ui/cockpit/widgets/sql-editor";
+
+/** The probe-sql request a Run submits — mirrors the /api/probe-sql body. A `type`
+ * (not `interface`) so it's assignable to the grid's `Record<string, unknown>` body. */
+type ProbeRun = {
+	source_name: string;
+	backend: string;
+	sql: string;
+};
+
+export function ProbeWidget({
+	state,
+}: {
+	state: Extract<CanvasState, { kind: "probe" }>;
+}) {
+	const sources = useQuery({
+		queryKey: ["configured-databases"],
+		queryFn: () => getConfiguredDatabases(),
+	});
+	const list = useMemo(() => sources.data ?? [], [sources.data]);
+
+	// Seed from the canvas state (agent-generate): a projected source + sql preload
+	// the picker + editor as INITIAL values; the user then edits freely.
+	const [selected, setSelected] = useState<string | null>(
+		state.source?.name ?? null,
+	);
+	const [sqlText, setSqlText] = useState<string>(state.sql ?? "");
+	const [submitted, setSubmitted] = useState<ProbeRun | null>(null);
+	// Bumped per Run so an identical re-run still remounts StreamingGrid (fresh
+	// stream + sort reset), not just a different query.
+	const [runId, setRunId] = useState(0);
+
+	const selectedSource = useMemo(
+		() => list.find((s) => s.name === selected) ?? null,
+		[list, selected],
+	);
+	const canRun = selectedSource !== null && sqlText.trim().length > 0;
+
+	const run = () => {
+		if (!selectedSource || sqlText.trim().length === 0) return;
+		setSubmitted({
+			source_name: selectedSource.name,
+			backend: selectedSource.backend,
+			sql: sqlText,
+		});
+		setRunId((r) => r + 1);
+	};
+
+	const noSources = !sources.isLoading && list.length === 0;
+
+	return (
+		<Stack gap="sm" data-testid="canvas-probe">
+			<Group justify="space-between" wrap="nowrap">
+				<Text size="sm" fw={600}>
+					Probe a database source
+				</Text>
+				{selectedSource && (
+					<Badge variant="light" size="sm" tt="none">
+						{selectedSource.backend}
+					</Badge>
+				)}
+			</Group>
+			<Text size="xs" c="dimmed">
+				Read-only SQL against a configured source — no data is imported.
+				⌘/Ctrl+Enter to run.
+			</Text>
+
+			<Select
+				data-testid="probe-source-select"
+				placeholder={
+					sources.isLoading
+						? "Loading sources…"
+						: list.length
+							? "Pick a source"
+							: "No configured sources"
+				}
+				data={list.map((s) => ({
+					value: s.name,
+					label: `${s.name} (${s.backend})`,
+				}))}
+				value={selected}
+				onChange={setSelected}
+				disabled={sources.isLoading || list.length === 0}
+				searchable
+			/>
+
+			{noSources && (
+				<Alert color="gray" data-testid="probe-no-sources">
+					No configured database sources. Set a{" "}
+					<Text span ff="monospace" size="xs">
+						DATARAUM_&lt;NAME&gt;_URL
+					</Text>{" "}
+					and bring the source up (see{" "}
+					<Text span ff="monospace" size="xs">
+						docker-compose.sources.yml
+					</Text>
+					).
+				</Alert>
+			)}
+
+			<SqlEditor
+				value={sqlText}
+				onChange={setSqlText}
+				onRun={run}
+				placeholder="SELECT TOP 100 * FROM Sales.Orders"
+			/>
+
+			<Group>
+				<Button
+					size="xs"
+					onClick={run}
+					disabled={!canRun}
+					data-testid="probe-run"
+				>
+					Run
+				</Button>
+			</Group>
+
+			{submitted && (
+				<StreamingGrid key={runId} endpoint="/api/probe-sql" body={submitted} />
+			)}
+		</Stack>
+	);
+}

--- a/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
@@ -280,43 +280,64 @@ export function ResultGridWidget({
 		() => JSON.stringify([state.sql, state.params ?? null]),
 		[state.sql, state.params],
 	);
-	return <StreamingGrid key={baseKey} sql={state.sql} params={state.params} />;
+	return (
+		<StreamingGrid
+			key={baseKey}
+			endpoint="/api/run-sql"
+			body={{ sql: state.sql, params: state.params }}
+		/>
+	);
 }
 
-/** Streams `/api/run-sql` for the carried query and owns the grid-local sort. */
-function StreamingGrid({
-	sql,
-	params,
+/** The grid stream routes return a 400 body as `{ "error": "<message>" }`; surface
+ * the message, not the raw JSON. Falls back to the raw text for any other body. */
+function extractError(text: string): string {
+	try {
+		const parsed = JSON.parse(text) as { error?: unknown };
+		if (parsed && typeof parsed.error === "string") return parsed.error;
+	} catch {
+		// not JSON — use the text as-is
+	}
+	return text;
+}
+
+/**
+ * Streams an NDJSON grid endpoint for the carried request and owns the grid-local
+ * sort. Endpoint-agnostic, so it backs BOTH `/api/run-sql` (the agent's lake query)
+ * and `/api/probe-sql` (the editable probe surface) — only the `body` shape
+ * differs; the grid injects its own `sort`. Reset sort by remounting on a new base
+ * request (a `key` on the parent), never a reset effect.
+ */
+export function StreamingGrid({
+	endpoint,
+	body,
 }: {
-	sql: string;
-	params?: (string | number | boolean | null)[];
+	endpoint: string;
+	/** The base request body (WITHOUT `sort` — the grid appends its own). */
+	body: Record<string, unknown>;
 }) {
 	const storeRef = useRef(new ColumnStore());
 	const [, bump] = useState(0);
 	const [fatal, setFatal] = useState<string | null>(null);
 	// Grid-local view state: which column the SERVER should order by. Reset to
-	// null on a new base query (this component remounts — see ResultGridWidget).
+	// null on a new base request (this component remounts — see the `key`).
 	const [sort, setSort] = useState<GridSort | null>(null);
 
 	// Header click cycles the sort for that column: unsorted → asc → desc →
-	// unsorted. Switching to a different column starts at asc.
-	// Stable identity (setSort is stable, no deps) so a future React.memo on the
-	// view doesn't re-render the grid on every sort-irrelevant parent render.
+	// unsorted. Switching to a different column starts at asc. Stable identity
+	// (setSort is stable) so a future React.memo on the view doesn't re-render on
+	// every sort-irrelevant parent render.
 	const toggleSort = useCallback((column: string) => {
 		setSort((cur) => cycleSort(cur, column));
 	}, []);
 
-	// Value-stable request identity: re-stream iff sql, params, OR sort changed.
-	// Parse them back out inside the effect so the effect's ONLY dependency is the
-	// key — no stale closures, no churn from ChatRail's fresh objects.
-	const requestKey = useMemo(
-		() => JSON.stringify([sql, params ?? null, sort]),
-		[sql, params, sort],
-	);
+	// Value-stable request identity: re-stream iff the body OR sort changed. Parse
+	// it back inside the effect so the effect's ONLY dependency is the key — no
+	// stale closures, no churn from a fresh `body` object each parent render.
+	const requestKey = useMemo(() => JSON.stringify([body, sort]), [body, sort]);
 	useEffect(() => {
-		const [qSql, qParams, qSort] = JSON.parse(requestKey) as [
-			string,
-			(string | number | boolean | null)[] | null,
+		const [qBody, qSort] = JSON.parse(requestKey) as [
+			Record<string, unknown>,
 			GridSort | null,
 		];
 		const store = new ColumnStore();
@@ -327,32 +348,30 @@ function StreamingGrid({
 		const ac = new AbortController();
 		void (async () => {
 			try {
-				const res = await fetch("/api/run-sql", {
+				const res = await fetch(endpoint, {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({
-						sql: qSql,
-						params: qParams ?? undefined,
-						sort: qSort ?? undefined,
-					}),
+					body: JSON.stringify({ ...qBody, sort: qSort ?? undefined }),
 					signal: ac.signal,
 				});
 				if (!res.ok || !res.body) {
 					const detail = await res.text().catch(() => res.statusText);
-					throw new Error(detail || `run-sql failed (${res.status})`);
+					throw new Error(
+						extractError(detail) || `request failed (${res.status})`,
+					);
 				}
 				await readNdjsonStream(res.body, (frame) => {
 					store.apply(frame);
 					bump((v) => v + 1);
 				});
 			} catch (err) {
-				// An aborted fetch (unmount / new query / new sort) is expected.
+				// An aborted fetch (unmount / new request / new sort) is expected.
 				if (ac.signal.aborted) return;
 				setFatal(err instanceof Error ? err.message : String(err));
 			}
 		})();
 		return () => ac.abort();
-	}, [requestKey]);
+	}, [requestKey, endpoint]);
 
 	return (
 		<ResultGridView

--- a/packages/cockpit/src/ui/cockpit/widgets/sql-editor.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/sql-editor.tsx
@@ -1,0 +1,126 @@
+// A minimal SQL editor over CodeMirror 6 PRIMARIES — no react wrapper (we depend
+// on @codemirror/* directly + integrate it here; wrappers are dependency hell).
+//
+// The EditorView is an external system (React idiom rule 2): created ONCE in an
+// effect, destroyed on cleanup. Callbacks are read through refs so a changing
+// onChange/onRun never tears the editor down and rebuilds it. SSR-safe — the view
+// is only ever constructed client-side inside the effect; the host renders an
+// empty div on the server (no module-level DOM access in @codemirror/*).
+
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { sql } from "@codemirror/lang-sql";
+import {
+	defaultHighlightStyle,
+	syntaxHighlighting,
+} from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+import {
+	placeholder as cmPlaceholder,
+	EditorView,
+	keymap,
+	lineNumbers,
+} from "@codemirror/view";
+import { useEffect, useRef } from "react";
+
+export function SqlEditor({
+	value,
+	onChange,
+	onRun,
+	placeholder,
+}: {
+	/** Current SQL text. External changes (e.g. an agent-seeded query) are synced
+	 * into the editor; the editor's own edits flow out through `onChange`. */
+	value: string;
+	onChange: (next: string) => void;
+	/** Invoked on Mod-Enter (⌘/Ctrl+Enter) — the run shortcut. */
+	onRun?: () => void;
+	placeholder?: string;
+}) {
+	const hostRef = useRef<HTMLDivElement>(null);
+	const viewRef = useRef<EditorView | null>(null);
+	// Latest callbacks, read by the editor's (construct-once) extensions. Synced in
+	// an effect, never written during render (React idiom rule 8).
+	const onChangeRef = useRef(onChange);
+	const onRunRef = useRef(onRun);
+	useEffect(() => {
+		onChangeRef.current = onChange;
+		onRunRef.current = onRun;
+	});
+
+	// Construct the EditorView once. `value` seeds the initial doc only; later
+	// external changes are applied by the sync effect below.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: construct once — value is the initial doc (synced below), placeholder is static.
+	useEffect(() => {
+		const host = hostRef.current;
+		if (!host) return;
+		const view = new EditorView({
+			parent: host,
+			state: EditorState.create({
+				doc: value,
+				extensions: [
+					lineNumbers(),
+					history(),
+					keymap.of([
+						{
+							key: "Mod-Enter",
+							run: () => {
+								onRunRef.current?.();
+								return true;
+							},
+						},
+						...defaultKeymap,
+						...historyKeymap,
+					]),
+					sql(),
+					syntaxHighlighting(defaultHighlightStyle),
+					...(placeholder ? [cmPlaceholder(placeholder)] : []),
+					EditorView.updateListener.of((update) => {
+						if (update.docChanged) {
+							onChangeRef.current(update.state.doc.toString());
+						}
+					}),
+					EditorView.theme({
+						"&": { fontSize: "13px", maxHeight: "260px" },
+						"&.cm-focused": { outline: "none" },
+						".cm-scroller": {
+							overflow: "auto",
+							fontFamily:
+								"var(--mantine-font-family-monospace, ui-monospace, monospace)",
+						},
+					}),
+				],
+			}),
+		});
+		viewRef.current = view;
+		return () => {
+			view.destroy();
+			viewRef.current = null;
+		};
+	}, []);
+
+	// Sync external `value` changes into the editor (e.g. agent-seeded SQL). When
+	// the change originated from typing, `value` already equals the doc, so this is
+	// a no-op — it never fights the user's cursor.
+	useEffect(() => {
+		const view = viewRef.current;
+		if (!view) return;
+		const current = view.state.doc.toString();
+		if (value !== current) {
+			view.dispatch({
+				changes: { from: 0, to: current.length, insert: value },
+			});
+		}
+	}, [value]);
+
+	return (
+		<div
+			ref={hostRef}
+			data-testid="sql-editor"
+			style={{
+				border: "1px solid var(--mantine-color-default-border)",
+				borderRadius: "var(--mantine-radius-sm)",
+				overflow: "hidden",
+			}}
+		/>
+	);
+}

--- a/packages/infra/docker-compose.sources.yml
+++ b/packages/infra/docker-compose.sources.yml
@@ -14,9 +14,11 @@
 #                  --profile mssql up -d --wait
 #
 # Then point the cockpit at it (host dev, `bun --bun run dev`) by setting in the
-# cockpit .env:
-#   DATARAUM_WWI_URL=Server=localhost,1433;Database=WideWorldImporters;UID=sa;PWD=Dataraum!Dev1;TrustServerCertificate=true
-# An in-container cockpit would use Server=mssql,1433 instead.
+# cockpit .env (a `scheme://` URL — the backend is inferred from the scheme, so the
+# source appears in the probe picker; a bare `Server=…` DSN attaches but isn't
+# classifiable — DAT-576 smoke):
+#   DATARAUM_WWI_URL=mssql://sa:Dataraum!Dev1@localhost:1433/WideWorldImporters?TrustServerCertificate=true
+# An in-container cockpit would use @mssql:1433 instead of @localhost:1433.
 #
 # Apple Silicon: SQL Server images are amd64-only — `platform: linux/amd64` runs them
 # under Rosetta (verified on SQL Server 2025). The self-signed cert is why the


### PR DESCRIPTION
Phase 1 (the keystone) of the **Cockpit UI brilliance** epic (DAT-574). A user-facing **probe** surface: pick a configured external DB source (MS SQL / postgres / mysql / sqlite), write/edit read-only SQL in a CodeMirror editor, and run it — results stream through a new `/api/probe-sql` into the same virtualized result grid the lake uses. The agent seeds the editor; the run is a direct fetch (no agent round-trip). Built + smoke-fixture proven against the DAT-589 Wide World Importers MS SQL stack.

## Commits
- **P1** — `openProbeConnection()` extracted from `probe.ts` (shared ATTACH setup); streaming `/api/probe-sql` over a per-request connection (disposed on end *and* cancel, unlike run-sql's shared lake conn). `parseSort` shared into `stream-sql.ts`.
- **P2** — ProbeWidget: `getConfiguredDatabases` server fn (URL never exposed) + a local `SqlEditor` over **CodeMirror primaries, no wrapper** + `ResultGridView` via a generalized `StreamingGrid(endpoint, body)`.
- **P3** — `open_probe` UI tool + `probe` projected (out of `CHIP_ONLY`, seeds the editor) + Connect-kind fencing.
- **review fixes** — redact the source URL from any mid-stream error footer (`streamNdjson` gains an optional `redact`); remount the probe panel on a changed agent seed (idiom rule 5).

## Reviewers
- **spec-compliance: COMPLIANT** — all 3 phases implemented; `parseSort`/`StreamingGrid`/server-fn refactors judged in-spirit; engine untouched; run-sql behavior preserved; probe tool contract intact.
- **senior-code: APPROVE** — connection lifecycle airtight; both findings (mid-stream credential leak, repeated-seed remount) fixed in this branch. Deferred (noted): alternate-form DSN redaction; an explicit dispose-on-ATTACH-failure test.

## Verified
- tsc + biome clean · **1232 unit tests** + a hermetic-sqlite streaming integration test pass.
- The streaming-over-ATTACH path was proven end-to-end against the live WWI MS SQL container during DAT-589 (73,595 rows, 36 lazy chunks).

## Pending
- **Live browser smoke** of the full Connect → open probe → pick WWI → write SQL → stream flow (the P5 widget-eval walk territory) — not yet run in this branch; the dev fixture is `docker compose -f packages/infra/docker-compose.yml -f packages/infra/docker-compose.sources.yml --profile mssql up -d --wait` + `DATARAUM_WWI_URL` in the cockpit `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)