### PR TITLE
DAT-517: expose the rebind teach type in the cockpit

### DIFF
--- a/packages/cockpit/src/tools/teach-routing.test.ts
+++ b/packages/cockpit/src/tools/teach-routing.test.ts
@@ -3,13 +3,14 @@ import { TEACH_TYPES } from "#/tools/teach.validation";
 import { affectedStage } from "#/tools/teach-routing";
 
 describe("affectedStage (DAT-531 teach → stage map)", () => {
-	it("routes grounding teaches (incl. concept_property) to add_source", () => {
+	it("routes grounding teaches (incl. concept_property + rebind) to add_source", () => {
 		for (const t of [
 			"type_pattern",
 			"null_value",
 			"unit",
 			"concept",
 			"concept_property",
+			"rebind",
 		]) {
 			expect(affectedStage(t)).toBe("add_source");
 		}

--- a/packages/cockpit/src/tools/teach-routing.ts
+++ b/packages/cockpit/src/tools/teach-routing.ts
@@ -26,6 +26,9 @@ const TEACH_STAGE: Record<TeachType, RunStage> = {
 	// A concept-property patch re-grounds the semantic binding too (add_source);
 	// operating_model going stale off a concept change derives downstream.
 	concept_property: "add_source",
+	// A rebind appends the column to the target concept's indicators → it only
+	// takes effect through the next run's grounding prompt (add_source).
+	rebind: "add_source",
 	// Relationships + dimension hierarchies are begin_session products
 	// (`run_relationships` / `run_dimension_hierarchies`).
 	relationship: "begin_session",

--- a/packages/cockpit/src/tools/teach.test.ts
+++ b/packages/cockpit/src/tools/teach.test.ts
@@ -265,6 +265,54 @@ describe("validateTeach", () => {
 		});
 	});
 
+	describe("rebind", () => {
+		it("accepts {vertical, concept, column} (DAT-517 column re-grounding)", () => {
+			// Engine consumer: _apply_rebind keys on {column, concept} and appends
+			// the column to the target concept's indicators (last rebind per column wins).
+			const out = validateTeach({
+				type: "rebind",
+				payload: {
+					vertical: "finance",
+					concept: "revenue",
+					column: "net_sales",
+				},
+			});
+			expect(out.concept).toBe("revenue");
+			expect(out.column).toBe("net_sales");
+		});
+
+		it("accepts an optional advisory table", () => {
+			const out = validateTeach({
+				type: "rebind",
+				payload: {
+					vertical: "finance",
+					concept: "revenue",
+					column: "net_sales",
+					table: "income_statement",
+				},
+			});
+			expect(out.table).toBe("income_statement");
+		});
+
+		it("rejects a missing column", () => {
+			expect(() =>
+				validateTeach({
+					type: "rebind",
+					payload: { vertical: "finance", concept: "revenue" },
+				}),
+			).toThrow(TeachValidationError);
+		});
+
+		it("rejects a missing concept", () => {
+			expect(() =>
+				validateTeach({
+					type: "rebind",
+					payload: { vertical: "finance", column: "net_sales" },
+				}),
+			).toThrow(TeachValidationError);
+		});
+	});
+
 	describe("relationship", () => {
 		it("accepts {action, from_column_id, to_column_id} (DAT-409 directional pair)", () => {
 			// Engine consumer: load_suppressed_relationship_pairs +
@@ -377,6 +425,7 @@ describe("validateTeach", () => {
 					"null_value",
 					"unit",
 					"concept_property",
+					"rebind",
 					"relationship",
 					"hierarchy",
 					"concept",
@@ -398,6 +447,7 @@ describe("validateTeach", () => {
 					"unit",
 					"concept",
 					"concept_property",
+					"rebind",
 					"relationship",
 					"hierarchy",
 				]),
@@ -422,6 +472,7 @@ describe("validateTeach", () => {
 			for (const t of [
 				"concept",
 				"concept_property",
+				"rebind",
 				"relationship",
 				"hierarchy",
 			]) {

--- a/packages/cockpit/src/tools/teach.test.ts
+++ b/packages/cockpit/src/tools/teach.test.ts
@@ -311,6 +311,15 @@ describe("validateTeach", () => {
 				}),
 			).toThrow(TeachValidationError);
 		});
+
+		it("rejects a missing vertical", () => {
+			expect(() =>
+				validateTeach({
+					type: "rebind",
+					payload: { concept: "revenue", column: "net_sales" },
+				}),
+			).toThrow(TeachValidationError);
+		});
 	});
 
 	describe("relationship", () => {

--- a/packages/cockpit/src/tools/teach.validation.ts
+++ b/packages/cockpit/src/tools/teach.validation.ts
@@ -133,9 +133,9 @@ const ConceptPropertyPayload = z
 // concept_property fixes a concept's attribute for ALL its columns; rebind moves
 // ONE column to the right concept. It's the lever for the `temporal_behavior`
 // detector's ignorance branch (it emits a `rebind` suggestion when a column is
-// bound to the wrong concept). The applier keys on {column, concept} (last rebind
-// per column wins); `vertical` scopes the row to the loading vertical; `table` is
-// advisory context only (the merge key is the column name).
+// bound to the wrong concept). The merge key is the column NAME: last rebind per
+// column wins, so a re-taught column lands only on its newest target concept.
+// `vertical` scopes the row to the loading vertical; `table` is advisory only.
 const RebindPayload = z
 	.object({
 		vertical: z

--- a/packages/cockpit/src/tools/teach.validation.ts
+++ b/packages/cockpit/src/tools/teach.validation.ts
@@ -126,6 +126,41 @@ const ConceptPropertyPayload = z
 	})
 	.passthrough();
 
+// `rebind` re-grounds a single COLUMN onto a different concept (DAT-517): the
+// engine (_apply_rebind, core/overlay.py) appends the column NAME to the target
+// concept's `indicators`, so the next run's grounding prompt re-grounds it. It's
+// the column-grain sibling of concept_property (which patches the concept itself):
+// concept_property fixes a concept's attribute for ALL its columns; rebind moves
+// ONE column to the right concept. It's the lever for the `temporal_behavior`
+// detector's ignorance branch (it emits a `rebind` suggestion when a column is
+// bound to the wrong concept). The applier keys on {column, concept} (last rebind
+// per column wins); `vertical` scopes the row to the loading vertical; `table` is
+// advisory context only (the merge key is the column name).
+const RebindPayload = z
+	.object({
+		vertical: z
+			.string()
+			.min(1)
+			.describe(
+				"The vertical the target concept lives in, e.g. 'finance' or '_adhoc'.",
+			),
+		concept: z
+			.string()
+			.min(1)
+			.describe("The concept to re-ground the column onto, e.g. 'revenue'."),
+		column: z
+			.string()
+			.min(1)
+			.describe("The column NAME to re-ground (not a column id)."),
+		table: z
+			.string()
+			.optional()
+			.describe(
+				"Advisory context — the table the column lives in (not used as a key).",
+			),
+	})
+	.passthrough();
+
 // Mirrors OntologyConcept (packages/engine/.../analysis/semantic/ontology.py).
 // Used both by user teach AND by the engine's cold-start _adhoc induction
 // (DAT-371), which inserts one `concept` row per induced concept instead of
@@ -273,6 +308,7 @@ const TYPE_SCHEMAS = {
 	unit: UnitPayload,
 	concept: ConceptPayload,
 	concept_property: ConceptPropertyPayload,
+	rebind: RebindPayload,
 	relationship: RelationshipPayload,
 	hierarchy: HierarchyPayload,
 	// validation/cycle/metric are NOT advertised to the agent (see
@@ -302,6 +338,7 @@ export const AGENT_TEACH_TYPES = [
 	"unit",
 	"concept",
 	"concept_property",
+	"rebind",
 	"relationship",
 	"hierarchy",
 ] as const satisfies readonly TeachType[];
@@ -342,6 +379,7 @@ export const TeachPayloadSchema = z
 		UnitPayload,
 		ConceptPayload,
 		ConceptPropertyPayload,
+		RebindPayload,
 		RelationshipPayload,
 		HierarchyPayload,
 	])
@@ -352,6 +390,8 @@ export const TeachPayloadSchema = z
 			"unit: {table, column, unit} (column identified by NAME); " +
 			"concept: {vertical, name, indicators?, …}; " +
 			"concept_property: {vertical, concept, property, value}; " +
+			"rebind: {vertical, concept, column, table?} (re-ground ONE column onto a " +
+			"different concept, by column NAME); " +
 			"relationship: {action: confirm|reject|add, from_column_id, to_column_id} " +
 			"(keep is engine-internal, not a user action); " +
 			"hierarchy: {action: add|reject|alias, table_id, members}.",


### PR DESCRIPTION
## What

Exposes the **`rebind`** teach type in the cockpit — the last gap from DAT-517.

`rebind` re-grounds a single column onto a different concept: the engine's `_apply_rebind` applier (`core/overlay.py`) appends the column name to the target concept's `indicators`, and the `temporal_behavior` detector already emits a `rebind` teach suggestion when a column is bound to the wrong concept — but there was no product path to act on it.

It's the column-grain sibling of `concept_property`: `concept_property` patches a concept's attribute (affects all its columns); `rebind` moves **one** column to the right concept.

## Changes (cockpit only)

- `RebindPayload` + `TYPE_SCHEMAS` entry, mirroring the engine payload `{vertical, concept, column, table?}`
- Added to `AGENT_TEACH_TYPES` + `TeachPayloadSchema` union (agent-advertised, judgement-family). Deliberately **excluded** from `AGENT_AUTOAPPLY_TEACH_TYPES` — re-grounding is judgement, not mechanical.
- `TEACH_STAGE`: `rebind → add_source` (takes effect via the next run's grounding prompt)
- Validation + routing tests

## DAT-517 closeout

- `unit` — already landed (since the 2026-06-15 audit)
- `rebind` — **this PR**
- `expected_dependency` — superseded by **DAT-585** (directed `column_dependency` teach), not needed here

## Tests

`bun run test src/tools/` → 411 pass · `tsc --noEmit` clean · `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)