### PR TITLE
DAT-595: record runs by real exec id (no placeholder) + per-import progress re-key

### DIFF
--- a/packages/cockpit/scripts/smoke-add-source.ts
+++ b/packages/cockpit/scripts/smoke-add-source.ts
@@ -80,14 +80,6 @@ async function seed(sourceId: string): Promise<void> {
 			updatedAt: now,
 		})
 		.onConflictDoNothing({ target: sourcesWrite.sourceId });
-	// Record the cockpit run (DAT-562: runs group by workspace, no session row);
-	// the run is keyed by the workspace's deterministic add_source workflow id.
-	await recordRun({
-		workspaceId: env.DATARAUM_WORKSPACE_ID,
-		kind: "onboarding",
-		stage: "add_source",
-		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
-	});
 }
 
 async function countOverlays(): Promise<number> {
@@ -130,6 +122,15 @@ async function runInitial(
 		taskQueue: engineTaskQueueFor(env.DATARAUM_WORKSPACE_ID),
 		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
 		args: [input],
+	});
+	// Record the cockpit run AFTER start with the real execution id (DAT-562/DAT-595:
+	// runs group by workspace; the row carries the Temporal exec id directly).
+	await recordRun({
+		workspaceId: env.DATARAUM_WORKSPACE_ID,
+		kind: "onboarding",
+		stage: "add_source",
+		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
+		runId: handle.firstExecutionRunId,
 	});
 	const result = (await handle.result()) as AddSourceResult;
 

--- a/packages/cockpit/scripts/smoke-begin-session.ts
+++ b/packages/cockpit/scripts/smoke-begin-session.ts
@@ -91,15 +91,6 @@ async function ingest(client: Client): Promise<string[]> {
 		})
 		.onConflictDoNothing({ target: sourcesWrite.sourceId });
 
-	// Record the add_source run in cockpit_db (DAT-562 — runs group by workspace,
-	// no session row; keyed by the workspace's deterministic add_source workflow id).
-	await recordRun({
-		workspaceId: env.DATARAUM_WORKSPACE_ID,
-		kind: "onboarding",
-		stage: "add_source",
-		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
-	});
-
 	const input: AddSourceInput = {
 		// FLAT, source-free input (DAT-506): no identity, no session/source id on the
 		// wire. The run's source SET (DAT-422) — one source here, so a 1-element set;
@@ -118,6 +109,15 @@ async function ingest(client: Client): Promise<string[]> {
 		taskQueue: engineTaskQueueFor(env.DATARAUM_WORKSPACE_ID),
 		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
 		args: [input],
+	});
+	// Record the add_source run in cockpit_db AFTER start with the real execution id
+	// (DAT-562/DAT-595 — runs group by workspace; the row carries the Temporal exec id).
+	await recordRun({
+		workspaceId: env.DATARAUM_WORKSPACE_ID,
+		kind: "onboarding",
+		stage: "add_source",
+		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
+		runId: handle.firstExecutionRunId,
 	});
 	const result = (await handle.result()) as AddSourceResult;
 	const typed = result.tables.map((t) => t.typed_table_id).filter(Boolean);

--- a/packages/cockpit/scripts/smoke-dat-461.ts
+++ b/packages/cockpit/scripts/smoke-dat-461.ts
@@ -22,12 +22,12 @@ import assert from "node:assert/strict";
 import { and, eq } from "drizzle-orm";
 import { cockpitDb } from "#/db/cockpit/client";
 import { DEFAULT_ACTOR_ID, resolveActiveWorkspace } from "#/db/cockpit/registry";
-import { attachRunId, markRunStatus, recordRun } from "#/db/cockpit/runs";
+import { markRunStatus, recordRun } from "#/db/cockpit/runs";
 import { actors, runs, workspaces } from "#/db/cockpit/schema";
 
-// DAT-562: a run is recorded keyed by its deterministic workflowId; runId is the
-// workflowId placeholder until attachRunId. Two stages on one workspace → two
-// distinct workflowIds (the begin_session run + the operating_model run).
+// DAT-562/DAT-595: a run is recorded keyed by (workflowId, REAL runId) — the run row
+// carries the Temporal execution id directly (recorded post-start), no placeholder.
+// Two stages on one workspace → two distinct workflowIds (begin_session + operating_model).
 const SUFFIX = crypto.randomUUID();
 const WF_1 = `beginsession-smoke-${SUFFIX}`;
 const WF_2 = `operatingmodel-smoke-${SUFFIX}`;
