### PR TITLE
DAT-600: per-call LLM telemetry (cockpit)

### DIFF
--- a/packages/cockpit/src/lib/agent-turn.ts
+++ b/packages/cockpit/src/lib/agent-turn.ts
@@ -20,6 +20,7 @@ import {
 	type ConversationKind,
 } from "#/db/cockpit/conversations";
 import { publish } from "#/lib/chat-bus";
+import { llmTelemetryMiddleware } from "#/lib/llm-telemetry";
 import { AGENT_LOOP_MAX_ITERATIONS, MAX_OUTPUT_TOKENS, MODEL } from "#/llm";
 import { getInstructions } from "#/prompts";
 import { toolsByKind } from "#/tools/registry";
@@ -102,6 +103,9 @@ export function buildChatOptions(
 		messages,
 		tools: [...toolsByKind[kind]],
 		abortController,
+		// Per-turn LLM telemetry (DAT-600). Observe-only; tags this orchestrator
+		// turn distinctly from the nested `answer` sub-agent (tools/query.ts).
+		middleware: [llmTelemetryMiddleware("orchestrator")],
 	};
 }
 

--- a/packages/cockpit/src/lib/llm-telemetry.test.ts
+++ b/packages/cockpit/src/lib/llm-telemetry.test.ts
@@ -1,9 +1,12 @@
 // Unit test for the DAT-600 LLM telemetry middleware. Drives the hooks with
 // synthetic SDK fixtures (no chat() / no network) and asserts the emitted
