### PR TITLE
DAT-600: per-call LLM latency + token telemetry (engine)

### DIFF
--- a/packages/engine/src/dataraum/analysis/cycles/agent.py
+++ b/packages/engine/src/dataraum/analysis/cycles/agent.py
@@ -134,6 +134,7 @@ class BusinessCycleAgent(LLMFeature):
             system=system_prompt,
             tools=[tool],
             tool_choice={"type": "tool", "name": "submit_analysis"},
+            label="business_cycles",
             max_tokens=self.MAX_TOKENS,
             temperature=temperature,
             model=model,

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -190,6 +190,7 @@ class SemanticAgent(LLMFeature):
             system=system_prompt,
             tools=[tool],
             tool_choice={"type": "tool", "name": "analyze_tables"},
+            label="semantic_per_table",
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
             model=model,

--- a/packages/engine/src/dataraum/analysis/semantic/column_agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/column_agent.py
@@ -145,6 +145,7 @@ class ColumnAnnotationAgent(LLMFeature):
             system=system_prompt,
             tools=[tool],
             tool_choice={"type": "tool", "name": "annotate_columns"},
+            label="column_annotation",
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
             model=model,

--- a/packages/engine/src/dataraum/analysis/slicing/agent.py
+++ b/packages/engine/src/dataraum/analysis/slicing/agent.py
@@ -121,6 +121,7 @@ class SlicingAgent(LLMFeature):
             system=system_prompt,
             tools=[tool],
             tool_choice={"type": "tool", "name": "analyze_slicing"},
+            label="slicing_analysis",
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
         )

--- a/packages/engine/src/dataraum/analysis/validation/agent.py
+++ b/packages/engine/src/dataraum/analysis/validation/agent.py
@@ -352,6 +352,7 @@ class ValidationAgent(LLMFeature):
             system=system_prompt,
             tools=[tool],
             tool_choice={"type": "tool", "name": "generate_validation_sql"},
+            label="validation_sql",
             max_tokens=self.MAX_TOKENS,
             temperature=temperature,
             model=model,

--- a/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
+++ b/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
@@ -121,6 +121,7 @@ class EnrichmentAgent(LLMFeature):
             system=system_prompt,
             tools=[tool],
             tool_choice={"type": "tool", "name": "analyze_enrichment"},
+            label="enrichment_analysis",
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
             model=model,

--- a/packages/engine/src/dataraum/documentation/agent.py
+++ b/packages/engine/src/dataraum/documentation/agent.py
@@ -117,6 +117,7 @@ class BatchPlanAgent:
             system=system_prompt,
             tools=[tool],
             tool_choice={"type": "tool", "name": "batch_action_plan"},
+            label="config_fix",
             max_tokens=4096,
             temperature=temperature,
             model=self.model,

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -462,6 +462,7 @@ class GraphAgent(LLMFeature):
             system=system_prompt,
             tools=[tool],
             tool_choice={"type": "tool", "name": "generate_sql"},
+            label="graph_sql_generation",
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
             model=model,
@@ -801,6 +802,7 @@ class GraphAgent(LLMFeature):
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
             model=self.provider.get_model_for_tier(model_tier),
+            label="sql_repair",
         )
 
         # converse raises a typed ProviderError on an API failure (DAT-503) —

--- a/packages/engine/src/dataraum/llm/providers/anthropic.py
+++ b/packages/engine/src/dataraum/llm/providers/anthropic.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any, cast
 
 import anthropic
@@ -174,7 +175,9 @@ class AnthropicProvider(LLMProvider):
             if request.tool_choice:
                 kwargs["tool_choice"] = request.tool_choice
 
+            start = time.perf_counter()
             response = self.client.messages.create(**kwargs)
+            elapsed_ms = round((time.perf_counter() - start) * 1000)
 
             # Extract content and tool calls from response
             text_content = ""
@@ -192,14 +195,45 @@ class AnthropicProvider(LLMProvider):
                         )
                     )
 
