### PR TITLE
DAT-616: honest-fail gate for silently-wrong metric SQL on long-format finance

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,6 +4,42 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
+## 2026-06-23: DAT-616 — metric honest-fail gate (silently-wrong metric SQL on long-format finance)
+
+The operating_model **metrics** phase no longer reports a silently-wrong metric as
+`executed`/green. A new post-execution verifier (`graphs/verifier.py`, run inside
+`GraphAgent.execute` before snippets are cached) keeps a metric **`grounded`/inconclusive
+with a stated reason** when:
+1. an extract aggregated to **NULL** (its filter matched no rows — "no support"); the
+   COALESCE-mask prompt rule (`graph_sql_generation.yaml` rule 7) was rewritten so an empty
+   `SUM/AVG` surfaces as NULL instead of a fabricated 0;
+2. the composed value is NULL (a contributing extract had no support);
+3. a catalogue-declared per-extract `validation:` condition is violated (e.g. revenue
+   `value > 0`, cogs `value >= 0`) — these were dead YAML before (the loader dropped them);
+   now parsed into `GraphStep.validations` and enforced.
+
+A **genuine 0** (filter matched rows summing to 0) still passes — the shared executor
+(`query/execution.py`) stopped conflating a real 0 with failure. Also fixed in the blast
+radius: `StepResult` building now handles `Decimal` (currency sums) — previously a Decimal
+extract value was read as NULL.
+
+### dataraum-eval
+- **This changes metric `executed` vs `grounded` outcomes** — a calibration that asserts
+  only `state == executed` will now (correctly) see `grounded` for an unsupported metric on
+  long/transactional finance data (no `revenue` column; "revenue" is a row filter). The
+  oracle that would have caught the original bug: **assert metric VALUES, not just
+  `executed`**, on a long-format fixture, plus a regression that an empty-filter extract
+  stays `grounded` with a `no support` reason.
+- No engine response-schema change; metric `output_value` semantics unchanged for a
+  supported metric. The new failure reason text is `"composed but not executed: …"`.
+- **Status**: pending
+
+### dataraum-testdata
+- Needs a **BookSQL-style long/transactional finance fixture** (one `Amount` column + an
+  `account_type` discriminator, no per-concept columns) with **ground-truth metric values**
+  for gross_margin / gross_profit — the fixture that reproduces the silent-wrong case and
+  would let eval assert real values.
+
 ## 2026-06-22: fix — deterministic `top_values` ordering (profiling reproducibility)
 
 `StatisticalProfile.top_values` is now ordered `count DESC, value` (was `count DESC` only),

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -4,41 +4,31 @@ Changes in dataraum that need attention in other repos.
 
 Updated by `/implement` in this repo. Read by `/accept` in dataraum-eval.
 
-## 2026-06-23: DAT-616 — metric honest-fail gate (silently-wrong metric SQL on long-format finance)
+## 2026-06-23: DAT-616 reworked + DAT-620 — metric grounding on long-format finance (REFRAMED)
 
-The operating_model **metrics** phase no longer reports a silently-wrong metric as
-`executed`/green. A new post-execution verifier (`graphs/verifier.py`, run inside
-`GraphAgent.execute` before snippets are cached) keeps a metric **`grounded`/inconclusive
-with a stated reason** when:
-1. an extract aggregated to **NULL** (its filter matched no rows — "no support"); the
-   COALESCE-mask prompt rule (`graph_sql_generation.yaml` rule 7) was rewritten so an empty
-   `SUM/AVG` surfaces as NULL instead of a fabricated 0;
-2. the composed value is NULL (a contributing extract had no support);
-3. a catalogue-declared per-extract `validation:` condition is violated (e.g. revenue
-   `value > 0`, cogs `value >= 0`) — these were dead YAML before (the loader dropped them);
-   now parsed into `GraphStep.validations` and enforced.
-
-A **genuine 0** (filter matched rows summing to 0) still passes — the shared executor
-(`query/execution.py`) stopped conflating a real 0 with failure. Also fixed in the blast
-radius: `StepResult` building now handles `Decimal` (currency sums) — previously a Decimal
-extract value was read as NULL.
+The silently-wrong metric bug is **context-engine starvation**, not a missing checker. Full
+reworked design: `docs/dat543-construct-dont-improvise.md` (this PR). The graph agent
+improvises the row filter because it is served `SELECT DISTINCT … LIMIT 5` (no counts) and no
+drivers. Fix = **FEED** it `top_values` + drivers + a teach-confirmed `concept→value-set`
+binding (new ticket **DAT-620**), and have it author SQL from a blueprint. The `verifier.py`
+in this PR stays as a cheap value-bound + NULL **sanity floor** — NOT the fix.
 
 ### dataraum-eval
-- **This changes metric `executed` vs `grounded` outcomes** — a calibration that asserts
-  only `state == executed` will now (correctly) see `grounded` for an unsupported metric on
-  long/transactional finance data (no `revenue` column; "revenue" is a row filter). The
-  oracle that would have caught the original bug: **assert metric VALUES, not just
-  `executed`**, on a long-format fixture, plus a regression that an empty-filter extract
-  stays `grounded` with a `no support` reason.
-- No engine response-schema change; metric `output_value` semantics unchanged for a
-  supported metric. The new failure reason text is `"composed but not executed: …"`.
-- **Status**: pending
+- The real oracle is now **DAT-620's proposer**, not the metric value alone. Needs a
+  long-format fixture with **ground-truth `concept → value-set` labels** (which
+  `account_type` values ARE revenue / cost_of_goods_sold / opex / …) so the proposer's
+  **precision/recall** can be scored — that p/r is the acceptance gate on DAT-620.
+- Keep the prior regressions too: assert metric VALUES (not just `executed`) on the
+  long-format fixture; an empty-filter extract stays `grounded` with a reason (the sanity
+  floor).
+- **Status**: pending (supersedes the earlier 'assert metric values' framing — same
+  fixture, now ALSO needs the concept→value labels).
 
 ### dataraum-testdata
-- Needs a **BookSQL-style long/transactional finance fixture** (one `Amount` column + an
-  `account_type` discriminator, no per-concept columns) with **ground-truth metric values**
-  for gross_margin / gross_profit — the fixture that reproduces the silent-wrong case and
-  would let eval assert real values.
+- A **BookSQL-style long/transactional finance fixture** (one `Amount` column + an
+  `account_type` discriminator, no per-concept columns) with TWO ground truths: (1) the
+  **`concept → value-set` labels** (the NEW requirement — for the DAT-620 proposer), and
+  (2) ground-truth metric values for gross_margin / gross_profit (the regression).
 
 ## 2026-06-22: fix — deterministic `top_values` ordering (profiling reproducibility)
 

