### PR TITLE
fix(stats): deterministic top_values ordering

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,18 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-22: fix — deterministic `top_values` ordering (profiling reproducibility)
+
+`StatisticalProfile.top_values` is now ordered `count DESC, value` (was `count DESC` only),
+so equal-frequency values no longer come back in arbitrary order across runs. The sampled
+values that feed the LLM semantic prompts (`DataSampler.prepare_samples` reads `top_values`)
+are therefore reproducible run-to-run for the same data.
+
+### dataraum-eval
+- **Reproducibility, not a detector change** — recall/precision unaffected; profiles +
+  LLM prompts are just stable across re-runs now. No schema change.
+- **Status**: pending
+
 ## 2026-06-22: fix — driver_rankings no longer crashes on a VARCHAR measure (TRY_CAST)
 
 The driver-discovery load (`analysis/drivers/processor.py`) projected measure columns

--- a/packages/engine/src/dataraum/analysis/statistics/profiler.py
+++ b/packages/engine/src/dataraum/analysis/statistics/profiler.py
@@ -199,7 +199,7 @@ def _profile_column_stats_parallel(
                     FROM "{table_duckdb_path}"
                     WHERE "{column_name}" IS NOT NULL
                     GROUP BY "{column_name}"
-                    ORDER BY count DESC
+                    ORDER BY count DESC, "{column_name}"
                     LIMIT {top_k}
                 """
                 top_values_rows = cursor.execute(top_values_query).fetchall()


### PR DESCRIPTION
`StatisticalProfile.top_values` was ordered `ORDER BY count DESC` only, so equal-frequency values came back in arbitrary order across runs. The sampled values that feed the LLM semantic prompts (`DataSampler.prepare_samples` → `top_values[:N]`) therefore varied run-to-run on identical data. Added the value as a tie-break (`count DESC, "{column}"`) so profiles are reproducible.

Reproducibility only — recall/precision unaffected, no schema change. Surfaced while standing up a calibration record/replay harness in dataraum-eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)