+            # Cache-usage fields are optional on the SDK Usage object (None when
+            # no cache_control is in play — the engine today, until DAT-601);
+            # coerce only None to 0 so telemetry stays numeric while preserving a
+            # genuine int(0) ("caching configured, nothing read") once 601 lands.
+            usage = response.usage
+            cache_read = (
+                usage.cache_read_input_tokens if usage.cache_read_input_tokens is not None else 0
+            )
+            cache_creation = (
+                usage.cache_creation_input_tokens
+                if usage.cache_creation_input_tokens is not None
+                else 0
+            )
+
+            # Per-call telemetry (DAT-600): elapsed + token usage, tagged by the
+            # caller's agent/phase label. Latency is output-decode-dominated, so
+            # output_tokens vs elapsed_ms is the wall-clock signal; the cache
+            # fields are the DAT-601 cost lever (zero until caching lands).
+            logger.info(
+                "llm_call",
+                label=request.label,
+                model=response.model,
+                elapsed_ms=elapsed_ms,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cache_read_input_tokens=cache_read,
+                cache_creation_input_tokens=cache_creation,
+            )
+
             return Result.ok(
                 ConversationResponse(
                     content=text_content,
                     tool_calls=tool_calls,
                     stop_reason=response.stop_reason or "end_turn",
                     model=response.model,
-                    input_tokens=response.usage.input_tokens,
-                    output_tokens=response.usage.output_tokens,
+                    input_tokens=usage.input_tokens,
+                    output_tokens=usage.output_tokens,
+                    cache_read_input_tokens=cache_read,
+                    cache_creation_input_tokens=cache_creation,
                 )
             )
 

--- a/packages/engine/src/dataraum/llm/providers/base.py
+++ b/packages/engine/src/dataraum/llm/providers/base.py
@@ -100,6 +100,10 @@ class ConversationRequest(BaseModel):
     max_tokens: int = 4096
     temperature: float = 0.0
     model: str | None = None  # Override default model
+    # Greppable agent/phase tag for per-call telemetry (DAT-600). The provider
+    # has no phase context of its own, so each call site stamps the prompt
+    # template / feature name it is invoking (e.g. "graph_sql_generation").
+    label: str | None = None
 
 
 class ConversationResponse(BaseModel):
@@ -111,6 +115,10 @@ class ConversationResponse(BaseModel):
     model: str
     input_tokens: int
     output_tokens: int
+    # Prompt-cache usage (DAT-600). Captured for telemetry today; the verifier
+    # for DAT-601 (engine prompt caching) reads cache_read to confirm hits.
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
 
 
 class LLMProvider(ABC):

--- a/packages/engine/tests/unit/llm/test_anthropic_provider.py
+++ b/packages/engine/tests/unit/llm/test_anthropic_provider.py
@@ -9,6 +9,7 @@ Result.error every intermediate layer would have to forward faithfully.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import anthropic
@@ -136,3 +137,94 @@ class TestConverseRaisesTypedError:
         with pytest.raises(TransientProviderError) as ei:
             provider.converse(_request())
         assert ei.value.__cause__ is original
