### PR TITLE
DAT-596: in-place re-import-with-replace for db_recipe sources

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,27 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-22: DAT-596 — in-place re-import-with-replace for db_recipe sources
+
+Re-importing a `db_recipe` source under the SAME user-chosen name with a CHANGED recipe
+(re-pointed SQL) no longer **fails loud**. The import phase
+(`pipeline/phases/import_phase.py::_load_database_source`) now tears the source's existing
+tables down across all layers (DuckDB tables, `Table`/`Column` rows, every run-versioned
+metadata child, the per-table `metadata_snapshot_head` rows) and rematerializes the new
+recipe in place, re-stamping `imported_recipe_hash`. New helper:
+`pipeline/phases/_source_teardown.py::teardown_source_tables`.
+
+### dataraum-eval
+- **Lifecycle change, NOT a detector / response-shape change** — no DB schema change, no
+  detector retuning expected; calibration recall should be unaffected. Flagged so eval is
+  aware re-import is no longer an error.
+- **Behavior delta to any harness that asserted the old guard:** the message
+  `"…re-import is not yet supported. Re-select … under a NEW source name…"` is GONE. A
+  re-pointed db_recipe import now SUCCEEDS (replaces the old tables) instead of returning a
+  FAILED `PhaseResult`. Scope is db_recipe ONLY (files are content-keyed → a new source on
+  change, never this path). Same-recipe retry still skips via `should_skip` (unchanged).
+- **Status**: pending
+
 ## 2026-06-22: DAT-524 — temporal value-analysis cut (seasonality/trend/change-points/stability removed)
 
 The degenerate value-analysis half of the temporal phase is gone (it ran on a constant

--- a/packages/engine/src/dataraum/pipeline/phases/_source_teardown.py
+++ b/packages/engine/src/dataraum/pipeline/phases/_source_teardown.py
@@ -26,7 +26,8 @@ in FK-safe order:
 4. the per-table ``metadata_snapshot_head`` rows (``table:{id}`` /
    ``GENERATION_STAGE``) so no head dangles at a deleted target,
 5. the ``tables`` rows (DB-cascades their ``columns``),
-6. the underlying DuckDB tables (``DROP TABLE IF EXISTS lake.<layer>.<name>``).
+6. the underlying DuckDB objects (``DROP TABLE`` for raw/typed/quarantine,
+   ``DROP VIEW`` for the ``enriched`` layer — it's a view, not a table).
 
 It runs inside the import activity's session (the phase runner rolls back on a
 FAILED result, DAT-502), so a mid-teardown failure leaves the prior state intact.
@@ -100,15 +101,19 @@ def teardown_source_tables(ctx: PhaseContext, source_id: str) -> int:
     ctx.session.execute(delete(Table).where(Table.table_id.in_(table_ids)))
     ctx.session.flush()
 
-    # 5. The underlying DuckDB tables, one per (layer, bare-name). Raw/typed/
-    #    quarantine share the bare ``duckdb_path``; the schema discriminates.
+    # 5. The underlying DuckDB objects, one per (layer, bare-name). Raw/typed/
+    #    quarantine share the bare ``duckdb_path``; the schema discriminates. The
+    #    ``enriched`` layer is a DuckDB VIEW (enriched_views_phase builds it with
+    #    CREATE OR REPLACE VIEW), so DROP TABLE would silently no-op and leave the
+    #    view dangling over the deleted typed tables — drop it as a VIEW.
     for table in tables:
         bare = table.duckdb_path
         if not bare:
             continue
         schema = schema_for_layer(table.layer)
         fqn = f'{LAKE_CATALOG_ALIAS}.{schema}."{bare}"'
-        ctx.duckdb_conn.execute(f"DROP TABLE IF EXISTS {fqn}")
+        kind = "VIEW" if table.layer == "enriched" else "TABLE"
+        ctx.duckdb_conn.execute(f"DROP {kind} IF EXISTS {fqn}")
 
     return len(tables)
 

--- a/packages/engine/src/dataraum/pipeline/phases/_source_teardown.py
+++ b/packages/engine/src/dataraum/pipeline/phases/_source_teardown.py
@@ -1,0 +1,197 @@
+"""In-place teardown of a source's materialized tables + metadata (DAT-596).
+
+Re-importing a ``db_recipe`` source under the SAME user-chosen name with a
+CHANGED recipe (re-pointed SQL) is a replace, not an error: the old raw/typed/
+quarantine tables and every metadata row hanging off them must go before the new
+recipe rematerializes. Files never reach here — they are content-keyed
+(``src_<digest>``), so changed bytes mint a new source — this is the db_recipe
+path only.
+
+Why a NAME-keyed drop is correct and unambiguous: table names are UNIQUE per
+workspace across raw/typed/quarantine/enriched (one ``ws_<id>`` schema per
+workspace), so enumerating a source's tables by ``source_id`` and dropping each
+``(layer, duckdb_path)`` cannot touch another source's data. No run-versioned
+raw identity is needed (deferred future work).
+
+The cascade surface this clears (verified against ``schema.sql``): only
+``columns.table_id`` FK-cascades on a ``tables`` delete — every other child that
+references ``tables`` (or ``columns``) has NO ``ON DELETE CASCADE`` (the
+torn-window cut removed them, see ``_column_cleanup``). So this helper deletes,
+in FK-safe order:
+
+1. column-keyed children via :func:`delete_column_dependents` (the 14 children
+   of ``columns``),
+2. the table-keyed children that reference ``tables`` directly,
+3. the source-keyed children (``fix_ledger``, ``column_eligibility``),
+4. the per-table ``metadata_snapshot_head`` rows (``table:{id}`` /
+   ``GENERATION_STAGE``) so no head dangles at a deleted target,
+5. the ``tables`` rows (DB-cascades their ``columns``),
+6. the underlying DuckDB tables (``DROP TABLE IF EXISTS lake.<layer>.<name>``).
+
+It runs inside the import activity's session (the phase runner rolls back on a
+FAILED result, DAT-502), so a mid-teardown failure leaves the prior state intact.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import delete, or_, select
+
+from dataraum.core.duckdb_naming import schema_for_layer
+from dataraum.pipeline.phases._column_cleanup import delete_column_dependents
+from dataraum.server.storage import LAKE_CATALOG_ALIAS
+from dataraum.storage import Column, Table
+from dataraum.storage.snapshot_head import GENERATION_STAGE, MetadataSnapshotHead
+
+if TYPE_CHECKING:
+    from dataraum.pipeline.base import PhaseContext
+
+
+def teardown_source_tables(ctx: PhaseContext, source_id: str) -> int:
+    """Drop every table a source materialized + all its metadata children (DAT-596).
+
+    Enumerates the source's ``Table`` rows across ALL layers (raw/typed/
+    quarantine/enriched) by ``source_id``, then removes — in FK-safe order — the
+    column-keyed and table-keyed metadata, the per-table snapshot heads, the
+    ``Table``/``Column`` rows, and the underlying DuckDB tables. Idempotent and
+    name-unambiguous: table names are unique per workspace, so a ``source_id``
+    enumeration never reaches another source's data.
+
+    Args:
+        ctx: The import phase context (its ``session`` + ``duckdb_conn`` carry the
+            teardown; the phase runner's rollback-on-FAILED keeps it atomic).
+        source_id: The source whose materialized tables are being replaced.
+
+    Returns:
+        The number of ``Table`` rows torn down.
+    """
+    tables = ctx.session.execute(select(Table).where(Table.source_id == source_id)).scalars().all()
+    if not tables:
+        return 0
+
+    table_ids = [t.table_id for t in tables]
+    column_ids = list(
+        ctx.session.execute(select(Column.column_id).where(Column.table_id.in_(table_ids)))
+        .scalars()
+        .all()
+    )
+
+    # 1. Column-keyed children (the 14 FK children of ``columns``).
+    delete_column_dependents(ctx, column_ids)
+
+    # 2. Table-keyed children that reference ``tables`` directly (none cascade).
+    _delete_table_dependents(ctx, table_ids, source_id)
+
+    # 3. Per-table snapshot heads — add_source promotes one ``(table:{id},
+    #    GENERATION_STAGE)`` head per table; remove them so none dangles at a
+    #    deleted target. (Catalog / operating_model heads are workspace-grain,
+    #    not per-table, so they are untouched.)
+    head_targets = [f"table:{tid}" for tid in table_ids]
+    ctx.session.execute(
+        delete(MetadataSnapshotHead).where(
+            MetadataSnapshotHead.target.in_(head_targets),
+            MetadataSnapshotHead.stage == GENERATION_STAGE,
+        )
+    )
+
+    # 4. The ``tables`` rows. ``columns.table_id`` ON DELETE CASCADE drops the
+    #    Column rows with them; passive_deletes lets the DB do it.
+    ctx.session.execute(delete(Table).where(Table.table_id.in_(table_ids)))
+    ctx.session.flush()
+
+    # 5. The underlying DuckDB tables, one per (layer, bare-name). Raw/typed/
+    #    quarantine share the bare ``duckdb_path``; the schema discriminates.
+    for table in tables:
+        bare = table.duckdb_path
+        if not bare:
+            continue
+        schema = schema_for_layer(table.layer)
+        fqn = f'{LAKE_CATALOG_ALIAS}.{schema}."{bare}"'
+        ctx.duckdb_conn.execute(f"DROP TABLE IF EXISTS {fqn}")
+
+    return len(tables)
+
+
+def _delete_table_dependents(ctx: PhaseContext, table_ids: list[str], source_id: str) -> None:
+    """Delete every run-stamped row that FK-references the given tables (DAT-596).
+
+    Covers each child of ``tables`` that does NOT ``ON DELETE CASCADE`` (only
+    ``columns`` does). Reached by whichever FK column points at ``tables`` —
+    single ``table_id``, the fact/view pair, the measure/event pair, or the
+    relationship from/to endpoints. ``fix_ledger`` and ``column_eligibility``
+    are removed by ``source_id`` (they carry it directly).
+
+    Run BEFORE deleting the ``tables`` rows so the FK constraints hold.
+    """
+    from dataraum.analysis.correlation.db_models import DerivedColumn
+    from dataraum.analysis.drivers.db_models import DriverRankingArtifact
+    from dataraum.analysis.eligibility.db_models import ColumnEligibilityRecord
+    from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
+    from dataraum.analysis.lineage.db_models import MeasureAggregationLineage
+    from dataraum.analysis.relationships.db_models import Relationship
+    from dataraum.analysis.semantic.db_models import TableEntity
+    from dataraum.analysis.slicing.db_models import SliceDefinition
+    from dataraum.analysis.typing.db_models import MaterializationRecipe
+    from dataraum.analysis.views.db_models import EnrichedView
+    from dataraum.documentation.db_models import FixLedgerEntry
+    from dataraum.entropy.db_models import (
+        ClaimWitnessRecord,
+        EntropyObjectRecord,
+        EntropyReadinessRecord,
+    )
+    from dataraum.investigation.db_models import RunTable
+
+    # Single ``table_id`` FK.
+    single_table_keyed = (
+        DerivedColumn,
+        DimensionHierarchy,
+        SliceDefinition,
+        MaterializationRecipe,
+        TableEntity,
+        RunTable,
+        ClaimWitnessRecord,
+        EntropyObjectRecord,
+        EntropyReadinessRecord,
+    )
+    for model in single_table_keyed:
+        ctx.session.execute(delete(model).where(model.table_id.in_(table_ids)))
+
+    # Fact / view pair.
+    ctx.session.execute(
+        delete(EnrichedView).where(
+            or_(
+                EnrichedView.fact_table_id.in_(table_ids),
+                EnrichedView.view_table_id.in_(table_ids),
+            )
+        )
+    )
+    # Measure / event pair.
+    ctx.session.execute(
+        delete(MeasureAggregationLineage).where(
+            or_(
+                MeasureAggregationLineage.measure_table_id.in_(table_ids),
+                MeasureAggregationLineage.event_table_id.in_(table_ids),
+            )
+        )
+    )
+    # Driver rankings are keyed on the measure table.
+    ctx.session.execute(
+        delete(DriverRankingArtifact).where(DriverRankingArtifact.measure_table_id.in_(table_ids))
+    )
+    # Relationships reach a table through either endpoint.
+    ctx.session.execute(
+        delete(Relationship).where(
+            or_(
+                Relationship.from_table_id.in_(table_ids),
+                Relationship.to_table_id.in_(table_ids),
+            )
+        )
+    )
+
+    # Source-keyed children.
+    ctx.session.execute(delete(FixLedgerEntry).where(FixLedgerEntry.source_id == source_id))
+    ctx.session.execute(
+        delete(ColumnEligibilityRecord).where(ColumnEligibilityRecord.source_id == source_id)
+    )
+    ctx.session.flush()

--- a/packages/engine/src/dataraum/pipeline/phases/import_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/import_phase.py
@@ -109,8 +109,8 @@ class ImportPhase(BasePhase):
         so its raw tables only justify a skip while the current ``recipe_hash``
         equals the ``imported_recipe_hash`` witness stamped at import. On a
         mismatch (or a missing hash) this returns ``None`` and ``_run``'s db
-        path fails loud before touching the backend — never a silent skip over
-        stale raw tables, never a silent re-materialization either.
+        path tears down the old tables and re-imports the re-pointed recipe in
+        place (DAT-596) — never a silent skip over stale raw tables.
         """
         source_id = ctx.config.get("source_id")
         stmt = select(Table).where(Table.source_id == source_id, Table.layer == "raw")
@@ -124,7 +124,7 @@ class ImportPhase(BasePhase):
             stored = config.get("recipe_hash")
             imported = config.get("imported_recipe_hash")
             if not (stored and imported and stored == imported):
-                return None  # → _run fails loud (recipe changed / unhashed import)
+                return None  # → _run tears down + re-imports (recipe changed / unhashed, DAT-596)
             return (
                 f"Source already has {len(existing_tables)} raw tables "
                 "(recipe unchanged since import)"
@@ -482,17 +482,18 @@ class ImportPhase(BasePhase):
 
         # Stamp the materialization witness (DAT-430): record WHICH recipe these
         # raw tables came from, so a later run can tell an idempotent re-select
-        # (hashes match → skip) from a re-pointed recipe (mismatch → loud
-        # failure). Merge into the ROW's current config, not the phase-start
-        # ``connection_config`` snapshot from ctx.config: if a re-select commits
-        # mid-import and the engine commits last, stamping the snapshot would
-        # silently REVERT the user's new recipe — merging the row value keeps it
-        # (the witness is still THIS import's ``recipe_hash``, so the next run's
-        # compare fails loud against the re-pointed recipe). The other wedge arm
-        # — select commits AFTER this stamp — replaces the JSON without the
-        # witness (select read the row pre-stamp), so the next run sees no
-        # witness and also fails loud; acceptable (loud-fail direction), full
-        # select/import serialization is deferred. A fresh dict, not in-place
+        # (hashes match → skip) from a re-pointed recipe (mismatch → teardown +
+        # re-import in place, DAT-596). Merge into the ROW's current config, not
+        # the phase-start ``connection_config`` snapshot from ctx.config: if a
+        # re-select commits mid-import and the engine commits last, stamping the
+        # snapshot would silently REVERT the user's new recipe — merging the row
+        # value keeps it (the witness is still THIS import's ``recipe_hash``, so
+        # the next run's compare mismatches the re-pointed recipe → replace). The
+        # other wedge arm — select commits AFTER this stamp — replaces the JSON
+        # without the witness (select read the row pre-stamp), so the next run
+        # sees no witness and also replaces; correct now (it re-imports the
+        # current recipe), full select/import serialization is still deferred.
+        # A fresh dict, not in-place
         # mutation — SQLAlchemy's plain JSON column only change-tracks on
         # reassignment. ``select`` carries this key forward when it re-points
         # the config (its upsert replaces the JSON).

--- a/packages/engine/src/dataraum/pipeline/phases/import_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/import_phase.py
@@ -31,11 +31,13 @@ Source shapes — both written by the cockpit ``select`` tool, the only producer
   success this phase copies the hash to ``imported_recipe_hash`` — the
   materialization witness ``select`` preserves across re-selects.
   ``should_skip`` skips only while the two match (idempotent re-select / teach
-  re-run); a changed recipe falls through to a loud failure instead of
-  silently serving the stale raw tables. Real re-import-with-replace is the
-  deferred GC feature, not this phase's job. The engine never recomputes the
-  hash — both values are opaque tokens minted by one writer (``select``), so
-  no cross-language canonicalization contract exists.
+  re-run); a changed recipe falls through to an in-place
+  re-import-with-replace (DAT-596) — the source's existing tables across every
+  layer (DuckDB tables, ``Table``/``Column`` rows, all run-versioned metadata
+  children, the per-table snapshot heads) are torn down, then the new recipe is
+  rematerialized — instead of silently serving the stale raw tables. The engine
+  never recomputes the hash — both values are opaque tokens minted by one writer
+  (``select``), so no cross-language canonicalization contract exists.
 
 Per DAT-389 the source path is an ``s3://<lake-bucket>/<key>`` URI handed
 verbatim to DuckDB's ``read_*_auto`` over httpfs — never to ``pathlib``. Because
@@ -345,14 +347,17 @@ class ImportPhase(BasePhase):
     ) -> PhaseResult:
         """Materialize a recipe-driven database source.
 
-        Guards the name-keyed staleness hole first (DAT-430): a db source that
-        already has raw tables only gets here when ``should_skip`` found the
-        current ``recipe_hash`` differing from the ``imported_recipe_hash``
-        witness (or either missing) — re-extracting would orphan the old raw
-        tables and clobber overlapping names, so fail loud instead; re-import
-        with replace is the deferred GC feature. A fresh import requires the
-        ``select``-stamped ``recipe_hash`` and copies it to
-        ``imported_recipe_hash`` on success, completing the witness pair.
+        Re-import-with-replace (DAT-596): a db source that already has raw tables
+        only reaches here when ``should_skip`` found the current ``recipe_hash``
+        differing from the ``imported_recipe_hash`` witness (or either missing) —
+        i.e. the recipe was re-pointed under the SAME source name. Rather than
+        fail loud (the old deferred-GC stance), tear the source's existing tables
+        down across ALL layers (raw/typed/quarantine/enriched) — DuckDB tables,
+        ``Table``/``Column`` rows, every run-versioned metadata child, and the
+        per-table snapshot heads — then rematerialize the new recipe in place.
+        Name-keyed teardown is unambiguous: table names are unique per workspace.
+        A fresh import requires the ``select``-stamped ``recipe_hash`` and copies
+        it to ``imported_recipe_hash`` on success, completing the witness pair.
 
         Then resolves credentials via ``CredentialChain`` keyed by source name
         (``DATARAUM_{NAME}_URL``) and delegates to ``extract_backend`` to
@@ -363,24 +368,19 @@ class ImportPhase(BasePhase):
         from uuid import uuid4
 
         from dataraum.core.credentials import CredentialChain
+        from dataraum.pipeline.phases._source_teardown import teardown_source_tables
         from dataraum.sources.backends import extract_backend
         from dataraum.sources.db_recipe import RecipeTable
 
-        existing = (
-            ctx.session.execute(
-                select(Table).where(Table.source_id == source.source_id, Table.layer == "raw")
-            )
-            .scalars()
-            .all()
-        )
-        if existing:
-            return PhaseResult.failed(
-                f"Recipe for database source '{source_name}' changed since its raw "
-                f"tables were imported (or that import predates recipe hashing) — "
-                "re-import is not yet supported. Re-select the new pick under a NEW "
-                "source name to import it fresh; re-import in place lands with the "
-                "deferred GC work."
-            )
+        # The recipe was re-pointed under the same source name (``should_skip``
+        # declined on a hash mismatch / missing witness, DAT-430). Replace in
+        # place: drop the old tables + every metadata child before extracting the
+        # new recipe, so no orphaned rows or dangling snapshot heads survive and
+        # the re-extract can't collide with the prior run's overlapping names.
+        # The phase runner rolls the session back on a FAILED result (DAT-502),
+        # so a mid-replace failure leaves the prior state intact. (Files never
+        # reach this branch — content-keyed sources mint a new id on change.)
+        teardown_source_tables(ctx, source.source_id)
 
         recipe_hash = connection_config.get("recipe_hash")
         if not isinstance(recipe_hash, str) or not recipe_hash:

--- a/packages/engine/tests/integration/pipeline/test_import_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_import_phase.py
@@ -357,13 +357,13 @@ class TestImportPhase:
         recipe_hash: str | None,
         imported_hash: str | None,
     ):
-        """A db source whose hashes don't BOTH match never skips — and fails loud.
+        """A db source whose hashes don't BOTH match never skips (DAT-430).
 
-        This is the DAT-430 staleness kill: re-selecting the same source name
-        with a changed pick used to presence-skip forever, silently 'succeeding'
-        over the old raw tables. Now ``should_skip`` declines and the db load
-        path refuses to re-extract (re-import-with-replace is deferred), naming
-        the source.
+        The DAT-430 staleness kill: re-selecting the same source name with a
+        changed pick used to presence-skip forever, silently 'succeeding' over
+        the old raw tables. ``should_skip`` must keep declining on any
+        non-matching hash pair so the db load path runs the re-import-with-replace
+        (DAT-596) instead of serving stale tables.
         """
         cc: dict[str, Any] = {"tables": [{"name": "t1", "sql": "SELECT 1"}]}
         if recipe_hash:
