### PR TITLE
DAT-624: Report button in the grid toolbar + round float display to 2dp

### DIFF
--- a/packages/cockpit/src/duckdb/cell-format.test.ts
+++ b/packages/cockpit/src/duckdb/cell-format.test.ts
@@ -69,10 +69,17 @@ describe("formatCell — numerics", () => {
 		expect(out.endsWith("67")).toBe(true);
 	});
 
-	it("groups floats and keeps their fractional digits", () => {
-		const out = formatCell(1234.5, DOUBLE);
-		expect(digits(out)).toBe("12345");
-		expect(out).toMatch(/1.234.5$/);
+	it("rounds FLOAT/DOUBLE to two places and groups them", () => {
+		// Binary-representation noise from a summed double is trimmed to 2 places.
+		const noisy = formatCell(183996.89999999967, DOUBLE);
+		expect(digits(noisy)).toBe("18399690");
+		expect(noisy).toMatch(/183.996.90$/);
+		// Rounds (not truncates) the third decimal.
+		expect(formatCell(1234.567, DOUBLE)).toMatch(/1.234.57$/);
+		// A clean half still renders a full two places.
+		const half = formatCell(1234.5, DOUBLE);
+		expect(digits(half)).toBe("123450");
+		expect(half.endsWith("50")).toBe(true);
 	});
 
 	it("handles negative numbers", () => {

--- a/packages/cockpit/src/duckdb/cell-format.ts
+++ b/packages/cockpit/src/duckdb/cell-format.ts
@@ -84,6 +84,12 @@ function typeIdOf(t: Json | undefined): number | undefined {
  * locale so grouped output uses the right separator for the fractional part. */
 const DECIMAL_SEP: string = (1.1).toLocaleString().replace(/\d/g, "");
 
+/** Decimal places FLOAT/DOUBLE columns render to. Binary floats carry
+ * representation noise — a summed 183996.9 comes back as 183996.89999999967 —
+ * so we round them for display. DECIMAL has an explicit, meaningful scale and
+ * the big-int types are exact strings, so those are left untouched. */
+const FLOAT_DISPLAY_DP = 2;
+
 /** Locale-group a numeric value WITHOUT precision loss. The value is a JS number
  * (small ints / floats) or a string (big ints / decimals). Groups the integer
  * part via BigInt (arbitrary precision) and re-attaches the exact fractional
@@ -146,7 +152,16 @@ export function formatCell(value: unknown, duckdbType?: Json): string {
 	const id = typeIdOf(duckdbType);
 	if (id !== undefined) {
 		if (NUMERIC_IDS.has(id)) {
-			const n = formatNumeric(value);
+			// Round binary floats to a fixed display precision; leave exact-scale
+			// DECIMAL and string-carried big ints alone (and pass Infinity/NaN through
+			// untouched so they aren't coerced to "Infinity.00").
+			const display =
+				(id === TYPE.FLOAT || id === TYPE.DOUBLE) &&
+				typeof value === "number" &&
+				Number.isFinite(value)
+					? value.toFixed(FLOAT_DISPLAY_DP)
+					: value;
+			const n = formatNumeric(display);
 			if (n !== null) return n;
 		} else if (id === TYPE.DATE) {
 			return formatDate(value);

--- a/packages/cockpit/src/ui/cockpit/widgets/answer-result.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/answer-result.tsx
@@ -181,51 +181,52 @@ export function AnswerResultWidget({
 		}
 	};
 
+	// The mint action rides in the grid's own toolbar (left of "View SQL") rather
+	// than floating above the grid — it's a peer of the result-surface actions.
+	const reportAction =
+		mintedId && wsId ? (
+			<Button
+				variant="light"
+				color="green"
+				size="compact-xs"
+				leftSection={<Library size={13} />}
+				data-testid="report-saved"
+				renderRoot={(props) => (
+					<Link
+						to="/workspace/$wsId/reports/$reportId"
+						params={{ wsId, reportId: mintedId }}
+						{...props}
+					/>
+				)}
+			>
+				Saved to Reports
+			</Button>
+		) : (
+			<Button
+				variant="subtle"
+				color="gray"
+				size="compact-xs"
+				leftSection={<Library size={13} />}
+				onClick={onMint}
+				loading={saving}
+				data-testid="report-mint"
+			>
+				Report
+			</Button>
+		);
+
 	return (
 		<div data-testid="canvas-answer-result">
 			<ConfidenceStrip confidence={state.confidence} />
-			<Group justify="flex-end" mb="xs">
-				{mintedId && wsId ? (
-					<Button
-						variant="light"
-						size="xs"
-						leftSection={<Library size={14} />}
-						data-testid="report-saved"
-						renderRoot={(props) => (
-							<Link
-								to="/workspace/$wsId/reports/$reportId"
-								params={{ wsId, reportId: mintedId }}
-								{...props}
-							/>
-						)}
-					>
-						Saved to Reports
-					</Button>
-				) : (
-					<Button
-						variant="light"
-						size="xs"
-						leftSection={<Library size={14} />}
-						onClick={onMint}
-						loading={saving}
-						data-testid="report-mint"
-					>
-						Report
-					</Button>
-				)}
-			</Group>
 			{mintFailed && (
-				<Text
-					size="xs"
-					c="red"
-					ta="right"
-					mb="xs"
-					data-testid="report-mint-error"
-				>
+				<Text size="xs" c="red" mb="xs" data-testid="report-mint-error">
 					Couldn’t save the report — try again.
 				</Text>
 			)}
-			<ResultGridWidget state={{ kind: "result-grid", sql: state.sql }} />
+			<ResultGridWidget
+				state={{ kind: "result-grid", sql: state.sql }}
+				toolbarActions={reportAction}
+			/>
 		</div>
 	);
 }

--- a/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
@@ -54,7 +54,14 @@ import {
 	Code,
 	Filter,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { cellAlign, columnFilterKind, formatCell } from "#/duckdb/cell-format";
 import {
 	GRID_PAGE_SIZE,
@@ -128,6 +135,7 @@ export function ResultGridView({
 	scrollResetKey,
 	sql,
 	sqlParams,
+	toolbarActions,
 }: {
 	store: GridView;
 	fatal?: string | null;
@@ -146,6 +154,10 @@ export function ResultGridView({
 	 * editor), so no button there. */
 	sql?: string;
 	sqlParams?: (string | number | boolean | null)[];
+	/** Extra toolbar actions rendered to the LEFT of "View SQL" — the answer surface
+	 * mounts its mint-to-Report button here so it sits with the grid's own actions
+	 * instead of floating above the grid. Omitted for plain run_sql / probe grids. */
+	toolbarActions?: ReactNode;
 }) {
 	// The filter row is hidden by default (a clean grid) and toggled by the funnel
 	// in the toolbar. An applied-but-hidden filter isn't stranded: the funnel stays
@@ -245,6 +257,7 @@ export function ResultGridView({
 					{store.rowCount} row{store.rowCount === 1 ? "" : "s"}
 				</Text>
 				<Group gap="xs">
+					{toolbarActions}
 					{sql && (
 						<Button
 							variant="subtle"
@@ -511,8 +524,11 @@ export function ResultGridView({
  */
 export function ResultGridWidget({
 	state,
+	toolbarActions,
 }: {
 	state: Extract<CanvasState, { kind: "result-grid" }>;
+	/** Forwarded to the grid toolbar (left of "View SQL") — see ResultGridView. */
+	toolbarActions?: ReactNode;
 }) {
 	// The provider derives a fresh canvas object on every message tick; serialize
 	// sql+params so a new `key` is produced only when the QUERY actually changes,
@@ -528,6 +544,7 @@ export function ResultGridWidget({
 			body={{ sql: state.sql, params: state.params }}
 			sql={state.sql}
 			sqlParams={state.params}
+			toolbarActions={toolbarActions}
 		/>
 	);
 }
@@ -563,6 +580,7 @@ export function WindowedGrid({
 	body,
 	sql,
 	sqlParams,
+	toolbarActions,
 }: {
 	endpoint: string;
 	/** The base request body (WITHOUT sort/filters/limit/offset — the grid appends those). */
@@ -570,6 +588,8 @@ export function WindowedGrid({
 	/** The query behind the grid, surfaced via the toolbar "Show SQL" modal. */
 	sql?: string;
 	sqlParams?: (string | number | boolean | null)[];
+	/** Forwarded to the grid toolbar (left of "View SQL") — see ResultGridView. */
+	toolbarActions?: ReactNode;
 }) {
 	const [sort, setSort] = useState<GridSort | null>(null);
 	const [filters, setFilters] = useState<GridFilter[]>([]);
@@ -692,6 +712,7 @@ export function WindowedGrid({
 			scrollResetKey={JSON.stringify([sort, filters])}
 			sql={sql}
 			sqlParams={sqlParams}
+			toolbarActions={toolbarActions}
 		/>
 	);
 }


### PR DESCRIPTION
Two review-driven polish fixes on the answer surface, following up the merged DAT-624 keystone (#376).

## Changes
- **Report button moved into the grid toolbar**, immediately left of *View SQL*, instead of floating above the grid. Implemented with a `toolbarActions` slot threaded through `ResultGridWidget → WindowedGrid → ResultGridView`; the answer widget mounts its mint/"Saved to Reports" button there. The report-detail grid omits the slot, so no Report button appears there.
- **FLOAT/DOUBLE cells round to 2 decimal places** for display. A summed double came back as `183996.89999999967` (binary-representation noise); it now renders `183,996.90`. DECIMAL (explicit, meaningful scale) and string-carried big ints are left untouched.

## Verification
- `tsc` clean, `biome` clean.
- Targeted unit tests green (40/40); updated the cell-format float test to assert the new 2dp rounding (rounds, not truncates; keeps trailing zeros; leaves DECIMAL exact).
- Container-smoked against a fresh prod build: toolbar order verified, all six numeric cells render at 2dp, a real mint produces a "Saved to Reports" link in the toolbar, and the report-detail live grid shows the same rounding. **0 console errors** on both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)