+
+
+def _ok_response(
+    *,
+    input_tokens: int = 100,
+    output_tokens: int = 20,
+    cache_read: int | None = 0,
+    cache_creation: int | None = 0,
+) -> SimpleNamespace:
+    """A minimal stand-in for the SDK Message a successful create() returns.
+
+    ``cache_read``/``cache_creation`` default to 0 but accept ``None`` to mirror
+    the SDK, which leaves those Usage fields unset when no ``cache_control`` is
+    in play (the engine today, until DAT-601).
+    """
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="hello")],
+        stop_reason="end_turn",
+        model="claude-x",
+        usage=SimpleNamespace(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
+        ),
+    )
+
+
+class TestConverseTelemetry:
+    """converse emits per-call latency + token telemetry (DAT-600) and surfaces
+    the cache-usage fields on the response."""
+
+    def test_logs_label_and_all_token_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _provider()
+        monkeypatch.setattr(
+            provider.client.messages,
+            "create",
+            lambda **_: _ok_response(
+                input_tokens=512, output_tokens=64, cache_read=480, cache_creation=32
+            ),
+        )
+        log = MagicMock()
+        monkeypatch.setattr("dataraum.llm.providers.anthropic.logger", log)
+
+        request = ConversationRequest(
+            messages=[Message(role="user", content="hi")], label="graph_sql_generation"
+        )
+        provider.converse(request).unwrap()
+
+        log.info.assert_called_once()
+        event, kwargs = log.info.call_args.args[0], log.info.call_args.kwargs
+        assert event == "llm_call"
+        assert kwargs["label"] == "graph_sql_generation"
+        assert kwargs["model"] == "claude-x"
+        assert isinstance(kwargs["elapsed_ms"], int) and kwargs["elapsed_ms"] >= 0
+        assert kwargs["input_tokens"] == 512
+        assert kwargs["output_tokens"] == 64
+        assert kwargs["cache_read_input_tokens"] == 480
+        assert kwargs["cache_creation_input_tokens"] == 32
+
+    def test_response_carries_cache_usage(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _provider()
+        monkeypatch.setattr(
+            provider.client.messages,
+            "create",
+            lambda **_: _ok_response(cache_read=480, cache_creation=32),
+        )
+
+        resp = provider.converse(_request()).unwrap()
+
+        assert resp.cache_read_input_tokens == 480
+        assert resp.cache_creation_input_tokens == 32
+
+    def test_missing_cache_fields_coerce_to_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No cache_control today → SDK leaves the Usage cache fields as None;
+        # telemetry must stay numeric, not propagate None.
+        provider = _provider()
+        monkeypatch.setattr(
+            provider.client.messages,
+            "create",
+            lambda **_: _ok_response(cache_read=None, cache_creation=None),
+        )
+        log = MagicMock()
+        monkeypatch.setattr("dataraum.llm.providers.anthropic.logger", log)
+
+        resp = provider.converse(_request()).unwrap()
+
+        assert resp.cache_read_input_tokens == 0
+        assert resp.cache_creation_input_tokens == 0
+        assert log.info.call_args.kwargs["cache_read_input_tokens"] == 0
+        assert log.info.call_args.kwargs["cache_creation_input_tokens"] == 0


### PR DESCRIPTION
**Epic:** DAT-599 (LLM agent latency & efficiency) · **Task:** DAT-600, engine half. The cockpit half follows on its own branch.

## What
Foundation telemetry so we stop optimizing the engine's LLM agents blind. Every successful `AnthropicProvider.converse` now emits one structured `llm_call` log at the single chokepoint:

`label · model · elapsed_ms · input_tokens · output_tokens · cache_read_input_tokens · cache_creation_input_tokens`

- Times `messages.create()` with `perf_counter`.
- Captures the two cache-usage fields that were previously **dropped** (None→0 coercion that preserves a genuine `int(0)` once DAT-601 lands), and surfaces them on `ConversationResponse` so DAT-601's caching verifier can read them.
- Adds an optional `label` to `ConversationRequest`; stamps each of the 9 `converse()` call sites with its rendered prompt-template name (greppable against `dataraum-config/llm/prompts/`): `graph_sql_generation`, `sql_repair`, `column_annotation`, `semantic_per_table`, `slicing_analysis`, `validation_sql`, `enrichment_analysis`, `business_cycles`, `config_fix`.

## Scope
Logging only. No prompt caching (DAT-601, deferred pending these numbers), no cockpit changes, no metrics fan-out restructure.

## Where the data lands
Structured log → stderr → `engine-worker` container logs. No aggregator yet (consistent with "logging only"):
`docker compose -f packages/infra/docker-compose.yml logs engine-worker | grep llm_call`
Worker runs console format today; a JSON-format toggle + per-run `run_id` correlation are noted as a small follow-on if repeatable analysis is wanted.

## Tests / gates
ruff + format + mypy clean; provider suite 24/24; full engine unit suite 1648 passed. Senior + spec-compliance reviewers both APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)