### PR TITLE
DAT-634: chat-open Workspace Briefing — landing canvas + per-turn agent digest (P3)

### DIFF
--- a/packages/cockpit/src/db/metadata/briefing/digest.test.ts
+++ b/packages/cockpit/src/db/metadata/briefing/digest.test.ts
@@ -1,0 +1,119 @@
+// Unit coverage for the per-turn agent digest (DAT-634) — pure. The key property:
+// the digest is PROJECTED, so a Connect chat isn't told to ground metrics and an
+// Analyse chat isn't told to fix typing — those are stage-owned actions.
+
+import { describe, expect, it } from "vitest";
+
+import { formatBriefingDigest } from "./digest";
+import type { WorkspaceBriefing } from "./types";
+
+// A briefing mid-pipeline: blocked columns (→ a stage "teach to unblock" action),
+// stuck metrics (→ a stage "teach to fix" action), and analyse ready (→ an analyse
+// "answer" action). nextActions are pre-ranked as assembleBriefing would emit them.
+function briefing(): WorkspaceBriefing {
+	return {
+		workspace: { id: "ws", vertical: "finance" },
+		inventory: {
+			sourceCount: 1,
+			tableCount: 5,
+			bandCounts: { ready: 2, investigate: 1, blocked: 2, unknown: 0 },
+			tables: [],
+		},
+		progress: { connect: "ready", stage: "needs_attention", analyse: "ready" },
+		attention: {
+			columnsBlocked: 3,
+			columnsInvestigate: 1,
+			readinessBlockers: [
+				{
+					target: "column:src_a__orders.amount",
+					source: "src_a",
+					label: "orders.amount",
+					band: "blocked",
+					topDriver: "Unit entropy",
+				},
+			],
+			stuckArtifacts: { total: 8, byType: [{ type: "metric", count: 8 }] },
+			pendingTeaches: { count: 0, needsReplay: false },
+			awaitingInput: [],
+		},
+		nextActions: [
+			{
+				kind: "teach",
+				label: "3 columns blocked — teach to unblock",
+				targetChat: "stage",
+				priority: 2,
+			},
+			{
+				kind: "teach",
+				label: "8 operating-model items need grounding — teach to fix",
+				targetChat: "stage",
+				priority: 2,
+			},
+			{
+				kind: "answer",
+				label: "Ready to answer questions",
+				targetChat: "analyse",
+				priority: 4,
+			},
+		],
+	};
+}
+
+describe("formatBriefingDigest", () => {
+	it("states the readiness facts so the agent needs no tool call", () => {
+		const d = formatBriefingDigest(briefing(), "stage");
+		expect(d).toContain("3 columns blocked");
+		expect(d).toContain("8 operating-model items need grounding");
+		expect(d).toContain("orders.amount"); // a named blocker
+	});
+
+	it("a Stage chat foregrounds the teach actions (it owns them)", () => {
+		const d = formatBriefingDigest(briefing(), "stage") ?? "";
+		const suggested = d.slice(d.indexOf("Suggested next here:"));
+		expect(suggested).toContain("teach to unblock");
+		expect(suggested).toContain("teach to fix");
+	});
+
+	it("an Analyse chat does NOT suggest typing/grounding (stage-owned) — only answer", () => {
+		const d = formatBriefingDigest(briefing(), "analyse") ?? "";
+		const suggested = d.slice(
+			d.indexOf("Suggested next here:"),
+			d.indexOf("Elsewhere:") >= 0 ? d.indexOf("Elsewhere:") : undefined,
+		);
+		expect(suggested).toContain("Ready to answer"); // analyse-owned
+		expect(suggested).not.toContain("teach to unblock"); // typing — stage's job
+		expect(suggested).not.toContain("teach to fix"); // grounding — stage's job
+		// They surface only as an "elsewhere" pointer.
+		expect(d).toContain("Elsewhere:");
+		expect(d.slice(d.indexOf("Elsewhere:"))).toContain("stage");
+	});
+
+	it("a Connect chat does NOT suggest metric-grounding (stage-owned)", () => {
+		const d = formatBriefingDigest(briefing(), "connect") ?? "";
+		const suggested =
+			d.indexOf("Suggested next here:") >= 0
+				? d.slice(
+						d.indexOf("Suggested next here:"),
+						d.indexOf("Elsewhere:") >= 0 ? d.indexOf("Elsewhere:") : undefined,
+					)
+				: "";
+		expect(suggested).not.toContain("teach to fix"); // metric grounding — stage's
+	});
+
+	it("returns null when there's nothing notable and nothing to do", () => {
+		const calm: WorkspaceBriefing = {
+			...briefing(),
+			progress: { connect: "ready", stage: "ready", analyse: "ready" },
+			attention: {
+				columnsBlocked: 0,
+				columnsInvestigate: 0,
+				readinessBlockers: [],
+				stuckArtifacts: { total: 0, byType: [] },
+				pendingTeaches: { count: 0, needsReplay: false },
+				awaitingInput: [],
+			},
+			nextActions: [],
+		};
+		expect(formatBriefingDigest(calm, "connect")).toBeNull();
+	});
+});

