### PR TITLE
DAT-548: inject driver rankings into the answer agent (<drivers> block)

### DIFF
--- a/packages/cockpit/src/tools/query-context.test.ts
+++ b/packages/cockpit/src/tools/query-context.test.ts
@@ -275,7 +275,9 @@ describe("formatDrivers", () => {
 		expect(block).toContain('top drivers: "region" (0.42), "channel" (0.18)');
 		// Multi-col path joined coarse→fine; single-col path kept.
 		expect(block).toContain('drill paths: "region" → "channel"; "segment"');
-		expect(block).toContain('notable slices: "region"=EMEA (effect 0.30, support 1200)');
+		expect(block).toContain(
+			'notable slices: "region"=EMEA (effect 0.30, support 1200)',
+		);
 	});
 
 	it("labels an entity grain as 'within <identity>' and keeps secondary drivers separate", () => {
@@ -285,11 +287,18 @@ describe("formatDrivers", () => {
 				grain: "entity",
 				entity: "customer_id",
 				secondary_dimensions: [
-					{ dimension: "tenure", gain: 0.22, grain: "entity", entity: "customer_id" },
+					{
+						dimension: "tenure",
+						gain: 0.22,
+						grain: "entity",
+						entity: "customer_id",
+					},
 				],
 			}),
 		]);
-		expect(block).toContain('Measure "ltv" (flow, within customer_id, n=12000):');
+		expect(block).toContain(
+			'Measure "ltv" (flow, within customer_id, n=12000):',
+		);
 		expect(block).toContain(
 			'other-grain drivers: "tenure" (within customer_id, 0.22)',
 		);
