### PR TITLE
DAT-594: move Import into the toolbar, reason on hover

### DIFF
--- a/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.test.tsx
@@ -248,10 +248,9 @@ describe("ProbeWidget staging hub (DAT-592 + DAT-594)", () => {
 		await waitFor(() => expect(addBtn().disabled).toBe(false));
 		fireEvent.click(addBtn());
 
+		// Start (the toolbar Import button) is gated; the reason now lives in its
+		// hover tooltip, so we assert the disabled gate itself.
 		expect(startBtn().disabled).toBe(true);
-		expect(screen.getByTestId("probe-start-blocked").textContent).toContain(
-			"business model",
-		);
 
 		// The model modal flipping framed → true opens the Start gate (the
 		// invalidation path is exercised by re-resolving the status query).

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
@@ -40,6 +40,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import {
+	Download as DownloadIcon,
 	FileText,
 	Layers,
 	Target,
@@ -404,6 +405,30 @@ function ProbePanel({
 							</Button>
 						</Tooltip>
 					)}
+					{/* The primary action lives here, last in the toolbar — gated on a
+					    non-empty set AND a framed workspace. The reason it's disabled
+					    shows on hover (the <span> wrapper is the tooltip target so it
+					    still fires while the Button has pointer-events:none). */}
+					<Tooltip
+						label={
+							startBlockedReason ??
+							`Import ${importSet.length} source${importSet.length === 1 ? "" : "s"} in one run`
+						}
+					>
+						<span>
+							<Button
+								size="compact-xs"
+								variant="filled"
+								leftSection={<DownloadIcon size={14} />}
+								onClick={onImport}
+								disabled={!canStart}
+								loading={pending}
+								data-testid="probe-start"
+							>
+								Import
+							</Button>
+						</span>
+					</Tooltip>
 				</Group>
 			</Group>
 			<Text size="xs" c="dimmed">
@@ -502,28 +527,6 @@ function ProbePanel({
 					data-testid="probe-add-to-set"
 				>
 					{nameStaged ? "Update query" : "Add to import set"}
-				</Button>
-			</Group>
-
-			{/* The primary action: import the whole staged set in one run. Gated on a
-			    framed workspace (DAT-594) — disabled tells the user why. */}
-			<Group justify="flex-end" gap="sm" wrap="nowrap">
-				{startBlockedReason && (
-					<Text size="xs" c="dimmed" data-testid="probe-start-blocked">
-						{startBlockedReason}
-					</Text>
-				)}
-				<Button
-					size="sm"
-					onClick={onImport}
-					disabled={!canStart}
-					loading={pending}
-					data-testid="probe-start"
-				>
-					Start import
-					{importSet.length > 0
-						? ` (${importSet.length} source${importSet.length === 1 ? "" : "s"})`
-						: ""}
 				</Button>
 			</Group>
 


### PR DESCRIPTION
Follow-up UX polish on the DAT-594 staging hub (PR #344).

## Problem
The **Start import** button sat bottom-right under the result grid — misplaced and easy to miss.

## Change
- Move the primary action into the header toolbar as the **last** item (after Upload · Model), renamed to just **Import** (download icon, filled).
- The disabled reason now shows as a **hover tooltip** (wrapped in a `<span>` so it fires while the disabled `Button` has `pointer-events:none`) — the inline `probe-start-blocked` help text is removed.
- Test follows the design: the reason is no longer inline DOM, so we assert the disabled gate itself (`probe-start` testid moved onto the toolbar button).

Cockpit-only. No engine/contract change.

## Verification
- Gates green: biome (387 files), tsc, vitest (143 files / 1290).
- Verified live in the container (built from this branch): toolbar reads **Upload · Model ✓ · Import**; the tooltip fires on the disabled button ("Stage a query or upload a file first.").

🤖 Generated with [Claude Code](https://claude.com/claude-code)