--- a/docs/dat543-construct-dont-improvise.md
+++ b/docs/dat543-construct-dont-improvise.md
@@ -1,0 +1,86 @@
+# Feed the agents — deterministic grounding + LLM-authored SQL (DAT-616 reframe)
+
+**Spine.** This is a context engine; the metric path is wrong because we **starve** the SQL agents of metadata we already compute — not because we lack a checker, and **not because we lack a deterministic SQL builder.** The shape space of metric SQL (sum, ratio, end-of-period, window, multi-column, signed measures, CTEs) is open-ended; every fixed builder has died on the tail before. So the LLM authors the SQL — that is the design, not a fallback. The fix is to **feed it the deterministic grounding** it's currently denied, and make that grounding **teach-confirmed and durable**. Deterministic *evidence* + LLM *authoring* + human *teach* — never deterministic authoring.
+
+All file:line verified on this branch.
+
+> **Ticket note:** the "grounding heart" below is **DAT-620** (new, under DAT-543). The real **DAT-581 is an unrelated cross-column dependency sniffer** — earlier notes mislabeled the grounding work as 581.
+
+## 1. The idiom — and its honest boundary
+
+The engine already runs "deterministic stats → narrow LLM decides → emit SQL":
+- **enriched_views** — `build_enriched_view_sql` (`analysis/views/builder.py`) is a deterministic builder, but it works **only because its shape is fixed** (one grain-preserving LEFT JOIN). The LLM (`enriched_views_phase.py:_get_llm_recommendations`) only picks dims. sqlglot-gated.
+- **slice agent** (`SlicingAgent(LLMFeature)`) — picks dims/values from `top_values`; doesn't author SQL.
+- **drivers** (`DriverRankingArtifact`, `analysis/drivers/`) — statistical (variance-reduction, min_support, p-value; precision/recall-calibrated).
+
+**Boundary (the lesson):** a deterministic builder is legitimate for *fixed* shapes (enriched_views) and nothing else. Metrics are not fixed-shape → **the LLM writes the metric SQL.** Do not build `build_extract_sql`. The deterministic part is the *grounding it consumes*, not the SQL it emits.
+
+## 2. The grounding (DAT-620) — the heart, one decision with two faces
+
+Grounding = `concept → (measure expression, predicate/value-set)`. **Both faces are one job (DAT-620), and it is an LLM+stats+teach job, not deterministic:**
+- **measure expression** — usually `SUM(amount)`, but may be `SUM(debit) − SUM(credit)`, a sign convention, a ratio (`Σnum/Σden`). Drivers already model this: `Measure{target_type: flow|stock|ratio, column|numerator/denominator}` (`drivers/models.py`), read from the catalog's `temporal_behavior`.
+- **predicate/value-set** — which `account_type` values *are* the concept.
+
+Inputs (deterministic evidence, fed to the grounding step):
+- `top_values` + `distinct_count` — the **complete enumeration** of the partition column (exhaustive iff `distinct_count ≤ K`).
+- drivers `ranked_dimensions` (which dim partitions the measure) + `interesting_slices` (`{dimension,value,effect,support}` — high-signal **hint**, recall<1, NOT the partition) + `measure_column_id` + `target_type`.
+- ontology `indicators`/`exclude_patterns` lexicon (`verticals/*/ontology.yaml`).
+
+The grounding is **proposed** by a narrow agent over those inputs, then **teach-confirmed**. (`interesting_slices` is a labeling hint; the labeling itself is the agent+teach step.)
+
+## 3. The binding table — the durable artifact
+
+A standalone per-workspace, run-versioned table: per `concept` a **predicate spec** — a conjunction of per-column labeled value-sets (single-column is the 1-element case) + measure expression + provenance (`lexicon|driver|teach`) + support. Multi-column is native (drivers' `driver_paths`/`DriverNode.children` already give multi-dimension drill vectors; the LLM authors the conjunction).
+
+**Fed by both, at different layers (the "true question", resolved):** the partition *structure* — dimension, values, support, effect — is deterministic from **drivers (DAT-546 today / DAT-573 on-demand) + `top_values`**; the concept *labels* over that structure are **DAT-620 (proposer + teach)**. So **DAT-620 owns the WRITE; drivers feed the evidence each row carries AND the freshness trigger** (a re-run surfacing a new value → re-label). 581 writes, 573 feeds + invalidates.
+
+Properties:
+- **Complete:** *every* live value of the partition column carries a label, including explicit `unmapped` — so a concept's `IN`-list can't silently miss a value (no `Direct Materials` undercount).
+- **Fall-loud on drift:** a value present in the live column but absent from the confirmed set (re-import) → the dependent metric is **inconclusive-with-reason until labeled**, never computed on a stale partition. (The graph cornerstone steer.)
+- The shared grounding artifact for DAT-620/591/611/619/617; "clear what it is for later reference."
+
+## 4. Feed the SQL agents (the actual DAT-616 fix)
+
+Serve the evidence + the confirmed binding into both authors so they **stop improvising the predicate**:
+- **Engine GraphAgent** — today starved: `_describe_table` sends `SELECT DISTINCT … LIMIT 5`, no counts (`agent.py:666`); `context.py:810-811` lifts only null/cardinality and **drops `top_values`/`distinct_count`** though the profile is in scope (`:803`); `graphs/context.py` loads **no drivers**. Serve: `top_values` (low-card dims) + `ranked_dimensions` + the binding.
+- **Cockpit answer agent** — better fed (`<drivers>` already serves driver slices, `query-context.ts:643`), but `<schema>`/`<dimensions>` strip values. Serve the binding + dimension values the same way.
+
+**How the agent authors — the template, moved into the LLM world (not a deterministic filler, not free improvisation):**
+- **Named-context contract.** The prompt names exactly what is available and grounded — measure expression (incl. signed/ratio), the predicate-spec (per-column labeled value-sets), dimension columns, aggregation, the catalog extract intent. The agent fills *these* slots; it never invents a filter.
+- **Blueprint library.** The prompt describes the SQL *shape* per pattern class and carries a few-shot exemplar for each: simple aggregate, end-of-period (latest-period CTE), window, multi-column conjunction, ratio (two extracts composed). **Shape coverage lives here** — CTE/window/multi-column are *taught as blueprints*, not hoped for. This is `graph_sql_generation.yaml`'s new job: a named-context contract + a covered blueprint library, replacing the improvise-the-filter instruction.
+
+This keeps the neat part of "fill a template" (a known shape, named slots) while putting the composition where it belongs — the LLM — so the open-ended shape tail doesn't break it. The agent writes SQL **from** the binding; it no longer guesses which rows.
+
+## 5. The gatekeeper (your fork) — deterministic routing on confidence, not SQL-shape
+
+Since the LLM always authors, the gate is not builder-vs-agent. It is a deterministic AND of trust signals deciding **auto-accept vs teach/editor**:
+- **grounding confidence** — binding teach-confirmed (auto) vs agent-proposed-only (review);
+- **execution** — runs vs `BinderException` (DAT-611's deterministic escalate→editable trigger);
+- **structural check** — the emitted predicate's column+literals match the confirmed binding; referenced columns exist (sqlglot, already in-tree: `core/sql_normalize.py`, `entropy/measurements/derived_value.py`).
+
+Confirmed binding + structural-match + executes → accept. Otherwise → `SqlEditor` / teach. The editor overwrite *is* a teaching.
+
+## 6. Verification — reframed, mostly gone
+
+- **context-free extract** (`concept+statement+aggregation`): structural check vs ontology (concept known, aggregation matches stock/flow). Deterministic, no data — the only legitimate "verify".
+- **grounding**: the trust boundary — teach-confirmed + drivers-evidenced + fall-loud. Not verified as an LLM output.
+- **emitted SQL**: structural match to the binding (§5), not a value-space judge.
+- **Keep the metric `validation:` checks as a cheap post-execution sanity floor (KEPT).** They're a one-number comparison on the step's already-aggregated scalar — `StepResult.value` = `result[0]` (`execution.py:155`, the step's `… AS value`) — evaluated by a Python-ast safe-evaluator (`verifier.py`); **SQL-untouched, in-memory-trivial, orthogonal to the grounding fix.** These are the metric-graph's own per-extract bounds (`loader.py` → `GraphStep.validations`), NOT the unrelated operating_model `ValidationAgent`. What was wrong in #369 was *framing* them (+ the NULL-support gate) as the honest-fail gate — they're blind to wrong-non-empty. So **keep `verifier.py` (value-bound + NULL floor) as sanity; it is NOT the fix.**
+- **Scalar LLM judge: out** (re-certifies the generator's own blind spot). **Execution self-consistency: deferred, not rejected — it is the *eventual* best validation for this problem.** Pre-feed it entrenches the modal-wrong binding (votes on a starved guess); *post-feed*, K well-grounded samples agreeing on the executed result is real confidence and disagreement flags residual grounding ambiguity. A later phase **after** the feed+binding lands — not now. Salvage from #369 = the de-financed prompt **+ validations-as-sanity**, minus the honest-fail-gate framing.
+
+## 7. Re-scope
+
+**Build order: DAT-620 FIRST (eval-driven) → 616 (feed + blueprint prompt) → 573/591/611/619/617.** The grounding is the heart and the risk, so it leads and is proven by eval before the rest builds on it.
+
+- **DAT-620 (first, eval-driven)** = the grounding (§2) — concept→(measure expression, predicate/value-set), both faces; the drivers+lexicon **proposer** agent + teach; writes the predicate-spec binding table. **Built from the eval side: a long-format fixture with ground-truth concept→value labels; the proposer's precision/recall against teach is the gate, not an afterthought** (cross-repo: dataraum-eval owns the fixture + oracle labels). Keystone.
+- **DAT-616** = feed the agents (§4): serve `top_values`/`ranked_dimensions`/binding into the GraphAgent; rewrite `graph_sql_generation.yaml` into the named-context contract + blueprint library; **keep `verifier.py` as a cheap value-bound + NULL-support sanity floor** (re-framed from #369's "honest-fail gate" — it's sanity, not the fix); keep de-financed prompt. **Salvage from #369 = de-financed prompt + the verifier-as-sanity (+ its loader/model wiring).** The metric stops improvising because it's *fed*, not because of the verifier.
+- **DAT-573** = on-demand drivers — the proven stats source feeding §2; serve into the GraphAgent (loads none today).
+- **DAT-591/611** = cockpit drill — deterministic metric→column edge + AST GROUP-BY rewrite + Haiku-on-`BinderException` + `SqlEditor`. Consumes the binding; downstream end of the same pipe. `json_serialize_sql` is the right tool *here* (manipulate existing SQL), not in the engine.
+- **DAT-619** = snippets = verified-skill store; entry gated on teach-confirmed-or-structural-pass, not blind `failure_count==0`.
+- **DAT-617** = consumer; rides the above.
+
+## 8. Honest unproven / open forks
+
+- **Unproven:** DAT-620 grounding quality (it's the hard heart — past deterministic attempts failed here); `top_values` truncation at `distinct_count > K` (full-DISTINCT pull or refuse-to-ground); the completeness/fall-loud invariant is per-column-clean for **conjunctions** but murky for arbitrary **OR-combinations across columns** (cross-product can't be enumerated) — that boolean-shape edge is the real one to watch, NOT column count.
+- **Settled:** labeling uses the drivers+lexicon **proposer** agent (proposes, teach confirms) — not teach-only. Binding = `concept → predicate spec` (conjunction of per-column value-sets), multi-column native, no single-dim limitation.
+- **Forks for the lead:** (1) binding persistence schema — exact predicate-spec shape + how the measure expression (incl. signed/ratio) is stored. (2) structural-check lives once (engine) or twice (engine+cockpit). (3) channel precedence on disagreement: teach(human) > drivers(signal) > top_values(enumeration); union vs confirmed-set as the structural-check oracle.

--- a/packages/cockpit/scripts/smoke-operating-model.ts
+++ b/packages/cockpit/scripts/smoke-operating-model.ts
@@ -37,15 +37,17 @@ import {
 	currentValidationResults,
 } from "#/db/metadata/schema";
 import { sourcesWrite } from "#/db/metadata/write-surface";
-import { beginSession } from "#/tools/begin-session";
 import type {
 	AddSourceInput,
 	AddSourceResult,
+	BeginSessionInput,
+	BeginSessionResult,
 	OperatingModelInput,
 	OperatingModelResult,
 } from "#/temporal/types";
 import {
 	addSourceWorkflowId,
+	beginSessionWorkflowId,
 	operatingModelWorkflowId,
 } from "#/temporal/workflow-id";
 
@@ -87,7 +89,13 @@ async function ingest(client: Client): Promise<string[]> {
 			engineSchema: `ws_${env.DATARAUM_WORKSPACE_ID.replaceAll("-", "_")}`,
 			vertical: VERTICAL,
 		})
-		.onConflictDoNothing();
+		// A workspace row may already exist from a prior smoke with a DIFFERENT
+		// vertical — onConflictDoNothing would leave it stale and the journey path
+		// would ground the wrong ontology. Force the vertical to this smoke's.
+		.onConflictDoUpdate({
+			target: workspaces.id,
+			set: { vertical: VERTICAL },
+		});
 
 	await metadataDb
 		.insert(sourcesWrite)
@@ -146,13 +154,28 @@ async function main(): Promise<void> {
 		const tableIds = await ingest(client);
 
 		// ---- begin_session: compose the workspace ---------------------------------
-		// Vertical is the workspace property (seeded = finance); the driver sources it.
-		const begun = await beginSession({ table_ids: tableIds });
-		// beginSession now returns a born-loud {error} when the workspace has no
-		// typed tables (DAT-534); the smoke ingested above, so it must have started.
-		if ("error" in begun) throw new Error(`begin_session refused: ${begun.error}`);
-		await client.workflow.getHandle(begun.workflow_id, begun.run_id).result();
-		console.log(`✓ begin_session completed: workflow=${begun.workflow_id}`);
+		// Drive the engine `beginSessionWorkflow` DIRECTLY on the workspace queue,
+		// mirroring add_source / operating_model above. The cockpit `beginSession`
+		// TOOL is a journey SIGNAL (DAT-530) — it returns the deterministic workflow
+		// id with `run_id == workflow_id` (a placeholder; the journey owns the real
+		// run id), so building a client handle from it fails with `Invalid RunId`.
+		// This is an integration smoke of the engine contract, not the journey, so we
+		// start + await the workflow ourselves with the real handle. Verticals are
+		// passed EXPLICITLY (= finance) — not read from the workspace row.
+		const beginInput: BeginSessionInput = {
+			workspace_id: env.DATARAUM_WORKSPACE_ID,
+			tables: tableIds,
+			verticals: [VERTICAL],
+		};
+		const beginHandle = await client.workflow.start<
+			(p: BeginSessionInput) => Promise<BeginSessionResult>
+		>("beginSessionWorkflow", {
+			taskQueue: env.TEMPORAL_TASK_QUEUE,
+			workflowId: beginSessionWorkflowId(env.DATARAUM_WORKSPACE_ID),
+			args: [beginInput],
+		});
+		const beginResult = (await beginHandle.result()) as BeginSessionResult;
+		console.log(`✓ begin_session completed: run_id=${beginResult.run_id}`);
 
 		// ---- operatingModelWorkflow: flat input (DAT-438, DAT-506) ----------------
 		// The stage re-reads the session's table set from the catalog head's

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -83,7 +83,10 @@ system_prompt: |
   5. Date functions: DATE_TRUNC('month', col), DATE_PART('year', col), col + INTERVAL '30 days'.
   6. Implicit casting: DuckDB is strict about types. Use explicit CAST() when comparing
      or joining columns of different types (e.g., VARCHAR vs INTEGER).
-  7. NULL handling: Use COALESCE(col, 0) for numeric aggregations that may include NULLs.
+  7. Empty aggregations: Do NOT wrap an aggregation in COALESCE(<agg>, 0). A SUM/AVG/MIN/MAX
+     over zero matching rows MUST surface as NULL — never a fabricated 0. A masked 0 reads as
+     a real value and silently corrupts the metric (e.g. cost_of_goods_sold=0 → gross_margin=100%).
+     Only COALESCE a genuinely-nullable NON-aggregate input where 0 is the semantically correct value.
   8. Table references: ALWAYS use enriched views (enriched_*) when available in <data_schema>.
      Do NOT query typed tables directly when enriched views exist — enriched views are pre-joined
      supersets with dimension columns (e.g., enriched_trial_balance has
@@ -205,8 +208,8 @@ user_prompt: |
      - llm_reasoning: brief explanation of your mapping strategy
 
   6. Document assumptions — interpretation decisions due to data uncertainty:
-     - Only record genuine ambiguity you resolved (e.g., "treating nulls as zero",
-       "using end-of-period balance from latest date", "assuming EUR currency")
+     - Only record genuine ambiguity you resolved (e.g., "treating an ambiguous column as
+       the revenue measure", "using end-of-period balance from latest date", "assuming EUR currency")
      - Include the entropy dimension, what column/relationship is affected, your
        decision, the basis (system_default/inferred/user_specified), and confidence
 

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -1,5 +1,5 @@
 name: "graph_sql_generation"
-version: "3.0"
+version: "3.1"
 description: "Generate executable SQL from a graph specification and data schema"
 temperature: 0.0
 
@@ -17,11 +17,12 @@ system_prompt: |
 
   - The QUERY AGENT receives your steps when users ask natural language questions.
     It matches steps by business concept (standard_field + statement + aggregation)
-    and reuses them instead of regenerating SQL. A well-written step for "revenue
-    from income_statement, summed" can serve dozens of future queries.
+    and reuses them instead of regenerating SQL. A well-written step for one
+    business concept (e.g. "<measure> from <statement>, summed") can serve dozens
+    of future queries.
 
-  - OTHER GRAPHS that need the same extract (e.g., both DSO and profit margin need
-    "revenue") reuse your cached step instead of calling the LLM again.
+  - OTHER GRAPHS that need the same extract (e.g., two metrics that both need the
+    same "<measure>") reuse your cached step instead of calling the LLM again.
 
   - CACHED STEPS you receive in <cached_steps> were produced by previous successful
     executions of this or related graphs. They have been tested against the actual
@@ -30,30 +31,32 @@ system_prompt: |
   This means:
   - Each step should compute ONE business concept — not a bespoke calculation for
     this specific graph. The concept must be reusable in other contexts.
-  - Step IDs should match the business concept (e.g., "revenue", "accounts_receivable",
-    "period_days"), not be generic ("step_1", "step_2").
+  - Step IDs should match the business concept (the standard_field name from the
+    active vertical, e.g. "<concept>" or "period_days"), not generic ("step_1", "step_2").
   - Filters specific to this graph belong in final_sql, not in the steps. A step
     that bakes in a time filter or region filter cannot be reused by other graphs.
   </why_your_output_matters>
 
   <field_resolution_strategy>
-  When a graph references a standard_field (e.g., "revenue", "accounts_receivable"):
+  When a graph references a standard_field (an abstract concept name from the active vertical):
 
-  IMPORTANT: Standard field names are ABSTRACT ontology vocabulary from config/verticals/.
-  They are NOT table names, column names, or SQL identifiers.
+  IMPORTANT: Standard field names are ABSTRACT ontology vocabulary from config/verticals/
+  — they belong to whatever vertical is active, NOT any one domain. They are NOT table
+  names, column names, or SQL identifiers.
   The semantic phase maps these abstract concepts to actual dataset columns.
 
   Resolution order:
   1. Use field_mappings — these contain the semantic phase's concept → column mappings.
      If a standard_field has a direct mapping, use the mapped table.column EXACTLY.
   1b. If no direct field mapping exists, check enriched view categorical dimensions.
-     For example, `revenue` may correspond to filtering `enriched_trial_balance`
-     WHERE `account_id__account_type = 'revenue'` (or ILIKE 'revenue').
+     A concept may correspond to filtering an enriched view on one of its categorical
+     dimensions (e.g. WHERE `<enriched_view>.<dimension>` = '<concept>' or ILIKE '<concept>').
   2. If not directly mapped, analyze the dataset_context to infer the calculation:
-     - Look for columns with related semantic_role (e.g., "measure", "amount")
+     - Look for columns with a related semantic_role (e.g., "measure", "amount")
      - Check business_concept annotations for clues
-     - Use transaction_type or similar columns to filter relevant rows
-     - Example: revenue = SUM(amount) WHERE transaction_type IN ('Invoice', 'Sale')
+     - Use a type/category column to filter to the relevant rows
+     - Example: a measure = SUM(`<amount_col>`) filtered via a categorical column
+       (e.g. WHERE `<type_col>` IN (<the relevant values>))
   3. Document your inference in the column_mappings with explanation
 
   NEVER use a standard_field name as a table name in SQL.
@@ -85,12 +88,12 @@ system_prompt: |
      or joining columns of different types (e.g., VARCHAR vs INTEGER).
   7. Empty aggregations: Do NOT wrap an aggregation in COALESCE(<agg>, 0). A SUM/AVG/MIN/MAX
      over zero matching rows MUST surface as NULL — never a fabricated 0. A masked 0 reads as
-     a real value and silently corrupts the metric (e.g. cost_of_goods_sold=0 → gross_margin=100%).
+     a real value and silently corrupts the metric (e.g. an empty filter → 0 → a fabricated 100% ratio).
      Only COALESCE a genuinely-nullable NON-aggregate input where 0 is the semantically correct value.
   8. Table references: ALWAYS use enriched views (enriched_*) when available in <data_schema>.
      Do NOT query typed tables directly when enriched views exist — enriched views are pre-joined
-     supersets with dimension columns (e.g., enriched_trial_balance has
-     chart_of_accounts__account_type). Use categorical dimensions for row-level filtering.
+     supersets with dimension columns (joined dimensions are named `<dimension>__<attribute>`,
+     e.g. `<fact_view>.<dimension>__<attribute>`). Use categorical dimensions for row-level filtering.
   </duckdb_dialect>
 
   <step_execution_model>
@@ -103,7 +106,7 @@ system_prompt: |
   - Each step must be standalone SQL (executable independently)
   - Each step should compute one business concept and return a single value
   - final_sql combines step results — this is where graph-specific logic lives
-  - Step IDs should match the business concept (e.g., "revenue", not "step_1")
+  - Step IDs should match the business concept (the standard_field name, not "step_1")
   </step_execution_model>
 
   <aggregation_types>
@@ -128,12 +131,12 @@ system_prompt: |
 
   - `temporal_behavior: point_in_time` — stock measure (balance, count, level
     at a moment). DO NOT SUM across periods. Use the `end_of_period` pattern:
-    filter to the latest period first, then aggregate within it. Examples:
-    accounts_receivable, inventory_value, cash_balance, headcount.
+    filter to the latest period first, then aggregate within it. Examples (across
+    domains): inventory_level, account_balance, headcount, active_subscriptions.
 
   - `temporal_behavior: additive` — flow measure (activity within a period).
-    SUM across periods is correct. Examples: revenue, expenses, units_sold,
-    transactions_count.
+    SUM across periods is correct. Examples (across domains): units_sold, sessions,
+    expenses, events_logged.
 
   If the graph step's declared `aggregation` conflicts with the column's
   `temporal_behavior` (e.g. `aggregation: sum` on a `point_in_time` column),
@@ -193,7 +196,7 @@ user_prompt: |
 
   3. Generate each step as standalone SQL:
      - One business concept per step, returning a single scalar value
-     - Step IDs match the business concept (e.g., "total_revenue", not "step_1")
+     - Step IDs match the business concept (the standard_field name, e.g. "<measure>", not "step_1")
      - Use the aggregation type from the graph specification
 
   4. Write final_sql to combine step results:
@@ -209,20 +212,22 @@ user_prompt: |
 
   6. Document assumptions — interpretation decisions due to data uncertainty:
      - Only record genuine ambiguity you resolved (e.g., "treating an ambiguous column as
-       the revenue measure", "using end-of-period balance from latest date", "assuming EUR currency")
+       the intended measure", "using the latest period's value for a point-in-time measure",
+       "assuming a single unit/currency across rows")
      - Include the entropy dimension, what column/relationship is affected, your
        decision, the basis (system_default/inferred/user_specified), and confidence
 
-  EXAMPLE:
+  EXAMPLE (illustrates STRUCTURE only — the <…> tokens are placeholders; substitute the
+  active vertical's concepts, views, and columns from <field_mappings>/<data_schema>):
   steps:
-    - step_id: "total_revenue"
-      sql: "SELECT SUM(\"Amount\") as value FROM enriched_transactions WHERE \"Type\" ILIKE 'Sale'"
-    - step_id: "total_ar"
-      sql: "SELECT SUM(\"Balance\") as value FROM enriched_trial_balance WHERE account_id__account_type ILIKE 'receivable'"
+    - step_id: "<numerator_measure>"
+      sql: "SELECT SUM(\"<amount_col>\") as value FROM <enriched_view> WHERE \"<category_col>\" ILIKE '<category>'"
+    - step_id: "<denominator_measure>"
+      sql: "SELECT SUM(\"<amount_col>\") as value FROM <enriched_view>"
     - step_id: "period_days"
       sql: "SELECT 30 as value"
 
-  final_sql: "SELECT (SELECT value FROM total_ar) / (SELECT value FROM total_revenue) * (SELECT value FROM period_days) AS dso"
+  final_sql: "SELECT (SELECT value FROM <numerator_measure>) / (SELECT value FROM <denominator_measure>) * (SELECT value FROM period_days) AS <metric_id>"
   </instructions>
 
   Use the generate_sql tool to provide the SQL steps, final SQL, column mappings, provenance, and assumptions.

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from decimal import Decimal
 from typing import Any
 from uuid import uuid4
 
@@ -40,6 +41,7 @@ from .models import (
     StepType,
     TransformationGraph,
 )
+from .verifier import verify_execution
 
 logger = get_logger(__name__)
 
@@ -270,8 +272,26 @@ class GraphAgent(LLMFeature):
 
         execution = exec_result.value
 
-        # Save snippets AFTER successful execution — includes repair info
-        # and only saves SQL that actually works.
+        # Verifier gate (DAT-616): execution-pass is NOT validation. A metric
+        # whose SQL ran cleanly is still inconclusive if an extract had no support
+        # (empty filter -> NULL), the composed value is degenerate (NULL), or a
+        # catalogue-declared condition is violated. Such a metric stays grounded
+        # with the reason — never executed-green — and its SQL is NOT cached (we
+        # return before _save_snippets). Reused cached snippets that produced the
+        # bad result are recorded failed so they self-heal on the next run.
+        verdict = verify_execution(graph, execution)
+        if not verdict.success:
+            if cached_snippets:
+                from dataraum.query.snippet_library import SnippetLibrary
+
+                failed_ids = [
+                    s["snippet_id"] for s in cached_snippets.values() if s.get("snippet_id")
+                ]
+                SnippetLibrary(session, workspace_id=workspace_id).record_failure(failed_ids)
+            return Result.fail(verdict.error or "metric verification failed")
+
+        # Save snippets AFTER successful execution AND verification — includes
+        # repair info and only saves SQL that actually works AND is trustworthy.
         self._save_snippets(
             session=session,
             graph=graph,
@@ -575,11 +595,15 @@ class GraphAgent(LLMFeature):
                     "repair_attempts": sr.repair_attempts,
                 },
             )
+            # bool BEFORE int (bool is an int subclass); Decimal IS the common
+            # currency type DuckDB returns for SUM over DECIMAL columns — it must
+            # land in value_scalar, else the verifier reads a real sum as NULL
+            # "no support" and false-fails every real metric (DAT-616).
             value = sr.value
-            if isinstance(value, (int, float)):
-                step_result.value_scalar = float(value)
-            elif isinstance(value, bool):
+            if isinstance(value, bool):
                 step_result.value_boolean = value
+            elif isinstance(value, (int, float, Decimal)):
+                step_result.value_scalar = float(value)
             elif isinstance(value, str):
                 step_result.value_string = value
 

--- a/packages/engine/src/dataraum/graphs/loader.py
+++ b/packages/engine/src/dataraum/graphs/loader.py
@@ -32,6 +32,7 @@ from .models import (
     ParameterDef,
     StepSource,
     StepType,
+    StepValidation,
     TransformationGraph,
 )
 
@@ -205,6 +206,19 @@ class GraphLoader:
                 statement=source_data.get("statement"),
             )
 
+        # Declared post-execution checks (DAT-616): the catalogue's per-extract
+        # `validation:` block was dropped on the floor before — now parsed and
+        # enforced by graphs.verifier against the executed value.
+        validations = [
+            StepValidation(
+                condition=v["condition"],
+                severity=v.get("severity", "error"),
+                message=v.get("message", ""),
+            )
+            for v in data.get("validation") or []
+            if isinstance(v, dict) and v.get("condition")
+        ]
+
         return GraphStep(
             step_id=step_id,
             step_type=step_type,
@@ -215,6 +229,7 @@ class GraphLoader:
             expression=data.get("expression"),
             depends_on=data.get("depends_on", []),
             output_step=data.get("output_step", False),
+            validations=validations,
         )
 
     def _parse_interpretation(self, data: dict[str, Any] | None) -> Interpretation | None:

--- a/packages/engine/src/dataraum/graphs/models.py
+++ b/packages/engine/src/dataraum/graphs/models.py
@@ -85,6 +85,22 @@ class StepSource:
 
 
 @dataclass
+class StepValidation:
+    """A declared post-execution check on a step's value (DAT-616).
+
+    From the catalogue's per-extract ``validation:`` block, e.g.
+    ``{condition: "value > 0", severity: "error", message: "Revenue must be positive"}``.
+    Enforced by :func:`dataraum.graphs.verifier.verify_execution` against the
+    executed value — execution-pass is not validation. Before DAT-616 the loader
+    dropped this block on the floor; it is now parsed into this model.
+    """
+
+    condition: str  # comparison over `value`, e.g. "value > 0" / "value >= 0"
+    severity: str = "error"
+    message: str = ""
+
+
+@dataclass
 class GraphStep:
     """A single step in a transformation graph."""
 
@@ -107,6 +123,9 @@ class GraphStep:
 
     # Output marker
     output_step: bool = False
+
+    # Declared post-execution checks (catalogue `validation:` block, DAT-616)
+    validations: list[StepValidation] = field(default_factory=list)
 
 
 @dataclass

--- a/packages/engine/src/dataraum/graphs/verifier.py
+++ b/packages/engine/src/dataraum/graphs/verifier.py
@@ -1,0 +1,134 @@
+"""Post-execution verifier for metric graphs (DAT-616).
+
+Execution-pass is *not* validation. A metric whose SQL ran cleanly can still be
+silently wrong: when an extract's filter matched no rows the aggregate is NULL
+("no support"), and when the prompt masks that NULL with ``COALESCE(col, 0)`` it
+reads as a real ``0`` — so a long-format finance metric (no ``revenue`` column,
+"revenue" is a row filter the agent improvises) reaches ``executed``/green with a
+fabricated value (the canonical case: ``gross_margin = 100%`` because cogs
+matched nothing).
+
+This verifier converts that into an honest *inconclusive*: a metric with an
+unsupported extract, a degenerate (NULL) composed value, or a violated
+catalogue-declared condition stays ``grounded`` with a stated reason — it is
+never reported as ``executed``. It mirrors the ``ValidationAgent``'s
+``row_count == 0 -> ERROR`` gate (``analysis/validation/agent.py``), the part the
+metric path lacked, and is the seed of the DAT-619 snippet-library verifier
+(nothing enters the reuse cache until it passed here — the caller gates
+``_save_snippets`` on this verdict).
+
+The signal is **support, not magnitude**: a genuine ``0`` (a filter that matched
+rows summing to zero) passes; only a NULL (nothing aggregated) fails.
+"""
+
+from __future__ import annotations
+
+import ast
+import operator
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from dataraum.core.models.base import Result
+
+if TYPE_CHECKING:
+    from dataraum.graphs.models import GraphExecution, TransformationGraph
+
+_COMPARATORS: dict[type[ast.cmpop], Callable[[Any, Any], bool]] = {
+    ast.Gt: operator.gt,
+    ast.GtE: operator.ge,
+    ast.Lt: operator.lt,
+    ast.LtE: operator.le,
+    ast.Eq: operator.eq,
+    ast.NotEq: operator.ne,
+}
+
+
+def verify_execution(graph: TransformationGraph, execution: GraphExecution) -> Result[None]:
+    """Judge a clean execution for support, non-degeneracy, and declared conditions.
+
+    Args:
+        graph: The metric graph (carries each step's declared ``validations``).
+        execution: The completed execution (per-step values + composed value).
+
+    Returns:
+        ``Result.ok(None)`` if the metric is trustworthy; ``Result.fail(reason)``
+        with a human-readable reason if it is inconclusive or violates a declared
+        condition — the caller keeps the artifact ``grounded`` with that reason
+        and does not cache the SQL.
+    """
+    by_step = {sr.step_id: sr for sr in execution.step_results}
+
+    # 1. Support: an extract whose aggregate is NULL matched no rows. With the
+    #    COALESCE mask removed from the prompt, an empty filter surfaces as NULL
+    #    here — no support, so the metric is inconclusive (not a real value).
+    for sr in execution.step_results:
+        if sr.value is None:
+            return Result.fail(
+                f"extract '{sr.step_id}' has no support: its filter matched no rows "
+                f"(aggregated to NULL) — metric inconclusive, not a real value"
+            )
+
+    # 2. Non-degeneracy of the composed value. A NULL output means a contributing
+    #    extract had no support; a genuine 0 is a real answer and passes.
+    if execution.output_value is None:
+        return Result.fail(
+            "composed metric value is NULL — a contributing extract had no support; inconclusive"
+        )
+
+    # 3. Enforce the catalogue's declared per-extract conditions (e.g. revenue
+    #    `value > 0`, cogs `value >= 0`), bound to the executed step by step_id
+    #    (the dependency key). An unbindable condition is skipped — the support
+    #    gate above already guards the real risk; DAT-619 hardens the binding.
+    for step_id, step in graph.steps.items():
+        bound = by_step.get(step_id)
+        if bound is None or bound.value is None:
+            continue
+        for check in step.validations:
+            if not _condition_holds(check.condition, bound.value):
+                reason = check.message or check.condition
+                return Result.fail(
+                    f"declared validation failed for '{step_id}': {reason} (value={bound.value})"
+                )
+
+    return Result.ok(None)
+
+
+def _condition_holds(condition: str, value: Any) -> bool:
+    """Evaluate a declared extract condition (e.g. ``value > 0``) against a value.
+
+    Only a comparison over the name ``value`` and numeric literals is permitted,
+    parsed via :mod:`ast` — never ``eval``. A malformed or over-broad condition
+    raises, so a bad catalogue condition fails loud rather than silently passing.
+    """
+    node = ast.parse(condition, mode="eval").body
+    return _truth(node, value)
+
+
+def _truth(node: ast.expr, value: Any) -> bool:
+    if isinstance(node, ast.Compare):
+        left = _term(node.left, value)
+        for op, comparator in zip(node.ops, node.comparators, strict=True):
+            comparator_fn = _COMPARATORS.get(type(op))
+            if comparator_fn is None:
+                raise ValueError(f"unsupported comparison operator in condition: {type(op).__name__}")
+            right = _term(comparator, value)
+            if not comparator_fn(left, right):
+                return False
+            left = right  # chained comparison: 0 < value < 100
+        return True
+    if isinstance(node, ast.BoolOp):
+        results = [_truth(v, value) for v in node.values]
+        return all(results) if isinstance(node.op, ast.And) else any(results)
+    raise ValueError(f"unsupported condition expression: {ast.dump(node)}")
+
+
+def _term(node: ast.expr, value: Any) -> Any:
+    if isinstance(node, ast.Name) and node.id == "value":
+        return value
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)) and not isinstance(
+        node.value, bool
+    ):
+        return node.value
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return -_term(node.operand, value)
+    raise ValueError(f"unsupported term in condition (only `value` and numbers): {ast.dump(node)}")

--- a/packages/engine/src/dataraum/graphs/verifier.py
+++ b/packages/engine/src/dataraum/graphs/verifier.py
@@ -29,6 +29,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from dataraum.core.models.base import Result
+from dataraum.graphs.models import StepType
 
 if TYPE_CHECKING:
     from dataraum.graphs.models import GraphExecution, TransformationGraph
@@ -60,12 +61,19 @@ def verify_execution(graph: TransformationGraph, execution: GraphExecution) -> R
 
     # 1. Support: an extract whose aggregate is NULL matched no rows. With the
     #    COALESCE mask removed from the prompt, an empty filter surfaces as NULL
-    #    here — no support, so the metric is inconclusive (not a real value).
+    #    here — no support, so the metric is inconclusive (not a real value). A
+    #    non-extract step (formula/constant) that is NULL is degenerate, not
+    #    "unfiltered" — word the reason for what the step actually is.
     for sr in execution.step_results:
         if sr.value is None:
+            step = graph.steps.get(sr.step_id)
+            if step is None or step.step_type == StepType.EXTRACT:
+                return Result.fail(
+                    f"extract '{sr.step_id}' has no support: its filter matched no rows "
+                    f"(aggregated to NULL) — metric inconclusive, not a real value"
+                )
             return Result.fail(
-                f"extract '{sr.step_id}' has no support: its filter matched no rows "
-                f"(aggregated to NULL) — metric inconclusive, not a real value"
+                f"step '{sr.step_id}' computed to NULL (degenerate) — metric inconclusive"
             )
 
     # 2. Non-degeneracy of the composed value. A NULL output means a contributing
@@ -84,7 +92,17 @@ def verify_execution(graph: TransformationGraph, execution: GraphExecution) -> R
         if bound is None or bound.value is None:
             continue
         for check in step.validations:
-            if not _condition_holds(check.condition, bound.value):
+            try:
+                holds = _condition_holds(check.condition, bound.value)
+            except ValueError as exc:
+                # A malformed catalogue condition fails loud HERE as a clean
+                # Result.fail (routed through the caller's snippet-failure path),
+                # not as a ValueError escaping to the blanket worker handler.
+                return Result.fail(
+                    f"catalogue validation condition for '{step_id}' is malformed "
+                    f"({check.condition!r}): {exc}"
+                )
+            if not holds:
                 reason = check.message or check.condition
                 return Result.fail(
                     f"declared validation failed for '{step_id}': {reason} (value={bound.value})"
@@ -110,7 +128,9 @@ def _truth(node: ast.expr, value: Any) -> bool:
         for op, comparator in zip(node.ops, node.comparators, strict=True):
             comparator_fn = _COMPARATORS.get(type(op))
             if comparator_fn is None:
-                raise ValueError(f"unsupported comparison operator in condition: {type(op).__name__}")
+                raise ValueError(
+                    f"unsupported comparison operator in condition: {type(op).__name__}"
+                )
             right = _term(comparator, value)
             if not comparator_fn(left, right):
                 return False
@@ -125,8 +145,10 @@ def _truth(node: ast.expr, value: Any) -> bool:
 def _term(node: ast.expr, value: Any) -> Any:
     if isinstance(node, ast.Name) and node.id == "value":
         return value
-    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)) and not isinstance(
-        node.value, bool
+    if (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, (int, float))
+        and not isinstance(node.value, bool)
     ):
         return node.value
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):

--- a/packages/engine/src/dataraum/graphs/verifier.py
+++ b/packages/engine/src/dataraum/graphs/verifier.py
@@ -1,21 +1,19 @@
-"""Post-execution verifier for metric graphs (DAT-616).
+"""Post-execution SANITY floor for metric graphs (DAT-616).
 
-Execution-pass is *not* validation. A metric whose SQL ran cleanly can still be
-silently wrong: when an extract's filter matched no rows the aggregate is NULL
-("no support"), and when the prompt masks that NULL with ``COALESCE(col, 0)`` it
-reads as a real ``0`` — so a long-format finance metric (no ``revenue`` column,
-"revenue" is a row filter the agent improvises) reaches ``executed``/green with a
-fabricated value (the canonical case: ``gross_margin = 100%`` because cogs
-matched nothing).
+This is a *cheap value-space sanity check*, NOT the grounding fix. It keeps a
+metric ``grounded``/inconclusive (never silently ``executed``/green) when:
+- an extract aggregated to NULL — its filter matched no rows ("no support");
+- the composed value is NULL (a contributing extract had no support);
+- a catalogue-declared per-extract ``validation:`` bound is violated (e.g. revenue
+  ``value > 0``) — a one-number comparison on the step's executed scalar.
 
-This verifier converts that into an honest *inconclusive*: a metric with an
-unsupported extract, a degenerate (NULL) composed value, or a violated
-catalogue-declared condition stays ``grounded`` with a stated reason — it is
-never reported as ``executed``. It mirrors the ``ValidationAgent``'s
-``row_count == 0 -> ERROR`` gate (``analysis/validation/agent.py``), the part the
-metric path lacked, and is the seed of the DAT-619 snippet-library verifier
-(nothing enters the reuse cache until it passed here — the caller gates
-``_save_snippets`` on this verdict).
+**It is structurally blind to the real bug** (DAT-616): a *wrong-but-non-empty*
+filter (the agent improvises ``WHERE account_type ILIKE '%cost%'`` and matches the
+wrong rows) returns a well-typed, in-range value that passes every check here. The
+grounding fix lives elsewhere — feed the agent the real value distribution + a
+teach-confirmed concept→value-set binding (DAT-620) so it stops improvising the
+predicate (design: ``docs/dat543-construct-dont-improvise.md``). Keep this as the
+cheap floor; do not mistake it for the fix.
 
 The signal is **support, not magnitude**: a genuine ``0`` (a filter that matched
 rows summing to zero) passes; only a NULL (nothing aggregated) fails.

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -261,8 +261,10 @@ class MetricsPhase(BasePhase):
             )
             results = _execute_metrics_serial(prep, ctx.session, exec_ctx, agent, schema_mapping_id)
 
-        # A composed metric that ran cleanly reaches executed; one whose SQL
-        # failed stays grounded with the reason (born loud, never silently absent).
+        # A composed metric that ran cleanly AND verified reaches executed; one
+        # whose SQL failed OR whose result was inconclusive (no support / a
+        # declared condition violated — DAT-616 verifier) stays grounded with the
+        # reason (born loud, never silently green).
         for graph_id, result, inspiration_id in results:
             artifact = artifacts[graph_id]
             if result.success:
@@ -276,8 +278,8 @@ class MetricsPhase(BasePhase):
                         ctx.session.delete(ad_hoc)
                         _log.info("snippet_promoted", graph_id=graph_id, snippet_id=inspiration_id)
             else:
-                artifact.state_reason = f"composed but execution failed: {result.error}"
-                _log.warning("metric_execution_failed", graph_id=graph_id, error=result.error)
+                artifact.state_reason = f"composed but not executed: {result.error}"
+                _log.warning("metric_not_executed", graph_id=graph_id, error=result.error)
 
         executed = sum(1 for a in artifacts.values() if a.state == "executed")
         grounded_stuck = sum(1 for a in artifacts.values() if a.state == "grounded")
@@ -306,7 +308,7 @@ class MetricsPhase(BasePhase):
             warnings=previews,
             summary=(
                 f"{executed}/{len(artifacts)} metrics executed; "
-                f"{declared_stuck} ungroundable, {grounded_stuck} composed but unexecutable"
+                f"{declared_stuck} ungroundable, {grounded_stuck} composed but inconclusive/failed"
             ),
         )
 

