### PR TITLE
DAT-592: import a probed query as a source — probe→import-set wiring (1 query = 1 source)

### DIFF
--- a/packages/cockpit/src/select/recipe-source.integration.test.ts
+++ b/packages/cockpit/src/select/recipe-source.integration.test.ts
@@ -1,0 +1,155 @@
+// Lane smoke for persistRecipeSources (DAT-592) — drives the import-set producer
+// against a REAL Postgres ws_<id>.sources table and asserts each staged query
+// lands as its OWN single-statement `db_recipe` source with the exact keys the
+// engine import phase reads (mirrors select.integration.test.ts).
+//
+// The contrast with the agent `select` path (proven in select.integration): a
+// table-pick `select` writes ONE source carrying N `{name, sql}` recipe entries;
+// the import set writes N sources, each carrying a SINGLE entry. Same row shape,
+// different grain. Drives the persist core directly — starting the real batched
+// addSourceWorkflow is the compose smoke's job.
+//
+// Requires a running compose stack (postgres on 127.0.0.1:5432 with the
+// engine-created ws_<id>.sources table). Skipped automatically when
+// METADATA_DATABASE_URL isn't set so unit-test CI without the stack stays green.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { recipeContentHash } from "./mappers";
+
+const STACK_AVAILABLE = !!process.env.METADATA_DATABASE_URL;
+
+// Stub the cockpit env so config.ts loads (source-write pulls the metadata client
+// → config). GATED on the stack so a skipped run never mutates the shared worker's
+// process.env.
+if (STACK_AVAILABLE) {
+	const REQUIRED_DEFAULTS: Record<string, string> = {
+		COCKPIT_DATABASE_URL:
+			process.env.COCKPIT_DATABASE_URL ??
+			"postgresql://dataraum:dataraum@127.0.0.1:5432/cockpit_db",
+		DATARAUM_WORKSPACE_ID:
+			process.env.DATARAUM_WORKSPACE_ID ??
+			"00000000-0000-0000-0000-000000000001",
+		DATARAUM_LAKE_PATH:
+			process.env.DATARAUM_LAKE_PATH ?? "s3://dataraum-lake/lake",
+		DUCKLAKE_CATALOG_URL:
+			process.env.DUCKLAKE_CATALOG_URL ??
+			"postgresql://dataraum:dataraum@127.0.0.1:5432/lake_catalog",
+		ANTHROPIC_API_KEY:
+			process.env.ANTHROPIC_API_KEY ?? "sk-ant-test-placeholder",
+		S3_ENDPOINT: process.env.S3_ENDPOINT ?? "127.0.0.1:8333",
+		S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID ?? "dataraum",
+		S3_SECRET_ACCESS_KEY:
+			process.env.S3_SECRET_ACCESS_KEY ?? "dataraum-s3-secret",
+		S3_BUCKET: process.env.S3_BUCKET ?? "dataraum-lake",
+	};
+	for (const [k, v] of Object.entries(REQUIRED_DEFAULTS)) {
+		if (!process.env[k]) process.env[k] = v;
+	}
+}
+
+const SCHEMA = STACK_AVAILABLE
+	? `ws_${(process.env.DATARAUM_WORKSPACE_ID as string).replaceAll("-", "_")}`
+	: "";
+
+describe.skipIf(!STACK_AVAILABLE)(
+	"persistRecipeSources writes one source per probed query (DAT-592)",
+	() => {
+		// biome-ignore lint/suspicious/noExplicitAny: dynamic-imported module shapes
+		let persistRecipeSources: any;
+		// biome-ignore lint/suspicious/noExplicitAny: dynamic-imported Bun SQL client
+		let sql: any;
+		const writtenNames: string[] = [];
+
+		beforeAll(async () => {
+			// Dynamic import so the missing-env skip works — a top-level import would
+			// boot config.ts before describe.skipIf runs.
+			const mod = await import("./recipe-source");
+			persistRecipeSources = mod.persistRecipeSources;
+			const { SQL } = await import("bun");
+			sql = new SQL(process.env.METADATA_DATABASE_URL as string);
+		});
+
+		afterAll(async () => {
+			if (sql) {
+				for (const name of writtenNames) {
+					await sql.unsafe(`DELETE FROM "${SCHEMA}".sources WHERE name = $1`, [
+						name,
+					]);
+				}
+				await sql.close();
+			}
+		});
+
+		async function readBack(name: string): Promise<{
+			source_type: string;
+			backend: string | null;
+			stage: string | null;
+			connection_config: Record<string, unknown>;
+		}> {
+			const rows = await sql<
+				{
+					source_type: string;
+					backend: string | null;
+					stage: string | null;
+					connection_config: Record<string, unknown>;
+				}[]
+			>`
+			SELECT source_type, backend, stage, connection_config
+			FROM ${sql(SCHEMA)}.sources
+			WHERE name = ${name}`;
+			return rows[0];
+		}
+
+		it("writes N independent single-statement db_recipe sources for a batch", async () => {
+			const stamp = Date.now();
+			const a = `imp592_orders_${stamp}`;
+			const b = `imp592_customers_${stamp}`;
+			writtenNames.push(a, b);
+			const sqlA = "SELECT * FROM Sales.Orders WHERE OrderDate > '2015-01-01'";
+			const sqlB = "SELECT CustomerID, CustomerName FROM Sales.Customers";
+
+			const result = await persistRecipeSources([
+				{ source_name: a, backend: "mssql", sql: sqlA },
+				{ source_name: b, backend: "mssql", sql: sqlB },
+			]);
+			expect(result).toHaveLength(2);
+
+			const rowA = await readBack(a);
+			expect(rowA.source_type).toBe("db_recipe");
+			expect(rowA.backend).toBe("mssql");
+			expect(rowA.stage).toBe("add_source");
+			const tablesA = [{ name: a, sql: sqlA }];
+			expect(rowA.connection_config).toEqual({
+				tables: tablesA,
+				recipe_hash: recipeContentHash("mssql", tablesA),
+			});
+			// One statement = one source: a single recipe entry, no file cross-contamination.
+			expect((rowA.connection_config.tables as unknown[]).length).toBe(1);
+			expect(rowA.connection_config).not.toHaveProperty("file_uris");
+
+			const rowB = await readBack(b);
+			expect((rowB.connection_config.tables as unknown[]).length).toBe(1);
+			expect(rowB.connection_config).toMatchObject({
+				tables: [{ name: b, sql: sqlB }],
+			});
+		});
+
+		it("UPSERTs on the unique name — re-importing the same query re-points in place", async () => {
+			const name = `imp592_upsert_${Date.now()}`;
+			writtenNames.push(name);
+
+			await persistRecipeSources([
+				{ source_name: name, backend: "mssql", sql: "SELECT 1 AS a" },
+			]);
+			await persistRecipeSources([
+				{ source_name: name, backend: "mssql", sql: "SELECT 2 AS b" },
+			]);
+
+			const row = await readBack(name);
+			expect(row.connection_config).toMatchObject({
+				tables: [{ name, sql: "SELECT 2 AS b" }],
+			});
+		});
+	},
+);

