### PR TITLE
DAT-540: demote slice_conditional_null off the loss path + fix VARCHAR-measure driver crash

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,26 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-22: fix — driver_rankings no longer crashes on a VARCHAR measure (TRY_CAST)
+
+The driver-discovery load (`analysis/drivers/processor.py`) projected measure columns
+with a hard `"{col}"::DOUBLE`, which throws `ConversionException` → `PhaseFailed` (non-
+retryable) → the whole `beginSessionWorkflow` fails when a measure column the typing left
+VARCHAR carries a non-numeric value. Now `TRY_CAST({col} AS DOUBLE)`: unparseable values
+load as NULL→NaN, which the numpy core already treats as missing (`_floats` nulls→NaN;
+ICC/targets mask `~isnan`). Behaviour-equivalent on clean numeric data (golden equivalence
++ grain suites green); only the crash path changes.
+
+### dataraum-eval
+- **Fixes a begin_session crash, NOT a detector change.** Surfaced by the DAT-540 queue:
+  `detection-null-v1` (null_tokens family injects `~~~~~` sentinels into `debit`/`amount`
+  at severity high → typing leaves the column VARCHAR) crashed at `driver_rankings`
+  (`PhaseFailed: Could not convert string '~~~~~' to DOUBLE ... "debit"::DOUBLE`). With the
+  fix the run completes; the dirty-measure rows just read as NaN in driver discovery.
+- Recall/precision unaffected; no schema change. Regression pinned by
+  `tests/unit/analysis/drivers/test_processor.py::TestDiscoverDrivers::test_dirty_varchar_measure_does_not_crash`.
+- **Status**: pending
+
 ## 2026-06-22: DAT-540 — slice_conditional_null DEMOTED off the loss path (informative DirectSignal)
 
 `slice_conditional_null` (bias-corrected Cramér's V of is-null × slice) was removed from

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,44 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-22: DAT-540 — slice_conditional_null DEMOTED off the loss path (informative DirectSignal)
+
+`slice_conditional_null` (bias-corrected Cramér's V of is-null × slice) was removed from
+`loss.yaml` (it had `query 0.4 / aggregation 0.7 / reporting 0.6`). It now falls through
+`assemble_readiness_context` to a **DirectSignal** — the benford/dimensional_entropy lane:
+the Cramér's V score + `expected_dependency`/`documented_dependency` teach still compute as
+context, but no longer drive intent readiness bands. The detector still runs (`statistics`
+phase, add_source detect) and still emits its column-scoped `value.nulls.slice_conditional_null`
+EntropyObject; only its loss row is gone.
+
+**Why** (eval band-impact ablation, DAT-540 P5 / ADR-0013, `dataraum-eval`
+`scripts/probes/dat540` — the {score}-detector analogue of the structural ablation):
+(1) its only OBSERVABLE band move is a **false positive on benign structural conditionality** —
+`bank_transactions.payment_id` (an optional FK, null-by-design when a transaction is not a
+payment, which the column's OWN `business_meaning` documents) scored V=0.97 on slice
+`counterparty` → blocked aggregation; optional FKs are ubiquitous, so the untaught default is
+to block them. (2) On its INJECTED columns (`credit`/`debit`) the aggregation band is already
+set by `cross_table_consistency` (0.80), so ablating slice_conditional_null moved NO band — its
+marginal loss value is unproven on the existing slice corpus (confounded). A loss signal whose
+only visible band move is a false block on a benign-by-default pattern is anti-predictive — the
+benford/DEMOTE signature. Recorded: eval `entropy_eval_architecture.md`.
+
+### dataraum-eval
+- **Changed (engine)**: `loss.yaml` (row removed + rationale comment),
+  `tests/unit/entropy/views/test_readiness_context.py` (added
+  `test_slice_conditional_null_is_a_direct_signal_not_a_band_driver`). No detector/registry/phase
+  change — the detector still exists and runs.
+- **Affects**: any column×intent band driven *only* by slice_conditional_null now drops one band
+  (it contributed agg 0.7·V / reporting 0.6·V / query 0.4·V). The `bank_transactions.payment_id`
+  false `blocked` aggregation clears. A column whose only object is slice_conditional_null is no
+  longer in `readiness.columns` — it's a `direct_signal`.
+- **Calibrate (eval-side, NOT in this engine branch)**: `detector_coverage.yaml` disposition flips
+  to `informative` (mirrors benford/dimensional_entropy); `intent_readiness.yaml` /
+  `test_intent_readiness.py` clean-readiness expectations for payment_id drop the slice block;
+  recall/teach for slice_conditional_null move to the DirectSignal grammar. The Cramér's V
+  statistic is unchanged, so its SCORE (and the precision/recall score-separation) is unchanged.
+- **Status**: pending
+
 ## 2026-06-22: DAT-516 — enriched-view shape is now sticky (deterministic across re-runs)
 
 The enriched-view shape (which `fk__attr` dimension columns a fact exposes) no longer

--- a/packages/dataraum-config/entropy/loss.yaml
+++ b/packages/dataraum-config/entropy/loss.yaml
@@ -85,16 +85,24 @@ measurements:
   # signal — became slice_conditional_null below (DAT-473): a proportions question
   # (bias-corrected Cramér's V on is-null × slice), grounded + teach-closeable.
 
-  slice_conditional_null:
-    # Nulls concentrated in a slice (bias-corrected Cramér's V of is-null × slice) — the
-    # flat null_ratio reads 5% while one slice is 60% null, silently biasing that slice's
-    # aggregates. Worst for aggregation (a sliced sum over the biased dimension) and
-    # reporting (a per-slice breakdown); a query can caveat the gap. Shaped after the
-    # null_ratio row (a per-column NULLS rate, not a divergence). PLACEHOLDER priors,
-    # calibrated: false — not tuned to pass any metric; recall is separation from clean.
-    query_intent: { score: 0.4 }
-    aggregation_intent: { score: 0.7 }
-    reporting_intent: { score: 0.6 }
+  # slice_conditional_null is NOT in the loss table (DEMOTED 2026-06-22, DAT-540 P5 /
+  # ADR-0013 eval gate) → informative DirectSignal, benford/dimensional_entropy lane.
+  # It WAS on the loss path (query 0.4 / agg 0.7 / reporting 0.6), so its bands had to
+  # predict WRONG ANSWERS — but the eval band-impact ablation (dataraum-eval
+  # scripts/probes/dat540, the {score}-detector analogue of the structural ablation)
+  # falsifies that: (1) its band move on a CLEAN column is a FALSE POSITIVE on benign
+  # structural conditionality — `bank_transactions.payment_id` (an optional FK, null
+  # by design when a transaction is not a payment, as the column's OWN business_meaning
+  # documents) scored Cramér's V 0.97 on slice `counterparty` → blocked aggregation;
+  # optional FKs are ubiquitous in real financial data, so the default (untaught)
+  # behaviour is to block them. (2) On its INJECTED columns (credit/debit) the band is
+  # already set by `cross_table_consistency` (0.80 agg) — removing slice_conditional_null
+  # moved NO band, so its marginal loss value is unproven (confounded by a GL-reconciliation
+  # flag, not separable on the existing slice corpus). A loss signal whose only observable
+  # band move is a false block on a benign-by-default pattern is anti-predictive — the
+  # benford/DEMOTE signature. Keep the Cramér's V score + `expected_dependency` /
+  # `documented_dependency` teach as a DirectSignal (context), remove the loss row so it
+  # stops driving bands. (eval catalog: entropy_eval_architecture.md)
 
   # Rates / magnitudes (not divergences): the "score" weight scores the detector's
   # existing [0,1] score directly. These three left the network with the dissolved

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -398,9 +398,14 @@ def discover_drivers(
     # Cast measure columns to DOUBLE in the projection so the polars→numpy handoff is a
     # clean float view (no int/decimal→float null-upcast copy, DAT-580); dims/identities
     # stay raw for categorical factorization. The hash sketch hashes the RAW columns so
-    # the DAT-571 cutoff is unchanged byte-for-byte.
+    # the DAT-571 cutoff is unchanged byte-for-byte. TRY_CAST (not ::DOUBLE): a measure the
+    # typing left VARCHAR — e.g. a column carrying null sentinels ('~~~~~') from a
+    # null_tokens injection, or any not-cleanly-numeric measure — yields NULL→NaN, which
+    # the numpy core already treats as missing (_floats nulls→NaN; ICC/targets mask
+    # ~isnan), instead of a hard ConversionException that fails the whole begin_session
+    # (the engine's "failed casts → null, never pipeline failure" rule).
     def project(c: str) -> str:
-        return f"{quote(c)}::DOUBLE AS {quote(c)}" if c in measure_cols else quote(c)
+        return f"TRY_CAST({quote(c)} AS DOUBLE) AS {quote(c)}" if c in measure_cols else quote(c)
 
     select_proj = ", ".join(project(c) for c in select_cols)
     hash_cols = ", ".join(quote(c) for c in select_cols)

--- a/packages/engine/tests/unit/analysis/drivers/test_processor.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_processor.py
@@ -160,6 +160,33 @@ class TestDiscoverDrivers:
         assert ALIAS not in sig  # the collapsed alias never even competed
         assert ranking.driver_paths and ranking.driver_paths[0][0] == ranking.root.dimension
 
+    def test_dirty_varchar_measure_does_not_crash(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """A measure the typing left VARCHAR (e.g. carrying null sentinels like '~~~~~'
+        from a null_tokens injection) must NOT crash driver discovery. The projection
+        TRY_CASTs measures, so unparseable values load as NaN (treated as missing by the
+        numpy core), not a hard ConversionException → PhaseFailed. Regression: the
+        detection-null-v1 begin_session crashed here (driver_rankings, '::DOUBLE')."""
+        tid = _seed(real_session, duck)
+        # Re-cast the measure to VARCHAR with a deterministic sentinel in ~1/137 of rows,
+        # mirroring a null_tokens injection the typing left as a string column.
+        duck.execute(
+            f'CREATE OR REPLACE TABLE "{VIEW}" AS '
+            f"SELECT * REPLACE (CASE WHEN rowid % 137 = 0 THEN '~~~~~' "
+            f'ELSE CAST(measure AS VARCHAR) END AS measure) FROM "{VIEW}"'
+        )
+        ranking = discover_drivers(
+            real_session,
+            duckdb_conn=duck,
+            fact_table_id=tid,
+            run_id=RUN,
+            measure=Measure(target_type="flow", column="measure"),
+            n_perm=50,
+        )
+        # No raise; the sentinel rows are kept as NaN (n_rows == full frame length).
+        assert ranking.n_rows == 20_000
+
     def test_no_enriched_view_returns_empty(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:

--- a/packages/engine/tests/unit/entropy/views/test_readiness_context.py
+++ b/packages/engine/tests/unit/entropy/views/test_readiness_context.py
@@ -275,6 +275,22 @@ class TestPerColumnAssembly:
             for ds in result.direct_signals
         )
 
+    def test_slice_conditional_null_is_a_direct_signal_not_a_band_driver(self):
+        """Demoted (2026-06-22, DAT-540): slice_conditional_null is informative — excluded
+        from the loss rollup, surfaced as a DirectSignal, never banding a column. A column
+        whose ONLY object is slice_conditional_null has no loss row → nothing to band."""
+        objects = [
+            make_entropy_object(
+                detector_id="slice_conditional_null", score=0.97, target="column:bank.payment_id"
+            ),
+        ]
+        result = assemble_readiness_context(objects)
+        assert "column:bank.payment_id" not in result.columns  # no loss row → nothing to band
+        assert any(
+            ds.target == "column:bank.payment_id" and ds.detector_id == "slice_conditional_null"
+            for ds in result.direct_signals
+        )
+
     def test_node_evidence_carries_raw_data(self):
         """ColumnNodeEvidence carries score, evidence, detector_id from the object."""
         evidence_data = [{"metric": "null_fraction", "value": 0.75}]


### PR DESCRIPTION
Two related changes from the DAT-540 P5 / ADR-0013 eval gate (both behaviour-equivalent on clean data; unit suites green).

## 1. `refactor(entropy)`: demote `slice_conditional_null` off the loss path
The DAT-540 band-impact ablation (dataraum-eval `scripts/calibrate_band_impact_ablation.py`) showed its only observable band move is a **false positive on a benign optional FK** (`bank_transactions.payment_id`, null-by-design, V=0.97 → blocked aggregation), and on its injected columns the band is already set by `cross_table_consistency` (0.80) so it moves no band (confounded). Anti-predictive = the benford/dimensional_entropy DEMOTE signature. Removes its `loss.yaml` row; the Cramér's V score + `expected_dependency` teach still compute as an informative DirectSignal. Adds `test_slice_conditional_null_is_a_direct_signal_not_a_band_driver`.

## 2. `fix(drivers)`: `TRY_CAST` measure columns
The driver-discovery projection hard-cast measures with `"{col}"::DOUBLE`, which throws `ConversionException` → `PhaseFailed` (non-retryable) → whole `beginSessionWorkflow` fails when a measure the typing left VARCHAR carries a non-numeric value (e.g. `~~~~~` null sentinels). Now `TRY_CAST(... AS DOUBLE)`: unparseable values load as NULL→NaN, which the numpy core already treats as missing. Golden-equivalence + grain suites green; regression pinned by `test_dirty_varchar_measure_does_not_crash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)