### PR TITLE
DAT-592 follow-up: credential_source decoupling + import-set frame gate + UX

### DIFF
--- a/packages/cockpit/src/select/mappers.test.ts
+++ b/packages/cockpit/src/select/mappers.test.ts
@@ -242,4 +242,17 @@ describe("recipeContentHash (DAT-430)", () => {
 		const h = recipeContentHash("mssql", tables);
 		expect(recipeContentHash("postgres", tables)).not.toBe(h);
 	});
+
+	it("folds credentialSource into the identity when present, leaving the table-pick hash byte-identical (DAT-592)", () => {
+		// A query-source reads through a named connection: same SQL, different
+		// connection = a different recipe, so re-pointing it must NOT match the
+		// witness (else a presence-skip over stale raw tables).
+		const withWwi = recipeContentHash("mssql", tables, "wwi");
+		expect(withWwi).toMatch(/^[0-9a-f]{64}$/);
+		expect(recipeContentHash("mssql", tables, "staging")).not.toBe(withWwi);
+		// The table-pick path (no credentialSource arg) keeps the OLD canonical
+		// {backend, tables} hash — existing import witnesses stay valid, and it is
+		// distinct from any credential-qualified hash.
+		expect(recipeContentHash("mssql", tables)).not.toBe(withWwi);
+	});
 });