--- a/packages/cockpit/src/select/recipe-source.test.ts
+++ b/packages/cockpit/src/select/recipe-source.test.ts
@@ -1,0 +1,155 @@
+// Unit tests for persistRecipeSources (DAT-592) — the import-set producer that
+// writes ONE single-statement `db_recipe` source per staged query.
+//
+// The write seam (`#/select/source-write`: upsertSource + importedRecipeHash) is
+// mocked so the row SHAPE + the loud-fail validation are asserted without a live
+// Postgres (the real write is covered by the *.integration test). The mock is on
+// the `#/` alias so it intercepts recipe-source's relative `./source-write`
+// import (same resolved module — the cockpit vitest mock-alias rule).
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { recipeContentHash, sanitizeRecipeName } from "./mappers";
+
+// recipe-source pulls SUPPORTED_BACKENDS from `#/duckdb/probe`, which imports
+// config at module load — stub it so the unit test needs no real env (same as
+// select.test.ts).
+vi.mock("#/config", () => ({ config: { s3Bucket: "dataraum-lake" } }));
+
+const h = vi.hoisted(() => ({
+	upserts: [] as Array<{
+		name: string;
+		sourceType: string;
+		backend: string | null;
+		connectionConfig: Record<string, unknown>;
+	}>,
+	witness: null as string | null,
+}));
+
+vi.mock("#/select/source-write", () => ({
+	STAGE_AFTER_SELECT: "add_source",
+	INITIAL_STATUS: "configured",
+	upsertSource: vi.fn(
+		async (v: {
+			name: string;
+			sourceType: string;
+			backend: string | null;
+			connectionConfig: Record<string, unknown>;
+		}) => {
+			h.upserts.push(v);
+			return `id_${v.name}`;
+		},
+	),
+	importedRecipeHash: vi.fn(async () => h.witness),
+}));
+
+import { ImportSetError, persistRecipeSources } from "./recipe-source";
+
+beforeEach(() => {
+	h.upserts.length = 0;
+	h.witness = null;
+});
+
+describe("persistRecipeSources validation (fails loud before any write)", () => {
+	it("rejects an empty batch", async () => {
+		await expect(persistRecipeSources([])).rejects.toBeInstanceOf(
+			ImportSetError,
+		);
+		expect(h.upserts).toHaveLength(0);
+	});
+
+	it("rejects an invalid source name", async () => {
+		await expect(
+			persistRecipeSources([
+				{ source_name: "Bad Name", backend: "mssql", sql: "SELECT 1" },
+			]),
+		).rejects.toThrow(/Invalid source name/);
+		expect(h.upserts).toHaveLength(0);
+	});
+
+	it("rejects a reserved family prefix", async () => {
+		await expect(
+			persistRecipeSources([
+				{ source_name: "src_orders", backend: "mssql", sql: "SELECT 1" },
+			]),
+		).rejects.toThrow(/reserved prefix/);
+		expect(h.upserts).toHaveLength(0);
+	});
+
+	it("rejects an unsupported backend", async () => {
+		await expect(
+			persistRecipeSources([
+				{ source_name: "orders", backend: "oracle", sql: "SELECT 1" },
+			]),
+		).rejects.toThrow(/Unsupported backend/);
+		expect(h.upserts).toHaveLength(0);
+	});
+
+	it("rejects empty SQL", async () => {
+		await expect(
+			persistRecipeSources([
+				{ source_name: "orders", backend: "mssql", sql: "   " },
+			]),
+		).rejects.toThrow(/empty SQL/);
+		expect(h.upserts).toHaveLength(0);
+	});
+
+	it("rejects a duplicate name in the batch — before persisting anything", async () => {
+		await expect(
+			persistRecipeSources([
+				{ source_name: "orders", backend: "mssql", sql: "SELECT 1" },
+				{ source_name: "orders", backend: "mssql", sql: "SELECT 2" },
+			]),
+		).rejects.toThrow(/Duplicate source name/);
+		// The whole batch is validated before the write loop — no half-state.
+		expect(h.upserts).toHaveLength(0);
+	});
+});
+
+describe("persistRecipeSources row shape (one source per query)", () => {
+	it("writes one single-statement db_recipe source per query", async () => {
+		const result = await persistRecipeSources([
+			{
+				source_name: "wwi_orders",
+				backend: "mssql",
+				sql: "SELECT * FROM Sales.Orders WHERE OrderDate > '2015-01-01'",
+			},
+			{
+				source_name: "wwi_customers",
+				backend: "mssql",
+				sql: "SELECT CustomerID, CustomerName FROM Sales.Customers",
+			},
+		]);
+
+		expect(h.upserts).toHaveLength(2);
+		expect(result.map((p) => p.source_id)).toEqual([
+			"id_wwi_orders",
+			"id_wwi_customers",
+		]);
+
+		// Each source carries a SINGLE recipe entry (1 query = 1 source).
+		const first = h.upserts[0];
+		expect(first.sourceType).toBe("db_recipe");
+		expect(first.backend).toBe("mssql");
+		const recipeTable = {
+			name: sanitizeRecipeName("wwi_orders"),
+			sql: "SELECT * FROM Sales.Orders WHERE OrderDate > '2015-01-01'",
+		};
+		expect(first.connectionConfig).toEqual({
+			tables: [recipeTable],
+			recipe_hash: recipeContentHash("mssql", [recipeTable]),
+		});
+		// db recipe and file URIs never cross-contaminate.
+		expect(first.connectionConfig).not.toHaveProperty("file_uris");
+	});
+
+	it("carries the engine-stamped import witness forward on re-select", async () => {
+		h.witness = "deadbeef";
+		await persistRecipeSources([
+			{ source_name: "wwi_orders", backend: "mssql", sql: "SELECT 1" },
+		]);
+		expect(h.upserts[0].connectionConfig).toMatchObject({
+			imported_recipe_hash: "deadbeef",
+		});
+	});
+});