@@ -381,10 +381,187 @@ class TestImportPhase:
 
         assert phase.should_skip(ctx) is None  # never a silent skip
 
-        result = phase._load_database_source(ctx, source, "warehouse", cc, "mssql")
-        assert result.status == PhaseStatus.FAILED
-        assert "warehouse" in (result.error or "")
-        assert "re-import is not yet supported" in (result.error or "")
+    def test_db_recipe_repointed_recipe_replaces_in_place(
+        self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+    ) -> None:
+        """A re-pointed recipe (changed pick, same name) replaces in place (DAT-596).
+
+        Import recipe v1 (columns a, b) so a raw + typed table and their metadata
+        children + a per-table snapshot head all exist; then re-import a re-pointed
+        v2 (columns b, c). The v1 tables (raw + typed) and their Table/Column rows,
+        the column-keyed metadata, and the per-table snapshot head must all be
+        GONE; only the v2 shape survives; ``imported_recipe_hash`` is re-stamped to
+        v2. Extraction + credentials are faked — the teardown+rematerialize
+        lifecycle, not the backend, is under test.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from dataraum.analysis.statistics.db_models import StatisticalProfile
+        from dataraum.core.models import Result
+        from dataraum.sources.backends import BackendExtractionResult, ExtractedTable
+        from dataraum.storage.snapshot_head import GENERATION_STAGE, MetadataSnapshotHead
+
+        source_id = str(uuid4())
+        _seed_db_source(
+            session,
+            source_id,
+            "warehouse",
+            {"tables": [{"name": "t1", "sql": "SELECT a, b FROM x"}], "recipe_hash": "hash-A"},
+            with_raw_table=False,
+        )
+        source = session.get(Source, source_id)
+        assert source is not None
+        phase = ImportPhase()
+        ctx = PhaseContext(
+            session=session, duckdb_conn=duckdb_conn, config={"source_id": source_id}
+        )
+
+        chain = MagicMock()
+        chain.resolve.return_value = MagicMock(url="mssql://ignored")
+
+        # --- v1 import: raw table warehouse__t1 with columns a, b ---
+        v1 = BackendExtractionResult(
+            tables=[
+                ExtractedTable(
+                    name="t1",
+                    duckdb_table="warehouse__t1",
+                    row_count=2,
+                    columns=[("a", "VARCHAR"), ("b", "VARCHAR")],
+                )
+            ]
+        )
+        with (
+            patch("dataraum.core.credentials.CredentialChain", return_value=chain),
+            patch("dataraum.sources.backends.extract_backend", return_value=Result.ok(v1)),
+        ):
+            cc_v1 = {
+                "tables": [{"name": "t1", "sql": "SELECT a, b FROM x"}],
+                "recipe_hash": "hash-A",
+            }
+            r1 = phase._load_database_source(ctx, source, "warehouse", cc_v1, "mssql")
+        assert r1.status == PhaseStatus.COMPLETED, r1.error
+        v1_raw_id = r1.outputs["raw_tables"][0]
+
+        # Add the surrounding state a real run would: a typed Table (sharing the
+        # source_id + bare name), a statistical_profiles row on a v1 column, and
+        # the per-table snapshot head add_source promotes.
+        v1_cols = (
+            session.execute(select(Column).where(Column.table_id == v1_raw_id)).scalars().all()
+        )
+        assert {c.column_name for c in v1_cols} == {"a", "b"}
+        typed_id = str(uuid4())
+        session.add(
+            Table(
+                table_id=typed_id,
+                source_id=source_id,
+                table_name="t1",
+                layer="typed",
+                duckdb_path="warehouse__t1",
+                row_count=2,
+            )
+        )
+        typed_col_id = str(uuid4())
+        session.add(
+            Column(
+                table_id=typed_id,
+                column_id=typed_col_id,
+                column_name="a",
+                column_position=0,
+                raw_type="VARCHAR",
+                resolved_type="VARCHAR",
+            )
+        )
+        session.flush()
+        session.add(
+            StatisticalProfile(
+                column_id=typed_col_id,
+                run_id="run-v1",
+                total_count=2,
+                null_count=0,
+                profile_data={},
+            )
+        )
+        session.add(
+            MetadataSnapshotHead(
+                target=f"table:{v1_raw_id}", stage=GENERATION_STAGE, run_id="run-v1"
+            )
+        )
+        session.add(
+            MetadataSnapshotHead(
+                target=f"table:{typed_id}", stage=GENERATION_STAGE, run_id="run-v1"
+            )
+        )
+        session.flush()
+        session.expire_all()
+
+        # --- v2 re-import: re-pointed recipe, columns b, c ---
+        source = session.get(Source, source_id)
+        assert source is not None
+        # The cockpit's re-select re-pointed the row's recipe; witness still hash-A.
+        source.connection_config = {
+            "tables": [{"name": "t1", "sql": "SELECT b, c FROM x"}],
+            "recipe_hash": "hash-B",
+            "imported_recipe_hash": "hash-A",
+        }
+        session.flush()
+        assert phase.should_skip(ctx) is None  # mismatch → replace, never skip
+
+        v2 = BackendExtractionResult(
+            tables=[
+                ExtractedTable(
+                    name="t1",
+                    duckdb_table="warehouse__t1",
+                    row_count=3,
+                    columns=[("b", "VARCHAR"), ("c", "VARCHAR")],
+                )
+            ]
+        )
+        cc_v2 = {
+            "tables": [{"name": "t1", "sql": "SELECT b, c FROM x"}],
+            "recipe_hash": "hash-B",
+        }
+        with (
+            patch("dataraum.core.credentials.CredentialChain", return_value=chain),
+            patch("dataraum.sources.backends.extract_backend", return_value=Result.ok(v2)),
+        ):
+            r2 = phase._load_database_source(ctx, source, "warehouse", cc_v2, "mssql")
+        assert r2.status == PhaseStatus.COMPLETED, r2.error
+        v2_raw_id = r2.outputs["raw_tables"][0]
+
+        session.flush()
+        session.expire_all()
+
+        # The old raw + typed Table rows are gone; only the v2 raw table remains.
+        remaining = (
+            session.execute(select(Table).where(Table.source_id == source_id)).scalars().all()
+        )
+        assert [t.table_id for t in remaining] == [v2_raw_id]
+        assert v1_raw_id != v2_raw_id
+
+        # The v1 columns are gone; the v2 raw table has the new shape (b, c).
+        assert session.get(Column, typed_col_id) is None
+        v2_cols = (
+            session.execute(select(Column).where(Column.table_id == v2_raw_id)).scalars().all()
+        )
+        assert {c.column_name for c in v2_cols} == {"b", "c"}
+
+        # No orphaned metadata children, no dangling snapshot heads.
+        assert (
+            session.execute(
+                select(StatisticalProfile).where(StatisticalProfile.column_id == typed_col_id)
+            ).scalar_one_or_none()
+            is None
+        )
+        heads = session.execute(select(MetadataSnapshotHead)).scalars().all()
+        stale = {f"table:{v1_raw_id}", f"table:{typed_id}"}
+        assert not ({h.target for h in heads} & stale)
+
+        # The witness is re-stamped to the v2 recipe.
+        source = session.get(Source, source_id)
+        assert source is not None
+        assert source.connection_config is not None
+        assert source.connection_config["imported_recipe_hash"] == "hash-B"
+        assert phase.should_skip(ctx) is not None  # now matches → clean skip
 
     def test_db_recipe_import_requires_recipe_hash(
         self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection

--- a/packages/engine/tests/unit/pipeline/test_import_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_import_phase.py
@@ -124,7 +124,7 @@ class TestImportDispatch:
         phase = ImportPhase()
         session = MagicMock()
         session.get.return_value = MagicMock()  # Source row present
-        # No existing raw tables for this source (the re-import guard reads []).
+        # No existing tables for this source (the teardown enumeration reads []).
         session.execute.return_value.scalars.return_value.all.return_value = []
         ctx = PhaseContext(
             session=session,


### PR DESCRIPTION
## What

A `db_recipe` source re-imported under the SAME user-chosen name with a CHANGED recipe (re-pointed SQL) used to **fail loud** (`"re-import is not yet supported"`). It now replaces in place: the import phase tears the source's existing tables down across every layer and rematerializes the new recipe, re-stamping the witness hash.

## Approach (Option C — in-place teardown + rematerialize)

- **Trigger unchanged.** `should_skip` still declines when the cockpit-stamped `recipe_hash` differs from the engine-stamped `imported_recipe_hash` (or either is missing). That mismatch — with raw tables present — is now the replace trigger instead of a loud failure. Same-recipe retry (hashes equal) still skips, so the partial-failure-then-retry path is intact.
- **The replace.** `_load_database_source` calls the new `teardown_source_tables(ctx, source_id)` before extracting, then the existing `extract_backend` path rematerializes and the existing post-import stamp re-stamps `imported_recipe_hash` to the new recipe.
- **Re-stamp confirmed generic** — the existing stamp at the end of `_load_database_source` runs on the replace path too.

## db_recipe-only scope

Files never reach this branch: they are content-keyed (`src_<digest>`), so changed bytes mint a NEW source. The guard lived only in `_load_database_source`; the file path is untouched.

## Name-keyed-drop rationale

Table names are UNIQUE per workspace across raw/typed/quarantine/enriched (one `ws_<id>` schema per workspace), so enumerating a source's tables by `source_id` and dropping each `(layer, duckdb_path)` cannot touch another source's data. No run-versioned raw identity is needed (deferred future work).

## Cascade surface cleaned

Verified against `schema.sql`: only `columns.table_id` has `ON DELETE CASCADE`. `teardown_source_tables` (`packages/engine/src/dataraum/pipeline/phases/_source_teardown.py`) deletes, in FK-safe order:

1. **Column-keyed children** — reuses `delete_column_dependents()` (14 FK children of `columns`).
2. **Table-keyed children** (none cascade) — `derived_columns`, `dimension_hierarchies`, `slice_definitions`, `materialization_recipes`, `table_entities`, `run_tables`, `claim_witnesses`, `entropy_objects`, `entropy_readiness` (single `table_id`); `enriched_views` (fact/view pair); `measure_aggregation_lineage` (measure/event pair); `driver_rankings` (measure table); `relationships` (from/to endpoints); plus the source-keyed `fix_ledger` + `column_eligibility`.
3. **Per-table snapshot heads** — `(table:{id}, GENERATION_STAGE)` rows so none dangles at a deleted target. Catalog / operating_model heads are workspace-grain and untouched.
4. **`Table` rows** (DB-cascades their `columns` via `ON DELETE CASCADE` + `passive_deletes`).
5. **DuckDB tables** — `DROP TABLE IF EXISTS lake.<layer>."<bare>"` via the engine FQN helpers.

Typed/quarantine `Table` rows carry the raw `source_id` (DAT-373 reconciliation), so the `source_id` enumeration tears the typed layer down too. Runs inside the import activity's session; the phase runner's rollback-on-FAILED (DAT-502) keeps it atomic.

## Tests

- **Integration** (`tests/integration/pipeline/test_import_phase.py::test_db_recipe_repointed_recipe_replaces_in_place`, real Postgres + lake-anchored DuckDB): import recipe v1 (cols a,b) + a typed Table, a `statistical_profiles` row, and per-table snapshot heads → re-import re-pointed v2 (cols b,c) → asserts old raw+typed `Table`/`Column` rows GONE, v2 shape present, no orphaned metadata, no dangling heads, `imported_recipe_hash` re-stamped to v2, and the subsequent same-recipe `should_skip` is a clean skip.
- **`test_db_recipe_changed_never_silently_skips`** adapted: drops the old loud-failure assertion, keeps the anti-regression that `should_skip` returns `None` on any non-matching hash pair.
- Unit comment touch-up for the credential-resolution test (teardown enumeration reads `[]`).

## Gates

`ruff format` + `ruff check` clean · `mypy` clean on changed source · full unit suite 1601 passed · import_phase integration 14 passed. No schema change (no new model), so `schema-drift` is unaffected.

## Smoke note

Re-import is now a lifecycle change, not a loud failure. Recommend smoking a re-pointed re-import on the live stack (re-select a probed query under the same source name with changed SQL, run add_source) to confirm the DuckDB drops + rematerialize end-to-end through the real worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)