### PR TITLE
DAT-594: frame from the staging set — unified Connect surface (files + SQL)

### DIFF
--- a/packages/cockpit/src/duckdb/connect.ts
+++ b/packages/cockpit/src/duckdb/connect.ts
@@ -380,6 +380,14 @@ async function connectDatabase(
 	};
 }
 
+/**
+ * Sniff a single `s3://` file's schema (DESCRIBE + a bounded sample) into one
+ * `ConnectSchema`. Exported so the probe staging hub (DAT-594) can assemble a
+ * file's schema for `frame` directly — the same sniff the `connect` tool's file
+ * branch uses, with the same `s3://<bucket>/<key>` security gate.
+ */
+export { connectFile as sniffFileSchema };
+
 async function connectFile(path: string): Promise<ConnectSchema> {
 	// Defense in depth (the tool's zod superRefine already gated this pre-SQL):
 	// re-validate the single allowed shape `s3://<bucket>/<key>` BEFORE any SQL

--- a/packages/cockpit/src/duckdb/probe.ts
+++ b/packages/cockpit/src/duckdb/probe.ts
@@ -163,6 +163,57 @@ export async function openProbeConnection(input: {
 	return { conn, dispose, redact };
 }
 
+/** A probed query's schema — its DESCRIBEd columns + a bounded sample of rows,
+ * the input to building a synthetic `ConnectSchema` for `frame` (DAT-594). */
+export interface ProbeSchema {
+	/** One row per output column: name + DuckDB column type. */
+	columns: { name: string; type: string }[];
+	/** A bounded sample of result rows (≤ `clampRowLimit`) for sample-value
+	 * induction quality — JSON-safe, the connection URL never included. */
+	sampleRows: Record<string, unknown>[];
+}
+
+/**
+ * Describe a probed query WITHOUT materializing the full result — run
+ * `DESCRIBE SELECT * FROM (<sql>)` (unwrapped, so DESCRIBE can introspect the
+ * query) plus a bounded sample, on the raw probe connection. This is the
+ * query analog of the file path's `DESCRIBE SELECT * FROM read_*(...)` sniff
+ * (connect.ts), the schema source for staging a probed query into `frame`
+ * (DAT-594). `probe()` wraps SQL in a `LIMIT` subquery so it cannot DESCRIBE,
+ * so this opens its own connection and runs DESCRIBE directly.
+ *
+ * Columns + rows only; the credential-bearing URL is redacted from any error.
+ */
+export async function probeDescribe(input: ProbeInput): Promise<ProbeSchema> {
+	const { conn, dispose, redact } = await openProbeConnection(input);
+	const limit = clampRowLimit(input.limit);
+	try {
+		// DESCRIBE the UNWRAPPED query — DuckDB returns one row per output column
+		// (column_name, column_type, null, …). Unlike probe(), no LIMIT subquery:
+		// DESCRIBE needs the bare SELECT to introspect its projection.
+		const describe = readerToResult(
+			await conn.runAndReadAll(`DESCRIBE SELECT * FROM (${input.sql})`),
+		);
+		const columns = (
+			describe.rows as { column_name: string; column_type: string }[]
+		).map((r) => ({ name: r.column_name, type: r.column_type }));
+		// A bounded sample feeds sample-value induction (the file sniff samples too).
+		const sample = readerToResult(
+			await conn.runAndReadAll(
+				`SELECT * FROM (${input.sql}) AS _probe LIMIT ${limit}`,
+			),
+		);
+		return { columns, sampleRows: sample.rows };
+	} catch (err) {
+		const raw = err instanceof Error ? err.message : String(err);
+		throw new Error(
+			`Describe of source '${input.source_name}' (${input.backend.toLowerCase()}) failed: ${redact(raw)}`,
+		);
+	} finally {
+		dispose();
+	}
+}
+
 /**
  * Run read-only SQL against an external database source and MATERIALIZE a bounded
  * sample — the AGENT path (the LLM must never get an unbounded result dumped into

--- a/packages/cockpit/src/select/file-source.test.ts
+++ b/packages/cockpit/src/select/file-source.test.ts
@@ -1,0 +1,94 @@
+// Unit tests for persistFileSources (DAT-594) — the import-set producer that
+// writes ONE content-keyed `src_<digest>` source per staged upload.
+//
+// The write seam (`#/select/source-write`: upsertSource) is mocked so the row
+// SHAPE + the content-keying are asserted without a live Postgres. The mock is on
+// the `#/` alias so it intercepts file-source's relative `./source-write` import
+// (same resolved module — the cockpit vitest mock-alias rule).
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// file-source pulls `sourceTypeForUri` from `#/select/mappers` (→ upload/policy),
+// which is crypto-bearing but config-free; no config stub needed. The content
+// digest lives in the upload URI shape, so no env is required.
+
+const h = vi.hoisted(() => ({
+	upserts: [] as Array<{
+		name: string;
+		sourceType: string;
+		backend: string | null;
+		connectionConfig: Record<string, unknown>;
+	}>,
+}));
+
+vi.mock("#/select/source-write", () => ({
+	STAGE_AFTER_SELECT: "add_source",
+	INITIAL_STATUS: "configured",
+	upsertSource: vi.fn(
+		async (v: {
+			name: string;
+			sourceType: string;
+			backend: string | null;
+			connectionConfig: Record<string, unknown>;
+		}) => {
+			h.upserts.push(v);
+			return `id_${v.name}`;
+		},
+	),
+}));
+
+import { persistFileSources } from "./file-source";
+
+// A staged upload URI is `s3://<bucket>/<ws>/uploads/<digest>/<file>` (DAT-505) —
+// the digest segment is what file-source content-keys the source on.
+const WS = "00000000-0000-0000-0000-000000000001";
+const A = `s3://dataraum-lake/${WS}/uploads/aaa111/orders.csv`;
+const B = `s3://dataraum-lake/${WS}/uploads/bbb222/customers.parquet`;
+
+beforeEach(() => {
+	h.upserts.length = 0;
+});
+
+describe("persistFileSources (DAT-594) — one content-keyed source per file", () => {
+	it("mints ONE content-keyed source per uploaded file", async () => {
+		const result = await persistFileSources([{ file_uri: A }, { file_uri: B }]);
+
+		expect(h.upserts).toHaveLength(2);
+		const byName = Object.fromEntries(
+			h.upserts.map((r) => [r.name, r]),
+		) as Record<string, (typeof h.upserts)[number]>;
+		expect(Object.keys(byName).sort()).toEqual(["src_aaa111", "src_bbb222"]);
+		expect(byName.src_aaa111.connectionConfig).toEqual({ file_uris: [A] });
+		expect(byName.src_aaa111.sourceType).toBe("csv");
+		expect(byName.src_bbb222.sourceType).toBe("parquet");
+		// file_uris and tables never cross-contaminate.
+		expect(byName.src_aaa111.connectionConfig).not.toHaveProperty("tables");
+
+		expect(result.map((p) => p.source_id).sort()).toEqual([
+			"id_src_aaa111",
+			"id_src_bbb222",
+		]);
+	});
+
+	it("dedups a repeated URI to ONE UPSERT (same content key)", async () => {
+		const result = await persistFileSources([{ file_uri: A }, { file_uri: A }]);
+		expect(h.upserts).toHaveLength(1);
+		expect(result).toHaveLength(1);
+		expect(result[0].file_uri).toBe(A);
+	});
+
+	it("fails loud on a non-upload URI BEFORE persisting (not content-addressed)", async () => {
+		await expect(
+			persistFileSources([
+				{ file_uri: "s3://dataraum-lake/data/2024/sales.csv" },
+			]),
+		).rejects.toThrow(/must be a staged upload/);
+		expect(h.upserts).toHaveLength(0);
+	});
+
+	it("persists nothing for an empty list", async () => {
+		const result = await persistFileSources([]);
+		expect(result).toEqual([]);
+		expect(h.upserts).toHaveLength(0);
+	});
+});

--- a/packages/cockpit/src/select/file-source.ts
+++ b/packages/cockpit/src/select/file-source.ts
@@ -1,0 +1,80 @@
+// Persist staged file uploads as content-keyed sources (DAT-594) — one
+// content-keyed `src_<digest>` source PER uploaded file, the file analog of
+// `recipe-source.ts`'s one-query = one-source path.
+//
+// This is the file-source persistence extracted OUT of the agent `select` tool
+// (tools/select.ts) so BOTH the agent and the probe surface's staging hub
+// (server/import-sources.ts) write file sources the same way. The model is locked
+// (DAT-422): one file = one content-keyed source, keyed by its upload digest, so
+// identical bytes (same digest) UPSERT one row and two distinct files never
+// collide on a raw table even with matching basenames.
+//
+// NO trigger here: persistence + validation only, mirroring `persistRecipeSources`.
+// `server/import-sources.ts` composes this with `persistRecipeSources` and ONE
+// `triggerAddSource` over the union so a heterogeneous import set (files + queries)
+// imports as one coherent run.
+
+import { contentKeyedSourceName, sourceTypeForUri } from "./mappers";
+import { upsertSource } from "./source-write";
+
+/** One staged upload the user chose to import — its `s3://` URI. */
+export interface FileSourceSpec {
+	/** The staged `s3://<bucket>/<ws>/uploads/<digest>/<filename>` upload URI. */
+	file_uri: string;
+}
+
+/** One persisted file source: its id + the content-keyed name + URI it landed as. */
+export interface PersistedFileSource {
+	source_id: string;
+	source_name: string;
+	source_type: string;
+	file_uri: string;
+}
+
+/**
+ * UPSERT one content-keyed `src_<digest>` source per staged upload URI and return
+ * their ids + names. Persistence ONLY — the caller triggers the batched import.
+ *
+ * Dedup by content key so a repeated URI UPSERTs once; `contentKeyedSourceName`
+ * fails loud on a non-upload URI (content identity requires the upload digest), so
+ * a bad batch fails before any write. The write loop is NOT a single transaction
+ * (matching the sibling recipe loop): a transient mid-loop failure leaves the
+ * earlier sources upserted while the trigger never fires — recoverable, not
+ * corrupting (every upsert is idempotent on the content-keyed name).
+ */
+export async function persistFileSources(
+	specs: FileSourceSpec[],
+): Promise<PersistedFileSource[]> {
+	const now = new Date();
+	// Dedup by content key — a repeated URI (same digest → same name) UPSERTs once.
+	// `contentKeyedSourceName` fails loud on a non-upload URI BEFORE any write.
+	const byName = new Map<string, { uri: string; sourceType: string }>();
+	for (const spec of specs) {
+		const name = contentKeyedSourceName(spec.file_uri);
+		if (!byName.has(name)) {
+			byName.set(name, {
+				uri: spec.file_uri,
+				sourceType: sourceTypeForUri(spec.file_uri),
+			});
+		}
+	}
+
+	const persisted: PersistedFileSource[] = [];
+	for (const [name, { uri, sourceType }] of byName) {
+		const sourceId = await upsertSource({
+			name,
+			sourceType,
+			backend: null,
+			// DISTINCT key from the db_recipe `tables` key — never folded together.
+			connectionConfig: { file_uris: [uri] },
+			now,
+		});
+		persisted.push({
+			source_id: sourceId,
+			source_name: name,
+			source_type: sourceType,
+			file_uri: uri,
+		});
+	}
+	return persisted;
+}

--- a/packages/cockpit/src/select/stage-schema.test.ts
+++ b/packages/cockpit/src/select/stage-schema.test.ts
@@ -1,0 +1,116 @@
+// Unit tests for the synthetic-ConnectSchema assembly (DAT-594) — the pure
+// builder that unions a heterogeneous staging set (probed queries + sniffed files)
+// into ONE ConnectSchema for `frame` to induce from. No driver: the per-item
+// schemas are handed in.
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { ConnectSchema } from "../duckdb/connect";
+import type { ProbeSchema } from "../duckdb/probe";
+
+// stage-schema pulls `collectSampleValues` from `#/duckdb/connect`, whose module
+// graph imports config at load — stub it so the pure-assembly unit test needs no
+// real env (the cockpit config-free-test idiom; the server fn wires the real one).
+vi.mock("#/config", () => ({ config: { s3Bucket: "dataraum-lake" } }));
+
+import { assembleStagingSchema, queryToConnectTable } from "./stage-schema";
+
+const ordersSchema: ProbeSchema = {
+	columns: [
+		{ name: "order_id", type: "BIGINT" },
+		{ name: "status", type: "VARCHAR" },
+	],
+	sampleRows: [
+		{ order_id: 1, status: "open" },
+		{ order_id: 2, status: "open" },
+		{ order_id: 3, status: "shipped" },
+	],
+};
+
+const customersFile: ConnectSchema = {
+	sourceKind: "file",
+	source: "s3://dataraum-lake/ws/uploads/aaa/customers.csv",
+	tables: [
+		{
+			name: "customers.csv",
+			rowCountEstimate: 2,
+			columns: [
+				{
+					name: "customer_id",
+					position: 1,
+					sourceType: "BIGINT",
+					nullable: false,
+					sampleValues: [10, 11],
+				},
+			],
+		},
+	],
+};
+
+describe("queryToConnectTable (DAT-594)", () => {
+	it("maps a probed query's DESCRIBE + sample to one named ConnectTable", () => {
+		const table = queryToConnectTable({
+			source_name: "wwi_orders",
+			schema: ordersSchema,
+		});
+		expect(table.name).toBe("wwi_orders");
+		expect(table.rowCountEstimate).toBeNull();
+		expect(table.columns.map((c) => c.name)).toEqual(["order_id", "status"]);
+		expect(table.columns[0]).toMatchObject({
+			position: 1,
+			sourceType: "BIGINT",
+			nullable: true,
+		});
+		// Sample values are derived from the sample rows (distinct, capped).
+		expect(table.columns[1].sampleValues).toEqual(["open", "shipped"]);
+	});
+});
+
+describe("assembleStagingSchema (DAT-594)", () => {
+	it("unions a query + a file into one schema (one table per staged item)", () => {
+		const schema = assembleStagingSchema({
+			queries: [{ source_name: "wwi_orders", schema: ordersSchema }],
+			files: [customersFile],
+		});
+		// Queries first, then files (matching the import-set union order).
+		expect(schema.tables.map((t) => t.name)).toEqual([
+			"wwi_orders",
+			"customers.csv",
+		]);
+		// A mixed set with a query reads as a database-kind schema.
+		expect(schema.sourceKind).toBe("database");
+		expect(schema.source).toContain("2 items");
+	});
+
+	it("reads as file-kind when the set is files only", () => {
+		const schema = assembleStagingSchema({
+			queries: [],
+			files: [customersFile],
+		});
+		expect(schema.sourceKind).toBe("file");
+		expect(schema.tables).toHaveLength(1);
+		expect(schema.source).toContain("1 item");
+	});
+
+	it("flattens multi-table file sniffs into the union", () => {
+		const twoTableFile: ConnectSchema = {
+			sourceKind: "file",
+			source: "x",
+			tables: [
+				{ name: "a", rowCountEstimate: null, columns: [] },
+				{ name: "b", rowCountEstimate: null, columns: [] },
+			],
+		};
+		const schema = assembleStagingSchema({
+			queries: [{ source_name: "q", schema: ordersSchema }],
+			files: [twoTableFile],
+		});
+		expect(schema.tables.map((t) => t.name)).toEqual(["q", "a", "b"]);
+	});
+
+	it("throws on an empty staging set (nothing to frame)", () => {
+		expect(() => assembleStagingSchema({ queries: [], files: [] })).toThrow(
+			/empty staging set/,
+		);
+	});
+});

--- a/packages/cockpit/src/select/stage-schema.ts
+++ b/packages/cockpit/src/select/stage-schema.ts
@@ -1,0 +1,81 @@
+// Synthetic ConnectSchema assembly for the probe staging hub (DAT-594).
+//
+// `frame` induces a business model from a `ConnectSchema` (DAT-381) — but the
+// staging hub assembles a HETEROGENEOUS set (probed SQL queries + uploaded files)
+// before there is any single connected source. So we synthesize ONE ConnectSchema
+// from the UNION of the staged items' schemas: one `tables[]` entry per staged item
+// (a query's DESCRIBE → columns+samples; a file's sniff → its ConnectSchema table),
+// and `frame` accepts it like any other (no tie to the `connect` tool).
+//
+// PURE assembly: no driver, no I/O — the per-item schemas are sniffed elsewhere
+// (`duckdb/probe.probeDescribe` for queries, `duckdb/connect.sniffFileSchema` for
+// files) and handed in. Unit-testable without a live source.
+
+import {
+	type ConnectColumnInfo,
+	type ConnectSchema,
+	type ConnectTableInfo,
+	collectSampleValues,
+} from "../duckdb/connect";
+import type { ProbeSchema } from "../duckdb/probe";
+
+/** One staged query's sniffed schema + the source name it will import as — the
+ * `frame` table is keyed by that name so the induced concepts anchor to it. */
+export interface StagedQuerySchema {
+	source_name: string;
+	schema: ProbeSchema;
+}
+
+/** Turn a probed query's DESCRIBE + sample into one `ConnectTableInfo` (named by
+ * the source it imports as), deriving per-column sample values from the sample
+ * rows exactly as the file/db sniff does (collectSampleValues). */
+export function queryToConnectTable(item: StagedQuerySchema): ConnectTableInfo {
+	const columns: ConnectColumnInfo[] = item.schema.columns.map((c, i) => ({
+		name: c.name,
+		position: i + 1,
+		sourceType: c.type,
+		// A probed query's projection nullability isn't reliably known from DESCRIBE
+		// (it reports the expression type, not a NOT NULL constraint), so default to
+		// nullable — induction reads samples + names, not this flag.
+		nullable: true,
+		sampleValues: collectSampleValues(item.schema.sampleRows, c.name),
+	}));
+	return {
+		name: item.source_name,
+		// A query's row count would cost a full scan — left null, like the DB sniff.
+		rowCountEstimate: null,
+		columns,
+	};
+}
+
+/**
+ * Assemble one synthetic `ConnectSchema` from the UNION of the staging set's
+ * sniffed schemas — one `tables[]` entry per staged query (named by its import
+ * source name) and per staged file (its sniffed table(s)). `frame` reads this for
+ * induction context exactly like a single-source connect schema.
+ *
+ * `sourceKind` reflects the set's composition (database when any query is present,
+ * else file) and `source` is a human label of the set — both informational; the
+ * induction uses `tables[]`. At least one item is required (an empty set has
+ * nothing to frame against).
+ */
+export function assembleStagingSchema(input: {
+	queries: StagedQuerySchema[];
+	files: ConnectSchema[];
+}): ConnectSchema {
+	const queryTables = input.queries.map(queryToConnectTable);
+	// Each file sniff is its own ConnectSchema (one table for a flat file) — flatten
+	// their tables into the union.
+	const fileTables = input.files.flatMap((f) => f.tables);
+	const tables = [...queryTables, ...fileTables];
+	if (tables.length === 0) {
+		throw new Error(
+			"Cannot frame an empty staging set — stage a query or a file first.",
+		);
+	}
+	const sourceKind: ConnectSchema["sourceKind"] =
+		input.queries.length > 0 ? "database" : "file";
+	const count = tables.length;
+	const source = `import set (${count} ${count === 1 ? "item" : "items"})`;
+	return { sourceKind, source, tables };
+}

--- a/packages/cockpit/src/server/import-sources.test.ts
+++ b/packages/cockpit/src/server/import-sources.test.ts
@@ -1,0 +1,116 @@
+// Unit tests for the import-set composition (DAT-594) — the heterogeneous set
+// (probed queries + uploaded files) persisted in one pass and unioned into the
+// source-id set the batched run ingests.
+//
+// `persistImportSet` takes injected persisters, so the union ordering + the id/name
+// carry are asserted WITHOUT a live Postgres or config (the real server fn wires
+// the dynamic imports). The Zod input contract (empty-set rejection, defaults) is
+// asserted against the exported schema shape.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { persistImportSet } from "./import-sources";
+
+describe("persistImportSet (DAT-594) — heterogeneous union", () => {
+	const persistRecipeSources = vi.fn(async (specs: { source_name: string }[]) =>
+		specs.map((s) => ({
+			source_id: `q_${s.source_name}`,
+			source_name: s.source_name,
+		})),
+	);
+	const persistFileSources = vi.fn(async (specs: { file_uri: string }[]) =>
+		specs.map((s) => ({
+			source_id: `f_${s.file_uri}`,
+			source_name: `src_${s.file_uri}`,
+		})),
+	);
+
+	// Shared mocks across cases — reset call history so a per-test
+	// `not.toHaveBeenCalled()` reads only its own invocations.
+	beforeEach(() => {
+		persistRecipeSources.mockClear();
+		persistFileSources.mockClear();
+	});
+
+	it("unions queries THEN files into one source-id set (queries first)", async () => {
+		const result = await persistImportSet(
+			{
+				queries: [
+					{
+						source_name: "wwi_orders",
+						credential_source: "wwi",
+						backend: "mssql",
+						sql: "SELECT 1",
+					},
+				],
+				files: [{ file_uri: "uri-a" }, { file_uri: "uri-b" }],
+			},
+			{ persistRecipeSources, persistFileSources },
+		);
+		// Queries are persisted (and unioned) before files.
+		expect(result.sourceIds).toEqual(["q_wwi_orders", "f_uri-a", "f_uri-b"]);
+		expect(result.sourceNames).toEqual([
+			"wwi_orders",
+			"src_uri-a",
+			"src_uri-b",
+		]);
+	});
+
+	it("skips a producer entirely when its half of the set is empty", async () => {
+		await persistImportSet(
+			{ queries: [], files: [{ file_uri: "uri-a" }] },
+			{ persistRecipeSources, persistFileSources },
+		);
+		// No queries → the recipe producer is never called (no empty-batch write).
+		expect(persistRecipeSources).not.toHaveBeenCalled();
+		expect(persistFileSources).toHaveBeenCalledOnce();
+	});
+
+	it("supports a files-only and a queries-only set", async () => {
+		const filesOnly = await persistImportSet(
+			{ queries: [], files: [{ file_uri: "uri-a" }] },
+			{ persistRecipeSources, persistFileSources },
+		);
+		expect(filesOnly.sourceIds).toEqual(["f_uri-a"]);
+
+		const queriesOnly = await persistImportSet(
+			{
+				queries: [
+					{
+						source_name: "orders",
+						credential_source: "wwi",
+						backend: "mssql",
+						sql: "SELECT 1",
+					},
+				],
+				files: [],
+			},
+			{ persistRecipeSources, persistFileSources },
+		);
+		expect(queriesOnly.sourceIds).toEqual(["q_orders"]);
+	});
+
+	it("propagates a producer validation failure (no half-state)", async () => {
+		const failing = vi.fn(async () => {
+			throw new Error("Duplicate source name");
+		});
+		await expect(
+			persistImportSet(
+				{
+					queries: [
+						{
+							source_name: "dup",
+							credential_source: "wwi",
+							backend: "mssql",
+							sql: "SELECT 1",
+						},
+					],
+					files: [{ file_uri: "uri-a" }],
+				},
+				{ persistRecipeSources: failing, persistFileSources },
+			),
+		).rejects.toThrow(/Duplicate source name/);
+		// Queries fail first → files are never persisted.
+		expect(persistFileSources).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cockpit/src/server/import-sources.ts
+++ b/packages/cockpit/src/server/import-sources.ts
@@ -1,51 +1,70 @@
-// Server fn: import the probe surface's import set (DAT-592) — persist each
-// staged query as its own single-statement `db_recipe` source, then start ONE
-// batched addSourceWorkflow run over the whole set.
+// Server fn: import the probe surface's STAGING SET (DAT-592, DAT-594) — a
+// heterogeneous import set of probed SQL queries AND uploaded files, persisted in
+// ONE pass and started as ONE batched addSourceWorkflow run over the whole union.
 //
 // This is the UI analog of the agent `select` tool: the probe panel is direct
-// manipulation (the user edits SQL and clicks, no LLM round-trip), so the import
-// flows through a server fn the widget calls directly — exactly like the probe
-// grid hits `/api/probe-sql`. It reuses the SAME persist seam (`persistRecipeSources`
-// → `source-write`) and the SAME trigger (`triggerAddSource`) as `select`, so the
-// run, its progress widget, and the grounding cascade are identical; only the
-// producer (one source per query, vs select's bundled table-pick) differs.
+// manipulation (the user edits SQL / uploads files and clicks, no LLM round-trip),
+// so the import flows through a server fn the widget calls directly. It reuses the
+// SAME persist seams — `persistRecipeSources` (one source per query) and
+// `persistFileSources` (one content-keyed source per file, DAT-594) — and the SAME
+// trigger (`triggerAddSource`) as `select`, so the run, its progress widget, and
+// the grounding cascade are identical; only the producer (a staged set, vs select's
+// per-tool grain) differs.
 //
-// One run for the batch: N queries → N sources → a single `triggerAddSource` over
-// the set, so the engine's run-scoped reduce + the grounding-teach loop run ONCE
-// over the union (not N times), which is the whole point of staging a set before
-// importing.
+// One run for the batch: the staged files + queries → a set of sources → a single
+// `triggerAddSource` over the union, so the engine's run-scoped reduce + the
+// grounding-teach loop run ONCE over the whole set (not per item), which is the
+// whole point of staging a set before importing. Mixed file+query in one run is
+// supported with no engine change — the import activity dispatches per-row off
+// `Source.source_type`.
 
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-
-// `persistRecipeSources` + `triggerAddSource` pull config-bearing modules
-// (duckdb/probe, config) at load. They run ONLY server-side inside the handler, so
-// they're imported there (dynamically) — NOT statically — to keep THIS module's
-// graph config-free. The probe WIDGET imports this server fn at module scope; a
-// static pull would drag config into every test that eagerly loads the widget
-// registry (the canvas registry is deliberately config-free). `runWithConversation`
-// is just AsyncLocalStorage (config-free), so it stays a normal import.
 import { runWithConversation } from "#/lib/run-context";
+// `persistRecipeSources` / `persistFileSources` + `triggerAddSource` pull
+// config-bearing modules (duckdb/probe, config) at load. They run ONLY server-side
+// inside the handler, so they're imported there (dynamically) — NOT statically — to
+// keep THIS module's graph config-free. The probe WIDGET imports this server fn at
+// module scope; a static pull would drag config into every test that eagerly loads
+// the widget registry (the canvas registry is deliberately config-free).
+// `runWithConversation` is just AsyncLocalStorage (config-free), so it stays a
+// normal import. The persist-fn TYPES are erased at build, so importing them as
+// `type` keeps the module graph config-free while the union helper stays typed.
+import type { FileSourceSpec } from "#/select/file-source";
+import type { RecipeSourceSpec } from "#/select/recipe-source";
 
-const ImportSourcesInput = z.object({
-	sources: z
-		.array(
-			z.object({
-				source_name: z.string(),
-				credential_source: z.string(),
-				backend: z.string(),
-				sql: z.string(),
-			}),
-		)
-		.min(1),
-	// The originating chat (route param). The agent `select` tool reads this from
-	// the request ALS (set by /api/chat); a direct server fn has none, so the widget
-	// passes it explicitly and we bind it around the trigger. Without it the run is
-	// recorded with no conversation → the completion-watcher (which filters by
-	// conversationId) never tracks it, so the inline progress never ticks and the
-	// completion never narrates. (Null when the widget is off-route — degraded.)
-	conversationId: z.string().nullish(),
+// One staged query → one single-statement `db_recipe` source.
+const QuerySpec = z.object({
+	source_name: z.string(),
+	credential_source: z.string(),
+	backend: z.string(),
+	sql: z.string(),
 });
+
+// One staged upload → one content-keyed `src_<digest>` file source (DAT-594).
+const FileSpec = z.object({
+	file_uri: z.string(),
+});
+
+const ImportSourcesInput = z
+	.object({
+		// The probed-query half of the set — each imports as its own db_recipe source.
+		queries: z.array(QuerySpec).default([]),
+		// The uploaded-file half of the set — each imports as its own content-keyed
+		// source (DAT-594). Mixing files + queries in one set is supported.
+		files: z.array(FileSpec).default([]),
+		// The originating chat (route param). The agent `select` tool reads this from
+		// the request ALS (set by /api/chat); a direct server fn has none, so the
+		// widget passes it explicitly and we bind it around the trigger. Without it the
+		// run is recorded with no conversation → the completion-watcher (which filters
+		// by conversationId) never tracks it, so the inline progress never ticks and
+		// the completion never narrates. (Null when the widget is off-route — degraded.)
+		conversationId: z.string().nullish(),
+	})
+	.refine((v) => v.queries.length + v.files.length > 0, {
+		message:
+			"The import set is empty — stage a query or a file before importing.",
+	});
 
 /** The started run + the sources it imports. The widget renders the
  * `add-source-progress` widget INLINE from this (the canvas is message-derived, so
@@ -54,20 +73,71 @@ const ImportSourcesInput = z.object({
 export interface ImportSourcesResult {
 	workflow_id: string;
 	run_id: string;
-	/** The minted/UPSERTed source ids the run ingests. */
+	/** The minted/UPSERTed source ids the run ingests (queries ∪ files). */
 	sources: string[];
-	/** The source names imported — for the success message. */
+	/** The source names imported — for the success message (query names + file
+	 * content-keyed names). */
 	source_names: string[];
 }
 
+/** The persist seams the union helper composes — injected so the union ordering +
+ * id/name carry are unit-testable without a live Postgres or config (the server fn
+ * wires the real dynamic imports). */
+export interface ImportSetPersisters {
+	persistRecipeSources: (
+		specs: RecipeSourceSpec[],
+	) => Promise<{ source_id: string; source_name: string }[]>;
+	persistFileSources: (
+		specs: FileSourceSpec[],
+	) => Promise<{ source_id: string; source_name: string }[]>;
+}
+
+/** The persisted union of the import set: the source ids the run ingests + their
+ * names for the success message. Queries first, then files (a query validation
+ * failure rejects before any file is written). */
+export interface ImportSet {
+	sourceIds: string[];
+	sourceNames: string[];
+}
+
 /**
- * Persist the import set as one source per query and start the batched import.
+ * Persist the heterogeneous import set (queries + files) and union the result.
  *
- * Validation (bad name / reserved prefix / unsupported backend / empty SQL /
- * duplicate name / empty set) raises BEFORE any write — `persistRecipeSources`
- * checks the whole batch first, so a rejected import leaves no half-state. A
- * Temporal start failure (infra) propagates as a thrown error the mutation
- * surfaces; re-invoking recovers (the source upserts are idempotent).
+ * VALIDATE-ALL-UP-FRONT then persist: both producers validate the whole batch
+ * BEFORE any write (bad name / reserved prefix / unsupported backend / empty SQL /
+ * duplicate name / non-upload URI), so a rejected import leaves no half-state.
+ * Queries are persisted first so a query validation failure rejects before any
+ * file is written. Persistence ONLY — the caller triggers the batched import.
+ */
+export async function persistImportSet(
+	data: { queries: RecipeSourceSpec[]; files: FileSourceSpec[] },
+	persist: ImportSetPersisters,
+): Promise<ImportSet> {
+	const persistedQueries =
+		data.queries.length > 0
+			? await persist.persistRecipeSources(data.queries)
+			: [];
+	const persistedFiles =
+		data.files.length > 0 ? await persist.persistFileSources(data.files) : [];
+
+	return {
+		sourceIds: [
+			...persistedQueries.map((p) => p.source_id),
+			...persistedFiles.map((p) => p.source_id),
+		],
+		sourceNames: [
+			...persistedQueries.map((p) => p.source_name),
+			...persistedFiles.map((p) => p.source_name),
+		],
+	};
+}
+
+/**
+ * Persist the heterogeneous import set (queries + files) and start the batched
+ * import over the union.
+ *
+ * A Temporal start failure (infra) propagates as a thrown error the mutation
+ * surfaces; re-invoking recovers — every upsert is idempotent (digest / recipe_hash).
  */
 export const importSources = createServerFn({ method: "POST" })
 	.inputValidator((input: z.infer<typeof ImportSourcesInput>) =>
@@ -75,9 +145,14 @@ export const importSources = createServerFn({ method: "POST" })
 	)
 	.handler(async ({ data }): Promise<ImportSourcesResult> => {
 		const { persistRecipeSources } = await import("#/select/recipe-source");
+		const { persistFileSources } = await import("#/select/file-source");
 		const { triggerAddSource } = await import("#/temporal/trigger-add-source");
-		const persisted = await persistRecipeSources(data.sources);
-		const sourceIds = persisted.map((p) => p.source_id);
+
+		const { sourceIds, sourceNames } = await persistImportSet(
+			{ queries: data.queries, files: data.files },
+			{ persistRecipeSources, persistFileSources },
+		);
+
 		// Bind the conversation so the run is recorded against it (the watcher routes
 		// progress + narration by conversationId). Off-route (no id) → bare trigger,
 		// the null-conversation run the watcher simply doesn't narrate.
@@ -90,6 +165,6 @@ export const importSources = createServerFn({ method: "POST" })
 			workflow_id: run.workflow_id,
 			run_id: run.run_id,
 			sources: sourceIds,
-			source_names: persisted.map((p) => p.source_name),
+			source_names: sourceNames,
 		};
 	});

--- a/packages/cockpit/src/server/stage-frame.ts
+++ b/packages/cockpit/src/server/stage-frame.ts
@@ -24,22 +24,32 @@ import type { UseVerticalResult } from "#/tools/use-vertical";
 // The staging set to seed induction from — the same query/file shapes the import
 // uses, minus what frame doesn't need (file_uri carries the schema; a query's SQL
 // + connection sniff its schema).
-const StageFrameInput = z.object({
-	queries: z
-		.array(
-			z.object({
-				source_name: z.string(),
-				credential_source: z.string(),
-				backend: z.string(),
-				sql: z.string(),
-			}),
-		)
-		.default([]),
-	files: z.array(z.object({ file_uri: z.string() })).default([]),
-	// The new vertical to declare the induced model under (the user can rename in
-	// the modal). Omitted → `_adhoc` (the cold-start fallback), per frame's default.
-	vertical_name: z.string().nullish(),
-});
+const StageFrameInput = z
+	.object({
+		queries: z
+			.array(
+				z.object({
+					source_name: z.string(),
+					credential_source: z.string(),
+					backend: z.string(),
+					// `.min(1)` closes the empty-SQL fragility: a blank query would reach
+					// `probeDescribe` as `DESCRIBE SELECT * FROM ()` (a syntax error). The
+					// modal caller always passes complete queries; this guards direct calls.
+					sql: z.string().min(1),
+				}),
+			)
+			.default([]),
+		files: z.array(z.object({ file_uri: z.string() })).default([]),
+		// The new vertical to declare the induced model under (the user can rename in
+		// the modal). Omitted → `_adhoc` (the cold-start fallback), per frame's default.
+		vertical_name: z.string().nullish(),
+	})
+	// Reject an empty staging set up front (mirrors ImportSourcesInput) — without
+	// this, `assembleStagingSchema` throws inside the handler and surfaces as a 500
+	// rather than a structured validation error.
+	.refine((v) => v.queries.length + v.files.length > 0, {
+		message: "The staging set is empty — stage a query or file before framing.",
+	});
 
 /** The frame outcome the staging modal needs — a SERIALIZABLE summary (counts +
  * the vertical it landed under), NOT the full `FrameResult` (whose validation
@@ -77,6 +87,8 @@ export const frameStagingSet = createServerFn({ method: "POST" })
 			Promise.all(
 				data.queries.map(async (q) => ({
 					source_name: q.source_name,
+					// probeDescribe samples at its DEFAULT_ROW_LIMIT (1000 rows) — sized for
+					// induction context; a deliberate default, not an oversight.
 					schema: await probeDescribe({
 						source_name: q.credential_source,
 						backend: q.backend,

--- a/packages/cockpit/src/server/stage-frame.ts
+++ b/packages/cockpit/src/server/stage-frame.ts
@@ -1,0 +1,140 @@
+// Server fns for the probe staging hub's frame/vertical step (DAT-594).
+//
+// The staging hub assembles a heterogeneous import set (probed queries + files),
+// then declares a business model over it — either FRAME a new vertical (induce
+// concepts from the assembled set's schemas) or USE_VERTICAL to adopt a builtin.
+// `frame` and `use_vertical` are agent-only tools, so the UI needs thin server-fn
+// wrappers it can call DIRECTLY (no LLM round-trip) — the same direct-manipulation
+// pattern as `importSources`.
+//
+// Schema assembly (`assembleStagingSchema`) sniffs each staged item — a query via
+// `probeDescribe` (DESCRIBE + sample), a file via `sniffFileSchema` (the connect
+// file sniff) — and unions them into ONE synthetic `ConnectSchema` to induce from.
+//
+// Server-only deps (duckdb, config, the tools) load INSIDE the handlers so this
+// module's static graph stays config-free — the probe WIDGET imports these at
+// module scope, and the canvas registry must not drag config (mirrors
+// server/import-sources.ts and server/active-vertical.ts).
+
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+
+import type { UseVerticalResult } from "#/tools/use-vertical";
+
+// The staging set to seed induction from — the same query/file shapes the import
+// uses, minus what frame doesn't need (file_uri carries the schema; a query's SQL
+// + connection sniff its schema).
+const StageFrameInput = z.object({
+	queries: z
+		.array(
+			z.object({
+				source_name: z.string(),
+				credential_source: z.string(),
+				backend: z.string(),
+				sql: z.string(),
+			}),
+		)
+		.default([]),
+	files: z.array(z.object({ file_uri: z.string() })).default([]),
+	// The new vertical to declare the induced model under (the user can rename in
+	// the modal). Omitted → `_adhoc` (the cold-start fallback), per frame's default.
+	vertical_name: z.string().nullish(),
+});
+
+/** The frame outcome the staging modal needs — a SERIALIZABLE summary (counts +
+ * the vertical it landed under), NOT the full `FrameResult` (whose validation
+ * `parameters: Record<string, unknown>` trips the server-fn serialization check,
+ * and which the modal doesn't render — the model-review widget is the agent path).
+ * The modal only flips the Start gate on success and shows what was written. */
+export interface FrameStagingResult {
+	vertical: string;
+	concept_count: number;
+	validation_count: number;
+	cycle_count: number;
+	metric_count: number;
+}
+
+/**
+ * Frame a NEW vertical from the assembled staging set: sniff each staged item's
+ * schema, union them into one synthetic ConnectSchema, and run `frame` over it
+ * (inducing concepts + the executable knowledge). Returns a serializable summary
+ * for the modal. An acting call — frame writes overlay rows immediately (DAT-598
+ * tracks a propose/commit split; here Start gates the IMPORT, not the frame).
+ */
+export const frameStagingSet = createServerFn({ method: "POST" })
+	.inputValidator((input: z.infer<typeof StageFrameInput>) =>
+		StageFrameInput.parse(input),
+	)
+	.handler(async ({ data }): Promise<FrameStagingResult> => {
+		const { probeDescribe } = await import("#/duckdb/probe");
+		const { sniffFileSchema } = await import("#/duckdb/connect");
+		const { assembleStagingSchema } = await import("#/select/stage-schema");
+		const { frame } = await import("#/tools/frame");
+
+		// Sniff every staged item's schema (queries describe their projection; files
+		// sniff their reader). Parallel — independent per item.
+		const [queries, files] = await Promise.all([
+			Promise.all(
+				data.queries.map(async (q) => ({
+					source_name: q.source_name,
+					schema: await probeDescribe({
+						source_name: q.credential_source,
+						backend: q.backend,
+						sql: q.sql,
+					}),
+				})),
+			),
+			Promise.all(data.files.map((f) => sniffFileSchema(f.file_uri))),
+		]);
+
+		const schema = assembleStagingSchema({ queries, files });
+		const result = await frame({ schema, vertical_name: data.vertical_name });
+		return {
+			vertical: result.vertical,
+			concept_count: result.concepts.length,
+			validation_count: result.validations.length,
+			cycle_count: result.cycles.length,
+			metric_count: result.metrics.length,
+		};
+	});
+
+/**
+ * Adopt an existing (builtin or already-framed) vertical onto the workspace —
+ * the UI wrapper over the `use_vertical` tool. No schema assembly: a builtin ships
+ * its own concepts, so there's nothing to induce. (Named `adopt…` not `useVertical…`
+ * so the React rules-of-hooks lint doesn't mistake the `use` prefix for a hook.)
+ */
+export const adoptVerticalForStaging = createServerFn({ method: "POST" })
+	.inputValidator((input: { name: string }) =>
+		z.object({ name: z.string() }).parse(input),
+	)
+	.handler(async ({ data }): Promise<UseVerticalResult> => {
+		const { useVertical } = await import("#/tools/use-vertical");
+		return useVertical(data.name);
+	});
+
+/** A vertical the staging modal can adopt — the subset of the tool's `Vertical`
+ * shape the picker renders. */
+export interface AdoptableVertical {
+	name: string;
+	kind: "builtin" | "framed";
+	description: string | null;
+	concept_count: number;
+}
+
+/**
+ * The verticals the staging modal can adopt (builtins + already-framed) — the UI
+ * wrapper over `list_verticals`. The modal offers these as the use_vertical path.
+ */
+export const listAdoptableVerticals = createServerFn({ method: "GET" }).handler(
+	async (): Promise<AdoptableVertical[]> => {
+		const { listVerticals } = await import("#/tools/list-verticals");
+		const verticals = await listVerticals();
+		return verticals.map((v) => ({
+			name: v.name,
+			kind: v.kind,
+			description: v.description,
+			concept_count: v.concept_count,
+		}));
+	},
+);

--- a/packages/cockpit/src/tools/select.ts
+++ b/packages/cockpit/src/tools/select.ts
@@ -60,14 +60,13 @@ import { config } from "../config";
 import { ConnectSchema } from "../duckdb/connect";
 import { SUPPORTED_BACKENDS } from "../duckdb/probe";
 import { enumeratePrefixUris } from "../select/enumerate";
+import { persistFileSources } from "../select/file-source";
 import {
 	connectTablesToRecipeTables,
-	contentKeyedSourceName,
 	RESERVED_SOURCE_NAME_PREFIXES,
 	recipeContentHash,
 	reservedSourceNamePrefix,
 	SOURCE_NAME_PATTERN,
-	sourceTypeForUri,
 } from "../select/mappers";
 import {
 	importedRecipeHash,
@@ -193,35 +192,17 @@ export async function persistSelection(
 			{ fileUris: input.file_uris, prefix: input.prefix },
 			enumerate,
 		);
-		// One content-keyed source per file (DAT-422). Dedup by content key so a
-		// repeated URI UPSERTs once; `contentKeyedSourceName` fails loud on a
-		// non-upload URI (content identity requires the upload digest).
-		const byName = new Map<string, { uri: string; sourceType: string }>();
-		for (const uri of uris) {
-			const name = contentKeyedSourceName(uri);
-			if (!byName.has(name)) {
-				byName.set(name, { uri, sourceType: sourceTypeForUri(uri) });
-			}
-		}
+		// One content-keyed source per file (DAT-422) — the shared persist seam
+		// (DAT-594, select/file-source.ts) the probe staging hub reuses. Dedups by
+		// content key and fails loud on a non-upload URI.
+		const persisted = await persistFileSources(
+			uris.map((file_uri) => ({ file_uri })),
+		);
 
-		const persisted = [...byName.entries()];
-		const sourceIdSet: string[] = [];
-		for (const [name, { uri, sourceType }] of persisted) {
-			sourceIdSet.push(
-				await upsertSource({
-					name,
-					sourceType,
-					backend: null,
-					// DISTINCT key from the db_recipe `tables` key — never folded together.
-					connectionConfig: { file_uris: [uri] },
-					now,
-				}),
-			);
-		}
-
-		const fileUris = persisted.map(([, p]) => p.uri);
+		const sourceIdSet = persisted.map((p) => p.source_id);
+		const fileUris = persisted.map((p) => p.file_uri);
 		const distinctTypes = [
-			...new Set(persisted.map(([, p]) => p.sourceType)),
+			...new Set(persisted.map((p) => p.source_type)),
 		].sort();
 		return {
 			sources: sourceIdSet,

--- a/packages/cockpit/src/ui/cockpit/widgets/model-modal.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/model-modal.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+
+// Behavior tests for the Frame / Vertical modal (DAT-594). The server fns are
+// stubbed (env/RPC, verified elsewhere); what we assert is the modal's own logic:
+// the frame path sends the staged set + vertical name, the adopt path sends the
+// picked vertical, both call onModelDeclared on success, and the empty-set guard.
+
+import { MantineProvider } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const frameStagingSetMock = vi.fn();
+const adoptVerticalForStagingMock = vi.fn();
+const listAdoptableVerticalsMock = vi.fn();
+vi.mock("#/server/stage-frame", () => ({
+	frameStagingSet: (args: unknown) => frameStagingSetMock(args),
+	adoptVerticalForStaging: (args: unknown) => adoptVerticalForStagingMock(args),
+	listAdoptableVerticals: () => listAdoptableVerticalsMock(),
+}));
+
+import {
+	ModelModal,
+	type StagedForFrame,
+} from "#/ui/cockpit/widgets/model-modal";
+import { theme } from "#/ui/theme";
+
+function renderModal(importSet: StagedForFrame[], onModelDeclared = vi.fn()) {
+	const qc = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	render(
+		<QueryClientProvider client={qc}>
+			<MantineProvider theme={theme} env="test">
+				<ModelModal
+					opened
+					onClose={vi.fn()}
+					importSet={importSet}
+					onModelDeclared={onModelDeclared}
+				/>
+			</MantineProvider>
+		</QueryClientProvider>,
+	);
+	return { onModelDeclared };
+}
+
+const STAGED: StagedForFrame[] = [
+	{
+		kind: "query",
+		source_name: "wwi_orders",
+		credential_source: "wwi",
+		backend: "mssql",
+		sql: "SELECT * FROM Sales.Orders",
+	},
+	{ kind: "file", file_uri: "s3://b/ws/uploads/aaa/orders.csv" },
+];
+
+beforeEach(() => {
+	listAdoptableVerticalsMock.mockResolvedValue([
+		{
+			name: "finance",
+			kind: "builtin",
+			description: "Ledgers",
+			concept_count: 12,
+		},
+	]);
+});
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe("ModelModal frame path (DAT-594)", () => {
+	it("frames over the staged set + vertical name and signals on success", async () => {
+		frameStagingSetMock.mockResolvedValue({
+			vertical: "sales",
+			concept_count: 4,
+			validation_count: 1,
+			cycle_count: 0,
+			metric_count: 0,
+		});
+		const { onModelDeclared } = renderModal(STAGED);
+
+		fireEvent.change(screen.getByTestId("model-vertical-name"), {
+			target: { value: "sales" },
+		});
+		fireEvent.click(screen.getByTestId("model-frame-run"));
+
+		await waitFor(() => expect(frameStagingSetMock).toHaveBeenCalledTimes(1));
+		expect(frameStagingSetMock).toHaveBeenCalledWith({
+			data: {
+				queries: [
+					{
+						source_name: "wwi_orders",
+						credential_source: "wwi",
+						backend: "mssql",
+						sql: "SELECT * FROM Sales.Orders",
+					},
+				],
+				files: [{ file_uri: "s3://b/ws/uploads/aaa/orders.csv" }],
+				vertical_name: "sales",
+			},
+		});
+		await waitFor(() => expect(onModelDeclared).toHaveBeenCalledTimes(1));
+	});
+
+	it("blocks frame on an empty staged set", () => {
+		renderModal([]);
+		expect(screen.getByTestId("model-empty-set")).toBeTruthy();
+		expect(
+			(screen.getByTestId("model-frame-run") as HTMLButtonElement).disabled,
+		).toBe(true);
+	});
+
+	it("surfaces a frame error", async () => {
+		frameStagingSetMock.mockRejectedValue(new Error("induction returned none"));
+		renderModal(STAGED);
+		fireEvent.click(screen.getByTestId("model-frame-run"));
+		const err = await screen.findByTestId("model-error");
+		expect(err.textContent).toContain("induction returned none");
+	});
+});
+
+describe("ModelModal adopt path (DAT-594)", () => {
+	it("adopts the picked builtin vertical and signals on success", async () => {
+		adoptVerticalForStagingMock.mockResolvedValue({
+			vertical: "finance",
+			kind: "builtin",
+		});
+		const { onModelDeclared } = renderModal(STAGED);
+
+		fireEvent.click(screen.getByTestId("model-mode-adopt"));
+		// The vertical list loads from the stubbed server fn.
+		await screen.findByTestId("model-vertical-list");
+		fireEvent.click(screen.getByLabelText(/finance/));
+		fireEvent.click(screen.getByTestId("model-adopt-run"));
+
+		await waitFor(() =>
+			expect(adoptVerticalForStagingMock).toHaveBeenCalledWith({
+				data: { name: "finance" },
+			}),
+		);
+		await waitFor(() => expect(onModelDeclared).toHaveBeenCalledTimes(1));
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/widgets/model-modal.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/model-modal.tsx
@@ -1,0 +1,235 @@
+// Frame / Vertical modal (DAT-594) — the staging hub's "declare a business model"
+// step. Two paths, both DIRECT (no LLM round-trip), mirroring the agent's frame vs
+// use_vertical fork:
+//   - FRAME a NEW vertical: induce concepts (+ the executable knowledge) from the
+//     staged set's UNIONED schemas (frameStagingSet sniffs each item server-side),
+//     under a user-named vertical.
+//   - USE an existing vertical: adopt a builtin (or already-framed) onto the
+//     workspace (useVerticalForStaging) — a builtin ships its own concepts.
+//
+// Either path writes the workspace's vertical; on success the caller invalidates
+// the active-vertical-status query so the Start gate flips immediately. Frame is an
+// ACTING step here (it writes overlay rows now) — the Start button, not this modal,
+// gates the import (DAT-598 tracks a propose/commit split for frame itself).
+
+import {
+	Alert,
+	Button,
+	Group,
+	Loader,
+	Modal,
+	Radio,
+	Stack,
+	Text,
+	TextInput,
+} from "@mantine/core";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import {
+	adoptVerticalForStaging,
+	frameStagingSet,
+	listAdoptableVerticals,
+} from "#/server/stage-frame";
+
+/** The staged-set shape the modal needs to seed a frame — only the query identity
+ * (sniffed server-side) and file URIs; the full item union lives in the widget. */
+export interface StagedForFrame {
+	kind: "query" | "file";
+	source_name?: string;
+	credential_source?: string;
+	backend?: string;
+	sql?: string;
+	file_uri?: string;
+}
+
+const VERTICAL_NAME_RE = /^[a-z][a-z0-9_]{1,48}$/;
+
+export function ModelModal({
+	opened,
+	onClose,
+	importSet,
+	onModelDeclared,
+}: {
+	opened: boolean;
+	onClose: () => void;
+	importSet: StagedForFrame[];
+	/** Called after a frame / use_vertical succeeds — the caller invalidates the
+	 * active-vertical-status query so the Start gate flips. */
+	onModelDeclared: () => void;
+}) {
+	const [mode, setMode] = useState<"frame" | "adopt">("frame");
+	const [verticalName, setVerticalName] = useState("");
+	const [adopt, setAdopt] = useState<string | null>(null);
+
+	const verticals = useQuery({
+		queryKey: ["adoptable-verticals"],
+		queryFn: () => listAdoptableVerticals(),
+		// Only fetched while the modal is open (it offers the adopt list).
+		enabled: opened,
+	});
+
+	const frameMutation = useMutation({
+		mutationFn: () =>
+			frameStagingSet({
+				data: {
+					queries: importSet
+						.filter((x) => x.kind === "query")
+						.map((x) => ({
+							source_name: x.source_name ?? "",
+							credential_source: x.credential_source ?? "",
+							backend: x.backend ?? "",
+							sql: x.sql ?? "",
+						})),
+					files: importSet
+						.filter((x) => x.kind === "file")
+						.map((x) => ({ file_uri: x.file_uri ?? "" })),
+					vertical_name: verticalName.trim() || null,
+				},
+			}),
+		onSuccess: onModelDeclared,
+	});
+
+	const adoptMutation = useMutation({
+		mutationFn: (name: string) => adoptVerticalForStaging({ data: { name } }),
+		onSuccess: onModelDeclared,
+	});
+
+	const error =
+		(frameMutation.error as Error | null)?.message ??
+		(adoptMutation.error as Error | null)?.message;
+	const pending = frameMutation.isPending || adoptMutation.isPending;
+
+	const nameValid =
+		verticalName.trim() === "" || VERTICAL_NAME_RE.test(verticalName.trim());
+	const emptySet = importSet.length === 0;
+	const canFrame = !emptySet && nameValid && !pending;
+	const canAdopt = adopt !== null && !pending;
+
+	return (
+		<Modal
+			opened={opened}
+			onClose={onClose}
+			centered
+			size="lg"
+			title="Declare a business model"
+			data-testid="model-modal"
+		>
+			<Stack gap="md">
+				<Text size="xs" c="dimmed">
+					An imported source grounds against the workspace's business model.
+					Frame a new one from your staged set, or adopt an existing vertical.
+				</Text>
+
+				{error && (
+					<Alert color="red" data-testid="model-error">
+						{error}
+					</Alert>
+				)}
+
+				<Radio.Group
+					value={mode}
+					onChange={(v) => setMode(v as "frame" | "adopt")}
+				>
+					<Stack gap="xs">
+						<Radio
+							value="frame"
+							label="Frame a new vertical from the staged set"
+							data-testid="model-mode-frame"
+						/>
+						<Radio
+							value="adopt"
+							label="Adopt an existing vertical (builtin or framed)"
+							data-testid="model-mode-adopt"
+						/>
+					</Stack>
+				</Radio.Group>
+
+				{mode === "frame" ? (
+					<Stack gap="sm">
+						{emptySet && (
+							<Alert color="yellow" data-testid="model-empty-set">
+								Stage at least one query or file first — frame induces the model
+								from the staged set's schemas.
+							</Alert>
+						)}
+						<TextInput
+							size="xs"
+							label="Vertical name (optional)"
+							placeholder="e.g. sales, logistics — lowercase; blank → _adhoc"
+							value={verticalName}
+							onChange={(e) => setVerticalName(e.currentTarget.value)}
+							error={
+								!nameValid
+									? "lowercase, start with a letter, [a-z0-9_], 2–49 chars"
+									: undefined
+							}
+							data-testid="model-vertical-name"
+						/>
+						<Group justify="flex-end">
+							<Button
+								size="xs"
+								onClick={() => frameMutation.mutate()}
+								disabled={!canFrame}
+								loading={frameMutation.isPending}
+								data-testid="model-frame-run"
+							>
+								Frame the model
+							</Button>
+						</Group>
+					</Stack>
+				) : (
+					<Stack gap="sm">
+						{verticals.isLoading ? (
+							<Group gap="xs">
+								<Loader size="sm" />
+								<Text size="sm" c="dimmed">
+									Loading verticals…
+								</Text>
+							</Group>
+						) : (verticals.data ?? []).length === 0 ? (
+							<Text size="sm" c="dimmed" data-testid="model-no-verticals">
+								No adoptable verticals — frame a new one instead.
+							</Text>
+						) : (
+							<Radio.Group
+								value={adopt}
+								onChange={setAdopt}
+								data-testid="model-vertical-list"
+							>
+								<Stack gap="xs">
+									{(verticals.data ?? []).map((v) => (
+										<Radio
+											key={v.name}
+											value={v.name}
+											label={
+												<Text size="sm">
+													{v.name}{" "}
+													<Text span c="dimmed" size="xs">
+														({v.kind}, {v.concept_count} concept
+														{v.concept_count === 1 ? "" : "s"}
+														{v.description ? ` — ${v.description}` : ""})
+													</Text>
+												</Text>
+											}
+										/>
+									))}
+								</Stack>
+							</Radio.Group>
+						)}
+						<Group justify="flex-end">
+							<Button
+								size="xs"
+								onClick={() => adopt && adoptMutation.mutate(adopt)}
+								disabled={!canAdopt}
+								loading={adoptMutation.isPending}
+								data-testid="model-adopt-run"
+							>
+								Adopt vertical
+							</Button>
+						</Group>
+					</Stack>
+				)}
+			</Stack>
+		</Modal>
+	);
+}

--- a/packages/cockpit/src/ui/cockpit/widgets/model-modal.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/model-modal.tsx
@@ -5,7 +5,7 @@
 //     staged set's UNIONED schemas (frameStagingSet sniffs each item server-side),
 //     under a user-named vertical.
 //   - USE an existing vertical: adopt a builtin (or already-framed) onto the
-//     workspace (useVerticalForStaging) — a builtin ships its own concepts.
+//     workspace (adoptVerticalForStaging) — a builtin ships its own concepts.
 //
 // Either path writes the workspace's vertical; on success the caller invalidates
 // the active-vertical-status query so the Start gate flips immediately. Frame is an
@@ -42,6 +42,9 @@ export interface StagedForFrame {
 	file_uri?: string;
 }
 
+// Client-side mirror of `frame.ts`'s VERTICAL_NAME_PATTERN (the authority — frame
+// re-validates server-side). Duplicated, like probe.tsx's SOURCE_NAME_RE, to keep
+// the server-only frame module out of the client bundle.
 const VERTICAL_NAME_RE = /^[a-z][a-z0-9_]{1,48}$/;
 
 export function ModelModal({
@@ -66,6 +69,9 @@ export function ModelModal({
 		queryFn: () => listAdoptableVerticals(),
 		// Only fetched while the modal is open (it offers the adopt list).
 		enabled: opened,
+		// Builtins are static; framed verticals change only when frame runs — so
+		// don't re-fetch the list on every modal open (matches active-vertical-status).
+		staleTime: 5 * 60 * 1000,
 	});
 
 	const frameMutation = useMutation({

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
-// Behavior tests for ProbeWidget (DAT-576 + DAT-592). The boundaries are stubbed —
-// they are external systems verified elsewhere: the server fns (env/RPC), the
-// CodeMirror editor (a DOM widget, smoke-verified), the streaming grid (network
-// I/O), the progress widget (Temporal polling), and the router. What we assert is
-// the widget's OWN logic: the no-sources state, run-gating, the probe-sql request
-// body, the import-set add/gate flow, and that Import calls importSources with the
-// staged specs + conversationId then shows progress.
+// Behavior tests for ProbeWidget → STAGING HUB (DAT-576 + DAT-592 + DAT-594). The
+// boundaries are stubbed — they are external systems verified elsewhere: the server
+// fns (env/RPC), the CodeMirror editor (a DOM widget, smoke-verified), the streaming
+// grid (network I/O), the progress widget (Temporal polling), the upload dropzone,
+// the model modal, and the router. What we assert is the widget's OWN logic: the
+// no-sources state, run-gating, the probe-sql request body, the staging add flow,
+// the MOVED gate (Add is free; Start gates on framed + non-empty set), and that
+// Start calls importSources with the staged set + conversationId then shows progress.
 
 import { MantineProvider } from "@mantine/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -30,6 +31,36 @@ vi.mock("#/server/active-vertical", () => ({
 const importSourcesMock = vi.fn();
 vi.mock("#/server/import-sources", () => ({
 	importSources: (args: unknown) => importSourcesMock(args),
+}));
+// The model modal pulls #/server/stage-frame; stub the modal itself (its own
+// behavior isn't under test here) but expose its props so we can drive the
+// model-declared callback that flips the gate.
+let modelModalProps: {
+	opened: boolean;
+	onModelDeclared: () => void;
+} | null = null;
+vi.mock("#/ui/cockpit/widgets/model-modal", () => ({
+	ModelModal: (props: { opened: boolean; onModelDeclared: () => void }) => {
+		modelModalProps = props;
+		return props.opened ? <div data-testid="model-modal" /> : null;
+	},
+}));
+vi.mock("#/ui/cockpit/upload-dropzone", () => ({
+	UploadDropzone: ({
+		onUploaded,
+	}: {
+		onUploaded: (uris: string[]) => void;
+	}) => (
+		<button
+			type="button"
+			data-testid="upload-dropzone"
+			onClick={() =>
+				onUploaded(["s3://dataraum-lake/ws/uploads/aaa111/orders.csv"])
+			}
+		>
+			upload
+		</button>
+	),
 }));
 // Route param the widget reads to record the run against the chat.
 vi.mock("@tanstack/react-router", () => ({
@@ -95,15 +126,17 @@ function renderProbe(
 const runBtn = () => screen.getByTestId("probe-run") as HTMLButtonElement;
 const addBtn = () =>
 	screen.getByTestId("probe-add-to-set") as HTMLButtonElement;
+const startBtn = () => screen.getByTestId("probe-start") as HTMLButtonElement;
 const seededState: Extract<CanvasState, { kind: "probe" }> = {
 	kind: "probe",
 	source: { name: "wwi", backend: "mssql" },
 	sql: "SELECT * FROM Sales.Orders",
 };
 
-// Default: a framed workspace, so the import-set gate is open. Tests that exercise
-// the unframed gate override this per-test (a later mockResolvedValue wins).
+// Default: a framed workspace, so the Start gate is open. Tests that exercise the
+// unframed gate override this per-test (a later mockResolvedValue wins).
 beforeEach(() => {
+	modelModalProps = null;
 	getActiveVerticalStatusMock.mockResolvedValue({
 		vertical: "retail",
 		framed: true,
@@ -162,16 +195,21 @@ describe("ProbeWidget (DAT-576)", () => {
 	});
 });
 
-describe("ProbeWidget import set (DAT-592)", () => {
+describe("ProbeWidget staging hub (DAT-592 + DAT-594)", () => {
 	afterEach(() => {
 		cleanup();
 		vi.clearAllMocks();
 	});
 
-	it("gates Add to import set on a source, non-empty SQL, and a valid name", async () => {
+	it("gates Add to import set on a source, non-empty SQL, and a valid name — NOT on framing", async () => {
 		getConfiguredDatabasesMock.mockResolvedValue([
 			{ name: "wwi", backend: "mssql" },
 		]);
+		// Unframed: Add must STILL be reachable (the gate moved to Start, DAT-594).
+		getActiveVerticalStatusMock.mockResolvedValue({
+			vertical: "_adhoc",
+			framed: false,
+		});
 		renderProbe(seededState);
 		await waitFor(() => expect(getConfiguredDatabasesMock).toHaveBeenCalled());
 		// Source + sql are seeded, but no name yet → disabled.
@@ -183,14 +221,14 @@ describe("ProbeWidget import set (DAT-592)", () => {
 		});
 		expect(addBtn().disabled).toBe(true);
 
-		// A valid name enables it.
+		// A valid name enables it EVEN THOUGH the workspace is unframed.
 		fireEvent.change(screen.getByTestId("probe-import-name"), {
 			target: { value: "wwi_orders" },
 		});
 		await waitFor(() => expect(addBtn().disabled).toBe(false));
 	});
 
-	it("blocks Add when the workspace is unframed (no business model)", async () => {
+	it("gates START on a framed workspace (the moved gate) and shows why when blocked", async () => {
 		getConfiguredDatabasesMock.mockResolvedValue([
 			{ name: "wwi", backend: "mssql" },
 		]);
@@ -199,17 +237,33 @@ describe("ProbeWidget import set (DAT-592)", () => {
 			framed: false,
 		});
 		renderProbe(seededState);
-		// The unframed banner shows; Add stays disabled even with a valid name + sql.
 		await waitFor(() =>
 			expect(screen.getByTestId("probe-unframed")).toBeTruthy(),
 		);
+
+		// Stage a query — Start is still blocked because the workspace is unframed.
 		fireEvent.change(screen.getByTestId("probe-import-name"), {
 			target: { value: "wwi_orders" },
 		});
-		expect(addBtn().disabled).toBe(true);
+		await waitFor(() => expect(addBtn().disabled).toBe(false));
+		fireEvent.click(addBtn());
+
+		expect(startBtn().disabled).toBe(true);
+		expect(screen.getByTestId("probe-start-blocked").textContent).toContain(
+			"business model",
+		);
+
+		// The model modal flipping framed → true opens the Start gate (the
+		// invalidation path is exercised by re-resolving the status query).
+		getActiveVerticalStatusMock.mockResolvedValue({
+			vertical: "retail",
+			framed: true,
+		});
+		modelModalProps?.onModelDeclared();
+		await waitFor(() => expect(startBtn().disabled).toBe(false));
 	});
 
-	it("stages a query, imports the set, and shows progress", async () => {
+	it("stages a query, starts the import, and shows progress", async () => {
 		getConfiguredDatabasesMock.mockResolvedValue([
 			{ name: "wwi", backend: "mssql" },
 		]);
@@ -228,20 +282,18 @@ describe("ProbeWidget import set (DAT-592)", () => {
 		await waitFor(() => expect(addBtn().disabled).toBe(false));
 		fireEvent.click(addBtn());
 
-		// The set lives behind a count symbol; open the modal to see it.
+		// The set lives behind a count symbol; the framed workspace opens Start.
 		const indicator = await screen.findByTestId("probe-import-indicator");
 		expect(indicator.textContent).toContain("1");
-		fireEvent.click(indicator);
-		const setPanel = await screen.findByTestId("probe-import-set");
-		expect(setPanel.textContent).toContain("wwi_orders");
+		await waitFor(() => expect(startBtn().disabled).toBe(false));
+		fireEvent.click(startBtn());
 
-		fireEvent.click(screen.getByTestId("probe-import-run"));
-
-		// importSources is called with the staged spec + the conversationId.
+		// importSources is called with the staged query + the conversationId, in the
+		// heterogeneous { queries, files } shape (DAT-594).
 		await waitFor(() => expect(importSourcesMock).toHaveBeenCalledTimes(1));
 		expect(importSourcesMock).toHaveBeenCalledWith({
 			data: {
-				sources: [
+				queries: [
 					{
 						source_name: "wwi_orders",
 						credential_source: "wwi",
@@ -249,6 +301,7 @@ describe("ProbeWidget import set (DAT-592)", () => {
 						sql: "SELECT * FROM Sales.Orders",
 					},
 				],
+				files: [],
 				conversationId: "conv-1",
 			},
 		});
@@ -261,6 +314,58 @@ describe("ProbeWidget import set (DAT-592)", () => {
 			screen.getByTestId("measure-progress").getAttribute("data-workflow"),
 		).toBe("addsource-ws");
 		expect(screen.queryByTestId("probe-import-indicator")).toBeNull();
+	});
+
+	it("stages an uploaded FILE into the set (mixed with queries)", async () => {
+		getConfiguredDatabasesMock.mockResolvedValue([
+			{ name: "wwi", backend: "mssql" },
+		]);
+		importSourcesMock.mockResolvedValue({
+			workflow_id: "addsource-ws",
+			run_id: "addsource-ws",
+			sources: ["sid-1", "sid-2"],
+			source_names: ["wwi_orders", "src_aaa111"],
+		});
+		renderProbe(seededState);
+		await waitFor(() => expect(getConfiguredDatabasesMock).toHaveBeenCalled());
+
+		// Stage a query.
+		fireEvent.change(screen.getByTestId("probe-import-name"), {
+			target: { value: "wwi_orders" },
+		});
+		await waitFor(() => expect(addBtn().disabled).toBe(false));
+		fireEvent.click(addBtn());
+
+		// Open the upload modal and "upload" a file (the stub fires onUploaded).
+		fireEvent.click(screen.getByTestId("probe-upload-open"));
+		fireEvent.click(await screen.findByTestId("upload-dropzone"));
+
+		// Set now holds 2 items (a query + a file).
+		await waitFor(() =>
+			expect(
+				screen.getByTestId("probe-import-indicator").textContent,
+			).toContain("2"),
+		);
+		await waitFor(() => expect(startBtn().disabled).toBe(false));
+		fireEvent.click(startBtn());
+
+		await waitFor(() => expect(importSourcesMock).toHaveBeenCalledTimes(1));
+		expect(importSourcesMock).toHaveBeenCalledWith({
+			data: {
+				queries: [
+					{
+						source_name: "wwi_orders",
+						credential_source: "wwi",
+						backend: "mssql",
+						sql: "SELECT * FROM Sales.Orders",
+					},
+				],
+				files: [
+					{ file_uri: "s3://dataraum-lake/ws/uploads/aaa111/orders.csv" },
+				],
+				conversationId: "conv-1",
+			},
+		});
 	});
 
 	it("re-adding a staged name updates its SQL rather than duplicating", async () => {
@@ -311,8 +416,8 @@ describe("ProbeWidget import set (DAT-592)", () => {
 		});
 		await waitFor(() => expect(addBtn().disabled).toBe(false));
 		fireEvent.click(addBtn());
-		fireEvent.click(await screen.findByTestId("probe-import-indicator"));
-		fireEvent.click(await screen.findByTestId("probe-import-run"));
+		await waitFor(() => expect(startBtn().disabled).toBe(false));
+		fireEvent.click(startBtn());
 
 		// The error surfaces and the set is NOT cleared — the symbol persists for retry.
 		const err = await screen.findByTestId("probe-import-error");

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
@@ -1,23 +1,26 @@
-// Probe widget (DAT-576 + DAT-592) — the editable Connect-phase surface: pick a
-// configured DB source, write/edit read-only SQL, run it against the external DB
-// BEFORE ingest, and (DAT-592) stage queries into an IMPORT SET that imports each
-// as its own single-statement `db_recipe` source.
+// Probe widget → STAGING HUB (DAT-576 + DAT-592 + DAT-594) — the unified Connect
+// surface: assemble a HETEROGENEOUS import set (uploaded FILES and probed SQL
+// QUERIES), declare a business model over it (FRAME a new vertical or adopt a
+// builtin), then click START to import the whole set in ONE batched
+// addSourceWorkflow run.
 //
-// Runs stream through /api/probe-sql into the SAME virtualized result grid the lake
-// uses (StreamingGrid), so a large external result never floods the DOM. The agent
-// only SEEDS this surface: a `probe` tool call projects its source + sql into the
-// editor (out of CHIP_ONLY) for the user to edit and re-run. The run itself is a
-// direct fetch — no agent round-trip.
+// Runs (probing) stream through /api/probe-sql into the SAME virtualized result
+// grid the lake uses (StreamingGrid), so a large external result never floods the
+// DOM. The agent only SEEDS this surface: a `probe` tool call projects its source +
+// sql into the editor (out of CHIP_ONLY) for the user to edit and re-run. The run
+// itself is a direct fetch — no agent round-trip.
 //
-// Import set (DAT-592): "Add to import set" stages {import-as name, backend, sql}.
-// The set lives behind a COUNT SYMBOL in the panel header (always visible, never
-// pushed below the tall result grid); clicking it opens a centered MODAL listing
-// the staged queries with remove + "Import N sources". Import calls the
+// Staging set (DAT-594): "Add to import set" stages a query, the 📤 Upload modal
+// stages files; both live behind a COUNT SYMBOL in the panel header (always
+// visible, never pushed below the tall result grid). The 🎯 Frame/Vertical modal
+// declares the model (seeded from the staged set's schemas, or pick a builtin). The
+// frame-before-import gate moved from "can't Add" to "can't START": staging is FREE,
+// Start is gated on a non-empty set AND a framed workspace. Import calls the
 // `importSources` server fn — deterministic, no LLM round-trip — which persists one
-// source per query and starts ONE batched addSourceWorkflow run. The run's progress
-// renders INLINE at the top here (the canvas is message-derived, so a direct action
-// can't project a canvas member), while the background completion-watcher narrates
-// completion into the chat (the run is recorded against the conversationId we pass).
+// source per item and starts ONE batched run. The run's progress renders INLINE at
+// the top here (the canvas is message-derived, so a direct action can't project a
+// canvas member), while the background completion-watcher narrates completion into
+// the chat (the run is recorded against the conversationId we pass).
 
 import {
 	ActionIcon,
@@ -34,28 +37,49 @@ import {
 	TextInput,
 	Tooltip,
 } from "@mantine/core";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
-import { Layers, X } from "lucide-react";
+import {
+	FileText,
+	Layers,
+	Target,
+	Upload as UploadIcon,
+	X,
+} from "lucide-react";
 import { useMemo, useState } from "react";
 import { getActiveVerticalStatus } from "#/server/active-vertical";
 import { getConfiguredDatabases } from "#/server/configured-databases";
 import { importSources } from "#/server/import-sources";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
+import { UploadDropzone } from "#/ui/cockpit/upload-dropzone";
 import { MeasureProgressWidget } from "#/ui/cockpit/widgets/measure-progress";
+import { ModelModal } from "#/ui/cockpit/widgets/model-modal";
 import { StreamingGrid } from "#/ui/cockpit/widgets/result-grid";
 import { SqlEditor } from "#/ui/cockpit/widgets/sql-editor";
 
-/** One staged query — becomes one single-statement `db_recipe` source on import.
- * A `type` (not `interface`) so it's assignable to the server fn's input shape.
+/** One staged QUERY — becomes one single-statement `db_recipe` source on import.
  * `credential_source` is the configured connection the query reads through (the
  * probed source) — distinct from `source_name`, the new source's own name. */
-type ImportSpec = {
+type QueryItem = {
+	kind: "query";
 	source_name: string;
 	credential_source: string;
 	backend: string;
 	sql: string;
 };
+
+/** One staged FILE — becomes one content-keyed `src_<digest>` source on import.
+ * `file_uri` is the staged `s3://…/<digest>/<filename>` upload handle; `filename`
+ * is its display leaf (the set lists files by original name, keyed by digest). */
+type FileItem = {
+	kind: "file";
+	file_uri: string;
+	filename: string;
+	source_type: string;
+};
+
+/** One staged item in the heterogeneous import set. */
+type ImportItem = QueryItem | FileItem;
 
 /** The probe-sql request a Run submits — mirrors the /api/probe-sql body. */
 type ProbeRun = {
@@ -69,6 +93,20 @@ type ProbeRun = {
 // of the client bundle (the upload/policy split precedent). Gates the "Add" button
 // for fast feedback only.
 const SOURCE_NAME_RE = /^[a-z][a-z0-9_]{1,48}$/;
+
+/** The display leaf (filename) of a staged `s3://…/<digest>/<filename>` URI. */
+function uploadFilename(uri: string): string {
+	return uri.split("/").filter(Boolean).at(-1) ?? uri;
+}
+
+/** The engine `source_type` from a URI suffix — a client-side mirror (the server
+ * re-derives via select/mappers; this is just for the set's display badge). */
+function sourceTypeForUriClient(uri: string): string {
+	const lower = uri.toLowerCase();
+	if (/\.(parquet|pq)$/.test(lower)) return "parquet";
+	if (/\.(json|ndjson|jsonl)$/.test(lower)) return "json";
+	return "csv";
+}
 
 export function ProbeWidget({
 	state,
@@ -87,19 +125,62 @@ export function ProbeWidget({
 	const params = useParams({ strict: false }) as { conversationId?: string };
 	const conversationId = params.conversationId ?? null;
 
-	const [importSet, setImportSet] = useState<ImportSpec[]>([]);
-	// Re-adding a name re-points its SQL (an edit), never a silent duplicate.
-	const addToSet = (spec: ImportSpec) =>
+	const [importSet, setImportSet] = useState<ImportItem[]>([]);
+	// Re-adding a query name re-points its SQL (an edit), never a silent duplicate;
+	// re-adding a file URI (same digest) is a no-op (dedup by digest, like the
+	// server). Queries key on source_name, files on file_uri.
+	const addQuery = (item: QueryItem) =>
 		setImportSet((s) => [
-			...s.filter((x) => x.source_name !== spec.source_name),
-			spec,
+			...s.filter(
+				(x) => !(x.kind === "query" && x.source_name === item.source_name),
+			),
+			item,
 		]);
-	const removeFromSet = (name: string) =>
-		setImportSet((s) => s.filter((x) => x.source_name !== name));
+	const addFiles = (uris: string[]) =>
+		setImportSet((s) => {
+			const have = new Set(
+				s
+					.filter((x): x is FileItem => x.kind === "file")
+					.map((x) => x.file_uri),
+			);
+			const fresh: FileItem[] = uris
+				.filter((uri) => !have.has(uri))
+				.map((uri) => ({
+					kind: "file",
+					file_uri: uri,
+					filename: uploadFilename(uri),
+					source_type: sourceTypeForUriClient(uri),
+				}));
+			return [...s, ...fresh];
+		});
+	// Remove by stable identity (query → source_name, file → file_uri).
+	const removeItem = (id: string) =>
+		setImportSet((s) =>
+			s.filter((x) =>
+				x.kind === "query" ? x.source_name !== id : x.file_uri !== id,
+			),
+		);
+
+	const queryCount = importSet.filter((x) => x.kind === "query").length;
 
 	const importMutation = useMutation({
-		mutationFn: (specs: ImportSpec[]) =>
-			importSources({ data: { sources: specs, conversationId } }),
+		mutationFn: (items: ImportItem[]) =>
+			importSources({
+				data: {
+					queries: items
+						.filter((x): x is QueryItem => x.kind === "query")
+						.map(({ source_name, credential_source, backend, sql }) => ({
+							source_name,
+							credential_source,
+							backend,
+							sql,
+						})),
+					files: items
+						.filter((x): x is FileItem => x.kind === "file")
+						.map((x) => ({ file_uri: x.file_uri })),
+					conversationId,
+				},
+			}),
 		// Clear the staged set on a successful start — the run is now live (its
 		// progress renders at the top); the set is free to build the next batch.
 		onSuccess: () => setImportSet([]),
@@ -151,8 +232,10 @@ export function ProbeWidget({
 				key={seedKey}
 				state={state}
 				importSet={importSet}
-				onAdd={addToSet}
-				onRemove={removeFromSet}
+				queryCount={queryCount}
+				onAddQuery={addQuery}
+				onAddFiles={addFiles}
+				onRemove={removeItem}
 				onImport={() => importMutation.mutate(importSet)}
 				pending={importMutation.isPending}
 			/>
@@ -163,18 +246,23 @@ export function ProbeWidget({
 function ProbePanel({
 	state,
 	importSet,
-	onAdd,
+	queryCount,
+	onAddQuery,
+	onAddFiles,
 	onRemove,
 	onImport,
 	pending,
 }: {
 	state: Extract<CanvasState, { kind: "probe" }>;
-	importSet: ImportSpec[];
-	onAdd: (spec: ImportSpec) => void;
-	onRemove: (name: string) => void;
+	importSet: ImportItem[];
+	queryCount: number;
+	onAddQuery: (item: QueryItem) => void;
+	onAddFiles: (uris: string[]) => void;
+	onRemove: (id: string) => void;
 	onImport: () => void;
 	pending: boolean;
 }) {
+	const queryClient = useQueryClient();
 	const sources = useQuery({
 		queryKey: ["configured-databases"],
 		queryFn: () => getConfiguredDatabases(),
@@ -182,14 +270,16 @@ function ProbePanel({
 	const list = useMemo(() => sources.data ?? [], [sources.data]);
 
 	// Is the workspace framed? Importing grounds against the vertical's concepts and
-	// fails loud if there are none, so the import set is gated on this (DAT-592
-	// follow-up). Probing (Run) stays open — read-only exploration is how you decide
-	// the frame. `framed` only when CONFIRMED true (loading/error → gated, safe).
+	// fails loud if there are none, so the import START is gated on this (DAT-594:
+	// the gate moved from Add to Start). Probing (Run) and staging stay open —
+	// read-only exploration + set-building is how you decide the frame. `framed`
+	// only when CONFIRMED true (loading/error → gated, safe).
 	const frameStatus = useQuery({
 		queryKey: ["active-vertical-status"],
 		queryFn: () => getActiveVerticalStatus(),
 		// Session-stable — only the `frame`/`use_vertical` flow changes it — so don't
-		// re-hit the server on every window focus.
+		// re-hit the server on every window focus. The frame/vertical modal
+		// invalidates this key on success so the Start gate flips immediately.
 		staleTime: 5 * 60 * 1000,
 	});
 	const framed = frameStatus.data?.framed === true;
@@ -206,9 +296,11 @@ function ProbePanel({
 	// Bumped per Run so an identical re-run still remounts StreamingGrid (fresh
 	// stream + sort reset), not just a different query.
 	const [runId, setRunId] = useState(0);
-	// The import-set modal — pure view state, fine to reset on re-seed (the SET
+	// View state for the three modals — pure UI, fine to reset on re-seed (the SET
 	// itself lives in ProbeWidget and survives).
 	const [setOpen, setSetOpen] = useState(false);
+	const [uploadOpen, setUploadOpen] = useState(false);
+	const [modelOpen, setModelOpen] = useState(false);
 
 	const selectedSource = useMemo(
 		() => list.find((s) => s.name === selected) ?? null,
@@ -228,19 +320,20 @@ function ProbePanel({
 	};
 
 	const nameValid = SOURCE_NAME_RE.test(importAs);
-	// Re-using a staged name UPDATES that query's SQL (addToSet replaces by name) —
+	// Re-using a staged name UPDATES that query's SQL (addQuery replaces by name) —
 	// a valid edit, not a duplicate. So the gate ALLOWS it; only the button label
 	// flips to "Update" so the action is unambiguous.
-	const nameStaged = importSet.some((s) => s.source_name === importAs);
-	// `framed` is the load-bearing gate (DAT-592 follow-up): no business model →
-	// the import would die at grounding, so staging is blocked until one exists.
-	const canAdd = selectedSource !== null && hasSql && nameValid && framed;
+	const nameStaged = importSet.some(
+		(s) => s.kind === "query" && s.source_name === importAs,
+	);
+	// Staging is FREE now (DAT-594): no `framed` gate on Add — the frame-before-
+	// import gate moved to START. Add only needs a source, SQL, and a valid name.
+	const canAdd = selectedSource !== null && hasSql && nameValid;
 
 	const add = () => {
-		// `framed` is guarded here too, not only via the disabled button — HTML
-		// `disabled` is a UI-only barrier; the handler must hold the invariant.
-		if (!selectedSource || !hasSql || !nameValid || !framed) return;
-		onAdd({
+		if (!selectedSource || !hasSql || !nameValid) return;
+		onAddQuery({
+			kind: "query",
 			source_name: importAs,
 			// The picked source IS the connection the query reads through; the engine
 			// resolves credentials from it, so the new source can be named freely.
@@ -252,12 +345,21 @@ function ProbePanel({
 	};
 
 	const noSources = !sources.isLoading && list.length === 0;
+	// The Start gate (DAT-594): a non-empty set AND a framed workspace. Disabled
+	// Start tells the user WHICH precondition is missing.
+	const canStart = importSet.length > 0 && framed;
+	const startBlockedReason =
+		importSet.length === 0
+			? "Stage a query or upload a file first."
+			: !framed
+				? "Declare a business model (Frame / Vertical) before importing."
+				: undefined;
 
 	return (
 		<Stack gap="sm" data-testid="probe-explore">
 			<Group justify="space-between" wrap="nowrap">
 				<Text size="sm" fw={600}>
-					Probe a database source
+					Assemble an import set
 				</Text>
 				<Group gap="xs" wrap="nowrap">
 					{selectedSource && (
@@ -265,8 +367,30 @@ function ProbePanel({
 							{selectedSource.backend}
 						</Badge>
 					)}
-					{/* The import-set count symbol — always here in the header (not pushed
-					    below the result grid), opens the staged-queries modal. */}
+					{/* Header toolbar (DAT-594): Upload files, declare the model, and the
+					    set count symbol — always here (not pushed below the result grid). */}
+					<Tooltip label="Upload files">
+						<Button
+							size="compact-xs"
+							variant="light"
+							leftSection={<UploadIcon size={14} />}
+							onClick={() => setUploadOpen(true)}
+							data-testid="probe-upload-open"
+						>
+							Upload
+						</Button>
+					</Tooltip>
+					<Tooltip label="Frame a model or pick a vertical">
+						<Button
+							size="compact-xs"
+							variant="light"
+							leftSection={<Target size={14} />}
+							onClick={() => setModelOpen(true)}
+							data-testid="probe-model-open"
+						>
+							{framed ? "Model ✓" : "Frame / Vertical"}
+						</Button>
+					</Tooltip>
 					{importSet.length > 0 && (
 						<Tooltip label="View import set">
 							<Button
@@ -283,9 +407,9 @@ function ProbePanel({
 				</Group>
 			</Group>
 			<Text size="xs" c="dimmed">
-				Read-only DuckDB SQL against a configured source (use LIMIT, not TOP) —
-				no data is imported until you add a query to the import set.
-				⌘/Ctrl+Enter to run.
+				Probe a database with read-only DuckDB SQL (use LIMIT, not TOP) and
+				stage queries, or upload files — then declare a model and Start the
+				import. ⌘/Ctrl+Enter to run.
 			</Text>
 
 			{unframed && (
@@ -302,9 +426,8 @@ function ProbePanel({
 							has no concepts
 						</>
 					)}
-					, so an imported source has nothing to ground against. Frame a
-					vertical (or pick one) in the chat before importing — probing here
-					still works.
+					. Stage your set, then declare a model (Frame / Vertical) before you
+					Start — an imported source has nothing to ground against without one.
 				</Alert>
 			)}
 
@@ -337,7 +460,7 @@ function ProbePanel({
 					<Text span ff="monospace" size="xs">
 						docker-compose.sources.yml
 					</Text>
-					).
+					), or upload files instead.
 				</Alert>
 			)}
 
@@ -382,9 +505,62 @@ function ProbePanel({
 				</Button>
 			</Group>
 
+			{/* The primary action: import the whole staged set in one run. Gated on a
+			    framed workspace (DAT-594) — disabled tells the user why. */}
+			<Group justify="flex-end" gap="sm" wrap="nowrap">
+				{startBlockedReason && (
+					<Text size="xs" c="dimmed" data-testid="probe-start-blocked">
+						{startBlockedReason}
+					</Text>
+				)}
+				<Button
+					size="sm"
+					onClick={onImport}
+					disabled={!canStart}
+					loading={pending}
+					data-testid="probe-start"
+				>
+					Start import
+					{importSet.length > 0
+						? ` (${importSet.length} source${importSet.length === 1 ? "" : "s"})`
+						: ""}
+				</Button>
+			</Group>
+
 			{submitted && (
 				<StreamingGrid key={runId} endpoint="/api/probe-sql" body={submitted} />
 			)}
+
+			{/* Upload modal — reuses the standalone dropzone; staged files join the set. */}
+			<Modal
+				opened={uploadOpen}
+				onClose={() => setUploadOpen(false)}
+				centered
+				size="lg"
+				title="Upload files to the import set"
+			>
+				<UploadDropzone
+					onUploaded={(uris) => {
+						onAddFiles(uris);
+						setUploadOpen(false);
+					}}
+				/>
+			</Modal>
+
+			{/* Frame / Vertical modal — declares the model from the staged set's schemas
+			    (frame a new vertical) or adopts a builtin; invalidates the status query
+			    on success so the Start gate flips. */}
+			<ModelModal
+				opened={modelOpen}
+				onClose={() => setModelOpen(false)}
+				importSet={importSet}
+				onModelDeclared={() => {
+					queryClient.invalidateQueries({
+						queryKey: ["active-vertical-status"],
+					});
+					setModelOpen(false);
+				}}
+			/>
 
 			<Modal
 				opened={setOpen}
@@ -395,39 +571,73 @@ function ProbePanel({
 			>
 				<Stack gap="sm">
 					<Text size="xs" c="dimmed">
-						Each query imports as its own source. They import together as one
-						run.
+						{queryCount} quer{queryCount === 1 ? "y" : "ies"} and{" "}
+						{importSet.length - queryCount} file
+						{importSet.length - queryCount === 1 ? "" : "s"}. Each imports as
+						its own source; they import together as one run.
 					</Text>
 					{importSet.length === 0 ? (
 						<Text size="sm" c="dimmed">
-							No queries staged yet.
+							No queries or files staged yet.
 						</Text>
 					) : (
 						<Stack gap="xs" data-testid="probe-import-set">
-							{importSet.map((spec) => (
-								<Group
-									key={spec.source_name}
-									justify="space-between"
-									wrap="nowrap"
-									align="flex-start"
-								>
-									<Stack gap={2} style={{ minWidth: 0, flex: 1 }}>
-										<Badge variant="light" size="sm" tt="none">
-											{spec.source_name}
-										</Badge>
-										<Code block>{spec.sql}</Code>
-									</Stack>
-									<ActionIcon
-										variant="subtle"
-										color="gray"
-										size="sm"
-										aria-label={`Remove ${spec.source_name}`}
-										onClick={() => onRemove(spec.source_name)}
+							{importSet.map((item) =>
+								item.kind === "query" ? (
+									<Group
+										key={`q:${item.source_name}`}
+										justify="space-between"
+										wrap="nowrap"
+										align="flex-start"
 									>
-										<X size={14} />
-									</ActionIcon>
-								</Group>
-							))}
+										<Stack gap={2} style={{ minWidth: 0, flex: 1 }}>
+											<Badge variant="light" size="sm" tt="none">
+												{item.source_name}
+											</Badge>
+											<Code block>{item.sql}</Code>
+										</Stack>
+										<ActionIcon
+											variant="subtle"
+											color="gray"
+											size="sm"
+											aria-label={`Remove ${item.source_name}`}
+											onClick={() => onRemove(item.source_name)}
+										>
+											<X size={14} />
+										</ActionIcon>
+									</Group>
+								) : (
+									<Group
+										key={`f:${item.file_uri}`}
+										justify="space-between"
+										wrap="nowrap"
+										align="center"
+									>
+										<Group
+											gap="xs"
+											style={{ minWidth: 0, flex: 1 }}
+											wrap="nowrap"
+										>
+											<FileText size={14} aria-hidden />
+											<Text size="sm" truncate>
+												{item.filename}
+											</Text>
+											<Badge variant="light" size="xs" tt="none">
+												{item.source_type}
+											</Badge>
+										</Group>
+										<ActionIcon
+											variant="subtle"
+											color="gray"
+											size="sm"
+											aria-label={`Remove ${item.filename}`}
+											onClick={() => onRemove(item.file_uri)}
+										>
+											<X size={14} />
+										</ActionIcon>
+									</Group>
+								),
+							)}
 						</Stack>
 					)}
 					<Group justify="flex-end">
@@ -441,8 +651,8 @@ function ProbePanel({
 							}}
 							data-testid="probe-import-run"
 						>
-							Import {importSet.length} source
-							{importSet.length === 1 ? "" : "s"}
+							Start import ({importSet.length} source
+							{importSet.length === 1 ? "" : "s"})
 						</Button>
 					</Group>
 				</Stack>

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
@@ -640,21 +640,8 @@ function ProbePanel({
 							)}
 						</Stack>
 					)}
-					<Group justify="flex-end">
-						<Button
-							size="xs"
-							disabled={importSet.length === 0 || !framed}
-							loading={pending}
-							onClick={() => {
-								onImport();
-								setSetOpen(false);
-							}}
-							data-testid="probe-import-run"
-						>
-							Start import ({importSet.length} source
-							{importSet.length === 1 ? "" : "s"})
-						</Button>
-					</Group>
+					{/* Review/remove only — Start funnels through the single panel-level
+					    button (probe-start) so the framed-gate lives in one place. */}
 				</Stack>
 			</Modal>
 		</Stack>


### PR DESCRIPTION
Turns the probe widget into a **staging hub**: the user assembles a heterogeneous import set (uploaded **files** AND probed **SQL queries**), declares a business model (**frame** a new vertical OR **use_vertical** to adopt a builtin) seeded from the assembled set's schemas, then clicks **Start** to import the whole set in ONE batched `addSourceWorkflow` run. **The frame-before-import gate moves from "can't Add" to "can't Start."**

Cockpit-only — no engine (Python) changes. The `trigger-add-source.ts` signature and the `addSourceWorkflow` contract are untouched; mixed file+query in one run is already supported by the engine (the import activity dispatches per-row off `Source.source_type`).

## Phase 1 — persist seam
- Extract file-source persistence out of the agent `select` tool into a shared `persistFileSources` (`select/file-source.ts`), mirroring `persistRecipeSources`. `select.ts` now calls the shared fn (no duplicated logic).
- Widen `server/import-sources.ts` from a query-only `{ sources }` input to a heterogeneous `{ queries, files }` set: validate-all-up-front, persist both kinds, union the source ids, ONE `triggerAddSource`. The `runWithConversation` threading is preserved. The union composition is factored into a testable `persistImportSet`.

## Phase 2 — schema assembly + frame/vertical server fns
- `probeDescribe()` (`duckdb/probe.ts`): runs `DESCRIBE SELECT * FROM (<sql>)` unwrapped (plus a bounded sample) on the raw probe connection — `probe()` wraps SQL in a `LIMIT` subquery so it can't DESCRIBE.
- Exported the connect file-sniff as `sniffFileSchema`.
- `assembleStagingSchema` (`select/stage-schema.ts`): a pure union of the staged items' schemas into one synthetic `ConnectSchema` for `frame` (one table per staged item).
- `server/stage-frame.ts`: UI-callable `frameStagingSet` / `adoptVerticalForStaging` / `listAdoptableVerticals` server fns wrapping the agent-only `frame` / `useVertical` / `listVerticals`. `frameStagingSet` returns a serializable summary (counts + vertical), not the full `FrameResult` (whose validation `parameters: Record<string, unknown>` trips the TanStack Start server-fn serialization check, and which the modal doesn't render).

## Phase 3 — UI staging hub
- `probe.tsx`: import set generalized from `ImportSpec[]` to a `{ kind: "query" | "file" }` tagged union (the cart lists files by original filename, keyed by digest internally). Header toolbar: **Upload** (modal reusing `<UploadDropzone />`), **Frame / Vertical** (the new `ModelModal`), and the existing set count symbol. A primary **Start** button. **The gate moved:** Add-to-set is now free (no `framed` condition); Start is gated on `importSet.length > 0 && framed`, with a reason shown when blocked. The model modal invalidates `["active-vertical-status"]` on success so the gate flips immediately.
- `model-modal.tsx`: frame-new (seeded from the staged set's schemas) OR adopt a builtin via the use_vertical server fn. Frame writes overlay rows immediately (acceptable here — Start gates the import, not the frame; a propose/commit split is DAT-598).

## Tests adapted
The old `probe.test.tsx` cases that asserted **Add** was disabled on an unframed workspace are adapted to the new design: Add is now free, and the gate lives on **Start** (asserted unframed → Start blocked with a reason, then `onModelDeclared` + re-resolving the status query flips it). New unit tests cover `persistFileSources`, the heterogeneous union (`persistImportSet`), the synthetic-schema assembly, the `probeDescribe` mapping, and the model modal's frame/adopt paths.

## Gates
`bun run check` (Biome), `bun run typecheck` (tsc), `bun run test` (vitest, 1290 passed) — all green locally.

## Pending human acceptance
The live browser smoke (docker stack + MS SQL + a framed workspace, interactive Playwright) is **not run here** — it's the human's acceptance step. The bar met here is full unit/tsc/biome green + a clean PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)