--- a/packages/cockpit/src/select/recipe-source.ts
+++ b/packages/cockpit/src/select/recipe-source.ts
@@ -1,0 +1,142 @@
+// Persist arbitrary probed queries as sources (DAT-592) — one single-statement
+// `db_recipe` source PER query, the producer behind the probe surface's import
+// set (`server/import-sources.ts`).
+//
+// This is the 1-query = 1-source path the epic locked: where the agent `select`
+// tool bundles a table-pick into ONE source carrying N `{name, sql}` recipe
+// entries (the documented multi-add path), the import set turns each staged
+// query into its OWN named source carrying a SINGLE recipe entry. Both write the
+// same row shape (`source-write.ts`) and feed the SAME batched addSourceWorkflow
+// run; only the grain differs. The engine import path is unchanged — it
+// materializes each `RecipeTable.sql` VERBATIM (sources/db_recipe), so an
+// arbitrary JOIN/filter/projection already works.
+//
+// NO trigger here: persistence + validation only, mirroring `persistSelection`.
+// `server/import-sources.ts` composes this with ONE `triggerAddSource` over the
+// whole set so N queries import as one coherent run (one grounding pass over the
+// union), after a proper frame.
+
+import { SUPPORTED_BACKENDS } from "../duckdb/probe";
+import {
+	RESERVED_SOURCE_NAME_PREFIXES,
+	recipeContentHash,
+	reservedSourceNamePrefix,
+	SOURCE_NAME_PATTERN,
+	sanitizeRecipeName,
+} from "./mappers";
+import { importedRecipeHash, upsertSource } from "./source-write";
+
+/** One staged query the user chose to import as its own source. */
+export interface RecipeSourceSpec {
+	/** The user-chosen source name (lowercase, letter-led — `SOURCE_NAME_PATTERN`). */
+	source_name: string;
+	/** The DB backend the query runs against (persisted as the `backend` column). */
+	backend: string;
+	/** The verbatim read-only SQL — materialized by the engine into one raw table. */
+	sql: string;
+}
+
+/** One persisted source: its id + the single-statement recipe that was stored. */
+export interface PersistedRecipeSource {
+	source_id: string;
+	source_name: string;
+	backend: string;
+	recipe_table: { name: string; sql: string };
+}
+
+/** Validation failure the UI surfaces verbatim (names/SQL/backend are all
+ * user-provided — no credentials pass through here, so echoing is safe). */
+export class ImportSetError extends Error {}
+
+/** Reject a single spec's name + backend up front, before any write, so a bad
+ * batch fails loud as a whole (the loop below validates ALL before persisting). */
+function validateSpec(spec: RecipeSourceSpec): void {
+	const name = spec.source_name;
+	if (!name || !SOURCE_NAME_PATTERN.test(name)) {
+		throw new ImportSetError(
+			`Invalid source name '${name ?? ""}'. Must match ${SOURCE_NAME_PATTERN.source} ` +
+				"(lowercase, start with a letter, 2–49 chars of [a-z0-9_]).",
+		);
+	}
+	const reserved = reservedSourceNamePrefix(name);
+	if (reserved !== null) {
+		throw new ImportSetError(
+			`Source name '${name}' starts with the reserved prefix '${reserved}' — ` +
+				`${RESERVED_SOURCE_NAME_PREFIXES.join("/")} name derived-table families. ` +
+				"Pick a different name.",
+		);
+	}
+	if (!SUPPORTED_BACKENDS.includes(spec.backend)) {
+		throw new ImportSetError(
+			`Unsupported backend '${spec.backend}' for source '${name}' ` +
+				`(supported: ${SUPPORTED_BACKENDS.join(", ")}).`,
+		);
+	}
+	if (spec.sql.trim().length === 0) {
+		throw new ImportSetError(`Source '${name}' has empty SQL.`);
+	}
+}
+
+/**
+ * UPSERT one `db_recipe` source per staged query and return their ids + the
+ * recipe each stored. Persistence ONLY — the caller triggers the batched import.
+ *
+ * Each source carries a SINGLE recipe entry (`tables: [{name, sql}]`): the recipe
+ * `name` is a sanitized identifier derived from the source name (it becomes the
+ * `<source>__<name>` raw table), the `sql` is the user's verbatim query.
+ * `recipe_hash` is computed per source over its `{backend, [one table]}` so the
+ * engine's re-import witnessing (DAT-430) holds per query; the engine-stamped
+ * `imported_recipe_hash` on an existing row is carried forward.
+ *
+ * Fails loud (before any write) on an empty batch or a duplicate source name in
+ * the batch — two queries sharing a name would UPSERT the same row, silently
+ * dropping one.
+ */
+export async function persistRecipeSources(
+	specs: RecipeSourceSpec[],
+): Promise<PersistedRecipeSource[]> {
+	if (specs.length === 0) {
+		throw new ImportSetError("No queries to import — the import set is empty.");
+	}
+	const seen = new Set<string>();
+	for (const spec of specs) {
+		validateSpec(spec);
+		if (seen.has(spec.source_name)) {
+			throw new ImportSetError(
+				`Duplicate source name '${spec.source_name}' in the import set — ` +
+					"each query needs a distinct name.",
+			);
+		}
+		seen.add(spec.source_name);
+	}
+
+	const now = new Date();
+	const persisted: PersistedRecipeSource[] = [];
+	for (const spec of specs) {
+		const recipeTable = {
+			name: sanitizeRecipeName(spec.source_name),
+			sql: spec.sql,
+		};
+		const witness = await importedRecipeHash(spec.source_name);
+		const connectionConfig: Record<string, unknown> = {
+			// DISTINCT key from the file `file_uris` key — never folded together.
+			tables: [recipeTable],
+			recipe_hash: recipeContentHash(spec.backend, [recipeTable]),
+			...(witness === null ? {} : { imported_recipe_hash: witness }),
+		};
+		const sourceId = await upsertSource({
+			name: spec.source_name,
+			sourceType: "db_recipe",
+			backend: spec.backend,
+			connectionConfig,
+			now,
+		});
+		persisted.push({
+			source_id: sourceId,
+			source_name: spec.source_name,
+			backend: spec.backend,
+			recipe_table: recipeTable,
+		});
+	}
+	return persisted;
+}