--- a/packages/engine/src/dataraum/query/execution.py
+++ b/packages/engine/src/dataraum/query/execution.py
@@ -116,12 +116,22 @@ def execute_sql_steps(
         return_table=return_table,
         display_limit=display_limit,
     )
-    if not final_result.success or not final_result.value:
+    # A clean execution returns its value faithfully — including a genuine 0 and a
+    # NULL (no-support) result. Degeneracy is judged downstream by the metric
+    # verifier (graphs.verifier), NOT conflated into a truthiness test here: the
+    # old `not final_result.value` rejected a real 0 and gave an empty-support
+    # result the generic reason "Final SQL failed". Only a thrown SQL error (after
+    # repair is exhausted) fails the run now. (DAT-616)
+    if not final_result.success:
         return Result.fail(final_result.error or "Final SQL failed")
 
     execution_result = ExecutionResult(step_results=step_results)
 
     if return_table:
+        # Table mode: _execute_final returns (columns, rows, total_count) on success
+        # (an empty table is an empty rows list, never None).
+        if final_result.value is None:
+            return Result.fail("Final SQL returned no result in table mode")
         columns, rows, total_count = final_result.value
         execution_result.columns = columns
         execution_result.rows = rows

--- a/packages/engine/tests/integration/graphs/test_agent.py
+++ b/packages/engine/tests/integration/graphs/test_agent.py
@@ -348,9 +348,7 @@ class TestGraphAgentVerifier:
         snippets = list(session.execute(select(SQLSnippetRecord)).scalars().all())
         assert snippets == []
 