@@ -312,6 +321,8 @@ describe("formatDrivers", () => {
 	it("drops a measure with no significant driver; all-empty → a note", () => {
 		const block = formatDrivers([
 			ranking({ measure: "kept" }),
+			// barren keeps the base fixture's slice but has no ranked dims/paths —
+			// still dropped (the filter gates on a driver, not on slices).
 			ranking({
 				measure: "barren",
 				ranked_dimensions: [],

--- a/packages/cockpit/src/tools/query-context.test.ts
+++ b/packages/cockpit/src/tools/query-context.test.ts
@@ -10,10 +10,12 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("#/config", () => ({ config: {} }));
 vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 
+import type { DriverRanking } from "./look-drivers";
 import {
 	type CatalogAxisRow,
 	type CatalogHierarchyRow,
 	formatCatalog,
+	formatDrivers,
 	formatSchema,
 	preferEnriched,
 	type SchemaColumnRow,
@@ -241,5 +243,94 @@ describe("formatCatalog (DAT-538 dimension catalog block)", () => {
 			new Map(),
 		);
 		expect(block).toContain("Table orphan:");
+	});
+});
+
+// --- formatDrivers (DAT-548): the <drivers> block projection ---------------------
+
+const ranking = (over: Partial<DriverRanking> = {}): DriverRanking => ({
+	measure: "revenue",
+	target_type: "flow",
+	grain: "row",
+	entity: null,
+	n_rows: 12000,
+	ranked_dimensions: [
+		{ dimension: "region", gain: 0.421 },
+		{ dimension: "channel", gain: 0.18 },
+	],
+	driver_paths: [["region", "channel"], ["segment"]],
+	interesting_slices: [
+		{ dimension: "region", value: "EMEA", effect: 0.3, support: 1200 },
+	],
+	secondary_dimensions: [],
+	...over,
+});
+
+describe("formatDrivers", () => {
+	it("renders a row-grain stanza with top drivers (gain) + drill paths", () => {
+		const block = formatDrivers([ranking()]);
+		expect(block).toContain("<drivers>");
+		expect(block).toContain('Measure "revenue" (flow, row-level, n=12000):');
+		// Gain rounded to 2dp, strongest first.
+		expect(block).toContain('top drivers: "region" (0.42), "channel" (0.18)');
+		// Multi-col path joined coarse→fine; single-col path kept.
+		expect(block).toContain('drill paths: "region" → "channel"; "segment"');
+		expect(block).toContain('notable slices: "region"=EMEA (effect 0.30, support 1200)');
+	});
+
+	it("labels an entity grain as 'within <identity>' and keeps secondary drivers separate", () => {
+		const block = formatDrivers([
+			ranking({
+				measure: "ltv",
+				grain: "entity",
+				entity: "customer_id",
+				secondary_dimensions: [
+					{ dimension: "tenure", gain: 0.22, grain: "entity", entity: "customer_id" },
+				],
+			}),
+		]);
+		expect(block).toContain('Measure "ltv" (flow, within customer_id, n=12000):');
+		expect(block).toContain(
+			'other-grain drivers: "tenure" (within customer_id, 0.22)',
+		);
+	});
+
+	it("caps the slice list to keep the block a hint, not a dump", () => {
+		const slices = Array.from({ length: 6 }, (_, i) => ({
+			dimension: "region",
+			value: `R${i}`,
+			effect: 0.1,
+			support: 10,
+		}));
+		const block = formatDrivers([ranking({ interesting_slices: slices })]);
+		expect(block).toContain('"region"=R0');
+		expect(block).toContain('"region"=R2');
+		// 4th+ slice dropped (MAX_SLICES_PER_MEASURE = 3).
+		expect(block).not.toContain('"region"=R3');
+	});
+
+	it("drops a measure with no significant driver; all-empty → a note", () => {
+		const block = formatDrivers([
+			ranking({ measure: "kept" }),
+			ranking({
+				measure: "barren",
+				ranked_dimensions: [],
+				driver_paths: [],
+			}),
+		]);
+		expect(block).toContain('Measure "kept"');
+		expect(block).not.toContain("barren");
+
+		const empty = formatDrivers([
+			ranking({ ranked_dimensions: [], driver_paths: [] }),
+		]);
+		expect(empty).toContain("No driver rankings yet");
+		expect(empty).toContain("<drivers>");
+	});
+
+	it("carries the inform-don't-block usage guidance", () => {
+		const block = formatDrivers([ranking()]);
+		expect(block).toContain("you still author the SQL");
+		expect(block).toContain("top-ranked dimension is the sensible default");
 	});
 });

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -475,6 +475,9 @@ export async function buildCatalogBlock(): Promise<string> {
 
 /** Cap the per-measure slice list so the block stays a hint, not a data dump. */
 const MAX_SLICES_PER_MEASURE = 3;
+/** Cap other-grain drivers too — bounds the block on a workspace with many
+ * identity columns (the engine doesn't cap secondary families before persisting). */
+const MAX_SECONDARY_PER_MEASURE = 5;
 
 /** Render a ranking's grain for the prompt: "row-level", or "within <identity>". */
 function grainLabel(grain: string, entity: string | null): string {
@@ -529,6 +532,7 @@ export function formatDrivers(rankings: DriverRanking[]): string {
 		if (r.secondary_dimensions.length)
 			lines.push(
 				`  other-grain drivers: ${r.secondary_dimensions
+					.slice(0, MAX_SECONDARY_PER_MEASURE)
 					.map(
 						(s) =>
 							`"${s.dimension}" (${grainLabel(s.grain, s.entity)}, ${g(s.gain)})`,
@@ -559,6 +563,16 @@ export function formatDrivers(rankings: DriverRanking[]): string {
  * context and an explicit look_drivers call never drift.
  */
 export async function buildDriversBlock(): Promise<string> {
-	const { rankings } = await lookDrivers({});
-	return formatDrivers(rankings);
+	// Soft-fail: driver grounding is degradable context (the agent still writes valid
+	// SQL without it), so a metadata read failure must not fail the whole answer —
+	// honor inform-don't-block. Mirrors describeEnrichedViews' fallback above.
+	try {
+		const { rankings } = await lookDrivers({});
+		return formatDrivers(rankings);
+	} catch (err) {
+		console.warn(
+			`[cockpit] buildDriversBlock failed — omitting drivers context: ${err}`,
+		);
+		return "<drivers>\n(No driver rankings yet.)\n</drivers>";
+	}
 }

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -39,6 +39,7 @@ import {
 } from "../db/metadata/schema";
 import { getLakeConnection, LAKE_ALIAS } from "../duckdb/lake";
 import { readerToResult } from "../duckdb/query-result";
+import { type DriverRanking, lookDrivers } from "./look-drivers";
 
 /** The clean, analysis-ready layer a question is answered over. */
 const TYPED_LAYER = "typed";
@@ -460,4 +461,104 @@ export async function buildCatalogBlock(): Promise<string> {
 			})),
 		tableAddressById,
 	);
+}
+
+// --- Driver rankings (DAT-548) ---------------------------------------------------
+//
+// The pre-computed driver rankings (DAT-545) tell the answer sub-agent which
+// dimensions most explain each measure's variation — context that turns a "why did X
+// change" / "X by ?" question from a guessed GROUP BY into a grounded one. Same read +
+// projection as the look_drivers tool (DAT-546), so the injected context and an
+// explicit look_drivers call never drift. Informational (inform-don't-block): the
+// agent still authors the SQL. Empty (no promoted begin_session run, or no measures
+// with a significant driver) → a one-line note.
+
+/** Cap the per-measure slice list so the block stays a hint, not a data dump. */
+const MAX_SLICES_PER_MEASURE = 3;
+
+/** Render a ranking's grain for the prompt: "row-level", or "within <identity>". */
+function grainLabel(grain: string, entity: string | null): string {
+	if (grain === "row") return "row-level";
+	return entity ? `within ${entity}` : grain;
+}
+
+/**
+ * Format the driver rankings as the sub-agent's `<drivers>` block (pure). One stanza
+ * per measure that has a significant driver (input order preserved — the view yields
+ * one row per measure column): the ranked dimensions (gain, strongest first), the
+ * surviving drill paths, a few sharp slices, and any other-grain (secondary) drivers
+ * kept labeled with their own grain. Measures with no driver are dropped; an entirely
+ * empty set → a one-line note.
+ */
+export function formatDrivers(rankings: DriverRanking[]): string {
+	const withDrivers = rankings.filter(
+		(r) => r.ranked_dimensions.length > 0 || r.driver_paths.length > 0,
+	);
+	if (withDrivers.length === 0) {
+		return "<drivers>\n(No driver rankings yet.)\n</drivers>";
+	}
+
+	const g = (n: number) => n.toFixed(2);
+	const stanzas = withDrivers.map((r) => {
+		const lines: string[] = [
+			`Measure "${r.measure}" (${r.target_type}, ${grainLabel(r.grain, r.entity)}, n=${r.n_rows}):`,
+		];
+		if (r.ranked_dimensions.length)
+			lines.push(
+				`  top drivers: ${r.ranked_dimensions
+					.map((d) => `"${d.dimension}" (${g(d.gain)})`)
+					.join(", ")}`,
+			);
+		const paths = r.driver_paths.filter((p) => p.length > 0);
+		if (paths.length)
+			lines.push(
+				`  drill paths: ${paths
+					.map((p) => p.map((n) => `"${n}"`).join(" → "))
+					.join("; ")}`,
+			);
+		const slices = r.interesting_slices.slice(0, MAX_SLICES_PER_MEASURE);
+		if (slices.length)
+			lines.push(
+				`  notable slices: ${slices
+					.map(
+						(s) =>
+							`"${s.dimension}"=${s.value} (effect ${g(s.effect)}, support ${s.support})`,
+					)
+					.join(", ")}`,
+			);
+		if (r.secondary_dimensions.length)
+			lines.push(
+				`  other-grain drivers: ${r.secondary_dimensions
+					.map(
+						(s) =>
+							`"${s.dimension}" (${grainLabel(s.grain, s.entity)}, ${g(s.gain)})`,
+					)
+					.join(", ")}`,
+			);
+		return lines.join("\n");
+	});
+
+	return (
+		"<drivers>\n" +
+		"Pre-computed driver rankings — which dimensions most explain each measure's " +
+		'variation (from the begin_session analysis). For a "why did X change / what ' +
+		'drives X" question, lean on these; for an open "X by ?" breakdown, the ' +
+		"top-ranked dimension is the sensible default. A drill path is an ordered way to " +
+		"decompose a measure (group by its columns coarse→fine). Other-grain drivers " +
+		"hold at a different unit (e.g. within an identity) — don't compare their gains " +
+		"to the primary list. Informational — you still author the SQL.\n\n" +
+		`${stanzas.join("\n\n")}\n` +
+		"</drivers>"
+	);
+}
+
+/**
+ * Read the workspace's promoted driver rankings and format them as the sub-agent's
+ * `<drivers>` block. Reuses look_drivers' read + projection (DAT-546) — the view
+ * already resolves to the promoted begin_session catalog head — so the injected
+ * context and an explicit look_drivers call never drift.
+ */
+export async function buildDriversBlock(): Promise<string> {
+	const { rankings } = await lookDrivers({});
+	return formatDrivers(rankings);
 }

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -51,7 +51,11 @@ import { getQueryInstructions } from "../prompts";
 import { asAgentError, withAgentError } from "./agent-error";
 import { computeGrainNote, loadNearUniqueColumns } from "./grain-note";
 import { listTables } from "./list-tables";
-import { buildCatalogBlock, buildSchemaBlock } from "./query-context";
+import {
+	buildCatalogBlock,
+	buildDriversBlock,
+	buildSchemaBlock,
+} from "./query-context";
 import { buildVocabularyBlock, snippetSearchTool } from "./snippet-search";
 
 // The three readiness bands the engine emits, worst-first ranked.
@@ -457,15 +461,21 @@ export async function querySubAgent(
 	question: string,
 	signal?: AbortSignal,
 ): Promise<AnswerResult> {
-	const [schemaBlock, catalogBlock, vocabularyBlock, nearUniqueColumns] =
-		await Promise.all([
-			buildSchemaBlock(),
-			buildCatalogBlock(),
-			buildVocabularyBlock(),
-			loadNearUniqueColumns(),
-		]);
+	const [
+		schemaBlock,
+		catalogBlock,
+		driversBlock,
+		vocabularyBlock,
+		nearUniqueColumns,
+	] = await Promise.all([
+		buildSchemaBlock(),
+		buildCatalogBlock(),
+		buildDriversBlock(),
+		buildVocabularyBlock(),
+		loadNearUniqueColumns(),
+	]);
 
-	const userMessage = `<question>\n${question}\n</question>\n\n${schemaBlock}\n\n${catalogBlock}\n\n${vocabularyBlock}`;
+	const userMessage = `<question>\n${question}\n</question>\n\n${schemaBlock}\n\n${catalogBlock}\n\n${driversBlock}\n\n${vocabularyBlock}`;
 
 	// Per-invocation capture cell — the run_steps tool writes the last successful
 	// validation here, so it's isolated across concurrent answer calls.


### PR DESCRIPTION
## What

Extends the DAT-538 answer-agent context seam with a `<drivers>` block. The cockpit `answer` sub-agent now reasons over the pre-computed driver rankings (DAT-545) — a *"why did margin drop?"* / *"revenue by ?"* question grounds its GROUP BY in the real drivers instead of guessing, without needing an explicit `look_drivers` call.

Closes the discovery loop: drivers were computed + persisted + readable via `look_drivers` (DAT-546), but never reached the agent's reasoning context until now.

## How

- **`query-context.ts`** — pure `formatDrivers()` + `buildDriversBlock()`. Reuses `lookDrivers()` + the `DriverRanking` type from `look-drivers.ts`, so the injected context and an explicit `look_drivers` call read the **same** view (`current_driver_rankings`, resolved to the promoted begin_session catalog head) through the **same** projection — they can never drift. Per measure: ranked dimensions (gain), drill paths, a few sharp slices, and other-grain drivers kept labeled. Context-only (**inform-don't-block**): the agent still authors the SQL; the block soft-fails to a one-line note on any read error.
- **`query.ts`** — `buildDriversBlock()` added to the `querySubAgent` `Promise.all`; `<drivers>` injected into the user message between the catalog and vocabulary blocks.
- **`query-context.test.ts`** — formatter unit coverage (grain labels, drill-path rendering, slice/secondary caps, drop-empty, guidance text).

## Scope (rescoped during /refine — the ticket was stale post-DAT-538)

- ❌ **No grain-safety guard** — DAT-538 already reframed that to an inform caveat (`grain-note.ts`); this change adds no gating.
- ❌ **No engine `GraphAgent` change** — drivers are deliberately *not* wired into metric composition (its job is generating working metric SQL, not segmentation; no consumer needs it). The catalog/hierarchy unification that AC wanted already shipped (DAT-536/537).
- ➡️ **Metrics-page driver breakdown split to DAT-591** (separate cockpit surface, reads the view directly).

## Test

- `query-context.test.ts` 21 pass · `query.test.ts` 19 pass · `tsc` clean · biome clean.
- Reviewers: senior-code-reviewer **APPROVE**, spec-compliance-reviewer **COMPLIANT** (both review findings applied: soft-fail + secondary cap).
- Deferred: live lane-smoke ("why did margin drop?" / "revenue by ?") — real LLM, run before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)