### PR TITLE
DAT-579: Stage/Analyse widget polish — badge clip, chip labels, + look_drivers widget

### DIFF
--- a/packages/cockpit/src/ui/cockpit/canvas-registry.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-registry.ts
@@ -11,6 +11,7 @@ import { ColumnProfileWidget } from "#/ui/cockpit/widgets/column-profile";
 import { ColumnWhyWidget } from "#/ui/cockpit/widgets/column-why";
 import { CycleListWidget } from "#/ui/cockpit/widgets/cycle-list";
 import { CycleWhyWidget } from "#/ui/cockpit/widgets/cycle-why";
+import { DriverListWidget } from "#/ui/cockpit/widgets/driver-list";
 import { EmptyWidget } from "#/ui/cockpit/widgets/empty";
 import { ErrorWidget } from "#/ui/cockpit/widgets/error";
 import { LoadingWidget } from "#/ui/cockpit/widgets/loading";
@@ -54,6 +55,7 @@ export const canvasRegistry = new WidgetRegistry()
 	.register({ kind: "cycle-why", component: CycleWhyWidget })
 	.register({ kind: "metric-list", component: MetricListWidget })
 	.register({ kind: "metric-why", component: MetricWhyWidget })
+	.register({ kind: "driver-list", component: DriverListWidget })
 	.register({ kind: "metric-shadow", component: MetricShadowWidget })
 	.register({ kind: "add-source-progress", component: MeasureProgressWidget })
 	.register({ kind: "session-progress", component: SessionProgressWidget })

--- a/packages/cockpit/src/ui/cockpit/canvas-state.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-state.ts
@@ -8,6 +8,7 @@
 import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
 import type { LookCycleResult } from "#/tools/look-cycle";
+import type { LookDriversResult } from "#/tools/look-drivers";
 import type { LookMetricResult } from "#/tools/look-metric";
 import type { LookProfileResult } from "#/tools/look-profile";
 import type { LookRelationshipsResult } from "#/tools/look-relationships";
@@ -77,6 +78,11 @@ export type CanvasState =
 	// first-class + the per-step SQL fragments (how it computes). Carries the
 	// why_metric result.
 	| { kind: "metric-why"; why: WhyMetricResult }