-    def test_genuine_zero_metric_executes(
-        self, session: Session, duckdb_with_data, sample_graph
-    ):
+    def test_genuine_zero_metric_executes(self, session: Session, duckdb_with_data, sample_graph):
         """A metric that genuinely computes 0 (rows matched, summing to 0) passes.
 
         `id = 1` matches a row; `amount * 0` sums to a real 0 — support exists, so

--- a/packages/engine/tests/integration/graphs/test_agent.py
+++ b/packages/engine/tests/integration/graphs/test_agent.py
@@ -286,6 +286,93 @@ class TestGraphAgentIntegration:
         assert execution.output_value == 600.0  # Sum of 100 + 200 + 300
 
 
+def _agent_with_sql(steps: list[dict[str, str]], final_sql: str) -> GraphAgent:
+    """A GraphAgent whose mocked LLM emits the given steps + final SQL."""
+    mock_config = MagicMock()
+    mock_config.limits.max_output_tokens_per_request = 4000
+    mock_config.limits.cache_ttl_seconds = 3600
+    mock_renderer = MagicMock()
+    mock_renderer.render_split.return_value = ("System prompt", "Test prompt", 0.0)
+
+    agent = GraphAgent(config=mock_config, provider=MagicMock(), prompt_renderer=mock_renderer)
+    agent.provider.get_model_for_tier.return_value = "test-model"
+
+    tool_call = MagicMock()
+    tool_call.name = "generate_sql"
+    tool_call.input = {
+        "summary": "test",
+        "steps": steps,
+        "final_sql": final_sql,
+        "column_mappings": {"amount": "amount"},
+    }
+    response = MagicMock()
+    response.tool_calls = [tool_call]
+    response.content = None
+    agent.provider.converse = MagicMock(return_value=Result.ok(response))
+    return agent
+
+
+class TestGraphAgentVerifier:
+    """The post-execution verifier converts silently-wrong metrics into honest fails (DAT-616)."""
+
+    def test_empty_support_extract_fails_grounded_and_caches_nothing(
+        self, session: Session, duckdb_with_data, sample_graph
+    ):
+        """An extract whose filter matches no rows is inconclusive, not executed-green.
+
+        Reproduces the long-format finance bug: a SUM over an empty filter (no
+        COALESCE mask) yields NULL → the metric stays grounded with a 'no support'
+        reason and its SQL is NOT promoted into the reuse cache.
+        """
+        from sqlalchemy import select
+
+        from dataraum.query.snippet_models import SQLSnippetRecord
+
+        agent = _agent_with_sql(
+            steps=[
+                {
+                    "step_id": "value",
+                    "sql": "SELECT SUM(amount) AS value FROM test_data WHERE id = 999",
+                    "description": "empty filter",
+                }
+            ],
+            final_sql="SELECT * FROM value",
+        )
+        context = _make_execution_context(duckdb_with_data)
+
+        result = agent.execute(session, sample_graph, context, workspace_id=baseline_run_id())
+
+        assert not result.success
+        assert "no support" in result.error
+        # The bad SQL must NOT enter the shared snippet cache (the verifier gates it).
+        snippets = list(session.execute(select(SQLSnippetRecord)).scalars().all())
+        assert snippets == []
+
+    def test_genuine_zero_metric_executes(
+        self, session: Session, duckdb_with_data, sample_graph
+    ):
+        """A metric that genuinely computes 0 (rows matched, summing to 0) passes.
+
+        `id = 1` matches a row; `amount * 0` sums to a real 0 — support exists, so
+        the metric is executed with value 0, not rejected as degenerate."""
+        agent = _agent_with_sql(
+            steps=[
+                {
+                    "step_id": "value",
+                    "sql": "SELECT SUM(amount * 0) AS value FROM test_data WHERE id = 1",
+                    "description": "genuine zero with support",
+                }
+            ],
+            final_sql="SELECT * FROM value",
+        )
+        context = _make_execution_context(duckdb_with_data)
+
+        result = agent.execute(session, sample_graph, context, workspace_id=baseline_run_id())
+
+        assert result.success
+        assert result.value.output_value == 0
+
+
 class TestGraphAgentSnippets:
     """Tests for GraphAgent snippet lifecycle."""
 

--- a/packages/engine/tests/integration/query/test_execution.py
+++ b/packages/engine/tests/integration/query/test_execution.py
@@ -129,6 +129,52 @@ class TestExecuteSqlSteps:
         assert not result.success
         assert "Final SQL failed" in result.error
 
+    def test_genuine_zero_final_passes(self, duckdb_conn):
+        """A genuine 0 final value is returned, not rejected (DAT-616).
+
+        The old guard `not final_result.value` conflated a real 0 with failure.
+        A metric that legitimately computes 0 (e.g. revenue == cogs) must succeed.
+        """
+        steps = [SQLStep(step_id="z", sql="SELECT 0 AS val", description="zero")]
+
+        result = execute_sql_steps(
+            steps=steps,
+            final_sql="SELECT 0 AS val",
+            duckdb_conn=duckdb_conn,
+        )
+
+        assert result.success
+        assert result.value is not None
+        assert result.value.final_value == 0
+
+    def test_empty_support_final_returns_null_ok_not_failure(self, duckdb_conn):
+        """An empty-support final aggregates to NULL and returns ok(None) (DAT-616).
+
+        The shared executor returns values faithfully — it no longer conflates an
+        empty/NULL result with a thrown error. Degeneracy (no support) is judged
+        downstream by the metric verifier, which has the catalogue + step context
+        to produce a precise per-extract reason.
+        """
+        steps = [
+            SQLStep(
+                step_id="empty",
+                sql="SELECT SUM(value) AS val FROM test_data WHERE name = 'nobody'",
+                description="sum over an empty filter",
+            )
+        ]
+
+        result = execute_sql_steps(
+            steps=steps,
+            final_sql="SELECT SUM(value) AS val FROM test_data WHERE name = 'nobody'",
+            duckdb_conn=duckdb_conn,
+        )
+
+        assert result.success  # not a failure — a faithful NULL
+        assert result.value is not None
+        assert result.value.final_value is None
+        # The per-step value is likewise None (no support) for the verifier to catch.
+        assert result.value.step_results[0].value is None
+
     def test_views_survive_for_export_reuse(self, duckdb_conn):
         """Temp views survive after execution (cursor-scoped, not explicitly dropped)."""
         steps = [

--- a/packages/engine/tests/unit/graphs/test_loader.py
+++ b/packages/engine/tests/unit/graphs/test_loader.py
@@ -49,6 +49,51 @@ class TestLoadMetricGraphs:
         assert loader.graphs.get("anomaly_rate") is None
 
 
+class TestParseStepValidation:
+    """The catalogue's per-extract `validation:` block is parsed, not dropped (DAT-616)."""
+
+    def test_finance_gross_margin_revenue_condition_parsed(self) -> None:
+        """gross_margin's revenue extract carries its declared `value > 0` check."""
+        loader = _finance_loader()
+        gm = loader.graphs["gross_margin"]
+        revenue = gm.steps["revenue"]
+        assert len(revenue.validations) == 1
+        assert revenue.validations[0].condition == "value > 0"
+        assert revenue.validations[0].severity == "error"
+        assert "positive" in revenue.validations[0].message.lower()
+        # The cogs extract declares no condition; the formula step none either.
+        assert gm.steps["cost_of_goods_sold"].validations == []
+        assert gm.steps["gross_margin"].validations == []
+
+    def test_finance_gross_profit_cogs_condition_parsed(self) -> None:
+        """gross_profit's cogs extract carries its declared `value >= 0` check."""
+        loader = _finance_loader()
+        gp = loader.graphs["gross_profit"]
+        cogs = gp.steps["cost_of_goods_sold"]
+        assert [v.condition for v in cogs.validations] == ["value >= 0"]
+        assert [v.condition for v in gp.steps["revenue"].validations] == ["value > 0"]
+
+    def test_missing_validation_block_yields_empty_list(self) -> None:
+        """A step with no `validation:` key parses to an empty list, not None."""
+        loader = GraphLoader()
+        loader.graphs.update(
+            loader.graphs_from_definitions(
+                {
+                    "m": {
+                        "graph_id": "m",
+                        "version": "1.0",
+                        "metadata": {"name": "M"},
+                        "output": {"type": "scalar"},
+                        "dependencies": {
+                            "x": {"type": "extract", "source": {"standard_field": "revenue"}}
+                        },
+                    }
+                }
+            )
+        )
+        assert loader.graphs["m"].steps["x"].validations == []
+
+
 class TestValidateStandardFields:
     """Tests for validate_standard_fields() against a vertical's ontology."""
 

