### PR TITLE
fix(cockpit): log answer-SQL validation + lake ATTACH failures

### DIFF
--- a/packages/cockpit/src/duckdb/lake.ts
+++ b/packages/cockpit/src/duckdb/lake.ts
@@ -107,6 +107,12 @@ async function openConnection(): Promise<DuckDBConnection> {
 export function getLakeConnection(): Promise<DuckDBConnection> {
 	if (!connectionPromise) {
 		connectionPromise = openConnection().catch((err) => {
+			// Surface WHY the lake is unreachable (catalog down, S3 creds, bad
+			// DATA_PATH) — otherwise it only ever reaches the agent as an opaque
+			// run_steps { error } string with no server trace.
+			console.error(
+				`[lake] ATTACH/connection failed: ${err instanceof Error ? err.message : String(err)}`,
+			);
 			// Clear the memo so a transient failure (catalog briefly unreachable)
 			// doesn't wedge the process into a permanently-rejected state.
 			connectionPromise = null;

--- a/packages/cockpit/src/duckdb/run-steps.ts
+++ b/packages/cockpit/src/duckdb/run-steps.ts
@@ -229,7 +229,19 @@ export async function runSteps(
 			truncated: overRowCap || byteTruncated,
 		};
 	} catch (err) {
-		return { error: err instanceof Error ? err.message : String(err) };
+		const message = err instanceof Error ? err.message : String(err);
+		// The { error } goes to the agent for in-loop repair, but a validation
+		// failure must NOT be silent server-side — log the real DuckDB/ATTACH error
+		// (and the offending SQL) so a no-grid answer is debuggable. Aborts are
+		// expected control-flow, not failures, so log them at debug volume.
+		if (signal?.aborted) {
+			console.debug(`[run-steps] aborted: ${message}`);
+		} else {
+			console.error(
+				`[run-steps] SQL validation failed: ${message}\nSQL: ${sql}`,
+			);
+		}
+		return { error: message };
 	} finally {
 		signal?.removeEventListener("abort", onAbort);
 		close();


### PR DESCRIPTION
The answer tool returned a no-grid result with ZERO server logs when the composed SQL failed to validate (run-steps swallowed the DuckDB error into the agent-only { error } envelope) — making a failed answer undebuggable. Log the real error (and the offending SQL) at run-steps before returning, and log the underlying reason a lake ATTACH/connection fails. Aborts stay debug-level.