-// `llm_call` line — snake_case keys + iteration count — mirrors the engine half.
+// `llm_call` line — snake_case keys, terminal status, iteration count — mirrors
+// the engine half.
 
 import type {
+	AbortInfo,
 	ChatMiddlewareContext,
+	ErrorInfo,
 	FinishInfo,
 	IterationInfo,
 	UsageInfo,
@@ -35,7 +38,7 @@ const usage = (over: Partial<UsageInfo>): UsageInfo =>
 afterEach(() => vi.restoreAllMocks());
 
 describe("llmTelemetryMiddleware", () => {
-	it("emits one llm_call with label, model, elapsed, mapped tokens, and iteration count", () => {
+	it("emits one finished llm_call with label, model, elapsed, mapped tokens, iterations", () => {
 		const info = vi.spyOn(console, "info").mockImplementation(() => {});
 		const mw = llmTelemetryMiddleware("answer_subagent");
 
@@ -59,6 +62,7 @@ describe("llmTelemetryMiddleware", () => {
 		expect(info).toHaveBeenCalledWith("llm_call", {
 			label: "answer_subagent",
 			model: "claude-x",
+			status: "finished",
 			elapsed_ms: 4201, // rounded
 			input_tokens: 512,
 			output_tokens: 64,
@@ -72,12 +76,13 @@ describe("llmTelemetryMiddleware", () => {
 		const info = vi.spyOn(console, "info").mockImplementation(() => {});
 		const mw = llmTelemetryMiddleware("orchestrator");
 
-		// No usage on the finish info, and no iterations recorded.
+		// usage field absent on the finish info, and no iterations recorded.
 		mw.onFinish?.(ctx("claude-y"), finish({ duration: 10, usage: undefined }));
 
 		expect(info).toHaveBeenCalledWith("llm_call", {
 			label: "orchestrator",
 			model: "claude-y",
+			status: "finished",
 			elapsed_ms: 10,
 			input_tokens: 0,
 			output_tokens: 0,
@@ -85,6 +90,48 @@ describe("llmTelemetryMiddleware", () => {
 			cache_creation_input_tokens: 0,
 			iterations: 0,
 		});
+	});
+
+	it("logs aborted runs with status + elapsed and zero tokens (frame induction aborts deliberately)", () => {
+		const info = vi.spyOn(console, "info").mockImplementation(() => {});
+		const mw = llmTelemetryMiddleware("frame_family");
+
+		mw.onIteration?.(ctx("claude-x"), iter(0));
+		mw.onAbort?.(ctx("claude-x"), {
+			reason: "captured",
+			duration: 87.4,
+		} as AbortInfo);
+
+		expect(info).toHaveBeenCalledWith("llm_call", {
+			label: "frame_family",
+			model: "claude-x",
+			status: "aborted",
+			elapsed_ms: 87,
+			input_tokens: 0,
+			output_tokens: 0,
+			cache_read_input_tokens: 0,
+			cache_creation_input_tokens: 0,
+			iterations: 1,
+		});
+	});
+
+	it("logs errored runs with status + elapsed", () => {
+		const info = vi.spyOn(console, "info").mockImplementation(() => {});
+		const mw = llmTelemetryMiddleware("grounding");
+
+		mw.onError?.(ctx("claude-x"), {
+			error: new Error("boom"),
+			duration: 200,
+		} as ErrorInfo);
+
+		expect(info).toHaveBeenCalledWith(
+			"llm_call",
+			expect.objectContaining({
+				label: "grounding",
+				status: "error",
+				elapsed_ms: 200,
+			}),
+		);
 	});
 
 	it("keeps the iteration counter private per middleware instance", () => {

--- a/packages/cockpit/src/lib/llm-telemetry.test.ts
+++ b/packages/cockpit/src/lib/llm-telemetry.test.ts
@@ -1,0 +1,113 @@
+// Unit test for the DAT-600 LLM telemetry middleware. Drives the hooks with
+// synthetic SDK fixtures (no chat() / no network) and asserts the emitted
+// `llm_call` line — snake_case keys + iteration count — mirrors the engine half.
+
+import type {
+	ChatMiddlewareContext,
+	FinishInfo,
+	IterationInfo,
+	UsageInfo,
+} from "@tanstack/ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { llmTelemetryMiddleware } from "./llm-telemetry";
+
+const ctx = (model: string) => ({ model }) as unknown as ChatMiddlewareContext;
+
+const iter = (i: number) => ({ iteration: i }) as unknown as IterationInfo;
+
+const finish = (over: Partial<FinishInfo>): FinishInfo =>
+	({
+		finishReason: "stop",
+		duration: 1234,
+		content: "",
+		...over,
+	}) as FinishInfo;
+
+const usage = (over: Partial<UsageInfo>): UsageInfo =>
+	({
+		promptTokens: 0,
+		completionTokens: 0,
+		totalTokens: 0,
+		...over,
+	}) as UsageInfo;
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("llmTelemetryMiddleware", () => {
+	it("emits one llm_call with label, model, elapsed, mapped tokens, and iteration count", () => {
+		const info = vi.spyOn(console, "info").mockImplementation(() => {});
+		const mw = llmTelemetryMiddleware("answer_subagent");
+
+		// Three agent-loop iterations before the run finishes.
+		mw.onIteration?.(ctx("claude-x"), iter(0));
+		mw.onIteration?.(ctx("claude-x"), iter(1));
+		mw.onIteration?.(ctx("claude-x"), iter(2));
+		mw.onFinish?.(
+			ctx("claude-x"),
+			finish({
+				duration: 4200.7,
+				usage: usage({
+					promptTokens: 512,
+					completionTokens: 64,
+					promptTokensDetails: { cachedTokens: 480, cacheWriteTokens: 32 },
+				}),
+			}),
+		);
+
+		expect(info).toHaveBeenCalledTimes(1);
+		expect(info).toHaveBeenCalledWith("llm_call", {
+			label: "answer_subagent",
+			model: "claude-x",
+			elapsed_ms: 4201, // rounded
+			input_tokens: 512,
+			output_tokens: 64,
+			cache_read_input_tokens: 480,
+			cache_creation_input_tokens: 32,
+			iterations: 3,
+		});
+	});
+
+	it("coerces missing usage / cache details to zero", () => {
+		const info = vi.spyOn(console, "info").mockImplementation(() => {});
+		const mw = llmTelemetryMiddleware("orchestrator");
+
+		// No usage on the finish info, and no iterations recorded.
+		mw.onFinish?.(ctx("claude-y"), finish({ duration: 10, usage: undefined }));
+
+		expect(info).toHaveBeenCalledWith("llm_call", {
+			label: "orchestrator",
+			model: "claude-y",
+			elapsed_ms: 10,
+			input_tokens: 0,
+			output_tokens: 0,
+			cache_read_input_tokens: 0,
+			cache_creation_input_tokens: 0,
+			iterations: 0,
+		});
+	});
+
+	it("keeps the iteration counter private per middleware instance", () => {
+		const info = vi.spyOn(console, "info").mockImplementation(() => {});
+		const a = llmTelemetryMiddleware("a");
+		const b = llmTelemetryMiddleware("b");
+
+		a.onIteration?.(ctx("m"), iter(0));
+		a.onIteration?.(ctx("m"), iter(1));
+		b.onIteration?.(ctx("m"), iter(0));
+
+		a.onFinish?.(ctx("m"), finish({}));
+		b.onFinish?.(ctx("m"), finish({}));
+
+		expect(info).toHaveBeenNthCalledWith(
+			1,
+			"llm_call",
+			expect.objectContaining({ label: "a", iterations: 2 }),
+		);
+		expect(info).toHaveBeenNthCalledWith(
+			2,
+			"llm_call",
+			expect.objectContaining({ label: "b", iterations: 1 }),
+		);
+	});
+});

--- a/packages/cockpit/src/lib/llm-telemetry.test.ts
+++ b/packages/cockpit/src/lib/llm-telemetry.test.ts
@@ -119,19 +119,23 @@ describe("llmTelemetryMiddleware", () => {
 		const info = vi.spyOn(console, "info").mockImplementation(() => {});
 		const mw = llmTelemetryMiddleware("grounding");
 
+		mw.onIteration?.(ctx("claude-x"), iter(0));
 		mw.onError?.(ctx("claude-x"), {
 			error: new Error("boom"),
 			duration: 200,
 		} as ErrorInfo);
 
-		expect(info).toHaveBeenCalledWith(
-			"llm_call",
-			expect.objectContaining({
-				label: "grounding",
-				status: "error",
-				elapsed_ms: 200,
-			}),
-		);
+		expect(info).toHaveBeenCalledWith("llm_call", {
+			label: "grounding",
+			model: "claude-x",
+			status: "error",
+			elapsed_ms: 200,
+			input_tokens: 0,
+			output_tokens: 0,
+			cache_read_input_tokens: 0,
+			cache_creation_input_tokens: 0,
+			iterations: 1,
+		});
 	});
 
 	it("keeps the iteration counter private per middleware instance", () => {

--- a/packages/cockpit/src/lib/llm-telemetry.ts
+++ b/packages/cockpit/src/lib/llm-telemetry.ts
@@ -1,39 +1,70 @@
 // Per-call LLM telemetry (DAT-600, cockpit half of epic DAT-599).
 //
 // A @tanstack/ai chat() middleware that emits ONE structured `llm_call` line per
-// turn — the cockpit mirror of the engine's provider-chokepoint log. Attach it to
-// each chat() with a distinct `label` so the orchestrator turn and the nested
-// `answer` sub-agent loop are attributable SEPARATELY (the epic suspects that
+// chat() run — the cockpit mirror of the engine's provider-chokepoint log. Attach
+// it to every chat() with a distinct `label` so each call site (orchestrator turn,
+// the nested `answer` sub-agent loop, the why-* narratives, frame induction, nav
+// classifier, grounding agent) is attributable separately (the epic suspects the
 // sub-agent loop is the latency multiplier — DAT-605 reads `iterations` from here).
 //
 // SERVER-ONLY: chat() runs server-side, so `console.info` lands on the cockpit
 // server process stdout (Nitro/Bun) — `docker compose logs cockpit` in a
-// container, the dev-server terminal under `bun --bun run dev`.
+// container, the dev-server terminal under `bun --bun run dev`. The grounding
+// agent runs in the co-located TS worker, so its lines land on that process.
 //
 // The key names are deliberately snake_case to match the engine's `llm_call`
 // shape, so `grep llm_call | jq` aggregates identically across both stacks even
 // though @tanstack/ai's TokenUsage is camelCase. The mapping:
-//   promptTokens                      -> input_tokens
-//   completionTokens                  -> output_tokens
-//   promptTokensDetails.cachedTokens  -> cache_read_input_tokens
-//   promptTokensDetails.cacheWriteTokens -> cache_creation_input_tokens
-// `elapsed_ms` is the whole-run duration the SDK already measures (FinishInfo).
+//   promptTokens                          -> input_tokens
+//   completionTokens                      -> output_tokens
+//   promptTokensDetails.cachedTokens      -> cache_read_input_tokens
+//   promptTokensDetails.cacheWriteTokens  -> cache_creation_input_tokens
+// `elapsed_ms` is the run duration the SDK already measures.
+//
+// The SDK guarantees exactly one terminal hook per run (onFinish/onAbort/onError),
+// so we log on all three with a `status` — unlike the engine (success-only), the
+// cockpit has deliberate early-abort paths (frame induction aborts after the
+// forced tool fires, ×4/frame), and an aborted/errored turn is still latency data.
+// Tokens are only known on a clean finish; abort/error lines carry zeros.
 //
 // Granularity note: the engine logs one line per model call; here one line is a
-// whole chat() turn — the RUN_FINISHED usage is the loop total across iterations
+// whole chat() run — the RUN_FINISHED usage is the loop total across iterations
 // (orchestrator ≤20, sub-agent ≤10). That is the right grain for "which agent
-// dominates wall-clock"; `iterations` exposes the per-turn round-trip depth.
+// dominates wall-clock"; `iterations` exposes the per-run round-trip depth.
 
-import type { ChatMiddleware } from "@tanstack/ai";
+import type { ChatMiddleware, TokenUsage } from "@tanstack/ai";
+
+type CallStatus = "finished" | "aborted" | "error";
+
+function emitLlmCall(
+	label: string,
+	model: string,
+	status: CallStatus,
+	durationMs: number,
+	iterations: number,
+	usage?: TokenUsage,
+): void {
+	const promptDetails = usage?.promptTokensDetails;
+	console.info("llm_call", {
+		label,
+		model,
+		status,
+		elapsed_ms: Math.round(durationMs),
+		input_tokens: usage?.promptTokens ?? 0,
+		output_tokens: usage?.completionTokens ?? 0,
+		cache_read_input_tokens: promptDetails?.cachedTokens ?? 0,
+		cache_creation_input_tokens: promptDetails?.cacheWriteTokens ?? 0,
+		iterations,
+	});
+}
 
 /**
  * Build a logging middleware that emits a single `llm_call` telemetry line when a
- * chat() turn finishes. `label` tags the call site (e.g. "orchestrator" /
- * "answer_subagent"). Observe-only — it never transforms config; an aborted or
- * errored turn emits nothing (parity with the engine, which logs success only).
+ * chat() run reaches a terminal hook. `label` tags the call site (e.g.
+ * "orchestrator" / "answer_subagent"). Observe-only — it never transforms config.
  *
- * A fresh instance is constructed per chat() invocation (both call sites build it
- * inline), so the `iterations` counter is private to that one turn — no cross-turn
+ * A fresh instance is constructed per chat() invocation (every call site builds it
+ * inline), so the `iterations` counter is private to that one run — no cross-run
  * or concurrent-call races.
  */
 export function llmTelemetryMiddleware(label: string): ChatMiddleware {
@@ -44,18 +75,20 @@ export function llmTelemetryMiddleware(label: string): ChatMiddleware {
 			iterations += 1;
 		},
 		onFinish(ctx, info) {
-			const usage = info.usage;
-			const promptDetails = usage?.promptTokensDetails;
-			console.info("llm_call", {
+			emitLlmCall(
 				label,
-				model: ctx.model,
-				elapsed_ms: Math.round(info.duration),
-				input_tokens: usage?.promptTokens ?? 0,
-				output_tokens: usage?.completionTokens ?? 0,
-				cache_read_input_tokens: promptDetails?.cachedTokens ?? 0,
-				cache_creation_input_tokens: promptDetails?.cacheWriteTokens ?? 0,
+				ctx.model,
+				"finished",
+				info.duration,
 				iterations,
-			});
+				info.usage,
+			);
+		},
+		onAbort(ctx, info) {
+			emitLlmCall(label, ctx.model, "aborted", info.duration, iterations);
+		},
+		onError(ctx, info) {
+			emitLlmCall(label, ctx.model, "error", info.duration, iterations);
 		},
 	};
 }

--- a/packages/cockpit/src/lib/llm-telemetry.ts
+++ b/packages/cockpit/src/lib/llm-telemetry.ts
@@ -1,0 +1,61 @@
+// Per-call LLM telemetry (DAT-600, cockpit half of epic DAT-599).
+//
+// A @tanstack/ai chat() middleware that emits ONE structured `llm_call` line per
+// turn — the cockpit mirror of the engine's provider-chokepoint log. Attach it to
+// each chat() with a distinct `label` so the orchestrator turn and the nested
+// `answer` sub-agent loop are attributable SEPARATELY (the epic suspects that
+// sub-agent loop is the latency multiplier — DAT-605 reads `iterations` from here).
+//
+// SERVER-ONLY: chat() runs server-side, so `console.info` lands on the cockpit
+// server process stdout (Nitro/Bun) — `docker compose logs cockpit` in a
+// container, the dev-server terminal under `bun --bun run dev`.
+//
+// The key names are deliberately snake_case to match the engine's `llm_call`
+// shape, so `grep llm_call | jq` aggregates identically across both stacks even
+// though @tanstack/ai's TokenUsage is camelCase. The mapping:
+//   promptTokens                      -> input_tokens
+//   completionTokens                  -> output_tokens
+//   promptTokensDetails.cachedTokens  -> cache_read_input_tokens
+//   promptTokensDetails.cacheWriteTokens -> cache_creation_input_tokens
+// `elapsed_ms` is the whole-run duration the SDK already measures (FinishInfo).
+//
+// Granularity note: the engine logs one line per model call; here one line is a
+// whole chat() turn — the RUN_FINISHED usage is the loop total across iterations
+// (orchestrator ≤20, sub-agent ≤10). That is the right grain for "which agent
+// dominates wall-clock"; `iterations` exposes the per-turn round-trip depth.
+
+import type { ChatMiddleware } from "@tanstack/ai";
+
+/**
+ * Build a logging middleware that emits a single `llm_call` telemetry line when a
+ * chat() turn finishes. `label` tags the call site (e.g. "orchestrator" /
+ * "answer_subagent"). Observe-only — it never transforms config; an aborted or
+ * errored turn emits nothing (parity with the engine, which logs success only).
+ *
+ * A fresh instance is constructed per chat() invocation (both call sites build it
+ * inline), so the `iterations` counter is private to that one turn — no cross-turn
+ * or concurrent-call races.
+ */
+export function llmTelemetryMiddleware(label: string): ChatMiddleware {
+	let iterations = 0;
+	return {
+		name: "llm-telemetry",
+		onIteration() {
+			iterations += 1;
+		},
+		onFinish(ctx, info) {
+			const usage = info.usage;
+			const promptDetails = usage?.promptTokensDetails;
+			console.info("llm_call", {
+				label,
+				model: ctx.model,
+				elapsed_ms: Math.round(info.duration),
+				input_tokens: usage?.promptTokens ?? 0,
+				output_tokens: usage?.completionTokens ?? 0,
+				cache_read_input_tokens: promptDetails?.cachedTokens ?? 0,
+				cache_creation_input_tokens: promptDetails?.cacheWriteTokens ?? 0,
+				iterations,
+			});
+		},
+	};
+}

--- a/packages/cockpit/src/lib/llm-telemetry.ts
+++ b/packages/cockpit/src/lib/llm-telemetry.ts
@@ -25,7 +25,10 @@
 // so we log on all three with a `status` — unlike the engine (success-only), the
 // cockpit has deliberate early-abort paths (frame induction aborts after the
 // forced tool fires, ×4/frame), and an aborted/errored turn is still latency data.
-// Tokens are only known on a clean finish; abort/error lines carry zeros.
+// Tokens are only known on a clean finish; abort/error lines carry zeros. So
+// any per-label token aggregation must FILTER `status == "finished"` first —
+// frame induction alone emits up to 4 aborted rows per frame() (it aborts after
+// the forced tool fires), and those intentional zeros would skew a naive average.
 //
 // Granularity note: the engine logs one line per model call; here one line is a
 // whole chat() run — the RUN_FINISHED usage is the loop total across iterations

--- a/packages/cockpit/src/lib/nav-agent.ts
+++ b/packages/cockpit/src/lib/nav-agent.ts
@@ -11,9 +11,9 @@
 import { chat } from "@tanstack/ai";
 import { createAnthropicChat } from "@tanstack/ai-anthropic";
 import { z } from "zod";
-
 import { config } from "#/config";
 import type { ConversationKind } from "#/db/cockpit/conversations";
+import { llmTelemetryMiddleware } from "#/lib/llm-telemetry";
 import { MAX_OUTPUT_TOKENS, NAV_MODEL } from "#/llm";
 
 const KINDS = ["connect", "stage", "analyse"] as const;
@@ -38,6 +38,7 @@ export async function classifyOpeningMessage(
 	try {
 		const result = await chat({
 			adapter: createAnthropicChat(NAV_MODEL, config.anthropicApiKey),
+			middleware: [llmTelemetryMiddleware("nav_classifier")],
 			modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
 			systemPrompts: [
 				{ content: `${SYSTEM}\nAvailable: ${available.join(", ")}.` },

--- a/packages/cockpit/src/tools/frame-family.ts
+++ b/packages/cockpit/src/tools/frame-family.ts
@@ -26,6 +26,7 @@ import type { z } from "zod";
 
 import { config } from "../config";
 import { linkedAbortController } from "../lib/abort";
+import { llmTelemetryMiddleware } from "../lib/llm-telemetry";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { teach } from "./teach";
 import type { TeachType } from "./teach.validation";
@@ -71,6 +72,7 @@ export async function induceStructured<R>(opts: {
 	const abortController = linkedAbortController(opts.signal);
 	const stream = await chat({
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
+		middleware: [llmTelemetryMiddleware("frame_family")],
 		abortController,
 		modelOptions: {
 			max_tokens: MAX_OUTPUT_TOKENS,

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -41,6 +41,7 @@ import {
 	validateStepNames,
 } from "../duckdb/run-steps";
 import { linkedAbortController } from "../lib/abort";
+import { llmTelemetryMiddleware } from "../lib/llm-telemetry";
 import { sqlEquivalent } from "../lib/sql-canonical";
 import {
 	MAX_OUTPUT_TOKENS,
@@ -604,6 +605,10 @@ export async function querySubAgent(
 				lookValuesTool,
 				makeRunStepsTool(captured, nearUniqueColumns),
 			],
+			// Per-turn LLM telemetry (DAT-600). Logs this nested sub-agent loop
+			// SEPARATELY from the orchestrator; `iterations` exposes its round-trip
+			// depth (the multiplier DAT-605 quantifies).
+			middleware: [llmTelemetryMiddleware("answer_subagent")],
 			outputSchema: QueryDraftSchema,
 		});
 	} catch (err) {

--- a/packages/cockpit/src/tools/why-column.ts
+++ b/packages/cockpit/src/tools/why-column.ts
@@ -32,6 +32,7 @@ import {
 } from "../db/metadata/schema";
 import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
+import { llmTelemetryMiddleware } from "../lib/llm-telemetry";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { getWhyInstructions } from "../prompts";
 import {
@@ -194,6 +195,7 @@ export async function synthesizeAnalysis(
 ): Promise<string> {
 	const result = await chat({
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
+		middleware: [llmTelemetryMiddleware("why_column")],
 		abortController: linkedAbortController(signal),
 		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
 		systemPrompts: [getWhyInstructions()],

--- a/packages/cockpit/src/tools/why-relationship.ts
+++ b/packages/cockpit/src/tools/why-relationship.ts
@@ -33,6 +33,7 @@ import {
 } from "../db/metadata/schema";
 import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
+import { llmTelemetryMiddleware } from "../lib/llm-telemetry";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { getWhyInstructions } from "../prompts";
 import {
@@ -207,6 +208,7 @@ export async function synthesizeAnalysis(
 	const toLabel = `${data.to_table_name ?? "?"}.${data.to_column_name ?? data.to_column_id}`;
 	const result = await chat({
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
+		middleware: [llmTelemetryMiddleware("why_relationship")],
 		abortController: linkedAbortController(signal),
 		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
 		systemPrompts: [getWhyInstructions()],

--- a/packages/cockpit/src/tools/why-table.ts
+++ b/packages/cockpit/src/tools/why-table.ts
@@ -33,6 +33,7 @@ import {
 } from "../db/metadata/schema";
 import { linkedAbortController } from "../lib/abort";
 import { displayTableName, renderEvidenceDetail } from "../lib/display-names";
+import { llmTelemetryMiddleware } from "../lib/llm-telemetry";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { getWhyInstructions } from "../prompts";
 import {
@@ -184,6 +185,7 @@ export async function synthesizeAnalysis(
 	const label = data.table_name ?? data.table_id;
 	const result = await chat({
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
+		middleware: [llmTelemetryMiddleware("why_table")],
 		abortController: linkedAbortController(signal),
 		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
 		systemPrompts: [getWhyInstructions()],

--- a/packages/cockpit/src/worker/grounding-agent.ts
+++ b/packages/cockpit/src/worker/grounding-agent.ts
@@ -20,12 +20,12 @@
 import { chat, maxIterations, toolDefinition } from "@tanstack/ai";
 import { createAnthropicChat } from "@tanstack/ai-anthropic";
 import { z } from "zod";
-
 import { config } from "#/config";
 import {
 	type GroundingReadinessRow,
 	readGroundingReadiness,
 } from "#/db/metadata/grounding-readiness";
+import { llmTelemetryMiddleware } from "#/lib/llm-telemetry";
 import { MAX_OUTPUT_TOKENS, MODEL } from "#/llm";
 import { teach } from "#/tools/teach";
 import {
@@ -159,6 +159,7 @@ export async function assessAndGround(
 	const captured = { count: 0 };
 	const verdict = await chat({
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
+		middleware: [llmTelemetryMiddleware("grounding")],
 		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
 		agentLoopStrategy: maxIterations(GROUNDING_LOOP_MAX_ITERATIONS),
 		systemPrompts: [GROUNDING_INSTRUCTIONS],


### PR DESCRIPTION
**Epic:** DAT-599 (LLM agent latency & efficiency) · **Task:** DAT-600, cockpit half. Engine half is #381.

## What
The cockpit half of DAT-599's logging foundation — so we stop optimizing the agent tier blind. A `@tanstack/ai` `ChatMiddleware` (`src/lib/llm-telemetry.ts`) attached to **every** cockpit `chat()` emits one structured line per turn:

`console.info("llm_call", { label, model, status, elapsed_ms, input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens, iterations })`

- **No chunk-parsing / no OTel infra:** `@tanstack/ai@0.28.0` exposes `onUsage`/`onFinish`/`onIteration` middleware hooks (RUN_FINISHED `TokenUsage` + run `duration`), so the middleware just reads them. `promptTokensDetails.cachedTokens`/`cacheWriteTokens` map to the cache pair.
- **8 sites, each labelled** so spend is attributable per agent — `orchestrator`, `answer_subagent`, `why_table`, `why_column`, `why_relationship`, `frame_family`, `nav_classifier`, `grounding`. The `answer_subagent` split is what lets DAT-605 see the nested-loop multiplier (`iterations`).
- **Terminal-hook complete:** logs on `onFinish`/`onAbort`/`onError` (SDK guarantees exactly one per run) with a `status`. Needed because frame induction deliberately aborts after its forced tool fires (×4/frame) — `onFinish` never runs there. Abort/error rows carry zero tokens (usage is only known on a clean finish); **aggregations must filter `status == "finished"` before averaging tokens** (documented in the module).

## Where the data lands
Server-side → cockpit process stdout (`docker compose logs cockpit`; the dev terminal under `bun --bun run dev`). The `grounding` agent runs in the co-located TS worker, so its lines land on that process. snake_case keys deliberately match the engine half so `grep llm_call | jq` aggregates identically across both stacks.

## Scope / parity notes
Logging only — observe-only middleware, no streaming/persistence/tool-behavior/prompt-caching changes; engine untouched. One intentional asymmetry vs the engine half: cockpit lines are per-`chat()`-turn (loop total) and carry a `status`; engine lines are per-model-call and success-only. Shared keys still align.

## Tests / gates
tsc clean, biome clean, telemetry suite 5/5 (finished / missing-usage coercion / aborted / errored / per-instance counter isolation), full cockpit unit suite 1332 passed. Senior + spec-compliance reviewers both APPROVE (re-reviewed after the 2→8-site expansion).

Not yet verified live (needs a real chat turn = real Anthropic calls): after merge, run one chat and `docker compose logs cockpit | grep llm_call`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)