--- a/packages/engine/tests/unit/graphs/test_verifier.py
+++ b/packages/engine/tests/unit/graphs/test_verifier.py
@@ -88,6 +88,22 @@ class TestSupportGate:
 
         assert verify_execution(graph, execution).success
 
+    def test_null_formula_step_reads_as_degenerate_not_unfiltered(self) -> None:
+        """A NULL non-extract step is 'degenerate', not 'filter matched no rows'."""
+        graph = _graph(
+            {
+                "revenue": _extract("revenue"),
+                "ratio": GraphStep(step_id="ratio", step_type=StepType.FORMULA, expression="x"),
+            }
+        )
+        execution = _execution({"revenue": 1000.0, "ratio": None}, output_value=None)
+
+        result = verify_execution(graph, execution)
+        assert not result.success
+        assert "ratio" in result.error
+        assert "degenerate" in result.error
+        assert "filter matched no rows" not in result.error
+
     def test_null_output_value_is_inconclusive(self) -> None:
         """Even with supported steps, a NULL composed value is degenerate."""
         graph = _graph({"revenue": _extract("revenue")})
@@ -127,9 +143,7 @@ class TestDeclaredConditions:
     def test_satisfied_condition_passes(self) -> None:
         graph = _graph(
             {
-                "revenue": _extract(
-                    "revenue", validations=[StepValidation(condition="value > 0")]
-                ),
+                "revenue": _extract("revenue", validations=[StepValidation(condition="value > 0")]),
                 "cogs": _extract("cogs", validations=[StepValidation(condition="value >= 0")]),
             }
         )
