### PR TITLE
DAT-607: feed table entity grain + time + identity into the answer sub-agent context

### DIFF
--- a/packages/cockpit/src/tools/query-context.test.ts
+++ b/packages/cockpit/src/tools/query-context.test.ts
@@ -11,11 +11,14 @@ vi.mock("#/config", () => ({ config: {} }));
 vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 
 import type { DriverRanking } from "./look-drivers";
+import type { TableEntity } from "./look-table";
 import {
 	type CatalogAxisRow,
 	type CatalogHierarchyRow,
+	type EntityBlockRow,
 	formatCatalog,
 	formatDrivers,
+	formatEntities,
 	formatSchema,
 	preferEnriched,
 	type SchemaColumnRow,
@@ -343,5 +346,139 @@ describe("formatDrivers", () => {
 		const block = formatDrivers([ranking()]);
 		expect(block).toContain("you still author the SQL");
 		expect(block).toContain("top-ranked dimension is the sensible default");
+	});
+});
+
+// --- <entities> block (DAT-607) --------------------------------------------------
+
+function entity(overrides: Partial<TableEntity> = {}): TableEntity {
+	return {
+		entity_type: "transaction",
+		is_fact_table: true,
+		is_dimension_table: false,
+		grain: ["OrderID"],
+		time_columns: [{ column: "OrderDate", aspect: "order", note: "Placed." }],
+		identity_columns: [
+			{ column: "CustomerID", note: "Recurring customer identity." },
+		],
+		description: "One row per order.",
+		...overrides,
+	};
+}
+
+const entAddr = (name: string) => `lake.typed.${name}`;
+
+describe("formatEntities (DAT-607)", () => {
+	it("renders grain, time, and identities per table with the entity head", () => {
+		const out = formatEntities([
+			{ address: entAddr("wwi_recent_orders"), entity: entity() },
+		]);
+		expect(out).toContain("<entities>");
+		expect(out).toContain(
+			"Table lake.typed.wwi_recent_orders — transaction (fact):",
+		);
+		expect(out).toContain("  grain: OrderID");
+		expect(out).toContain("  time: OrderDate (order)");
+		expect(out).toContain(
+			"  identities: CustomerID — Recurring customer identity.",
+		);
+	});
+
+	it("labels a dimension table and omits the kind when neither flag is set", () => {
+		const dim = formatEntities([
+			{
+				address: entAddr("wwi_suppliers"),
+				entity: entity({
+					entity_type: "suppliers",
+					is_fact_table: false,
+					is_dimension_table: true,
+					grain: ["SupplierID"],
+					time_columns: [],
+					identity_columns: [],
+				}),
+			},
+		]);
+		expect(dim).toContain(
+			"Table lake.typed.wwi_suppliers — suppliers (dimension):",
+		);
+		expect(dim).toContain("  grain: SupplierID");
+		expect(dim).not.toContain("  time:");
+		expect(dim).not.toContain("  identities:");
+
+		const noKind = formatEntities([
+			{
+				address: entAddr("t"),
+				entity: entity({
+					entity_type: "thing",
+					is_fact_table: false,
+					is_dimension_table: false,
+					time_columns: [],
+					identity_columns: [],
+				}),
+			},
+		]);
+		expect(noKind).toContain("Table lake.typed.t — thing:");
+	});
+
+	it("drops a table with no grain/time/identity signal", () => {
+		const out = formatEntities([
+			{
+				address: entAddr("empty"),
+				entity: entity({
+					entity_type: "thing",
+					grain: [],
+					time_columns: [],
+					identity_columns: [],
+				}),
+			},
+		]);
+		expect(out).toBe(
+			"<entities>\n(No table entities detected yet.)\n</entities>",
+		);
+	});
+
+	it("returns the one-line note for an empty entity set", () => {
+		expect(formatEntities([])).toBe(
+			"<entities>\n(No table entities detected yet.)\n</entities>",
+		);
+	});
+
+	it("sorts stanzas by address (deterministic prompt)", () => {
+		const out = formatEntities([
+			{ address: entAddr("zebra"), entity: entity({ grain: ["z"] }) },
+			{ address: entAddr("alpha"), entity: entity({ grain: ["a"] }) },
+		]);
+		expect(out.indexOf("lake.typed.alpha")).toBeLessThan(
+			out.indexOf("lake.typed.zebra"),
+		);
+	});
+
+	it("caps identities per table and clamps a long note", () => {
+		const many: EntityBlockRow[] = [
+			{
+				address: entAddr("wide"),
+				entity: entity({
+					identity_columns: Array.from({ length: 12 }, (_, i) => ({
+						column: `id_${i}`,
+						note: "",
+					})),
+				}),
+			},
+		];
+		const capped = formatEntities(many);
+		expect(capped).toContain("id_7"); // 8th (index 7) kept
+		expect(capped).not.toContain("id_8"); // 9th dropped by the cap
+
+		const longNote = "x".repeat(300);
+		const clamped = formatEntities([
+			{
+				address: entAddr("n"),
+				entity: entity({
+					identity_columns: [{ column: "CustomerID", note: longNote }],
+				}),
+			},
+		]);
+		expect(clamped).toContain("…");
+		expect(clamped).not.toContain(longNote);
 	});
 });

