### PR TITLE
DAT-594: model modal reflects the active vertical (single-model state)

### DIFF
--- a/packages/cockpit/src/ui/cockpit/widgets/model-modal.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/model-modal.test.tsx
@@ -24,6 +24,10 @@ vi.mock("#/server/stage-frame", () => ({
 	adoptVerticalForStaging: (args: unknown) => adoptVerticalForStagingMock(args),
 	listAdoptableVerticals: () => listAdoptableVerticalsMock(),
 }));
+const getActiveVerticalStatusMock = vi.fn();
+vi.mock("#/server/active-vertical", () => ({
+	getActiveVerticalStatus: () => getActiveVerticalStatusMock(),
+}));
 
 import {
 	ModelModal,
@@ -70,6 +74,12 @@ beforeEach(() => {
 			concept_count: 12,
 		},
 	]);
+	// Default: unframed workspace (no current-model banner) — the banner tests
+	// override this.
+	getActiveVerticalStatusMock.mockResolvedValue({
+		vertical: "_adhoc",
+		framed: false,
+	});
 });
 
 afterEach(() => {
@@ -125,6 +135,26 @@ describe("ModelModal frame path (DAT-594)", () => {
 		fireEvent.click(screen.getByTestId("model-frame-run"));
 		const err = await screen.findByTestId("model-error");
 		expect(err.textContent).toContain("induction returned none");
+	});
+});
+
+describe("ModelModal current-model banner (DAT-594 follow-up)", () => {
+	it("reflects the active model when one is set (not a from-scratch pick)", async () => {
+		getActiveVerticalStatusMock.mockResolvedValue({
+			vertical: "finance",
+			framed: true,
+		});
+		renderModal(STAGED);
+		const banner = await screen.findByTestId("model-current");
+		expect(banner.textContent).toContain("finance");
+		// The from-scratch declare intro is replaced by the current-model banner.
+		expect(screen.queryByText(/An imported source grounds against/)).toBeNull();
+	});
+
+	it("shows the declare intro (no banner) when the workspace is unframed", async () => {
+		renderModal(STAGED);
+		await waitFor(() => expect(getActiveVerticalStatusMock).toHaveBeenCalled());
+		expect(screen.queryByTestId("model-current")).toBeNull();
 	});
 });
 

--- a/packages/cockpit/src/ui/cockpit/widgets/model-modal.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/model-modal.tsx
@@ -25,6 +25,7 @@ import {
 } from "@mantine/core";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
+import { getActiveVerticalStatus } from "#/server/active-vertical";
 import {
 	adoptVerticalForStaging,
 	frameStagingSet,
@@ -74,6 +75,19 @@ export function ModelModal({
 		staleTime: 5 * 60 * 1000,
 	});
 
+	// The workspace's CURRENT model (DAT-594 follow-up). One vertical per workspace,
+	// so when one is already set this modal CHANGES it — not a from-scratch pick; the
+	// banner says so. Shares the ["active-vertical-status"] cache + post-declare
+	// invalidation with the probe widget, so it reflects the latest state.
+	const activeVertical = useQuery({
+		queryKey: ["active-vertical-status"],
+		queryFn: () => getActiveVerticalStatus(),
+		enabled: opened,
+		staleTime: 5 * 60 * 1000,
+	});
+	const currentModel =
+		activeVertical.data?.framed === true ? activeVertical.data.vertical : null;
+
 	const frameMutation = useMutation({
 		mutationFn: () =>
 			frameStagingSet({
@@ -121,10 +135,21 @@ export function ModelModal({
 			data-testid="model-modal"
 		>
 			<Stack gap="md">
-				<Text size="xs" c="dimmed">
-					An imported source grounds against the workspace's business model.
-					Frame a new one from your staged set, or adopt an existing vertical.
-				</Text>
+				{currentModel ? (
+					<Alert color="green" variant="light" data-testid="model-current">
+						Current model:{" "}
+						<Text span fw={600}>
+							{currentModel}
+						</Text>
+						. Your imports ground against it. One model per workspace — frame a
+						new vertical or adopt a different one below only to change it.
+					</Alert>
+				) : (
+					<Text size="xs" c="dimmed">
+						An imported source grounds against the workspace's business model.
+						Frame a new one from your staged set, or adopt an existing vertical.
+					</Text>
+				)}
 
 				{error && (
 					<Alert color="red" data-testid="model-error">


### PR DESCRIPTION
## Problem
With one vertical per workspace, reopening **Declare a business model** after a model was already set (toolbar shows **Model ✓**) presented a blank from-scratch picker — defaulting to "Frame a new vertical" + the empty-set warning — giving the impression you had to re-select the model from scratch.

## Fix
`model-modal.tsx` now fetches the active vertical status (sharing the `["active-vertical-status"]` cache + post-declare invalidation with the probe widget) and, when one is set, shows a **"Current model: `<vertical>`"** banner that frames the two options as *changing* the single workspace model rather than declaring one from scratch. Unframed workspaces keep the original declare copy.

Cockpit-only. No engine/contract change.

## Verification
- biome (387 files), tsc, vitest (143 files / 1292, +2 new: banner reflects the active model + replaces the declare intro; no banner when unframed).
- Verified live (rebased on main): opening Model ✓ on a framed workspace shows "Current model: **finance**. … One model per workspace — … only to change it."

🤖 Generated with [Claude Code](https://claude.com/claude-code)