@@ -141,25 +155,32 @@ class TestDeclaredConditions:
         """A condition whose step_id has no executed step is skipped, not failed —
         the support gate already guards the real risk; DAT-619 hardens binding."""
         graph = _graph(
-            {
-                "revenue": _extract(
-                    "revenue", validations=[StepValidation(condition="value > 0")]
-                )
-            }
+            {"revenue": _extract("revenue", validations=[StepValidation(condition="value > 0")])}
         )
         # The executed step is named differently (LLM renamed it) — no binding.
         execution = _execution({"total_revenue": 1000.0}, output_value=1000.0)
 
         assert verify_execution(graph, execution).success
 
-    def test_decimal_value_is_comparable(self) -> None:
-        """Currency sums arrive as Decimal in production — conditions still hold."""
+    def test_malformed_condition_fails_loud_not_raises(self) -> None:
+        """A malformed catalogue condition becomes a clean Result.fail, not a raise."""
         graph = _graph(
             {
                 "revenue": _extract(
-                    "revenue", validations=[StepValidation(condition="value > 0")]
+                    "revenue", validations=[StepValidation(condition="value.__class__")]
                 )
             }
+        )
+        execution = _execution({"revenue": 1000.0}, output_value=1000.0)
+
+        result = verify_execution(graph, execution)
+        assert not result.success
+        assert "malformed" in result.error
+
+    def test_decimal_value_is_comparable(self) -> None:
+        """Currency sums arrive as Decimal in production — conditions still hold."""
+        graph = _graph(
+            {"revenue": _extract("revenue", validations=[StepValidation(condition="value > 0")])}
         )
         ex = GraphExecution(execution_id="e", graph_id="gross_margin", source=GraphSource.SYSTEM)
         sr = StepResult(step_id="revenue")

