### PR TITLE
DAT-566: surface identity_columns in look_table, table-readiness widget, answer-agent context

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,24 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-22: DAT-566 — `identity_columns` now in the answer-agent metadata document
+
+`semantic_per_table` has produced+persisted `TableEntity.identity_columns` since DAT-565
+(recurring real-world identities / would-be FKs, distinct from `grain`), but it was
+write-only on the answer-agent surface. The metadata document (`graphs/context.py`,
+`format_metadata_document`) now renders an **`**Identity columns**: <col> (<note>), …`**
+clause on a table's meta line, right after the time-column clause, sourced from
+`TableContext.identity_columns` (new dataclass field, populated from `TableEntity`).
+
+### dataraum-eval
+- **Prompt-surface change only** (no detector, no threshold, no response-schema change): the
+  SQL-gen context the GraphAgent/answer agent sees now lists each table's recurring identities,
+  so it can ground "per &lt;entity&gt;" groupings (e.g. "per customer") on the real cluster key.
+  Calibrations that snapshot/diff the metadata document will see the added clause; tables with
+  no identities render nothing (unchanged output).
+- Affected: `graphs/context.py` (`TableContext.identity_columns` + render). Cockpit-side
+  surfacing (`look_table`, table-readiness widget) is out of eval scope.
+
 ## 2026-06-22: DAT-516 — enriched-view shape is now sticky (deterministic across re-runs)
 
 The enriched-view shape (which `fk__attr` dimension columns a fact exposes) no longer

--- a/packages/cockpit/src/tools/look-table.test.ts
+++ b/packages/cockpit/src/tools/look-table.test.ts
@@ -188,6 +188,9 @@ function entityRow(overrides: Partial<TableEntityRow> = {}): TableEntityRow {
 				note: "When the order was placed.",
 			},
 		],
+		identityColumns: [
+			{ column: "order_id", note: "Recurring order identity (would-be FK)." },
+		],
 		description: "One row per order line item.",
 		...overrides,
 	};
@@ -207,6 +210,9 @@ describe("projectTableEntity (DAT-476)", () => {
 					note: "When the order was placed.",
 				},
 			],
+			identity_columns: [
+				{ column: "order_id", note: "Recurring order identity (would-be FK)." },
+			],
 			description: "One row per order line item.",
 		});
 	});
@@ -217,6 +223,16 @@ describe("projectTableEntity (DAT-476)", () => {
 		).toEqual([]);
 		expect(
 			projectTableEntity(entityRow({ timeColumns: "nope" })).time_columns,
+		).toEqual([]);
+	});
+
+	it("tolerates a null/malformed identity_columns blob (degrades to [])", () => {
+		expect(
+			projectTableEntity(entityRow({ identityColumns: null })).identity_columns,
+		).toEqual([]);
+		expect(
+			projectTableEntity(entityRow({ identityColumns: "nope" }))
+				.identity_columns,
 		).toEqual([]);
 	});
 
@@ -251,11 +267,15 @@ describe("projectTableEntity (DAT-476)", () => {
 				timeColumns: [
 					{ column: `src_${D}__order_date`, aspect: "order", note: "Placed." },
 				],
+				identityColumns: [
+					{ column: `src_${D}__order_id`, note: "Recurring identity." },
+				],
 				description: `One row per line in src_${D}__orders.`,
 			}),
 		);
 		expect(out.grain).toEqual(["order_id", "line_no"]);
 		expect(out.time_columns[0].column).toBe("order_date");
+		expect(out.identity_columns[0].column).toBe("order_id");
 		// The 40-hex digest is gone from every projected field.
 		expect(JSON.stringify(out)).not.toMatch(/src_[0-9a-f]{40}/);
 	});

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -101,7 +101,7 @@ export type TableReadiness = z.infer<typeof TableReadiness>;
 
 // The table descriptive header (DAT-476) — the cockpit analog of MCP
 // `look(target="table")`'s entity block: what kind of table this is (fact /
-// dimension), its grain, its time column, and a short description.
+// dimension), its grain, its time/identity columns, and a short description.
 // begin_session's `detect` writes it; `current_table_entities` head-resolves to
 // the promoted run. Null when no detect run has promoted (pre-session).
 // One event-time axis (DAT-565): a denormalized table commonly has several