--- a/packages/cockpit/src/select/mappers.ts
+++ b/packages/cockpit/src/select/mappers.ts
@@ -163,10 +163,17 @@ export interface RecipeTable {
 export function recipeContentHash(
 	backend: string,
 	tables: RecipeTable[],
+	credentialSource?: string,
 ): string {
-	return createHash("sha256")
-		.update(JSON.stringify({ backend, tables }))
-		.digest("hex");
+	// `credentialSource` (DAT-592) is part of the recipe identity when present: a
+	// query-source reads through a named connection, so re-pointing it (same SQL,
+	// different DB) is a DIFFERENT recipe. Omitted for the table-pick path (a source
+	// that is its own credential), keeping that path's hash byte-identical.
+	const canonical =
+		credentialSource === undefined
+			? { backend, tables }
+			: { backend, credential_source: credentialSource, tables };
+	return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
 }
 
 /** Quote a single SQL identifier segment, doubling embedded double-quotes.

--- a/packages/cockpit/src/select/recipe-source.integration.test.ts
+++ b/packages/cockpit/src/select/recipe-source.integration.test.ts
@@ -110,8 +110,18 @@ describe.skipIf(!STACK_AVAILABLE)(
 			const sqlB = "SELECT CustomerID, CustomerName FROM Sales.Customers";
 
 			const result = await persistRecipeSources([
-				{ source_name: a, backend: "mssql", sql: sqlA },
-				{ source_name: b, backend: "mssql", sql: sqlB },
+				{
+					source_name: a,
+					credential_source: "wwi",
+					backend: "mssql",
+					sql: sqlA,
+				},
+				{
+					source_name: b,
+					credential_source: "wwi",
+					backend: "mssql",
+					sql: sqlB,
+				},
 			]);
 			expect(result).toHaveLength(2);
 
@@ -122,7 +132,8 @@ describe.skipIf(!STACK_AVAILABLE)(
 			const tablesA = [{ name: a, sql: sqlA }];
 			expect(rowA.connection_config).toEqual({
 				tables: tablesA,
-				recipe_hash: recipeContentHash("mssql", tablesA),
+				credential_source: "wwi",
+				recipe_hash: recipeContentHash("mssql", tablesA, "wwi"),
 			});
 			// One statement = one source: a single recipe entry, no file cross-contamination.
 			expect((rowA.connection_config.tables as unknown[]).length).toBe(1);
@@ -140,10 +151,20 @@ describe.skipIf(!STACK_AVAILABLE)(
 			writtenNames.push(name);
 
 			await persistRecipeSources([
-				{ source_name: name, backend: "mssql", sql: "SELECT 1 AS a" },
+				{
+					source_name: name,
+					credential_source: "wwi",
+					backend: "mssql",
+					sql: "SELECT 1 AS a",
+				},
 			]);
 			await persistRecipeSources([
-				{ source_name: name, backend: "mssql", sql: "SELECT 2 AS b" },
+				{
+					source_name: name,
+					credential_source: "wwi",
+					backend: "mssql",
+					sql: "SELECT 2 AS b",
+				},
 			]);
 
 			const row = await readBack(name);

--- a/packages/cockpit/src/select/recipe-source.test.ts
+++ b/packages/cockpit/src/select/recipe-source.test.ts
@@ -61,7 +61,12 @@ describe("persistRecipeSources validation (fails loud before any write)", () => 
 	it("rejects an invalid source name", async () => {
 		await expect(
 			persistRecipeSources([
-				{ source_name: "Bad Name", backend: "mssql", sql: "SELECT 1" },
+				{
+					source_name: "Bad Name",
+					credential_source: "wwi",
+					backend: "mssql",
+					sql: "SELECT 1",
+				},
 			]),
 		).rejects.toThrow(/Invalid source name/);
 		expect(h.upserts).toHaveLength(0);
@@ -70,7 +75,12 @@ describe("persistRecipeSources validation (fails loud before any write)", () => 
 	it("rejects a reserved family prefix", async () => {
 		await expect(
 			persistRecipeSources([
-				{ source_name: "src_orders", backend: "mssql", sql: "SELECT 1" },
+				{
+					source_name: "src_orders",
+					credential_source: "wwi",
+					backend: "mssql",
+					sql: "SELECT 1",
+				},
 			]),
 		).rejects.toThrow(/reserved prefix/);
 		expect(h.upserts).toHaveLength(0);
@@ -79,7 +89,12 @@ describe("persistRecipeSources validation (fails loud before any write)", () => 
 	it("rejects an unsupported backend", async () => {
 		await expect(
 			persistRecipeSources([
-				{ source_name: "orders", backend: "oracle", sql: "SELECT 1" },
+				{
+					source_name: "orders",
+					credential_source: "wwi",
+					backend: "oracle",
+					sql: "SELECT 1",
+				},
 			]),
 		).rejects.toThrow(/Unsupported backend/);
 		expect(h.upserts).toHaveLength(0);
@@ -88,17 +103,46 @@ describe("persistRecipeSources validation (fails loud before any write)", () => 
 	it("rejects empty SQL", async () => {
 		await expect(
 			persistRecipeSources([
-				{ source_name: "orders", backend: "mssql", sql: "   " },
+				{
+					source_name: "orders",
+					credential_source: "wwi",
+					backend: "mssql",
+					sql: "   ",
+				},
 			]),
 		).rejects.toThrow(/empty SQL/);
+		expect(h.upserts).toHaveLength(0);
+	});
+
+	it("rejects a spec with an empty credential_source", async () => {
+		await expect(
+			persistRecipeSources([
+				{
+					source_name: "orders",
+					credential_source: "",
+					backend: "mssql",
+					sql: "SELECT 1",
+				},
+			]),
+		).rejects.toThrow(/credential_source/);
 		expect(h.upserts).toHaveLength(0);
 	});
 
 	it("rejects a duplicate name in the batch — before persisting anything", async () => {
 		await expect(
 			persistRecipeSources([
-				{ source_name: "orders", backend: "mssql", sql: "SELECT 1" },
-				{ source_name: "orders", backend: "mssql", sql: "SELECT 2" },
+				{
+					source_name: "orders",
+					credential_source: "wwi",
+					backend: "mssql",
+					sql: "SELECT 1",
+				},
+				{
+					source_name: "orders",
+					credential_source: "wwi",
+					backend: "mssql",
+					sql: "SELECT 2",
+				},
 			]),
 		).rejects.toThrow(/Duplicate source name/);
 		// The whole batch is validated before the write loop — no half-state.
@@ -111,11 +155,13 @@ describe("persistRecipeSources row shape (one source per query)", () => {
 		const result = await persistRecipeSources([
 			{
 				source_name: "wwi_orders",
+				credential_source: "wwi",
 				backend: "mssql",
 				sql: "SELECT * FROM Sales.Orders WHERE OrderDate > '2015-01-01'",
 			},
 			{
 				source_name: "wwi_customers",
+				credential_source: "wwi",
 				backend: "mssql",
 				sql: "SELECT CustomerID, CustomerName FROM Sales.Customers",
 			},
@@ -137,7 +183,9 @@ describe("persistRecipeSources row shape (one source per query)", () => {
 		};
 		expect(first.connectionConfig).toEqual({
 			tables: [recipeTable],
-			recipe_hash: recipeContentHash("mssql", [recipeTable]),
+			// The connection the query reads through — a NAME reference (DAT-592).
+			credential_source: "wwi",
+			recipe_hash: recipeContentHash("mssql", [recipeTable], "wwi"),
 		});
 		// db recipe and file URIs never cross-contaminate.
 		expect(first.connectionConfig).not.toHaveProperty("file_uris");
@@ -146,7 +194,12 @@ describe("persistRecipeSources row shape (one source per query)", () => {
 	it("carries the engine-stamped import witness forward on re-select", async () => {
 		h.witness = "deadbeef";
 		await persistRecipeSources([
-			{ source_name: "wwi_orders", backend: "mssql", sql: "SELECT 1" },
+			{
+				source_name: "wwi_orders",
+				credential_source: "wwi",
+				backend: "mssql",
+				sql: "SELECT 1",
+			},
 		]);
 		expect(h.upserts[0].connectionConfig).toMatchObject({
 			imported_recipe_hash: "deadbeef",

--- a/packages/cockpit/src/select/recipe-source.ts
+++ b/packages/cockpit/src/select/recipe-source.ts
@@ -30,6 +30,11 @@ import { importedRecipeHash, upsertSource } from "./source-write";
 export interface RecipeSourceSpec {
 	/** The user-chosen source name (lowercase, letter-led — `SOURCE_NAME_PATTERN`). */
 	source_name: string;
+	/** The configured CONNECTION the query reads through — the probed source name
+	 * (DAT-592). Distinct from `source_name`: the engine resolves credentials from
+	 * THIS (`DATARAUM_{credential_source}_URL`), so a query imported as a new name
+	 * still reads the right DB. Never the secret URL — just the reference. */
+	credential_source: string;
 	/** The DB backend the query runs against (persisted as the `backend` column). */
 	backend: string;
 	/** The verbatim read-only SQL — materialized by the engine into one raw table. */
@@ -56,6 +61,12 @@ function validateSpec(spec: RecipeSourceSpec): void {
 		throw new ImportSetError(
 			`Invalid source name '${name ?? ""}'. Must match ${SOURCE_NAME_PATTERN.source} ` +
 				"(lowercase, start with a letter, 2–49 chars of [a-z0-9_]).",
+		);
+	}
+	if (!spec.credential_source) {
+		throw new ImportSetError(
+			`Source '${name}' has no credential_source — the configured connection ` +
+				"to read through (the probed source) is required.",
 		);
 	}
 	const reserved = reservedSourceNamePrefix(name);
@@ -130,7 +141,14 @@ export async function persistRecipeSources(
 		const connectionConfig: Record<string, unknown> = {
 			// DISTINCT key from the file `file_uris` key — never folded together.
 			tables: [recipeTable],
-			recipe_hash: recipeContentHash(spec.backend, [recipeTable]),
+			// The connection to read through (DAT-592) — a NAME reference the engine
+			// resolves credentials from, never the secret URL.
+			credential_source: spec.credential_source,
+			recipe_hash: recipeContentHash(
+				spec.backend,
+				[recipeTable],
+				spec.credential_source,
+			),
 			...(witness === null ? {} : { imported_recipe_hash: witness }),
 		};
 		const sourceId = await upsertSource({

--- a/packages/cockpit/src/server/active-vertical.ts
+++ b/packages/cockpit/src/server/active-vertical.ts
@@ -1,0 +1,36 @@
+// Server fn: is the active workspace FRAMED? (DAT-592 follow-up)
+//
+// Importing a source runs `semantic_per_column` grounding, which fails loud when
+// the workspace's vertical has no concepts ("Run frame before add_source"). The
+// probe import set is a deterministic button that bypasses the agent's frame step,
+// so it must pre-check: don't let the user stage/import sources into an unframed
+// workspace, only to have the run die deep in the pipeline.
+//
+// `framed` reuses the SAME concept count the engine's grounding guard keys off
+// (`verticalConceptCount` — builtin ontology + active config_overlay concept rows),
+// so the UI gate and the engine's fail-loud agree. A selected builtin vertical
+// (shipped concepts) and a framed `_adhoc` both read framed=true; a cold-start
+// `_adhoc` reads false.
+//
+// Server-only deps load INSIDE the handler so this module's static graph stays
+// config-free — the probe WIDGET imports it at module scope, and the canvas
+// registry must not drag config (mirrors server/import-sources.ts).
+
+import { createServerFn } from "@tanstack/react-start";
+
+export interface ActiveVerticalStatus {
+	/** The active workspace's vertical (`_adhoc` when cold-start / unframed). */
+	vertical: string;
+	/** True when that vertical resolves to ≥1 concept — the import set's gate. */
+	framed: boolean;
+}
+
+export const getActiveVerticalStatus = createServerFn({
+	method: "GET",
+}).handler(async (): Promise<ActiveVerticalStatus> => {
+	const { resolveActiveWorkspaceRow } = await import("#/db/cockpit/registry");
+	const { verticalConceptCount } = await import("#/tools/list-verticals");
+	const ws = await resolveActiveWorkspaceRow();
+	const count = await verticalConceptCount(ws.vertical);
+	return { vertical: ws.vertical, framed: count > 0 };
+});

--- a/packages/cockpit/src/server/import-sources.ts
+++ b/packages/cockpit/src/server/import-sources.ts
@@ -32,6 +32,7 @@ const ImportSourcesInput = z.object({
 		.array(
 			z.object({
 				source_name: z.string(),
+				credential_source: z.string(),
 				backend: z.string(),
 				sql: z.string(),
 			}),

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
@@ -17,11 +17,15 @@ import {
 	screen,
 	waitFor,
 } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getConfiguredDatabasesMock = vi.fn();
 vi.mock("#/server/configured-databases", () => ({
 	getConfiguredDatabases: () => getConfiguredDatabasesMock(),
+}));
+const getActiveVerticalStatusMock = vi.fn();
+vi.mock("#/server/active-vertical", () => ({
+	getActiveVerticalStatus: () => getActiveVerticalStatusMock(),
 }));
 const importSourcesMock = vi.fn();
 vi.mock("#/server/import-sources", () => ({
@@ -96,6 +100,15 @@ const seededState: Extract<CanvasState, { kind: "probe" }> = {
 	source: { name: "wwi", backend: "mssql" },
 	sql: "SELECT * FROM Sales.Orders",
 };
+
+// Default: a framed workspace, so the import-set gate is open. Tests that exercise
+// the unframed gate override this. (afterEach clears mocks; this re-seeds the default.)
+beforeEach(() => {
+	getActiveVerticalStatusMock.mockResolvedValue({
+		vertical: "retail",
+		framed: true,
+	});
+});
 
 describe("ProbeWidget (DAT-576)", () => {
 	afterEach(() => {
@@ -175,6 +188,25 @@ describe("ProbeWidget import set (DAT-592)", () => {
 			target: { value: "wwi_orders" },
 		});
 		await waitFor(() => expect(addBtn().disabled).toBe(false));
+	});
+
+	it("blocks Add when the workspace is unframed (no business model)", async () => {
+		getConfiguredDatabasesMock.mockResolvedValue([
+			{ name: "wwi", backend: "mssql" },
+		]);
+		getActiveVerticalStatusMock.mockResolvedValue({
+			vertical: "_adhoc",
+			framed: false,
+		});
+		renderProbe(seededState);
+		// The unframed banner shows; Add stays disabled even with a valid name + sql.
+		await waitFor(() =>
+			expect(screen.getByTestId("probe-unframed")).toBeTruthy(),
+		);
+		fireEvent.change(screen.getByTestId("probe-import-name"), {
+			target: { value: "wwi_orders" },
+		});
+		expect(addBtn().disabled).toBe(true);
 	});
 
 	it("stages a query, imports the set, and shows progress", async () => {

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
@@ -196,7 +196,10 @@ describe("ProbeWidget import set (DAT-592)", () => {
 		await waitFor(() => expect(addBtn().disabled).toBe(false));
 		fireEvent.click(addBtn());
 
-		// The staged query shows in the import-set panel.
+		// The set lives behind a count symbol; open the modal to see it.
+		const indicator = await screen.findByTestId("probe-import-indicator");
+		expect(indicator.textContent).toContain("1");
+		fireEvent.click(indicator);
 		const setPanel = await screen.findByTestId("probe-import-set");
 		expect(setPanel.textContent).toContain("wwi_orders");
 
@@ -209,6 +212,7 @@ describe("ProbeWidget import set (DAT-592)", () => {
 				sources: [
 					{
 						source_name: "wwi_orders",
+						credential_source: "wwi",
 						backend: "mssql",
 						sql: "SELECT * FROM Sales.Orders",
 					},
@@ -224,7 +228,7 @@ describe("ProbeWidget import set (DAT-592)", () => {
 		expect(
 			screen.getByTestId("measure-progress").getAttribute("data-workflow"),
 		).toBe("addsource-ws");
-		expect(screen.queryByTestId("probe-import-set")).toBeNull();
+		expect(screen.queryByTestId("probe-import-indicator")).toBeNull();
 	});
 
 	it("re-adding a staged name updates its SQL rather than duplicating", async () => {
@@ -252,8 +256,11 @@ describe("ProbeWidget import set (DAT-592)", () => {
 		expect(addBtn().disabled).toBe(false);
 		fireEvent.click(addBtn());
 
-		// One entry, updated SQL — not a duplicate.
-		const setPanel = screen.getByTestId("probe-import-set");
+		// Still one staged source (the symbol reads 1); open the modal to verify SQL.
+		const indicator = screen.getByTestId("probe-import-indicator");
+		expect(indicator.textContent).toContain("1");
+		fireEvent.click(indicator);
+		const setPanel = await screen.findByTestId("probe-import-set");
 		expect(setPanel.textContent).toContain("SELECT 99 AS x");
 		expect(setPanel.textContent).not.toContain("SELECT * FROM Sales.Orders");
 		expect(screen.getAllByText("wwi_orders")).toHaveLength(1);
@@ -272,12 +279,13 @@ describe("ProbeWidget import set (DAT-592)", () => {
 		});
 		await waitFor(() => expect(addBtn().disabled).toBe(false));
 		fireEvent.click(addBtn());
-		fireEvent.click(screen.getByTestId("probe-import-run"));
+		fireEvent.click(await screen.findByTestId("probe-import-indicator"));
+		fireEvent.click(await screen.findByTestId("probe-import-run"));
 
-		// The error surfaces and the set is NOT cleared — the user can retry.
+		// The error surfaces and the set is NOT cleared — the symbol persists for retry.
 		const err = await screen.findByTestId("probe-import-error");
 		expect(err.textContent).toContain("Temporal not configured");
-		expect(screen.getByTestId("probe-import-set")).toBeTruthy();
+		expect(screen.getByTestId("probe-import-indicator")).toBeTruthy();
 		expect(screen.queryByTestId("probe-import-progress")).toBeNull();
 	});
 });

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
@@ -102,7 +102,7 @@ const seededState: Extract<CanvasState, { kind: "probe" }> = {
 };
 
 // Default: a framed workspace, so the import-set gate is open. Tests that exercise
-// the unframed gate override this. (afterEach clears mocks; this re-seeds the default.)
+// the unframed gate override this per-test (a later mockResolvedValue wins).
 beforeEach(() => {
 	getActiveVerticalStatusMock.mockResolvedValue({
 		vertical: "retail",

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
@@ -188,6 +188,9 @@ function ProbePanel({
 	const frameStatus = useQuery({
 		queryKey: ["active-vertical-status"],
 		queryFn: () => getActiveVerticalStatus(),
+		// Session-stable — only the `frame`/`use_vertical` flow changes it — so don't
+		// re-hit the server on every window focus.
+		staleTime: 5 * 60 * 1000,
 	});
 	const framed = frameStatus.data?.framed === true;
 	const unframed = frameStatus.isSuccess && !framed;
@@ -234,7 +237,9 @@ function ProbePanel({
 	const canAdd = selectedSource !== null && hasSql && nameValid && framed;
 
 	const add = () => {
-		if (!selectedSource || !hasSql || !nameValid) return;
+		// `framed` is guarded here too, not only via the disabled button — HTML
+		// `disabled` is a UI-only barrier; the handler must hold the invariant.
+		if (!selectedSource || !hasSql || !nameValid || !framed) return;
 		onAdd({
 			source_name: importAs,
 			// The picked source IS the connection the query reads through; the engine
@@ -285,13 +290,21 @@ function ProbePanel({
 
 			{unframed && (
 				<Alert color="yellow" data-testid="probe-unframed">
-					No business model yet — the workspace vertical{" "}
-					<Text span ff="monospace" size="xs">
-						{frameStatus.data?.vertical}
-					</Text>{" "}
-					has no concepts, so an imported source has nothing to ground against.
-					Frame a vertical (or pick one) in the chat before importing — probing
-					here still works.
+					No business model yet —{" "}
+					{frameStatus.data?.vertical === "_adhoc" ? (
+						"this workspace hasn't been framed"
+					) : (
+						<>
+							the vertical{" "}
+							<Text span ff="monospace" size="xs">
+								{frameStatus.data?.vertical}
+							</Text>{" "}
+							has no concepts
+						</>
+					)}
+					, so an imported source has nothing to ground against. Frame a
+					vertical (or pick one) in the chat before importing — probing here
+					still works.
 				</Alert>
 			)}
 

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
@@ -38,6 +38,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { Layers, X } from "lucide-react";
 import { useMemo, useState } from "react";
+import { getActiveVerticalStatus } from "#/server/active-vertical";
 import { getConfiguredDatabases } from "#/server/configured-databases";
 import { importSources } from "#/server/import-sources";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
@@ -180,6 +181,17 @@ function ProbePanel({
 	});
 	const list = useMemo(() => sources.data ?? [], [sources.data]);
 
+	// Is the workspace framed? Importing grounds against the vertical's concepts and
+	// fails loud if there are none, so the import set is gated on this (DAT-592
+	// follow-up). Probing (Run) stays open — read-only exploration is how you decide
+	// the frame. `framed` only when CONFIRMED true (loading/error → gated, safe).
+	const frameStatus = useQuery({
+		queryKey: ["active-vertical-status"],
+		queryFn: () => getActiveVerticalStatus(),
+	});
+	const framed = frameStatus.data?.framed === true;
+	const unframed = frameStatus.isSuccess && !framed;
+
 	// Seed from the canvas state (agent-generate): a projected source + sql preload
 	// the picker + editor as INITIAL values; the user then edits freely.
 	const [selected, setSelected] = useState<string | null>(
@@ -217,7 +229,9 @@ function ProbePanel({
 	// a valid edit, not a duplicate. So the gate ALLOWS it; only the button label
 	// flips to "Update" so the action is unambiguous.
 	const nameStaged = importSet.some((s) => s.source_name === importAs);
-	const canAdd = selectedSource !== null && hasSql && nameValid;
+	// `framed` is the load-bearing gate (DAT-592 follow-up): no business model →
+	// the import would die at grounding, so staging is blocked until one exists.
+	const canAdd = selectedSource !== null && hasSql && nameValid && framed;
 
 	const add = () => {
 		if (!selectedSource || !hasSql || !nameValid) return;
@@ -268,6 +282,18 @@ function ProbePanel({
 				no data is imported until you add a query to the import set.
 				⌘/Ctrl+Enter to run.
 			</Text>
+
+			{unframed && (
+				<Alert color="yellow" data-testid="probe-unframed">
+					No business model yet — the workspace vertical{" "}
+					<Text span ff="monospace" size="xs">
+						{frameStatus.data?.vertical}
+					</Text>{" "}
+					has no concepts, so an imported source has nothing to ground against.
+					Frame a vertical (or pick one) in the chat before importing — probing
+					here still works.
+				</Alert>
+			)}
 
 			<Select
 				data-testid="probe-source-select"
@@ -394,7 +420,7 @@ function ProbePanel({
 					<Group justify="flex-end">
 						<Button
 							size="xs"
-							disabled={importSet.length === 0}
+							disabled={importSet.length === 0 || !framed}
 							loading={pending}
 							onClick={() => {
 								onImport();

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
@@ -9,13 +9,15 @@
 // editor (out of CHIP_ONLY) for the user to edit and re-run. The run itself is a
 // direct fetch — no agent round-trip.
 //
-// Import set (DAT-592): "Add to import set" stages {import-as name, backend, sql};
-// "Import N sources" calls the `importSources` server fn — deterministic, no LLM
-// round-trip — which persists one source per query and starts ONE batched
-// addSourceWorkflow run. The run's progress renders INLINE here (the canvas is
-// message-derived, so a direct action can't project a canvas member), while the
-// background completion-watcher narrates completion into the chat (the run is
-// recorded against the conversationId we pass through).
+// Import set (DAT-592): "Add to import set" stages {import-as name, backend, sql}.
+// The set lives behind a COUNT SYMBOL in the panel header (always visible, never
+// pushed below the tall result grid); clicking it opens a centered MODAL listing
+// the staged queries with remove + "Import N sources". Import calls the
+// `importSources` server fn — deterministic, no LLM round-trip — which persists one
+// source per query and starts ONE batched addSourceWorkflow run. The run's progress
+// renders INLINE at the top here (the canvas is message-derived, so a direct action
+// can't project a canvas member), while the background completion-watcher narrates
+// completion into the chat (the run is recorded against the conversationId we pass).
 
 import {
 	ActionIcon,
@@ -24,15 +26,17 @@ import {
 	Button,
 	Code,
 	Group,
-	Paper,
+	Loader,
+	Modal,
 	Select,
 	Stack,
 	Text,
 	TextInput,
+	Tooltip,
 } from "@mantine/core";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
-import { X } from "lucide-react";
+import { Layers, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { getConfiguredDatabases } from "#/server/configured-databases";
 import { importSources } from "#/server/import-sources";
@@ -42,9 +46,12 @@ import { StreamingGrid } from "#/ui/cockpit/widgets/result-grid";
 import { SqlEditor } from "#/ui/cockpit/widgets/sql-editor";
 
 /** One staged query — becomes one single-statement `db_recipe` source on import.
- * A `type` (not `interface`) so it's assignable to the server fn's input shape. */
+ * A `type` (not `interface`) so it's assignable to the server fn's input shape.
+ * `credential_source` is the configured connection the query reads through (the
+ * probed source) — distinct from `source_name`, the new source's own name. */
 type ImportSpec = {
 	source_name: string;
+	credential_source: string;
 	backend: string;
 	sql: string;
 };
@@ -93,7 +100,7 @@ export function ProbeWidget({
 		mutationFn: (specs: ImportSpec[]) =>
 			importSources({ data: { sources: specs, conversationId } }),
 		// Clear the staged set on a successful start — the run is now live (its
-		// progress renders below); the set is free to build the next batch.
+		// progress renders at the top); the set is free to build the next batch.
 		onSuccess: () => setImportSet([]),
 	});
 
@@ -101,28 +108,20 @@ export function ProbeWidget({
 
 	return (
 		<Stack gap="md" data-testid="canvas-probe">
-			<ProbePanel
-				key={seedKey}
-				state={state}
-				stagedNames={importSet.map((s) => s.source_name)}
-				onAdd={addToSet}
-			/>
-
-			{importSet.length > 0 && (
-				<ImportSetPanel
-					set={importSet}
-					onRemove={removeFromSet}
-					onImport={() => importMutation.mutate(importSet)}
-					pending={importMutation.isPending}
-				/>
-			)}
-
+			{/* Run status sits at the TOP, always visible — never below the tall grid. */}
 			{importMutation.error && (
 				<Alert color="red" data-testid="probe-import-error">
 					{(importMutation.error as Error).message}
 				</Alert>
 			)}
-
+			{importMutation.isPending && !run && (
+				<Group gap="xs" data-testid="probe-import-starting">
+					<Loader size="sm" />
+					<Text size="sm" c="dimmed">
+						Starting import…
+					</Text>
+				</Group>
+			)}
 			{run && (
 				<Stack gap="xs" data-testid="probe-import-progress">
 					<Text size="sm" c="dimmed">
@@ -146,18 +145,34 @@ export function ProbeWidget({
 					/>
 				</Stack>
 			)}
+
+			<ProbePanel
+				key={seedKey}
+				state={state}
+				importSet={importSet}
+				onAdd={addToSet}
+				onRemove={removeFromSet}
+				onImport={() => importMutation.mutate(importSet)}
+				pending={importMutation.isPending}
+			/>
 		</Stack>
 	);
 }
 
 function ProbePanel({
 	state,
-	stagedNames,
+	importSet,
 	onAdd,
+	onRemove,
+	onImport,
+	pending,
 }: {
 	state: Extract<CanvasState, { kind: "probe" }>;
-	stagedNames: string[];
+	importSet: ImportSpec[];
 	onAdd: (spec: ImportSpec) => void;
+	onRemove: (name: string) => void;
+	onImport: () => void;
+	pending: boolean;
 }) {
 	const sources = useQuery({
 		queryKey: ["configured-databases"],
@@ -176,6 +191,9 @@ function ProbePanel({
 	// Bumped per Run so an identical re-run still remounts StreamingGrid (fresh
 	// stream + sort reset), not just a different query.
 	const [runId, setRunId] = useState(0);
+	// The import-set modal — pure view state, fine to reset on re-seed (the SET
+	// itself lives in ProbeWidget and survives).
+	const [setOpen, setSetOpen] = useState(false);
 
 	const selectedSource = useMemo(
 		() => list.find((s) => s.name === selected) ?? null,
@@ -198,13 +216,16 @@ function ProbePanel({
 	// Re-using a staged name UPDATES that query's SQL (addToSet replaces by name) —
 	// a valid edit, not a duplicate. So the gate ALLOWS it; only the button label
 	// flips to "Update" so the action is unambiguous.
-	const nameStaged = stagedNames.includes(importAs);
+	const nameStaged = importSet.some((s) => s.source_name === importAs);
 	const canAdd = selectedSource !== null && hasSql && nameValid;
 
 	const add = () => {
 		if (!selectedSource || !hasSql || !nameValid) return;
 		onAdd({
 			source_name: importAs,
+			// The picked source IS the connection the query reads through; the engine
+			// resolves credentials from it, so the new source can be named freely.
+			credential_source: selectedSource.name,
 			backend: selectedSource.backend,
 			sql: sqlText,
 		});
@@ -219,11 +240,28 @@ function ProbePanel({
 				<Text size="sm" fw={600}>
 					Probe a database source
 				</Text>
-				{selectedSource && (
-					<Badge variant="light" size="sm" tt="none">
-						{selectedSource.backend}
-					</Badge>
-				)}
+				<Group gap="xs" wrap="nowrap">
+					{selectedSource && (
+						<Badge variant="light" size="sm" tt="none">
+							{selectedSource.backend}
+						</Badge>
+					)}
+					{/* The import-set count symbol — always here in the header (not pushed
+					    below the result grid), opens the staged-queries modal. */}
+					{importSet.length > 0 && (
+						<Tooltip label="View import set">
+							<Button
+								size="compact-xs"
+								variant="light"
+								leftSection={<Layers size={14} />}
+								onClick={() => setSetOpen(true)}
+								data-testid="probe-import-indicator"
+							>
+								{importSet.length}
+							</Button>
+						</Tooltip>
+					)}
+				</Group>
 			</Group>
 			<Text size="xs" c="dimmed">
 				Read-only DuckDB SQL against a configured source (use LIMIT, not TOP) —
@@ -308,70 +346,68 @@ function ProbePanel({
 			{submitted && (
 				<StreamingGrid key={runId} endpoint="/api/probe-sql" body={submitted} />
 			)}
-		</Stack>
-	);
-}
 
-function ImportSetPanel({
-	set,
-	onRemove,
-	onImport,
-	pending,
-}: {
-	set: ImportSpec[];
-	onRemove: (name: string) => void;
-	onImport: () => void;
-	pending: boolean;
-}) {
-	return (
-		<Paper withBorder p="sm" radius="sm" data-testid="probe-import-set">
-			<Stack gap="xs">
-				<Text size="sm" fw={600}>
-					Import set ({set.length})
-				</Text>
-				<Text size="xs" c="dimmed">
-					Each query imports as its own source. They import together as one run.
-				</Text>
-				<Stack gap={4}>
-					{set.map((spec) => (
-						<Group key={spec.source_name} justify="space-between" wrap="nowrap">
-							<Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
-								<Badge variant="light" size="sm" tt="none">
-									{spec.source_name}
-								</Badge>
-								<Code
-									style={{
-										overflow: "hidden",
-										textOverflow: "ellipsis",
-										whiteSpace: "nowrap",
-									}}
+			<Modal
+				opened={setOpen}
+				onClose={() => setSetOpen(false)}
+				centered
+				size="lg"
+				title={`Import set (${importSet.length})`}
+			>
+				<Stack gap="sm">
+					<Text size="xs" c="dimmed">
+						Each query imports as its own source. They import together as one
+						run.
+					</Text>
+					{importSet.length === 0 ? (
+						<Text size="sm" c="dimmed">
+							No queries staged yet.
+						</Text>
+					) : (
+						<Stack gap="xs" data-testid="probe-import-set">
+							{importSet.map((spec) => (
+								<Group
+									key={spec.source_name}
+									justify="space-between"
+									wrap="nowrap"
+									align="flex-start"
 								>
-									{spec.sql}
-								</Code>
-							</Group>
-							<ActionIcon
-								variant="subtle"
-								color="gray"
-								size="sm"
-								aria-label={`Remove ${spec.source_name}`}
-								onClick={() => onRemove(spec.source_name)}
-							>
-								<X size={14} />
-							</ActionIcon>
-						</Group>
-					))}
+									<Stack gap={2} style={{ minWidth: 0, flex: 1 }}>
+										<Badge variant="light" size="sm" tt="none">
+											{spec.source_name}
+										</Badge>
+										<Code block>{spec.sql}</Code>
+									</Stack>
+									<ActionIcon
+										variant="subtle"
+										color="gray"
+										size="sm"
+										aria-label={`Remove ${spec.source_name}`}
+										onClick={() => onRemove(spec.source_name)}
+									>
+										<X size={14} />
+									</ActionIcon>
+								</Group>
+							))}
+						</Stack>
+					)}
+					<Group justify="flex-end">
+						<Button
+							size="xs"
+							disabled={importSet.length === 0}
+							loading={pending}
+							onClick={() => {
+								onImport();
+								setSetOpen(false);
+							}}
+							data-testid="probe-import-run"
+						>
+							Import {importSet.length} source
+							{importSet.length === 1 ? "" : "s"}
+						</Button>
+					</Group>
 				</Stack>
-				<Group>
-					<Button
-						size="xs"
-						onClick={onImport}
-						loading={pending}
-						data-testid="probe-import-run"
-					>
-						Import {set.length} source{set.length === 1 ? "" : "s"}
-					</Button>
-				</Group>
-			</Stack>
-		</Paper>
+			</Modal>
+		</Stack>
 	);
 }

--- a/packages/engine/src/dataraum/pipeline/phases/import_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/import_phase.py
@@ -411,12 +411,27 @@ class ImportPhase(BasePhase):
                 )
             queries.append(RecipeTable(name=q["name"], sql=q["sql"]))
 
+        # The CONNECTION a db_recipe source reads from is decoupled from the
+        # source's own NAME (DAT-592). A probed query imported as a new source
+        # (`wwi_recent_orders`) still reads through the configured connection it was
+        # probed against (`wwi`): `connection_config.credential_source` names that
+        # connection. Absent it, a source IS its own credential — the table-pick
+        # model, where the source name equals the `DATARAUM_{NAME}_URL` key. Only
+        # the CREDENTIAL lookup uses this; the raw-table prefix below stays the
+        # source's own name, so two query-sources off one DB never collide.
+        cred_ref = connection_config.get("credential_source")
+        credential_source = cred_ref if isinstance(cred_ref, str) and cred_ref else source_name
         chain = CredentialChain()
-        credential = chain.resolve(source_name)
+        credential = chain.resolve(credential_source)
         if credential is None:
+            named = (
+                f"'{source_name}'"
+                if credential_source == source_name
+                else f"'{source_name}' (connection '{credential_source}')"
+            )
             return PhaseResult.failed(
-                f"No credentials found for database source '{source_name}'. "
-                f"Set DATARAUM_{source_name.upper()}_URL in the environment "
+                f"No credentials found for database source {named}. "
+                f"Set DATARAUM_{credential_source.upper()}_URL in the environment "
                 "(via .env or the docker-compose environment)."
             )
 

--- a/packages/engine/tests/unit/pipeline/test_import_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_import_phase.py
@@ -110,6 +110,44 @@ class TestImportDispatch:
         assert result.status == PhaseStatus.FAILED
         assert "backend" in (result.error or "").lower()
 
+    def test_db_recipe_resolves_credentials_by_credential_source(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A db_recipe source reads through ``credential_source``, NOT its own name
+        (DAT-592): a probed query imported as ``wwi_recent_orders`` resolves the
+        ``wwi`` connection's ``DATARAUM_WWI_URL`` — never
+        ``DATARAUM_WWI_RECENT_ORDERS_URL``. Both env keys are unset here, so the
+        lookup fails; the message must name the CONNECTION's key, proving
+        ``credential_source`` (not the source name) is the resolution key."""
+        monkeypatch.delenv("DATARAUM_WWI_URL", raising=False)
+        monkeypatch.delenv("DATARAUM_WWI_RECENT_ORDERS_URL", raising=False)
+        phase = ImportPhase()
+        session = MagicMock()
+        session.get.return_value = MagicMock()  # Source row present
+        # No existing raw tables for this source (the re-import guard reads []).
+        session.execute.return_value.scalars.return_value.all.return_value = []
+        ctx = PhaseContext(
+            session=session,
+            duckdb_conn=MagicMock(),
+            config={
+                "source_id": "test-source",
+                "source_name": "wwi_recent_orders",
+                "source_type": "db_recipe",
+                "source_connection_config": {
+                    "tables": [{"name": "t", "sql": "SELECT 1"}],
+                    "recipe_hash": "abc",
+                    "credential_source": "wwi",
+                },
+                "source_backend": "mssql",
+            },
+        )
+        result = phase._run(ctx)
+        assert result.status == PhaseStatus.FAILED
+        err = result.error or ""
+        assert "DATARAUM_WWI_URL" in err
+        assert "DATARAUM_WWI_RECENT_ORDERS_URL" not in err
+        assert "connection 'wwi'" in err
+
 
 class TestSuffixDispatch:
     """File-source loader selection is driven by the URI suffix alone (DAT-389).

--- a/packages/infra/docker-compose.sources.yml
+++ b/packages/infra/docker-compose.sources.yml
@@ -25,13 +25,21 @@
 # connection string needs `TrustServerCertificate=true`.
 
 services:
-  # Wire the sample source into the cockpit CONTAINER's env so its probe surface
-  # offers it (host dev reads the cockpit .env instead; the core compose stays
-  # backend-neutral, so this lives in the opt-in overlay). The in-container cockpit
-  # reaches MS SQL by SERVICE NAME — `@mssql:1433`, not `@localhost` (DAT-576 smoke:
-  # the URL must be a `scheme://` form so the backend is inferred and the source is
-  # offered). Merges into the base cockpit service's `environment` across -f files.
+  # Wire the sample source's credential into BOTH services that touch it (host dev
+  # reads the cockpit .env instead; the core compose stays backend-neutral, so this
+  # lives in the opt-in overlay). Both reach MS SQL by SERVICE NAME — `@mssql:1433`,
+  # not `@localhost` (DAT-576 smoke: the URL must be a `scheme://` form so the
+  # backend is inferred). `DATARAUM_WWI_URL` IS the credential the engine resolves
+  # by connection name (DAT-592 `credential_source`); merges into each base
+  # service's `environment` across -f files.
+  #
+  #   - cockpit:       PROBES the source (READ_ONLY ATTACH) + offers it in the picker.
+  #   - engine-worker: IMPORTS it — resolves the credential + ATTACHes during the
+  #                    add_source run. Needs the SAME var or the import fails loud.
   cockpit:
+    environment:
+      DATARAUM_WWI_URL: mssql://sa:${MSSQL_SA_PASSWORD:-Dataraum!Dev1}@mssql:1433/WideWorldImporters?TrustServerCertificate=true
+  engine-worker:
     environment:
       DATARAUM_WWI_URL: mssql://sa:${MSSQL_SA_PASSWORD:-Dataraum!Dev1}@mssql:1433/WideWorldImporters?TrustServerCertificate=true
 

--- a/packages/infra/docker-compose.sources.yml
+++ b/packages/infra/docker-compose.sources.yml
@@ -25,6 +25,16 @@
 # connection string needs `TrustServerCertificate=true`.
 
 services:
+  # Wire the sample source into the cockpit CONTAINER's env so its probe surface
+  # offers it (host dev reads the cockpit .env instead; the core compose stays
+  # backend-neutral, so this lives in the opt-in overlay). The in-container cockpit
+  # reaches MS SQL by SERVICE NAME — `@mssql:1433`, not `@localhost` (DAT-576 smoke:
+  # the URL must be a `scheme://` form so the backend is inferred and the source is
+  # offered). Merges into the base cockpit service's `environment` across -f files.
+  cockpit:
+    environment:
+      DATARAUM_WWI_URL: mssql://sa:${MSSQL_SA_PASSWORD:-Dataraum!Dev1}@mssql:1433/WideWorldImporters?TrustServerCertificate=true
+
   # SQL Server 2025 — a sample MS SQL source. Profile-gated so a default `up` (even
   # with this file merged) never starts it.
   mssql:


### PR DESCRIPTION
**Epic:** DAT-574 · follow-up to merged **DAT-592** (import a probed query as a source). A live smoke of DAT-592 found the feature didn't actually import — this PR makes it work end-to-end and gates it correctly. Driven entirely by smoke findings.

## What the smoke found, and the fixes

### 1. Imports failed — credentials were keyed to the source's own name
The engine resolved a `db_recipe` source's DB credentials by the source's **own** name (`DATARAUM_{SOURCE_NAME}_URL`), so a probed query imported as a new name (`wwi_recent_orders`) looked for `DATARAUM_WWI_RECENT_ORDERS_URL` instead of the probed connection's `DATARAUM_WWI_URL`. One DB → N named sources was impossible.

**Fix — decouple a source's identity from its connection:**
- **Engine** `import_phase` resolves credentials from `connection_config.credential_source` (the configured connection / probed source), falling back to `source_name` (the table-pick model: a source that IS its own credential). The raw-table prefix still uses the source's own name, so two query-sources off one DB never collide. **The secret URL is never stored — only the connection NAME reference.** + unit test.
- **Cockpit** carries/stamps `credential_source` (the picked probe source) through `ImportSpec → importSources → persistRecipeSources`, folded into `recipeContentHash` (re-pointing the connection is correctly a new recipe; the table-pick hash stays byte-identical).
- No Temporal/contract change — additive `connection_config` key.

### 2. The import-set let you fire a doomed import (no frame)
Importing grounds against the workspace vertical's concepts and fails loud at `semantic_per_column` if there are none — and the deterministic import button bypassed the agent's frame step.

**Fix — gate the import set on a framed workspace:**
- `server/active-vertical.ts` (`getActiveVerticalStatus`) reuses `verticalConceptCount` — the **same** count the engine's grounding guard checks, so the UI gate and the engine fail-loud agree.
- `probe.tsx` disables **Add to import set** (and the modal Import) until framed, with a banner pointing to framing. **Probing (Run) stays open** — read-only exploration is how you decide the frame.

### 3. Import-set UX (your design)
Staged queries live behind a **count symbol** in the panel header opening a **centered modal** (name badge + SQL + remove + Import N), so staging is never pushed below the tall result grid.

### 4. Infra
`docker-compose.sources.yml` wires `DATARAUM_WWI_URL` (`@mssql:1433`) into **both** the cockpit (probes) and engine-worker (imports) containers — the probe picker was empty / the import couldn't ATTACH otherwise.

## Smoke-validated end-to-end
- `credential_source`: `import → typing → statistics → …` all **completed** against real MS SQL (WideWorldImporters).
- Frame gate: banner + Add disabled while `_adhoc` unframed; Run still enabled.
- Count-symbol + modal; container picker populated.

## Out of scope (filed as follow-ups, deliberately absent here)
- Actually **framing** a vertical from the probe (frame-per-selected-source).
- Progress-widget **staleness** when firing repeated imports (`run_id == workflow_id` reuse — pre-existing).
- Re-import-with-replace (engine guard: re-import under a new name).

## Tests / review
- Engine 22 + cockpit 1267 unit green; tsc + biome + ruff clean.
- senior-code-reviewer: **APPROVE** · spec-compliance-reviewer findings (engine-worker compose block; hash test; `add()` guard) **addressed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)