### PR TITLE
fix(relationships): restore fan-trap flag on LLM-synthesized relationships

### DIFF
--- a/packages/engine/src/dataraum/analysis/relationships/evaluator.py
+++ b/packages/engine/src/dataraum/analysis/relationships/evaluator.py
@@ -242,7 +242,7 @@ def evaluate_relationship_candidate(
     join_success_rate = best_join.left_referential_integrity
 
     # Check for duplicate introduction (fan trap)
-    introduces_duplicates = _check_duplicate_introduction(
+    introduces_duplicates = compute_introduces_duplicates(
         table1_path,
         table2_path,
         best_join.column1,
@@ -259,7 +259,7 @@ def evaluate_relationship_candidate(
     )
 
 
-def _check_duplicate_introduction(
+def compute_introduces_duplicates(
     table1_path: str,
     table2_path: str,
     col1: str,
@@ -269,7 +269,9 @@ def _check_duplicate_introduction(
     """Check if joining introduces duplicate rows (fan trap).
 
     A fan trap occurs when joining through a relationship causes
-    row multiplication, which can inflate aggregates.
+    row multiplication, which can inflate aggregates. Public (used by the
+    structural evaluator AND the LLM-synthesis processor) so synthesized
+    relationships carry the same empirical fan-trap signal as structural ones.
 
     Args:
         table1_path: DuckDB path to first table

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 from dataraum.analysis.relationships.db_models import Relationship as RelationshipModel
 from dataraum.analysis.relationships.evaluator import (
     compute_actual_cardinality,
+    compute_introduces_duplicates,
     compute_ri_metrics,
 )
 from dataraum.analysis.semantic.agent import SemanticAgent
@@ -401,6 +402,31 @@ def synthesize_and_store_tables(
                 )
 
         cardinality = _resolve_cardinality(rel=rel, evidence=evidence, duckdb_conn=duckdb_conn)
+
+        # Fan-trap signal. The structural evaluator computes this (evaluate_relationship_
+        # candidate -> compute_introduces_duplicates), but the LLM-synthesis path lost it
+        # in the DAT-362 split: this branch recomputes cardinality + RI from data yet
+        # dropped the duplicate-introduction check, so synthesized relationships carried a
+        # NULL introduces_duplicates and BOTH SQL agents' fan-out cautions read a dead flag
+        # (a many-to-many join silently double-counts). Restore it — empirically, the same
+        # LEFT-JOIN row-count check the structural path uses — whenever a candidate didn't
+        # already supply it and the lake is reachable.
+        if "introduces_duplicates" not in evidence and duckdb_conn is not None:
+            try:
+                evidence["introduces_duplicates"] = compute_introduces_duplicates(
+                    f'lake.typed."{rel.from_table}"',
+                    f'lake.typed."{rel.to_table}"',
+                    rel.from_column,
+                    rel.to_column,
+                    duckdb_conn,
+                )
+            except Exception as e:
+                logger.warning(
+                    "introduces_duplicates_computation_failed",
+                    from_table=rel.from_table,
+                    to_table=rel.to_table,
+                    error=str(e),
+                )
 
         rel_rows.append(
             {

--- a/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
@@ -239,6 +239,69 @@ class TestSynthesizeAndStoreTables:
         assert len(rels) == 1 and rels[0].cardinality is None  # no duckdb → unresolved
         assert anns == []  # per-table synthesis never writes column annotations
 
+    def test_synthesized_relationship_gets_fan_trap_flag_from_data(self, session) -> None:
+        """Regression: a synthesized (table_synthesis) relationship with NO structural
+        candidate must still get introduces_duplicates computed EMPIRICALLY from the lake.
+
+        The DAT-362 semantic split rebuilt this path to recompute cardinality + RI from
+        data but dropped the duplicate-introduction check, so synthesized relationships
+        carried a NULL fan-trap flag — both SQL agents' fan-out cautions then read a dead
+        flag and a many-to-many join silently double-counts (the gross_margin smoke).
+        """
+        import duckdb
+
+        orders = _table_with_columns(session, "orders", ["order_id", "customer_id"])
+        customers = _table_with_columns(session, "customers", ["id"])
+
+        conn = duckdb.connect()
+        conn.execute("ATTACH ':memory:' AS lake")
+        conn.execute("CREATE SCHEMA lake.typed")
+        conn.execute("CREATE TABLE lake.typed.orders (order_id INTEGER, customer_id INTEGER)")
+        conn.execute("INSERT INTO lake.typed.orders VALUES (1, 100), (2, 100)")
+        # customer 100 recurs THREE times → joining fans out (2 rows → 6): a fan trap.
+        conn.execute("CREATE TABLE lake.typed.customers (id INTEGER)")
+        conn.execute("INSERT INTO lake.typed.customers VALUES (100), (100), (100)")
+
+        agent = MagicMock()
+        agent.synthesize_tables = MagicMock(
+            return_value=Result.ok(
+                SemanticEnrichmentResult(
+                    annotations=[],
+                    entity_detections=[],
+                    relationships=[
+                        Relationship(
+                            relationship_id="rel-1",
+                            from_table="orders",
+                            from_column="customer_id",
+                            to_table="customers",
+                            to_column="id",
+                            relationship_type=RelationshipType.FOREIGN_KEY,
+                            confidence=0.9,
+                            detection_method="llm_tool",
+                            evidence={"source": "table_synthesis"},  # no candidate flag
+                        )
+                    ],
+                )
+            )
+        )
+
+        result = synthesize_and_store_tables(
+            session,
+            agent,
+            [orders.table_id, customers.table_id],
+            duckdb_conn=conn,
+            run_id=baseline_run_id(),
+        )
+        session.flush()
+
+        assert result.success
+        rel = (
+            session.execute(select(RelationshipDB).where(RelationshipDB.detection_method == "llm"))
+            .scalars()
+            .one()
+        )
+        assert rel.evidence["introduces_duplicates"] is True
+
     @staticmethod
     def _agent() -> MagicMock:
         """An agent that always classifies `orders` and confirms the orders→customers FK."""


### PR DESCRIPTION
## Regression
`introduces_duplicates` — the fan-trap signal both SQL agents read to warn that a join double-counts — is computed by the structural evaluator (`evaluate_relationship_candidate` → `compute_introduces_duplicates`, a real LEFT-JOIN row-count check) but was **dropped on the LLM table-synthesis path** in the DAT-362 semantic split. That path recompute cardinality + RI metrics from the lake yet never re-ran the duplicate check, so every synthesized (`evidence.source = "table_synthesis"`) relationship carried a **NULL** flag.

Consequence: both fan-out cautions — engine `graphs/context.py` `## Relationships` and the cockpit `<relationships>` block — read a dead flag, so a **many-to-many join silently double-counts** (the `gross_margin` 0.70-vs-true-0.84 BookSQL smoke).

## Fix (at the source)
- Make `compute_introduces_duplicates` public (was `_check_duplicate_introduction`) — same empirical check, now shared by the structural evaluator AND the synthesis processor.
- In `synthesize_and_store_tables`, compute it whenever a structural candidate didn't already supply the flag and the lake is reachable. Guarded + logged like the sibling RI computation.
- Consumers keep **reading** the flag — no per-renderer cardinality derivation (that consumer-side band-aid was tried and reverted).

## Test
Regression test: a synthesized fan-out join (`customers.id` duplicated) now persists `introduces_duplicates=True`. 114 relationships+semantic unit tests green.

Resolves the source half of **DAT-628**. Does NOT fix the underlying many-to-many cause (missing composite key `account_name + business_id`) — that's **DAT-277**; this just makes the fan-out *visible* so the agents can warn/abstain instead of silently over-counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)