### PR TITLE
DAT-615: push run completion via Temporal result() — retire the get_progress done-poll

### DIFF
--- a/packages/cockpit/drizzle/cockpit/20260623170501_perpetual_chimera/migration.sql
+++ b/packages/cockpit/drizzle/cockpit/20260623170501_perpetual_chimera/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "runs" DROP COLUMN "completion_narrated_at";

--- a/packages/cockpit/drizzle/cockpit/20260623170501_perpetual_chimera/snapshot.json
+++ b/packages/cockpit/drizzle/cockpit/20260623170501_perpetual_chimera/snapshot.json
@@ -1,0 +1,779 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "28839c05-c05c-422f-ac6b-fcef56926790",
+  "prevIds": [
+    "b29775e2-e5fe-4d46-8b18-15caa92e35dd"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "actors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "conversation_messages",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "conversations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "runs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "ui_state",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "workspaces",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "actors"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "actors"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "actors"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seq",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "model_only",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_active_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stage",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workflow_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "run_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'running'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "awaiting_note",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "pinned_call_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "engine_schema",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'_adhoc'",
+      "generated": null,
+      "identity": null,
+      "name": "vertical",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "conversation_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "seq",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "conversation_messages_conversation_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "conversations_workspace_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workflow_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "run_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "runs_workflow_run_uq",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "runs_workspace_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "conversation_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "runs_conversation_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "conversation_messages_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "workspace_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "workspaces",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "conversations_workspace_id_workspaces_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "workspace_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "workspaces",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "runs_workspace_id_workspaces_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "runs_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "ui_state_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "actors_pkey",
+      "schema": "public",
+      "table": "actors",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "conversation_messages_pkey",
+      "schema": "public",
+      "table": "conversation_messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "conversations_pkey",
+      "schema": "public",
+      "table": "conversations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "runs_pkey",
+      "schema": "public",
+      "table": "runs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "conversation_id"
+      ],
+      "nameExplicit": false,
+      "name": "ui_state_pkey",
+      "schema": "public",
+      "table": "ui_state",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "workspaces_pkey",
+      "schema": "public",
+      "table": "workspaces",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/cockpit/src/db/cockpit/runs.ts
+++ b/packages/cockpit/src/db/cockpit/runs.ts
@@ -22,7 +22,7 @@
 // the generation heads, so the cockpit never stores it (DAT-506: nothing reads it back).
 
 import { randomUUID } from "node:crypto";
-import { and, count, desc, eq, gt, isNull, notExists } from "drizzle-orm";
+import { and, count, desc, eq, gt, notExists } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { currentConversationId } from "#/lib/run-context";
 import { cockpitDb } from "./client";
@@ -97,10 +97,10 @@ export async function recordRun(input: RecordRunInput): Promise<void> {
 }
 
 /**
- * Mark a recorded run terminal (completed | failed) — called best-effort when a
- * run's completion is observed (the workflow-progress poll, DAT-461). The
- * reload-recovery reconcile (DAT-462) is the other writer. No-op if the run
- * isn't recorded (a run started before this feature shipped).
+ * Mark a recorded run terminal (completed | failed) — best-effort. Writers: the
+ * completion-watcher's `result()` awaiter (DAT-615, the primary path), the
+ * workflow-progress seed route (DAT-461), and the reload-recovery reconcile
+ * (DAT-462). No-op if the run isn't recorded.
  */
 export async function markRunStatus(
 	workflowId: string,
@@ -148,40 +148,6 @@ export async function markRunAwaitingInput(
 		console.warn(
 			`[cockpit] markRunAwaitingInput failed for ${workflowId}: ${err}`,
 		);
-	}
-}
-
-/**
- * Atomically claim a run's completion narration (Phase 2A). The conditional
- * UPDATE sets `completion_narrated_at` only when it's still NULL and RETURNs the
- * row — so the FIRST caller wins (returns true) and every later one (another
- * tab's watcher, a re-observation) gets false. This is what makes the agent
- * narrate a completed run EXACTLY once across the several watchers a multi-tab
- * conversation can have. Best-effort: a DB error returns false (skip the
- * narration) rather than risk a double-fire.
- */
-export async function claimRunNarration(
-	workflowId: string,
-	runId: string,
-): Promise<boolean> {
-	try {
-		const claimed = await cockpitDb
-			.update(runs)
-			.set({ completionNarratedAt: new Date() })
-			.where(
-				and(
-					eq(runs.workflowId, workflowId),
-					eq(runs.runId, runId),
-					isNull(runs.completionNarratedAt),
-				),
-			)
-			.returning({ id: runs.id });
-		return claimed.length > 0;
-	} catch (err) {
-		console.warn(
-			`[cockpit] claimRunNarration failed for run ${runId} (${workflowId}): ${err}`,
-		);
-		return false;
 	}
 }
 
@@ -235,9 +201,8 @@ export async function listRunningStages(
 	return rows.map((r) => r.stage as RunStage);
 }
 