--- a/packages/cockpit/src/tools/query-context.test.ts
+++ b/packages/cockpit/src/tools/query-context.test.ts
@@ -481,4 +481,24 @@ describe("formatEntities (DAT-607)", () => {
 		expect(clamped).toContain("…");
 		expect(clamped).not.toContain(longNote);
 	});
+
+	it("caps the table count and summarizes the overflow in a tail note", () => {
+		const rows: EntityBlockRow[] = Array.from({ length: 30 }, (_, i) => ({
+			// zero-pad so address sort matches numeric order — the first 25 are kept.
+			address: entAddr(`t_${String(i).padStart(2, "0")}`),
+			entity: entity({ grain: [`g_${i}`] }),
+		}));
+		const out = formatEntities(rows);
+		expect(out).toContain("lake.typed.t_00");
+		expect(out).toContain("lake.typed.t_24"); // 25th kept
+		expect(out).not.toContain("lake.typed.t_25"); // 26th dropped by the cap
+		expect(out).toContain("(… 5 more tables omitted.)");
+	});
+
+	it("tells the agent the columns also apply to the enriched view (prefer-enriched reconciliation)", () => {
+		const out = formatEntities([
+			{ address: entAddr("wwi_recent_orders"), entity: entity() },
+		]);
+		expect(out).toContain("When the <schema> block shows an enriched view");
+	});
 });

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -487,6 +487,9 @@ export interface EntityBlockRow {
 const MAX_IDENTITIES_PER_TABLE = 8;
 /** Clamp an LLM-authored identity note — keeps one stanza to a readable line. */
 const MAX_NOTE_CHARS = 140;
+/** Cap the number of table stanzas — bounds the block on a wide workspace; the
+ * overflow is summarized in a tail note rather than silently dropped. */
+const MAX_ENTITY_TABLES = 25;
 
 function clampNote(note: string): string {
 	const n = note.trim();
@@ -538,14 +541,20 @@ export function formatEntities(rows: EntityBlockRow[]): string {
 	}
 	if (stanzas.length === 0)
 		return "<entities>\n(No table entities detected yet.)\n</entities>";
+	// Bound the block on a wide workspace — keep the first N (already address-sorted)
+	// and summarize the rest rather than bloat the prompt or silently truncate.
+	const overflow = stanzas.length - MAX_ENTITY_TABLES;
+	const kept = overflow > 0 ? stanzas.slice(0, MAX_ENTITY_TABLES) : stanzas;
+	const tail = overflow > 0 ? `\n\n(… ${overflow} more tables omitted.)` : "";
 	return (
 		"<entities>\n" +
 		"What each table represents and its natural keys. Grain is the table's unit " +
 		"(one row per these columns). Identities are recurring real-world keys (would-be " +
 		'foreign keys) — to answer "per <entity>", group by the matching identity ' +
-		"column. Time columns are the event-time axes. These columns are present on the " +
-		"table and on any enriched view built from it.\n\n" +
-		`${stanzas.join("\n\n")}\n` +
+		"column. Time columns are the event-time axes. When the <schema> block shows an " +
+		"enriched view instead of the typed table below, these columns apply to that view " +
+		"too — an enriched view includes every column of the typed table it's built from.\n\n" +
+		`${kept.join("\n\n")}${tail}\n` +
 		"</entities>"
 	);
 }
@@ -553,9 +562,9 @@ export function formatEntities(rows: EntityBlockRow[]): string {
 /**
  * Read the table entities for the active workspace's promoted catalog head and format
  * them as the sub-agent's `<entities>` block. Joined to the typed tables for their
- * `lake.typed.<name>` address. The view is head-resolved (one row per table_id); the
- * `detected_at desc` order makes the first-seen row the deterministic pick for any
- * defensive duplicate (session-grain contract, DAT-474).
+ * `lake.typed.<name>` address. The view is head-resolved to one row per table_id; the
+ * `detected_at desc` order + first-seen-wins dedup is the deterministic tiebreak the
+ * session-grain contract (DAT-474) requires for a multi-row read.
  */
 export async function buildEntitiesBlock(): Promise<string> {
 	const rows = await metadataDb
@@ -581,9 +590,10 @@ export async function buildEntitiesBlock(): Promise<string> {
 	const blockRows: EntityBlockRow[] = [];
 	for (const r of rows) {
 		const tableId = r.tableId ?? "";
-		if (!tableId || seen.has(tableId)) continue;
+		const physicalName = r.physicalName ?? "";
+		if (!tableId || !physicalName || seen.has(tableId)) continue;
 		seen.add(tableId);
-		const address = `${LAKE_ALIAS}.${schemaForLayer(r.layer ?? TYPED_LAYER)}.${r.physicalName}`;
+		const address = `${LAKE_ALIAS}.${schemaForLayer(r.layer ?? TYPED_LAYER)}.${physicalName}`;
 		blockRows.push({
 			address,
 			entity: projectTableEntity({

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -26,7 +26,7 @@
 // + `preferEnriched` are unit-tested; the Drizzle reads + the DESCRIBE are
 // smoke/integration-covered.
 
-import { and, asc, eq, inArray, isNull } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
 
 import { metadataDb } from "../db/metadata/client";
 import {
@@ -34,12 +34,14 @@ import {
 	currentDimensionHierarchies,
 	currentSemanticAnnotations,
 	currentSliceDefinitions,
+	currentTableEntities,
 	sources,
 	tables,
 } from "../db/metadata/schema";
 import { getLakeConnection, LAKE_ALIAS } from "../duckdb/lake";
 import { readerToResult } from "../duckdb/query-result";
 import { type DriverRanking, lookDrivers } from "./look-drivers";
+import { projectTableEntity, type TableEntity } from "./look-table";
 
 /** The clean, analysis-ready layer a question is answered over. */
 const TYPED_LAYER = "typed";
@@ -461,6 +463,141 @@ export async function buildCatalogBlock(): Promise<string> {
 			})),
 		tableAddressById,
 	);
+}
+
+// --- Table entities (DAT-607) ----------------------------------------------------
+//
+// Per-table entity grounding (DAT-565/566): what each table represents, its grain
+// (one row per …), event-time axes, and recurring identities (would-be FKs). The
+// prefer-enriched `<schema>` block is column-grain and, when enriched views exist,
+// surfaces ONLY those views — hiding the typed facts AND every dimension table. This
+// block is table-grain over the typed facts/dims (where `TableEntity` lives), giving
+// the agent the natural grouping keys ("per <entity>" → an identity column) and a
+// reminder that the hidden dimension tables exist. Same projection the look_table
+// tool uses (`projectTableEntity`: `src_<digest>` strip, degrade-to-empty).
+// Informational (inform-don't-block). Empty (no promoted catalog run) → a one-line note.
+
+/** One typed table's entity header, addressed for the prompt. */
+export interface EntityBlockRow {
+	address: string;
+	entity: TableEntity;
+}
+
+/** Cap a single table's identity list — bounds the block on a wide entity. */
+const MAX_IDENTITIES_PER_TABLE = 8;
+/** Clamp an LLM-authored identity note — keeps one stanza to a readable line. */
+const MAX_NOTE_CHARS = 140;
+
+function clampNote(note: string): string {
+	const n = note.trim();
+	return n.length > MAX_NOTE_CHARS
+		? `${n.slice(0, MAX_NOTE_CHARS - 1).trimEnd()}…`
+		: n;
+}
+
+/**
+ * Format the table entities as the sub-agent's `<entities>` block (pure). One stanza
+ * per table that carries an entity signal (grain / time / identity), sorted by
+ * address; a table with no signal is dropped (a bare entity_type is noise for SQL
+ * grounding). Identity notes are clamped and the per-table identity list capped.
+ * Empty input → a one-line note.
+ */
+export function formatEntities(rows: EntityBlockRow[]): string {
+	const stanzas: string[] = [];
+	for (const { address, entity } of [...rows].sort((a, b) =>
+		a.address.localeCompare(b.address),
+	)) {
+		const lines: string[] = [];
+		if (entity.grain.length) lines.push(`  grain: ${entity.grain.join(", ")}`);
+		if (entity.time_columns.length)
+			lines.push(
+				`  time: ${entity.time_columns
+					.map((t) => (t.aspect ? `${t.column} (${t.aspect})` : t.column))
+					.join(", ")}`,
+			);
+		if (entity.identity_columns.length)
+			lines.push(
+				`  identities: ${entity.identity_columns
+					.slice(0, MAX_IDENTITIES_PER_TABLE)
+					.map((i) =>
+						i.note ? `${i.column} — ${clampNote(i.note)}` : i.column,
+					)
+					.join("; ")}`,
+			);
+		// A table with no grain/time/identity is noise for SQL grounding — drop it.
+		if (lines.length === 0) continue;
+		const kind = entity.is_fact_table
+			? "fact"
+			: entity.is_dimension_table
+				? "dimension"
+				: null;
+		const head = entity.entity_type
+			? `Table ${address} — ${entity.entity_type}${kind ? ` (${kind})` : ""}:`
+			: `Table ${address}${kind ? ` (${kind})` : ""}:`;
+		stanzas.push(`${head}\n${lines.join("\n")}`);
+	}
+	if (stanzas.length === 0)
+		return "<entities>\n(No table entities detected yet.)\n</entities>";
+	return (
+		"<entities>\n" +
+		"What each table represents and its natural keys. Grain is the table's unit " +
+		"(one row per these columns). Identities are recurring real-world keys (would-be " +
+		'foreign keys) — to answer "per <entity>", group by the matching identity ' +
+		"column. Time columns are the event-time axes. These columns are present on the " +
+		"table and on any enriched view built from it.\n\n" +
+		`${stanzas.join("\n\n")}\n` +
+		"</entities>"
+	);
+}
+
+/**
+ * Read the table entities for the active workspace's promoted catalog head and format
+ * them as the sub-agent's `<entities>` block. Joined to the typed tables for their
+ * `lake.typed.<name>` address. The view is head-resolved (one row per table_id); the
+ * `detected_at desc` order makes the first-seen row the deterministic pick for any
+ * defensive duplicate (session-grain contract, DAT-474).
+ */
+export async function buildEntitiesBlock(): Promise<string> {
+	const rows = await metadataDb
+		.select({
+			tableId: currentTableEntities.tableId,
+			physicalName: tables.tableName,
+			layer: tables.layer,
+			detectedEntityType: currentTableEntities.detectedEntityType,
+			isFactTable: currentTableEntities.isFactTable,
+			isDimensionTable: currentTableEntities.isDimensionTable,
+			grainColumns: currentTableEntities.grainColumns,
+			timeColumns: currentTableEntities.timeColumns,
+			identityColumns: currentTableEntities.identityColumns,
+			description: currentTableEntities.description,
+		})
+		.from(currentTableEntities)
+		.innerJoin(tables, eq(tables.tableId, currentTableEntities.tableId))
+		.innerJoin(sources, eq(sources.sourceId, tables.sourceId))
+		.where(and(isNull(sources.archivedAt), eq(tables.layer, TYPED_LAYER)))
+		.orderBy(desc(currentTableEntities.detectedAt));
+
+	const seen = new Set<string>();
+	const blockRows: EntityBlockRow[] = [];
+	for (const r of rows) {
+		const tableId = r.tableId ?? "";
+		if (!tableId || seen.has(tableId)) continue;
+		seen.add(tableId);
+		const address = `${LAKE_ALIAS}.${schemaForLayer(r.layer ?? TYPED_LAYER)}.${r.physicalName}`;
+		blockRows.push({
+			address,
+			entity: projectTableEntity({
+				detectedEntityType: r.detectedEntityType ?? null,
+				isFactTable: r.isFactTable ?? null,
+				isDimensionTable: r.isDimensionTable ?? null,
+				grainColumns: r.grainColumns,
+				timeColumns: r.timeColumns,
+				identityColumns: r.identityColumns,
+				description: r.description ?? null,
+			}),
+		});
+	}
+	return formatEntities(blockRows);
 }
 
 // --- Driver rankings (DAT-548) ---------------------------------------------------

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -54,6 +54,7 @@ import { listTables } from "./list-tables";
 import {
 	buildCatalogBlock,
 	buildDriversBlock,
+	buildEntitiesBlock,
 	buildSchemaBlock,
 } from "./query-context";
 import { buildVocabularyBlock, snippetSearchTool } from "./snippet-search";
@@ -463,19 +464,21 @@ export async function querySubAgent(
 ): Promise<AnswerResult> {
 	const [
 		schemaBlock,
+		entitiesBlock,
 		catalogBlock,
 		driversBlock,
 		vocabularyBlock,
 		nearUniqueColumns,
 	] = await Promise.all([
 		buildSchemaBlock(),
+		buildEntitiesBlock(),
 		buildCatalogBlock(),
 		buildDriversBlock(),
 		buildVocabularyBlock(),
 		loadNearUniqueColumns(),
 	]);
 
-	const userMessage = `<question>\n${question}\n</question>\n\n${schemaBlock}\n\n${catalogBlock}\n\n${driversBlock}\n\n${vocabularyBlock}`;
+	const userMessage = `<question>\n${question}\n</question>\n\n${schemaBlock}\n\n${entitiesBlock}\n\n${catalogBlock}\n\n${driversBlock}\n\n${vocabularyBlock}`;
 
 	// Per-invocation capture cell — the run_steps tool writes the last successful
 	// validation here, so it's isolated across concurrent answer calls.


### PR DESCRIPTION
## What

The interactive answer agent (`querySubAgent` / the `answer` tool) assembles its LLM context from `<schema>` (prefer-enriched, column-grain) + `<dimensions>` + `<drivers>` + `<vocabulary>` — reading **neither** `current_table_entities` **nor** the engine metadata document. So it had **no grain, no time columns, no identity columns**. DAT-566 put identities only in front of the *engine* GraphAgent (metrics phase); this closes the gap for the live Q&A agent.

Adds an `<entities>` block: per typed table with a `TableEntity`, its `entity_type` + fact/dim + grain + time + identity columns (with notes), so the agent can ground "per &lt;entity&gt;" groupings on the real identity/grain columns.

## How

- **`query-context.ts`** — new `formatEntities` (pure) + `buildEntitiesBlock`. Reads `current_table_entities` joined to the typed tables (one row per `table_id`, `detected_at desc` deterministic pick per the session-grain contract), reuses `look-table`'s `projectTableEntity` (`src_<digest>` strip, degrade-to-empty). Identity list capped (8), notes clamped (140), table count capped (25) with an overflow tail. Tables with no grain/time/identity signal dropped; empty → one-line note.
- **`query.ts`** — parallel-load `buildEntitiesBlock`, inject `<entities>` after `<schema>`.

## Design note

The `<entities>` block uses its **own** table set (all typed tables with a `TableEntity`), broader than the prefer-enriched `<schema>` block — so it also surfaces the dimension tables that prefer-enriched hides (the live binder failure we smoked was the agent unable to see `wwi_promo`). A preamble sentence reconciles addressing: when `<schema>` shows an enriched view, the grain/identity/time columns apply to that view too (an enriched view includes every column of the typed table it's built from). Engine GraphAgent untouched — it already has identities via DAT-566.

## Tests / verification

- Unit: 29 `query-context.test.ts` tests (render / fact-dim labelling / drop-empty / cap / clamp / ordering / degrade / stanza-cap overflow / reconciliation sentence). tsc + biome clean.
- Reviewers (senior + spec-compliance): **PASS**; all three findings addressed (prefer-enriched reconciliation, `physicalName` null-safety, stanza-count cap).
- **Live block dump** against the running cluster — the real `<entities>` block renders correctly (order facts show `time` + `identities: CustomerID` with notes; dimensions show grain).
- **Browser smoke** (rebuilt cockpit): "How many orders per customer?" grounded directly on `CustomerID` (assumption: "counted by distinct OrderID rows per CustomerID"), proper grouped grid, no "missing structured result", 0 console errors.

## Note for eval

Cockpit-only, so no `.claude/handoff.md` entry per the implement-skill scope rule — but the answer-agent prompt grew an `<entities>` block. If dataraum-eval snapshots that prompt, it will see the new block.

Part of epic DAT-543. Sibling DAT-608 (answer sub-agent iteration-exhaustion robustness) filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)