@@ -109,6 +109,14 @@ export type TableReadiness = z.infer<typeof TableReadiness>;
 const TimeColumn = z.object({
 	column: z.string(),
 	aspect: z.string(),
+	note: z.string(),
+});
+
+// A recurring real-world identity (DAT-565): a would-be foreign key —
+// high-cardinality, recurs across rows, functionally determines other columns —
+// distinct from `grain`. Each carries a one-line note explaining the identity.
+const IdentityColumn = z.object({
+	column: z.string(),
 	note: z.string(),
 });
 
@@ -120,6 +128,8 @@ const TableEntity = z.object({
 	grain: z.array(z.string()),
 	// Every event-time axis the table records, each labelled + described.
 	time_columns: z.array(TimeColumn),
+	// Every recurring identity (would-be FK) the table records, each with a note.
+	identity_columns: z.array(IdentityColumn),
 	description: z.string().nullable(),
 });
 export type TableEntity = z.infer<typeof TableEntity>;
@@ -297,6 +307,7 @@ export interface TableEntityRow {
 	isDimensionTable: boolean | null;
 	grainColumns: unknown;
 	timeColumns: unknown;
+	identityColumns: unknown;
 	description: string | null;
 }
 
@@ -305,6 +316,13 @@ export interface TableEntityRow {
 // degrades to []. Anything else is dropped rather than thrown.
 const TimeColumns = z.array(
 	z.object({ column: z.string(), aspect: z.string(), note: z.string() }),
+);
+
+// The persisted identity shape (DAT-565): the engine writes a JSON list of
+// `{column, note}` (`analysis/semantic/processor.py`); null/malformed degrades
+// to []. Anything else is dropped rather than thrown.
+const IdentityColumns = z.array(
+	z.object({ column: z.string(), note: z.string() }),
 );
 
 // The persisted grain shape. The engine ALWAYS writes the dict form
@@ -330,6 +348,7 @@ const GrainColumns = z.union([
 export function projectTableEntity(row: TableEntityRow): TableEntity {
 	const grain = GrainColumns.safeParse(row.grainColumns);
 	const times = TimeColumns.safeParse(row.timeColumns);
+	const identities = IdentityColumns.safeParse(row.identityColumns);
 	return {
 		entity_type: row.detectedEntityType ?? null,
 		is_fact_table: row.isFactTable ?? null,
@@ -338,6 +357,13 @@ export function projectTableEntity(row: TableEntityRow): TableEntity {
 		// Strip src_<digest> from each axis column; aspect/note pass through.
 		time_columns: times.success
 			? times.data.map((tc) => ({ ...tc, column: stripSrcDigests(tc.column) }))
+			: [],
+		// Strip src_<digest> from each identity column; note passes through.
+		identity_columns: identities.success
+			? identities.data.map((ic) => ({
+					...ic,
+					column: stripSrcDigests(ic.column),
+				}))
 			: [],
 		description:
 			row.description == null ? null : stripSrcDigests(row.description),
@@ -506,7 +532,7 @@ export function tableEntityWhere(tableId: string) {
 }
 
 /** Resolve a table's descriptive header (DAT-476) — entity type / fact-dimension
- * / grain / time column / description from `current_table_entities`. The view
+ * / grain / time + identity columns / description from `current_table_entities`. The view
  * resolves at the workspace catalog head (DAT-506), one row per table_id, so the
  * {@link tableEntityWhere} filter is exact; the `detected_at desc` order is the
  * defensive tiebreak. Null when no begin_session catalog run has promoted yet. */
@@ -519,6 +545,7 @@ async function loadTableEntity(tableId: string): Promise<TableEntity | null> {
 			isDimensionTable: currentTableEntities.isDimensionTable,
 			grainColumns: currentTableEntities.grainColumns,
 			timeColumns: currentTableEntities.timeColumns,
+			identityColumns: currentTableEntities.identityColumns,
 			description: currentTableEntities.description,
 		})
 		.from(currentTableEntities)

--- a/packages/cockpit/src/ui/cockpit/widgets/table-readiness.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-readiness.test.tsx
@@ -170,6 +170,37 @@ describe("TableReadinessWidget (DAT-350)", () => {
 		expect(screen.getByTestId("canvas-table-readiness-empty")).toBeTruthy();
 	});
 
+	// DAT-566: the entity header surfaces recurring identities (would-be FKs)
+	// alongside grain / time, with the per-item note on hover.
+	const entity: NonNullable<LookTableResult["entity"]> = {
+		entity_type: "transaction",
+		is_fact_table: true,
+		is_dimension_table: false,
+		grain: ["order_id", "line_no"],
+		time_columns: [],
+		identity_columns: [
+			{ column: "customer_id", note: "Recurring customer identity." },
+		],
+		description: null,
+	};
+
+	it("renders identity columns (with the note on hover) in the entity header", () => {
+		renderWidget({ ...analyzed, entity });
+		const header = within(screen.getByTestId("canvas-table-readiness-entity"));
+		expect(header.getByText(/Identity:/)).toBeTruthy();
+		expect(header.getByText(/customer_id/)).toBeTruthy();
+		// The note rides the hover title, not the inline label.
+		expect(header.getByText(/customer_id/).getAttribute("title")).toMatch(
+			/Recurring customer identity\./,
+		);
+	});
+
+	it("omits the identity block when the entity has no identity columns", () => {
+		renderWidget({ ...analyzed, entity: { ...entity, identity_columns: [] } });
+		const header = within(screen.getByTestId("canvas-table-readiness-entity"));
+		expect(header.queryByText(/Identity:/)).toBeNull();
+	});
+
 	// DAT-352: clicking a column routes a why_column request through the chat-loop
 	// hook (sendMessage), carrying the row's column_id — it does NOT call
 	// whyColumn directly (the request runs once per click through the agent loop,

--- a/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/table-readiness.tsx
@@ -111,6 +111,19 @@ function TableEntityHeader({ entity }: { entity: TableEntity }) {
 							.join(", ")}
 					</Text>
 				)}
+				{entity.identity_columns.length > 0 && (
+					<Text
+						span
+						size="xs"
+						c="dimmed"
+						title={entity.identity_columns
+							.map((ic) => `${ic.column}: ${ic.note}`)
+							.join("\n")}
+					>
+						Identity:{" "}
+						{entity.identity_columns.map((ic) => ic.column).join(", ")}
+					</Text>
+				)}
 			</Group>
 			{entity.description && (
 				<Text size="sm" c="dimmed">

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -100,6 +100,8 @@ class TableContext:
     grain_columns: list[str] = field(default_factory=list)
     # DAT-565: all event-time axes — [{"column", "aspect", "note"}, ...].
     time_columns: list[dict[str, Any]] = field(default_factory=list)
+    # DAT-565: recurring identities (would-be FKs) — [{"column", "note"}, ...].
+    identity_columns: list[dict[str, Any]] = field(default_factory=list)
 
     # Columns
     columns: list[ColumnContext] = field(default_factory=list)
@@ -910,6 +912,7 @@ def build_execution_context(
                 table_description=table_entity.description if table_entity else None,
                 grain_columns=grain_cols,
                 time_columns=(table_entity.time_columns or []) if table_entity else [],
+                identity_columns=((table_entity.identity_columns or []) if table_entity else []),
                 columns=column_contexts,
                 flags=table_flags,
                 table_entropy=tbl_entropy,
@@ -1150,6 +1153,19 @@ def format_metadata_document(
             if tc.get("note"):
                 time_info += f". {tc['note']}"
             meta_parts.append(time_info.rstrip(".") + ".")
+        # Recurring identities (DAT-565): would-be foreign keys / cluster keys —
+        # the agent uses these for "per <entity>" grouping when writing queries.
+        identity_parts = []
+        for ic in table.identity_columns:
+            name = ic.get("column")
+            if not name:
+                continue
+            entry = name
+            if ic.get("note"):
+                entry += f" ({ic['note'].rstrip('.')})"
+            identity_parts.append(entry)
+        if identity_parts:
+            meta_parts.append(f"**Identity columns**: {', '.join(identity_parts)}.")
         if meta_parts:
             lines.append(" ".join(meta_parts))
 

--- a/packages/engine/tests/unit/graphs/test_context.py
+++ b/packages/engine/tests/unit/graphs/test_context.py
@@ -308,6 +308,8 @@ class TestFormatMetadataDocument:
         assert "Invoice Amount" in result
         assert "currency_code" in result
         assert "qty * price" in result
+        # DAT-566: a table with no identity_columns renders no identity clause.
+        assert "Identity columns" not in result
 
     def test_entropy_scores_per_column(self) -> None:
         """Entropy scores shown per column in data quality notes."""

--- a/packages/engine/tests/unit/graphs/test_context.py
+++ b/packages/engine/tests/unit/graphs/test_context.py
@@ -247,6 +247,7 @@ class TestFormatMetadataDocument:
             time_columns=[
                 {"column": "created_at", "aspect": "created", "note": "When the row was created."}
             ],
+            identity_columns=[{"column": "customer_id", "note": "Recurring customer identity."}],
             columns=[
                 ColumnContext(
                     column_id="col-1",
@@ -273,6 +274,10 @@ class TestFormatMetadataDocument:
         assert "by created" in result
         assert "2024-01-01 to 2024-12-31" in result
         assert "When the row was created." in result
+        # DAT-566: recurring identities surface with their note for "per <entity>".
+        assert "Identity columns" in result
+        assert "customer_id" in result
+        assert "Recurring customer identity" in result
 
     def test_column_table_format(self) -> None:
         """Columns are formatted in a table with business metadata."""

--- a/packages/engine/tests/unit/graphs/test_context_builder.py
+++ b/packages/engine/tests/unit/graphs/test_context_builder.py
@@ -149,7 +149,7 @@ class TestBuilderExtractsSemanticFields:
 
 
 class TestBuilderExtractsTableEntity:
-    """Verify builder reads table_description, grain_columns, time_column."""
+    """Verify builder reads table_description, grain_columns, time/identity columns."""
 
     def test_table_description_and_grain(self, session: Session) -> None:
         from dataraum.analysis.semantic.db_models import TableEntity
@@ -170,6 +170,9 @@ class TestBuilderExtractsTableEntity:
                 time_columns=[
                     {"column": "created_at", "aspect": "created", "note": "Row created."}
                 ],
+                identity_columns=[
+                    {"column": "customer_id", "note": "Recurring customer identity."}
+                ],
                 is_fact_table=True,
             )
         )
@@ -186,6 +189,9 @@ class TestBuilderExtractsTableEntity:
         assert table.table_description == "Records of all financial transactions"
         assert table.grain_columns == ["invoice_id"]
         assert [tc["column"] for tc in table.time_columns] == ["created_at"]
+        # DAT-566: identity_columns flows through the DB→context read path (the
+        # `or []` None-guard branch is the common pre-DAT-565 case).
+        assert [ic["column"] for ic in table.identity_columns] == ["customer_id"]
 
     def test_unresolved_catalog_reads_no_run_versioned_data(self, session: Session) -> None:
         """Fail-closed (DAT-429): no resolved catalog run ⇒ no entities/relationships.


### PR DESCRIPTION
## What

Surfaces the already-persisted `TableEntity.identity_columns` (recurring real-world identities / would-be FKs, distinct from `grain` — produced + persisted since DAT-565, shape `[{column, note}]`) on the three remaining read surfaces. It was write-only until now. This is a faithful mirror of the DAT-565 `time_columns` treatment.

## Surfaces

1. **`look-table.ts`** — `identity_columns` as `[{column, note}]` on the `TableEntity` result; per-item `src_<digest>` strip (note passthrough); null/malformed → `[]`.
2. **`table-readiness.tsx`** — `Identity:` clause in the entity header next to grain/time, with per-item notes on hover.
3. **`graphs/context.py`** — `TableContext.identity_columns` field + an `**Identity columns**:` clause in the answer-agent metadata document, so the agent can ground "per &lt;entity&gt;" groupings on the real cluster key.

## Scope notes

- **No schema regen** — engine model, `schema.sql`, and the cockpit drizzle mirror already carried `identity_columns` from DAT-565.
- **Out of scope (by design):** `list-tables.ts` (consistently omits `time_columns` too) and the relationship-hints follow-on (different subsystem; the ticket hedged it).
- **Eval correction:** the ticket said "eval: none", but `graphs/context.py` is the eval-calibrated metadata surface, so a `.claude/handoff.md` note was added.

## Tests / verification

- Cockpit: tsc + biome clean; vitest `look-table.test.ts` + `table-readiness.test.tsx` (projection: present / src-strip / malformed→[]; widget: renders identity / omits when none).
- Engine: ruff/mypy/vulture clean; `test_context.py` (render + explicit no-identity assertion) + `test_context_builder.py` (DB→context read path).
- Both reviewers (senior + spec-compliance): **PASS**; their one shared finding (explicit no-identity coverage) addressed in the second commit.
- **Browser smoke** against a rebuilt cockpit + engine on the running cluster: `orders` renders `Identity: CustomerID` with the LLM note on hover; `suppliers` (empty) renders no Identity clause; 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)