@@ -54,16 +54,17 @@ async function main(): Promise<void> {
 		.limit(1);
 	assert.equal(actor?.id, DEFAULT_ACTOR_ID, "default actor seeded");
 
-	// 2. recordRun: writes one `runs` row (DAT-562) keyed by (workflowId, runId);
+	// 2. recordRun: writes one `runs` row (DAT-562) keyed by (workflowId, real runId);
 	//    re-recording the same run is a UNIQUE no-op. The kind lives on the run row.
 	const base = {
 		workspaceId: wsId,
 		kind: "begin_session",
 		stage: "begin_session",
 		workflowId: WF_1,
+		runId: TEMPORAL_RUN,
 	} as const;
 	await recordRun(base);
-	await recordRun(base); // re-record same run → UNIQUE no-op (runId=WF_1 placeholder)
+	await recordRun(base); // re-record same (workflowId, runId) → UNIQUE no-op
 	const wf1Rows = await cockpitDb
 		.select({ runId: runs.runId, status: runs.status, kind: runs.kind })
 		.from(runs)
@@ -71,17 +72,8 @@ async function main(): Promise<void> {
 	assert.equal(wf1Rows.length, 1, "one run after idempotent re-record");
 	assert.equal(wf1Rows[0].kind, "begin_session", "run kind recorded on the row");
 	assert.equal(wf1Rows[0].status, "running", "run starts running");
-	// Provisional runId = the workflowId until attachRunId.
-	assert.equal(wf1Rows[0].runId, WF_1, "runId is the workflowId placeholder");
-
-	// attachRunId rewrites the provisional runId to the Temporal execution id.
-	await attachRunId(WF_1, TEMPORAL_RUN);
-	const [attached] = await cockpitDb
-		.select({ runId: runs.runId })
-		.from(runs)
-		.where(eq(runs.workflowId, WF_1))
-		.limit(1);
-	assert.equal(attached?.runId, TEMPORAL_RUN, "runId finalized to the exec id");
+	// runId is the REAL Temporal execution id, recorded directly (DAT-595).
+	assert.equal(wf1Rows[0].runId, TEMPORAL_RUN, "runId is the real execution id");
 
 	// A second stage with a DIFFERENT workflowId adds a second run row (same
 	// workspace) — runs group by workspace, not by a shared session.

--- a/packages/cockpit/scripts/smoke-dat-462.ts
+++ b/packages/cockpit/scripts/smoke-dat-462.ts
@@ -37,9 +37,9 @@ import {
 import { loadUiState, saveUiState } from "#/db/cockpit/ui-state";
 
 const WF = `wf-${crypto.randomUUID()}`;
-// DAT-506: recordRun keys the run by its workflowId; the runId is the workflowId
-// placeholder until attachRunId, so the listed/marked runId is WF here.
-const RUN = WF;
+// DAT-595: recordRun keys the run by (workflowId, REAL runId) — the row carries the
+// Temporal execution id directly, so the listed/marked runId is this exec id.
+const RUN = `exec-${crypto.randomUUID()}`;
 
 const msg = (id: string, role: "user" | "assistant", text: string): UIMessage =>
 	({ id, role, parts: [{ type: "text", content: text }] }) as UIMessage;
@@ -108,6 +108,7 @@ async function main(): Promise<void> {
 			kind: "begin_session",
 			stage: "begin_session",
 			workflowId: WF,
+			runId: RUN,
 		}),
 	);
 	const running = await listNonTerminalRuns(CONV, 50);

--- a/packages/cockpit/scripts/smoke-operating-model.ts
+++ b/packages/cockpit/scripts/smoke-operating-model.ts
@@ -102,15 +102,6 @@ async function ingest(client: Client): Promise<string[]> {
 		})
 		.onConflictDoNothing({ target: sourcesWrite.sourceId });
 
-	// Record the add_source run in cockpit_db (DAT-562 — runs group by workspace,
-	// no session row; keyed by the workspace's deterministic add_source workflow id).
-	await recordRun({
-		workspaceId: env.DATARAUM_WORKSPACE_ID,
-		kind: "onboarding",
-		stage: "add_source",
-		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
-	});
-
 	const input: AddSourceInput = {
 		// FLAT, source-free input (DAT-506): no identity, no session/source id.
 		workspace_id: env.DATARAUM_WORKSPACE_ID,
@@ -123,6 +114,15 @@ async function ingest(client: Client): Promise<string[]> {
 		taskQueue: env.TEMPORAL_TASK_QUEUE,
 		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
 		args: [input],
+	});
+	// Record the add_source run in cockpit_db AFTER start with the real execution id
+	// (DAT-562/DAT-595 — runs group by workspace; the row carries the Temporal exec id).
+	await recordRun({
+		workspaceId: env.DATARAUM_WORKSPACE_ID,
+		kind: "onboarding",
+		stage: "add_source",
+		workflowId: addSourceWorkflowId(env.DATARAUM_WORKSPACE_ID),
+		runId: handle.firstExecutionRunId,
 	});
 	const result = (await handle.result()) as AddSourceResult;
 	const typed = result.tables.map((t) => t.typed_table_id).filter(Boolean);

--- a/packages/cockpit/src/db/cockpit/runs.test.ts
+++ b/packages/cockpit/src/db/cockpit/runs.test.ts
@@ -1,10 +1,10 @@
-// Unit tests for control-plane run recording (DAT-461, DAT-506, DAT-562). Mocks the
-// cockpit_db client at the `#/` boundary (no DB). Asserts recordRun inserts the run
-// row directly (workspace-grouped, conflict target = workflow+run) keyed by the
-// workflowId placeholder runId; that it is AUTHORITATIVE (Q4: a db error THROWS — an
-// unrecorded run is orphaned, so the caller must not start it); attachRunId finalizes
-// the runId; and that markRunStatus issues the terminal update (still best-effort).
-// The real SQL + idempotency/append are covered by the Bun lane smoke.
+// Unit tests for control-plane run recording (DAT-461, DAT-506, DAT-562, DAT-595).
+// Mocks the cockpit_db client at the `#/` boundary (no DB). Asserts recordRun inserts
+// the run row directly (workspace-grouped, conflict target = workflow+run) keyed by the
+// REAL Temporal execution id (DAT-595 — recorded post-start, so each run of the reused
+// `addsource-<ws>` id is a distinct row, no placeholder/attachRunId swap); that a db
+// error THROWS; and that markRunStatus issues the terminal update (best-effort). The
+// real SQL + idempotency/append are covered by the Bun lane smoke.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -69,18 +69,15 @@ vi.mock("#/db/cockpit/client", () => ({
 }));
 
 import { runWithConversation } from "#/lib/run-context";