--- a/packages/engine/tests/unit/graphs/test_verifier.py
+++ b/packages/engine/tests/unit/graphs/test_verifier.py
@@ -1,0 +1,198 @@
+"""Unit tests for the metric post-execution verifier (DAT-616).
+
+The verifier is the honest-fail gate the metric path lacked: execution-pass is
+not validation. It converts a silently-wrong metric (an extract whose filter
+matched no rows, masked into a fake 0) into an inconclusive — grounded with a
+reason — and enforces the catalogue's per-extract conditions. The signal is
+*support*, not magnitude: a genuine 0 passes; only a NULL fails.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from dataraum.graphs.models import (
+    GraphExecution,
+    GraphMetadata,
+    GraphSource,
+    GraphStep,
+    OutputDef,
+    OutputType,
+    StepResult,
+    StepType,
+    StepValidation,
+    TransformationGraph,
+)
+from dataraum.graphs.verifier import _condition_holds, verify_execution
+
+
+def _graph(steps: dict[str, GraphStep]) -> TransformationGraph:
+    return TransformationGraph(
+        graph_id="gross_margin",
+        version="1.0",
+        metadata=GraphMetadata(
+            name="Gross Margin", description="", category="profitability", source=GraphSource.SYSTEM
+        ),
+        output=OutputDef(output_type=OutputType.SCALAR),
+        steps=steps,
+    )
+
+
+def _extract(step_id: str, *, validations: list[StepValidation] | None = None) -> GraphStep:
+    return GraphStep(
+        step_id=step_id,
+        step_type=StepType.EXTRACT,
+        aggregation="sum",
+        validations=validations or [],
+    )
+
+
+def _step_result(step_id: str, value: float | None) -> StepResult:
+    sr = StepResult(step_id=step_id)
+    if value is not None:
+        sr.value_scalar = float(value)
+    return sr
+
+
+def _execution(step_values: dict[str, float | None], output_value: object) -> GraphExecution:
+    ex = GraphExecution(execution_id="e1", graph_id="gross_margin", source=GraphSource.SYSTEM)
+    ex.step_results = [_step_result(sid, v) for sid, v in step_values.items()]
+    ex.output_value = output_value
+    return ex
+
+
+class TestSupportGate:
+    def test_null_extract_is_inconclusive(self) -> None:
+        """An extract that aggregated to NULL (no rows matched) fails loud."""
+        graph = _graph({"revenue": _extract("revenue"), "cogs": _extract("cogs")})
+        execution = _execution({"revenue": 1000.0, "cogs": None}, output_value=100.0)
+
+        result = verify_execution(graph, execution)
+
+        assert not result.success
+        assert "cogs" in result.error
+        assert "no support" in result.error
+
+    def test_all_supported_passes(self) -> None:
+        graph = _graph({"revenue": _extract("revenue"), "cogs": _extract("cogs")})
+        execution = _execution({"revenue": 1000.0, "cogs": 600.0}, output_value=40.0)
+
+        assert verify_execution(graph, execution).success
+
+    def test_genuine_zero_extract_passes(self) -> None:
+        """A real 0 (rows matched, summed to 0) has support — it is not NULL."""
+        graph = _graph({"revenue": _extract("revenue"), "cogs": _extract("cogs")})
+        execution = _execution({"revenue": 1000.0, "cogs": 0.0}, output_value=100.0)
+
+        assert verify_execution(graph, execution).success
+
+    def test_null_output_value_is_inconclusive(self) -> None:
+        """Even with supported steps, a NULL composed value is degenerate."""
+        graph = _graph({"revenue": _extract("revenue")})
+        execution = _execution({"revenue": 1000.0}, output_value=None)
+
+        result = verify_execution(graph, execution)
+        assert not result.success
+        assert "NULL" in result.error
+
+    def test_genuine_zero_output_value_passes(self) -> None:
+        """A composed value of exactly 0 is a real answer, not degenerate."""
+        graph = _graph({"revenue": _extract("revenue")})
+        execution = _execution({"revenue": 1000.0}, output_value=0.0)
+
+        assert verify_execution(graph, execution).success
+
+
+class TestDeclaredConditions:
+    def test_violated_condition_fails_with_message(self) -> None:
+        """A declared `value > 0` on a 0-valued extract fails with the message."""
+        graph = _graph(
+            {
+                "revenue": _extract(
+                    "revenue",
+                    validations=[
+                        StepValidation(condition="value > 0", message="Revenue must be positive")
+                    ],
+                )
+            }
+        )
+        execution = _execution({"revenue": 0.0}, output_value=0.0)
+
+        result = verify_execution(graph, execution)
+        assert not result.success
+        assert "Revenue must be positive" in result.error
+
+    def test_satisfied_condition_passes(self) -> None:
+        graph = _graph(
+            {
+                "revenue": _extract(
+                    "revenue", validations=[StepValidation(condition="value > 0")]
+                ),
+                "cogs": _extract("cogs", validations=[StepValidation(condition="value >= 0")]),
+            }
+        )
+        execution = _execution({"revenue": 1000.0, "cogs": 0.0}, output_value=100.0)
+
+        assert verify_execution(graph, execution).success
+
+    def test_unbindable_condition_is_skipped(self) -> None:
+        """A condition whose step_id has no executed step is skipped, not failed —
+        the support gate already guards the real risk; DAT-619 hardens binding."""
+        graph = _graph(
+            {
+                "revenue": _extract(
+                    "revenue", validations=[StepValidation(condition="value > 0")]
+                )
+            }
+        )
+        # The executed step is named differently (LLM renamed it) — no binding.
+        execution = _execution({"total_revenue": 1000.0}, output_value=1000.0)
+
+        assert verify_execution(graph, execution).success
+
+    def test_decimal_value_is_comparable(self) -> None:
+        """Currency sums arrive as Decimal in production — conditions still hold."""
+        graph = _graph(
+            {
+                "revenue": _extract(
+                    "revenue", validations=[StepValidation(condition="value > 0")]
+                )
+            }
+        )
+        ex = GraphExecution(execution_id="e", graph_id="gross_margin", source=GraphSource.SYSTEM)
+        sr = StepResult(step_id="revenue")
+        sr.value_scalar = float(Decimal("1234.56"))
+        ex.step_results = [sr]
+        ex.output_value = Decimal("1234.56")
+
+        assert verify_execution(graph, ex).success
+
+
+class TestConditionEvaluator:
+    @pytest.mark.parametrize(
+        ("condition", "value", "expected"),
+        [
+            ("value > 0", 5, True),
+            ("value > 0", 0, False),
+            ("value > 0", -1, False),
+            ("value >= 0", 0, True),
+            ("value >= 0", -0.01, False),
+            ("value < 100", 50, True),
+            ("value != 0", 0, False),
+            ("value == 42", 42, True),
+            ("0 < value < 100", 50, True),
+            ("0 < value < 100", 150, False),
+            ("value > -10", -5, True),
+        ],
+    )
+    def test_evaluates(self, condition: str, value: float, expected: bool) -> None:
+        assert _condition_holds(condition, value) is expected
+
+    def test_malformed_condition_raises(self) -> None:
+        """An over-broad/unsupported condition fails loud, never silently passes."""
+        with pytest.raises(ValueError):
+            _condition_holds("value.__class__", 1)
+        with pytest.raises(ValueError):
+            _condition_holds("other > 0", 1)


### PR DESCRIPTION
## What & why

The operating_model **metrics** phase reported a silently-wrong metric as `executed`/green. On long/transactional finance data (no `revenue` column — "revenue" is a row filter), the graph agent improvises an empty SQL filter, the prompt's `COALESCE(col,0)` rule masks the empty `SUM` as a real `0`, and the only guard fired on SQL that *throws* — so valid-but-wrong SQL sailed through (canonical case: cogs matched nothing → `gross_margin = 100%` green, no error).

This is **DAT-616 P0** — the honest-fail gate. The metric now stays **`grounded`/inconclusive with a stated reason**, mirroring `ValidationAgent`'s empty→ERROR gate. (Part of the snippet-library reframe; full library = DAT-619, consumer = DAT-617. Design: [DD/39944194](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/39944194). Blocks honest DAT-611.)

## Changes (engine-only)

- **`graphs/verifier.py` (new)** — `verify_execution()` runs inside `GraphAgent.execute` **before** snippets are cached: NULL extract = no support → fail; NULL composed value → fail; **genuine 0 passes** (the signal is *support*, not magnitude); enforces catalogue-declared per-extract `validation:` conditions via a safe `ast` comparator (no `eval`, no regex). A malformed catalogue condition fails loud as a clean `Result.fail`.
- **`models.py` / `loader.py`** — the catalogue's `validation:` block (`revenue value > 0`, `cogs value >= 0`) was **dead YAML, dropped at parse** (confirmed the ticket's open question). Now parsed into `GraphStep.validations` and enforced.
- **`graph_sql_generation.yaml`** — rule 7 rewritten from "use `COALESCE(col,0)`" into a guardrail forbidding masking; de-nudged the paired "treating nulls as zero" assumption example. **No SQL/regex post-processing.**
- **`query/execution.py`** — stopped conflating a genuine `0` with failure; returns values faithfully (the executor has one production caller, the GraphAgent) and lets the verifier judge degeneracy.
- **`agent.py`** — `StepResult` building now handles `Decimal` (currency `SUM`s) and checks `bool` before `int`; previously a `Decimal` extract value was read as NULL, which would have false-failed *every real metric* under the new gate.
- **`metrics_phase.py`** — an inconclusive metric is "composed but not executed", no longer mislabeled "execution failed".

Commit 1 also fixes `scripts/smoke-operating-model.ts`, the reproduction harness (drove begin_session via the journey-signal tool → `Invalid RunId`; now drives `beginSessionWorkflow` directly with explicit verticals).

## Acceptance

- [x] Empty-filter extract no longer reaches `executed`/green — `grounded` with a `no support` reason.
- [x] Catalogue per-extract `validation:` conditions enforced (were dead YAML — now wired).
- [x] `COALESCE(col,0)` rule removed from the prompt; no regex/SQL post-processing added.
- [x] A genuine zero (rows matched, summing to 0) still passes.

## Testing

New verifier unit suite (support gate, genuine-0, declared conditions, safe evaluator, malformed-condition clean-fail, formula-step message), loader parse of the real finance catalogue, executor genuine-0/empty-support, and an end-to-end agent regression (empty filter → grounded with `no support` **and caches no snippet**). 283 affected tests pass; ruff + mypy + vulture clean. Lightly smoke-tested (BookSQL × finance).

Reviewers: senior-code-reviewer → **APPROVE**; spec-compliance-reviewer → **COMPLIANT**.

## Cross-repo (see `.claude/handoff.md`)

- **eval:** assert metric *values* (not just `executed`) on a long-format fixture; add a regression that an empty-filter extract stays `grounded`.
- **testdata:** a BookSQL-style long/transactional finance fixture with ground-truth metric values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)