-/** A run the completion-watcher should poll: in-flight (`running`) and not yet
- * narrated. Carries `stage` so the narration can name what finished ("the import"
- * vs "the session"). */
+/** A run the completion-watcher should track: in-flight (`running`). Carries `stage`
+ * so the narration can name what finished ("the import" vs "the session"). */
 export interface WatchableRun {
 	workflowId: string;
 	runId: string;
@@ -249,16 +214,13 @@ export interface WatchableRun {
 }
 
 /**
- * The CONVERSATION's runs the completion-watcher should track — in-flight AND not
- * yet narrated, newest first, bounded. THIS is the run-routing filter (DAT-528):
- * scoping by `conversationId` is what makes a run narrate into the chat that
- * STARTED it, not whichever workspace watcher claims it first (the old
- * order-dependent bug). The watcher captures these while `running`, then polls
- * each against Temporal directly (the source of truth for completion), so a run
- * the progress poll separately marks terminal is still narrated. The
- * `completion_narrated_at IS NULL` filter keeps already-narrated runs out; the
- * per-run claim (`claimRunNarration`) is the once-only guard across a chat's
- * tabs.
+ * The CONVERSATION's in-flight (`running`) runs, newest first, bounded. THIS is the
+ * run-routing filter (DAT-528): scoping by `conversationId` is what makes a run
+ * narrate into the chat that STARTED it, not whichever workspace watcher claims it
+ * first (the old order-dependent bug). The watcher tracks these while `running` and
+ * AWAITS each run's Temporal `result()` (DAT-615) — `markRunStatus` flips a finished
+ * run out of this `status='running'` set, so it's narrated exactly once (no
+ * `completion_narrated_at` claim needed; the chat-bus is single-instance).
  */
 export async function listWatchableRuns(
 	conversationId: string,
@@ -273,11 +235,7 @@ export async function listWatchableRuns(
 		})
 		.from(runs)
 		.where(
-			and(
-				eq(runs.conversationId, conversationId),
-				eq(runs.status, "running"),
-				isNull(runs.completionNarratedAt),
-			),
+			and(eq(runs.conversationId, conversationId), eq(runs.status, "running")),
 		)
 		.orderBy(desc(runs.startedAt))
 		.limit(limit);

--- a/packages/cockpit/src/db/cockpit/schema.ts
+++ b/packages/cockpit/src/db/cockpit/schema.ts
@@ -112,14 +112,6 @@ export const runs = pgTable(
 		),
 		status: varchar("status").notNull().default("running"),
 		startedAt: timestamp("started_at", { mode: "date" }).notNull().defaultNow(),
-		// The atomic claim for the run-completion narration (Phase 2A): the server
-		// watcher sets this (conditional UPDATE … WHERE … IS NULL) the first time it
-		// narrates a run's completion, so the agent narrates EXACTLY once even with
-		// several watchers for one conversation (multi-tab — each open
-		// /api/chat-stream hosts its own watcher). Distinct from `status`: the
-		// terminal-status writers (the progress poll / reconcile) don't touch it, so
-		// the claim never races them. NULL = not yet narrated.
-		completionNarratedAt: timestamp("completion_narrated_at", { mode: "date" }),
 		// Why the run is parked in `status='awaiting_input'` (DAT-551 P3c): the
 		// grounding-teach agent fixed what it mechanically could and a human-judgement
 		// gap remains (a concept/relationship the agent must not auto-apply), or it hit

--- a/packages/cockpit/src/lib/completion-watcher.test.ts
+++ b/packages/cockpit/src/lib/completion-watcher.test.ts
@@ -1,31 +1,45 @@
-// Run-routing proof (DAT-528) — THE load-bearing acceptance criterion: a run
-// started in conversation A narrates into A, even when another conversation's
-// watcher is live. Before DAT-528 the watcher tracked ALL of a workspace's runs
-// and whichever stream's claim landed first narrated it (order-dependent). Now
-// each watcher tracks only `listWatchableRuns(itsConversationId)`, so a run only
-// surfaces in the watcher of the chat that started it.
+// Run-completion watcher (DAT-528 run-routing + DAT-615 push-completion).
 //
-// We drive `pollOnce` (the extracted poll tick) directly — no timer, no loop. The
-// `listWatchableRuns` mock is CONVERSATION-SCOPED exactly as the real SQL is
-// (returns runs only for the queried id), so the test exercises the real routing
-// contract: the watcher passes its own conversationId, the query filters on it.
+// Two surfaces, tested separately because completion is now fire-and-forget:
+//   • `pollOnce` — the DISCOVERY tick: lists THIS conversation's in-flight runs
+//     (conversation-scoped, DAT-528), spawns a `result()` awaiter per run, and pushes
+//     the phase pills. It does NOT itself narrate (the awaiter does), so its tests
+//     assert routing/discovery, not narration.
+//   • `awaitCompletion` — the per-run completion path: `await handle.result()` (push,
+//     DAT-615) → markRunStatus → narrate. Awaitable, so its tests assert the
+//     narration contract (routing into its conversation, DAT-597 import-skip, failure).
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const h = vi.hoisted(() => ({
-	// The one in-flight run — it belongs to conversation "A".
-	runForA: {
-		workflowId: "wf-A",
-		runId: "r-A",
-		stage: "begin_session" as const,
-		kind: "begin_session" as const,
-	},
-	narrated: [] as string[],
+const h = vi.hoisted(() => {
+	// Stand-in for the SDK error `handle.result()` throws on a failed run — the module
+	// under test does `err instanceof WorkflowFailedError`, so the mock exports THIS class.
+	class WorkflowFailedError extends Error {}
+	return {
+		WorkflowFailedError,
+		runForA: {
+			workflowId: "wf-A",
+			runId: "r-A",
+			stage: "begin_session" as const,
+			kind: "begin_session" as const,
+		},
+		narrated: [] as string[],
+		markStatus: [] as Array<{
+			workflowId: string;
+			runId: string;
+			status: string;
+		}>,
+		// handle.result() — resolves (completed) by default; a test can reject it.
+		result: vi.fn(async () => ({})),
+		getHandle: vi.fn(),
+	};
+});
+
+vi.mock("@temporalio/client", () => ({
+	WorkflowFailedError: h.WorkflowFailedError,
 }));
 
 vi.mock("#/db/cockpit/conversations", () => ({
-	// narrateCompletion resolves the chat's kind (DAT-532) before narrating; a
-	// non-null row lets the narration proceed (kind drives its toolstack).
 	getConversation: vi.fn(async (id: string) => ({
 		id,
 		workspaceId: "ws-1",
@@ -42,8 +56,11 @@ vi.mock("#/db/cockpit/runs", () => ({
 		conversationId === "A" ? [h.runForA] : [],
 	),
 	listRunningStages: vi.fn(async () => []),
-	markRunStatus: vi.fn(async () => {}),
-	claimRunNarration: vi.fn(async () => true),
+	markRunStatus: vi.fn(
+		async (workflowId: string, runId: string, status: string) => {
+			h.markStatus.push({ workflowId, runId, status });
+		},
+	),
 }));
 
 vi.mock("#/lib/chat-bus", () => ({
@@ -66,113 +83,123 @@ vi.mock("#/prompts/workspace-context", () => ({
 	buildWorkspaceContext: async () => null,
 }));
 vi.mock("#/temporal/progress", () => ({
-	getWorkflowProgress: vi.fn(async () => ({ done: true, status: "COMPLETED" })),
-	terminalRunStatus: () => "completed",
+	// The completion-watcher awaits handle.result() via this client; getHandle returns
+	// a handle whose result() is the controllable mock.
+	getTemporalClient: vi.fn(async () => ({
+		workflow: { getHandle: (...args: unknown[]) => h.getHandle(...args) },
+	})),
+	getWorkflowProgress: vi.fn(async () => ({
+		done: true,
+		status: "COMPLETED",
+		failure: null,
+	})),
 }));
 
-import { listWatchableRuns, type WatchableRun } from "#/db/cockpit/runs";
 import { streamAgentTurnToBus } from "#/lib/agent-turn";
-import { getWorkflowProgress } from "#/temporal/progress";
-import { pollOnce } from "./completion-watcher";
+import { getTemporalClient, getWorkflowProgress } from "#/temporal/progress";
+import { awaitCompletion, pollOnce } from "./completion-watcher";
 
 beforeEach(() => {
 	h.narrated = [];
+	h.markStatus = [];
 	vi.clearAllMocks();
+	h.result.mockResolvedValue({});
+	h.getHandle.mockReturnValue({ result: h.result });
 });
 afterEach(() => vi.restoreAllMocks());
 
-describe("run-routing (DAT-528): a run narrates only into its own conversation", () => {
-	it("conversation B's watcher does NOT narrate A's run", async () => {
-		await pollOnce(
-			"B",
-			new Map<string, WatchableRun>(),
-			new AbortController().signal,
-		);
+const liveSignal = (): AbortSignal => new AbortController().signal;
+
+describe("pollOnce — discovery + routing (DAT-528)", () => {
+	it("conversation B's tick does NOT touch A's run (scoped by conversationId)", async () => {
+		await pollOnce("B", new Set<string>(), liveSignal());
+		// No run for B → no awaiter spawned (no client handle), no progress query.
+		expect(getTemporalClient).not.toHaveBeenCalled();
+		expect(getWorkflowProgress).not.toHaveBeenCalled();
+	});
+
+	it("conversation A's tick discovers A's run: pins the real id + spawns one awaiter", async () => {
+		const tracked = new Set<string>();
+		await pollOnce("A", tracked, liveSignal());
+		// Pills query pins the exact (workflowId, runId) — the real id (DAT-595).
+		expect(getWorkflowProgress).toHaveBeenCalledWith({
+			workflow_id: "wf-A",
+			run_id: "r-A",
+		});
+		// The run is now being awaited — a second tick must NOT spawn a 2nd awaiter.
+		expect(tracked.has("wf-A:r-A")).toBe(true);
+		const handleCalls = h.getHandle.mock.calls.length;
+		await pollOnce("A", tracked, liveSignal());
+		expect(h.getHandle.mock.calls.length).toBe(handleCalls); // no re-spawn
+	});
+});
+
+describe("awaitCompletion — push completion via result() (DAT-615)", () => {
+	it("awaits the run's result(), marks it completed, and narrates into ITS conversation", async () => {
+		await awaitCompletion("A", h.runForA, liveSignal());
+		// Pinned the exact execution + awaited result() (the push edge, no poll).
+		expect(h.getHandle).toHaveBeenCalledWith("wf-A", "r-A");
+		expect(h.result).toHaveBeenCalledTimes(1);
+		// markRunStatus BEFORE narrate (once-only via the status filter).
+		expect(h.markStatus).toEqual([
+			{ workflowId: "wf-A", runId: "r-A", status: "completed" },
+		]);
+		expect(h.narrated).toEqual(["A"]); // routed into A
+	});
+
+	it("marks FAILED when result() throws WorkflowFailedError (still narrates)", async () => {
+		h.result.mockRejectedValueOnce(new h.WorkflowFailedError("boom"));
+		await awaitCompletion("A", h.runForA, liveSignal());
+		expect(h.markStatus).toEqual([
+			{ workflowId: "wf-A", runId: "r-A", status: "failed" },
+		]);
+		expect(h.narrated).toEqual(["A"]);
+	});
+
+	it("an INFRA error (not WorkflowFailedError) is swallowed — no mark, no narrate (re-discovered next tick)", async () => {
+		h.result.mockRejectedValueOnce(new Error("temporal hiccup"));
+		await awaitCompletion("A", h.runForA, liveSignal());
+		expect(h.markStatus).toEqual([]);
 		expect(streamAgentTurnToBus).not.toHaveBeenCalled();
 	});
 
-	it("conversation A's watcher narrates A's run, into A", async () => {
-		await pollOnce(
+	it("does NOT narrate an onboarding add_source — the hub owns import progress (DAT-597)", async () => {
+		await awaitCompletion(
 			"A",
-			new Map<string, WatchableRun>(),
-			new AbortController().signal,
-		);
-		expect(streamAgentTurnToBus).toHaveBeenCalledTimes(1);
-		// The narration turn targets conversation A — the routing guarantee.
-		expect(h.narrated).toEqual(["A"]);
-	});
-
-	it("A narrates into A even while B's watcher polls concurrently (the proof)", async () => {
-		const trackedA = new Map<string, WatchableRun>();
-		const trackedB = new Map<string, WatchableRun>();
-		const signal = new AbortController().signal;
-		// Both watchers tick; only A's tracks (and narrates) the run.
-		await Promise.all([
-			pollOnce("A", trackedA, signal),
-			pollOnce("B", trackedB, signal),
-		]);
-		expect(h.narrated).toEqual(["A"]);
-		expect(trackedB.size).toBe(0);
-	});
-});
-
-describe("tracks + pins a run by its real execution id (DAT-595)", () => {
-	it("tracks and polls a recorded run — every run carries its real runId (no placeholder phase)", async () => {
-		// Post-DAT-595 a recorded run always carries the real Temporal execution id
-		// (recorded post-start), never the workflowId placeholder, so getWorkflowProgress
-		// always PINS the exact (workflowId, runId) — a reused `addsource-<ws>` id can
-		// never resolve a sibling run's terminal state.
-		vi.mocked(listWatchableRuns).mockResolvedValueOnce([
 			{
 				workflowId: "addsource-ws",
-				runId: "exec-real",
-				stage: "begin_session",
-				kind: "begin_session",
-			},
-		]);
-		const tracked = new Map<string, WatchableRun>();
-		await pollOnce("A", tracked, new AbortController().signal);
-		expect(getWorkflowProgress).toHaveBeenCalledWith({
-			workflow_id: "addsource-ws",
-			run_id: "exec-real",
-		});
-	});
-});
-
-describe("import vs teach→replay narration (DAT-597)", () => {
-	it("does NOT narrate an onboarding add_source run — the hub owns import progress", async () => {
-		// Real id (runId != workflowId) so it clears the DAT-595 placeholder skip;
-		// the DAT-597 gate then suppresses the chat echo of an import.
-		vi.mocked(listWatchableRuns).mockResolvedValueOnce([
-			{
-				workflowId: "addsource-ws",
-				runId: "real-run",
+				runId: "r1",
 				stage: "add_source",
 				kind: "onboarding",
 			},
-		]);
-		await pollOnce(
-			"A",
-			new Map<string, WatchableRun>(),
-			new AbortController().signal,
+			liveSignal(),
 		);
+		// Still marked terminal (the monitor/inbox need it), just not narrated into chat.
+		expect(h.markStatus).toEqual([
+			{ workflowId: "addsource-ws", runId: "r1", status: "completed" },
+		]);
 		expect(streamAgentTurnToBus).not.toHaveBeenCalled();
 	});
 
-	it("DOES narrate a replay add_source run — the teach→re-ground verification", async () => {
-		vi.mocked(listWatchableRuns).mockResolvedValueOnce([
+	it("DOES narrate a replay add_source — the teach→re-ground verification (DAT-597)", async () => {
+		await awaitCompletion(
+			"A",
 			{
 				workflowId: "addsource-ws",
-				runId: "real-run",
+				runId: "r2",
 				stage: "add_source",
 				kind: "replay",
 			},
-		]);
-		await pollOnce(
-			"A",
-			new Map<string, WatchableRun>(),
-			new AbortController().signal,
+			liveSignal(),
 		);
-		expect(streamAgentTurnToBus).toHaveBeenCalledTimes(1);
+		expect(h.narrated).toEqual(["A"]);
+	});
+
+	it("skips post-completion work once the stream has closed (signal aborted)", async () => {
+		const ac = new AbortController();
+		ac.abort();
+		await awaitCompletion("A", h.runForA, ac.signal);
+		expect(h.markStatus).toEqual([]);
+		expect(streamAgentTurnToBus).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cockpit/src/lib/completion-watcher.ts
+++ b/packages/cockpit/src/lib/completion-watcher.ts
@@ -200,6 +200,10 @@ export async function awaitCompletion(
 		);
 		return;
 	}
+	// `result()` is not itself cancelled when the stream closes mid-run — the SDK
+	// long-poll runs until the workflow finishes, then we drop the post-completion
+	// work here. Accepted: Temporal reaps the server-side poll, and runs are
+	// seconds-to-minutes, so the dangling poll is bounded and cheap.
 	if (signal.aborted) return;
 
 	// Terminal snapshot for the pills' final state + the note's failure message.

--- a/packages/cockpit/src/lib/completion-watcher.ts
+++ b/packages/cockpit/src/lib/completion-watcher.ts
@@ -1,28 +1,32 @@
-// Run-completion watcher (Phase 2A.2) — the server-side half of "the agent tells
-// you when a background run finishes". It lives inside an open /api/chat-stream
-// subscription (one watcher per open stream), polls the conversation's in-flight
-// Temporal runs, and on the not-done→done edge runs ONE agent turn whose
-// narration is published over the bus → rendered in the chat. No client polling.
+// Run-completion watcher (Phase 2A.2; push-completion DAT-615) — the server-side
+// half of "the agent tells you when a background run finishes". It lives inside an
+// open /api/chat-stream subscription (one watcher per open stream) and, for each of
+// the conversation's in-flight runs, AWAITS the run's Temporal `result()` — the
+// built-in completion push (the SDK long-polls; to us it's an `await`). On
+// resolution it marks the run terminal and runs ONE agent turn whose narration is
+// published over the bus → rendered in the chat. No client polling; no server-side
+// poll for the DONE edge.
 //
-// This replaces the old loop where the agent itself called the `workflow_status`
-// tool on a timer, flooding the transcript with poll cards. The user already sees
-// live progress in the canvas widget; the agent's only job is to react ONCE when
-// a run lands — which is exactly what this does.
+// Live phase progress (the pills + the staging-hub bar) is the one thing Temporal
+// can't push to a client — `get_progress` is a @workflow.query — so it stays a light
+// query while a run is in flight (DAT-615 wrinkle #2, accepted). Completion does NOT
+// ride that query anymore; it rides `result()`.
 //
-// Correctness:
-//   - A run is captured into `tracked` while it's still `running`, then polled
-//     against Temporal DIRECTLY (the source of truth) — so the separate
-//     progress-poll marking a run terminal in cockpit_db can't make the watcher
-//     miss it.
-//   - `claimRunNarration` is an atomic cockpit_db claim, so a conversation open in
-//     several tabs (each hosting its own watcher) narrates a run EXACTLY once.
-//   - A run that completed while NO client was connected was never tracked (it's
-//     already terminal in cockpit_db on reconnect), so it isn't narrated — the
-//     canvas already shows its terminal state; consistent, not a regression.
+// Once-only: `acquireCompletionWatcher` refcounts to EXACTLY ONE watcher per
+// conversation, so a run gets ONE `result()` awaiter; `markRunStatus` runs BEFORE
+// narrate, so a completed run drops out of `listWatchableRuns` (`status='running'`)
+// and a stream reopen never re-narrates it. The old cross-process `claimRunNarration`
+// claim is gone — the chat-bus is single-instance by design (see chat-bus.ts), so the
+// multi-process case it guarded can't occur.
+//
+// A run that completed while NO client was connected was marked terminal by its own
+// worker (`runStage` / the reconcile), so it isn't watchable on reconnect → not
+// narrated; the canvas already shows its terminal state. Consistent, not a regression.
 //
 // SERVER-ONLY (Temporal client + cockpit_db + the agent loop).
 
 import type { StreamChunk } from "@tanstack/ai";
+import { WorkflowFailedError } from "@temporalio/client";
 
 import {
 	appendMessages,
@@ -30,7 +34,6 @@ import {
 	loadModelTranscript,
 } from "#/db/cockpit/conversations";
 import {
-	claimRunNarration,
 	listRunningStages,
 	listWatchableRuns,
 	markRunStatus,
@@ -45,13 +48,14 @@ import { runWithConversation } from "#/lib/run-context";
 import { WORKFLOW_PROGRESS_EVENT } from "#/lib/workflow-progress-event";
 import { buildWorkspaceContext } from "#/prompts/workspace-context";
 import {
+	getTemporalClient,
 	getWorkflowProgress,
-	terminalRunStatus,
 	type WorkflowProgress,
 } from "#/temporal/progress";
 
-/** Poll cadence. Workflows run for seconds-to-minutes, so a tracked run is seen
- * `running` on many ticks before it lands — the edge is never missed. */
+/** Discovery + phase-pill cadence. Workflows run seconds-to-minutes; this only
+ * paces the cheap cockpit_db run-list + the phase `query` — the DONE edge is the
+ * `result()` await, not this tick, so its latency no longer gates completion. */
 const POLL_MS = 2500;
 /** Cap the per-tick run fan-out so a stale backlog can't blow up Temporal load. */
 const WATCH_LIMIT = 20;
@@ -71,9 +75,8 @@ const watchers = new Map<string, WatcherEntry>();
  * Ensure EXACTLY ONE watcher runs per conversation, however many
  * /api/chat-stream connections are open for it. The first open starts the loop;
  * each later open just bumps the refcount; `releaseCompletionWatcher` stops the
- * loop when the LAST one closes. This keeps the Temporal poll AND the narration
- * single regardless of the dev double-subscribe / real multi-tab (the per-run
- * claim is still the once-only backstop). `startFn` is injectable for tests.
+ * loop when the LAST one closes. One watcher per conversation ⇒ one `result()`
+ * awaiter per run ⇒ one narration. `startFn` is injectable for tests.
  */
 export function acquireCompletionWatcher(
 	conversationId: string,
@@ -116,93 +119,130 @@ async function watchLoop(
 	conversationId: string,
 	signal: AbortSignal,
 ): Promise<void> {
-	const tracked = new Map<string, WatchableRun>();
+	// runKeys with a live `result()` awaiter — so a still-running run discovered on
+	// many ticks gets exactly one awaiter.
+	const awaiting = new Set<string>();
 	while (!signal.aborted) {
-		await sleep(POLL_MS, signal);
+		await pollOnce(conversationId, awaiting, signal);
 		if (signal.aborted) return;
-		await pollOnce(conversationId, tracked, signal);
+		await sleep(POLL_MS, signal);
 	}
 }
 
 /**
- * One poll tick — capture this CONVERSATION's newly in-flight runs, poll each
- * against Temporal, and narrate on the done edge. Extracted from the loop so the
- * run-routing contract is unit-tested without the timer (conventions rule 10): a
- * watcher narrates ONLY runs started in ITS conversation, because the runs it
- * tracks come from `listWatchableRuns(conversationId)` (DAT-528). `tracked`
- * persists across ticks (a run seen `running` on earlier ticks still narrates when
- * it lands). Exported for the proof test.
+ * One discovery tick — for THIS conversation's in-flight runs (DAT-528 run-routing:
+ * `listWatchableRuns(conversationId)` scopes a watcher to its own chat's runs):
+ *   1. spawn a `result()` awaiter ONCE per run (the DONE edge → narrate; push), and
+ *   2. push the current phase snapshot (the pills) via a light `get_progress` query.
+ * `awaiting` persists across ticks so a run isn't double-awaited. Exported for tests.
  */
 export async function pollOnce(
 	conversationId: string,
-	tracked: Map<string, WatchableRun>,
+	awaiting: Set<string>,
 	signal: AbortSignal,
 ): Promise<void> {
-	// Nothing to narrate to if no client is listening (defensive — the watcher
-	// rides an open stream, but the connection can close between ticks).
+	// Nothing to push to if no client is listening (the watcher rides an open stream,
+	// but the connection can close between ticks).
 	if (!hasSubscribers(conversationId)) return;
 
-	// (1) Capture newly in-flight, un-narrated runs FOR THIS CONVERSATION — the
-	// run-routing filter: another chat's runs never enter this watcher's `tracked`.
 	const candidates = await listWatchableRuns(conversationId, WATCH_LIMIT).catch(
 		() => [] as WatchableRun[],
 	);
+
 	for (const run of candidates) {
-		// Every recorded run carries its REAL Temporal execution id (DAT-595 — recorded
-		// post-start), so getWorkflowProgress always PINS the exact (workflowId, runId)
-		// and a reused workflow id (`addsource-<ws>`) can never read a PRIOR run's
-		// terminal state for the run being watched. (No pre-attach placeholder phase to
-		// skip anymore.)
-		tracked.set(runKey(run), run);
-	}
-
-	// (2) Poll each tracked run against Temporal; narrate on the done edge.
-	for (const [key, run] of [...tracked]) {
-		let progress: WorkflowProgress;
-		try {
-			progress = await getWorkflowProgress({
-				workflow_id: run.workflowId,
-				run_id: run.runId,
-			});
-		} catch {
-			continue; // transient Temporal hiccup — retry next tick.
-		}
-
-		// Push this snapshot to the widget (Phase 2A.3) — every tick AND the
-		// done tick, so the progress widget renders live and its terminal state
-		// WITHOUT polling. The provider's onChunk writes it to the query cache.
-		publish(conversationId, {
-			type: "CUSTOM",
-			name: WORKFLOW_PROGRESS_EVENT,
-			value: {
-				workflow_id: run.workflowId,
-				run_id: run.runId,
-				progress,
-			},
-		} as unknown as StreamChunk);
-
-		if (!progress.done) continue;
-
-		tracked.delete(key);
-		await markRunStatus(run.workflowId, run.runId, terminalRunStatus(progress));
-		// Import (onboarding add_source) is NOT narrated into the chat (DAT-597):
-		// its progress + outcome live in the staging hub widget (Connect's canvas)
-		// + the "Needs you" inbox, so a chat echo would be a SECOND progress surface.
-		// The live progress push above still fires (the widget needs it); we only
-		// skip the agent-turn narration. A `replay` (teach→re-ground) DOES narrate —
-		// that's the teach surface verifying the teach helped.
-		if (run.stage === "add_source" && run.kind === "onboarding") continue;
-		// The atomic claim is the once-only guard across a chat's tabs.
-		if (await claimRunNarration(run.workflowId, run.runId)) {
-			await narrateCompletion(conversationId, run, progress, signal).catch(
-				(err) => {
-					console.warn(
-						`[completion-watcher] narrate failed for run ${run.runId}: ${err}`,
-					);
-				},
+		const key = runKey(run);
+		// (1) Completion is PUSH: one `result()` awaiter per run (DAT-615). It reads the
+		// watcher signal so its post-completion work is skipped once the last stream closes.
+		if (!awaiting.has(key)) {
+			awaiting.add(key);
+			void awaitCompletion(conversationId, run, signal).finally(() =>
+				awaiting.delete(key),
 			);
 		}
+
+		// (2) Live phase pills — the one residual pull (Temporal has no progress push
+		// to a client; `get_progress` is a query). Pin the exact (workflowId, runId)
+		// — the run row carries the real execution id (DAT-595).
+		const progress = await getWorkflowProgress({
+			workflow_id: run.workflowId,
+			run_id: run.runId,
+		}).catch(() => null);
+		if (progress) publishProgress(conversationId, run, progress);
 	}
+}
+
+/**
+ * Await ONE run's completion via Temporal's `result()` (push), then mark it terminal
+ * and narrate. `result()` resolves when the run finishes and throws
+ * `WorkflowFailedError` if it failed — so this is the DONE edge, instant, with no
+ * poll. A transient/infra error (anything but a clean fail) is logged and the run is
+ * re-discovered next tick (it's removed from `awaiting` by the caller's `finally`).
+ */
+export async function awaitCompletion(
+	conversationId: string,
+	run: WatchableRun,
+	signal: AbortSignal,
+): Promise<void> {
+	let status: "completed" | "failed";
+	try {
+		const client = await getTemporalClient();
+		const handle = client.workflow.getHandle(run.workflowId, run.runId);
+		try {
+			await handle.result();
+			status = "completed";
+		} catch (err) {
+			if (!(err instanceof WorkflowFailedError)) throw err; // infra → re-discover
+			status = "failed";
+		}
+	} catch (err) {
+		console.warn(
+			`[completion-watcher] await result for run ${run.runId}: ${err}`,
+		);
+		return;
+	}
+	if (signal.aborted) return;
+
+	// Terminal snapshot for the pills' final state + the note's failure message.
+	const finalProgress = await getWorkflowProgress({
+		workflow_id: run.workflowId,
+		run_id: run.runId,
+	}).catch(() => null);
+	if (finalProgress) publishProgress(conversationId, run, finalProgress);
+
+	// markRunStatus BEFORE narrate: a completed run drops out of `listWatchableRuns`
+	// (status='running'), so a stream reopen never re-narrates it (the once-only).
+	await markRunStatus(run.workflowId, run.runId, status);
+
+	// Import (onboarding add_source) is NOT narrated into the chat (DAT-597): its
+	// progress + outcome live in the staging hub widget + the "Needs you" inbox. A
+	// `replay` (teach→re-ground) DOES narrate — the teach-verification message.
+	if (run.stage === "add_source" && run.kind === "onboarding") return;
+
+	await narrateCompletion(
+		conversationId,
+		run,
+		status,
+		finalProgress,
+		signal,
+	).catch((err) => {
+		console.warn(
+			`[completion-watcher] narrate failed for run ${run.runId}: ${err}`,
+		);
+	});
+}
+
+/** Push a phase snapshot to the widget (Phase 2A.3) — the provider's onChunk writes
+ * it to the query cache, so the progress widget renders live WITHOUT polling. */
+function publishProgress(
+	conversationId: string,
+	run: WatchableRun,
+	progress: WorkflowProgress,
+): void {
+	publish(conversationId, {
+		type: "CUSTOM",
+		name: WORKFLOW_PROGRESS_EVENT,
+		value: { workflow_id: run.workflowId, run_id: run.runId, progress },
+	} as unknown as StreamChunk);
 }
 
 /** Append the model-only note, then run an agent turn whose narration is teed +
@@ -210,7 +250,8 @@ export async function pollOnce(
 async function narrateCompletion(
 	conversationId: string,
 	run: WatchableRun,
-	progress: WorkflowProgress,
+	status: "completed" | "failed",
+	finalProgress: WorkflowProgress | null,
 	signal: AbortSignal,
 ): Promise<void> {
 	// The chat's kind (DAT-532) selects the narration turn's toolstack + prompt —
@@ -219,16 +260,15 @@ async function narrateCompletion(
 	const conversation = await getConversation(conversationId).catch(() => null);
 	if (!conversation) return;
 	// The OTHER stages still running for THIS conversation — the agent must narrate
-	// only this run and not claim these finished (DAT-510). The just-finished run
-	// is already marked terminal upstream, so it's excluded from this set. On a DB
-	// hiccup, degrade to `[]` (the solo-run boundary): safe direction — the note
-	// still pins to this run, it just can't name the others.
+	// only this run and not claim these finished (DAT-510). The just-finished run is
+	// already marked terminal upstream, so it's excluded from this set. On a DB
+	// hiccup, degrade to `[]` (the solo-run boundary): safe direction.
 	const inFlight = await listRunningStages(conversationId).catch(() => []);
 	const note = completionNote(
 		run.stage,
 		{
-			failed: terminalRunStatus(progress) === "failed",
-			failureMessage: progress.failure?.message ?? null,
+			failed: status === "failed",
+			failureMessage: finalProgress?.failure?.message ?? null,
 		},
 		inFlight,
 	);

--- a/packages/cockpit/src/routes/api/chat.test.ts
+++ b/packages/cockpit/src/routes/api/chat.test.ts
@@ -40,7 +40,6 @@ vi.mock("#/db/cockpit/registry", () => ({
 }));
 vi.mock("#/db/cockpit/runs", () => ({
 	recordRun: async () => {},
-	attachRunId: async () => {},
 	hasRunningRun: async () => false,
 }));
 // The server-owned chat loop (DAT-462) persists via the conversations seam —

--- a/packages/cockpit/src/routes/api/workflow-progress.ts
+++ b/packages/cockpit/src/routes/api/workflow-progress.ts
@@ -41,12 +41,11 @@ export const Route = createFileRoute("/api/workflow-progress")({
 				}
 
 				try {
-					// The widget seed posts the PLACEHOLDER run_id (=== workflow_id), so
-					// getWorkflowProgress takes the latest-execution fallback here; the
-					// watcher is the path that pins a real id (DAT-595). markRunStatus below
-					// targets the (workflowId, run_id) row — for the placeholder that's the
-					// pre-attach row, harmless (the watcher's claimRunNarration is the
-					// once-only narration guard regardless).
+					// The widget seed posts run_id === workflow_id, so getWorkflowProgress
+					// takes the latest-execution fallback here (the seed can't know the
+					// exact execution id); the completion-watcher pins the real id it reads
+					// from the recorded run row and AWAITS its result() to narrate (DAT-595 /
+					// DAT-615). markRunStatus below targets the (workflowId, run_id) row.
 					const result = await getWorkflowProgress(parsed.data);
 					// The poll is the observation point for run completion — mark the
 					// recorded session_run terminal so the reload-recovery substrate

--- a/packages/cockpit/src/temporal/orchestration-trigger.test.ts
+++ b/packages/cockpit/src/temporal/orchestration-trigger.test.ts
@@ -187,7 +187,7 @@ describe("startDirectRun (DAT-609 — replay / manual operating_model)", () => {
 	it("fails loud when Temporal isn't configured — BEFORE recording the run", async () => {
 		h.config = {};
 		await expect(startDirectRun(spec)).rejects.toThrow(/not configured/);
-		// The config guard runs first, so no phantom placeholder row is recorded.
+		// The config guard runs first, so recording happens only after a real start.
 		expect(h.recordRun).not.toHaveBeenCalled();
 		expect(h.start).not.toHaveBeenCalled();
 	});

--- a/packages/cockpit/src/temporal/progress.ts
+++ b/packages/cockpit/src/temporal/progress.ts
@@ -117,7 +117,7 @@ function requireTemporalConfig(): { host: string; namespace: string } {
  */
 let temporalClientPromise: Promise<Client> | null = null;
 
-function getTemporalClient(): Promise<Client> {
+export function getTemporalClient(): Promise<Client> {
 	if (!temporalClientPromise) {
 		const { host, namespace } = requireTemporalConfig();
 		temporalClientPromise = Connection.connect({ address: host })

--- a/packages/cockpit/src/tools/registry.test.ts
+++ b/packages/cockpit/src/tools/registry.test.ts
@@ -26,7 +26,6 @@ vi.mock("#/db/cockpit/registry", () => ({
 }));
 vi.mock("#/db/cockpit/runs", () => ({
 	recordRun: async () => {},
-	attachRunId: async () => {},
 	hasRunningRun: async () => false,
 }));
 

--- a/packages/cockpit/src/worker/workflows/run-stage.ts
+++ b/packages/cockpit/src/worker/workflows/run-stage.ts
@@ -102,7 +102,12 @@ export async function runStage(spec: StageSpec): Promise<StageOutcome> {
 			err: String(err),
 		});
 		// Mark failed best-effort, but only if the child started (we have a real runId);
-		// a pre-start failure recorded nothing, so there is nothing to mark.
+		// a pre-start failure recorded nothing, so there is nothing to mark. One residual
+		// window: if `recordRun` itself threw AFTER startChild, runId is set but no row
+		// exists — the markRunStatus below is a harmless no-op, and the ABANDON'd child
+		// runs to completion INVISIBLY (the reconcile keys off recorded rows, so it can't
+		// see an unrecorded run). Accepted: recordRun is a durable activity that retries,
+		// so this needs a total activity-failure, and the engine work still completes.
 		if (runId !== null) {
 			await markRunStatus(spec.workflowId, runId, "failed").catch((markErr) => {
 				log.warn("orchestration stage mark-failed write failed", {


### PR DESCRIPTION
## What

Completion of a background run is now a **push** off Temporal's `handle.result()` instead of a client-side poll of the `get_progress` query. The done-edge moves out of `pollOnce` into a per-run `awaitCompletion` awaiter; `pollOnce` keeps only the residual phase-pill query (the one thing Temporal can't push to a client). This is the unfinished half of the DAT-609 orchestration simplification — the run lifecycle is now keyed end-to-end on the **real `run_id`** (DAT-595), not a placeholder/`workflow_id` swap.

Cockpit-only. No engine changes, no new TS workflows.

## How

- **`completion-watcher.ts`** — `awaitCompletion(conversationId, run, signal)`: `getHandle(workflowId, runId)` pins the exact execution → `await handle.result()` is the done-edge (resolves on finish, throws `WorkflowFailedError` on failure; any other throw = infra → swallow + re-discover next tick). Then `markRunStatus` **before** narrate (once-only), DAT-597 onboarding-import skip preserved, conversation-scoped routing preserved (DAT-528). `pollOnce` spawns one awaiter per run (tracked in a `Set`) + pushes the phase snapshot; the done-edge poll is gone.
- **Retire `claimRunNarration` + `completion_narrated_at`** — the cross-process narration claim guarded a multi-instance case the single-instance chat-bus can't produce (publisher + subscriber are the same process by design). Once-only is now: one watcher per conversation (refcount) → one awaiter per run → `markRunStatus` flips the run out of `listWatchableRuns` (`status='running'`). Column dropped (migration `20260623170501_perpetual_chimera`), filter removed from `listWatchableRuns`.

## Reviews

- **Senior code reviewer: APPROVE** — no critical issues; error taxonomy correct, once-only proof holds, replay-safe.
- **Spec compliance reviewer: COMPLIANT** — full requirements traceability passed.
- Applied both reviewers' zero-risk findings (dropped two stale `attachRunId` mock stubs; documented the accepted abort-leak + recordRun orphan window; cleaned legacy "placeholder" wording).

## Verification

- `tsc` + biome clean; 1294 unit tests pass (the one failing suite is the container/CI-gated `connect.integration.test.ts`, untouched, needs an env var absent from the host shell).
- **Live browser smoke**: drove a real Stage `begin_session` over 8 typed tables → run completed → narration appeared in the originating chat **the instant the run finished** (no client done-poll); cockpit_db shows the run terminal with a real `run_id ≠ workflow_id`, scoped to the originating conversation; the cascade auto-started `operating_model`; zero watcher errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
