### PR TITLE
graph prompt: harden step/CTE authoring rules (born-loud compose failures)

### DIFF
--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -118,6 +118,15 @@ system_prompt: |
      a real value and silently corrupts the metric (e.g. an empty filter → 0 → a fabricated 100% ratio).
      Only COALESCE a genuinely-nullable NON-aggregate input where 0 is the semantically correct value.
   8. Table references: ALWAYS use enriched views (enriched_*) when available in <data_schema>.
+  9. Every step body is a query (a SELECT) — NEVER a bare expression. A formula step that
+     combines earlier steps still wraps the arithmetic in a SELECT aliased `AS value`.
+     WRONG: operating_income AS ((SELECT value FROM rev) - (SELECT value FROM cogs))
+     RIGHT: operating_income AS (SELECT (SELECT value FROM rev) - (SELECT value FROM cogs) AS value)
+     (Folded as a CTE, a bare-expression body is a syntax error at the first operator.)
+  10. NEVER define a CTE in final_sql whose name matches a step — steps are ALREADY CTEs,
+     so this is a "Duplicate CTE name" error. Reference the step by name; do not redefine it.
+     WRONG: WITH revenue AS (...) SELECT ... FROM revenue   (when a step is already named "revenue")
+     RIGHT: SELECT (SELECT value FROM revenue) / (SELECT value FROM net_income) AS value
      Do NOT query typed tables directly when enriched views exist — enriched views are pre-joined
      supersets with dimension columns (joined dimensions are named `<dimension>__<attribute>`,
      e.g. `<fact_view>.<dimension>__<attribute>`). Filter those categorical dimensions with an


### PR DESCRIPTION
## What
Two `operating_model` metrics fell loud on compose-standalone SQL errors the graph prompt discouraged but didn't enforce hard (surfaced by the DAT-621 BookSQL smoke):

- **net_margin** — a formula step authored as a bare expression `op_income AS ((SELECT value FROM rev) - …)` → *"syntax error at or near -"* (a CTE body must be a `SELECT`).
- **operating_margin** — a step named `revenue` plus a `revenue` CTE in `final_sql` → *"Duplicate CTE name revenue"*.

Promotes both to **hard DuckDB-dialect rules (9, 10)** in `graph_sql_generation.yaml` with exact wrong/right examples.

## Why prompt, not executor
Fix is at the source (authoring), not `compose_standalone`:
- `graph.steps` is dict-keyed → step↔step name dups are impossible.
- The step↔`final_sql`-WITH collision already raises a clear DuckDB error the repair loop receives.
- Statically validating / auto-rewriting agent SQL risks false positives on nested CTEs and is a band-aid over an authoring bug.

These are **born-loud** (no wrong number); this reduces the born-loud rate. Config is bind-mounted, so the rules are live without a rebuild.

## Context
Part of the DAT-616/DAT-621 grounding work. Related born-loud / correctness follow-ons filed separately: **DAT-629** (within-run snippet reuse is racy under parallel metric authoring → pre-pass), **DAT-277 + DAT-628** (composite-key joins + fan-trap flag — the `gross_margin` 0.70-vs-true-0.84 join fan-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)