### PR TITLE
DAT-595: pin the watched execution in progress polls (no new run id)

### DIFF
--- a/packages/cockpit/src/lib/completion-watcher.test.ts
+++ b/packages/cockpit/src/lib/completion-watcher.test.ts
@@ -69,8 +69,9 @@ vi.mock("#/temporal/progress", () => ({
 	terminalRunStatus: () => "completed",
 }));
 
-import type { WatchableRun } from "#/db/cockpit/runs";
+import { listWatchableRuns, type WatchableRun } from "#/db/cockpit/runs";
 import { streamAgentTurnToBus } from "#/lib/agent-turn";
+import { getWorkflowProgress } from "#/temporal/progress";
 import { pollOnce } from "./completion-watcher";
 
 beforeEach(() => {
@@ -111,5 +112,26 @@ describe("run-routing (DAT-528): a run narrates only into its own conversation",
 		]);
 		expect(h.narrated).toEqual(["A"]);
 		expect(trackedB.size).toBe(0);
+	});
+});
+
+describe("placeholder runs are skipped until attachRunId finalizes the real id (DAT-595)", () => {
+	it("does NOT track, poll, or narrate a run whose runId still equals its workflowId", async () => {
+		// A just-recorded run carries the workflowId PLACEHOLDER until attachRunId
+		// rewrites it post-start. getWorkflowProgress can only PIN a real id, so the
+		// watcher must skip the placeholder — otherwise a reused workflow id would
+		// resolve a PRIOR run's terminal state and mark this one done off it (DAT-595).
+		vi.mocked(listWatchableRuns).mockResolvedValueOnce([
+			{
+				workflowId: "addsource-ws",
+				runId: "addsource-ws",
+				stage: "add_source",
+			},
+		]);
+		const tracked = new Map<string, WatchableRun>();
+		await pollOnce("A", tracked, new AbortController().signal);
+		expect(tracked.size).toBe(0);
+		expect(getWorkflowProgress).not.toHaveBeenCalled();
+		expect(streamAgentTurnToBus).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cockpit/src/lib/completion-watcher.ts
+++ b/packages/cockpit/src/lib/completion-watcher.ts
@@ -147,7 +147,17 @@ export async function pollOnce(
 	const candidates = await listWatchableRuns(conversationId, WATCH_LIMIT).catch(
 		() => [] as WatchableRun[],
 	);
-	for (const run of candidates) tracked.set(runKey(run), run);
+	for (const run of candidates) {
+		// Skip a run still at its pre-attach PLACEHOLDER id (runId === workflowId):
+		// getWorkflowProgress can only PIN a real execution id, and the placeholder
+		// would fall back to the latest execution — which, for a REUSED workflow id
+		// (`addsource-<ws>`), can read a PRIOR run's terminal state and mark THIS run
+		// done off the wrong snapshot (the DAT-595 conflation). `attachRunId`
+		// finalizes the real id moments after start, so the row is tracked on the
+		// next tick (sub-second) and then pinned precisely.
+		if (run.runId === run.workflowId) continue;
+		tracked.set(runKey(run), run);
+	}
 
 	// (2) Poll each tracked run against Temporal; narrate on the done edge.
 	for (const [key, run] of [...tracked]) {

--- a/packages/cockpit/src/routes/api/workflow-progress.ts
+++ b/packages/cockpit/src/routes/api/workflow-progress.ts
@@ -41,6 +41,12 @@ export const Route = createFileRoute("/api/workflow-progress")({
 				}
 
 				try {
+					// The widget seed posts the PLACEHOLDER run_id (=== workflow_id), so
+					// getWorkflowProgress takes the latest-execution fallback here; the
+					// watcher is the path that pins a real id (DAT-595). markRunStatus below
+					// targets the (workflowId, run_id) row — for the placeholder that's the
+					// pre-attach row, harmless (the watcher's claimRunNarration is the
+					// once-only narration guard regardless).
 					const result = await getWorkflowProgress(parsed.data);
 					// The poll is the observation point for run completion — mark the
 					// recorded session_run terminal so the reload-recovery substrate

--- a/packages/cockpit/src/temporal/progress.test.ts
+++ b/packages/cockpit/src/temporal/progress.test.ts
@@ -130,7 +130,7 @@ beforeEach(() => {
 });
 
 describe("getWorkflowProgress (DAT-352)", () => {
-	it("queries get_progress on the latest execution by workflowId and maps the shape (DAT-530)", async () => {
+	it("PINS the precise (workflowId, runId) execution and maps the shape (DAT-595)", async () => {
 		h.snapshot = {
 			phase: "processing_tables",
 			tables_total: 4,
@@ -141,7 +141,9 @@ describe("getWorkflowProgress (DAT-352)", () => {
 			run_id: "run-1",
 		});
 
-		expect(getHandleMock).toHaveBeenCalledWith("addsource-ws-src");
+		// A real run id pins the exact execution — a reused workflow id can't read a
+		// prior run's snapshot for the run being watched (DAT-595).
+		expect(getHandleMock).toHaveBeenCalledWith("addsource-ws-src", "run-1");
 		expect(h.queryName).toBe("get_progress");
 		expect(result).toEqual({
 			phase: "processing_tables",
@@ -152,6 +154,27 @@ describe("getWorkflowProgress (DAT-352)", () => {
 			status: "RUNNING",
 			done: false,
 		});
+	});
+
+	it("falls back to the LATEST execution for the pre-attach placeholder (run_id === workflow_id)", async () => {
+		// The widget seed passes the placeholder (the trigger returns it before the
+		// journey knows the execution id) — there's no precise run to pin, so we
+		// resolve the latest execution (also gives a reload-pinned widget its terminal
+		// state). DAT-595.
+		h.snapshot = {
+			phase: "processing_tables",
+			tables_total: 1,
+			tables_completed: 0,
+		};
+		await getWorkflowProgress({
+			workflow_id: "addsource-ws",
+			run_id: "addsource-ws",
+		});
+		expect(getHandleMock).toHaveBeenCalledWith("addsource-ws");
+		expect(getHandleMock).not.toHaveBeenCalledWith(
+			"addsource-ws",
+			"addsource-ws",
+		);
 	});
 
 	it("resolves per-table ids to names and passes the failure through", async () => {

--- a/packages/cockpit/src/temporal/progress.ts
+++ b/packages/cockpit/src/temporal/progress.ts
@@ -10,9 +10,11 @@
 // branch); a workflow without the query (none today; forward-compat) degrades to
 // describe()-only.
 //
-// Targets the PRECISE run_id: the workflow id is reused per session under
-// ALLOW_DUPLICATE across replays, so getHandle(id, runId) pins the iteration the
-// TRIGGER returned. NON-mutating (query + describe) → safe to poll on an interval.
+// Targets the PRECISE run when given a real Temporal run id (the workflow id is
+// REUSED across runs — `addsource-<ws>` — so getHandle(id, runId) pins the exact
+// execution); falls back to the LATEST execution only for the pre-attach
+// placeholder (run_id === workflow_id). See getWorkflowProgress for the two-caller
+// rationale (DAT-595). NON-mutating (query + describe) → safe to poll on an interval.
 
 import { Client, Connection } from "@temporalio/client";
 import { inArray } from "drizzle-orm";
@@ -198,12 +200,30 @@ export async function getWorkflowProgress(
 	input: WorkflowProgressInput,
 ): Promise<WorkflowProgress> {
 	const client = await getTemporalClient();
-	// Resolve the LATEST execution of the workflow id (DAT-530): a journey-started
-	// stage's runId isn't known to the caller, and progress always reflects the
-	// current run, so we key on the workflow id and let getHandle pick the latest
-	// execution. `run_id` is still accepted in the input (the poll body sends it)
-	// but no longer pins the iteration.
-	const handle = client.workflow.getHandle(input.workflow_id);
+	// Pin the PRECISE execution when we hold a real Temporal run id; resolve the
+	// LATEST execution only for the pre-attach PLACEHOLDER (DAT-595).
+	//
+	// Run-id semantics (cockpit_db.runs): a run row's `runId` IS Temporal's
+	// execution id (firstExecutionRunId) — but it is recorded as the workflowId
+	// PLACEHOLDER until `attachRunId` rewrites it just after start. So this has two
+	// callers with two different ids, and must treat them differently:
+	//   • the COMPLETION WATCHER passes the real, attached run id → we PIN it
+	//     (getHandle(workflowId, runId)). A workspace's workflow id is REUSED across
+	//     runs (`addsource-<ws>`), so resolving "latest" here let a PRIOR run's
+	//     terminal state be read for the run actually being watched — which marked a
+	//     2nd import done off the 1st's snapshot and stranded it (DAT-595). Pinning
+	//     reads exactly the watched execution.
+	//   • the widget SEED passes the placeholder (`run_id === workflow_id` — the
+	//     trigger returns it before the journey knows the execution id), where the
+	//     precise run isn't knowable, so we take the latest execution. That also
+	//     gives a reload-pinned widget its terminal state; a placeholder PIN would
+	//     404 → PENDING forever on a completed run.
+	// The watcher SKIPS placeholder rows (completion-watcher.ts) so its path ALWAYS
+	// pins — only the seed ever takes the latest-execution fallback.
+	const handle =
+		input.run_id === input.workflow_id
+			? client.workflow.getHandle(input.workflow_id)
+			: client.workflow.getHandle(input.workflow_id, input.run_id);
 
 	// describe() throws WorkflowNotFoundError when the workflow id has no execution
 	// yet — the poll-race the trigger opens (DAT-570). Report PENDING (not a 500) so

--- a/packages/cockpit/src/temporal/reconcile.ts
+++ b/packages/cockpit/src/temporal/reconcile.ts
@@ -37,6 +37,9 @@ export async function reconcileActiveRuns(
 
 async function reconcileOne(run: ActiveRun): Promise<void> {
 	try {
+		// A placeholder runId (=== workflowId, pre-attachRunId) takes
+		// getWorkflowProgress's latest-execution fallback — correct for a reconcile
+		// that fires during the attach window; a real id pins the exact run (DAT-595).
 		const progress = await getWorkflowProgress({
 			workflow_id: run.workflowId,
 			run_id: run.runId,

--- a/packages/cockpit/src/temporal/trigger-add-source.ts
+++ b/packages/cockpit/src/temporal/trigger-add-source.ts
@@ -62,8 +62,11 @@ function requireTemporalConfig(): void {
  * Signal the workspace's JourneyWorkflow to run an add_source stage (DAT-551).
  * Returns the deterministic workflow + minted session id immediately; the journey
  * records the run (authoritative, before start) and starts + awaits the engine
- * child, narrating completion into the originating chat. The caller does NOT poll a
- * run id — progress resolves the latest execution by workflow id.
+ * child, narrating completion into the originating chat. Returns the workflowId as
+ * a PLACEHOLDER run_id — the real Temporal execution id is minted by the journey
+ * post-start and rewritten via `attachRunId` (DAT-595). The widget seed + reconcile
+ * use the placeholder (latest-execution fallback in getWorkflowProgress); the
+ * completion-watcher waits for the real id, then PINS it.
  *
  * No engine seed (DAT-506): the run's table set is anchored by `run_tables` (keyed
  * by `run_id`), and the `vertical` is the workspace property from the registry.
@@ -96,9 +99,11 @@ export async function triggerAddSource(
 	});
 
 	return {
-		// The deterministic workflow id; run_id mirrors it (the journey owns the real
-		// execution id — progress resolves the latest run by workflow_id, DAT-530).
 		workflow_id: workflowId,
+		// PLACEHOLDER run_id (DAT-595): the journey mints the real Temporal execution
+		// id post-start and rewrites it via `attachRunId`. The widget seed + reconcile
+		// take getWorkflowProgress's latest-execution fallback until then; the
+		// completion-watcher SKIPS the placeholder and pins the real id once attached.
 		run_id: workflowId,
 		sources: input.sources,
 	};


### PR DESCRIPTION
## Problem
Consecutive `add_source` runs share one **reused** workflow id (`addsource-<ws>`). `getWorkflowProgress` resolved the **latest** execution by workflow id and **ignored `run_id`** (a DAT-530 change — the module header still claimed it pinned, a contradiction). So the completion-watcher, polling run *N*, could read run *N-1*'s terminal state, mark run *N* done off it, narrate it, and drop it from tracking — stranding the new run's widget on the prior run's stale snapshot (the "stale failure alert" from the #342 smoke). Fast-fail froze the same way.

This is an **execution-conflation** bug, not a missing identity — so the fix invents **no new id**.

## Fix (uses the one real identity already in `cockpit_db.runs.runId`)
- **`temporal/progress.ts`** — `getWorkflowProgress` **pins** `getHandle(workflowId, runId)` when `run_id` is a real execution id; falls back to *latest* only for the pre-attach **placeholder** (`run_id === workflow_id`), which is what the widget seed + reload-pinned cases legitimately pass (a placeholder pin would 404 → PENDING forever on a completed run). Fixed the contradictory header comment.
- **`lib/completion-watcher.ts`** — the watcher **skips placeholder rows** (`runId === workflowId`) so it only ever polls a *pinned, real* execution. `attachRunId` finalizes the real id a beat after start, so the row is tracked on the next tick (sub-second) and then pinned precisely.

No new id, no trigger change, no journey change, no Python change.

## Run-id semantics, now unambiguous in code
1. **Temporal execution id** (`firstExecutionRunId`) → `runs.runId` via `attachRunId` — the one cockpit-facing run identity, recorded as the workflowId **placeholder** until finalized.
2. **Engine** internal metadata `run_id` (version axis) — cockpit never stores/reads it.

## Verification
- biome (387 files), tsc, vitest (143 files / **1292**, +2 new: pin / placeholder-fallback / watcher-skip).
- Live smoke (two consecutive imports each showing their own progress) pending — to run on the existing stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)