+	// DAT-546/DAT-579: the begin_session driver rankings — one row per ranked
+	// measure with its target type, grain, effective sample, and the dimensions
+	// that best explain its variation. Read-only (no per-row drill tool). Carries
+	// the look_drivers result.
+	| { kind: "driver-list"; look: LookDriversResult }
 	// DAT-482: the shipped metric DAG a teach OVERRIDE replaces. Carries ONLY the
 	// (vertical, graph_id) key — the widget RE-FETCHES the shipped output +
 	// dependencies via getShippedMetricDag, so the heavy graph never rides the lean

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -52,11 +52,12 @@ describe("toolLabel", () => {
 });
 
 describe("isCanvasTool", () => {
-	it("marks the 21 canvas-producing tools clickable", () => {
+	it("marks the 22 canvas-producing tools clickable", () => {
 		// DAT-597 removed the acquisition tools (connect, frame, select, upload,
 		// probe) — acquisition is now the staging hub, not agent tools. ONE opener is
 		// kept: open_staging_hub re-mounts that hub on the canvas (DAT-597 follow-up).
-		expect(CANVAS_TOOLS.size).toBe(21);
+		// DAT-579 follow-up: look_drivers gained a canvas widget (driver-list).
+		expect(CANVAS_TOOLS.size).toBe(22);
 		for (const name of [
 			// The retained hub opener — projects the `probe` (staging-hub) canvas.
 			"open_staging_hub",
@@ -74,6 +75,7 @@ describe("isCanvasTool", () => {
 			"why_cycle",
 			"look_metric",
 			"why_metric",
+			"look_drivers",
 			// teach_metric: an OVERRIDE projects the metric-shadow canvas (DAT-482).
 			"teach_metric",
 			"begin_session",

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.test.ts
@@ -17,6 +17,12 @@ describe("toolLabel", () => {
 		expect(toolLabel("run_sql")).toBe("Query");
 		expect(toolLabel("why_column")).toBe("Column detail");
 		expect(toolLabel("look_table")).toBe("Table readiness");
+		// DAT-579: cycle / metric / drivers titles (were falling through to the verb).
+		expect(toolLabel("look_cycle")).toBe("Business cycles");
+		expect(toolLabel("why_cycle")).toBe("Cycle detail");
+		expect(toolLabel("look_metric")).toBe("Metrics");
+		expect(toolLabel("why_metric")).toBe("Metric detail");
+		expect(toolLabel("look_drivers")).toBe("Drivers");
 	});
 
 	it("humanizes an unmapped tool instead of leaking snake_case", () => {
@@ -301,6 +307,106 @@ describe("toolChipSummary — completed canvas tools (no JSON, readable)", () =>
 				{},
 				{ analyzed: false, validations: [] },
 			),
+		).toBe("not yet run");
+	});
+
+	// DAT-579: the cycle / metric / drivers tools were missing from the mapper, so
+	// their chips fell through to the humanized verb as BOTH title and summary
+	// ("Look cycle / Look cycle"). These mirror the validation family.
+	it("look_cycle counts cycles + executed (DAT-579)", () => {
+		expect(
+			toolChipSummary(
+				"look_cycle",
+				{},
+				{
+					analyzed: true,
+					cycles: [{ state: "executed" }, { state: "declared" }],
+				},
+			),
+		).toBe("2 cycles (1 executed)");
+		expect(
+			toolChipSummary("look_cycle", {}, { analyzed: true, cycles: [] }),
+		).toBe("no cycles declared");
+		expect(
+			toolChipSummary("look_cycle", {}, { analyzed: false, cycles: [] }),
+		).toBe("not yet run");
+	});
+
+	it("why_cycle names the cycle + lifecycle state (DAT-579)", () => {
+		expect(
+			toolChipSummary(
+				"why_cycle",
+				{},
+				{ found: true, cycle_name: "Accounts Payable", state: "executed" },
+			),
+		).toBe("Accounts Payable — executed");
+		expect(
+			toolChipSummary(
+				"why_cycle",
+				{},
+				{ found: false, cycle_name: null, state: null },
+			),
+		).toBe("cycle not found");
+	});
+
+	it("look_metric counts metrics + executed (DAT-579)", () => {
+		expect(
+			toolChipSummary(
+				"look_metric",
+				{},
+				{
+					analyzed: true,
+					metrics: [
+						{ state: "executed" },
+						{ state: "grounded" },
+						{ state: "executed" },
+					],
+				},
+			),
+		).toBe("3 metrics (2 executed)");
+		expect(
+			toolChipSummary("look_metric", {}, { analyzed: true, metrics: [] }),
+		).toBe("no metrics declared");
+		expect(
+			toolChipSummary("look_metric", {}, { analyzed: false, metrics: [] }),
+		).toBe("not yet run");
+	});
+
+	it("why_metric humanizes the graph_id + lifecycle state — never snake_case (DAT-579)", () => {
+		expect(
+			toolChipSummary(
+				"why_metric",
+				{},
+				{ graph_id: "gross_margin", found: true, state: "executed" },
+			),
+		).toBe("Gross margin — executed");
+		// A grounded-but-failed metric reads its lifecycle state, not a verdict.
+		expect(
+			toolChipSummary(
+				"why_metric",
+				{},
+				{ graph_id: "ebitda", found: true, state: "grounded" },
+			),
+		).toBe("Ebitda — grounded");
+		expect(
+			toolChipSummary(
+				"why_metric",
+				{},
+				{ graph_id: "ebitda", found: false, state: null },
+			),
+		).toBe("metric not found");
+	});
+
+	it("look_drivers counts the driver rankings (DAT-579)", () => {
+		expect(
+			toolChipSummary(
+				"look_drivers",
+				{},
+				{ analyzed: true, rankings: [{}, {}, {}] },
+			),
+		).toBe("3 drivers");
+		expect(
+			toolChipSummary("look_drivers", {}, { analyzed: false, rankings: [] }),
 		).toBe("not yet run");
 	});
 

--- a/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-chip-summary.ts
@@ -21,6 +21,9 @@ import { humanizeIdentifier } from "#/lib/display-names";
 import { isAgentError } from "#/tools/agent-error";
 import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
+import type { LookCycleResult } from "#/tools/look-cycle";
+import type { LookDriversResult } from "#/tools/look-drivers";
+import type { LookMetricResult } from "#/tools/look-metric";
 import type { LookProfileResult } from "#/tools/look-profile";
 import type { LookRelationshipsResult } from "#/tools/look-relationships";
 import type { LookTableResult } from "#/tools/look-table";
@@ -30,6 +33,8 @@ import type { TeachCycleResult } from "#/tools/teach-cycle";
 import type { TeachMetricResult } from "#/tools/teach-metric";
 import type { TeachValidationResult } from "#/tools/teach-validation";
 import type { WhyColumnResult } from "#/tools/why-column";
+import type { WhyCycleResult } from "#/tools/why-cycle";
+import type { WhyMetricResult } from "#/tools/why-metric";
 import type { WhyRelationshipResult } from "#/tools/why-relationship";
 import type { WhyTableResult } from "#/tools/why-table";
 import type { WhyValidationResult } from "#/tools/why-validation";
@@ -65,6 +70,11 @@ const TOOL_LABELS: Record<string, string> = {
 	look_relationships: "Relationships",
 	look_validation: "Validations",
 	why_validation: "Validation detail",
+	look_cycle: "Business cycles",
+	why_cycle: "Cycle detail",
+	look_metric: "Metrics",
+	why_metric: "Metric detail",
+	look_drivers: "Drivers",
 	operating_model: "Starting validation run",
 	begin_session: "Starting session",
 	run_sql: "Query",
@@ -248,6 +258,46 @@ export function toolChipSummary(
 						? "passed"
 						: "failed";
 			return `${label} — ${verdict}`;
+		}
+		case "look_cycle": {
+			const r = output as LookCycleResult | undefined;
+			if (!r || !Array.isArray(r.cycles)) return "reading business cycles…";
+			if (!r.analyzed) return "not yet run";
+			if (r.cycles.length === 0) return "no cycles declared";
+			const executed = r.cycles.filter((c) => c.state === "executed").length;
+			return `${plural(r.cycles.length, "cycle")} (${executed} executed)`;
+		}
+		case "why_cycle": {
+			const r = output as WhyCycleResult | undefined;
+			if (!r) return "explaining cycle…";
+			if (!r.found) return "cycle not found";
+			// A cycle is keyed by its name (which may already be display-form);
+			// humanize, then fall back to the raw name before the generic word.
+			const label =
+				humanizeIdentifier(r.cycle_name ?? "") || r.cycle_name || "cycle";
+			return `${label} — ${r.state ?? "not run"}`;
+		}
+		case "look_metric": {
+			const r = output as LookMetricResult | undefined;
+			if (!r || !Array.isArray(r.metrics)) return "reading metrics…";
+			if (!r.analyzed) return "not yet run";
+			if (r.metrics.length === 0) return "no metrics declared";
+			const executed = r.metrics.filter((m) => m.state === "executed").length;
+			return `${plural(r.metrics.length, "metric")} (${executed} executed)`;
+		}
+		case "why_metric": {
+			const r = output as WhyMetricResult | undefined;
+			if (!r) return "explaining metric…";
+			if (!r.found) return "metric not found";
+			// graph_id is a snake_case key (e.g. gross_margin) — humanize it.
+			const label = humanizeIdentifier(r.graph_id) || "metric";
+			return `${label} — ${r.state ?? "not run"}`;
+		}
+		case "look_drivers": {
+			const r = output as LookDriversResult | undefined;
+			if (!r || !Array.isArray(r.rankings)) return "reading drivers…";
+			if (!r.analyzed) return "not yet run";
+			return plural(r.rankings.length, "driver");
 		}
 		case "operating_model": {
 			// Non-blocking driver: done = the durable run STARTED (ids in the

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -16,6 +16,7 @@ import { isAgentError } from "#/tools/agent-error";
 import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
 import type { LookCycleResult } from "#/tools/look-cycle";
+import type { LookDriversResult } from "#/tools/look-drivers";
 import type { LookMetricResult } from "#/tools/look-metric";
 import type { LookProfileResult } from "#/tools/look-profile";
 import type { LookRelationshipsResult } from "#/tools/look-relationships";
@@ -186,6 +187,12 @@ const PROJECTORS: Record<string, CanvasProjector> = {
 		isWhyResult(result)
 			? { kind: "metric-why", why: result as WhyMetricResult }
 			: null,
+	// The begin_session driver rankings (DAT-546/DAT-579). Project only a complete
+	// result (a `rankings` array) — same partial/errored-output guard as look_metric.
+	look_drivers: (result) =>
+		Array.isArray((result as { rankings?: unknown } | null)?.rankings)
+			? { kind: "driver-list", look: result as LookDriversResult }
+			: null,
 	// DAT-482: a teach_metric OVERRIDE surfaces the shipped DAG it replaces. Unlike
 	// the other teach tools (rail-only), an override carries a renderable surface —
 	// but only an override: a fresh declaration (override:false) or an errored
@@ -303,7 +310,6 @@ export const CANVAS_TOOLS: ReadonlySet<string> = new Set(
  * guardrail for the DAT-526 P1 registry split. Disjoint from `CANVAS_TOOLS`.
  */
 export const CHIP_ONLY: ReadonlySet<string> = new Set([
-	"look_drivers", // driver rankings → chip summary; a dedicated widget is a fast-follow (DAT-546)
 	"teach", // writes an overlay row; outcome surfaces after a re-run, not a widget
 	"teach_validation",
 	"teach_cycle",
@@ -333,7 +339,7 @@ export function toolResultToCanvas(
  * shapes the SDK can emit: an `output` on the `tool-call` part, or a correlated
  * `tool-result` part (content is JSON; fall back to the raw string if it isn't).
  *
- * "Maps to a canvas" is the key word: a non-canvas tool (teach, look_drivers)
+ * "Maps to a canvas" is the key word: a non-canvas tool (teach, teach_cycle)
  * completing LAST must NOT shadow the last real canvas result — otherwise
  * `canvasFromMessages` returns null and the caller, which optimistically set the
  * canvas to "loading" on submit, has nothing to reconcile to (the stuck-spinner

--- a/packages/cockpit/src/ui/cockpit/widgets/driver-list.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/driver-list.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+//
+// Render tests for the DriverListWidget (DAT-579 follow-up): one row per ranked
+// measure with humanized measure + target badge + grain + sample + the top driver
+// dimensions, the "+N more" tail, the honest no-significant-driver case, the
+// not-run / empty states, and the overflow cap (rule 15). Read-only — no click
+// drill (there is no why_drivers tool).
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { DriverRanking, LookDriversResult } from "#/tools/look-drivers";
+import { DriverListWidget } from "#/ui/cockpit/widgets/driver-list";
+import { theme } from "#/ui/theme";
+
+function renderWidget(look: LookDriversResult) {
+	render(
+		<MantineProvider theme={theme} env="test">
+			<DriverListWidget state={{ kind: "driver-list", look }} />
+		</MantineProvider>,
+	);
+}
+
+const ranking = (over: Partial<DriverRanking> = {}): DriverRanking => ({
+	measure: "net_revenue",
+	target_type: "flow",
+	grain: "row",
+	entity: null,
+	n_rows: 50000,
+	ranked_dimensions: [
+		{ dimension: "supplier_region", gain: 0.4 },
+		{ dimension: "product_category", gain: 0.2 },
+	],
+	driver_paths: [],
+	interesting_slices: [],
+	secondary_dimensions: [],
+	...over,
+});
+
+const analyzed: LookDriversResult = {
+	analyzed: true,
+	rankings: [ranking()],
+};
+
+afterEach(cleanup);
+
+describe("DriverListWidget (DAT-579 follow-up)", () => {
+	it("renders a row per measure: humanized measure, type, sample, top drivers", () => {
+		renderWidget(analyzed);
+		expect(screen.getByTestId("canvas-driver-list")).toBeTruthy();
+		expect(screen.getByText("Net revenue")).toBeTruthy();
+		expect(screen.getByText("flow")).toBeTruthy();
+		// Effective sample is shown. toLocaleString's separator is locale-specific
+		// ("50,000" en-US, "50'000" de-CH), so strip every non-digit from the table
+		// text and assert the bare sample — separator- and locale-agnostic.
+		expect(
+			screen.getByTestId("driver-rows").textContent?.replace(/\D/g, ""),
+		).toContain("50000");
+		// The ranked dimensions are humanized + comma-joined.
+		expect(screen.getByText(/Supplier region, Product category/)).toBeTruthy();
+	});
+
+	it("labels an entity-grain measure as 'per <entity>'", () => {
+		renderWidget({
+			analyzed: true,
+			rankings: [ranking({ grain: "entity", entity: "customer_id" })],
+		});
+		expect(screen.getByText("per Customer id")).toBeTruthy();
+	});
+
+	it("caps the named drivers at three and shows a '+N more' tail", () => {
+		renderWidget({
+			analyzed: true,
+			rankings: [
+				ranking({
+					ranked_dimensions: [
+						{ dimension: "a", gain: 0.5 },
+						{ dimension: "b", gain: 0.4 },
+						{ dimension: "c", gain: 0.3 },
+						{ dimension: "d", gain: 0.2 },
+						{ dimension: "e", gain: 0.1 },
+					],
+				}),
+			],
+		});
+		expect(screen.getByText(/\+2 more/)).toBeTruthy();
+	});
+
+	it("shows the honest no-significant-driver case (empty ranking)", () => {
+		renderWidget({
+			analyzed: true,
+			rankings: [ranking({ ranked_dimensions: [] })],
+		});
+		expect(screen.getByText("no significant driver")).toBeTruthy();
+	});
+
+	it("renders the not-run state pointing at begin_session", () => {
+		renderWidget({ analyzed: false, rankings: [] });
+		expect(screen.getByTestId("canvas-driver-list-unanalyzed")).toBeTruthy();
+	});
+
+	it("renders the empty state for a run that ranked no measures", () => {
+		renderWidget({ analyzed: true, rankings: [] });
+		expect(screen.getByTestId("canvas-driver-list-empty")).toBeTruthy();
+	});
+
+	it("caps rendered rows and shows the overflow tail (rule 15)", () => {
+		const many = Array.from({ length: 120 }, (_, i) =>
+			ranking({ measure: `measure_${i}` }),
+		);
+		renderWidget({ analyzed: true, rankings: many });
+		expect(screen.getAllByText("flow")).toHaveLength(100);
+		expect(screen.getByTestId("driver-list-overflow").textContent).toContain(
+			"…and 20 more",
+		);
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/widgets/driver-list.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/driver-list.tsx
@@ -1,0 +1,171 @@
+// Driver-list widget (DAT-579 follow-up) — renders the `look_drivers` result as one
+// row per ranked measure: the measure, its target type, the grain the story holds at,
+// the effective sample size, and the dimensions that best explain its variation
+// (significance-gated, strongest first). Unlike metric/cycle/validation there is NO
+// per-row drill tool (no why_drivers), so rows are read-only — the headline ranking
+// IS the widget; the agent narrates the slices/paths/secondary families.
+//
+// Every value is the engine's persisted driver-ranking output verbatim (the
+// variance-reduction tree + permutation null, DAT-545/561/563) — never recomputed
+// here. A measure with no significant driver shows that honestly (the no-driver case
+// is first-class row content, not an empty cell).
+
+import { Alert, Badge, Stack, Table, Text } from "@mantine/core";
+import { humanizeIdentifier } from "#/lib/display-names";
+import type { DriverRanking } from "#/tools/look-drivers";
+import type { CanvasState } from "#/ui/cockpit/canvas-state";
+
+// Cap the rows rendered into the DOM (rule 15). A begin_session run ranks a handful
+// of measures per fact; the cap keeps the list usable if a wide fact ships many.
+const MAX_VISIBLE_ROWS = 100;
+
+// How many ranked dimensions to name inline before collapsing to a "+N more" tail —
+// the headline is the strongest few, the full ranking is the agent's to narrate.
+const MAX_NAMED_DRIVERS = 3;
+
+// target_type → Mantine color. A coarse visual key (flow / stock / ratio); unknown
+// types degrade to gray rather than crashing the row.
+const TARGET_COLOR: Record<string, string> = {
+	flow: "blue",
+	stock: "grape",
+	ratio: "teal",
+};
+
+/** "row", or "per <entity>" when the measure clusters within an identity grain. */
+function grainLabel(r: DriverRanking): string {
+	if (r.grain === "entity" && r.entity) {
+		return `per ${humanizeIdentifier(r.entity) || r.entity}`;
+	}
+	return "row";
+}
+
+export function DriverListWidget({
+	state,
+}: {
+	state: Extract<CanvasState, { kind: "driver-list" }>;
+}) {
+	const { look } = state;
+
+	if (!look.analyzed) {
+		return (
+			<Stack gap="xs" data-testid="canvas-driver-list">
+				<Text size="sm" fw={600}>
+					Drivers
+				</Text>
+				<Alert color="gray" data-testid="canvas-driver-list-unanalyzed">
+					This workspace has no begin_session run yet — run a session to compute
+					the driver rankings for its measures.
+				</Alert>
+			</Stack>
+		);
+	}
+
+	if (look.rankings.length === 0) {
+		return (
+			<Stack gap="xs" data-testid="canvas-driver-list">
+				<Text size="sm" fw={600}>
+					Drivers
+				</Text>
+				<Alert color="gray" data-testid="canvas-driver-list-empty">
+					The session ranked no measures — its facts ship none, or none survived
+					significance gating.
+				</Alert>
+			</Stack>
+		);
+	}
+
+	const visible = look.rankings.slice(0, MAX_VISIBLE_ROWS);
+	const overflow = look.rankings.length - visible.length;
+
+	return (
+		<Stack gap="sm" data-testid="canvas-driver-list">
+			<Text size="sm" fw={600}>
+				Drivers{" "}
+				<Text span c="dimmed" size="xs">
+					{look.rankings.length} ranked{" "}
+					{look.rankings.length === 1 ? "measure" : "measures"}
+				</Text>
+			</Text>
+
+			<Table.ScrollContainer minWidth={480}>
+				<Table striped highlightOnHover data-testid="driver-rows">
+					<Table.Thead>
+						<Table.Tr>
+							<Table.Th>Measure</Table.Th>
+							<Table.Th>Type</Table.Th>
+							<Table.Th>Grain</Table.Th>
+							<Table.Th>Sample</Table.Th>
+							<Table.Th>Top drivers</Table.Th>
+						</Table.Tr>
+					</Table.Thead>
+					<Table.Tbody>
+						{visible.map((r) => {
+							const named = r.ranked_dimensions
+								.slice(0, MAX_NAMED_DRIVERS)
+								.map((d) => humanizeIdentifier(d.dimension) || d.dimension);
+							const more = r.ranked_dimensions.length - named.length;
+							return (
+								<Table.Tr
+									key={r.measure}
+									data-testid={`driver-row-${r.measure}`}
+								>
+									<Table.Td>
+										<Text size="sm">
+											{humanizeIdentifier(r.measure) || r.measure}
+										</Text>
+									</Table.Td>
+									<Table.Td>
+										<Badge
+											color={TARGET_COLOR[r.target_type] ?? "gray"}
+											variant="light"
+											size="sm"
+											tt="none"
+											styles={{ label: { overflow: "visible" } }}
+										>
+											{r.target_type || "—"}
+										</Badge>
+									</Table.Td>
+									<Table.Td>
+										<Text span size="xs" c="dimmed">
+											{grainLabel(r)}
+										</Text>
+									</Table.Td>
+									<Table.Td>
+										<Text span size="xs" c="dimmed">
+											{r.n_rows.toLocaleString()}
+										</Text>
+									</Table.Td>
+									<Table.Td>
+										{named.length === 0 ? (
+											// The honest no-driver case — nothing explained the measure
+											// at this sample size (first-class, not a blank cell).
+											<Text span size="xs" c="dimmed" fs="italic">
+												no significant driver
+											</Text>
+										) : (
+											<Text size="xs">
+												{named.join(", ")}
+												{more > 0 && (
+													<Text span c="dimmed">
+														{" "}
+														+{more} more
+													</Text>
+												)}
+											</Text>
+										)}
+									</Table.Td>
+								</Table.Tr>
+							);
+						})}
+					</Table.Tbody>
+				</Table>
+			</Table.ScrollContainer>
+
+			{overflow > 0 && (
+				<Text size="xs" c="dimmed" data-testid="driver-list-overflow">
+					…and {overflow} more — ask the agent about a specific measure.
+				</Text>
+			)}
+		</Stack>
+	);
+}

--- a/packages/cockpit/src/ui/cockpit/widgets/lifecycle-badges.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/lifecycle-badges.tsx
@@ -40,6 +40,12 @@ export function LifecycleStateBadge({
 			variant="light"
 			size="sm"
 			tt="none"
+			// The lifecycle state is a short closed-enum word (declared / grounded /
+			// executed). Mantine's Badge label clips with an ellipsis by default, so in
+			// a starved table column it rendered "Executed" → "Exec…" (DAT-579). Let the
+			// label show in full and the badge size to its content — these labels are
+			// never long enough to need truncation.
+			styles={{ label: { overflow: "visible" } }}
 		>
 			{state.charAt(0).toUpperCase() + state.slice(1)}
 		</Badge>


### PR DESCRIPTION
## What

Three findings from the DAT-579 widget walk (Connect / Stage / Analyse), all fixed + verified live in a browser.

### 1. Lifecycle State badge clipped its label
metric / cycle / validation list widgets rendered "Executed" → "Exec…" / "Grounded" → "Grou…". Root cause (diagnosed live via computed styles): Mantine's `Badge` `.mantine-Badge-label` carries its own `overflow:hidden; text-overflow:ellipsis`, so the short lifecycle word clipped regardless of cell `white-space`. **Fixed once in the shared `LifecycleStateBadge`** (rule 13): `styles={{ label: { overflow: "visible" } }}`.

### 2. cycle / metric / drivers tool chips showed the raw verb as title AND subtitle
`look_cycle` / `look_metric` / `why_metric` / `why_cycle` / `look_drivers` were missing from `tool-chip-summary.ts` (only the validation family was wired), so both the chip title and summary fell through to the humanized verb ("Look cycle / Look cycle"). Added `TOOL_LABELS` + `toolChipSummary` cases for all five, mirroring the validation family.

### 3. `look_drivers` had no canvas widget (the coverage-audit gap)
Every other `look_*`/`why_*` inspect tool projects a widget; `look_drivers` (DAT-546) only ever rendered as a chip. Added **`DriverListWidget`** — one row per ranked measure: measure, target-type badge, grain ("row" / "per <entity>"), effective sample, and the top driver dimensions (humanized, capped at 3 + "+N more"); the honest no-significant-driver case is first-class. Read-only (no `why_drivers` drill), rule-15 capped. Wired through the three canvas seams (state + registry + projector); `look_drivers` moves `CHIP_ONLY` → `PROJECTORS` (CANVAS_TOOLS 21 → 22).

## Verification

- tsc + biome clean; full cockpit unit suite green (the one failing file is the container/CI-gated `connect.integration.test.ts`, untouched). New tests: `toolLabel`/`toolChipSummary` for the five tools, the `DriverListWidget` render suite, and the canvas-XOR-chip-only partition + canvas-tools-count updates.
- **Live browser** (rebuilt container): badges measured `clientWidth === scrollWidth` (no clip); cards read "Business cycles / 12 cycles (4 executed)", "Metrics / 12 metrics (5 executed)", "Metric detail / Cash conversion cycle — executed"; and a real `look_drivers` call projected the new widget — 6 measures at `business_id` entity grain (27 entities), all "no significant driver", matching the agent's narration.

## Out of scope (noted, not patched)

- The metric Detail cell's **over-escaped engine error** (literal `\n`, `^` caret in `state_reason`) is engine-side — **noted on DAT-616**.
- An Analyse coherence nit (a "can't complete" answer still shows a green "100 rows DONE" grid of column names) is answer-agent SQL behavior, not a widget bug — deferred (likely resolves as that agent is tuned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