--- a/packages/cockpit/src/db/metadata/briefing/digest.ts
+++ b/packages/cockpit/src/db/metadata/briefing/digest.ts
@@ -32,9 +32,12 @@ export function formatBriefingDigest(
 	if (a.pendingTeaches.needsReplay)
 		facts.push(`${a.pendingTeaches.count} teaches pending (replay to apply)`);
 
-	// Nothing notable AND nothing for this chat to do → no digest (the base
-	// workspace-context block already names the tables + vertical).
-	if (facts.length === 0 && foreground.length === 0) return null;
+	// Nothing notable, nothing for this chat to do, AND nothing waiting elsewhere →
+	// no digest (the base workspace-context block already names the tables +
+	// vertical). A background-only state (e.g. an Analyse chat whose model isn't
+	// staged yet) still emits the "elsewhere" pointer.
+	if (facts.length === 0 && foreground.length === 0 && background.length === 0)
+		return null;
 
 	const blockers = a.readinessBlockers
 		.slice(0, DIGEST_BLOCKER_CAP)

--- a/packages/cockpit/src/db/metadata/briefing/digest.ts
+++ b/packages/cockpit/src/db/metadata/briefing/digest.ts
@@ -1,0 +1,57 @@
+// Per-turn agent digest (DAT-634) — pure. A compact, PROJECTED summary of the
+// briefing for the chat's kind, appended to the agent's per-turn system context so
+// it can say "3 columns are blocked" without a tool round-trip (closing the
+// asymmetry where the cockpit chat agent — unlike the engine GraphAgent — was
+// blind to readiness). Projected so a Connect chat isn't told to ground metrics,
+// nor an Analyse chat to fix typing — those surface only as a brief "elsewhere"
+// pointer. Bounded (counts + a capped blocker list); full detail stays behind the
+// why_* tools.
+
+import type { ConversationKind } from "#/db/cockpit/conversations";
+import { projectBriefing } from "./project";
+import type { WorkspaceBriefing } from "./types";
+
+/** Top blockers named in the digest — the rest stay behind why_column. */
+const DIGEST_BLOCKER_CAP = 5;
+
+export function formatBriefingDigest(
+	briefing: WorkspaceBriefing,
+	kind: ConversationKind,
+): string | null {
+	const a = briefing.attention;
+	const { foreground, background } = projectBriefing(briefing, kind);
+
+	const facts: string[] = [];
+	if (a.columnsBlocked > 0) facts.push(`${a.columnsBlocked} columns blocked`);
+	if (a.columnsInvestigate > 0)
+		facts.push(`${a.columnsInvestigate} columns to investigate`);
+	if (a.stuckArtifacts.total > 0)
+		facts.push(
+			`${a.stuckArtifacts.total} operating-model items need grounding`,
+		);
+	if (a.pendingTeaches.needsReplay)
+		facts.push(`${a.pendingTeaches.count} teaches pending (replay to apply)`);
+
+	// Nothing notable AND nothing for this chat to do → no digest (the base
+	// workspace-context block already names the tables + vertical).
+	if (facts.length === 0 && foreground.length === 0) return null;
+
+	const blockers = a.readinessBlockers
+		.slice(0, DIGEST_BLOCKER_CAP)
+		.map((b) => (b.source ? `${b.source}/${b.label}` : b.label));
+
+	const parts: string[] = [
+		`WORKSPACE STATE — ${facts.length > 0 ? `${facts.join(", ")}.` : "nothing blocking."}`,
+	];
+	if (blockers.length > 0) parts.push(`Blocked: ${blockers.join(", ")}.`);
+	if (foreground.length > 0)
+		parts.push(
+			`Suggested next here: ${foreground.map((f) => f.label).join("; ")}.`,
+		);
+	if (background.length > 0)
+		parts.push(
+			`Elsewhere: ${background.map((b) => `${b.chat} — ${b.label}`).join("; ")}.`,
+		);
+	parts.push("Use look_table / why_column for the detail behind these.");
+	return parts.join(" ");
+}

--- a/packages/cockpit/src/db/metadata/briefing/index.ts
+++ b/packages/cockpit/src/db/metadata/briefing/index.ts
@@ -3,6 +3,7 @@
 
 export { assembleBriefing } from "./assemble";
 export { buildWorkspaceBriefing } from "./build";
+export { formatBriefingDigest } from "./digest";
 export { computeNextActions } from "./next-actions";
 export { projectBriefing } from "./project";
 export type * from "./types";

--- a/packages/cockpit/src/lib/completion-watcher.ts
+++ b/packages/cockpit/src/lib/completion-watcher.ts
@@ -280,7 +280,9 @@ async function narrateCompletion(
 	const modelMessages = buildModelMessages(
 		await loadModelTranscript(conversationId),
 	);
-	const workspaceContext = await buildWorkspaceContext().catch(() => null);
+	const workspaceContext = await buildWorkspaceContext(conversation.kind).catch(
+		() => null,
+	);
 	const abortController = linkedAbortController(signal);
 	// Bind the conversationId (DAT-528): if this narration turn starts a follow-up
 	// run, it routes back to THIS chat — same contract as the send path (chat.ts).

--- a/packages/cockpit/src/prompts/workspace-context.test.ts
+++ b/packages/cockpit/src/prompts/workspace-context.test.ts
@@ -8,6 +8,9 @@ import { describe, expect, it, vi } from "vitest";
 // Mock every DB seam the module imports so a bare import opens no connection
 // (the DB readers themselves are smoke-covered; only the formatter is unit-tested).
 vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
+// The briefing digest (DAT-634) pulls the cockpit_db client (bun:sql) via runs.ts;
+// mock it so a bare import opens no connection under node-vitest.
+vi.mock("#/db/cockpit/client", () => ({ cockpitDb: {} }));
 vi.mock("#/db/cockpit/registry", () => ({
 	resolveActiveWorkspaceRow: async () => ({
 		id: "ws-test",

--- a/packages/cockpit/src/prompts/workspace-context.ts
+++ b/packages/cockpit/src/prompts/workspace-context.ts
@@ -13,7 +13,12 @@
 // and the context block names the workspace, not a session.
 
 import { eq } from "drizzle-orm";
+import type { ConversationKind } from "../db/cockpit/conversations";
 import { resolveActiveWorkspaceRow } from "../db/cockpit/registry";
+import {
+	buildWorkspaceBriefing,
+	formatBriefingDigest,
+} from "../db/metadata/briefing";
 import { metadataDb } from "../db/metadata/client";
 import { GENERATION_STAGE } from "../db/metadata/relationship-target";
 import {
@@ -69,9 +74,22 @@ export function formatWorkspaceContext(
  * WORKSPACE's (DAT-506: a workspace property); the table set is the workspace-current
  * set (the generation heads).
  */
-export async function buildWorkspaceContext(): Promise<string | null> {
+export async function buildWorkspaceContext(
+	kind: ConversationKind,
+): Promise<string | null> {
 	const workspace = await resolveActiveWorkspaceRow();
 	const tableNames = await workspaceTableNames();
 	if (tableNames.length === 0) return null;
-	return formatWorkspaceContext(workspace.vertical, tableNames);
+	const block = formatWorkspaceContext(workspace.vertical, tableNames);
+
+	// Append a compact, PROJECTED readiness digest (DAT-634) so the agent can speak
+	// to "what's blocked / what to do next" for this chat's kind without a tool
+	// round-trip. Soft: a briefing read blip just drops the digest, keeping the base
+	// block. TODO(DAT-634): cache candidate — buildWorkspaceBriefing runs ~9 queries
+	// per turn here; a short-TTL / invalidate-on-promote cache would cut it.
+	// Intentionally UNCACHED for now (correctness first; DB cost is negligible beside
+	// the LLM call). Do NOT add a cache without measuring.
+	const briefing = await buildWorkspaceBriefing().catch(() => null);
+	const digest = briefing ? formatBriefingDigest(briefing, kind) : null;
+	return digest && block ? `${block}\n\n${digest}` : block;
 }

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.tsx
@@ -16,6 +16,7 @@ import {
 import { resolveActiveWorkspace } from "#/db/cockpit/registry";
 import { listRunningStages } from "#/db/cockpit/runs";
 import { loadUiState, saveUiState } from "#/db/cockpit/ui-state";
+import { buildWorkspaceBriefing } from "#/db/metadata/briefing";
 import { hasImportedTables } from "#/db/metadata/workspace-state";
 import { chatReadiness } from "#/lib/chat-readiness";
 import { reconcileActiveRuns } from "#/temporal/reconcile";
@@ -58,12 +59,16 @@ const loadChat = createServerFn({ method: "GET", strict: { output: false } })
 			if (!conversation) return { notFound: true as const };
 			// Readiness inputs (DAT-534) alongside hydration — both soft (a read blip
 			// just drops the advisory banner, never the chat).
-			const [initialMessages, uiState, hasTables, runningStages] =
+			const [initialMessages, uiState, hasTables, runningStages, briefing] =
 				await Promise.all([
 					loadDisplayMessages(conversationId),
 					loadUiState(conversationId),
 					hasImportedTables().catch(() => false),
 					listRunningStages(conversationId).catch(() => []),
+					// The chat-open Workspace Briefing (DAT-634) — the landing canvas for
+					// a fresh stage/analyse chat. Soft: a read blip just drops the landing
+					// orientation (falls back to empty), never the chat.
+					buildWorkspaceBriefing().catch(() => null),
 				]);
 			void reconcileActiveRuns(conversationId);
 			return {
@@ -73,6 +78,7 @@ const loadChat = createServerFn({ method: "GET", strict: { output: false } })
 				title: conversation.title,
 				initialMessages,
 				uiState,
+				briefing,
 				readiness: chatReadiness(conversation.kind, {
 					hasTables,
 					hasActiveRun: runningStages.length > 0,
@@ -90,6 +96,7 @@ const loadChat = createServerFn({ method: "GET", strict: { output: false } })
 				title: null,
 				initialMessages: undefined,
 				uiState: null,
+				briefing: null,
 				readiness: null,
 			};
 		}
@@ -126,8 +133,14 @@ function CockpitChat() {
 	// drives the readiness banner (DAT-534), and is the composer drop-up's active
 	// type. The readiness banner is advisory + non-blocking — shown only when the
 	// chat's kind can't act yet (no data / a run in progress).
-	const { conversationId, kind, initialMessages, uiState, readiness } =
-		Route.useLoaderData();
+	const {
+		conversationId,
+		kind,
+		initialMessages,
+		uiState,
+		briefing,
+		readiness,
+	} = Route.useLoaderData();
 	const { wsId } = Route.useParams();
 	const navigate = useNavigate();
 	// The layout loader carries availability + latest-by-kind for the drop-up; read
@@ -188,6 +201,7 @@ function CockpitChat() {
 			conversationKind={kind}
 			initialMessages={initialMessages}
 			initialUiState={uiState}
+			initialBriefing={briefing}
 			seedMessage={seedMessage}
 			typeNav={typeNav}
 			onPersistPin={(pinnedCallId) =>

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.tsx
@@ -59,16 +59,21 @@ const loadChat = createServerFn({ method: "GET", strict: { output: false } })
 			if (!conversation) return { notFound: true as const };
 			// Readiness inputs (DAT-534) alongside hydration — both soft (a read blip
 			// just drops the advisory banner, never the chat).
+			// The chat-open Workspace Briefing (DAT-634) — the landing canvas for a
+			// fresh stage/analyse chat. Connect keeps its probe hub and discards the
+			// briefing, so don't pay the read there. Soft: a blip drops the landing
+			// orientation (falls back to empty), never the chat.
+			const briefingPromise =
+				conversation.kind === "connect"
+					? Promise.resolve(null)
+					: buildWorkspaceBriefing().catch(() => null);
 			const [initialMessages, uiState, hasTables, runningStages, briefing] =
 				await Promise.all([
 					loadDisplayMessages(conversationId),
 					loadUiState(conversationId),
 					hasImportedTables().catch(() => false),
 					listRunningStages(conversationId).catch(() => []),
-					// The chat-open Workspace Briefing (DAT-634) — the landing canvas for
-					// a fresh stage/analyse chat. Soft: a read blip just drops the landing
-					// orientation (falls back to empty), never the chat.
-					buildWorkspaceBriefing().catch(() => null),
+					briefingPromise,
 				]);
 			void reconcileActiveRuns(conversationId);
 			return {

--- a/packages/cockpit/src/routes/api/chat.ts
+++ b/packages/cockpit/src/routes/api/chat.ts
@@ -226,7 +226,7 @@ export const Route = createFileRoute("/api/chat")({
 				// OPPORTUNISTIC enrichment: a DB hiccup must NOT take down chat, so a
 				// throw degrades to no block (the agent falls back to asking — the
 				// pre-fix behavior), never a dead turn.
-				const workspaceContext = await buildWorkspaceContext().catch(
+				const workspaceContext = await buildWorkspaceContext(kind).catch(
 					(err: unknown) => {
 						console.error(
 							"[chat] workspace-context read failed — continuing without it:",

--- a/packages/cockpit/src/ui/cockpit/canvas-registry.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-registry.ts
@@ -7,6 +7,7 @@
 
 import { WidgetRegistry } from "#/ui/cockpit/widget-registry";
 import { AnswerResultWidget } from "#/ui/cockpit/widgets/answer-result";
+import { BriefingWidget } from "#/ui/cockpit/widgets/briefing";
 import { ColumnProfileWidget } from "#/ui/cockpit/widgets/column-profile";
 import { ColumnWhyWidget } from "#/ui/cockpit/widgets/column-why";
 import { CycleListWidget } from "#/ui/cockpit/widgets/cycle-list";
@@ -63,4 +64,5 @@ export const canvasRegistry = new WidgetRegistry()
 		kind: "operating-model-progress",
 		component: OperatingModelProgressWidget,
 	})
-	.register({ kind: "probe", component: ProbeWidget });
+	.register({ kind: "probe", component: ProbeWidget })
+	.register({ kind: "briefing", component: BriefingWidget });

--- a/packages/cockpit/src/ui/cockpit/canvas-state.ts
+++ b/packages/cockpit/src/ui/cockpit/canvas-state.ts
@@ -5,6 +5,8 @@
 // tool→canvas mapper case — they never touch the canvas/stream/shell plumbing.
 // Keep the union sorted baseline-first so the extension point is obvious.
 
+import type { ConversationKind } from "#/db/cockpit/conversations";
+import type { WorkspaceBriefing } from "#/db/metadata/briefing/types";
 import type { AvailableSource } from "#/tools/list-sources";
 import type { InventoryTable } from "#/tools/list-tables";
 import type { LookCycleResult } from "#/tools/look-cycle";
@@ -134,6 +136,17 @@ export type CanvasState =
 			kind: "probe";
 			source?: { name: string; backend: string };
 			sql?: string;
+	  }
+	// DAT-634: the chat-open "Workspace Briefing" — the LANDING orientation for a
+	// fresh stage/analyse chat (the idle fallback, replacing blank `empty`). Carries
+	// the full briefing + this chat's kind; the widget projects client-side
+	// (`projectBriefing`) to foreground this chat's actions. It yields to any live
+	// tool canvas on the first turn; the durable, always-fresh view is the
+	// Governance route (DAT-633), so this is never re-fetched or kept live here.
+	| {
+			kind: "briefing";
+			briefing: WorkspaceBriefing;
+			chatKind: ConversationKind;
 	  };
 
 /** Every `kind` a canvas member can have — handy for registry/test exhaustion. */

--- a/packages/cockpit/src/ui/cockpit/cockpit-state.tsx
+++ b/packages/cockpit/src/ui/cockpit/cockpit-state.tsx
@@ -36,6 +36,7 @@ import {
 // the client bundle — only the UiState shape rides along.
 import type { ConversationKind } from "#/db/cockpit/conversations";
 import type { UiState } from "#/db/cockpit/ui-state";
+import type { WorkspaceBriefing } from "#/db/metadata/briefing/types";
 import {
 	asWorkflowProgressEvent,
 	progressQueryKey,
@@ -134,6 +135,7 @@ export function CockpitProvider({
 	conversationKind,
 	initialMessages,
 	initialUiState,
+	initialBriefing,
 	onPersistPin,
 	seedMessage,
 	typeNav,
@@ -151,6 +153,11 @@ export function CockpitProvider({
 	conversationId?: string;
 	initialMessages?: Array<UIMessage>;
 	initialUiState?: UiState | null;
+	/** The chat-open Workspace Briefing (DAT-634) from the route loader — the LANDING
+	 * canvas for a fresh stage/analyse chat. A load-time snapshot; it yields to any
+	 * live tool canvas on the first turn and is never refreshed here (Governance is
+	 * the durable view). Null for connect (uses the probe hub) or on a read blip. */
+	initialBriefing?: WorkspaceBriefing | null;
 	/** Persist a canvas-pin change (server fn from the route); fire-and-forget. */
 	onPersistPin?: (pinnedCallId: string | null) => void;
 	/** The landing nav-agent's opening message (DAT-534) — sent ONCE on mount into
@@ -280,12 +287,26 @@ export function CockpitProvider({
 	// still takes the canvas as `live`; the hub returns underneath. The hub wins over
 	// `loading` too — it's always useful, and acquisition + teaching are sequential so
 	// there is no half-built import set to hide behind a spinner.
+	// A fresh stage/analyse chat (no messages yet) lands on the Workspace Briefing
+	// (DAT-634) — the "here's where you are, here's what to do" orientation that
+	// replaces a blank `empty`. It's the idle fallback only: once the user sends a
+	// turn (messages.length > 0) it yields, and any live tool result wins above. The
+	// durable, always-fresh view is the Governance route, so this snapshot is never
+	// refreshed here. Connect keeps its probe hub.
 	const fallback: CanvasState =
 		conversationKind === "connect"
 			? { kind: "probe" }
-			: isLoading
-				? { kind: "loading", label: pendingLabel }
-				: { kind: "empty" };
+			: initialBriefing != null &&
+					conversationKind != null &&
+					messages.length === 0
+				? {
+						kind: "briefing",
+						briefing: initialBriefing,
+						chatKind: conversationKind,
+					}
+				: isLoading
+					? { kind: "loading", label: pendingLabel }
+					: { kind: "empty" };
 	const canvas = useStableValue<CanvasState>(pinned ?? live ?? fallback);
 
 	// Reactive state — recreated each streaming tick (messages/canvas change).

--- a/packages/cockpit/src/ui/cockpit/widgets/briefing-seeds.test.ts
+++ b/packages/cockpit/src/ui/cockpit/widgets/briefing-seeds.test.ts
@@ -1,0 +1,52 @@
+// Unit coverage for the briefing chip seeds (DAT-634) — pure.
+
+import { describe, expect, it } from "vitest";
+
+import type { BriefingAction } from "#/db/metadata/briefing";
+import { nextActionSeed } from "./briefing-seeds";
+
+function action(over: Partial<BriefingAction>): BriefingAction {
+	return {
+		kind: "teach",
+		label: "x",
+		targetChat: "stage",
+		priority: 2,
+		...over,
+	};
+}
+
+describe("nextActionSeed", () => {
+	it("replay → asks to replay", () => {
+		expect(nextActionSeed(action({ kind: "replay" }))).toContain("replay");
+	});
+
+	it("teach → folds the label into the request", () => {
+		const seed = nextActionSeed(
+			action({ kind: "teach", label: "3 columns blocked — teach to unblock" }),
+		);
+		expect(seed).toContain("3 columns blocked");
+	});
+
+	it("begin_session → asks to build the model", () => {
+		expect(nextActionSeed(action({ kind: "begin_session" }))).toContain(
+			"begin_session",
+		);
+	});
+
+	it("operating_model → asks to run the operating model", () => {
+		expect(nextActionSeed(action({ kind: "operating_model" }))).toContain(
+			"operating model",
+		);
+	});
+
+	it("answer → opens an analysis question", () => {
+		expect(nextActionSeed(action({ kind: "answer" }))).toContain("analyze");
+	});
+
+	it("review_blocker → folds the note into the request", () => {
+		const seed = nextActionSeed(
+			action({ kind: "review_blocker", label: "Tell me the NULL token" }),
+		);
+		expect(seed).toContain("Tell me the NULL token");
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/widgets/briefing-seeds.ts
+++ b/packages/cockpit/src/ui/cockpit/widgets/briefing-seeds.ts
@@ -1,0 +1,27 @@
+// Pure: a briefing `nextAction` → the chat message its chip seeds (DAT-634). The
+// briefing canvas foregrounds the actions THIS chat can act on; clicking a chip
+// sends one of these as a user turn, so the agent opens already working it.
+
+import type { BriefingAction } from "#/db/metadata/briefing/types";
+
+export function nextActionSeed(action: BriefingAction): string {
+	switch (action.kind) {
+		case "replay":
+			return "Apply the pending teaches by running replay over the workspace.";
+		case "teach":
+			// The label carries the specifics ("3 columns blocked …" / "5
+			// operating-model items …"), so fold it into the request.
+			return `Help me address this — ${action.label}.`;
+		case "begin_session":
+			return "Build the model over the imported tables (begin_session).";
+		case "operating_model":
+			return "Run the operating model over the workspace.";
+		case "answer":
+			return "What can I analyze in this data?";
+		case "review_blocker":
+			return `A run needs input: ${action.label}. Help me resolve it.`;
+		default:
+			// Exhaustive over BriefingActionKind; a new kind is a compile error here.
+			return action.label;
+	}
+}

--- a/packages/cockpit/src/ui/cockpit/widgets/briefing-seeds.ts
+++ b/packages/cockpit/src/ui/cockpit/widgets/briefing-seeds.ts
@@ -20,8 +20,11 @@ export function nextActionSeed(action: BriefingAction): string {
 			return "What can I analyze in this data?";
 		case "review_blocker":
 			return `A run needs input: ${action.label}. Help me resolve it.`;
-		default:
-			// Exhaustive over BriefingActionKind; a new kind is a compile error here.
-			return action.label;
+		default: {
+			// Exhaustive over BriefingActionKind — adding a kind without a case above
+			// is a compile error here (a real guarantee, not just a comment).
+			const _exhaustive: never = action.kind;
+			return _exhaustive;
+		}
 	}
 }

--- a/packages/cockpit/src/ui/cockpit/widgets/briefing.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/briefing.tsx
@@ -1,0 +1,152 @@
+// Workspace Briefing canvas (DAT-634) — the LANDING orientation for a fresh
+// stage/analyse chat. Pure render of the briefing (cockpit React rule 12): it
+// projects client-side (`projectBriefing`) to foreground THIS chat's actions and
+// points at the others. Chips dispatch through the action context — a foreground
+// chip seeds a turn into this chat; a background pointer switches chat type.
+// Yields to any live tool canvas on the first turn; the durable view is Governance.
+
+import { Badge, Button, Group, Stack, Text, Title } from "@mantine/core";
+
+// Import the PURE project/types modules directly — NOT the `#/db/metadata/briefing`
+// barrel, which re-exports build.ts (the postgres IO). A client widget pulling the
+// barrel would drag `metadataDb` (postgres-at-import) into the client bundle.
+import { projectBriefing } from "#/db/metadata/briefing/project";
+import type { StageStatus } from "#/db/metadata/briefing/types";
+import type { CanvasState } from "#/ui/cockpit/canvas-state";
+import { useCockpitActions } from "#/ui/cockpit/cockpit-state";
+import { nextActionSeed } from "#/ui/cockpit/widgets/briefing-seeds";
+
+const STAGE_TONE: Record<StageStatus, string> = {
+	empty: "gray",
+	in_progress: "blue",
+	ready: "green",
+	needs_attention: "yellow",
+};
+const STAGE_LABEL: Record<StageStatus, string> = {
+	empty: "Not started",
+	in_progress: "Running",
+	ready: "Ready",
+	needs_attention: "Needs attention",
+};
+
+const CHAT_LABEL = { connect: "Connect", stage: "Stage", analyse: "Analyse" };
+
+function plural(n: number, one: string, many: string): string {
+	return n === 1 ? one : many;
+}
+
+export function BriefingWidget({
+	state,
+}: {
+	state: Extract<CanvasState, { kind: "briefing" }>;
+}) {
+	const { briefing, chatKind } = state;
+	const { sendMessage, typeNav } = useCockpitActions();
+	const projected = projectBriefing(briefing, chatKind);
+	const a = briefing.attention;
+
+	// Compact attention summary — the facts, not the full Governance detail.
+	const facts: string[] = [];
+	if (a.columnsBlocked > 0)
+		facts.push(
+			`${a.columnsBlocked} ${plural(a.columnsBlocked, "column", "columns")} blocked`,
+		);
+	if (a.columnsInvestigate > 0)
+		facts.push(`${a.columnsInvestigate} to investigate`);
+	if (a.stuckArtifacts.total > 0)
+		facts.push(
+			`${a.stuckArtifacts.total} operating-model ${plural(a.stuckArtifacts.total, "item", "items")} need grounding`,
+		);
+	if (a.pendingTeaches.needsReplay)
+		facts.push(
+			`${a.pendingTeaches.count} ${plural(a.pendingTeaches.count, "teach", "teaches")} pending`,
+		);
+
+	const progress: { label: string; status: StageStatus }[] = [
+		{ label: "Connect", status: briefing.progress.connect },
+		{ label: "Stage", status: briefing.progress.stage },
+		{ label: "Analyse", status: briefing.progress.analyse },
+	];
+
+	return (
+		<Stack gap="md" h="100%" p="md" data-testid="canvas-briefing">
+			<Stack gap={4}>
+				<Title order={4}>Where you are</Title>
+				<Text c="dimmed" size="sm">
+					{briefing.workspace.vertical
+						? `Workspace vertical ${briefing.workspace.vertical}. `
+						: ""}
+					Pick up where it makes sense — the full picture is in Governance.
+				</Text>
+			</Stack>
+
+			<Group gap="md">
+				{progress.map((s) => (
+					<Group key={s.label} gap={6}>
+						<Text size="sm" fw={500}>
+							{s.label}
+						</Text>
+						<Badge variant="light" color={STAGE_TONE[s.status]} size="sm">
+							{STAGE_LABEL[s.status]}
+						</Badge>
+					</Group>
+				))}
+			</Group>
+
+			{facts.length > 0 && (
+				<Text size="sm" data-testid="briefing-facts">
+					{facts.join(" · ")}.
+				</Text>
+			)}
+
+			{projected.foreground.length > 0 && (
+				<Stack gap="xs" data-testid="briefing-foreground">
+					<Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+						Do next
+					</Text>
+					<Group gap="xs">
+						{projected.foreground.map((action) => (
+							<Button
+								key={`${action.kind}:${action.label}`}
+								size="xs"
+								variant="light"
+								onClick={() => sendMessage(nextActionSeed(action))}
+							>
+								{action.label}
+							</Button>
+						))}
+					</Group>
+				</Stack>
+			)}
+
+			{projected.background.length > 0 && typeNav && (
+				<Stack gap="xs" data-testid="briefing-background">
+					<Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+						Elsewhere
+					</Text>
+					<Group gap="xs">
+						{projected.background.map((ptr) => (
+							<Button
+								key={ptr.chat}
+								size="xs"
+								variant="subtle"
+								onClick={() => typeNav.onOpen(ptr.chat)}
+							>
+								{CHAT_LABEL[ptr.chat]}: {ptr.label} →
+							</Button>
+						))}
+					</Group>
+				</Stack>
+			)}
+
+			{facts.length === 0 &&
+				projected.foreground.length === 0 &&
+				projected.background.length === 0 && (
+					<Text c="dimmed" size="sm" data-testid="briefing-clear">
+						Nothing needs attention — ask away in this {CHAT_LABEL[chatKind]}{" "}
+						chat.
+					</Text>
+				)}
+		</Stack>
+	);
+}


### PR DESCRIPTION
P3 of the Workspace Briefing sub-stream (epic **DAT-574**), on top of P1+P2 (merged in #385). Rebased onto current `main`.

## What this adds
Surfaces the briefing where the user lands — the chat. Two coordinated parts, both consuming the P1 read-model.

**Part A — the `briefing` canvas kind:** the LANDING orientation for a fresh stage/analyse chat (the idle fallback, replacing blank `empty`; connect keeps its `probe` hub). The chat loader fetches the full `WorkspaceBriefing`; the widget projects client-side (`projectBriefing`) to foreground THIS chat's actions and point at the others. It **yields to any live tool canvas on the first turn** — the durable, always-fresh view is the Governance route (P2), so it's never refreshed in-chat. Action chips seed a turn (foreground) or switch chat type (background).

**Part B — the per-turn agent digest:** `buildWorkspaceContext(kind)` appends a compact **projected** readiness summary (counts + capped blockers + this chat's suggested-next) so the agent can say "3 columns are blocked" with no tool call — closing the asymmetry where the cockpit agent (unlike the engine GraphAgent) was blind to readiness. Projected, so a Connect chat isn't told to ground metrics nor an Analyse chat to fix typing. A `TODO` marks the per-turn read a cache candidate; **no cache was added** (deliberate).

## Testing
- tsc + biome clean; full suite green (1394 tests; +37 briefing/widget/digest unit tests).
- Senior + spec reviewed; 3 findings fixed (real `never`-exhaustive seed check; skip the briefing fetch for connect; background-only digest).
- **Smoke-validated** against the live 3-source workspace: the briefing canvas renders on a fresh Stage chat (progress + facts + stage-only "Do next" chips), **yields** to the live tool canvas on the first turn, and the agent demonstrably used the digest (named the blocker locations before any tool call). No console errors.

## Bundle safety
The client widget imports the pure `briefing/project` + `briefing/types` modules directly — NOT the `#/db/metadata/briefing` barrel (which re-exports the postgres IO).

## Scope
Cockpit-only — no engine change, no eval/testdata.

## Follow-ups (filed during smoke/review, not in this PR)
- **DAT-639** — duplicate-source import (no dedup/archival).
- **DAT-640** — onboarding runs never reconciled (Runs monitor vs Temporal).
- **DAT-641** — concurrent typing → DuckLake commit-conflict fails the replay (likely a `ducklake_max_retry_count` tune + Temporal retry; amplified by DAT-639).

🤖 Generated with [Claude Code](https://claude.com/claude-code)