-import {
-	attachRunId,
-	markRunAwaitingInput,
-	markRunStatus,
-	recordRun,
-} from "./runs";
+import { markRunAwaitingInput, markRunStatus, recordRun } from "./runs";
 
 const BASE = {
 	workspaceId: "ws-1",
 	kind: "begin_session" as const,
 	stage: "begin_session" as const,
 	workflowId: "wf-1",
+	// The real Temporal execution id (DAT-595 — recorded post-start).
+	runId: "run-real-1",
 };
 
 beforeEach(() => {
@@ -104,8 +101,8 @@ describe("recordRun (DAT-461, DAT-506, DAT-562)", () => {
 		expect(run?.row.kind).toBe("begin_session");
 		expect(run?.row.stage).toBe("begin_session");
 		expect(run?.row.workflowId).toBe("wf-1");
-		// Provisional runId = the deterministic workflowId until attachRunId.
-		expect(run?.row.runId).toBe("wf-1");
+		// The REAL Temporal execution id (DAT-595) — distinct from the reused workflowId.
+		expect(run?.row.runId).toBe("run-real-1");
 		expect(run?.row.status).toBe("running");
 		// No originating chat outside a runWithConversation scope → null (the run
 		// simply won't narrate). DAT-528.
@@ -136,28 +133,9 @@ describe("recordRun (DAT-461, DAT-506, DAT-562)", () => {
 		expect(run?.row.conversationId).toBeNull();
 	});
 
-	it("is AUTHORITATIVE: a db error THROWS (an unrecorded run is orphaned)", async () => {
+	it("throws on a db error (an unrecorded run is invisible to the cockpit)", async () => {
 		h.throwOnInsert = true;
 		await expect(recordRun(BASE)).rejects.toThrow(/db down/);
-	});
-});
-
-describe("attachRunId (DAT-506)", () => {
-	it("rewrites the provisional runId to the Temporal execution id", async () => {
-		await attachRunId("wf-1", "run-real");
-		expect(h.updates).toHaveLength(1);
-		expect(h.updates[0].table).toBe("runs");
-		expect(h.updates[0].set).toEqual({ runId: "run-real" });
-	});
-
-	it("is best-effort: swallows a db error", async () => {
-		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-		const boom = await import("./client");
-		vi.spyOn(boom.cockpitDb, "update").mockImplementation(() => {
-			throw new Error("db down");
-		});
-		await expect(attachRunId("wf-1", "run-real")).resolves.toBeUndefined();
-		expect(warn).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/packages/cockpit/src/db/cockpit/runs.ts
+++ b/packages/cockpit/src/db/cockpit/runs.ts
@@ -1,5 +1,6 @@
-// Control-plane run recording (DAT-461, DAT-506, DAT-562) — the driver tools call
-// this BEFORE a Temporal workflow starts to record the run in cockpit_db.
+// Control-plane run recording (DAT-461, DAT-506, DAT-562, DAT-595) — the driver
+// records the run in cockpit_db RIGHT AFTER `workflow.start`, keyed by the real
+// execution id.
 //
 // Runs group by WORKSPACE (DAT-562 retired the `sessions` table — a cockpit session
 // scoped nothing post-DAT-506 and minting one per import only fragmented grouping).
@@ -7,21 +8,18 @@
 // `(workflowId, runId)` the reload-recovery substrate (DAT-462) reads to re-attach
 // progress.
 //
-// AUTHORITATIVE, not best-effort (Q4 ruling, DAT-506): an unrecorded run is
-// orphaned — the reload-recovery substrate can't re-attach to it — so recordRun runs
-// BEFORE `workflow.start` and THROWS on failure, aborting the start. Idempotent so a
-// retried start is safe: `(workflowId, runId)` is UNIQUE so a repeated record is a
-// no-op. The COMPLETION-side writers (`markRunStatus` / `claimRunNarration`) stay
-// best-effort — by then the run is recorded and live.
-//
-// `runId` is Temporal's EXECUTION id (`firstExecutionRunId`, minted only at
-// `workflow.start`) — the poll/reconcile identity. The pre-start call records the
-// run keyed by its deterministic `workflowId` with `runId` left as the workflowId
-// placeholder; `attachRunId` rewrites it to the real execution id right after start.
-// That post-record writer is best-effort — the orphan-critical run row already
-// exists by then. The engine mints its own internal metadata `run_id` (the version
-// axis) and resolves replay from the generation heads, so the cockpit never stores
-// it (DAT-506: nothing reads it back).
+// `runId` is Temporal's EXECUTION id (`firstExecutionRunId`), minted at
+// `workflow.start` — so recordRun runs JUST AFTER start with the real id (DAT-595),
+// NOT before with a workflowId placeholder. Under the reused per-workspace workflow id
+// (`addsource-<ws>`, DAT-562) that real id is what makes `(workflowId, runId)` UNIQUE
+// per execution; recording it directly retired the old workflowId-placeholder +
+// `attachRunId` swap, whose shared placeholder key conflated a NEW run with a prior
+// run's stuck placeholder (a best-effort attachRunId that never persisted → the next
+// run skipped its own insert and hijacked the stale row). Recording post-start is
+// orphan-safe: the orchestration workflow records via a durable (retried) activity,
+// and the direct tool path records immediately after a synchronous start. The engine
+// mints its own internal metadata `run_id` (the version axis) and resolves replay from
+// the generation heads, so the cockpit never stores it (DAT-506: nothing reads it back).
 
 import { randomUUID } from "node:crypto";
 import { and, count, desc, eq, gt, isNull, notExists } from "drizzle-orm";
@@ -41,9 +39,15 @@ export interface RecordRunInput {
 	// the run row itself; operating_model re-uses "begin_session", as before).
 	kind: RunKind;
 	stage: RunStage;
-	// The deterministic workflow id (known before start). The run row is keyed by
-	// it; `runId` is the workflowId placeholder until `attachRunId` finalizes it.
+	// The deterministic workflow id (`addsource-<ws>` etc.) — REUSED per workspace
+	// across runs (DAT-562), so it does NOT identify a run on its own.
 	workflowId: string;
+	// The Temporal EXECUTION id (`firstExecutionRunId`) — minted by `workflow.start`,
+	// so the run is recorded RIGHT AFTER start (DAT-595): this is what makes a run row
+	// unique (`(workflowId, runId)`) under the reused workflow id. Recording the real
+	// id directly retired the old workflowId-placeholder + `attachRunId` swap, whose
+	// shared placeholder key conflated a new run with a prior run's stuck placeholder.
+	runId: string;
 	// The originating chat (DAT-528) for run→chat narration routing. OMITTED by
 	// the in-request tool drivers — they fall back to the request-scoped ALS
 	// (`currentConversationId()`). Passed EXPLICITLY by the orchestration worker
@@ -54,10 +58,14 @@ export interface RecordRunInput {
 }
 
 /**
- * Record the run AUTHORITATIVELY, BEFORE `workflow.start`. Throws on failure (the
- * caller must not start an unrecorded — orphaned — run). The run row's `runId` is
- * the deterministic `workflowId` until `attachRunId` rewrites it to the Temporal
- * execution id post-start.
+ * Record the run with its REAL Temporal execution id, RIGHT AFTER `workflow.start`
+ * (DAT-595). Safe to record post-start: the orchestration workflow records via a
+ * durable activity (retried on crash), and the direct tool path records immediately
+ * after a synchronous `start` (negligible window, idempotent re-trigger recovers).
+ *
+ * Idempotent on `(workflowId, runId)` — UNIQUE per execution, so a retry is a no-op
+ * and two runs of the reused `addsource-<ws>` id never collide (the conflation the
+ * old workflowId-placeholder scheme allowed; DAT-595).
  */
 export async function recordRun(input: RecordRunInput): Promise<void> {
 	await cockpitDb
@@ -68,10 +76,8 @@ export async function recordRun(input: RecordRunInput): Promise<void> {
 			kind: input.kind,
 			stage: input.stage,
 			workflowId: input.workflowId,
-			// Provisional until attachRunId: the Temporal execution runId isn't known
-			// until after start. Keyed by the deterministic workflowId so the row is
-			// addressable now and the (workflowId, runId) UNIQUE upsert is idempotent.
-			runId: input.workflowId,
+			// The real Temporal execution id — unique per run under the reused workflow id.
+			runId: input.runId,
 			// The originating chat (DAT-528). An explicit value (incl. null) wins —
 			// the orchestration worker passes it, since it has no request ALS. When
 			// omitted (the in-request tool drivers), fall back to the ALS context the
@@ -83,37 +89,11 @@ export async function recordRun(input: RecordRunInput): Promise<void> {
 					: currentConversationId(),
 			status: "running",
 		})
-		// Idempotent on the deterministic (workflowId, runId=workflowId) key. Workflow
-		// ids are constant-per-workspace now (DAT-562), so this also guards a second
-		// trigger for the same stage — but single-flight (DAT-609: the workflow-id reuse
-		// policy, `ALLOW_DUPLICATE` + conflict `FAIL`) rejects a second start while one
-		// is running, and `attachRunId` rewrites the provisional runId off the
-		// placeholder right after start, so two adds never race for this one row.
+		// Idempotent on the UNIQUE (workflowId, real runId) — a retried record is a
+		// no-op; distinct executions of the reused workflow id are distinct rows.
 		.onConflictDoNothing({
 			target: [runs.workflowId, runs.runId],
 		});
-}
-
-/**
- * Rewrite a recorded run's provisional `runId` (the workflowId placeholder) to
- * the real Temporal execution id, right after `workflow.start`. Best-effort: the
- * orphan-critical run row already exists; this only refines the run's
- * Temporal identity for the progress poll / reload-recovery.
- */
-export async function attachRunId(
-	workflowId: string,
-	runId: string,
-): Promise<void> {
-	try {
-		await cockpitDb
-			.update(runs)
-			.set({ runId })
-			.where(and(eq(runs.workflowId, workflowId), eq(runs.runId, workflowId)));
-	} catch (err) {
-		console.warn(
-			`[cockpit] attachRunId failed for ${workflowId} (run ${runId}): ${err}`,
-		);
-	}
 }
 
 /**

--- a/packages/cockpit/src/lib/completion-watcher.test.ts
+++ b/packages/cockpit/src/lib/completion-watcher.test.ts
@@ -116,25 +116,26 @@ describe("run-routing (DAT-528): a run narrates only into its own conversation",
 	});
 });
 
-describe("placeholder runs are skipped until attachRunId finalizes the real id (DAT-595)", () => {
-	it("does NOT track, poll, or narrate a run whose runId still equals its workflowId", async () => {
-		// A just-recorded run carries the workflowId PLACEHOLDER until attachRunId
-		// rewrites it post-start. getWorkflowProgress can only PIN a real id, so the
-		// watcher must skip the placeholder — otherwise a reused workflow id would
-		// resolve a PRIOR run's terminal state and mark this one done off it (DAT-595).
+describe("tracks + pins a run by its real execution id (DAT-595)", () => {
+	it("tracks and polls a recorded run — every run carries its real runId (no placeholder phase)", async () => {
+		// Post-DAT-595 a recorded run always carries the real Temporal execution id
+		// (recorded post-start), never the workflowId placeholder, so getWorkflowProgress
+		// always PINS the exact (workflowId, runId) — a reused `addsource-<ws>` id can
+		// never resolve a sibling run's terminal state.
 		vi.mocked(listWatchableRuns).mockResolvedValueOnce([
 			{
 				workflowId: "addsource-ws",
-				runId: "addsource-ws",
-				stage: "add_source",
-				kind: "onboarding",
+				runId: "exec-real",
+				stage: "begin_session",
+				kind: "begin_session",
 			},
 		]);
 		const tracked = new Map<string, WatchableRun>();
 		await pollOnce("A", tracked, new AbortController().signal);
-		expect(tracked.size).toBe(0);
-		expect(getWorkflowProgress).not.toHaveBeenCalled();
-		expect(streamAgentTurnToBus).not.toHaveBeenCalled();
+		expect(getWorkflowProgress).toHaveBeenCalledWith({
+			workflow_id: "addsource-ws",
+			run_id: "exec-real",
+		});
 	});
 });
 

--- a/packages/cockpit/src/lib/completion-watcher.ts
+++ b/packages/cockpit/src/lib/completion-watcher.ts
@@ -148,14 +148,11 @@ export async function pollOnce(
 		() => [] as WatchableRun[],
 	);
 	for (const run of candidates) {
-		// Skip a run still at its pre-attach PLACEHOLDER id (runId === workflowId):
-		// getWorkflowProgress can only PIN a real execution id, and the placeholder
-		// would fall back to the latest execution — which, for a REUSED workflow id
-		// (`addsource-<ws>`), can read a PRIOR run's terminal state and mark THIS run
-		// done off the wrong snapshot (the DAT-595 conflation). `attachRunId`
-		// finalizes the real id moments after start, so the row is tracked on the
-		// next tick (sub-second) and then pinned precisely.
-		if (run.runId === run.workflowId) continue;
+		// Every recorded run carries its REAL Temporal execution id (DAT-595 — recorded
+		// post-start), so getWorkflowProgress always PINS the exact (workflowId, runId)
+		// and a reused workflow id (`addsource-<ws>`) can never read a PRIOR run's
+		// terminal state for the run being watched. (No pre-attach placeholder phase to
+		// skip anymore.)
 		tracked.set(runKey(run), run);
 	}
 

--- a/packages/cockpit/src/temporal/orchestration-trigger.test.ts
+++ b/packages/cockpit/src/temporal/orchestration-trigger.test.ts
@@ -23,8 +23,6 @@ const h = vi.hoisted(() => {
 		start: vi.fn(async () => ({ firstExecutionRunId: "exec-1" })),
 		close: vi.fn(async () => {}),
 		recordRun: vi.fn(async () => {}),
-		attachRunId: vi.fn(async () => {}),
-		markRunStatus: vi.fn(async () => {}),
 	};
 });
 
@@ -42,8 +40,6 @@ vi.mock("@temporalio/client", () => ({
 }));
 vi.mock("#/db/cockpit/runs", () => ({
 	recordRun: h.recordRun,
-	attachRunId: h.attachRunId,
-	markRunStatus: h.markRunStatus,
 }));
 
 import {
@@ -63,8 +59,6 @@ beforeEach(() => {
 	h.start.mockResolvedValue({ firstExecutionRunId: "exec-1" });
 	h.close.mockClear();
 	h.recordRun.mockClear();
-	h.attachRunId.mockClear();
-	h.markRunStatus.mockClear();
 });
 
 const SINGLE_FLIGHT = {
@@ -155,16 +149,8 @@ describe("startDirectRun (DAT-609 — replay / manual operating_model)", () => {
 		busyMessage: "already running",
 	};
 
-	it("records the run BEFORE start, then starts the engine workflow + attaches the real id", async () => {
+	it("starts the engine workflow, then records the run with the REAL execution id (DAT-595)", async () => {
 		await startDirectRun(spec);
-		// Authoritative record before start (conversationId omitted ⇒ recordRun's ALS
-		// fallback) — the engine workflow id + queue, not an orchestration id.
-		expect(h.recordRun).toHaveBeenCalledWith({
-			workspaceId: "ws-1",
-			kind: "replay",
-			stage: "add_source",
-			workflowId: "addsource-ws-1",
-		});
 		expect(h.start).toHaveBeenCalledWith(
 			"addSourceWorkflow",
 			expect.objectContaining({
@@ -174,24 +160,28 @@ describe("startDirectRun (DAT-609 — replay / manual operating_model)", () => {
 				...SINGLE_FLIGHT,
 			}),
 		);
-		expect(h.attachRunId).toHaveBeenCalledWith("addsource-ws-1", "exec-1");
-		// recordRun happened before start.
-		expect(h.recordRun.mock.invocationCallOrder[0]).toBeLessThan(
-			h.start.mock.invocationCallOrder[0],
+		// Recorded AFTER start with the child's real runId (the start handle's
+		// firstExecutionRunId = "exec-1") — no workflowId placeholder, no attachRunId.
+		// conversationId omitted ⇒ recordRun's request-ALS fallback.
+		expect(h.recordRun).toHaveBeenCalledWith({
+			workspaceId: "ws-1",
+			kind: "replay",
+			stage: "add_source",
+			workflowId: "addsource-ws-1",
+			runId: "exec-1",
+		});
+		// start happened before recordRun (we need the real runId first).
+		expect(h.start.mock.invocationCallOrder[0]).toBeLessThan(
+			h.recordRun.mock.invocationCallOrder[0],
 		);
 	});
 
-	it("marks the placeholder failed + translates a conflict to an actionable error", async () => {
+	it("translates a conflict to an actionable error and records NOTHING (run never started)", async () => {
 		h.start.mockRejectedValueOnce(new h.AlreadyStarted());
 		const err = await startDirectRun(spec).catch((e) => e);
 		expect(err).toBeInstanceOf(RunAlreadyRunningError);
-		// The recorded placeholder row (runId === workflowId) is dropped out of running.
-		expect(h.markRunStatus).toHaveBeenCalledWith(
-			"addsource-ws-1",
-			"addsource-ws-1",
-			"failed",
-		);
-		expect(h.attachRunId).not.toHaveBeenCalled();
+		// Recording is AFTER start, so a rejected start leaves no row to clean up.
+		expect(h.recordRun).not.toHaveBeenCalled();
 	});
 
 	it("fails loud when Temporal isn't configured — BEFORE recording the run", async () => {

--- a/packages/cockpit/src/temporal/orchestration-trigger.ts
+++ b/packages/cockpit/src/temporal/orchestration-trigger.ts
@@ -150,8 +150,9 @@ export interface DirectRunSpec {
  * nothing on a conflict/failure — the run never started, so there's no row to clean up.
  * `recordRun` omits `conversationId` ⇒ it falls back to the request-scoped ALS (these
  * run inside the chat turn, unlike the worker) so the completion still narrates into
- * THIS chat. The tiny start→record window is orphan-safe enough: the re-trigger is
- * idempotent and the reconcile/monitor read by workspace.
+ * THIS chat. Orphan-safety differs from the durable `runStage` path: this is a request
+ * handler, so a crash in the tiny start→record window fails the HTTP request and the
+ * user re-triggers — idempotent via recordRun's `onConflictDoNothing`.
  */
 export async function startDirectRun(spec: DirectRunSpec): Promise<void> {
 	let runId: string;

--- a/packages/cockpit/src/temporal/orchestration-trigger.ts
+++ b/packages/cockpit/src/temporal/orchestration-trigger.ts
@@ -18,13 +18,7 @@ import {
 } from "@temporalio/client";
 
 import { config } from "#/config";
-import {
-	attachRunId,
-	markRunStatus,
-	type RunKind,
-	type RunStage,
-	recordRun,
-} from "#/db/cockpit/runs";
+import { type RunKind, type RunStage, recordRun } from "#/db/cockpit/runs";
 import { AgentActionableError } from "#/tools/agent-error";
 import {
 	GROUNDING_LOOP_WORKFLOW_TYPE,
@@ -132,8 +126,8 @@ async function startOrchestration(
 
 /** A direct single-shot engine run (replay add_source, manual operating_model) — no
  * orchestration workflow, because there is no follow-on stage to await. The tool
- * brackets it exactly as the journey did: `recordRun` (authoritative, before start) →
- * start the engine workflow directly → `attachRunId` the real execution id. */
+ * starts the engine workflow, then records the run with its REAL execution id
+ * (DAT-595). */
 export interface DirectRunSpec {
 	workspaceId: string;
 	/** The run's origin for the run row (replay → "replay"; manual OM → "begin_session"). */
@@ -149,24 +143,20 @@ export interface DirectRunSpec {
 }
 
 /**
- * Run a direct single-shot engine workflow with the same run-recording bracket the orchestration workflows use.
- * `recordRun` omits `conversationId` ⇒ it falls back to the request-scoped ALS
- * (these run inside the chat turn, unlike the worker) so the completion still narrates
- * into THIS chat. On a start failure the placeholder run row is marked failed so it
- * can't linger as a phantom in-flight run.
+ * Run a direct single-shot engine workflow: start it, then record the run with the
+ * REAL execution id (DAT-595 — recording post-start with the real id keeps every run
+ * a distinct `(workflowId, runId)` row under the reused `addsource-<ws>` id, retiring
+ * the placeholder + attachRunId swap that conflated runs). Recording AFTER start drops
+ * nothing on a conflict/failure — the run never started, so there's no row to clean up.
+ * `recordRun` omits `conversationId` ⇒ it falls back to the request-scoped ALS (these
+ * run inside the chat turn, unlike the worker) so the completion still narrates into
+ * THIS chat. The tiny start→record window is orphan-safe enough: the re-trigger is
+ * idempotent and the reconcile/monitor read by workspace.
  */
 export async function startDirectRun(spec: DirectRunSpec): Promise<void> {
-	// Guard config BEFORE recording — an unconfigured start must not leave a phantom
-	// `running` placeholder row to clean up. (withClient re-checks; cheap.)
-	requireTemporalConfig();
-	await recordRun({
-		workspaceId: spec.workspaceId,
-		kind: spec.kind,
-		stage: spec.stage,
-		workflowId: spec.workflowId,
-	});
+	let runId: string;
 	try {
-		const runId = await withClient((client) =>
+		runId = await withClient((client) =>
 			client.workflow
 				.start(spec.workflowType, {
 					taskQueue: spec.taskQueue,
@@ -176,15 +166,18 @@ export async function startDirectRun(spec: DirectRunSpec): Promise<void> {
 				})
 				.then((handle) => handle.firstExecutionRunId),
 		);
-		await attachRunId(spec.workflowId, runId);
 	} catch (err) {
-		// The run never started — drop the placeholder out of `running` so it isn't a
-		// phantom in-flight run (the watcher already skips placeholders; this keeps
-		// hasRunningRun / the monitor honest).
-		await markRunStatus(spec.workflowId, spec.workflowId, "failed");
 		if (err instanceof WorkflowExecutionAlreadyStartedError) {
 			throw new RunAlreadyRunningError(spec.busyMessage);
 		}
 		throw err;
 	}
+	// Record with the real execution id, right after start.
+	await recordRun({
+		workspaceId: spec.workspaceId,
+		kind: spec.kind,
+		stage: spec.stage,
+		workflowId: spec.workflowId,
+		runId,
+	});
 }

--- a/packages/cockpit/src/temporal/progress.ts
+++ b/packages/cockpit/src/temporal/progress.ts
@@ -200,26 +200,20 @@ export async function getWorkflowProgress(
 	input: WorkflowProgressInput,
 ): Promise<WorkflowProgress> {
 	const client = await getTemporalClient();
-	// Pin the PRECISE execution when we hold a real Temporal run id; resolve the
-	// LATEST execution only for the pre-attach PLACEHOLDER (DAT-595).
+	// Pin the PRECISE execution when given a real Temporal run id; resolve the LATEST
+	// execution only when the caller passes the workflowId as the run id (DAT-595).
 	//
-	// Run-id semantics (cockpit_db.runs): a run row's `runId` IS Temporal's
-	// execution id (firstExecutionRunId) — but it is recorded as the workflowId
-	// PLACEHOLDER until `attachRunId` rewrites it just after start. So this has two
-	// callers with two different ids, and must treat them differently:
-	//   • the COMPLETION WATCHER passes the real, attached run id → we PIN it
-	//     (getHandle(workflowId, runId)). A workspace's workflow id is REUSED across
-	//     runs (`addsource-<ws>`), so resolving "latest" here let a PRIOR run's
-	//     terminal state be read for the run actually being watched — which marked a
-	//     2nd import done off the 1st's snapshot and stranded it (DAT-595). Pinning
-	//     reads exactly the watched execution.
-	//   • the widget SEED passes the placeholder (`run_id === workflow_id` — the
-	//     trigger returns it before the workflow knows the execution id), where the
-	//     precise run isn't knowable, so we take the latest execution. That also
-	//     gives a reload-pinned widget its terminal state; a placeholder PIN would
-	//     404 → PENDING forever on a completed run.
-	// The watcher SKIPS placeholder rows (completion-watcher.ts) so its path ALWAYS
-	// pins — only the seed ever takes the latest-execution fallback.
+	// Two callers, two ids:
+	//   • the COMPLETION WATCHER / reconcile read the run row's `runId`, which IS the
+	//     real Temporal execution id (firstExecutionRunId, recorded directly post-start
+	//     — DAT-595), and pass it here → we PIN it (getHandle(workflowId, runId)). A
+	//     workspace's workflow id is REUSED across runs (`addsource-<ws>`), so resolving
+	//     "latest" for a watched run would let a PRIOR run's terminal state be read for
+	//     it; pinning reads exactly the watched execution.
+	//   • the widget SEED passes `run_id === workflow_id` — the trigger returns the
+	//     deterministic workflowId because the execution id isn't knowable at trigger
+	//     time — so here we take the LATEST execution. That also gives a reload-pinned
+	//     widget its terminal state (a non-existent-id PIN would 404 → PENDING forever).
 	const handle =
 		input.run_id === input.workflow_id
 			? client.workflow.getHandle(input.workflow_id)

--- a/packages/cockpit/src/temporal/reconcile.ts
+++ b/packages/cockpit/src/temporal/reconcile.ts
@@ -37,9 +37,9 @@ export async function reconcileActiveRuns(
 
 async function reconcileOne(run: ActiveRun): Promise<void> {
 	try {
-		// A placeholder runId (=== workflowId, pre-attachRunId) takes
-		// getWorkflowProgress's latest-execution fallback — correct for a reconcile
-		// that fires during the attach window; a real id pins the exact run (DAT-595).
+		// Every recorded run carries its real Temporal execution id (DAT-595), so this
+		// pins the EXACT run — a reused workflow id (`addsource-<ws>`) never reconciles
+		// against a sibling run's terminal state.
 		const progress = await getWorkflowProgress({
 			workflow_id: run.workflowId,
 			run_id: run.runId,

--- a/packages/cockpit/src/temporal/trigger-add-source.ts
+++ b/packages/cockpit/src/temporal/trigger-add-source.ts
@@ -58,16 +58,17 @@ function requireTemporalConfig(): void {
 
 /**
  * Start the workspace's groundingLoopWorkflow for an onboarding import (DAT-609).
- * Returns the deterministic engine workflow id immediately; the workflow records the
- * run (authoritative, before start) and starts + awaits the engine child, then runs
- * the autonomous teach loop. Returns the workflowId as a PLACEHOLDER run_id — the real
- * Temporal execution id is minted by the workflow post-start and rewritten via
- * `attachRunId` (DAT-595). The widget seed + reconcile use the placeholder
- * (latest-execution fallback in getWorkflowProgress); the completion-watcher waits for
- * the real id, then PINS it.
+ * Returns the deterministic engine workflow id immediately; the workflow starts the
+ * engine child, records the run with its real Temporal execution id (DAT-595), and
+ * runs the autonomous teach loop. The returned `run_id` is the deterministic
+ * `workflowId` because the engine execution id isn't knowable at trigger time — the
+ * widget seed polls `getWorkflowProgress`, which resolves the LATEST execution when
+ * `run_id === workflow_id` (correct for the seed; the watcher pins the real id it
+ * reads from the recorded run row).
  *
  * No engine seed (DAT-506): the run's table set is anchored by `run_tables` (keyed
- * by `run_id`), and the `vertical` is the workspace property from the registry.
+ * by the engine's metadata `run_id`), and the `vertical` is the workspace property
+ * from the registry.
  */
 export async function triggerAddSource(
 	input: TriggerAddSourceInput,
@@ -97,10 +98,11 @@ export async function triggerAddSource(
 
 	return {
 		workflow_id: workflowId,
-		// PLACEHOLDER run_id (DAT-595): the workflow mints the real Temporal execution
-		// id post-start and rewrites it via `attachRunId`. The widget seed + reconcile
-		// take getWorkflowProgress's latest-execution fallback until then; the
-		// completion-watcher SKIPS the placeholder and pins the real id once attached.
+		// run_id mirrors the deterministic workflowId: the engine execution id isn't
+		// knowable at trigger time, so the widget seed polls by workflowId and
+		// getWorkflowProgress resolves the LATEST execution (run_id === workflow_id).
+		// The recorded run row carries the real execution id (DAT-595), which the
+		// watcher/reconcile pin precisely.
 		run_id: workflowId,
 		sources: input.sources,
 	};

--- a/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/probe.tsx
@@ -48,6 +48,7 @@ import {
 	X,
 } from "lucide-react";
 import { useMemo, useState } from "react";
+import { progressQueryKey } from "#/lib/workflow-progress-event";
 import { getActiveVerticalStatus } from "#/server/active-vertical";
 import { getConfiguredDatabases } from "#/server/configured-databases";
 import { importSources } from "#/server/import-sources";
@@ -164,6 +165,12 @@ export function ProbeWidget({
 
 	const queryCount = importSet.filter((x) => x.kind === "query").length;
 
+	const queryClient = useQueryClient();
+	// Bumped per import so a SECOND import in this chat REMOUNTS the progress widget.
+	// The run's workflow id is the reused per-workspace `addsource-<ws>` (DAT-562), so
+	// without a per-import key the widget would keep the prior import's node (DAT-595).
+	const [importEpoch, setImportEpoch] = useState(0);
+
 	const importMutation = useMutation({
 		mutationFn: (items: ImportItem[]) =>
 			importSources({
@@ -182,9 +189,19 @@ export function ProbeWidget({
 					conversationId,
 				},
 			}),
-		// Clear the staged set on a successful start — the run is now live (its
-		// progress renders at the top); the set is free to build the next batch.
-		onSuccess: () => setImportSet([]),
+		onSuccess: (data) => {
+			// Clear the staged set — the run is now live (its progress renders at the
+			// top); the set is free to build the next batch.
+			setImportSet([]);
+			setImportEpoch((e) => e + 1);
+			// Reset the PRIOR import's cached (terminal) progress under the reused
+			// `addsource-<ws>` key so the widget re-seeds to THIS run's latest execution
+			// — the poll is `refetchInterval: false`, so a stale done-snapshot would
+			// otherwise linger and show the previous import's tables (DAT-595).
+			queryClient.resetQueries({
+				queryKey: progressQueryKey(data.workflow_id),
+			});
+		},
 	});
 
 	const run = importMutation.data;
@@ -215,11 +232,11 @@ export function ProbeWidget({
 							? " You'll be told in the chat when it's done."
 							: ""}
 					</Text>
-					{/* Keyed by workflow id so a second import (a new run id under the same
-					    per-workspace workflow id) remounts cleanly rather than reusing a
-					    stale node — forward-compat if the id ever becomes per-run. */}
+					{/* Keyed per IMPORT (workflow id + epoch), not just the reused
+					    per-workspace workflow id, so a second import remounts a fresh
+					    progress node instead of reusing the prior import's (DAT-595). */}
 					<MeasureProgressWidget
-						key={run.workflow_id}
+						key={`${run.workflow_id}:${importEpoch}`}
 						state={{
 							kind: "add-source-progress",
 							workflowId: run.workflow_id,

--- a/packages/cockpit/src/worker/activities.ts
+++ b/packages/cockpit/src/worker/activities.ts
@@ -21,7 +21,6 @@
 // workflow's deterministic loop drives the replays around it.
 
 export {
-	attachRunId,
 	markRunAwaitingInput,
 	markRunStatus,
 	recordRun,

--- a/packages/cockpit/src/worker/workflows/run-stage.ts
+++ b/packages/cockpit/src/worker/workflows/run-stage.ts
@@ -19,9 +19,7 @@ import type * as activities from "../activities";
 
 // The cockpit_db writers the stage brackets each child with. Short timeout — these
 // are quick local writes, not the (long) engine stage.
-const { recordRun, attachRunId, markRunStatus } = proxyActivities<
-	typeof activities
->({
+const { recordRun, markRunStatus } = proxyActivities<typeof activities>({
 	startToCloseTimeout: "1 minute",
 	retry: { maximumAttempts: 3 },
 });
@@ -57,26 +55,20 @@ export interface StageOutcome {
 }
 
 /**
- * Run one engine stage as a cross-language child. Records the run authoritatively
- * before start, attaches the child's real execution id, marks it terminal on
- * completion. Returns {ok, result}. A failure NEVER throws out of the workflow: the
- * run is marked failed and the caller decides whether to stop (it always does — a
- * failed stage has no clean follow-on).
+ * Run one engine stage as a cross-language child. Starts the child, records the run
+ * with the child's REAL execution id (DAT-595 — recording post-start under the reused
+ * `addsource-<ws>` id keeps every run a distinct `(workflowId, runId)` row, retiring
+ * the workflowId-placeholder + attachRunId swap that conflated runs), then marks it
+ * terminal on completion. Returns {ok, result}. A failure NEVER throws out of the
+ * workflow: the run is marked failed (if recorded) and the caller decides whether to
+ * stop (it always does — a failed stage has no clean follow-on).
+ *
+ * Recording post-start is orphan-safe HERE: recordRun is a durable activity, so a
+ * worker crash replays the workflow and re-runs it (the ABANDON child keeps going).
  */
 export async function runStage(spec: StageSpec): Promise<StageOutcome> {
-	// runId is the deterministic workflowId placeholder until the child mints its
-	// execution id (so a failure before start still has a key to mark).
-	let runId = spec.workflowId;
+	let runId: string | null = null;
 	try {
-		// Authoritative record BEFORE start (throws → caught below, child not started).
-		await recordRun({
-			workspaceId: spec.workspaceId,
-			kind: spec.kind,
-			stage: spec.stage,
-			workflowId: spec.workflowId,
-			conversationId: spec.conversationId,
-		});
-
 		const child = await startChild(spec.workflowType, {
 			taskQueue: spec.taskQueue,
 			workflowId: spec.workflowId,
@@ -88,7 +80,17 @@ export async function runStage(spec: StageSpec): Promise<StageOutcome> {
 			args: spec.args,
 		});
 		runId = child.firstExecutionRunId;
-		await attachRunId(spec.workflowId, runId);
+
+		// Record with the child's REAL execution id (DAT-595) — unique per run under
+		// the reused workflow id; no placeholder, no attachRunId, no cross-run conflation.
+		await recordRun({
+			workspaceId: spec.workspaceId,
+			kind: spec.kind,
+			stage: spec.stage,
+			workflowId: spec.workflowId,
+			runId,
+			conversationId: spec.conversationId,
+		});
 
 		const result = await child.result();
 		await markRunStatus(spec.workflowId, runId, "completed");
@@ -99,14 +101,16 @@ export async function runStage(spec: StageSpec): Promise<StageOutcome> {
 			workflowId: spec.workflowId,
 			err: String(err),
 		});
-		// Mark failed best-effort (markRunStatus is a no-op if the run wasn't recorded).
-		// If even this write fails, log it — else the run lingers as phantom `running`.
-		await markRunStatus(spec.workflowId, runId, "failed").catch((markErr) => {
-			log.warn("orchestration stage mark-failed write failed", {
-				workflowId: spec.workflowId,
-				err: String(markErr),
+		// Mark failed best-effort, but only if the child started (we have a real runId);
+		// a pre-start failure recorded nothing, so there is nothing to mark.
+		if (runId !== null) {
+			await markRunStatus(spec.workflowId, runId, "failed").catch((markErr) => {
+				log.warn("orchestration stage mark-failed write failed", {
+					workflowId: spec.workflowId,
+					err: String(markErr),
+				});
 			});
-		});
+		}
 		return { ok: false, result: null };
 	}
 }


### PR DESCRIPTION
Two reused-workflow-id (`addsource-<ws>`) bugs surfaced by the DAT-579 widget walk — both verified fixed live in a rebuilt container (two imports in one Connect chat → distinct tracked runs + the progress widget follows the current import).

## #1 — run-row conflation
`recordRun` inserted with `runId = workflowId` PLACEHOLDER + `onConflictDoNothing`, and a **best-effort** `attachRunId` swapped in the real execution id post-start. When a prior run's `attachRunId` never persisted (e.g. a transient failure, or the journey→609 cutover), it left a **stuck placeholder** row — so the next run's `recordRun` skipped its own insert (conflict on the shared placeholder key) and its `attachRunId` **hijacked the stale row**. The new run went untracked; the old row got mis-stamped.

**Fix:** record with the child's **real `firstExecutionRunId`**, recorded **right after start** (a durable activity in the orchestration workflow; synchronous start in the direct tool path). `(workflowId, realRunId)` is unique per execution, so no shared placeholder and no conflation. Retired `attachRunId` and the completion-watcher's placeholder-skip.

## #2 — progress widget one-behind
`probe.tsx` keyed the `add-source-progress` widget on `run.workflow_id` (the reused `addsource-<ws>`), and the progress `useQuery` is keyed on the same id with `refetchInterval: false` — so a **second** import in a chat shared the first's cached *done* snapshot and showed the **prior import's tables**.

**Fix:** a per-import `epoch` in the widget key (remount) + `resetQueries(progressQueryKey)` on import success, so the widget re-seeds to the current run.

## Scope
`runs.ts` · `worker/workflows/run-stage.ts` · `temporal/orchestration-trigger.ts` (`startDirectRun`) · `temporal/reconcile.ts` · `lib/completion-watcher.ts` · `ui/cockpit/widgets/probe.tsx`. Tests updated: `runs.test`, `orchestration-trigger.test`, `completion-watcher.test`, and the DAT-461/462 + add_source/begin_session/operating_model lane smokes (record post-start with the real id). Engine untouched → no eval handoff. tsc + 1257 unit tests + biome green.

## Not fixed here (filed)
**DAT-618** — far-future SQL Server `datetime2` (temporal `ValidTo` `9999-12-31`) renders as `1816`. Proven a **DuckDB mssql-extension** `TIMESTAMP_NS` int64 overflow at the read (`CAST(ValidTo AS VARCHAR)` → `1816…`, `typeof` → `TIMESTAMP_NS`), upstream of all cockpit code — the fix belongs at the read layer, not the formatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)