--- a/packages/cockpit/src/select/recipe-source.ts
+++ b/packages/cockpit/src/select/recipe-source.ts
@@ -91,6 +91,15 @@ function validateSpec(spec: RecipeSourceSpec): void {
  * Fails loud (before any write) on an empty batch or a duplicate source name in
  * the batch — two queries sharing a name would UPSERT the same row, silently
  * dropping one.
+ *
+ * The write loop is NOT a single transaction (matching the sibling file-source
+ * loop in `tools/select.ts`): a transient mid-loop failure can leave the earlier
+ * sources upserted while the trigger never fires. That's recoverable, not
+ * corrupting — every upsert is idempotent (name UNIQUE + the `recipe_hash`
+ * witness), and the caller (`server/import-sources.ts` via the widget's mutation)
+ * keeps the import set on error, so re-running the same batch re-upserts the
+ * already-written rows and starts the run. The orphaned rows sit at
+ * `status=configured` until that retry imports them.
  */
 export async function persistRecipeSources(
 	specs: RecipeSourceSpec[],

--- a/packages/cockpit/src/select/source-write.ts
+++ b/packages/cockpit/src/select/source-write.ts
@@ -1,0 +1,94 @@
+// Shared source-row write primitives (DAT-592) — the cross-schema UPSERT into
+// the engine-owned `ws_<id>.sources` table + the import-witness read, extracted
+// from `tools/select.ts` so BOTH the agent `select` tool (table-pick / file
+// selections) AND the UI import-set (`server/import-sources.ts`, one source per
+// probed query) write rows the same way.
+//
+// `select` OWNS the INSERT (the documented metadata-client policy break — the
+// engine's import phase assumes the cockpit wrote the source row before
+// triggering addSourceWorkflow). These two helpers ARE that write seam; nothing
+// here decides the row SHAPE (that's `select/mappers.ts`), only how it lands.
+
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+
+import { metadataDb } from "../db/metadata/client";
+import { sources } from "../db/metadata/schema";
+import { sourcesWrite } from "../db/metadata/write-surface";
+
+// The onboarding stage a freshly registered source sits at. The cockpit drives
+// `connect → frame → select → add_source`; the row is written already at
+// `add_source`, the cursor the journey readiness reads.
+export const STAGE_AFTER_SELECT = "add_source";
+
+// Initial source status — registered by the cockpit but not yet imported reads
+// `configured` (mirrors the integration seed in scripts/smoke-add-source.ts).
+export const INITIAL_STATUS = "configured";
+
+/**
+ * UPSERT one `sources` row (on the UNIQUE name) and return its source_id.
+ *
+ * A fresh name INSERTs a new source_id; re-selecting the same name re-points its
+ * `connection_config` / `source_type` / `backend` / `stage` (an idempotent
+ * re-select, not a duplicate-name error). `created_at` is only set on insert; the
+ * update touches `updated_at`. Workspace scope is implicit in the ws_<id> schema
+ * the client targets (no workspace_id column post-DAT-343).
+ */
+export async function upsertSource(values: {
+	name: string;
+	sourceType: string;
+	backend: string | null;
+	connectionConfig: Record<string, unknown>;
+	now: Date;
+}): Promise<string> {
+	const [row] = await metadataDb
+		.insert(sourcesWrite)
+		.values({
+			sourceId: randomUUID(),
+			name: values.name,
+			sourceType: values.sourceType,
+			connectionConfig: values.connectionConfig,
+			status: INITIAL_STATUS,
+			stage: STAGE_AFTER_SELECT,
+			backend: values.backend,
+			createdAt: values.now,
+			updatedAt: values.now,
+		})
+		.onConflictDoUpdate({
+			target: sourcesWrite.name,
+			set: {
+				sourceType: values.sourceType,
+				connectionConfig: values.connectionConfig,
+				status: INITIAL_STATUS,
+				stage: STAGE_AFTER_SELECT,
+				backend: values.backend,
+				updatedAt: values.now,
+			},
+		})
+		.returning({ sourceId: sourcesWrite.sourceId });
+	return row.sourceId;
+}
+
+/**
+ * The engine-stamped `imported_recipe_hash` witness on an existing source row,
+ * if any (DAT-430).
+ *
+ * At import success the engine copies the recipe's `recipe_hash` into
+ * `connection_config.imported_recipe_hash` — the record of WHICH recipe the
+ * source's raw tables were materialized from. A db-source upsert REPLACES the
+ * whole `connection_config` JSON, so the caller must carry that engine-owned key
+ * forward: preserving it is what lets the engine skip an idempotent re-select
+ * (current hash == witness) and fail loud on a re-pointed recipe (mismatch)
+ * instead of silently serving stale raw tables. A fresh name (or a never-imported
+ * source) has no witness — returns null, and the key is simply absent.
+ */
+export async function importedRecipeHash(name: string): Promise<string | null> {
+	const rows = await metadataDb
+		.select({ connectionConfig: sources.connectionConfig })
+		.from(sources)
+		.where(eq(sources.name, name))
+		.limit(1);
+	const cc = rows[0]?.connectionConfig as Record<string, unknown> | null;
+	const witness = cc?.imported_recipe_hash;
+	return typeof witness === "string" && witness.length > 0 ? witness : null;
+}

--- a/packages/cockpit/src/server/import-sources.ts
+++ b/packages/cockpit/src/server/import-sources.ts
@@ -18,8 +18,14 @@
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 
-import { persistRecipeSources } from "#/select/recipe-source";
-import { triggerAddSource } from "#/temporal/trigger-add-source";
+// `persistRecipeSources` + `triggerAddSource` pull config-bearing modules
+// (duckdb/probe, config) at load. They run ONLY server-side inside the handler, so
+// they're imported there (dynamically) — NOT statically — to keep THIS module's
+// graph config-free. The probe WIDGET imports this server fn at module scope; a
+// static pull would drag config into every test that eagerly loads the widget
+// registry (the canvas registry is deliberately config-free). `runWithConversation`
+// is just AsyncLocalStorage (config-free), so it stays a normal import.
+import { runWithConversation } from "#/lib/run-context";
 
 const ImportSourcesInput = z.object({
 	sources: z
@@ -31,10 +37,19 @@ const ImportSourcesInput = z.object({
 			}),
 		)
 		.min(1),
+	// The originating chat (route param). The agent `select` tool reads this from
+	// the request ALS (set by /api/chat); a direct server fn has none, so the widget
+	// passes it explicitly and we bind it around the trigger. Without it the run is
+	// recorded with no conversation → the completion-watcher (which filters by
+	// conversationId) never tracks it, so the inline progress never ticks and the
+	// completion never narrates. (Null when the widget is off-route — degraded.)
+	conversationId: z.string().nullish(),
 });
 
-/** The started run + the sources it imports — the widget flips the canvas to the
- * `add-source-progress` member on this (same carry as the `select` tool result). */
+/** The started run + the sources it imports. The widget renders the
+ * `add-source-progress` widget INLINE from this (the canvas is message-derived, so
+ * a direct action can't project a canvas member) — same carry as the `select`
+ * tool result; the background completion-watcher narrates completion into the chat. */
 export interface ImportSourcesResult {
 	workflow_id: string;
 	run_id: string;
@@ -58,9 +73,18 @@ export const importSources = createServerFn({ method: "POST" })
 		ImportSourcesInput.parse(input),
 	)
 	.handler(async ({ data }): Promise<ImportSourcesResult> => {
+		const { persistRecipeSources } = await import("#/select/recipe-source");
+		const { triggerAddSource } = await import("#/temporal/trigger-add-source");
 		const persisted = await persistRecipeSources(data.sources);
 		const sourceIds = persisted.map((p) => p.source_id);
-		const run = await triggerAddSource({ sources: sourceIds });
+		// Bind the conversation so the run is recorded against it (the watcher routes
+		// progress + narration by conversationId). Off-route (no id) → bare trigger,
+		// the null-conversation run the watcher simply doesn't narrate.
+		const run = await (data.conversationId
+			? runWithConversation(data.conversationId, () =>
+					triggerAddSource({ sources: sourceIds }),
+				)
+			: triggerAddSource({ sources: sourceIds }));
 		return {
 			workflow_id: run.workflow_id,
 			run_id: run.run_id,

--- a/packages/cockpit/src/server/import-sources.ts
+++ b/packages/cockpit/src/server/import-sources.ts
@@ -1,0 +1,70 @@
+// Server fn: import the probe surface's import set (DAT-592) — persist each
+// staged query as its own single-statement `db_recipe` source, then start ONE
+// batched addSourceWorkflow run over the whole set.
+//
+// This is the UI analog of the agent `select` tool: the probe panel is direct
+// manipulation (the user edits SQL and clicks, no LLM round-trip), so the import
+// flows through a server fn the widget calls directly — exactly like the probe
+// grid hits `/api/probe-sql`. It reuses the SAME persist seam (`persistRecipeSources`
+// → `source-write`) and the SAME trigger (`triggerAddSource`) as `select`, so the
+// run, its progress widget, and the grounding cascade are identical; only the
+// producer (one source per query, vs select's bundled table-pick) differs.
+//
+// One run for the batch: N queries → N sources → a single `triggerAddSource` over
+// the set, so the engine's run-scoped reduce + the grounding-teach loop run ONCE
+// over the union (not N times), which is the whole point of staging a set before
+// importing.
+
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+
+import { persistRecipeSources } from "#/select/recipe-source";
+import { triggerAddSource } from "#/temporal/trigger-add-source";
+
+const ImportSourcesInput = z.object({
+	sources: z
+		.array(
+			z.object({
+				source_name: z.string(),
+				backend: z.string(),
+				sql: z.string(),
+			}),
+		)
+		.min(1),
+});
+
+/** The started run + the sources it imports — the widget flips the canvas to the
+ * `add-source-progress` member on this (same carry as the `select` tool result). */
+export interface ImportSourcesResult {
+	workflow_id: string;
+	run_id: string;
+	/** The minted/UPSERTed source ids the run ingests. */
+	sources: string[];
+	/** The source names imported — for the success message. */
+	source_names: string[];
+}
+
+/**
+ * Persist the import set as one source per query and start the batched import.
+ *
+ * Validation (bad name / reserved prefix / unsupported backend / empty SQL /
+ * duplicate name / empty set) raises BEFORE any write — `persistRecipeSources`
+ * checks the whole batch first, so a rejected import leaves no half-state. A
+ * Temporal start failure (infra) propagates as a thrown error the mutation
+ * surfaces; re-invoking recovers (the source upserts are idempotent).
+ */
+export const importSources = createServerFn({ method: "POST" })
+	.inputValidator((input: z.infer<typeof ImportSourcesInput>) =>
+		ImportSourcesInput.parse(input),
+	)
+	.handler(async ({ data }): Promise<ImportSourcesResult> => {
+		const persisted = await persistRecipeSources(data.sources);
+		const sourceIds = persisted.map((p) => p.source_id);
+		const run = await triggerAddSource({ sources: sourceIds });
+		return {
+			workflow_id: run.workflow_id,
+			run_id: run.run_id,
+			sources: sourceIds,
+			source_names: persisted.map((p) => p.source_name),
+		};
+	});

--- a/packages/cockpit/src/tools/select.ts
+++ b/packages/cockpit/src/tools/select.ts
@@ -41,7 +41,13 @@
 //               against a different backend; the engine-stamped
 //               `imported_recipe_hash` witness on an existing row is carried
 //               forward. The user-chosen `source_name` is required here (files
-//               are content-keyed, so it is ignored for them).
+//               are content-keyed, so it is ignored for them). This table-pick
+//               path stays the BUNDLED multi-add: N picked tables → ONE source
+//               carrying N recipe entries. The probe surface's import set
+//               (DAT-592, `server/import-sources.ts` → `select/recipe-source.ts`)
+//               is the 1-query = 1-source path — each arbitrary probed query is
+//               its own source — sharing the same write seam (`source-write.ts`)
+//               and the same batched trigger, only at a finer grain.
 //
 // An acting tool: it mutates workspace state (creates/updates source rows) AND
 // starts a durable engine run, so it runs on the user's explicit instruction —

--- a/packages/cockpit/src/tools/select.ts
+++ b/packages/cockpit/src/tools/select.ts
@@ -47,15 +47,10 @@
 // starts a durable engine run, so it runs on the user's explicit instruction —
 // there is no approval gate, exactly like `teach`/`frame`/`replay`.
 
-import { randomUUID } from "node:crypto";
 import { toolDefinition } from "@tanstack/ai";
-import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { config } from "../config";
-import { metadataDb } from "../db/metadata/client";
-import { sources } from "../db/metadata/schema";
-import { sourcesWrite } from "../db/metadata/write-surface";
 import { ConnectSchema } from "../duckdb/connect";
 import { SUPPORTED_BACKENDS } from "../duckdb/probe";
 import { enumeratePrefixUris } from "../select/enumerate";
@@ -68,22 +63,17 @@ import {
 	SOURCE_NAME_PATTERN,
 	sourceTypeForUri,
 } from "../select/mappers";
+import {
+	importedRecipeHash,
+	STAGE_AFTER_SELECT,
+	upsertSource,
+} from "../select/source-write";
 import { triggerAddSource } from "../temporal/trigger-add-source";
 import {
 	AgentActionableError,
 	catchActionable,
 	withAgentError,
 } from "./agent-error";
-
-// The onboarding stage `select` leaves the source(s) at. The cockpit drives a
-// source `connect → frame → select → add_source` BEFORE the workflow triggers;
-// `select` writes the row already at `add_source`, the next interactive stage.
-const STAGE_AFTER_SELECT = "add_source";
-
-// Initial source status. Mirrors the seed in the integration driver
-// (`scripts/smoke-add-source.ts`): a source the cockpit has registered but not
-// yet imported reads `configured`.
-const INITIAL_STATUS = "configured";
 
 /** The persisted Source descriptor + the started run's identity. The
  * workflow/run ids are what the progress canvas member keys its `get_progress`
@@ -170,78 +160,9 @@ async function resolveFileUris(
 	return [schema.source];
 }
 
-/**
- * UPSERT one `sources` row (on the UNIQUE name) and return its source_id.
- *
- * A fresh name INSERTs a new source_id; re-selecting the same name re-points its
- * `connection_config` / `source_type` / `backend` / `stage` (an idempotent
- * re-select, not a duplicate-name error). `created_at` is only set on insert; the
- * update touches `updated_at`. Workspace scope is implicit in the ws_<id> schema
- * the client targets (no workspace_id column post-DAT-343).
- */
-async function upsertSource(values: {
-	name: string;
-	sourceType: string;
-	backend: string | null;
-	connectionConfig: Record<string, unknown>;
-	now: Date;
-}): Promise<string> {
-	const [row] = await metadataDb
-		.insert(sourcesWrite)
-		.values({
-			sourceId: randomUUID(),
-			name: values.name,
-			sourceType: values.sourceType,
-			connectionConfig: values.connectionConfig,
-			status: INITIAL_STATUS,
-			stage: STAGE_AFTER_SELECT,
-			backend: values.backend,
-			createdAt: values.now,
-			updatedAt: values.now,
-		})
-		.onConflictDoUpdate({
-			target: sourcesWrite.name,
-			set: {
-				sourceType: values.sourceType,
-				connectionConfig: values.connectionConfig,
-				status: INITIAL_STATUS,
-				stage: STAGE_AFTER_SELECT,
-				backend: values.backend,
-				updatedAt: values.now,
-			},
-		})
-		.returning({ sourceId: sourcesWrite.sourceId });
-	return row.sourceId;
-}
-
 /** The display basename (filename leaf) of an `s3://` URI. */
 function basename(uri: string): string {
 	return uri.split("/").filter(Boolean).at(-1) ?? uri;
-}
-
-/**
- * The engine-stamped `imported_recipe_hash` witness on an existing source row,
- * if any (DAT-430).
- *
- * At import success the engine copies the recipe's `recipe_hash` into
- * `connection_config.imported_recipe_hash` — the record of WHICH recipe the
- * source's raw tables were materialized from. The db-source upsert below
- * REPLACES the whole `connection_config` JSON, so `select` must carry that
- * engine-owned key forward: preserving it is what lets the engine skip an
- * idempotent re-select (current hash == witness) and fail loud on a re-pointed
- * recipe (mismatch) instead of silently serving stale raw tables. A fresh name
- * (or a never-imported source) has no witness — returns null, and the key is
- * simply absent from the new config.
- */
-async function importedRecipeHash(name: string): Promise<string | null> {
-	const rows = await metadataDb
-		.select({ connectionConfig: sources.connectionConfig })
-		.from(sources)
-		.where(eq(sources.name, name))
-		.limit(1);
-	const cc = rows[0]?.connectionConfig as Record<string, unknown> | null;
-	const witness = cc?.imported_recipe_hash;
-	return typeof witness === "string" && witness.length > 0 ? witness : null;
 }
 
 /**

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 
-// Behavior tests for ProbeWidget (DAT-576). The boundaries are stubbed — they are
-// external systems verified elsewhere: the server fn (env/RPC), the CodeMirror
-// editor (a DOM widget, smoke-verified), and the streaming grid (network I/O). What
-// we assert here is the widget's OWN logic: the no-sources state, run-gating (needs
-// a configured source AND non-empty SQL), and that a Run streams /api/probe-sql with
-// the right request body — including the agent-seed (source + sql) path.
+// Behavior tests for ProbeWidget (DAT-576 + DAT-592). The boundaries are stubbed —
+// they are external systems verified elsewhere: the server fns (env/RPC), the
+// CodeMirror editor (a DOM widget, smoke-verified), the streaming grid (network
+// I/O), the progress widget (Temporal polling), and the router. What we assert is
+// the widget's OWN logic: the no-sources state, run-gating, the probe-sql request
+// body, the import-set add/gate flow, and that Import calls importSources with the
+// staged specs + conversationId then shows progress.
 
 import { MantineProvider } from "@mantine/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -21,6 +22,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const getConfiguredDatabasesMock = vi.fn();
 vi.mock("#/server/configured-databases", () => ({
 	getConfiguredDatabases: () => getConfiguredDatabasesMock(),
+}));
+const importSourcesMock = vi.fn();
+vi.mock("#/server/import-sources", () => ({
+	importSources: (args: unknown) => importSourcesMock(args),
+}));
+// Route param the widget reads to record the run against the chat.
+vi.mock("@tanstack/react-router", () => ({
+	useParams: () => ({ conversationId: "conv-1" }),
 }));
 vi.mock("#/ui/cockpit/widgets/sql-editor", () => ({
 	SqlEditor: ({
@@ -52,6 +61,13 @@ vi.mock("#/ui/cockpit/widgets/result-grid", () => ({
 		/>
 	),
 }));
+vi.mock("#/ui/cockpit/widgets/measure-progress", () => ({
+	MeasureProgressWidget: ({
+		state,
+	}: {
+		state: { workflowId: string; runId: string };
+	}) => <div data-testid="measure-progress" data-workflow={state.workflowId} />,
+}));
 
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
 import { ProbeWidget } from "#/ui/cockpit/widgets/probe";
@@ -61,7 +77,7 @@ function renderProbe(
 	state: Extract<CanvasState, { kind: "probe" }> = { kind: "probe" },
 ) {
 	const qc = new QueryClient({
-		defaultOptions: { queries: { retry: false } },
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
 	});
 	return render(
 		<QueryClientProvider client={qc}>
@@ -73,6 +89,13 @@ function renderProbe(
 }
 
 const runBtn = () => screen.getByTestId("probe-run") as HTMLButtonElement;
+const addBtn = () =>
+	screen.getByTestId("probe-add-to-set") as HTMLButtonElement;
+const seededState: Extract<CanvasState, { kind: "probe" }> = {
+	kind: "probe",
+	source: { name: "wwi", backend: "mssql" },
+	sql: "SELECT * FROM Sales.Orders",
+};
 
 describe("ProbeWidget (DAT-576)", () => {
 	afterEach(() => {
@@ -94,12 +117,10 @@ describe("ProbeWidget (DAT-576)", () => {
 		getConfiguredDatabasesMock.mockResolvedValue([
 			{ name: "wwi", backend: "mssql" },
 		]);
-		// Seed the source (agent-generate path) but no SQL → still disabled.
 		renderProbe({ kind: "probe", source: { name: "wwi", backend: "mssql" } });
 		await waitFor(() => expect(getConfiguredDatabasesMock).toHaveBeenCalled());
 		expect(runBtn().disabled).toBe(true);
 
-		// Typing SQL enables it.
 		fireEvent.change(screen.getByTestId("sql-editor"), {
 			target: { value: "SELECT 1" },
 		});
@@ -125,5 +146,84 @@ describe("ProbeWidget (DAT-576)", () => {
 			backend: "mssql",
 			sql: "SELECT TOP 10 * FROM Sales.Orders",
 		});
+	});
+});
+
+describe("ProbeWidget import set (DAT-592)", () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("gates Add to import set on a source, non-empty SQL, and a valid name", async () => {
+		getConfiguredDatabasesMock.mockResolvedValue([
+			{ name: "wwi", backend: "mssql" },
+		]);
+		renderProbe(seededState);
+		await waitFor(() => expect(getConfiguredDatabasesMock).toHaveBeenCalled());
+		// Source + sql are seeded, but no name yet → disabled.
+		expect(addBtn().disabled).toBe(true);
+
+		// An invalid name (uppercase) stays disabled.
+		fireEvent.change(screen.getByTestId("probe-import-name"), {
+			target: { value: "Bad Name" },
+		});
+		expect(addBtn().disabled).toBe(true);
+
+		// A valid name enables it.
+		fireEvent.change(screen.getByTestId("probe-import-name"), {
+			target: { value: "wwi_orders" },
+		});
+		await waitFor(() => expect(addBtn().disabled).toBe(false));
+	});
+
+	it("stages a query, imports the set, and shows progress", async () => {
+		getConfiguredDatabasesMock.mockResolvedValue([
+			{ name: "wwi", backend: "mssql" },
+		]);
+		importSourcesMock.mockResolvedValue({
+			workflow_id: "addsource-ws",
+			run_id: "addsource-ws",
+			sources: ["sid-1"],
+			source_names: ["wwi_orders"],
+		});
+		renderProbe(seededState);
+		await waitFor(() => expect(getConfiguredDatabasesMock).toHaveBeenCalled());
+
+		fireEvent.change(screen.getByTestId("probe-import-name"), {
+			target: { value: "wwi_orders" },
+		});
+		await waitFor(() => expect(addBtn().disabled).toBe(false));
+		fireEvent.click(addBtn());
+
+		// The staged query shows in the import-set panel.
+		const setPanel = await screen.findByTestId("probe-import-set");
+		expect(setPanel.textContent).toContain("wwi_orders");
+
+		fireEvent.click(screen.getByTestId("probe-import-run"));
+
+		// importSources is called with the staged spec + the conversationId.
+		await waitFor(() => expect(importSourcesMock).toHaveBeenCalledTimes(1));
+		expect(importSourcesMock).toHaveBeenCalledWith({
+			data: {
+				sources: [
+					{
+						source_name: "wwi_orders",
+						backend: "mssql",
+						sql: "SELECT * FROM Sales.Orders",
+					},
+				],
+				conversationId: "conv-1",
+			},
+		});
+
+		// On success the set clears and the inline progress widget shows.
+		await waitFor(() =>
+			expect(screen.getByTestId("probe-import-progress")).toBeTruthy(),
+		);
+		expect(
+			screen.getByTestId("measure-progress").getAttribute("data-workflow"),
+		).toBe("addsource-ws");
+		expect(screen.queryByTestId("probe-import-set")).toBeNull();
 	});
 });

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
@@ -226,4 +226,58 @@ describe("ProbeWidget import set (DAT-592)", () => {
 		).toBe("addsource-ws");
 		expect(screen.queryByTestId("probe-import-set")).toBeNull();
 	});
+
+	it("re-adding a staged name updates its SQL rather than duplicating", async () => {
+		getConfiguredDatabasesMock.mockResolvedValue([
+			{ name: "wwi", backend: "mssql" },
+		]);
+		renderProbe(seededState);
+		await waitFor(() => expect(getConfiguredDatabasesMock).toHaveBeenCalled());
+
+		// Stage wwi_orders with the seeded SQL.
+		fireEvent.change(screen.getByTestId("probe-import-name"), {
+			target: { value: "wwi_orders" },
+		});
+		await waitFor(() => expect(addBtn().disabled).toBe(false));
+		fireEvent.click(addBtn());
+
+		// Edit the SQL, re-stage under the SAME name (the button now reads "Update").
+		fireEvent.change(screen.getByTestId("sql-editor"), {
+			target: { value: "SELECT 99 AS x" },
+		});
+		fireEvent.change(screen.getByTestId("probe-import-name"), {
+			target: { value: "wwi_orders" },
+		});
+		await waitFor(() => expect(addBtn().textContent).toContain("Update"));
+		expect(addBtn().disabled).toBe(false);
+		fireEvent.click(addBtn());
+
+		// One entry, updated SQL — not a duplicate.
+		const setPanel = screen.getByTestId("probe-import-set");
+		expect(setPanel.textContent).toContain("SELECT 99 AS x");
+		expect(setPanel.textContent).not.toContain("SELECT * FROM Sales.Orders");
+		expect(screen.getAllByText("wwi_orders")).toHaveLength(1);
+	});
+
+	it("surfaces an import error and preserves the set for retry", async () => {
+		getConfiguredDatabasesMock.mockResolvedValue([
+			{ name: "wwi", backend: "mssql" },
+		]);
+		importSourcesMock.mockRejectedValue(new Error("Temporal not configured"));
+		renderProbe(seededState);
+		await waitFor(() => expect(getConfiguredDatabasesMock).toHaveBeenCalled());
+
+		fireEvent.change(screen.getByTestId("probe-import-name"), {
+			target: { value: "wwi_orders" },
+		});
+		await waitFor(() => expect(addBtn().disabled).toBe(false));
+		fireEvent.click(addBtn());
+		fireEvent.click(screen.getByTestId("probe-import-run"));
+
+		// The error surfaces and the set is NOT cleared — the user can retry.
+		const err = await screen.findByTestId("probe-import-error");
+		expect(err.textContent).toContain("Temporal not configured");
+		expect(screen.getByTestId("probe-import-set")).toBeTruthy();
+		expect(screen.queryByTestId("probe-import-progress")).toBeNull();
+	});
 });

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
@@ -128,10 +128,16 @@ export function ProbeWidget({
 					<Text size="sm" c="dimmed">
 						Importing {run.source_names.length} source
 						{run.source_names.length === 1 ? "" : "s"}:{" "}
-						{run.source_names.join(", ")}. You'll be told in the chat when it's
-						done.
+						{run.source_names.join(", ")}.
+						{conversationId
+							? " You'll be told in the chat when it's done."
+							: ""}
 					</Text>
+					{/* Keyed by workflow id so a second import (a new run id under the same
+					    per-workspace workflow id) remounts cleanly rather than reusing a
+					    stale node — forward-compat if the id ever becomes per-run. */}
 					<MeasureProgressWidget
+						key={run.workflow_id}
 						state={{
 							kind: "add-source-progress",
 							workflowId: run.workflow_id,
@@ -189,8 +195,11 @@ function ProbePanel({
 	};
 
 	const nameValid = SOURCE_NAME_RE.test(importAs);
+	// Re-using a staged name UPDATES that query's SQL (addToSet replaces by name) —
+	// a valid edit, not a duplicate. So the gate ALLOWS it; only the button label
+	// flips to "Update" so the action is unambiguous.
 	const nameStaged = stagedNames.includes(importAs);
-	const canAdd = selectedSource !== null && hasSql && nameValid && !nameStaged;
+	const canAdd = selectedSource !== null && hasSql && nameValid;
 
 	const add = () => {
 		if (!selectedSource || !hasSql || !nameValid) return;
@@ -282,9 +291,7 @@ function ProbePanel({
 					error={
 						importAs.length > 0 && !nameValid
 							? "lowercase, start with a letter, [a-z0-9_], 2–49 chars"
-							: nameStaged
-								? "already in the import set"
-								: undefined
+							: undefined
 					}
 					data-testid="probe-import-name"
 				/>
@@ -294,7 +301,7 @@ function ProbePanel({
 					disabled={!canAdd}
 					data-testid="probe-add-to-set"
 				>
-					Add to import set
+					{nameStaged ? "Update query" : "Add to import set"}
 				</Button>
 			</Group>
 

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
@@ -1,55 +1,157 @@
-// Probe widget (DAT-576) — the editable Connect-phase surface: pick a configured
-// DB source, write/edit read-only SQL, and run it against the external DB BEFORE
-// ingest. Runs stream through /api/probe-sql into the SAME virtualized result grid
-// the lake uses (StreamingGrid), so a large external result never floods the DOM.
+// Probe widget (DAT-576 + DAT-592) — the editable Connect-phase surface: pick a
+// configured DB source, write/edit read-only SQL, run it against the external DB
+// BEFORE ingest, and (DAT-592) stage queries into an IMPORT SET that imports each
+// as its own single-statement `db_recipe` source.
 //
-// The agent only SEEDS this surface: a `probe` tool call projects its source + sql
-// into the editor (out of CHIP_ONLY, Phase 3) for the user to edit and re-run. The
-// run itself is a direct fetch — no agent round-trip — exactly like the run_sql
-// result grid.
+// Runs stream through /api/probe-sql into the SAME virtualized result grid the lake
+// uses (StreamingGrid), so a large external result never floods the DOM. The agent
+// only SEEDS this surface: a `probe` tool call projects its source + sql into the
+// editor (out of CHIP_ONLY) for the user to edit and re-run. The run itself is a
+// direct fetch — no agent round-trip.
+//
+// Import set (DAT-592): "Add to import set" stages {import-as name, backend, sql};
+// "Import N sources" calls the `importSources` server fn — deterministic, no LLM
+// round-trip — which persists one source per query and starts ONE batched
+// addSourceWorkflow run. The run's progress renders INLINE here (the canvas is
+// message-derived, so a direct action can't project a canvas member), while the
+// background completion-watcher narrates completion into the chat (the run is
+// recorded against the conversationId we pass through).
 
 import {
+	ActionIcon,
 	Alert,
 	Badge,
 	Button,
+	Code,
 	Group,
+	Paper,
 	Select,
 	Stack,
 	Text,
+	TextInput,
 } from "@mantine/core";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useParams } from "@tanstack/react-router";
+import { X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { getConfiguredDatabases } from "#/server/configured-databases";
+import { importSources } from "#/server/import-sources";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
+import { MeasureProgressWidget } from "#/ui/cockpit/widgets/measure-progress";
 import { StreamingGrid } from "#/ui/cockpit/widgets/result-grid";
 import { SqlEditor } from "#/ui/cockpit/widgets/sql-editor";
 
-/** The probe-sql request a Run submits — mirrors the /api/probe-sql body. A `type`
- * (not `interface`) so it's assignable to the grid's `Record<string, unknown>` body. */
+/** One staged query — becomes one single-statement `db_recipe` source on import.
+ * A `type` (not `interface`) so it's assignable to the server fn's input shape. */
+type ImportSpec = {
+	source_name: string;
+	backend: string;
+	sql: string;
+};
+
+/** The probe-sql request a Run submits — mirrors the /api/probe-sql body. */
 type ProbeRun = {
 	source_name: string;
 	backend: string;
 	sql: string;
 };
 
+// Client mirror of select/mappers SOURCE_NAME_PATTERN — the AUTHORITY lives there
+// and the server re-validates loud; inlined to keep that crypto-bearing module out
+// of the client bundle (the upload/policy split precedent). Gates the "Add" button
+// for fast feedback only.
+const SOURCE_NAME_RE = /^[a-z][a-z0-9_]{1,48}$/;
+
 export function ProbeWidget({
 	state,
 }: {
 	state: Extract<CanvasState, { kind: "probe" }>;
 }) {
-	// Remount the panel whenever the agent SEED (the source + sql projected onto the
-	// canvas) changes, so a repeated probe / open_probe in a later turn re-seeds the
-	// editor + picker via fresh state init — never a reset effect (idiom rule 5, the
-	// ResultGridWidget → StreamingGrid pattern). User edits don't touch the seed, so
-	// typing never remounts.
+	// Remount the EXPLORE panel whenever the agent SEED (source + sql) changes, so a
+	// repeated probe / open_probe re-seeds the editor + picker via fresh state init
+	// (idiom rule 5). The import set + an in-flight run's progress live ABOVE this
+	// key so a re-seed never wipes a half-built set or a running import.
 	const seedKey = `${state.source?.name ?? ""}|${state.sql ?? ""}`;
-	return <ProbePanel key={seedKey} state={state} />;
+
+	// The originating chat (route param) — threaded to the import so the run is
+	// recorded against it (the completion-watcher routes progress + narration by
+	// conversationId). Absent off-route (the unit tests) → a null-conversation run.
+	const params = useParams({ strict: false }) as { conversationId?: string };
+	const conversationId = params.conversationId ?? null;
+
+	const [importSet, setImportSet] = useState<ImportSpec[]>([]);
+	// Re-adding a name re-points its SQL (an edit), never a silent duplicate.
+	const addToSet = (spec: ImportSpec) =>
+		setImportSet((s) => [
+			...s.filter((x) => x.source_name !== spec.source_name),
+			spec,
+		]);
+	const removeFromSet = (name: string) =>
+		setImportSet((s) => s.filter((x) => x.source_name !== name));
+
+	const importMutation = useMutation({
+		mutationFn: (specs: ImportSpec[]) =>
+			importSources({ data: { sources: specs, conversationId } }),
+		// Clear the staged set on a successful start — the run is now live (its
+		// progress renders below); the set is free to build the next batch.
+		onSuccess: () => setImportSet([]),
+	});
+
+	const run = importMutation.data;
+
+	return (
+		<Stack gap="md" data-testid="canvas-probe">
+			<ProbePanel
+				key={seedKey}
+				state={state}
+				stagedNames={importSet.map((s) => s.source_name)}
+				onAdd={addToSet}
+			/>
+
+			{importSet.length > 0 && (
+				<ImportSetPanel
+					set={importSet}
+					onRemove={removeFromSet}
+					onImport={() => importMutation.mutate(importSet)}
+					pending={importMutation.isPending}
+				/>
+			)}
+
+			{importMutation.error && (
+				<Alert color="red" data-testid="probe-import-error">
+					{(importMutation.error as Error).message}
+				</Alert>
+			)}
+
+			{run && (
+				<Stack gap="xs" data-testid="probe-import-progress">
+					<Text size="sm" c="dimmed">
+						Importing {run.source_names.length} source
+						{run.source_names.length === 1 ? "" : "s"}:{" "}
+						{run.source_names.join(", ")}. You'll be told in the chat when it's
+						done.
+					</Text>
+					<MeasureProgressWidget
+						state={{
+							kind: "add-source-progress",
+							workflowId: run.workflow_id,
+							runId: run.run_id,
+						}}
+					/>
+				</Stack>
+			)}
+		</Stack>
+	);
 }
 
 function ProbePanel({
 	state,
+	stagedNames,
+	onAdd,
 }: {
 	state: Extract<CanvasState, { kind: "probe" }>;
+	stagedNames: string[];
+	onAdd: (spec: ImportSpec) => void;
 }) {
 	const sources = useQuery({
 		queryKey: ["configured-databases"],
@@ -63,6 +165,7 @@ function ProbePanel({
 		state.source?.name ?? null,
 	);
 	const [sqlText, setSqlText] = useState<string>(state.sql ?? "");
+	const [importAs, setImportAs] = useState<string>("");
 	const [submitted, setSubmitted] = useState<ProbeRun | null>(null);
 	// Bumped per Run so an identical re-run still remounts StreamingGrid (fresh
 	// stream + sort reset), not just a different query.
@@ -72,10 +175,11 @@ function ProbePanel({
 		() => list.find((s) => s.name === selected) ?? null,
 		[list, selected],
 	);
-	const canRun = selectedSource !== null && sqlText.trim().length > 0;
+	const hasSql = sqlText.trim().length > 0;
+	const canRun = selectedSource !== null && hasSql;
 
 	const run = () => {
-		if (!selectedSource || sqlText.trim().length === 0) return;
+		if (!selectedSource || !hasSql) return;
 		setSubmitted({
 			source_name: selectedSource.name,
 			backend: selectedSource.backend,
@@ -84,10 +188,24 @@ function ProbePanel({
 		setRunId((r) => r + 1);
 	};
 
+	const nameValid = SOURCE_NAME_RE.test(importAs);
+	const nameStaged = stagedNames.includes(importAs);
+	const canAdd = selectedSource !== null && hasSql && nameValid && !nameStaged;
+
+	const add = () => {
+		if (!selectedSource || !hasSql || !nameValid) return;
+		onAdd({
+			source_name: importAs,
+			backend: selectedSource.backend,
+			sql: sqlText,
+		});
+		setImportAs("");
+	};
+
 	const noSources = !sources.isLoading && list.length === 0;
 
 	return (
-		<Stack gap="sm" data-testid="canvas-probe">
+		<Stack gap="sm" data-testid="probe-explore">
 			<Group justify="space-between" wrap="nowrap">
 				<Text size="sm" fw={600}>
 					Probe a database source
@@ -100,7 +218,8 @@ function ProbePanel({
 			</Group>
 			<Text size="xs" c="dimmed">
 				Read-only DuckDB SQL against a configured source (use LIMIT, not TOP) —
-				no data is imported. ⌘/Ctrl+Enter to run.
+				no data is imported until you add a query to the import set.
+				⌘/Ctrl+Enter to run.
 			</Text>
 
 			<Select
@@ -143,14 +262,39 @@ function ProbePanel({
 				placeholder="SELECT * FROM my_schema.my_table LIMIT 100"
 			/>
 
-			<Group>
+			<Group align="flex-end" gap="sm" wrap="nowrap">
 				<Button
 					size="xs"
+					variant="default"
 					onClick={run}
 					disabled={!canRun}
 					data-testid="probe-run"
 				>
 					Run
+				</Button>
+				<TextInput
+					size="xs"
+					flex={1}
+					label="Import as"
+					placeholder="source_name (lowercase, e.g. wwi_open_orders)"
+					value={importAs}
+					onChange={(e) => setImportAs(e.currentTarget.value)}
+					error={
+						importAs.length > 0 && !nameValid
+							? "lowercase, start with a letter, [a-z0-9_], 2–49 chars"
+							: nameStaged
+								? "already in the import set"
+								: undefined
+					}
+					data-testid="probe-import-name"
+				/>
+				<Button
+					size="xs"
+					onClick={add}
+					disabled={!canAdd}
+					data-testid="probe-add-to-set"
+				>
+					Add to import set
 				</Button>
 			</Group>
 
@@ -158,5 +302,69 @@ function ProbePanel({
 				<StreamingGrid key={runId} endpoint="/api/probe-sql" body={submitted} />
 			)}
 		</Stack>
+	);
+}
+
+function ImportSetPanel({
+	set,
+	onRemove,
+	onImport,
+	pending,
+}: {
+	set: ImportSpec[];
+	onRemove: (name: string) => void;
+	onImport: () => void;
+	pending: boolean;
+}) {
+	return (
+		<Paper withBorder p="sm" radius="sm" data-testid="probe-import-set">
+			<Stack gap="xs">
+				<Text size="sm" fw={600}>
+					Import set ({set.length})
+				</Text>
+				<Text size="xs" c="dimmed">
+					Each query imports as its own source. They import together as one run.
+				</Text>
+				<Stack gap={4}>
+					{set.map((spec) => (
+						<Group key={spec.source_name} justify="space-between" wrap="nowrap">
+							<Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
+								<Badge variant="light" size="sm" tt="none">
+									{spec.source_name}
+								</Badge>
+								<Code
+									style={{
+										overflow: "hidden",
+										textOverflow: "ellipsis",
+										whiteSpace: "nowrap",
+									}}
+								>
+									{spec.sql}
+								</Code>
+							</Group>
+							<ActionIcon
+								variant="subtle"
+								color="gray"
+								size="sm"
+								aria-label={`Remove ${spec.source_name}`}
+								onClick={() => onRemove(spec.source_name)}
+							>
+								<X size={14} />
+							</ActionIcon>
+						</Group>
+					))}
+				</Stack>
+				<Group>
+					<Button
+						size="xs"
+						onClick={onImport}
+						loading={pending}
+						data-testid="probe-import-run"
+					>
+						Import {set.length} source{set.length === 1 ? "" : "s"}
+					</Button>
+				</Group>
+			</Stack>
+		</Paper>
 	);
 }


### PR DESCRIPTION
**Epic:** DAT-574 (cockpit UI brilliance) · fast-follow to **DAT-576** (probe surface, merged). **Cockpit-only — engine + the agent `select` tool unchanged.**

## What

Lets a user import an arbitrary **probed SQL query** as a data source, straight from the probe surface. Each staged query becomes its **own** single-statement `db_recipe` source; a batch of staged queries imports as **one** `addSourceWorkflow` run (one grounding pass over the union — not N runs).

The engine already materializes arbitrary recipe SQL verbatim (`sources/db_recipe`, `import_phase`); the only gap was a cockpit producer for arbitrary SQL. This is that producer + the UI.

## How

- **`select/source-write.ts`** (new) — extracted the shared `upsertSource` + `importedRecipeHash` write seam from `tools/select.ts` (no behavior change to the agent `select`).
- **`select/recipe-source.ts`** (new) — `persistRecipeSources`: one `db_recipe` source per query, batch-validated loud (bad name / reserved prefix / unsupported backend / empty SQL / duplicate name / empty set) **before any write**; per-source `recipe_hash` + import-witness carry-forward (DAT-430). Non-atomic-but-idempotent-retry documented (matches the sibling file-source loop).
- **`server/import-sources.ts`** (new) — the `importSources` server fn (deterministic, **no LLM round-trip**): persist the set → **one** `triggerAddSource`. `conversationId` threaded (via `runWithConversation`) so the completion-watcher routes live progress + chat narration. Server-only deps load dynamically inside the handler to keep the module's static graph **config-free** (the widget imports it at module scope; the canvas registry must not drag `config`).
- **`ui/cockpit/widgets/probe.tsx`** — the **import set**: "Import as &lt;name&gt;" + Add (re-add **updates** a staged query), a staged list with remove, "Import N sources", and inline run progress via the existing `MeasureProgressWidget` (the canvas is message-derived, so a direct action renders progress inline rather than projecting a canvas member). The cart lives above the seed-remount key, so an agent re-seed never wipes a half-built set.

## ACs (DAT-592)

- [x] `select`/import (database) accepts an arbitrary `{name, sql}` recipe from the probe surface; SQL persisted verbatim, imported by the unchanged engine path.
- [x] Probe panel has an "Import this query" affordance (name + editor SQL → import).
- [x] One imported query = one source (single-statement recipe); re-import idempotent via `recipe_hash`.
- [x] Table-pick `select` left as the **documented** bundled multi-add path (the AC's chosen branch).
- [x] Engine untouched.

## Out of scope (separate follow-up)

Frame-per-selected-source / typed query-schema → `frame` / batch-frame flow; cart durability across canvas-focus-away; extending the import set to files.

## Tests / review

- 138 files / 1244 unit tests pass; tsc + biome clean. New unit + integration tests for `persistRecipeSources` and the import-set UI (add/update/remove/gate, import→progress, error→set-preserved).
- senior-code-reviewer: **APPROVED** · spec-compliance-reviewer: **COMPLIANT**.
- Not yet browser-smoked (the import fires a real grounding run) — smoking on `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)