### PR TITLE
DAT-625: Report staleness — fingerprint + outdated badge + 1-click Haiku regenerate

### DIFF
--- a/packages/cockpit/src/db/cockpit/reports.test.ts
+++ b/packages/cockpit/src/db/cockpit/reports.test.ts
@@ -24,6 +24,7 @@ vi.mock("#/db/cockpit/schema", () => ({
 		parentId: "parent_id",
 		title: "title",
 		summary: "summary",
+		summaryFingerprint: "summary_fingerprint",
 		sql: "sql",
 		confidence: "confidence",
 		createdAt: "created_at",
@@ -78,7 +79,9 @@ import {
 	getReport,
 	listReports,
 	renameReport,
+	setReportFingerprint,
 	softDeleteReport,
+	updateReportSummary,
 } from "./reports";
 
 const confidence: AnswerConfidence = {
@@ -118,6 +121,28 @@ describe("createReport", () => {
 			sql: "SELECT 1",
 			confidence,
 		});
+	});
+
+	it("stores the mint-time fingerprint, defaulting it to null when absent (DAT-625)", async () => {
+		await createReport({
+			workspaceId: "ws-1",
+			title: "t",
+			summary: "s",
+			sql: "SELECT 1",
+			confidence,
+			summaryFingerprint: "abc123",
+		});
+		expect(h.inserts[0].rows).toMatchObject({ summaryFingerprint: "abc123" });
+
+		h.inserts = [];
+		await createReport({
+			workspaceId: "ws-1",
+			title: "t",
+			summary: "s",
+			sql: "SELECT 1",
+			confidence,
+		});
+		expect(h.inserts[0].rows).toMatchObject({ summaryFingerprint: null });
 	});
 
 	it("defaults absent provenance/lineage to null (workspaceId is the only owner)", async () => {
@@ -168,6 +193,28 @@ describe("renameReport", () => {
 		await renameReport("r1", "New title");
 		const upd = h.updates.find((u) => u.table === "reports");
 		expect(upd?.set).toEqual({ title: "New title" });
+		expect(JSON.stringify(h.whereArgs)).toContain("deleted_at");
+	});
+});
+
+describe("updateReportSummary", () => {
+	it("sets summary + fingerprint together, scoped to live rows (the only summary write)", async () => {
+		await updateReportSummary("r1", "Refreshed prose.", "fp-new");
+		const upd = h.updates.find((u) => u.table === "reports");
+		expect(upd?.set).toEqual({
+			summary: "Refreshed prose.",
+			summaryFingerprint: "fp-new",
+		});
+		expect(JSON.stringify(h.whereArgs)).toContain("deleted_at");
+	});
+});
+
+describe("setReportFingerprint", () => {
+	it("backfills only the fingerprint (summary untouched), scoped to live rows", async () => {
+		await setReportFingerprint("r1", "fp-backfill");
+		const upd = h.updates.find((u) => u.table === "reports");
+		expect(upd?.set).toEqual({ summaryFingerprint: "fp-backfill" });
+		expect(upd?.set.summary).toBeUndefined();
 		expect(JSON.stringify(h.whereArgs)).toContain("deleted_at");
 	});
 });

--- a/packages/cockpit/src/db/cockpit/reports.ts
+++ b/packages/cockpit/src/db/cockpit/reports.ts
@@ -32,16 +32,21 @@ export interface CreateReportInput {
 	summary: string;
 	sql: string;
 	confidence: AnswerConfidence;
+	/** Headline result fingerprint at mint (DAT-625). Drives drift detection on open;
+	 * null only if fingerprinting failed (best-effort), then lazy-backfilled later. */
+	summaryFingerprint?: string | null;
 }
 
-/** A report as the gallery + detail render it. `chartConfig` is reserved (DAT-626);
- * `summaryFingerprint` drives the DAT-625 staleness flag — both null until then. */
+/** A report as the gallery + detail render it. `chartConfig` is reserved (DAT-626).
+ * `summaryFingerprint` is the result fingerprint at last summary-gen (DAT-625) — the
+ * detail loader compares it to a fresh fingerprint to flag the summary outdated. */
 export interface ReportRow {
 	id: string;
 	workspaceId: string;
 	parentId: string | null;
 	title: string;
 	summary: string;
+	summaryFingerprint: string | null;
 	sql: string;
 	confidence: AnswerConfidence;
 	createdAt: Date;
@@ -62,6 +67,7 @@ export async function createReport(input: CreateReportInput): Promise<string> {
 		parentId: input.parentId ?? null,
 		title: input.title,
 		summary: input.summary,
+		summaryFingerprint: input.summaryFingerprint ?? null,
 		sql: input.sql,
 		confidence: input.confidence,
 	});
@@ -83,6 +89,7 @@ export async function listReports(
 			parentId: reports.parentId,
 			title: reports.title,
 			summary: reports.summary,
+			summaryFingerprint: reports.summaryFingerprint,
 			sql: reports.sql,
 			confidence: reports.confidence,
 			createdAt: reports.createdAt,
@@ -105,6 +112,7 @@ export async function getReport(reportId: string): Promise<ReportRow | null> {
 			parentId: reports.parentId,
 			title: reports.title,
 			summary: reports.summary,
+			summaryFingerprint: reports.summaryFingerprint,
 			sql: reports.sql,
 			confidence: reports.confidence,
 			createdAt: reports.createdAt,
@@ -126,6 +134,39 @@ export async function renameReport(
 	await cockpitDb
 		.update(reports)
 		.set({ title })
+		.where(and(eq(reports.id, reportId), isNull(reports.deletedAt)));
+}
+
+/**
+ * Refresh a report's summary + its result fingerprint together (DAT-625 regenerate).
+ * This is the ONLY path that mutates `summary` — `sql` stays immutable. Atomic so the
+ * stored fingerprint always matches the summary it was generated against (no window
+ * where the prose is new but the fingerprint still flags it outdated). Live-rows only.
+ */
+export async function updateReportSummary(
+	reportId: string,
+	summary: string,
+	summaryFingerprint: string,
+): Promise<void> {
+	await cockpitDb
+		.update(reports)
+		.set({ summary, summaryFingerprint })
+		.where(and(eq(reports.id, reportId), isNull(reports.deletedAt)));
+}
+
+/**
+ * Lazy-backfill a report's fingerprint (DAT-625) — for reports minted before this
+ * existed, or when mint-time fingerprinting failed. Written on first open so the
+ * report starts tracking drift WITHOUT touching `summary` (the prose is unchanged, so
+ * it's not "outdated" — we just had nothing to compare against yet). Live-rows only.
+ */
+export async function setReportFingerprint(
+	reportId: string,
+	summaryFingerprint: string,
+): Promise<void> {
+	await cockpitDb
+		.update(reports)
+		.set({ summaryFingerprint })
 		.where(and(eq(reports.id, reportId), isNull(reports.deletedAt)));
 }
 

--- a/packages/cockpit/src/duckdb/report-fingerprint-read.ts
+++ b/packages/cockpit/src/duckdb/report-fingerprint-read.ts
@@ -1,0 +1,30 @@
+// Lake-reading side of the report fingerprint (DAT-625) — the impure wrapper that
+// runs a report's SQL against the READ_ONLY lake and turns it into a headline
+// fingerprint. Split from the pure `report-fingerprint.ts` so that module's
+// determinism rules stay unit-testable without booting config/the lake; this file
+// is exercised by the container smoke (it needs an attached lake).
+
+import { getLakeConnection } from "./lake";
+import { type QueryResult, readerToResult } from "./query-result";
+import { FINGERPRINT_ROW_LIMIT, fingerprintRows } from "./report-fingerprint";
+
+/**
+ * Run a report's SQL against the lake and return its headline fingerprint plus the
+ * materialized rows (reused as the regenerate prompt's fresh result, so the SQL runs
+ * once per regenerate). The query is wrapped `SELECT * FROM (<sql>) ORDER BY ALL
+ * LIMIT N` — the canonical grid order — so the same data fingerprints identically
+ * regardless of the scan's physical row order. Read-only by construction (the lake
+ * is ATTACHed READ_ONLY).
+ */
+export async function computeReportFingerprint(
+	sql: string,
+	params?: (string | number | boolean | null)[],
+): Promise<{ fingerprint: string; result: QueryResult }> {
+	const conn = await getLakeConnection();
+	const wrapped = `SELECT * FROM (${sql}) AS _report ORDER BY ALL LIMIT ${FINGERPRINT_ROW_LIMIT}`;
+	const reader = params
+		? await conn.runAndReadAll(wrapped, params)
+		: await conn.runAndReadAll(wrapped);
+	const result = readerToResult(reader);
+	return { fingerprint: fingerprintRows(result.rows), result };
+}

--- a/packages/cockpit/src/duckdb/report-fingerprint-read.ts
+++ b/packages/cockpit/src/duckdb/report-fingerprint-read.ts
@@ -15,16 +15,17 @@ import { FINGERPRINT_ROW_LIMIT, fingerprintRows } from "./report-fingerprint";
  * LIMIT N` — the canonical grid order — so the same data fingerprints identically
  * regardless of the scan's physical row order. Read-only by construction (the lake
  * is ATTACHed READ_ONLY).
+ *
+ * No bind params: a report's `sql` is the LLM-authored composed query persisted as
+ * literal text (never a parameterized statement), so there is nothing to bind — and
+ * forwarding params here would bind them against the WRAPPED outer SELECT, shifting
+ * any positions in the inner SQL. Keep it literal.
  */
 export async function computeReportFingerprint(
 	sql: string,
-	params?: (string | number | boolean | null)[],
 ): Promise<{ fingerprint: string; result: QueryResult }> {
 	const conn = await getLakeConnection();
 	const wrapped = `SELECT * FROM (${sql}) AS _report ORDER BY ALL LIMIT ${FINGERPRINT_ROW_LIMIT}`;
-	const reader = params
-		? await conn.runAndReadAll(wrapped, params)
-		: await conn.runAndReadAll(wrapped);
-	const result = readerToResult(reader);
+	const result = readerToResult(await conn.runAndReadAll(wrapped));
 	return { fingerprint: fingerprintRows(result.rows), result };
 }

--- a/packages/cockpit/src/duckdb/report-fingerprint.test.ts
+++ b/packages/cockpit/src/duckdb/report-fingerprint.test.ts
@@ -1,0 +1,98 @@
+// Unit tests for the pure report-fingerprint core (DAT-625). The lake-reading
+// `computeReportFingerprint` is smoke-covered (needs an attached lake); the
+// determinism + normalization claims that make the drift signal TRUE rather than
+// flaky are proven here on the pure functions.
+
+import type { Json } from "@duckdb/node-api";
+import { describe, expect, it } from "vitest";
+import {
+	fingerprintRows,
+	normalizeForFingerprint,
+} from "#/duckdb/report-fingerprint";
+
+const rows = (...r: Record<string, Json>[]) => r;
+
+describe("fingerprintRows — determinism", () => {
+	it("is stable: same rows → same hash", () => {
+		const a = rows({ k: "Income", v: 100 }, { k: "Bank", v: 50 });
+		const b = rows({ k: "Income", v: 100 }, { k: "Bank", v: 50 });
+		expect(fingerprintRows(a)).toBe(fingerprintRows(b));
+	});
+
+	it("returns a 64-char hex sha256 digest", () => {
+		expect(fingerprintRows(rows({ v: 1 }))).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("distinguishes row order (the caller orders rows canonically before hashing)", () => {
+		const ordered = rows({ k: "a", v: 1 }, { k: "b", v: 2 });
+		const swapped = rows({ k: "b", v: 2 }, { k: "a", v: 1 });
+		expect(fingerprintRows(ordered)).not.toBe(fingerprintRows(swapped));
+	});
+});
+
+describe("fingerprintRows — float-noise immunity (the key correctness rule)", () => {
+	it("collapses non-associative-sum noise to the same fingerprint", () => {
+		// The same headline number a re-ordered SUM(double) can yield as different
+		// raw doubles a few ULP apart. Built at runtime (1e-9 ≫ the ~3e-11 ULP here,
+		// yet far below the 12-sig-digit budget at this magnitude) so the two are
+		// genuinely different doubles that MUST collapse to one fingerprint.
+		const base = 183996.9;
+		const noisy = base + 1e-9;
+		expect(noisy).not.toBe(base); // sanity: distinct raw doubles
+		const a = rows({ account: "A/P", total: base });
+		const b = rows({ account: "A/P", total: noisy });
+		expect(fingerprintRows(a)).toBe(fingerprintRows(b));
+	});
+
+	it("still detects a genuine change in the same column", () => {
+		const before = rows({ total: 100.0 });
+		const after = rows({ total: 200.0 });
+		expect(fingerprintRows(before)).not.toBe(fingerprintRows(after));
+	});
+
+	it("detects a change beyond the significant-digit budget is NOT masked at the headline scale", () => {
+		// 12 sig-digits: a cents-level move on a million-scale value is preserved.
+		const before = rows({ total: 1234567.89 });
+		const after = rows({ total: 1234567.9 });
+		expect(fingerprintRows(before)).not.toBe(fingerprintRows(after));
+	});
+});
+
+describe("normalizeForFingerprint", () => {
+	it("rounds binary floats to the significant-digit budget", () => {
+		expect(normalizeForFingerprint(183996.89999999967)).toBe(183996.9);
+	});
+
+	it("leaves exact big-number STRINGS untouched (they arrive lossless from neo)", () => {
+		expect(normalizeForFingerprint("9007199254740993")).toBe(
+			"9007199254740993",
+		);
+		expect(normalizeForFingerprint("12345.67")).toBe("12345.67");
+	});
+
+	it("passes booleans, null, and text through unchanged", () => {
+		expect(normalizeForFingerprint(true)).toBe(true);
+		expect(normalizeForFingerprint(null)).toBe(null);
+		expect(normalizeForFingerprint("Income")).toBe("Income");
+	});
+
+	it("recurses into nested STRUCT / LIST values", () => {
+		const nested: Json = {
+			agg: [1.000000000001, 2.5],
+			meta: { ratio: 0.3333333333339 },
+		};
+		expect(normalizeForFingerprint(nested)).toEqual({
+			agg: [1, 2.5],
+			meta: { ratio: 0.333333333334 },
+		});
+	});
+
+	it("keeps non-finite floats deterministic (NaN/Infinity round to themselves)", () => {
+		expect(normalizeForFingerprint(Number.POSITIVE_INFINITY)).toBe(
+			Number.POSITIVE_INFINITY,
+		);
+		expect(Number.isNaN(normalizeForFingerprint(Number.NaN) as number)).toBe(
+			true,
+		);
+	});
+});

--- a/packages/cockpit/src/duckdb/report-fingerprint.test.ts
+++ b/packages/cockpit/src/duckdb/report-fingerprint.test.ts
@@ -23,7 +23,7 @@ describe("fingerprintRows — determinism", () => {
 		expect(fingerprintRows(rows({ v: 1 }))).toMatch(/^[0-9a-f]{64}$/);
 	});
 
-	it("distinguishes row order (the caller orders rows canonically before hashing)", () => {
+	it("is sensitive to row order (so the canonical ORDER BY ALL wrapping is load-bearing)", () => {
 		const ordered = rows({ k: "a", v: 1 }, { k: "b", v: 2 });
 		const swapped = rows({ k: "b", v: 2 }, { k: "a", v: 1 });
 		expect(fingerprintRows(ordered)).not.toBe(fingerprintRows(swapped));

--- a/packages/cockpit/src/duckdb/report-fingerprint.ts
+++ b/packages/cockpit/src/duckdb/report-fingerprint.ts
@@ -1,0 +1,75 @@
+// Report result fingerprint (DAT-625) — the staleness signal for a minted report.
+//
+// A report's data is LIVE (the SQL re-runs on every open) but its `summary` is
+// frozen prose baking in specific numbers. When the data drifts, the summary
+// silently lies. We detect drift by fingerprinting the result at mint and on each
+// regenerate, then comparing against a fresh fingerprint on open.
+//
+// Two correctness rules make the fingerprint a TRUE drift signal rather than a
+// flaky one — both learned the hard way (DAT-625 refinement):
+//
+//   1. DETERMINISTIC ORDER. DuckDB result order without ORDER BY varies run-to-run
+//      (parallel scan), so a raw row-prefix would flap — false "outdated" on data
+//      that never changed. We impose `ORDER BY ALL` (the SAME canonical order the
+//      grid uses, grid-query.ts) before truncating to the headline rows.
+//
+//   2. NUMERIC NORMALIZATION. A re-run `SUM(double)` over a re-ordered scan is NOT
+//      bit-identical (float addition isn't associative): 183996.89999999967 vs
+//      …90000000001. Hashing raw doubles → spurious drift. We round floats to
+//      FLOAT_SIG_DIGITS significant digits, which kills last-ULP noise across all
+//      magnitudes WITHOUT masking a genuine change. (This is a different rule from
+//      the grid's 2-decimal-place *display* rounding, which would collapse a small
+//      ratio column to 0.00 and hide real movement — wrong for a fingerprint.)
+//
+// The fingerprint is HEADLINE-scoped (first FINGERPRINT_ROW_LIMIT ordered rows),
+// not a full-result hash: cheap, and the summary only references headline numbers.
+// Big ints / decimals arrive as exact STRINGS from getRowObjectsJson and pass
+// through untouched; only binary floats (JS numbers) are normalized.
+//
+// This module is PURE (crypto + types only) so the determinism/normalization rules
+// are unit-tested without booting config/the lake. The lake-reading wrapper that
+// turns a report's SQL into a fingerprint lives in `report-fingerprint-read.ts`.
+
+import { createHash } from "node:crypto";
+import type { Json } from "@duckdb/node-api";
+
+/** Headline row cap for the fingerprint read. Bounded (cockpit "bound every data
+ * surface"); covers a typical GROUP-BY report whole, while keeping the read cheap
+ * for a large detail result. */
+export const FINGERPRINT_ROW_LIMIT = 200;
+
+/** Significant digits floats are rounded to before hashing. ~12 sig-digits sits
+ * well below a double's ~15-17 digit precision, so it absorbs the last few ULPs of
+ * non-associative-sum noise while still distinguishing any change a report summary
+ * would ever mention. */
+export const FLOAT_SIG_DIGITS = 12;
+
+/** Recursively round binary floats in a JSON value to FLOAT_SIG_DIGITS, leaving
+ * everything else (exact-string big numbers, booleans, null, text, nested keys)
+ * byte-identical. Integer-valued numbers survive unchanged within the digit
+ * budget; non-finite numbers (NaN/Infinity) round to themselves and serialize
+ * deterministically. */
+export function normalizeForFingerprint(value: Json): Json {
+	if (typeof value === "number") {
+		return Number.isFinite(value)
+			? Number(value.toPrecision(FLOAT_SIG_DIGITS))
+			: value;
+	}
+	if (Array.isArray(value)) return value.map(normalizeForFingerprint);
+	if (value !== null && typeof value === "object") {
+		const out: Record<string, Json> = {};
+		for (const [k, v] of Object.entries(value))
+			out[k] = normalizeForFingerprint(v);
+		return out;
+	}
+	return value;
+}
+
+/** Deterministic sha256 of a result's headline rows. Pure: same rows → same hash;
+ * float-noise-only differences collapse to the same hash; any normalized-value
+ * change yields a different hash. The rows are assumed already canonically ordered
+ * by the caller (see {@link computeReportFingerprint}); we hash them in order. */
+export function fingerprintRows(rows: Record<string, Json>[]): string {
+	const normalized = rows.map((row) => normalizeForFingerprint(row));
+	return createHash("sha256").update(JSON.stringify(normalized)).digest("hex");
+}

--- a/packages/cockpit/src/duckdb/report-fingerprint.ts
+++ b/packages/cockpit/src/duckdb/report-fingerprint.ts
@@ -46,9 +46,10 @@ export const FLOAT_SIG_DIGITS = 12;
 
 /** Recursively round binary floats in a JSON value to FLOAT_SIG_DIGITS, leaving
  * everything else (exact-string big numbers, booleans, null, text, nested keys)
- * byte-identical. Integer-valued numbers survive unchanged within the digit
- * budget; non-finite numbers (NaN/Infinity) round to themselves and serialize
- * deterministically. */
+ * byte-identical. Integer-valued numbers survive unchanged within the digit budget.
+ * The `Number.isFinite` guard is defensive: in practice getRowObjectsJson emits
+ * NaN/Infinity as the STRINGS "NaN"/"Infinity" (they pass through unchanged), but a
+ * non-finite JS number would still serialize deterministically rather than throw. */
 export function normalizeForFingerprint(value: Json): Json {
 	if (typeof value === "number") {
 		return Number.isFinite(value)

--- a/packages/cockpit/src/lib/report-summary-agent.ts
+++ b/packages/cockpit/src/lib/report-summary-agent.ts
@@ -17,9 +17,12 @@ import { config } from "#/config";
 import type { QueryResult } from "#/duckdb/query-result";
 import { MAX_OUTPUT_TOKENS, SUMMARY_MODEL } from "#/llm";
 
-const SYSTEM = `You refresh the saved summary of a data report. The report's SQL is unchanged; only the underlying data has moved, so some numbers/claims in the old summary are now stale.
+const SYSTEM = `You refresh the saved summary of a data report. The report's SQL is unchanged; only the underlying data has moved, so the figures and comparative claims in the previous summary may now be wrong.
 
-Given the PREVIOUS summary and the CURRENT result, rewrite the summary so every figure and claim matches the current result. Preserve the original voice, structure, length, and level of detail — change the numbers and any claim they support, nothing else. Do not add commentary about the refresh, the data change, or the SQL. Output only the new summary prose.`;
+Rewrite the summary so it accurately describes the CURRENT result. Rules:
+- Derive EVERY claim from the current result, never from the previous summary's wording. This covers the numbers AND every comparative or superlative claim: which value is largest or smallest, the ranking/ordering of items, and words like "dominates", "leads", "top", "second", "negligible". Compare the actual current figures to decide these — do not assume the result rows are sorted by magnitude, and do not carry a ranking over from the old summary.
+- Keep the previous summary's voice, tone, length, and overall shape — but any claim the current data contradicts MUST change, even if that reshapes the sentence. Correctness outranks matching the old structure.
+- Do not mention the refresh, the data change, the SQL, or that you are an AI. Output only the new summary prose.`;
 
 /** How many headline rows of the fresh result to put in front of the model. The
  * result is already bounded to the fingerprint's headline rows; this caps the prompt

--- a/packages/cockpit/src/lib/report-summary-agent.ts
+++ b/packages/cockpit/src/lib/report-summary-agent.ts
@@ -1,0 +1,53 @@
+// Report-summary regenerator (DAT-625) — a Haiku ONE-SHOT that refreshes a stale
+// report summary against the current result. Nested `chat()` with an outputSchema,
+// the proven nav-agent / answer-tool pattern; runs only when the user clicks
+// "Regenerate" on an outdated report. SERVER-ONLY (adapter + key).
+//
+// Unlike the nav-agent, this is NOT best-effort: a failure surfaces to the caller so
+// the route can report it and keep the old summary + outdated badge — a wrong refresh
+// would silently replace a human-trusted summary with worse prose, so we'd rather
+// fail loudly than guess. The SQL is unchanged; only the data moved, so the job is
+// purely "restate the same analysis with the current numbers, same voice".
+
+import { chat } from "@tanstack/ai";
+import { createAnthropicChat } from "@tanstack/ai-anthropic";
+import { z } from "zod";
+
+import { config } from "#/config";
+import type { QueryResult } from "#/duckdb/query-result";
+import { MAX_OUTPUT_TOKENS, SUMMARY_MODEL } from "#/llm";
+
+const SYSTEM = `You refresh the saved summary of a data report. The report's SQL is unchanged; only the underlying data has moved, so some numbers/claims in the old summary are now stale.
+
+Given the PREVIOUS summary and the CURRENT result, rewrite the summary so every figure and claim matches the current result. Preserve the original voice, structure, length, and level of detail — change the numbers and any claim they support, nothing else. Do not add commentary about the refresh, the data change, or the SQL. Output only the new summary prose.`;
+
+/** How many headline rows of the fresh result to put in front of the model. The
+ * result is already bounded to the fingerprint's headline rows; this caps the prompt
+ * payload further so a wide result can't blow the Haiku context. */
+const PROMPT_ROW_CAP = 50;
+
+/**
+ * Regenerate a report's summary against its current result via a Haiku one-shot,
+ * preserving the original voice. Throws on any LLM failure — the caller keeps the old
+ * summary and the outdated badge rather than persisting an unverified replacement.
+ */
+export async function regenerateSummary(
+	oldSummary: string,
+	result: QueryResult,
+): Promise<string> {
+	const preview = {
+		columns: result.columns,
+		rows: result.rows.slice(0, PROMPT_ROW_CAP),
+		rowCount: result.rowCount,
+	};
+	const userContent = `PREVIOUS SUMMARY:\n${oldSummary}\n\nCURRENT RESULT (JSON):\n${JSON.stringify(preview)}`;
+
+	const { summary } = await chat({
+		adapter: createAnthropicChat(SUMMARY_MODEL, config.anthropicApiKey),
+		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
+		systemPrompts: [{ content: SYSTEM }],
+		messages: [{ role: "user", content: userContent }],
+		outputSchema: z.object({ summary: z.string() }),
+	});
+	return summary;
+}

--- a/packages/cockpit/src/llm.ts
+++ b/packages/cockpit/src/llm.ts
@@ -23,6 +23,12 @@ export const MODEL = "claude-sonnet-4-6";
 // dated `claude-haiku-4-5-20251001` only if the alias ever fails to resolve.
 export const NAV_MODEL = "claude-haiku-4-5";
 
+// The report-summary regenerator's model (DAT-625) — a cheap Haiku one-shot that
+// rewrites a stale report summary against the fresh result, in the original voice.
+// Same undated Haiku alias as NAV_MODEL; kept as its own constant so the model
+// choice for this surface is explicit and tunable independently.
+export const SUMMARY_MODEL = "claude-haiku-4-5";
+
 export const MAX_OUTPUT_TOKENS = 24576;
 
 // The agent-loop iteration ceiling for /api/chat. chat() defaults to

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/reports/$reportId.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/reports/$reportId.tsx
@@ -15,15 +15,24 @@ import {
 	useRouter,
 } from "@tanstack/react-router";
 import { createServerFn, useServerFn } from "@tanstack/react-start";
-import { Check, Pencil, Trash2, TriangleAlert, X } from "lucide-react";
+import {
+	Check,
+	Pencil,
+	RefreshCw,
+	Trash2,
+	TriangleAlert,
+	X,
+} from "lucide-react";
 import { useState } from "react";
 import {
 	getReport,
 	renameReport,
 	setReportFingerprint,
 	softDeleteReport,
+	updateReportSummary,
 } from "#/db/cockpit/reports";
 import { computeReportFingerprint } from "#/duckdb/report-fingerprint-read";
+import { regenerateSummary } from "#/lib/report-summary-agent";
 import { ConfidenceStrip } from "#/ui/cockpit/widgets/answer-result";
 import { ResultGridWidget } from "#/ui/cockpit/widgets/result-grid";
 
@@ -75,6 +84,20 @@ const deleteReportFn = createServerFn({ method: "POST" })
 		await softDeleteReport(reportId);
 	});
 
+// Regenerate (DAT-625): re-run the SQL, hand the old summary + fresh result to Haiku,
+// and persist the new summary together with the fresh fingerprint — the one path that
+// mutates `summary`. A throw here (missing report, LLM failure) propagates to the
+// caller, which keeps the old summary + outdated badge rather than half-applying.
+const regenerateSummaryFn = createServerFn({ method: "POST" })
+	.inputValidator((reportId: string) => reportId)
+	.handler(async ({ data: reportId }) => {
+		const report = await getReport(reportId);
+		if (!report) throw notFound();
+		const { fingerprint, result } = await computeReportFingerprint(report.sql);
+		const summary = await regenerateSummary(report.summary, result);
+		await updateReportSummary(reportId, summary, fingerprint);
+	});
+
 export const Route = createFileRoute(
 	"/(app)/workspace/$wsId/reports/$reportId",
 )({
@@ -93,6 +116,7 @@ function ReportDetail() {
 	const navigate = useNavigate();
 	const rename = useServerFn(renameReportFn);
 	const remove = useServerFn(deleteReportFn);
+	const regenerate = useServerFn(regenerateSummaryFn);
 
 	const [editing, setEditing] = useState(false);
 	// Seeded when the editor opens (below), NOT from useState(report.title): after a
@@ -100,6 +124,24 @@ function ReportDetail() {
 	// once-initialized draft would show the stale pre-rename title on the next open.
 	const [draft, setDraft] = useState("");
 	const [busy, setBusy] = useState(false);
+	const [regenerating, setRegenerating] = useState(false);
+	const [regenFailed, setRegenFailed] = useState(false);
+
+	// Refresh the stale summary: regenerate server-side, then re-load so the new prose
+	// + cleared badge render. On failure keep the old summary + badge and flag inline.
+	const refreshSummary = async () => {
+		setRegenerating(true);
+		setRegenFailed(false);
+		try {
+			await regenerate({ data: report.id });
+			await router.invalidate();
+		} catch (err) {
+			console.error("[reports] regenerate summary failed:", err);
+			setRegenFailed(true);
+		} finally {
+			setRegenerating(false);
+		}
+	};
 
 	// Mutations fired by user events live in handlers, not effects (React conv. 4).
 	const saveTitle = async () => {
@@ -205,7 +247,23 @@ function ReportDetail() {
 							>
 								Outdated — data changed since this summary
 							</Badge>
+							<Button
+								variant="light"
+								color="yellow"
+								size="compact-xs"
+								leftSection={<RefreshCw size={13} />}
+								onClick={refreshSummary}
+								loading={regenerating}
+								data-testid="report-regenerate"
+							>
+								Regenerate
+							</Button>
 						</Group>
+					)}
+					{regenFailed && (
+						<Text size="xs" c="red" data-testid="report-regenerate-error">
+							Couldn’t regenerate the summary — try again.
+						</Text>
 					)}
 					<Text>{report.summary}</Text>
 				</Stack>

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/reports/$reportId.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/reports/$reportId.tsx
@@ -1,5 +1,6 @@
 import {
 	ActionIcon,
+	Badge,
 	Button,
 	Group,
 	Stack,
@@ -14,27 +15,53 @@ import {
 	useRouter,
 } from "@tanstack/react-router";
 import { createServerFn, useServerFn } from "@tanstack/react-start";
-import { Check, Pencil, Trash2, X } from "lucide-react";
+import { Check, Pencil, Trash2, TriangleAlert, X } from "lucide-react";
 import { useState } from "react";
 import {
 	getReport,
 	renameReport,
+	setReportFingerprint,
 	softDeleteReport,
 } from "#/db/cockpit/reports";
+import { computeReportFingerprint } from "#/duckdb/report-fingerprint-read";
 import { ConfidenceStrip } from "#/ui/cockpit/widgets/answer-result";
 import { ResultGridWidget } from "#/ui/cockpit/widgets/result-grid";
 
-// Report detail (DAT-624) — the frozen artifact rendered over LIVE data: the SQL is
-// re-run on every open through the same result-grid stream, so numbers stay current.
-// The title is the one editable field (inline); the SQL / summary / confidence are
-// immutable. Delete is soft (the row stays; children keep their lineage).
+// Report detail (DAT-624 / DAT-625) — the frozen artifact rendered over LIVE data:
+// the SQL is re-run on every open through the same result-grid stream, so numbers
+// stay current. The title is the one editable field (inline); the SQL / confidence
+// are immutable; the summary is frozen prose, refreshed only via regenerate. Delete
+// is soft (the row stays; children keep their lineage).
+//
+// On open we re-fingerprint the live result (DAT-625) and compare it to the stored
+// fingerprint: a mismatch means the frozen summary is talking about stale numbers, so
+// it's badged "outdated". A null stored fingerprint (pre-DAT-625 report, or a failed
+// mint-time fingerprint) is lazy-backfilled here — start tracking, show clean.
 //
 // The loader + action server fns are defined inline (the cockpit route convention)
-// so the plugin strips their cockpit_db handlers from the client bundle.
+// so the plugin strips their cockpit_db + lake handlers from the client bundle.
 
 const loadReport = createServerFn({ method: "GET" })
 	.inputValidator((reportId: string) => reportId)
-	.handler(async ({ data: reportId }) => getReport(reportId));
+	.handler(async ({ data: reportId }) => {
+		const report = await getReport(reportId);
+		if (!report) return null;
+		let outdated = false;
+		try {
+			const { fingerprint } = await computeReportFingerprint(report.sql);
+			if (report.summaryFingerprint === null) {
+				// First time we can fingerprint this report — backfill, don't badge.
+				await setReportFingerprint(report.id, fingerprint);
+			} else {
+				outdated = report.summaryFingerprint !== fingerprint;
+			}
+		} catch (err) {
+			// Best-effort: if the live result can't be fingerprinted (a since-broken
+			// SQL, a lake hiccup), don't badge — the grid surfaces the real error.
+			console.error("[reports] drift check failed — not flagging:", err);
+		}
+		return { report, outdated };
+	});
 
 const renameReportFn = createServerFn({ method: "POST" })
 	.inputValidator((data: { id: string; title: string }) => data)
@@ -52,15 +79,15 @@ export const Route = createFileRoute(
 	"/(app)/workspace/$wsId/reports/$reportId",
 )({
 	loader: async ({ params }) => {
-		const report = await loadReport({ data: params.reportId });
-		if (!report) throw notFound();
-		return report;
+		const data = await loadReport({ data: params.reportId });
+		if (!data) throw notFound();
+		return data;
 	},
 	component: ReportDetail,
 });
 
 function ReportDetail() {
-	const report = Route.useLoaderData();
+	const { report, outdated } = Route.useLoaderData();
 	const { wsId } = Route.useParams();
 	const router = useRouter();
 	const navigate = useNavigate();
@@ -165,7 +192,24 @@ function ReportDetail() {
 				</Button>
 			</Group>
 
-			{report.summary && <Text>{report.summary}</Text>}
+			{report.summary && (
+				<Stack gap="xs">
+					{outdated && (
+						<Group gap="xs">
+							<Badge
+								color="yellow"
+								variant="light"
+								leftSection={<TriangleAlert size={12} />}
+								tt="none"
+								data-testid="report-outdated"
+							>
+								Outdated — data changed since this summary
+							</Badge>
+						</Group>
+					)}
+					<Text>{report.summary}</Text>
+				</Stack>
+			)}
 			<ConfidenceStrip confidence={report.confidence} />
 			<ResultGridWidget state={{ kind: "result-grid", sql: report.sql }} />
 		</Stack>

--- a/packages/cockpit/src/routes/api/reports/mint.ts
+++ b/packages/cockpit/src/routes/api/reports/mint.ts
@@ -9,6 +9,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { resolveActiveWorkspace } from "#/db/cockpit/registry";
 import { createReport } from "#/db/cockpit/reports";
+import { computeReportFingerprint } from "#/duckdb/report-fingerprint-read";
 import type { AnswerConfidence } from "#/ui/cockpit/canvas-state";
 
 interface MintBody {
@@ -25,6 +26,20 @@ export const Route = createFileRoute("/api/reports/mint")({
 			POST: async ({ request }) => {
 				const body = (await request.json()) as MintBody;
 				const workspaceId = await resolveActiveWorkspace();
+				// Fingerprint the result at mint so the summary can be flagged outdated
+				// when the live data drifts (DAT-625). Best-effort: a fingerprint failure
+				// must not block minting — null is lazy-backfilled on first open.
+				let summaryFingerprint: string | null = null;
+				try {
+					({ fingerprint: summaryFingerprint } = await computeReportFingerprint(
+						body.sql,
+					));
+				} catch (err) {
+					console.error(
+						"[reports] mint fingerprint failed — backfill on open:",
+						err,
+					);
+				}
 				const id = await createReport({
 					workspaceId,
 					conversationId: body.conversationId ?? null,
@@ -32,6 +47,7 @@ export const Route = createFileRoute("/api/reports/mint")({
 					summary: body.summary,
 					sql: body.sql,
 					confidence: body.confidence,
+					summaryFingerprint,
 				});
 				return Response.json({ id });
 			},


### PR DESCRIPTION
Phase 2 of the Cockpit Reports epic (DAT-623). A minted report is `{ frozen SQL + summary + confidence }` over **live** data — the SQL re-runs on every open. The `summary` is frozen prose baking in numbers, so when the data drifts the summary silently lies. This detects drift and lets the user refresh the prose in one click, without re-freezing the data.

## What it does
- **Fingerprint** the result at mint and on each regenerate — `sha256` of the first 200 rows of `SELECT * FROM (<sql>) ORDER BY ALL LIMIT 200`, floats normalized to 12 significant digits.
- **Drift on open**: the detail loader re-fingerprints the live result and compares to the stored one — a mismatch badges the summary **Outdated**.
- **Regenerate**: a one-click Haiku one-shot rewrites the summary against the fresh result (same voice), persists the new summary + fresh fingerprint atomically, and clears the badge.
- **Lazy backfill**: a null stored fingerprint (pre-DAT-625 report, or a failed mint-time fingerprint) is computed-and-stored on first open — start tracking, shown clean.

## Two correctness rules (the reason the drift signal is true, not flaky)
- **`ORDER BY ALL` before truncation** — DuckDB scan order isn't stable run-to-run, so a raw row-prefix would flap false "outdated". Uses the same canonical order the grid does.
- **Float normalization to 12 sig-digits** — a re-ordered `SUM(double)` isn't bit-identical, so hashing raw doubles would register false drift. (Different rule from the grid's 2-dp *display* rounding, which would mask small-magnitude change.)

## Error philosophy
Mint + drift-check are **best-effort** (a fingerprint failure never blocks the user — null is backfilled later). Regenerate **throws** (a failure keeps the old summary + badge rather than persisting unverified prose).

## Verification
- **tsc + biome green.** Unit tests: 11 (fingerprint determinism + FP-noise immunity + normalization) + 9 (data-layer mutators, incl. the `summary`-immutability guarantee).
- **Container-smoked** (prod build, not dev): mint stores a fingerprint · clean open shows no badge · tampered fingerprint → Outdated badge + Regenerate button (old summary preserved) · lazy-backfill recomputes a fingerprint **identical to the mint-time hash** (cross-run determinism) · **real Haiku regenerate**: given a deliberately wrong-number summary, Haiku rewrote it with every figure corrected to the live data, badge cleared. 0 console errors throughout.
- **Reviews:** senior-code-reviewer **APPROVE**, spec-compliance-reviewer **COMPLIANT**. Senior's one actionable (drop the unused `params` arg) is applied.

## Note
A late commit tightens the regenerate prompt so comparative/superlative claims (rankings, "dominates/second/negligible") are re-derived from the current figures rather than inherited from the old sentence skeleton. The original prompt was smoked end-to-end (numbers corrected) but muddled an item *ranking*; the tightened prompt's re-smoke is pending the local backend coming back up — code is tsc/biome/unit green.

Cockpit-only; no cross-repo handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)