### PR TITLE
DAT-639: narrow, workspace-unique table identity (complete DAT-506)

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -1,0 +1,67 @@
+# Engine → eval/testdata handoff
+
+Bridge for `dataraum-eval` (calibration) and `dataraum-testdata`. One entry per
+change that affects a detector, pipeline phase, or a response shape eval consumes.
+
+---
+
+## DAT-639 — narrow, workspace-unique table names (no `src_<digest>__` prefix)
+
+**Branch:** `fix/dat-639-narrow-table-identity`.
+
+### What changed (response shape)
+Physical raw/typed/quarantine table names are now **NARROW and workspace-unique**
+— the file stem / recipe name, sanitized, with **no `src_<digest>__` (or `raw_`)
+source prefix**. `Table.table_name` and `Table.duckdb_path` both store the bare
+narrow name (e.g. `orders`, not `src_abc…__orders`). The per-workspace DuckLake
+catalog is the namespace; `Table` uniqueness is now `(table_name, layer)`
+(`uq_table_name_layer`), not source-scoped. (Completes DAT-506 into physical
+naming.)
+
+### Engine routes / phases affected
+- `pipeline/phases/import_phase.py` — loaders compose the narrow name via the new
+  `sources.base.raw_table_name_for_uri`; db recipe extract uses `raw_prefix=""`.
+  New **pre-flight collision guard** (`_first_name_collision`): importing a source
+  whose narrow table name is already owned by a **different** source now **FAILS
+  LOUD** ("retire that source first") instead of silently materializing a parallel
+  table. Same-source re-import still replays (upload: `should_skip`; db recipe:
+  recipe-hash teardown).
+- `pipeline/phases/typing_phase.py` — unit-override teaches key on the bare
+  `<table>.<column>` only (the dual qualified/de-prefixed lookup is gone).
+- `entropy/detectors/computational/cross_table_consistency.py` — **detector
+  change**: `_own_columns_used` now matches a validation check's `columns_used`
+  `"table.column"` refs by **exact narrow table name**. The `src_<digest>__`
+  prefix-strip fallback is deleted.
+
+### What eval must do
+- **Any ground truth / fixture that references a physical table name must use the
+  NARROW form** (`orders`, not `src_<digest>__orders` and not `<source>__orders`).
+  This includes: unit-teach keys (`overrides.units` → `"<table>.<column>"`), the
+  validation phase's `columns_used` refs, and any assertion on `Table.table_name`
+  / `duckdb_path` / enriched view names (`enriched_<table>`).
+- **Re-seeding the same content under a new source name now FAILS** (collision
+  fail-loud + `uq_table_name_layer`). Calibration/smoke harnesses that re-add the
+  same files each run must either reuse a stable content-keyed source id (so it
+  replays) or use distinct table names — a fresh random `source_<uuid>` re-import
+  of the same files will be rejected, not duplicated. (This is the intended fix
+  for the DAT-639 duplication bug; harness hygiene is the follow-up.)
+
+### Calibration to run
+- `cross_table_consistency` recall/precision — confirm column-fan-out still bands
+  the right columns when `columns_used` uses narrow names (the detector's match is
+  now exact; a fixture still carrying a `src_<digest>__` prefix would silently stop
+  matching → false "clean").
+- Unit-teach (DAT-428) calibration — confirm a `<table>.<column>` unit teach still
+  lands now that there's no de-prefix fallback.
+- A full fresh-workspace re-seed (the migration for this change is fresh re-seed,
+  no in-place migration) before any calibration that reads table names.
+
+### Thresholds / new fields
+None. No score thresholds changed; no new response fields. Names changed shape
+only (prefix dropped).
+
+### testdata hints
+The collision fail-loud is testable: two sources whose names/files resolve to the
+same narrow table name should now produce one materialized table + one loud
+failure, not two parallel tables. An injection that re-imports identical content
+under a second name is the natural regression for the original duplication bug.

--- a/packages/cockpit/scripts/smoke-add-source.ts
+++ b/packages/cockpit/scripts/smoke-add-source.ts
@@ -104,11 +104,13 @@ async function runInitial(
 		// wire. The run's source SET (DAT-422) — one source here, so a 1-element set.
 		workspace_id: env.DATARAUM_WORKSPACE_ID,
 		sources: [sourceId],
-		// `_adhoc` is the empty / start-here vertical (DAT-371), on the workflow INPUT
-		// now (DAT-506): cold-start induction generates concepts from the data and
-		// stores them as `concept` overlay rows. This smoke is the real DAT-371
-		// acceptance test — a clean run proves induction works against the mounted config.
-		verticals: ["_adhoc"],
+		// A BUILTIN vertical whose `concept` rows ship with the mounted config, so
+		// grounding has concepts to ground against. `_adhoc` + cold-start induction
+		// (the old DAT-371 "generate concepts from the data" path) was RETIRED — a
+		// vertical must DECLARE its concepts; `_adhoc` has none, so add_source's
+		// semantic_per_column grounding fails loud ("run frame first"). `finance`
+		// (builtin, ~22 concepts) is the standard smoke vertical.
+		verticals: ["finance"],
 	};
 	// `start` (not `execute`) so we can capture the run id — the replay
 	// assertion compares its fresh run_id against the initial one.

--- a/packages/cockpit/src/db/metadata/workspace-state.ts
+++ b/packages/cockpit/src/db/metadata/workspace-state.ts
@@ -7,7 +7,7 @@
 // is data to stage/analyse. The typed-vs-raw refinement (`tables.layer`) and a
 // vertical-present gate can extend this later without changing the caller.
 
-import { eq, isNull } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { metadataDb } from "./client";
 import { sources, tables } from "./schema";
 
@@ -40,4 +40,27 @@ export async function currentTypedTableIds(): Promise<string[]> {
 		.innerJoin(sources, eq(sources.sourceId, tables.sourceId))
 		.where(isNull(sources.archivedAt));
 	return rows.flatMap((r) => (r.tableId ? [r.tableId] : []));
+}
+
+/**
+ * The workspace's existing NARROW raw-layer physical table names from
+ * non-archived sources (DAT-639) — the set the import-set collision guard
+ * pre-checks new candidate names against, in front of the engine's hard
+ * `uq_table_name_layer` backstop.
+ *
+ * Post-DAT-639 a raw table's `duckdbPath` IS its narrow workspace-unique name
+ * (no `src_<digest>__` / `raw_` prefix), so it compares directly against the
+ * candidate names the cockpit derives (`sanitizeRecipeName` for recipes,
+ * `uploadTableName` for files). Filtered to the `raw` layer (the narrow names a
+ * fresh import mints) and non-archived sources — same archival filter as
+ * `currentTypedTableIds` / the list_tables inventory; a retired source's tables
+ * don't reserve a name.
+ */
+export async function existingRawTableNames(): Promise<Set<string>> {
+	const rows = await metadataDb
+		.select({ duckdbPath: tables.duckdbPath })
+		.from(tables)
+		.innerJoin(sources, eq(sources.sourceId, tables.sourceId))
+		.where(and(eq(tables.layer, "raw"), isNull(sources.archivedAt)));
+	return new Set(rows.flatMap((r) => (r.duckdbPath ? [r.duckdbPath] : [])));
 }

--- a/packages/cockpit/src/lib/display-names.test.ts
+++ b/packages/cockpit/src/lib/display-names.test.ts
@@ -10,112 +10,37 @@ import {
 const DIGEST = "204bc8e118543a6c35654c1f68c43539a2e226f2";
 
 describe("displayTableName", () => {
-	it("strips the exact `<source>__` prefix when the source name is known", () => {
-		expect(
-			displayTableName("finance_data__trial_balance", "finance_data"),
-		).toBe("trial_balance");
-	});
-
-	it("falls back to dropping up to the first `__` when no source name is given", () => {
-		expect(displayTableName("detection_v1__bank_transactions")).toBe(
-			"bank_transactions",
-		);
-	});
-
-	it("strips a content-keyed `src_<digest>__` prefix via the fallback", () => {
-		expect(displayTableName(`src_${DIGEST}__journal_lines`)).toBe(
-			"journal_lines",
-		);
-	});
-
-	it("leaves a name without a `__` separator untouched", () => {
+	// Post-DAT-639 a stored table name is already NARROW + workspace-unique, so
+	// display is the identity — no `<source>__` / `src_<digest>__` prefix to strip,
+	// no enriched/slice family to special-case (slices were removed entirely).
+	it("returns a narrow table name unchanged", () => {
+		expect(displayTableName("trial_balance")).toBe("trial_balance");
 		expect(displayTableName("payments")).toBe("payments");
-		expect(displayTableName("payments", "finance")).toBe("payments");
 	});
 
-	it("only strips the first segment (logical names with `__` survive)", () => {
-		expect(displayTableName("src__a__b")).toBe("a__b");
+	it("ignores the (retained-for-stability) sourceName arg", () => {
+		expect(displayTableName("orders", "finance")).toBe("orders");
 	});
 
-	// Enriched-view family (DAT-433): `enriched_<source>__<table>` keeps its
-	// prefix so the display name never collides with the base table's.
-	it("maps an enriched view to `enriched_<table>` instead of the bare table", () => {
-		expect(displayTableName(`enriched_src_${DIGEST}__journal_lines`)).toBe(
-			"enriched_journal_lines",
-		);
-		expect(displayTableName("enriched_finance__journal_lines")).toBe(
-			"enriched_journal_lines",
-		);
-	});
-
-	it("leaves an enriched name without a `__` remainder untouched", () => {
-		expect(displayTableName("enriched_thing")).toBe("enriched_thing");
-	});
-
-	// Slice family (DAT-433): the engine's slice sanitizer collapses `__` → `_`,
-	// so the digest would otherwise survive the generic fallback.
-	it("strips the digest from a slice table name, keeping the family prefix", () => {
-		expect(
-			displayTableName(`slice_src_${DIGEST}_journal_lines_region_emea`),
-		).toBe("slice_journal_lines_region_emea");
-	});
-
-	it("leaves a slice over a human-named source untouched (no digest to strip)", () => {
-		expect(displayTableName("slice_finance_journal_lines_region_emea")).toBe(
-			"slice_finance_journal_lines_region_emea",
-		);
-	});
-
-	it("family handling applies even when the raw source name is passed", () => {
-		// An enriched name never starts with `<sourceName>__` (the family prefix
-		// comes first), so the exact-prefix check falls through to the family rule.
-		expect(
-			displayTableName(`enriched_src_${DIGEST}__orders`, `src_${DIGEST}`),
-		).toBe("enriched_orders");
-	});
-
-	it("a source legitimately named enriched_* is not mistaken for the family", () => {
-		expect(displayTableName("enriched_data__report", "enriched_data")).toBe(
-			"report",
-		);
-	});
-
-	it("an enriched_* name with NO sourceName context is the family (prefix reservation)", () => {
-		// `enriched_` is a RESERVED source-name prefix (select/mappers.ts
-		// RESERVED_SOURCE_NAME_PREFIXES, enforced by tools/select.ts), so a
-		// physical name starting with it can ONLY be an actual enriched view —
-		// here the enriched view of source `data`'s `report` table. This is what
-		// makes the no-sourceName callers (why_*/look_relationships) sound.
-		expect(displayTableName("enriched_data__report")).toBe("enriched_report");
-	});
-
-	it("a slice_src_* name with NO sourceName context is the slice family (prefix reservation)", () => {
-		// `src_` is reserved too, so `slice_src_<digest>_…` can only be a slice
-		// table over a content-keyed upload — never a table of a source that
-		// happens to be named `slice_src_…`.
-		expect(displayTableName(`slice_src_${DIGEST}_orders_region_emea`)).toBe(
-			"slice_orders_region_emea",
-		);
+	it("leaves an enriched view name as-is (no digest, narrow base)", () => {
+		expect(displayTableName("enriched_orders")).toBe("enriched_orders");
 	});
 });
 
 describe("stripSrcDigests", () => {
-	it("drops `src_<digest>__` physical-name prefixes from free text", () => {
-		expect(
-			stripSrcDigests(`typing failed for src_${DIGEST}__journal_lines`),
-		).toBe("typing failed for journal_lines");
-	});
-
 	it("neutralizes a bare `src_<digest>` source name as `upload`", () => {
 		expect(stripSrcDigests(`source src_${DIGEST} not found`)).toBe(
 			"source upload not found",
 		);
 	});
 
-	it("neutralizes the digest inside an underscore-collapsed slice name", () => {
-		expect(stripSrcDigests(`slice_src_${DIGEST}_orders_region_emea`)).toBe(
-			"slice_upload_orders_region_emea",
-		);
+	it("neutralizes a digest even if other text trails it (no digest leaks)", () => {
+		// Physical names are narrow now, but the bare-digest replace is the
+		// backstop for any shape engine free text invents — the digest never
+		// survives, whatever follows it.
+		const out = stripSrcDigests(`unexpected src_${DIGEST}__orders in log`);
+		expect(out).not.toMatch(/[0-9a-f]{40}/);
+		expect(out).toContain("upload");
 	});
 
 	it("returns digest-free text unchanged", () => {
@@ -166,19 +91,19 @@ describe("renderEvidenceDetail", () => {
 				metric: "undeclared_ratio",
 				value: 0.8,
 				_column_name: "amount",
-				_table_name: `src_${DIGEST}__orders`,
+				_table_name: "orders",
 			},
 		]);
 		expect(detail).toBe('[{"metric":"undeclared_ratio","value":0.8}]');
 	});
 
-	it("display-maps the explicit table-name keys instead of dropping them", () => {
+	it("keeps narrow table-name keys as-is (no per-key remap needed post-DAT-639)", () => {
 		const detail = renderEvidenceDetail([
 			{
 				path_status: "resolved",
-				from_table: `src_${DIGEST}__orders`,
-				to_table: `src_${DIGEST}__customers`,
-				_table_name: `src_${DIGEST}__orders`,
+				from_table: "orders",
+				to_table: "customers",
+				_table_name: "orders",
 			},
 		]);
 		expect(JSON.parse(detail)).toEqual([
@@ -186,36 +111,24 @@ describe("renderEvidenceDetail", () => {
 		]);
 	});
 
-	it("display-maps slice_table_name through the slice family rule", () => {
-		const detail = renderEvidenceDetail([
-			{
-				null_ratio: 0.1,
-				slice_table_name: `slice_src_${DIGEST}_orders_region_emea`,
-			},
-		]);
-		expect(JSON.parse(detail)).toEqual([
-			{ null_ratio: 0.1, slice_table_name: "slice_orders_region_emea" },
-		]);
-	});
-
 	it("sanitizes nested structures recursively", () => {
 		const detail = renderEvidenceDetail({
-			slices: [
-				{ _table_name: `src_${DIGEST}__a`, rows: 10 },
-				{ _table_name: `src_${DIGEST}__b`, rows: 20 },
+			rows: [
+				{ _table_name: "a", n: 10 },
+				{ _table_name: "b", n: 20 },
 			],
 		});
 		expect(JSON.parse(detail)).toEqual({
-			slices: [{ rows: 10 }, { rows: 20 }],
+			rows: [{ n: 10 }, { n: 20 }],
 		});
 	});
 
-	it("backstops digests in unanticipated keys via stripSrcDigests", () => {
+	it("backstops a content-keyed source name leaking into free-text evidence", () => {
 		const detail = renderEvidenceDetail([
-			{ note: `joined src_${DIGEST}__orders to dim` },
+			{ note: `joined src_${DIGEST} into the run` },
 		]);
 		expect(detail).not.toMatch(/[0-9a-f]{40}/);
-		expect(detail).toContain("joined orders to dim");
+		expect(detail).toContain("joined upload into the run");
 	});
 
 	it("keeps a non-object evidence value as its JSON form", () => {

--- a/packages/cockpit/src/lib/display-names.ts
+++ b/packages/cockpit/src/lib/display-names.ts
@@ -1,26 +1,24 @@
 // Display + sanitization helpers that turn engine-internal identifiers into the
-// names a person (or the agent) reads. The engine stores physical tables as
-// `<source>__<table>` and reports dimensions/detectors as dotted snake_case
-// paths; widgets render the human form while the raw value stays in the
-// underlying tool JSON. This module is ALSO the agent-facing leak barrier
-// (DAT-431/DAT-433): an uploaded file's source is content-keyed `src_<40-hex
-// sha1>`, and that digest must never reach LLM context — the tool projections
-// strip it via these helpers. Pure (no React/DB) so each is unit-testable in
-// isolation.
+// names a person (or the agent) reads. Post-DAT-639 physical table names are
+// NARROW and workspace-unique (the per-workspace DuckLake catalog is the
+// namespace, so `orders` is just `orders` — no `<source>__` / `src_<digest>__`
+// prefix), so a stored table name IS already its display name. What this module
+// still owns is the agent-facing LEAK BARRIER (DAT-431/DAT-433): an uploaded
+// file's SOURCE is content-keyed `src_<40-hex sha1>` and that digest lives on
+// `sources.name` + in the upload's s3 URI — it must never reach LLM context, so
+// the tool projections strip it from free text via `stripSrcDigests`. Pure (no
+// React/DB) so each is unit-testable in isolation.
 
-// The content-keyed source name a file upload mints (`src_` + the upload's
+// The content-keyed source NAME a file upload mints (`src_` + the upload's
 // 40-char sha-1 content digest — see select/mappers.ts `contentKeyedSourceName`).
-// Physical table names derived from it embed `src_<digest>__` (raw/typed
-// layers), `enriched_src_<digest>__` (enriched views), or — underscore-collapsed
-// by the engine's slice sanitizer — `slice_src_<digest>_` (slice tables).
-// `(?![0-9a-f])` pins the digest to EXACTLY 40 hex chars — `src_` + 41 hex is
-// NOT a digest, and stripping its first 40 chars would mid-word mangle the
-// token, so it must not match. The `i` flag is free insurance (the engine
-// emits lowercase digests today).
+// This is a SOURCE name, not a table name (DAT-639 dropped the digest from
+// physical table names); it still appears bare in engine free text (failure
+// messages, the source's own name). `(?![0-9a-f])` pins the digest to EXACTLY 40
+// hex chars — `src_` + 41 hex is NOT a digest, and stripping its first 40 chars
+// would mid-word mangle the token, so it must not match. The `i` flag is free
+// insurance (the engine emits lowercase digests today).
 const SRC_DIGEST = /src_[0-9a-f]{40}(?![0-9a-f])/i;
-const SRC_DIGEST_PREFIX_G = /src_[0-9a-f]{40}(?![0-9a-f])__/gi;
 const SRC_DIGEST_G = /src_[0-9a-f]{40}(?![0-9a-f])/gi;
-const SLICE_FAMILY = /^slice_src_[0-9a-f]{40}(?![0-9a-f])_(.+)$/i;
 // A staged-upload object path (`uploads/<digest>/<file>`, upload/policy.ts
 // buildUploadKey) — the one place a BARE digest (no `src_` prefix) reaches
 // engine-built text, e.g. an import-failure message quoting the s3 URI.
@@ -33,81 +31,31 @@ const UPLOAD_URI_PREFIX =
 const UPLOAD_URI_PREFIX_G = new RegExp(UPLOAD_URI_PREFIX.source, "gi");
 
 /**
- * Drop the engine's `<source>__` physical-table prefix for display, e.g.
- * `finance_data__trial_balance` → `trial_balance`. When the source name is known
- * we try to strip exactly that prefix; otherwise (or if it doesn't match — the
- * stored prefix is the *sanitized* source name, so a raw name with spaces/caps
- * won't match) we fall back to dropping everything up to and including the first
- * `__`.
- *
- * INVARIANT the fallback rests on (cite both sides before changing either): a
- * physical name has exactly one `__` separator because BOTH writers collapse
- * underscore runs inside each segment — the engine's `sanitize_identifier`
- * (`packages/engine/src/dataraum/core/duckdb_naming.py`) and the cockpit's
- * `sanitizeRecipeName` (`select/mappers.ts`). A change to either sanitizer that
- * lets `__` survive inside a segment breaks this contract.
- *
- * Two derived-table families DON'T fit the one-`__` shape (DAT-433) and get
- * deliberate prefix-aware handling before the generic rules:
- * - Enriched views are `enriched_<source>__<table>` (engine
- *   `pipeline/phases/enriched_views_phase.py`). The generic fallback would strip
- *   to the bare `<table>`, colliding with the base table's display name — so the
- *   family keeps its prefix: `enriched_<table>`.
- * - Slice tables are `slice_<sanitized source table>_<col>_<value>` with NO `__`
- *   (the engine's slice `_sanitize_name` collapses `__` → `_`, see
- *   `analysis/slicing/slice_runner.py`), so for a content-keyed source the
- *   digest would survive the fallback. The digest family maps
- *   `slice_src_<digest>_<rest>` → `slice_<rest>`. A human-named source's
- *   boundary is unrecoverable after the collapse (`slice_finance_journal_…`) —
- *   left as-is, which is fine: a human-chosen name is not a leak.
- *
- * SOUNDNESS of the family rules rests on the name reservation in select
- * (select/mappers.ts `RESERVED_SOURCE_NAME_PREFIXES`, enforced by the db-source
- * branch of tools/select.ts): a user-chosen source name can never start with
- * `src_`/`enriched_`/`slice_`, so a physical name carrying one of those
- * prefixes can ONLY be the corresponding derived family — never a plain table
- * of a source that happens to share the prefix. Without it, callers that pass
- * no sourceName (the why_column / why_table / why_relationship /
- * look_relationships projections) would family-map a db source named
- * `enriched_data` differently from the sourceName-passing callers AND collide
- * it with the real enriched view of a source named `data`.
+ * The display name for a physical table. Post-DAT-639 this is the identity: a
+ * stored table name is already NARROW and workspace-unique (no `<source>__` /
+ * `src_<digest>__` prefix, no `enriched_<source>__` digest form, and slices —
+ * which were the one underscore-collapsed `slice_src_<digest>_…` family — have
+ * been removed). Retained as the single stable seam every tool/widget routes
+ * table-name display through, so any future divergence between physical and
+ * display naming has one home; the `sourceName` arg is kept for that same
+ * call-site stability though it's no longer consulted.
  */
 export function displayTableName(
 	tableName: string,
-	sourceName?: string,
+	_sourceName?: string,
 ): string {
-	// Exact source-prefix strip first: an actual enriched/slice name never
-	// starts with `<sourceName>__` (it starts with its family prefix), so this
-	// only fires for a plain physical table. Family-prefixed SOURCE names can't
-	// exist (reserved at select validation — see the doc above); this branch
-	// stays as defense-in-depth for any pre-reservation row.
-	if (sourceName) {
-		const prefix = `${sourceName}__`;
-		if (tableName.startsWith(prefix)) return tableName.slice(prefix.length);
-	}
-	if (tableName.startsWith("enriched_")) {
-		const rest = tableName.slice("enriched_".length);
-		const j = rest.indexOf("__");
-		if (j >= 0) return `enriched_${rest.slice(j + 2)}`;
-		return tableName;
-	}
-	const slice = SLICE_FAMILY.exec(tableName);
-	if (slice) return `slice_${slice[1]}`;
-	const i = tableName.indexOf("__");
-	return i >= 0 ? tableName.slice(i + 2) : tableName;
+	return tableName;
 }
 
 /**
  * Backstop strip for engine-built FREE TEXT (failure messages, serialized
- * evidence) that can embed content-keyed names this module's structured
- * handling didn't see. Three rules, most-specific first:
- * - a staged-upload URI (`s3://<bucket>/uploads/<digest>/<file>` — the one
- *   shape where the BARE digest appears with no `src_` prefix, e.g. an import
- *   failure quoting the source URI) drops down to its trailing filename;
- * - `src_<digest>__` physical-name prefixes drop (leaving the table stem);
- * - a remaining bare `src_<digest>` (the source name itself, or a digest
- *   inside an underscore-collapsed slice name) reads as `upload` — a neutral,
- *   digest-free stand-in.
+ * evidence) that can embed the content-keyed SOURCE name or its upload URI. Two
+ * rules, most-specific first:
+ * - a staged-upload URI (`s3://<bucket>/uploads/<digest>/<file>` — the one shape
+ *   where the BARE digest appears with no `src_` prefix, e.g. an import failure
+ *   quoting the source URI) drops down to its trailing filename;
+ * - a remaining bare `src_<digest>` (the source name itself) reads as `upload` —
+ *   a neutral, digest-free stand-in.
  * The `upload` collapse is LOSSY: distinct digests all read `upload`, so a
  * message naming two uploads loses which is which — the structured
  * `failure.table_id` projected alongside is the disambiguator. This is the
@@ -116,48 +64,22 @@ export function displayTableName(
  */
 export function stripSrcDigests(text: string): string {
 	if (!SRC_DIGEST.test(text) && !UPLOAD_URI_PREFIX.test(text)) return text;
-	return text
-		.replace(UPLOAD_URI_PREFIX_G, "")
-		.replace(SRC_DIGEST_PREFIX_G, "")
-		.replace(SRC_DIGEST_G, "upload");
+	return text.replace(UPLOAD_URI_PREFIX_G, "").replace(SRC_DIGEST_G, "upload");
 }
 
-// Evidence keys that carry a PHYSICAL table name by engine convention:
-// relationship detectors stamp `from_table`/`to_table`
-// (`entropy/detectors/structural/relations.py`), slice detectors
-// `slice_table_name` (`entropy/detectors/value/slice_variance.py`). These get
-// display-mapped rather than dropped — the name is meaningful, the digest isn't.
-//
-// KNOWN LIMITATION: evidence carries no sourceName context, so the mapping is
-// displayTableName's no-sourceName form — two same-stem tables from DIFFERENT
-// sources (two distinct "orders.csv" uploads → src_<d1>__orders /
-// src_<d2>__orders) collapse to the same display name ("orders") inside an
-// evidence detail. The top-level from_table_name/to_table_name on the tool
-// result remain the more reliable identifiers. Deliberately NOT "fixed" by
-// threading source context through every evidence node — the plumbing cost
-// outweighs the cross-source same-stem corner case.
-const EVIDENCE_TABLE_NAME_KEYS = new Set([
-	"from_table",
-	"to_table",
-	"slice_table_name",
-]);
-
-/** Recursively sanitize one evidence node: drop `_`-prefixed keys, display-map
- * known table-name keys, recurse into nested arrays/objects. */
+/** Recursively sanitize one evidence node: drop engine-internal `_`-prefixed
+ * keys (plumbing the agent never needs — `entropy/detectors/base.py` stamps
+ * `_table_name`/`_column_name` into every persisted evidence dict) and recurse
+ * into nested arrays/objects. Table-name values need no per-key display-mapping
+ * post-DAT-639 (they're already narrow); the bare-digest backstop runs once over
+ * the whole serialized blob in `renderEvidenceDetail`. */
 function sanitizeEvidenceNode(node: unknown): unknown {
 	if (Array.isArray(node)) return node.map(sanitizeEvidenceNode);
 	if (node !== null && typeof node === "object") {
 		const out: Record<string, unknown> = {};
 		for (const [key, value] of Object.entries(node)) {
-			// Engine-internal self-identification keys (`_table_name`,
-			// `_column_name` — stamped into EVERY persisted evidence dict by
-			// `entropy/detectors/base.py` create_entropy_object) are plumbing the
-			// agent never needs; `_table_name` carries the raw digest name.
 			if (key.startsWith("_")) continue;
-			out[key] =
-				EVIDENCE_TABLE_NAME_KEYS.has(key) && typeof value === "string"
-					? displayTableName(value)
-					: sanitizeEvidenceNode(value);
+			out[key] = sanitizeEvidenceNode(value);
 		}
 		return out;
 	}
@@ -168,9 +90,9 @@ function sanitizeEvidenceNode(node: unknown): unknown {
  * Compact, agent-safe rendering of a detector's persisted evidence blob
  * (DAT-433). The why_* tools put this string in `evidence[].detail`, which
  * reaches BOTH the agent's tool result and the synthesis prompt — so the
- * engine-internal `_`-keys are dropped, explicit table-name keys are
- * display-mapped, and `stripSrcDigests` backstops whatever shape a future
- * detector invents. Engine evidence shape itself is deliberately untouched.
+ * engine-internal `_`-keys are dropped and `stripSrcDigests` backstops any
+ * content-keyed source name/URI a detector's evidence carries. Engine evidence
+ * shape itself is deliberately untouched.
  */
 export function renderEvidenceDetail(evidence: unknown): string {
 	if (evidence === null || evidence === undefined) return "";

--- a/packages/cockpit/src/select/mappers.test.ts
+++ b/packages/cockpit/src/select/mappers.test.ts
@@ -19,6 +19,7 @@ import {
 	reservedSourceNamePrefix,
 	sanitizeRecipeName,
 	sourceTypeForUri,
+	uploadTableName,
 } from "./mappers";
 
 // A real 40-char sha-1 hex digest (the digest of the empty string) — the shape
@@ -135,6 +136,49 @@ describe("sanitizeRecipeName", () => {
 		for (const display of ["dbo.Invoices", "2024_x", "A B C", "tbl"]) {
 			expect(sanitizeRecipeName(display)).toMatch(/^[a-z][a-z0-9_]*$/);
 		}
+	});
+});
+
+describe("uploadTableName (DAT-639)", () => {
+	it("names a file's raw table after the sanitized stem (mirrors raw_table_name_for_uri)", () => {
+		// The engine drops the `src_<digest>__` source prefix post-DAT-639: a CSV at
+		// uploads/<digest>/Orders.CSV loads into the NARROW raw table `orders`.
+		expect(
+			uploadTableName(`s3://dataraum-lake/${WS}/uploads/${DIGEST}/Orders.CSV`),
+		).toBe("orders");
+	});
+
+	it("sanitizes a dashed/odd filename sensibly (lowercase, underscores, letter-led)", () => {
+		expect(
+			uploadTableName(
+				`s3://dataraum-lake/${WS}/uploads/${DIGEST}/Master TXN-sample.csv`,
+			),
+		).toBe("master_txn_sample");
+		// A digit-led stem gets the `t_` lead-letter fix (sanitizeRecipeName rule).
+		expect(
+			uploadTableName(
+				`s3://dataraum-lake/${WS}/uploads/${DIGEST}/2024_orders.parquet`,
+			),
+		).toBe("t_2024_orders");
+	});
+
+	it("keys on the filename, not the digest — two files with the same stem collide", () => {
+		// The narrow-name guard's whole point: two distinct uploads whose stems match
+		// resolve to ONE raw table name (the duplication DAT-639 catches).
+		const a = uploadTableName(
+			`s3://dataraum-lake/${WS}/uploads/${DIGEST}/orders.csv`,
+		);
+		const b = uploadTableName(
+			"s3://dataraum-lake/ws2/uploads/0000000000000000000000000000000000000000/orders.csv",
+		);
+		expect(a).toBe("orders");
+		expect(b).toBe("orders");
+	});
+
+	it("handles a stem with no extension (a dotless basename stays whole)", () => {
+		expect(
+			uploadTableName(`s3://dataraum-lake/${WS}/uploads/${DIGEST}/README`),
+		).toBe("readme");
 	});
 });
 

--- a/packages/cockpit/src/select/mappers.test.ts
+++ b/packages/cockpit/src/select/mappers.test.ts
@@ -85,7 +85,6 @@ describe("reservedSourceNamePrefix (DAT-433)", () => {
 	it("flags each derived-table family prefix", () => {
 		expect(reservedSourceNamePrefix("src_mydata")).toBe("src_");
 		expect(reservedSourceNamePrefix("enriched_data")).toBe("enriched_");
-		expect(reservedSourceNamePrefix("slice_metrics")).toBe("slice_");
 	});
 
 	it("passes bare words and near-misses (only the prefixed forms collide)", () => {

--- a/packages/cockpit/src/select/mappers.ts
+++ b/packages/cockpit/src/select/mappers.ts
@@ -35,27 +35,22 @@ import { UPLOAD_PREFIX } from "../upload/policy";
 // engine's legacy `SourceManager` and its `_NAME_PATTERN`; `select` is the only
 // writer of source rows): lowercase, starts with a letter, 2–49 chars of
 // `[a-z0-9_]`. The engine consumes the persisted name verbatim — the credential
-// lookup `DATARAUM_<NAME>_URL` and the raw-table prefix `<name>__` both key off
-// it — and it is UNIQUE (`uq_sources_name`). Lives here in the pure-shape module
-// so both the db-source name validation (`tools/select.ts`) and the content-keyed
-// file-source name derivation below agree on one pattern.
+// lookup `DATARAUM_<NAME>_URL` keys off it — and it is UNIQUE (`uq_sources_name`).
+// (Post-DAT-639 there is no `<name>__` raw-table prefix; physical table names are
+// narrow.) Lives here in the pure-shape module so both the db-source name
+// validation (`tools/select.ts`) and the content-keyed file-source name
+// derivation below agree on one pattern.
 export const SOURCE_NAME_PATTERN = /^[a-z][a-z0-9_]{1,48}$/;
 
-// Reserved family prefixes (DAT-433). The display rules in lib/display-names.ts
-// are SOUND only because a user-chosen source name can never start with a
-// derived-table family prefix: `src_` (content-keyed upload sources →
-// `src_<digest>__<table>` physical names), `enriched_` (enriched views
-// `enriched_<source>__<table>`), `slice_` (slice tables
-// `slice_<source table>_<col>_<value>`). Without the reservation, a db source
-// named `enriched_data` would display differently per tool (callers without
-// sourceName context apply the family rule) AND collide with the real enriched
-// view of a source named `data`. Only the PREFIXED forms collide — the bare
-// words `src`/`enriched`/`slice` are fine as source names.
-export const RESERVED_SOURCE_NAME_PREFIXES = [
-	"src_",
-	"enriched_",
-	"slice_",
-] as const;
+// Reserved family prefixes (DAT-433). A user-chosen source name can never start
+// with a derived-name family prefix: `src_` (the content-keyed upload SOURCE name
+// itself is `src_<digest>`) or `enriched_` (enriched views are `enriched_<table>`
+// — engine `enriched_views_phase.py`). Without the reservation, a source named
+// `enriched_orders` would collide with the real enriched view of a table
+// `orders`. (Post-DAT-639 physical TABLE names are narrow — no `src_<digest>__` /
+// `<source>__` prefix — and slices were removed, so the `slice_` family is gone.)
+// Only the PREFIXED forms collide — the bare words `src`/`enriched` are fine.
+export const RESERVED_SOURCE_NAME_PREFIXES = ["src_", "enriched_"] as const;
 
 /**
  * The reserved family prefix a candidate source name starts with, or null when

--- a/packages/cockpit/src/select/mappers.ts
+++ b/packages/cockpit/src/select/mappers.ts
@@ -131,6 +131,34 @@ export function contentKeyedSourceName(uri: string): string {
 	return name;
 }
 
+// --- narrow raw-table name a file upload loads into (DAT-639) ----------------
+
+/**
+ * The NARROW, workspace-unique raw table name a staged upload URI loads into —
+ * the cockpit mirror of the engine's `raw_table_name_for_uri`
+ * (sources/base.py, DAT-639).
+ *
+ * Post-DAT-639 raw table names are narrow (no `src_<digest>__` source prefix):
+ * the per-workspace DuckLake catalog is the namespace, and `(table_name, layer)`
+ * is workspace-unique (`uq_table_name_layer`). The engine names a file's raw
+ * table after the FILE STEM — the last path segment with its extension stripped,
+ * sanitized — NOT the content-keyed `src_<digest>` source name. So a CSV at
+ * `…/uploads/<digest>/Orders.CSV` loads into raw table `orders`.
+ *
+ * This is the cockpit "say no" pre-check input (DAT-639): the import-set guard
+ * derives each file's candidate name through here so it can reject a collision
+ * (with an existing workspace table, or another file in the same batch) BEFORE
+ * any write, in front of the engine's hard `uq_table_name_layer` backstop. Minor
+ * lead-digit edge divergence from the engine sanitizer is acceptable — the engine
+ * is the authoritative backstop; this stays simple and reuses `sanitizeRecipeName`.
+ */
+export function uploadTableName(fileUri: string): string {
+	const basename = fileUri.split("/").filter(Boolean).at(-1) ?? "";
+	const dot = basename.lastIndexOf(".");
+	const stem = dot > 0 ? basename.slice(0, dot) : basename;
+	return sanitizeRecipeName(stem);
+}
+
 // --- recipe synthesis (db_recipe `connection_config.tables`) -----------------
 
 /** One synthesized recipe query the engine materializes into `raw_<name>`. */

--- a/packages/cockpit/src/server/import-sources.test.ts
+++ b/packages/cockpit/src/server/import-sources.test.ts
@@ -9,7 +9,12 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { persistImportSet } from "./import-sources";
+import {
+	candidateTableNames,
+	firstNameCollision,
+	persistImportSet,
+	runImport,
+} from "./import-sources";
 
 describe("persistImportSet (DAT-594) — heterogeneous union", () => {
 	const persistRecipeSources = vi.fn(async (specs: { source_name: string }[]) =>
@@ -112,5 +117,130 @@ describe("persistImportSet (DAT-594) — heterogeneous union", () => {
 		).rejects.toThrow(/Duplicate source name/);
 		// Queries fail first → files are never persisted.
 		expect(persistFileSources).not.toHaveBeenCalled();
+	});
+});
+
+describe("candidateTableNames (DAT-639) — narrow names a batch mints", () => {
+	it("derives recipe names (sanitizeRecipeName) then file names (uploadTableName), queries first", () => {
+		expect(
+			candidateTableNames({
+				queries: [
+					{
+						source_name: "WWI Orders",
+						credential_source: "wwi",
+						backend: "mssql",
+						sql: "SELECT 1",
+					},
+				],
+				files: [
+					{ file_uri: "s3://b/ws/uploads/aaa/Customers.CSV" },
+					{ file_uri: "s3://b/ws/uploads/bbb/vendor_table.parquet" },
+				],
+			}),
+		).toEqual(["wwi_orders", "customers", "vendor_table"]);
+	});
+});
+
+describe("firstNameCollision (DAT-639) — the say-no pre-check", () => {
+	it("returns null for a clean batch (no in-batch dup, none existing)", () => {
+		expect(
+			firstNameCollision(["orders", "customers"], new Set(["vendors"])),
+		).toBeNull();
+	});
+
+	it("flags an in-batch duplicate first, naming the collision", () => {
+		const msg = firstNameCollision(["orders", "orders"], new Set());
+		expect(msg).toMatch(/Two sources in this import set resolve to the same/);
+		expect(msg).toMatch(/'orders'/);
+	});
+
+	it("flags a candidate that already exists in the workspace", () => {
+		const msg = firstNameCollision(["orders"], new Set(["orders"]));
+		expect(msg).toMatch(/already exists in this workspace/);
+		expect(msg).toMatch(/'orders'/);
+	});
+
+	it("checks in-batch duplicates BEFORE existing-workspace names", () => {
+		// Both conditions hold; the in-batch message wins (clearer for the user).
+		const msg = firstNameCollision(["orders", "orders"], new Set(["orders"]));
+		expect(msg).toMatch(/Two sources in this import set/);
+	});
+});
+
+describe("runImport (DAT-639) — guard before write", () => {
+	const persistRecipeSources = vi.fn(async (specs: { source_name: string }[]) =>
+		specs.map((s) => ({
+			source_id: `q_${s.source_name}`,
+			source_name: s.source_name,
+		})),
+	);
+	const persistFileSources = vi.fn(async (specs: { file_uri: string }[]) =>
+		specs.map((s) => ({
+			source_id: `f_${s.file_uri}`,
+			source_name: `src_${s.file_uri}`,
+		})),
+	);
+	const triggerAddSource = vi.fn(async () => ({
+		workflow_id: "wf_1",
+		run_id: "run_1",
+	}));
+
+	beforeEach(() => {
+		persistRecipeSources.mockClear();
+		persistFileSources.mockClear();
+		triggerAddSource.mockClear();
+	});
+
+	it("rejects on a candidate colliding with an existing workspace table — NO persist, NO trigger", async () => {
+		await expect(
+			runImport(
+				{
+					queries: [],
+					files: [{ file_uri: "s3://b/ws/uploads/aaa/orders.csv" }],
+				},
+				null,
+				{
+					persistRecipeSources,
+					persistFileSources,
+					// `orders.csv` → narrow name `orders`, already live in the workspace.
+					existingRawTableNames: async () => new Set(["orders"]),
+					triggerAddSource,
+				},
+			),
+		).rejects.toThrow(/already exists in this workspace/);
+		// Failed BEFORE any write → no half-state.
+		expect(persistRecipeSources).not.toHaveBeenCalled();
+		expect(persistFileSources).not.toHaveBeenCalled();
+		expect(triggerAddSource).not.toHaveBeenCalled();
+	});
+
+	it("persists + triggers on a clean batch (no collision)", async () => {
+		const result = await runImport(
+			{
+				queries: [
+					{
+						source_name: "orders",
+						credential_source: "wwi",
+						backend: "mssql",
+						sql: "SELECT 1",
+					},
+				],
+				files: [{ file_uri: "s3://b/ws/uploads/aaa/customers.csv" }],
+			},
+			null,
+			{
+				persistRecipeSources,
+				persistFileSources,
+				existingRawTableNames: async () => new Set(["vendors"]),
+				triggerAddSource,
+			},
+		);
+		expect(persistRecipeSources).toHaveBeenCalledOnce();
+		expect(persistFileSources).toHaveBeenCalledOnce();
+		expect(triggerAddSource).toHaveBeenCalledWith({
+			sources: ["q_orders", "f_s3://b/ws/uploads/aaa/customers.csv"],
+		});
+		expect(result.workflow_id).toBe("wf_1");
+		expect(result.run_id).toBe("run_1");
 	});
 });

--- a/packages/cockpit/src/server/import-sources.ts
+++ b/packages/cockpit/src/server/import-sources.ts
@@ -21,6 +21,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { runWithConversation } from "#/lib/run-context";
+import type { FileSourceSpec } from "#/select/file-source";
 // `persistRecipeSources` / `persistFileSources` + `triggerAddSource` pull
 // config-bearing modules (duckdb/probe, config) at load. They run ONLY server-side
 // inside the handler, so they're imported there (dynamically) — NOT statically — to
@@ -30,7 +31,10 @@ import { runWithConversation } from "#/lib/run-context";
 // `runWithConversation` is just AsyncLocalStorage (config-free), so it stays a
 // normal import. The persist-fn TYPES are erased at build, so importing them as
 // `type` keeps the module graph config-free while the union helper stays typed.
-import type { FileSourceSpec } from "#/select/file-source";
+// `mappers` is config-free (node:crypto + a type + UPLOAD_PREFIX only), so the
+// candidate-name derivation stays a static import — it does NOT drag config into
+// this module's graph the way the persist fns / metadata client do.
+import { sanitizeRecipeName, uploadTableName } from "#/select/mappers";
 import type { RecipeSourceSpec } from "#/select/recipe-source";
 
 // One staged query → one single-statement `db_recipe` source.
@@ -101,6 +105,63 @@ export interface ImportSet {
 }
 
 /**
+ * The NARROW raw-table names a batch will mint, in import order (DAT-639) — the
+ * cockpit mirror of what the engine's import phase will CREATE, derived through
+ * the SAME pure functions the engine collision-guard derives through:
+ *   - each recipe → `sanitizeRecipeName(source_name)` (the engine extracts a db
+ *     recipe into a narrow `<name>` table, `raw_prefix=""`), and
+ *   - each file → `uploadTableName(file_uri)` (the file-stem rule, mirroring
+ *     `raw_table_name_for_uri`).
+ * Queries first then files — the same order `persistImportSet` writes.
+ */
+export function candidateTableNames(data: {
+	queries: RecipeSourceSpec[];
+	files: FileSourceSpec[];
+}): string[] {
+	return [
+		...data.queries.map((q) => sanitizeRecipeName(q.source_name)),
+		...data.files.map((f) => uploadTableName(f.file_uri)),
+	];
+}
+
+/**
+ * The first narrow-name collision the batch would hit, or `null` when it's clean
+ * (DAT-639) — the friendly "say no" pre-check in front of the engine's hard
+ * `uq_table_name_layer` backstop. A workspace holds exactly one table of a given
+ * narrow name, so a fresh import must not (a) repeat a name WITHIN the batch (two
+ * sources resolving to the same narrow table), nor (b) reuse a name already live
+ * in the workspace. Pure over the derived candidates + the existing-name set, so
+ * the handler can fail BEFORE any write (no half-state) and it's unit-testable
+ * without a live Postgres. In-batch duplicates are checked first (a clearer
+ * message than "exists in workspace" when the collision is the user's own batch).
+ */
+export function firstNameCollision(
+	candidates: string[],
+	existing: ReadonlySet<string>,
+): string | null {
+	const seen = new Set<string>();
+	for (const name of candidates) {
+		if (seen.has(name)) {
+			return (
+				`Two sources in this import set resolve to the same table name ` +
+				`'${name}' — each table is unique. Rename one of them before importing.`
+			);
+		}
+		seen.add(name);
+	}
+	for (const name of candidates) {
+		if (existing.has(name)) {
+			return (
+				`Table name '${name}' already exists in this workspace — each table ` +
+				`is unique. Rename the source/recipe (or remove the existing one ` +
+				`first) before importing.`
+			);
+		}
+	}
+	return null;
+}
+
+/**
  * Persist the heterogeneous import set (queries + files) and union the result.
  *
  * VALIDATE-ALL-UP-FRONT then persist: both producers validate the whole batch
@@ -132,6 +193,60 @@ export async function persistImportSet(
 	};
 }
 
+/** The collaborators the import orchestration composes — the persisters, the
+ * existing-name read seam (DAT-639 guard), and the batched-run trigger. Injected
+ * so the guard-before-write ordering + the no-persist/no-trigger-on-collision
+ * contract are unit-testable without a live Postgres, config, or Temporal (the
+ * server fn wires the real dynamic imports). */
+export interface ImportDeps extends ImportSetPersisters {
+	existingRawTableNames: () => Promise<ReadonlySet<string>>;
+	triggerAddSource: (input: {
+		sources: string[];
+	}) => Promise<{ workflow_id: string; run_id: string }>;
+}
+
+/**
+ * Run the import: GUARD → persist → trigger (DAT-594, DAT-639).
+ *
+ * The "say no" collision guard runs FIRST, before any write: it rejects when a
+ * candidate narrow table name repeats within the batch or already lives in the
+ * workspace — the friendly pre-check in front of the engine's hard
+ * `uq_table_name_layer` backstop. A rejection throws BEFORE `persistImportSet`,
+ * so nothing is persisted and no run starts (no half-state). On a clean batch the
+ * union is persisted and the batched add-source run is triggered (bound to the
+ * conversation when present, so the completion-watcher narrates it).
+ */
+export async function runImport(
+	data: { queries: RecipeSourceSpec[]; files: FileSourceSpec[] },
+	conversationId: string | null | undefined,
+	deps: ImportDeps,
+): Promise<ImportSourcesResult> {
+	const collision = firstNameCollision(
+		candidateTableNames(data),
+		await deps.existingRawTableNames(),
+	);
+	if (collision !== null) {
+		throw new Error(collision);
+	}
+
+	const { sourceIds, sourceNames } = await persistImportSet(data, deps);
+
+	// Bind the conversation so the run is recorded against it (the watcher routes
+	// progress + narration by conversationId). Off-route (no id) → bare trigger,
+	// the null-conversation run the watcher simply doesn't narrate.
+	const run = await (conversationId
+		? runWithConversation(conversationId, () =>
+				deps.triggerAddSource({ sources: sourceIds }),
+			)
+		: deps.triggerAddSource({ sources: sourceIds }));
+	return {
+		workflow_id: run.workflow_id,
+		run_id: run.run_id,
+		sources: sourceIds,
+		source_names: sourceNames,
+	};
+}
+
 /**
  * Persist the heterogeneous import set (queries + files) and start the batched
  * import over the union.
@@ -147,24 +262,21 @@ export const importSources = createServerFn({ method: "POST" })
 		const { persistRecipeSources } = await import("#/select/recipe-source");
 		const { persistFileSources } = await import("#/select/file-source");
 		const { triggerAddSource } = await import("#/temporal/trigger-add-source");
-
-		const { sourceIds, sourceNames } = await persistImportSet(
-			{ queries: data.queries, files: data.files },
-			{ persistRecipeSources, persistFileSources },
+		// The metadata client pulls config at load — dynamic-import it inside the
+		// handler (same rule as the persist fns) so THIS module's graph stays
+		// config-free for the canvas registry / tests that eagerly load the widget.
+		const { existingRawTableNames } = await import(
+			"#/db/metadata/workspace-state"
 		);
 
-		// Bind the conversation so the run is recorded against it (the watcher routes
-		// progress + narration by conversationId). Off-route (no id) → bare trigger,
-		// the null-conversation run the watcher simply doesn't narrate.
-		const run = await (data.conversationId
-			? runWithConversation(data.conversationId, () =>
-					triggerAddSource({ sources: sourceIds }),
-				)
-			: triggerAddSource({ sources: sourceIds }));
-		return {
-			workflow_id: run.workflow_id,
-			run_id: run.run_id,
-			sources: sourceIds,
-			source_names: sourceNames,
-		};
+		return runImport(
+			{ queries: data.queries, files: data.files },
+			data.conversationId,
+			{
+				persistRecipeSources,
+				persistFileSources,
+				existingRawTableNames,
+				triggerAddSource,
+			},
+		);
 	});

--- a/packages/cockpit/src/tools/agent-name-leaks.test.ts
+++ b/packages/cockpit/src/tools/agent-name-leaks.test.ts
@@ -1,22 +1,22 @@
 // Property-style leak tests (DAT-433): no content-keyed `src_<digest>` name
-// reaches the agent through ANY tool projection. Fixtures are ENGINE-SHAPED —
-// they mirror what the engine actually persists:
+// reaches the agent through ANY tool projection. Post-DAT-639 physical table
+// names are NARROW (no `src_<digest>__` prefix), so the digest only survives on
+// the upload SOURCE name (`sources.name` = `src_<digest>`) and the staged-upload
+// s3 URI — those are the live leak vectors these tests pin. Fixtures are
+// ENGINE-SHAPED — they mirror what the engine actually persists:
 //   - every evidence dict carries `_column_name` + `_table_name` (stamped by
 //     `entropy/detectors/base.py` create_entropy_object),
 //   - relationship detectors add explicit `from_table`/`to_table`
 //     (`entropy/detectors/structural/relations.py`),
-//   - slice detectors add `slice_table_name` with the underscore-collapsed
-//     slice name (`entropy/detectors/value/slice_variance.py` +
-//     `analysis/slicing/slice_runner.py` naming),
-//   - workflow failures embed raw physical names in engine-built message text
-//     (`worker.contracts.ProgressFailure`).
+//   - workflow failures embed physical names in engine-built message text
+//     (`worker.contracts.ProgressFailure`),
+//   - an upload source's row carries `src_<digest>` as its name + the digest s3
+//     URI in `connection_config` (the list_tables case).
 //
 // The property: JSON.stringify of the FULL projected result never matches
-// /src_[0-9a-f]{40}/ — with ONE sanctioned exception: list_tables/look_table
-// deliberately carry the raw DuckDB name in `physical_name` (the run_sql
-// round-trip key; the agent cannot reconstruct the digest from a display
-// name). For those two, the property holds on the result MINUS that field,
-// and the orchestrator prompt forbids echoing it in prose.
+// /src_[0-9a-f]{40}/. list_tables/look_table carry the raw DuckDB name in
+// `physical_name` (the run_sql round-trip key) — now narrow, so the property
+// holds on the full result.
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -49,12 +49,13 @@ import { projectWhyValidation } from "./why-validation";
 
 const LEAK = /src_[0-9a-f]{40}/;
 
-// Two distinct content digests (sha-1 hex), as the upload sources mint them.
+// A content digest (sha-1 hex), as the upload sources mint them. Lives on the
+// SOURCE name + URI now — never on a table name (DAT-639).
 const D1 = "204bc8e118543a6c35654c1f68c43539a2e226f2";
-const D2 = "3cb4f3325aa757324f32b2dbe30b4ca5a55a8b50";
-const RAW_ORDERS = `src_${D1}__orders`;
-const RAW_CUSTOMERS = `src_${D2}__customers`;
-const RAW_SLICE = `slice_src_${D1}_orders_region_emea`;
+// Narrow, workspace-unique table names (DAT-639): the physical name IS the
+// display name — there is no digest to strip out of it.
+const ORDERS = "orders";
+const CUSTOMERS = "customers";
 
 // Engine-shaped per-column evidence: detector payload + the stamped `_` keys.
 const columnEvidence: WhyEvidenceRow[] = [
@@ -69,26 +70,7 @@ const columnEvidence: WhyEvidenceRow[] = [
 				metric: "undeclared_ratio",
 				value: 0.8,
 				_column_name: "amount",
-				_table_name: RAW_ORDERS,
-			},
-		],
-	},
-	{
-		layer: "value",
-		dimension: "distribution",
-		subDimension: "slice_variance",
-		score: 0.6,
-		detectorId: "slice_variance",
-		evidence: [
-			{
-				null_ratio: 0.1,
-				distinct_count: 5,
-				row_count: 100,
-				slice_table_name: RAW_SLICE,
-				outlier_ratio: 0.0,
-				benford_p_value: null,
-				_column_name: "amount",
-				_table_name: RAW_ORDERS,
+				_table_name: ORDERS,
 			},
 		],
 	},
@@ -98,12 +80,12 @@ const columnEvidence: WhyEvidenceRow[] = [
 const relationshipEvidence = [
 	{
 		path_status: "ambiguous",
-		from_table: RAW_ORDERS,
-		to_table: RAW_CUSTOMERS,
+		from_table: ORDERS,
+		to_table: CUSTOMERS,
 		distinct_join_paths: 2,
 		resolved_by_overlay: false,
 		_column_name: "customer_id",
-		_table_name: RAW_ORDERS,
+		_table_name: ORDERS,
 	},
 ];
 
@@ -112,7 +94,7 @@ describe("agent name-leak property (DAT-433)", () => {
 		const readiness: WhyReadinessRow = {
 			columnId: "c_amount",
 			columnName: "amount",
-			tableName: RAW_ORDERS,
+			tableName: ORDERS,
 			band: "investigate",
 			bandStage: "add_source",
 			bandComputedAt: null,
@@ -121,16 +103,14 @@ describe("agent name-leak property (DAT-433)", () => {
 		};
 		const out = projectWhyData(readiness, columnEvidence, 1);
 		expect(JSON.stringify(out)).not.toMatch(LEAK);
-		// The display name survives — sanitization is not erasure.
 		expect(out.table_name).toBe("orders");
-		expect(out.evidence[1]?.detail).toContain("slice_orders_region_emea");
 	});
 
 	it("why_table: full result is digest-free", () => {
 		const evidenceRows: WhyTableEvidenceRow[] = columnEvidence;
 		const out = projectWhyTable(
 			"t_orders",
-			RAW_ORDERS,
+			ORDERS,
 			{
 				band: "investigate",
 				bandStage: "session_detect",
@@ -147,9 +127,9 @@ describe("agent name-leak property (DAT-433)", () => {
 
 	it("why_relationship: full result is digest-free", () => {
 		const endpoints: RelEndpoints = {
-			fromTableName: RAW_ORDERS,
+			fromTableName: ORDERS,
 			fromColumnName: "customer_id",
-			toTableName: RAW_CUSTOMERS,
+			toTableName: CUSTOMERS,
 			toColumnName: "id",
 		};
 		const evidenceRows: WhyRelEvidenceRow[] = [
@@ -179,7 +159,7 @@ describe("agent name-leak property (DAT-433)", () => {
 		expect(JSON.stringify(out)).not.toMatch(LEAK);
 		expect(out.from_table_name).toBe("orders");
 		expect(out.to_table_name).toBe("customers");
-		// The relationship detector's explicit name keys are display-mapped.
+		// The relationship detector's explicit name keys survive verbatim (narrow).
 		expect(out.evidence[0]?.detail).toContain('"from_table":"orders"');
 		expect(out.evidence[0]?.detail).toContain('"to_table":"customers"');
 	});
@@ -193,19 +173,22 @@ describe("agent name-leak property (DAT-433)", () => {
 			topDrivers: [],
 		};
 		const names: ColumnNameLookup = new Map([
-			["c_from", { columnName: "customer_id", tableName: RAW_ORDERS }],
-			["c_to", { columnName: "id", tableName: RAW_CUSTOMERS }],
+			["c_from", { columnName: "customer_id", tableName: ORDERS }],
+			["c_to", { columnName: "id", tableName: CUSTOMERS }],
 		]);
 		const out = projectRelationshipReadiness(row, names);
 		expect(JSON.stringify(out)).not.toMatch(LEAK);
 		expect(out?.from_table_name).toBe("orders");
 	});
 
-	it("list_tables: result minus the sanctioned physical_name is digest-free", () => {
+	it("list_tables: a content-keyed source name + upload URI never leak", () => {
+		// The live digest vector post-DAT-639: the upload's source row carries
+		// `src_<digest>` as its name and the digest s3 URI in connection_config.
+		// The projection must surface the human filename, never the digest.
 		const rows: InventoryTableRow[] = [
 			{
 				tableId: "t_orders",
-				tableName: RAW_ORDERS,
+				tableName: ORDERS,
 				layer: "typed",
 				rowCount: 100,
 				sourceId: "s1",
@@ -218,18 +201,17 @@ describe("agent name-leak property (DAT-433)", () => {
 			},
 		];
 		const [out] = buildInventory(rows, []);
-		const { physical_name, ...rest } = out;
-		expect(JSON.stringify(rest)).not.toMatch(LEAK);
-		// The round-trip key still carries the raw DuckDB name.
-		expect(physical_name).toBe(RAW_ORDERS);
+		expect(JSON.stringify(out)).not.toMatch(LEAK);
+		// The round-trip key carries the (now narrow) physical name.
+		expect(out.physical_name).toBe(ORDERS);
 		expect(out.table_name).toBe("orders");
 		expect(out.source_name).toBe("orders.csv");
 	});
 
-	it("look_table: result minus the sanctioned physical_name is digest-free", () => {
+	it("look_table: full result is digest-free", () => {
 		const out = projectLookTable(
 			"t_orders",
-			RAW_ORDERS,
+			ORDERS,
 			[
 				projectColumnReadiness({
 					columnId: "c_amount",
@@ -244,27 +226,24 @@ describe("agent name-leak property (DAT-433)", () => {
 			null,
 			0,
 		);
-		const { physical_name, ...rest } = out;
-		expect(JSON.stringify(rest)).not.toMatch(LEAK);
-		expect(physical_name).toBe(RAW_ORDERS);
+		expect(JSON.stringify(out)).not.toMatch(LEAK);
+		expect(out.physical_name).toBe(ORDERS);
 		expect(out.table_name).toBe("orders");
 	});
 
 	it("look_validation: full result is digest-free, reason stays readable", () => {
-		// Engine-built lifecycle reasons + result messages embed raw physical
-		// names (the validation binder works on lake tables).
 		const out = projectValidationOverview(
 			{
 				artifactKey: "gl_invoice_match",
 				state: "declared",
-				stateReason: `Missing required tables: ${RAW_ORDERS} and ${RAW_CUSTOMERS}`,
+				stateReason: `Missing required tables: ${ORDERS} and ${CUSTOMERS}`,
 			},
 			{
 				status: "executed",
 				severity: "error",
 				passed: false,
-				message: `12 rows in ${RAW_ORDERS} have no match`,
-				columnsUsed: [`${RAW_ORDERS}.customer_id`],
+				message: `12 rows in ${ORDERS} have no match`,
+				columnsUsed: [`${ORDERS}.customer_id`],
 			},
 		);
 		expect(JSON.stringify(out)).not.toMatch(LEAK);
@@ -274,7 +253,7 @@ describe("agent name-leak property (DAT-433)", () => {
 		expect(out.message).toBe("12 rows in orders have no match");
 	});
 
-	it("why_validation: full result is digest-free, SQL + grounding sanitized", () => {
+	it("why_validation: full result is digest-free, SQL + grounding readable", () => {
 		const out = projectWhyValidation(
 			"gl_invoice_match",
 			{
@@ -282,29 +261,27 @@ describe("agent name-leak property (DAT-433)", () => {
 				stateReason: null,
 				strictness: 0.8,
 				groundedAgainst: {
-					from_table: RAW_ORDERS,
-					to_table: RAW_CUSTOMERS,
-					_table_name: RAW_ORDERS,
+					from_table: ORDERS,
+					to_table: CUSTOMERS,
+					_table_name: ORDERS,
 				},
 			},
 			{
 				status: "executed",
 				severity: "error",
 				passed: false,
-				message: `12 rows in ${RAW_ORDERS} have no match`,
-				sqlUsed: `SELECT count(*) FROM lake.typed.${RAW_ORDERS} o LEFT JOIN lake.typed.${RAW_CUSTOMERS} c ON o.customer_id = c.id`,
+				message: `12 rows in ${ORDERS} have no match`,
+				sqlUsed: `SELECT count(*) FROM lake.typed.${ORDERS} o LEFT JOIN lake.typed.${CUSTOMERS} c ON o.customer_id = c.id`,
 				executedAt: new Date("2026-06-07T12:00:00Z"),
-				details: { table: RAW_ORDERS, failing_rows: 12 },
-				columnsUsed: [`${RAW_ORDERS}.customer_id`],
+				details: { table: ORDERS, failing_rows: 12 },
+				columnsUsed: [`${ORDERS}.customer_id`],
 			},
 			0,
 		);
 		expect(JSON.stringify(out)).not.toMatch(LEAK);
-		// The SQL stays readable as evidence — digest prefixes dropped.
 		expect(out.sql_used).toContain("lake.typed.orders");
 		expect(out.sql_used).toContain("lake.typed.customers");
-		// The grounding render display-maps known table-name keys and drops
-		// engine-internal `_` keys (shared evidence sanitizer).
+		// The grounding render keeps narrow table-name keys + drops engine `_` keys.
 		expect(out.grounded_against).toContain('"from_table":"orders"');
 		expect(out.grounded_against).not.toContain("_table_name");
 	});

--- a/packages/cockpit/src/tools/list-tables.test.ts
+++ b/packages/cockpit/src/tools/list-tables.test.ts
@@ -28,7 +28,7 @@ function tableRow(
 ): InventoryTableRow {
 	return {
 		tableId: "t_orders",
-		tableName: `src_${DIGEST}__orders`,
+		tableName: `orders`,
 		layer: "typed",
 		rowCount: 1000,
 		sourceId: "s_sales",
@@ -47,10 +47,10 @@ describe("buildInventory (DAT-349)", () => {
 		const [out] = buildInventory([tableRow()], []);
 		expect(out).toMatchObject({
 			table_id: "t_orders",
-			// Prose name: digest prefix stripped; the raw DuckDB name rides in
-			// physical_name for the run_sql round-trip.
+			// Prose name + physical_name are both the narrow name now (DAT-639);
+			// physical_name stays the run_sql round-trip key.
 			table_name: "orders",
-			physical_name: `src_${DIGEST}__orders`,
+			physical_name: `orders`,
 			layer: "typed",
 			row_count: 1000,
 			source_id: "s_sales",
@@ -65,7 +65,7 @@ describe("buildInventory (DAT-349)", () => {
 		const [out] = buildInventory(
 			[
 				tableRow({
-					tableName: "finance__journal_lines",
+					tableName: "journal_lines",
 					sourceName: "finance",
 					sourceType: "db_recipe",
 					sourceBackend: "postgres",
@@ -76,7 +76,7 @@ describe("buildInventory (DAT-349)", () => {
 		);
 		expect(out.source_name).toBe("finance");
 		expect(out.table_name).toBe("journal_lines");
-		expect(out.physical_name).toBe("finance__journal_lines");
+		expect(out.physical_name).toBe("journal_lines");
 	});
 
 	it("degrades a malformed upload config to the neutral 'upload', never the digest", () => {
@@ -259,20 +259,20 @@ describe("buildInventory entity + enriched_views (DAT-477)", () => {
 		const views: EnrichedViewRow[] = [
 			{
 				factTableId: "t_orders",
-				viewName: `enriched_src_${DIGEST}__orders`,
+				viewName: `enriched_orders`,
 				isGrainVerified: true,
 				createdAt: new Date("2026-06-01T00:00:00Z"),
 			},
 			{
 				factTableId: "t_orders",
-				viewName: `enriched_src_${DIGEST}__orders_by_region`,
+				viewName: `enriched_orders_by_region`,
 				isGrainVerified: false,
 				createdAt: new Date("2026-06-01T00:00:00Z"),
 			},
 			// A different fact table's view must not leak onto t_orders.
 			{
 				factTableId: "t_items",
-				viewName: `enriched_src_${DIGEST}__items`,
+				viewName: `enriched_items`,
 				isGrainVerified: false,
 				createdAt: new Date("2026-06-01T00:00:00Z"),
 			},
@@ -317,7 +317,7 @@ describe("buildInventory entity + enriched_views (DAT-477)", () => {
 			},
 			{
 				factTableId: "t_orders",
-				viewName: `enriched_src_${DIGEST}__orders`,
+				viewName: `enriched_orders`,
 				isGrainVerified: false,
 				createdAt: new Date("2026-06-01T00:00:00Z"),
 			},
@@ -354,7 +354,7 @@ describe("buildInventory entity + enriched_views (DAT-477)", () => {
 		expect(out).toMatchObject({
 			table_id: "t_orders",
 			table_name: "orders",
-			physical_name: `src_${DIGEST}__orders`,
+			physical_name: `orders`,
 			row_count: 1000,
 			column_count: 2,
 			worst_band: "blocked",
@@ -423,7 +423,7 @@ describe("buildInventory entity + enriched_views (DAT-477)", () => {
 				// Older session: a single, unverified view.
 				{
 					factTableId: "t_orders",
-					viewName: `enriched_src_${DIGEST}__orders_old`,
+					viewName: `enriched_orders_old`,
 					isGrainVerified: false,
 					createdAt: t1,
 				},
@@ -431,13 +431,13 @@ describe("buildInventory entity + enriched_views (DAT-477)", () => {
 				// whole, with no carry-over from the older session.
 				{
 					factTableId: "t_orders",
-					viewName: `enriched_src_${DIGEST}__orders`,
+					viewName: `enriched_orders`,
 					isGrainVerified: true,
 					createdAt: t2,
 				},
 				{
 					factTableId: "t_orders",
-					viewName: `enriched_src_${DIGEST}__orders_by_region`,
+					viewName: `enriched_orders_by_region`,
 					isGrainVerified: false,
 					createdAt: t2,
 				},

--- a/packages/cockpit/src/tools/look-cycle.test.ts
+++ b/packages/cockpit/src/tools/look-cycle.test.ts
@@ -18,8 +18,6 @@ vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 import type { LifecycleArtifactRow } from "../db/metadata/lifecycle-artifacts";
 import { type CycleDetectionRow, projectCycleOverview } from "./look-cycle";
 
-const D1 = "204bc8e118543a6c35654c1f68c43539a2e226f2";
-
 describe("projectCycleOverview (DAT-465)", () => {
 	it("joins an executed artifact with its detection row — values verbatim", () => {
 		const artifact: LifecycleArtifactRow = {
@@ -96,14 +94,14 @@ describe("projectCycleOverview (DAT-465)", () => {
 		expect(projected.completion_rate).toBeNull();
 	});
 
-	it("strips content-keyed src_<digest> names from engine-built free text", () => {
+	it("renders narrow names in engine-built free text; stays digest-free (DAT-639)", () => {
 		const artifact: LifecycleArtifactRow = {
 			artifactKey: "inventory_cycle",
 			state: "declared",
-			stateReason: `not detected: src_${D1}__inventory missing`,
+			stateReason: `not detected: inventory missing`,
 		};
 		const detected: CycleDetectionRow = {
-			cycleName: `Flow over src_${D1}__inventory`,
+			cycleName: `Flow over inventory`,
 			businessValue: "medium",
 			isKnownType: false,
 			confidence: 0.4,

--- a/packages/cockpit/src/tools/look-drivers.test.ts
+++ b/packages/cockpit/src/tools/look-drivers.test.ts
@@ -17,8 +17,6 @@ vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 
 import { type DriverRankingRow, projectDriverRanking } from "./look-drivers";
 
-const D1 = "204bc8e118543a6c35654c1f68c43539a2e226f2";
-
 describe("projectDriverRanking (DAT-546)", () => {
 	it("preserves per-family grain labels — primary + secondaries never merged", () => {
 		const row: DriverRankingRow = {
@@ -63,18 +61,18 @@ describe("projectDriverRanking (DAT-546)", () => {
 		});
 	});
 
-	it("sanitizes content-keyed src_<digest>__ prefixes on dimension names", () => {
+	it("renders narrow dimension names as-is (DAT-639)", () => {
 		const row: DriverRankingRow = {
 			measureLabel: "amount",
 			targetType: "flow",
 			grain: "row",
 			entity: null,
 			nRows: 10_000,
-			rankedDimensions: [{ dimension: `src_${D1}__region`, gain: 0.3 }],
-			driverPaths: [[`src_${D1}__region`, "channel"]],
+			rankedDimensions: [{ dimension: `region`, gain: 0.3 }],
+			driverPaths: [[`region`, "channel"]],
 			interestingSlices: [
 				{
-					dimension: `src_${D1}__region`,
+					dimension: `region`,
 					value: "CH",
 					effect: 0.4,
 					support: 90,

--- a/packages/cockpit/src/tools/look-metric.test.ts
+++ b/packages/cockpit/src/tools/look-metric.test.ts
@@ -17,8 +17,6 @@ vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
 import type { LifecycleArtifactRow } from "../db/metadata/lifecycle-artifacts";
 import { metricSnippetSource, projectMetricOverview } from "./look-metric";
 
-const D1 = "204bc8e118543a6c35654c1f68c43539a2e226f2";
-
 describe("metricSnippetSource (DAT-466)", () => {
 	it("builds the graph:<id> provenance link", () => {
 		expect(metricSnippetSource("ebitda")).toBe("graph:ebitda");
@@ -69,11 +67,11 @@ describe("projectMetricOverview (DAT-466)", () => {
 		expect(projected.snippet_count).toBe(3);
 	});
 
-	it("strips content-keyed src_<digest> names from engine-built free text", () => {
+	it("renders narrow names in engine-built free text; stays digest-free (DAT-639)", () => {
 		const artifact: LifecycleArtifactRow = {
 			artifactKey: "gross_margin",
 			state: "declared",
-			stateReason: `ungroundable: src_${D1}__income missing`,
+			stateReason: `ungroundable: income missing`,
 		};
 		const projected = projectMetricOverview(artifact, 0);
 		expect(projected.state_reason).toBe("ungroundable: income missing");

--- a/packages/cockpit/src/tools/look-profile.test.ts
+++ b/packages/cockpit/src/tools/look-profile.test.ts
@@ -62,12 +62,11 @@ function candidate(
 }
 
 describe("projectColumnProfile — identity + not-found (DAT-475)", () => {
-	it("strips the digest prefix to a display table_name; column_id stays the round-trip key", () => {
-		const DIGEST = "204bc8e118543a6c35654c1f68c43539a2e226f2";
+	it("renders the narrow table_name; column_id stays the round-trip key (DAT-639)", () => {
 		const out = projectColumnProfile(
 			"c_1",
 			"amount",
-			`src_${DIGEST}__orders`,
+			`orders`,
 			"DECIMAL(18,2)",
 			EMPTY_ROWS,
 		);

--- a/packages/cockpit/src/tools/look-relationships.test.ts
+++ b/packages/cockpit/src/tools/look-relationships.test.ts
@@ -173,7 +173,7 @@ describe("projectRelationshipReadiness (DAT-409)", () => {
 		expect(out?.band).toBe("investigate");
 	});
 
-	it("strips the content-keyed `src_<digest>__` prefix from endpoint table names (DAT-431)", () => {
+	it("renders narrow endpoint table names as-is (DAT-639)", () => {
 		// This result goes back to the agent — never the hash form. The drill-down
 		// round-trip (why_relationship) keys on the column ids, which pass through raw.
 		const lookup: ColumnNameLookup = new Map([
@@ -181,14 +181,14 @@ describe("projectRelationshipReadiness (DAT-409)", () => {
 				FROM,
 				{
 					columnName: "invoice_id",
-					tableName: "src_204bc8e118543a6c35654c1f68c43539a2e226f2__payments",
+					tableName: "payments",
 				},
 			],
 			[
 				TO,
 				{
 					columnName: "invoice_id",
-					tableName: "src_3cb4f3325aa757324f32b2dbe30b4ca5a55a8b50__invoices",
+					tableName: "invoices",
 				},
 			],
 		]);

--- a/packages/cockpit/src/tools/look-table.test.ts
+++ b/packages/cockpit/src/tools/look-table.test.ts
@@ -257,20 +257,17 @@ describe("projectTableEntity (DAT-476)", () => {
 		).toEqual([]);
 	});
 
-	it("strips src_<digest>__ prefixes from grain / time-axis columns / description", () => {
-		// Engine free-text/name fields can carry the content-keyed source prefix;
-		// the projection digest-strips them before they reach the tool output.
-		const D = "204bc8e118543a6c35654c1f68c43539a2e226f2";
+	it("renders narrow grain / time-axis columns / description (DAT-639)", () => {
+		// Engine free-text/name fields are NARROW post-DAT-639; the projection
+		// renders them as-is and the result stays digest-free.
 		const out = projectTableEntity(
 			entityRow({
-				grainColumns: { columns: [`src_${D}__order_id`, "line_no"] },
+				grainColumns: { columns: [`order_id`, "line_no"] },
 				timeColumns: [
-					{ column: `src_${D}__order_date`, aspect: "order", note: "Placed." },
+					{ column: `order_date`, aspect: "order", note: "Placed." },
 				],
-				identityColumns: [
-					{ column: `src_${D}__order_id`, note: "Recurring identity." },
-				],
-				description: `One row per line in src_${D}__orders.`,
+				identityColumns: [{ column: `order_id`, note: "Recurring identity." }],
+				description: `One row per line in orders.`,
 			}),
 		);
 		expect(out.grain).toEqual(["order_id", "line_no"]);
@@ -384,19 +381,17 @@ describe("projectTableBand (DAT-415)", () => {
 });
 
 describe("projectLookTable (DAT-433)", () => {
-	const DIGEST = "204bc8e118543a6c35654c1f68c43539a2e226f2";
-
-	it("splits the raw name into display table_name + raw physical_name", () => {
+	it("surfaces the narrow table_name + the physical_name round-trip key (DAT-639)", () => {
 		const out = projectLookTable(
 			"t_orders",
-			`src_${DIGEST}__orders`,
+			`orders`,
 			[projectColumnReadiness(row())],
 			null,
 			2,
 			projectTableEntity(entityRow()),
 		);
 		expect(out.table_name).toBe("orders");
-		expect(out.physical_name).toBe(`src_${DIGEST}__orders`);
+		expect(out.physical_name).toBe(`orders`);
 		expect(out.analyzed).toBe(true);
 		expect(out.pending_teaches).toBe(2);
 		// The entity header carries straight through (DAT-476).

--- a/packages/cockpit/src/tools/look-validation.test.ts
+++ b/packages/cockpit/src/tools/look-validation.test.ts
@@ -20,8 +20,6 @@ import {
 	type ValidationResultRow,
 } from "./look-validation";
 
-const D1 = "204bc8e118543a6c35654c1f68c43539a2e226f2";
-
 describe("projectValidationOverview (DAT-440)", () => {
 	it("joins an executed artifact with its result row — values verbatim", () => {
 		const artifact: LifecycleArtifactRow = {
@@ -69,18 +67,18 @@ describe("projectValidationOverview (DAT-440)", () => {
 		expect(projected.severity).toBeNull();
 	});
 
-	it("strips content-keyed src_<digest> names from engine-built free text", () => {
+	it("renders narrow names in engine-built free text; stays digest-free (DAT-639)", () => {
 		const artifact: LifecycleArtifactRow = {
 			artifactKey: "balance_check",
 			state: "declared",
-			stateReason: `Missing required tables: src_${D1}__orders`,
+			stateReason: `Missing required tables: orders`,
 		};
 		const result: ValidationResultRow = {
 			status: "executed",
 			severity: null,
 			passed: true,
-			message: `checked src_${D1}__orders rows`,
-			columnsUsed: [`src_${D1}__orders.amount`],
+			message: `checked orders rows`,
+			columnsUsed: [`orders.amount`],
 		};
 
 		const projected = projectValidationOverview(artifact, result);

--- a/packages/cockpit/src/tools/operating-model-graph.test.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.test.ts
@@ -67,7 +67,7 @@ const base = (): OperatingModelGraphInput => ({
 	tables: [
 		// Content-keyed physical name: the validation→column match must resolve via the
 		// DISPLAY name ("sales"), since columns_used arrives digest-stripped.
-		{ tableId: "t1", tableName: "src_abcd1234__sales" },
+		{ tableId: "t1", tableName: "sales" },
 		{ tableId: "t2", tableName: "customers" },
 	],
 });

--- a/packages/cockpit/src/tools/why-column.test.ts
+++ b/packages/cockpit/src/tools/why-column.test.ts
@@ -118,12 +118,12 @@ describe("projectWhyData (DAT-351)", () => {
 		expect(out.evidence[0].detail).toBe("");
 	});
 
-	it("strips the content-keyed `src_<digest>__` prefix from table_name (DAT-431)", () => {
+	it("renders the narrow table_name as-is (DAT-639)", () => {
 		// The result feeds the agent's context + the synthesis prompt — never the
 		// hash form. Round-trips key on column_id, so nothing depends on the raw name.
 		const out = projectWhyData(
 			readiness({
-				tableName: "src_204bc8e118543a6c35654c1f68c43539a2e226f2__orders",
+				tableName: "orders",
 			}),
 			evidenceRows,
 			0,

--- a/packages/cockpit/src/tools/why-cycle.test.ts
+++ b/packages/cockpit/src/tools/why-cycle.test.ts
@@ -120,32 +120,32 @@ describe("projectWhyCycle (DAT-465)", () => {
 		expect(projected.completion_rate).toBeNull();
 	});
 
-	it("strips content-keyed digests from reason/name/description/status; sanitizes JSON blobs", () => {
+	it("renders narrow names in reason/name/description/status; stays digest-free (DAT-639)", () => {
 		const projected = projectWhyCycle(
 			"inventory_cycle",
 			{
 				state: "executed",
-				stateReason: `measured on src_${D1}__inventory`,
+				stateReason: `measured on inventory`,
 				strictness: null,
 				// `_`-prefixed engine plumbing keys are dropped by the sanitizer.
 				groundedAgainst: { _detect: `src_${D1}`, detect: "run-9" },
 			},
 			{
-				cycleName: `Flow over src_${D1}__inventory`,
+				cycleName: `Flow over inventory`,
 				isKnownType: false,
 				businessValue: "low",
 				confidence: 0.5,
-				description: `Cycle through src_${D1}__inventory`,
+				description: `Cycle through inventory`,
 				completionRate: 0.6,
 				completedCycles: 6,
 				totalRecords: 10,
-				statusTable: `src_${D1}__inventory`,
+				statusTable: `inventory`,
 				statusColumn: "state",
 				completionValue: "shipped",
-				stages: [{ table: `src_${D1}__inventory` }],
+				stages: [{ table: `inventory` }],
 				entityFlows: null,
-				tablesInvolved: [`src_${D1}__inventory`],
-				evidence: { table: `src_${D1}__inventory` },
+				tablesInvolved: [`inventory`],
+				evidence: { table: `inventory` },
 			},
 			0,
 		);

--- a/packages/cockpit/src/tools/why-metric.test.ts
+++ b/packages/cockpit/src/tools/why-metric.test.ts
@@ -19,8 +19,6 @@ import {
 	type WhyMetricArtifactRow,
 } from "./why-metric";
 
-const D1 = "204bc8e118543a6c35654c1f68c43539a2e226f2";
-
 const executedArtifact: WhyMetricArtifactRow = {
 	state: "executed",
 	stateReason: null,
@@ -155,16 +153,16 @@ describe("projectWhyMetric (DAT-466)", () => {
 		expect(projected.steps[0].label).toBe("(constant)");
 	});
 
-	it("strips content-keyed digests from the SQL, description, and labels", () => {
+	it("renders narrow names in SQL, description, and labels; stays digest-free (DAT-639)", () => {
 		const dirty: MetricSnippetRow = {
 			snippetId: "snip-dirty",
 			snippetType: "extract",
-			standardField: `src_${D1}__revenue`,
+			standardField: `revenue`,
 			statement: null,
 			aggregation: "sum",
 			normalizedExpression: null,
-			sql: `SELECT sum(x) FROM lake.typed.src_${D1}__income`,
-			description: `pulls src_${D1}__revenue`,
+			sql: `SELECT sum(x) FROM lake.typed.income`,
+			description: `pulls revenue`,
 			executionCount: 0,
 			failureCount: 0,
 		};
@@ -172,9 +170,9 @@ describe("projectWhyMetric (DAT-466)", () => {
 			"m",
 			{
 				state: "executed",
-				stateReason: `measured src_${D1}__income`,
+				stateReason: `measured income`,
 				strictness: null,
-				groundedAgainst: { _internal: `src_${D1}`, detect: "run-9" },
+				groundedAgainst: { detect: "run-9" },
 			},
 			[dirty],
 			0,

--- a/packages/cockpit/src/tools/why-relationship.test.ts
+++ b/packages/cockpit/src/tools/why-relationship.test.ts
@@ -135,14 +135,14 @@ describe("projectWhyRelationship (DAT-409)", () => {
 		expect(out.pending_teaches).toBe(2);
 	});
 
-	it("strips the content-keyed `src_<digest>__` prefix from endpoint table names (DAT-431)", () => {
+	it("renders narrow endpoint table names as-is (DAT-639)", () => {
 		// The result feeds the agent's context + the synthesis prompt — never the
 		// hash form. Round-trips key on the column ids. Null endpoints stay null.
 		const out = projectWhyRelationship(
 			FROM,
 			TO,
 			{
-				fromTableName: "src_204bc8e118543a6c35654c1f68c43539a2e226f2__payments",
+				fromTableName: "payments",
 				fromColumnName: "invoice_id",
 				toTableName: null,
 				toColumnName: null,

--- a/packages/cockpit/src/tools/why-table.test.ts
+++ b/packages/cockpit/src/tools/why-table.test.ts
@@ -123,17 +123,11 @@ describe("projectWhyTable (DAT-415)", () => {
 		expect(out.pending_teaches).toBe(2);
 	});
 
-	it("strips the content-keyed `src_<digest>__` prefix from table_name (DAT-431)", () => {
+	it("renders the narrow table_name as-is (DAT-639)", () => {
 		// The result feeds the agent's context + the synthesis prompt — never the
 		// hash form. The round-trip key is table_id; the caller keeps the raw name
 		// for the readiness target.
-		const out = projectWhyTable(
-			TABLE_ID,
-			"src_204bc8e118543a6c35654c1f68c43539a2e226f2__payments",
-			readiness(),
-			[],
-			0,
-		);
+		const out = projectWhyTable(TABLE_ID, "payments", readiness(), [], 0);
 		expect(out.table_name).toBe("payments");
 	});
 });

--- a/packages/cockpit/src/tools/why-validation.test.ts
+++ b/packages/cockpit/src/tools/why-validation.test.ts
@@ -19,8 +19,6 @@ import {
 	type WhyValidationResultRow,
 } from "./why-validation";
 
-const D1 = "204bc8e118543a6c35654c1f68c43539a2e226f2";
-
 const executedArtifact: WhyValidationArtifactRow = {
 	state: "executed",
 	stateReason: null,
@@ -104,25 +102,25 @@ describe("projectWhyValidation (DAT-440)", () => {
 		expect(projected.status).toBeNull();
 	});
 
-	it("strips content-keyed digests from reason, message, and SQL; sanitizes JSON blobs", () => {
+	it("renders narrow names in reason, message, and SQL; stays digest-free (DAT-639)", () => {
 		const projected = projectWhyValidation(
 			"balance_check",
 			{
 				state: "executed",
-				stateReason: `bound against src_${D1}__orders`,
+				stateReason: `bound against orders`,
 				strictness: null,
 				// `_`-prefixed engine plumbing keys are dropped by the sanitizer.
-				groundedAgainst: { _table_name: `src_${D1}__orders`, table: "orders" },
+				groundedAgainst: { _table_name: `orders`, table: "orders" },
 			},
 			{
 				status: "executed",
 				severity: null,
 				passed: true,
-				message: `src_${D1}__orders is balanced`,
-				sqlUsed: `SELECT count(*) FROM lake.typed.src_${D1}__orders`,
+				message: `orders is balanced`,
+				sqlUsed: `SELECT count(*) FROM lake.typed.orders`,
 				executedAt: null,
-				details: { table: `src_${D1}__orders` },
-				columnsUsed: [`src_${D1}__orders.amount`],
+				details: { table: `orders` },
+				columnsUsed: [`orders.amount`],
 			},
 			0,
 		);

--- a/packages/cockpit/src/ui/cockpit/widgets/measure-progress.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/measure-progress.test.tsx
@@ -288,17 +288,17 @@ describe("MeasureProgressWidget (DAT-352)", () => {
 				tables: [
 					{
 						raw_table_id: "r1",
-						name: "finance_data__payments",
+						name: "payments",
 						status: "done",
 					},
 					{
 						raw_table_id: "r2",
-						name: "finance_data__invoices",
+						name: "invoices",
 						status: "done",
 					},
 					{
 						raw_table_id: "r3",
-						name: "finance_data__fx_rates",
+						name: "fx_rates",
 						status: "done",
 					},
 				],
@@ -335,7 +335,7 @@ describe("MeasureProgressWidget (DAT-352)", () => {
 		);
 	});
 
-	it("strips the `<source>__` prefix from table names in the list AND the failure message", () => {
+	it("renders narrow table names in the list AND the failure message (DAT-639)", () => {
 		h.queryResult = {
 			data: {
 				phase: "processing_tables",
@@ -344,12 +344,12 @@ describe("MeasureProgressWidget (DAT-352)", () => {
 				tables: [
 					{
 						raw_table_id: "r1",
-						name: "finance_data__trial_balance",
+						name: "trial_balance",
 						status: "done",
 					},
 					{
 						raw_table_id: "r2",
-						name: "finance_data__journal_lines",
+						name: "journal_lines",
 						status: "failed",
 					},
 				],
@@ -367,11 +367,9 @@ describe("MeasureProgressWidget (DAT-352)", () => {
 		renderWidget();
 		const list = screen.getByTestId("measure-progress-tables");
 		expect(list.textContent).toContain("trial_balance");
-		expect(list.textContent).not.toContain("finance_data__trial_balance");
-		// The failure path strips the prefix too — the bug the review caught.
+		// The failure path resolves the table by id → its narrow name.
 		const alert = screen.getByTestId("measure-progress-failed");
 		expect(alert.textContent).toContain("journal_lines");
-		expect(alert.textContent).not.toContain("finance_data__journal_lines");
 	});
 
 	it("strips content-keyed digests from the failure message (DAT-433 — same treatment as the agent side)", () => {

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -189,7 +189,7 @@ CREATE TABLE tables (
 	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	last_profiled_at TIMESTAMP WITHOUT TIME ZONE, 
 	CONSTRAINT pk_tables PRIMARY KEY (table_id), 
-	CONSTRAINT uq_source_table_layer UNIQUE (source_id, table_name, layer), 
+	CONSTRAINT uq_table_name_layer UNIQUE (table_name, layer), 
 	CONSTRAINT fk_tables_source_id_sources FOREIGN KEY(source_id) REFERENCES sources (source_id)
 );
 

--- a/packages/engine/src/dataraum/analysis/eligibility/evaluator.py
+++ b/packages/engine/src/dataraum/analysis/eligibility/evaluator.py
@@ -138,9 +138,9 @@ def quarantine_and_drop_columns(
 
     Args:
         conn: DuckDB connection with the ``lake`` catalog attached.
-        typed_table: Bare name of the typed table (e.g., ``"source__orders"``
-            — the ``<source>__<table>`` form stored on ``Table.duckdb_path``
-            post-DAT-341).
+        typed_table: Narrow name of the typed table (e.g., ``"orders"`` — the
+            workspace-unique form stored on ``Table.duckdb_path``, no source
+            prefix per DAT-639).
         columns_data: List of (Column, reason) tuples to drop.
         typed_recipe_ddl: The run's stored typed-layer materialization DDL
             (``CREATE OR REPLACE TABLE lake.typed.… AS SELECT …``), re-executed

--- a/packages/engine/src/dataraum/analysis/relationships/evaluator.py
+++ b/packages/engine/src/dataraum/analysis/relationships/evaluator.py
@@ -327,10 +327,10 @@ def compute_ri_metrics(
 
     Args:
         from_table: Fully-qualified DuckDB path to source table
-            (e.g., ``lake.typed."source__orders"`` post-DAT-341).
+            (e.g., ``lake.typed."orders"`` — narrow, DAT-639).
         from_column: Column name in source table
         to_table: Fully-qualified DuckDB path to target table
-            (e.g., ``lake.typed."source__customers"`` post-DAT-341).
+            (e.g., ``lake.typed."customers"`` — narrow, DAT-639).
         to_column: Column name in target table
         duckdb_conn: DuckDB connection
         cardinality: Optional cardinality to verify (e.g., "one-to-many")

--- a/packages/engine/src/dataraum/analysis/typing/resolution.py
+++ b/packages/engine/src/dataraum/analysis/typing/resolution.py
@@ -101,8 +101,8 @@ def reconcile_typed_table(
     """Find-or-create the ``layer`` Table for ``raw_table`` and refresh its stats.
 
     Stable typed identity (DAT-373 Option A): a re-type REUSES the existing
-    ``typed`` / ``quarantine`` ``Table`` row (matched by
-    ``(source_id, table_name, layer)`` — unique per ``uq_source_table_layer``)
+    ``typed`` / ``quarantine`` ``Table`` row (the typed sibling shares the raw's
+    ``source_id`` and its now workspace-unique ``(table_name, layer)`` — DAT-639)
     rather than minting a fresh ``table_id``. Reusing the row keeps the typed
     Table id — and the Column ids reconciled under it — stable across teach
     replays, so other stages' per-Column rows stay attached. Only the

--- a/packages/engine/src/dataraum/core/connections.py
+++ b/packages/engine/src/dataraum/core/connections.py
@@ -410,6 +410,15 @@ class ConnectionManager:
 
         raw_conn = connect_session()
         raw_conn.execute(f"SET memory_limit='{self.config.duckdb_memory_limit}'")
+        # Raise the DuckLake commit-retry budget (DAT-641 groundwork): the per-table
+        # typing fan-out has many connections racing for the next snapshot id; the
+        # default 10 retries is exhausted on a wide replay, failing the run. Distinct
+        # tables are non-logical conflicts that auto-resolve on retry, so a larger
+        # budget makes concurrent typing reliable. Read from settings directly (like
+        # bootstrap_lake's pool tuning) — it's process-wide, not per-ConnectionConfig.
+        raw_conn.execute(
+            f"SET ducklake_max_retry_count = {get_settings().ducklake_max_retry_count}"
+        )
         # The lake DATA_PATH is an ``s3://`` URI; this connection reads/writes
         # lake parquet, so it needs the object-store secret too. DuckDB's secret
         # manager is per-instance and this shares the anchor's named in-memory

--- a/packages/engine/src/dataraum/core/duckdb_naming.py
+++ b/packages/engine/src/dataraum/core/duckdb_naming.py
@@ -18,7 +18,8 @@ including the catalog compose it at query time.
 
 Convention for ``Table.duckdb_path``:
 
-    Stores the **unqualified table name** (e.g., ``"csv_source__orders"``).
+    Stores the **unqualified, narrow table name** (e.g., ``"orders"`` — no
+    source prefix, workspace-unique per DAT-639).
     The schema is derived from ``Table.layer`` via :func:`schema_for_layer`.
     Reads pre-DAT-341 produced bare names like ``"raw_orders"`` resolved
     via the connection's ``USE`` state; post-DAT-341 the connection USEs

--- a/packages/engine/src/dataraum/core/duckdb_naming.py
+++ b/packages/engine/src/dataraum/core/duckdb_naming.py
@@ -104,38 +104,40 @@ def schema_for_layer(layer: str) -> str:
     return _LAYER_SCHEMA.get(layer, _DEFAULT_SCHEMA)
 
 
-def table_name_for_source(source_name: str, table_name: str) -> str:
-    """Compose a per-source table name with collision-safe separator.
+def workspace_table_name(table_name: str) -> str:
+    """Compose the workspace-unique physical table name — NARROW (DAT-639).
 
-    Two different sources may carry tables with the same logical name
-    (e.g., both an MSSQL source and a CSV source register ``orders``).
-    Prefixing the source disambiguates within a single layer schema.
+    Tables are per-WORKSPACE, not per-source: a workspace holds one ``orders``,
+    full stop. The source is an atomic content-hashed wrapper (how the table
+    arrived), not a namespace — so the physical name carries NO source prefix.
+    This completes DAT-506 (source dropped as a DB identifier) into the physical
+    naming, which had kept the ``{source}__`` prefix. A second source trying to
+    land the same name is a conflict (resolved at import: replay on the same
+    content hash, else fail-loud), never a silently-disambiguated parallel table.
 
     Args:
-        source_name: Logical name of the source the table belongs to.
-        table_name: Logical name of the table within that source.
+        table_name: Logical name of the table.
 
     Returns:
-        ``"<source>__<table>"`` with both segments sanitized.
+        ``"<table>"`` sanitized — safe to embed unquoted in SQL.
     """
-    return f"{sanitize_identifier(source_name)}__{sanitize_identifier(table_name)}"
+    return sanitize_identifier(table_name)
 
 
-def qualified_table(layer: str, source_name: str, table_name: str) -> str:
+def qualified_table(layer: str, table_name: str) -> str:
     """Return the schema-qualified ``"schema.table"`` form (no catalog).
 
     Compose with a catalog alias at query time for full FQN, e.g.
-    ``f"lake.{qualified_table(layer, src, tbl)}"``.
+    ``f"lake.{qualified_table(layer, tbl)}"``.
 
     Args:
         layer: ``Table.layer`` value.
-        source_name: Logical name of the source.
-        table_name: Logical name of the table within the source.
+        table_name: Logical (narrow) name of the table.
 
     Returns:
-        ``"<schema>.<source>__<table>"``, safe to embed unquoted in SQL.
+        ``"<schema>.<table>"``, safe to embed unquoted in SQL.
     """
-    return f"{schema_for_layer(layer)}.{table_name_for_source(source_name, table_name)}"
+    return f"{schema_for_layer(layer)}.{workspace_table_name(table_name)}"
 
 
 # Schemas reserved for slice 2 substrate (session overlays + archive). Documented

--- a/packages/engine/src/dataraum/core/settings.py
+++ b/packages/engine/src/dataraum/core/settings.py
@@ -93,6 +93,14 @@ class Settings(BaseSettings):
     ducklake_pg_pool_max: int = 16
     ducklake_skip_install: bool = False
     duckdb_extension_directory: Path | None = None
+    # Max retry attempts for a DuckLake transaction commit (DAT-641 groundwork).
+    # DuckLake serializes snapshots via a PK on snapshot_id, so concurrent writers
+    # (the per-table typing fan-out) race for the next id and retry. The default
+    # is 10 (ducklake docs) — too low for a wide replay fan-out, where 7–21 tables
+    # commit at once. Non-logical conflicts (distinct tables) auto-resolve on
+    # retry, so a higher budget makes the fan-out reliable. Set per lake connection
+    # in core/connections. (The Temporal-retry fallback stays in DAT-641 proper.)
+    ducklake_max_retry_count: int = 100
 
     # --- Promoted-read surface (ADR-0008 / DAT-453; defaulted for dev) ---
     # Password for the cluster-global ``cockpit_reader`` role the bootstrap

--- a/packages/engine/src/dataraum/entropy/detectors/computational/cross_table_consistency.py
+++ b/packages/engine/src/dataraum/entropy/detectors/computational/cross_table_consistency.py
@@ -28,7 +28,6 @@ Aggregation: max() — worst validation failure drives the table's score.
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from sqlalchemy import select
@@ -39,15 +38,6 @@ from dataraum.entropy.dimensions import AnalysisKey, Dimension, Layer, SubDimens
 from dataraum.entropy.models import EntropyObject
 
 logger = get_logger(__name__)
-
-# The content-keyed upload prefix (src_<sha1>__) — the ONLY prefix the logical
-# table-name fallback strips. A bare '__' split would eat legitimate name parts
-# and cross-claim same-named tables from different sources.
-_UPLOAD_PREFIX = re.compile(r"^src_[0-9a-f]{40}__")
-
-
-def _strip_upload_prefix(name: str) -> str:
-    return _UPLOAD_PREFIX.sub("", name)
 
 
 def _score_validation_result(result: Any) -> float:
@@ -233,26 +223,17 @@ class CrossTableConsistencyDetector(EntropyDetector):
     def _own_columns_used(context: DetectorContext, result: Any) -> list[str]:
         """The failing check's ``columns_used`` entries that name THIS table.
 
-        Entries are LLM-declared ``"table.column"`` strings; the table part may
-        carry the physical ``src_<digest>__`` upload prefix or the logical name,
-        so both sides compare suffix-stripped.
+        Entries are LLM-declared ``"table.column"`` strings. Table names are
+        workspace-unique and narrow (DAT-639 — no ``src_<digest>__`` prefix), so a
+        single exact match is correct and unambiguous: there is exactly one table
+        of a given name in the workspace, so this can't cross-claim another
+        source's same-named table.
         """
-
         table_name = context.table_name or ""
-        own_logical = _strip_upload_prefix(table_name)
         out: list[str] = []
         for ref in getattr(result, "columns_used", None) or []:
             table_part, _, column_part = ref.partition(".")
-            if not column_part:
-                continue
-            # Exact physical match first; the logical fallback strips ONLY the
-            # src_<digest>__ upload prefix (never any '__') and requires the
-            # ref to be unprefixed — otherwise a check touching source A's
-            # journal_lines would band source B's same-named table (review
-            # wave-1, the suffix-matching bug class for the third time).
-            if table_part == table_name or (
-                table_part == _strip_upload_prefix(table_part) and table_part == own_logical
-            ):
+            if column_part and table_part == table_name:
                 out.append(column_part)
         return out
 

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -314,10 +314,10 @@ class EnrichedViewsPhase(BasePhase):
                     reason="no qualifying dimension joins",
                 )
 
-            # Collision-free identities: name the view off the fact's
-            # source-qualified duckdb_path (``enriched_{source}__{table}``), so two
-            # sources that each have an ``orders`` fact don't clash on
-            # ``enriched_orders``. Every source is fully-qualified, so CREATE OR
+            # Name the view off the fact's narrow, workspace-unique duckdb_path
+            # (``enriched_{table}`` — DAT-639). Table names are workspace-unique
+            # (``uq_table_name_layer``), so two sources can't each own an
+            # ``orders`` fact in the first place. CREATE OR
             # REPLACE only ever replaces THIS view on a re-run, never a sibling.
             view_name = f"enriched_{fact_table.duckdb_path}"
             view_fqn = _lake_fqn("enriched", view_name)

--- a/packages/engine/src/dataraum/pipeline/phases/import_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/import_phase.py
@@ -63,6 +63,7 @@ from dataraum.core.uri import uri_suffix, validate_source_uri
 from dataraum.pipeline.base import PhaseContext, PhaseResult, PhaseStatus
 from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.registry import analysis_phase
+from dataraum.sources.base import raw_table_name_for_uri
 from dataraum.sources.csv import CSVLoader
 from dataraum.sources.csv.null_values import load_null_value_config
 from dataraum.sources.json import JsonLoader
@@ -196,9 +197,51 @@ class ImportPhase(BasePhase):
                     validate_source_uri(uri)
                 except ValueError as e:
                     return PhaseResult.failed(str(e))
+            collision = self._first_name_collision(
+                ctx, source_id, [raw_table_name_for_uri(uri) for uri in source_uris]
+            )
+            if collision is not None:
+                return PhaseResult.failed(collision)
             result = self._load_file_source(ctx, source, source_name, source_uris)
 
         return result
+
+    @staticmethod
+    def _first_name_collision(
+        ctx: PhaseContext, source_id: str | None, target_names: list[str]
+    ) -> str | None:
+        """Fail loud if a target raw-table name is already owned by ANOTHER source.
+
+        Workspace-unique table identity (DAT-639): the per-workspace DuckLake
+        catalog holds exactly one raw ``orders``. This import is about to write
+        ``CREATE OR REPLACE TABLE lake.raw."<name>"`` for each ``target_names``
+        entry — a physical write OUTSIDE the SQLAlchemy transaction the phase
+        runner rolls back (DAT-502). So a name already materialized by a DIFFERENT
+        source must be caught BEFORE the loaders run, or the CREATE OR REPLACE
+        silently overwrites that source's data. The same-source case is NOT a
+        collision: an upload replays via ``should_skip`` (content-keyed id), a db
+        recipe replaces in place via the recipe-hash teardown.
+
+        Returns an actionable failure message (retire the owning source first) on
+        the first cross-source collision, else ``None``. The DB ``uq_table_name_
+        layer`` constraint is the backstop if a name slips past this pre-check.
+        """
+        if not target_names:
+            return None
+        rows = ctx.session.execute(
+            select(Table.table_name, Table.source_id, Source.name)
+            .join(Source, Source.source_id == Table.source_id)
+            .where(Table.layer == "raw", Table.table_name.in_(target_names))
+        ).all()
+        for table_name, owner_id, owner_name in rows:
+            if owner_id != source_id:
+                return (
+                    f"Workspace already has a raw table '{table_name}' from source "
+                    f"'{owner_name}'. A workspace holds exactly one '{table_name}' — "
+                    "retire that source first to replace it (re-importing identical "
+                    "content replays automatically; different content must be retired)."
+                )
+        return None
 
     @staticmethod
     def _resolve_file_uris(connection_config: dict[str, Any]) -> list[str]:
@@ -365,6 +408,24 @@ class ImportPhase(BasePhase):
         from dataraum.pipeline.phases._source_teardown import teardown_source_tables
         from dataraum.sources.backends import extract_backend
         from dataraum.sources.db_recipe import RecipeTable
+
+        # Workspace-unique guard (DAT-639), BEFORE teardown: if this recipe targets
+        # a raw-table name ANOTHER source already owns, fail loud now — never tear
+        # down or overwrite across sources. A name owned by THIS source is the
+        # in-place replace handled just below. The recipe query names ARE the
+        # narrow physical table names (no prefix; ``raw_prefix=""``).
+        recipe_tables = connection_config.get("tables") or []
+        collision = self._first_name_collision(
+            ctx,
+            source.source_id,
+            [
+                q["name"]
+                for q in recipe_tables
+                if isinstance(q, dict) and isinstance(q.get("name"), str)
+            ],
+        )
+        if collision is not None:
+            return PhaseResult.failed(collision)
 
         # The recipe was re-pointed under the same source name (``should_skip``
         # declined on a hash mismatch / missing witness, DAT-430). Replace in

--- a/packages/engine/src/dataraum/pipeline/phases/import_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/import_phase.py
@@ -9,8 +9,8 @@ ingests a SET of sources, ``AddSourceWorkflow`` executes this phase once per
    wrote before triggering ``addSourceWorkflow``.
 2. Dispatches by ``source_type``: db_recipe → extract_backend; otherwise →
    file loader (CSV/Parquet/JSON) selected by the source URI's suffix.
-3. Creates raw Table + Column records, table names prefixed with
-   ``{source_name}__`` to keep them recognizable in DuckDB.
+3. Creates raw Table + Column records with NARROW, workspace-unique table names
+   (DAT-639 — no source prefix; the source is an atomic wrapper, not a namespace).
 
 Source shapes — both written by the cockpit ``select`` tool, the only producer:
 
@@ -228,13 +228,13 @@ class ImportPhase(BasePhase):
         Each element of ``source_uris`` is an ``s3://<lake-bucket>/<key>`` URI
         (already validated by ``_run``) handed verbatim to the loader, which
         passes it to DuckDB's ``read_*_auto`` — the loader is selected per
-        element by its own suffix and names each raw table
-        ``<source_name>__<file_stem>``. The cockpit ``select`` tool persists
-        one-element lists (one content-keyed source per file, DAT-422), so the
-        loop runs once today; it stays list-generic because it is the load
-        mechanism. A per-element failure fails the whole import (no silent
-        swallow); the phase runner's rollback-on-FAILED keeps it all-or-nothing
-        (DAT-502).
+        element by its own suffix and names each raw table by its NARROW,
+        workspace-unique stem (``<file_stem>``, no source prefix — DAT-639).
+        The cockpit ``select`` tool persists one-element lists (one
+        content-keyed source per file, DAT-422), so the loop runs once today;
+        it stays list-generic because it is the load mechanism. A per-element
+        failure fails the whole import (no silent swallow); the phase runner's
+        rollback-on-FAILED keeps it all-or-nothing (DAT-502).
         """
         null_config = load_null_value_config()
         junk_columns = ctx.config.get("junk_columns", [])
@@ -244,9 +244,7 @@ class ImportPhase(BasePhase):
         warnings_acc: list[str] = []
 
         for source_uri in source_uris:
-            result = self._load_single_file_with_prefix(
-                ctx, source, source_name, source_uri, null_config, junk_columns
-            )
+            result = self._load_single_uri(ctx, source, source_uri, null_config, junk_columns)
             if result.status != PhaseStatus.COMPLETED:
                 # Multi-URI import is all-or-nothing — and that atomicity is owned
                 # by the phase runner, not this loop (DAT-502): ``run_phase`` /
@@ -273,21 +271,20 @@ class ImportPhase(BasePhase):
             summary=f"{len(table_ids)} tables, {records_processed:,} rows",
         )
 
-    def _load_single_file_with_prefix(
+    def _load_single_uri(
         self,
         ctx: PhaseContext,
         source: Source,
-        source_name: str,
         source_uri: str,
         null_config: Any,
         junk_columns: list[str],
     ) -> PhaseResult:
-        """Load a single file. Loaders write directly into ``lake.raw.<source>__<table>``.
+        """Load a single file. Loaders write directly into ``lake.raw.<table>``.
 
-        Post-DAT-341 the loader composes the source-prefixed identifier and
-        writes the DuckDB table into ``lake.raw.*`` via fully-qualified
-        ``CREATE OR REPLACE TABLE`` (DAT-378 — idempotent across retries). There
-        is no rename / cross-schema move step here.
+        Post-DAT-341 the loader writes the DuckDB table into ``lake.raw.*`` via
+        a fully-qualified ``CREATE OR REPLACE TABLE`` (DAT-378 — idempotent
+        across retries) under its NARROW, workspace-unique name (no source
+        prefix — DAT-639). There is no rename / cross-schema move step here.
 
         ``source_uri`` is an ``s3://<lake-bucket>/<key>`` URI; dispatch is on its
         suffix alone.
@@ -299,7 +296,6 @@ class ImportPhase(BasePhase):
             result = pq_loader._load_single_file(
                 source_uri=source_uri,
                 source_id=source.source_id,
-                source_name=source_name,
                 duckdb_conn=ctx.duckdb_conn,
                 session=ctx.session,
             )
@@ -308,7 +304,6 @@ class ImportPhase(BasePhase):
             result = json_loader._load_single_file(
                 source_uri=source_uri,
                 source_id=source.source_id,
-                source_name=source_name,
                 duckdb_conn=ctx.duckdb_conn,
                 session=ctx.session,
             )
@@ -317,7 +312,6 @@ class ImportPhase(BasePhase):
             result = csv_loader._load_single_file(
                 source_uri=source_uri,
                 source_id=source.source_id,
-                source_name=source_name,
                 duckdb_conn=ctx.duckdb_conn,
                 session=ctx.session,
                 null_config=null_config,
@@ -435,13 +429,14 @@ class ImportPhase(BasePhase):
                 "(via .env or the docker-compose environment)."
             )
 
-        prefix = f"{source_name}__"
+        # Narrow, workspace-unique table names (DAT-639) — no source prefix; the
+        # recipe's query name IS the table name in the workspace.
         result = extract_backend(
             backend=backend,
             url=credential.url,
             queries=queries,
             duckdb_conn=ctx.duckdb_conn,
-            raw_prefix=prefix,
+            raw_prefix="",
         )
         if not result.success or result.value is None:
             return PhaseResult.failed(

--- a/packages/engine/src/dataraum/pipeline/phases/import_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/import_phase.py
@@ -225,6 +225,16 @@ class ImportPhase(BasePhase):
         Returns an actionable failure message (retire the owning source first) on
         the first cross-source collision, else ``None``. The DB ``uq_table_name_
         layer`` constraint is the backstop if a name slips past this pre-check.
+
+        Concurrency caveat (best-effort, NOT serialization): this guard + the DB
+        constraint protect against the common case, but two import activities for
+        DIFFERENT sources landing the SAME narrow name concurrently can still race
+        — A's check passes, B's ``CREATE OR REPLACE`` overwrites A's DuckDB table,
+        then B's ``Table`` insert trips ``uq_table_name_layer`` and rolls back the
+        SQLAlchemy session, but the DuckDB write is OUTSIDE that rollback (DAT-502).
+        Closing that window needs per-workspace import serialization at the
+        Temporal layer (deferred); narrow naming makes the window exist where
+        source-prefixed names made it structurally impossible.
         """
         if not target_names:
             return None

--- a/packages/engine/src/dataraum/pipeline/phases/typing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/typing_phase.py
@@ -397,18 +397,11 @@ def _apply_unit_overrides(
     if not isinstance(units, dict) or not units:
         return
 
-    # Strip the ``src_<digest>__`` source-qualifier so a teach keyed by the bare
-    # table name resolves; the qualified key still matches too.
-    qualified = table.table_name
-    raw_name = (
-        qualified.split("__", 1)[1]
-        if qualified.startswith("src_") and "__" in qualified
-        else qualified
-    )
-
+    # Table names are narrow (DAT-639 — no ``src_<digest>__`` qualifier), so a
+    # teach keys directly on the bare ``<table>.<column>``.
     for col in table.columns:
-        col_ref = f"{qualified}.{col.column_name}"
-        entry = units.get(col_ref) or units.get(f"{raw_name}.{col.column_name}")
+        col_ref = f"{table.table_name}.{col.column_name}"
+        entry = units.get(col_ref)
         if not isinstance(entry, dict):
             continue
         unit = entry.get("unit")

--- a/packages/engine/src/dataraum/pipeline/phases/typing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/typing_phase.py
@@ -377,10 +377,9 @@ def _apply_unit_overrides(
     Reads ``overrides.units`` from typing config (the column-scoped unit teach,
     DAT-428). Keys are ``"table.column"``; values contain ``{unit: "USD"}``.
 
-    A teach names the table by its USER-FACING identity (``bank_transactions``),
-    but a raw table's stored name is source-qualified (``src_<digest>__bank_transactions``).
-    So we match a key against BOTH the qualified name and the de-prefixed raw name —
-    a human teach lands without the user having to know the internal source digest.
+    Table names are narrow and workspace-unique (DAT-639 — no ``src_<digest>__``
+    qualifier), so a teach keys directly on the bare ``<table>.<column>``; there
+    is no source-qualified form to also match.
 
     ``run_id`` scopes the patch to THIS run's candidate. A teach RE-RUN leaves the
     prior run's TypeCandidate rows in place, so an unscoped ``confidence DESC`` pick

--- a/packages/engine/src/dataraum/sources/base.py
+++ b/packages/engine/src/dataraum/sources/base.py
@@ -47,6 +47,40 @@ def normalize_column_name(header: str, position: int = 0) -> str:
     return name
 
 
+def _sanitize_table_stem(name: str) -> str:
+    """Sanitize a logical table stem before ``workspace_table_name`` (DAT-639).
+
+    The pre-pass a file's table name goes through: strip any extension, fold
+    ``- . space`` to ``_``, guard a non-letter lead with ``t_``, lowercase. The
+    result is then run through ``workspace_table_name`` for the final narrow,
+    workspace-unique identifier. Kept distinct from ``sanitize_identifier`` only
+    because the ``t_`` lead-guard predates it and its exact output is asserted by
+    callers' tests; composing the two is the single canonical derivation.
+    """
+    if "." in name:
+        name = name.rsplit(".", 1)[0]
+    name = name.replace("-", "_").replace(" ", "_").replace(".", "_")
+    if name and not (name[0].isalpha() or name[0] == "_"):
+        name = f"t_{name}"
+    return name.lower()
+
+
+def raw_table_name_for_uri(source_uri: str) -> str:
+    """The NARROW, workspace-unique raw table name a file URI loads into (DAT-639).
+
+    The SINGLE source of truth for a file source's physical raw-table name: the
+    URI stem, sanitized, run through ``workspace_table_name`` (no source prefix —
+    the per-workspace DuckLake catalog is the namespace). Both the loaders (which
+    CREATE the table) and the import phase's pre-flight collision guard derive the
+    name through this one function, so the guard can never disagree with the name
+    the loader will actually write.
+    """
+    from dataraum.core.duckdb_naming import workspace_table_name
+    from dataraum.core.uri import uri_stem
+
+    return workspace_table_name(_sanitize_table_stem(uri_stem(source_uri)))
+
+
 class TypeSystemStrength(StrEnum):
     """Classification of source type system strength."""
 
@@ -97,23 +131,5 @@ class LoaderBase(ABC):
         pass
 
     def _sanitize_table_name(self, name: str) -> str:
-        """Sanitize table name for use in SQL.
-
-        Args:
-            name: Original table name
-
-        Returns:
-            Sanitized table name
-        """
-        # Remove extension
-        if "." in name:
-            name = name.rsplit(".", 1)[0]
-
-        # Replace invalid characters
-        name = name.replace("-", "_").replace(" ", "_").replace(".", "_")
-
-        # Ensure it starts with a letter or underscore
-        if name and not (name[0].isalpha() or name[0] == "_"):
-            name = f"t_{name}"
-
-        return name.lower()
+        """Sanitize a logical table name for SQL — see :func:`_sanitize_table_stem`."""
+        return _sanitize_table_stem(name)

--- a/packages/engine/src/dataraum/sources/csv/loader.py
+++ b/packages/engine/src/dataraum/sources/csv/loader.py
@@ -128,8 +128,9 @@ class CSVLoader(LoaderBase):
         Returns:
             Result containing StagedTable
         """
-        from dataraum.core.duckdb_naming import schema_for_layer, workspace_table_name
+        from dataraum.core.duckdb_naming import schema_for_layer
         from dataraum.server.storage import LAKE_CATALOG_ALIAS
+        from dataraum.sources.base import raw_table_name_for_uri
 
         file_stem = uri_stem(source_uri)
         try:
@@ -148,10 +149,10 @@ class CSVLoader(LoaderBase):
                 return Result.fail("No columns found in CSV")
 
             # Compose the narrow, workspace-unique name (DAT-639 — no source
-            # prefix). The catalog alias is resolved here so the loader can write
-            # directly into ``lake.raw.*``.
-            file_table_name = self._sanitize_table_name(file_stem)
-            bare = workspace_table_name(file_table_name)
+            # prefix) via the single canonical derivation the import phase's
+            # collision guard also uses. The catalog alias is resolved here so
+            # the loader can write directly into ``lake.raw.*``.
+            bare = raw_table_name_for_uri(source_uri)
             raw_target = f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("raw")}."{bare}"'
 
             # Track which columns are junk for later filtering (match on original name)

--- a/packages/engine/src/dataraum/sources/csv/loader.py
+++ b/packages/engine/src/dataraum/sources/csv/loader.py
@@ -104,7 +104,6 @@ class CSVLoader(LoaderBase):
         self,
         source_uri: str,
         source_id: str,
-        source_name: str,
         duckdb_conn: duckdb.DuckDBPyConnection,
         session: Session,
         null_config: NullValueConfig,
@@ -120,8 +119,6 @@ class CSVLoader(LoaderBase):
         Args:
             source_uri: URI of the CSV file (passed straight to ``read_csv``).
             source_id: ID of the parent source
-            source_name: Logical name of the parent source (used to compose
-                the source-prefixed table identifier in ``lake.raw``).
             duckdb_conn: DuckDB connection
             session: SQLAlchemy session
             null_config: Null value configuration
@@ -131,7 +128,7 @@ class CSVLoader(LoaderBase):
         Returns:
             Result containing StagedTable
         """
-        from dataraum.core.duckdb_naming import schema_for_layer, table_name_for_source
+        from dataraum.core.duckdb_naming import schema_for_layer, workspace_table_name
         from dataraum.server.storage import LAKE_CATALOG_ALIAS
 
         file_stem = uri_stem(source_uri)
@@ -150,10 +147,11 @@ class CSVLoader(LoaderBase):
             if not columns:
                 return Result.fail("No columns found in CSV")
 
-            # Compose the source-prefixed name. The catalog alias is resolved
-            # here so the loader can write directly into ``lake.raw.*``.
+            # Compose the narrow, workspace-unique name (DAT-639 — no source
+            # prefix). The catalog alias is resolved here so the loader can write
+            # directly into ``lake.raw.*``.
             file_table_name = self._sanitize_table_name(file_stem)
-            bare = table_name_for_source(source_name, file_table_name)
+            bare = workspace_table_name(file_table_name)
             raw_target = f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("raw")}."{bare}"'
 
             # Track which columns are junk for later filtering (match on original name)

--- a/packages/engine/src/dataraum/sources/db_recipe/recipe.py
+++ b/packages/engine/src/dataraum/sources/db_recipe/recipe.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 class RecipeTable(BaseModel):
     """One named SELECT inside a recipe.
 
-    `name` becomes the DuckDB table name (`raw_{name}` in staging).
+    `name` becomes the DuckDB table name in `lake.raw` (narrow, no prefix — DAT-639).
     `sql` is materialized verbatim against the attached database.
     """
 

--- a/packages/engine/src/dataraum/sources/json/loader.py
+++ b/packages/engine/src/dataraum/sources/json/loader.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from dataraum.core.logging import get_logger
 from dataraum.core.models import Result, SourceConfig
-from dataraum.core.uri import uri_basename, uri_stem
+from dataraum.core.uri import uri_basename
 from dataraum.sources.base import ColumnInfo, LoaderBase, normalize_column_name
 from dataraum.sources.csv.models import StagedTable
 from dataraum.storage import Column, Table
@@ -111,8 +111,9 @@ class JsonLoader(LoaderBase):
         Returns:
             Result containing StagedTable.
         """
-        from dataraum.core.duckdb_naming import schema_for_layer, workspace_table_name
+        from dataraum.core.duckdb_naming import schema_for_layer
         from dataraum.server.storage import LAKE_CATALOG_ALIAS
+        from dataraum.sources.base import raw_table_name_for_uri
 
         try:
             # Escape single quotes in the URI for SQL safety
@@ -141,10 +142,10 @@ class JsonLoader(LoaderBase):
                 col_mapping.append((original, normalized))
 
             # Compose the narrow, workspace-unique name (DAT-639 — no source
-            # prefix). The catalog alias is resolved here so the loader can write
-            # directly into ``lake.raw.*``.
-            file_table_name = self._sanitize_table_name(uri_stem(source_uri))
-            bare = workspace_table_name(file_table_name)
+            # prefix) via the single canonical derivation the import phase's
+            # collision guard also uses. The catalog alias is resolved here so
+            # the loader can write directly into ``lake.raw.*``.
+            bare = raw_table_name_for_uri(source_uri)
             raw_target = f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("raw")}."{bare}"'
 
             # Build SELECT: serialize every column to VARCHAR via to_json().

--- a/packages/engine/src/dataraum/sources/json/loader.py
+++ b/packages/engine/src/dataraum/sources/json/loader.py
@@ -93,7 +93,6 @@ class JsonLoader(LoaderBase):
         self,
         source_uri: str,
         source_id: str,
-        source_name: str,
         duckdb_conn: duckdb.DuckDBPyConnection,
         session: Session,
     ) -> Result[StagedTable]:
@@ -106,15 +105,13 @@ class JsonLoader(LoaderBase):
         Args:
             source_uri: URI of the JSON file (passed straight to ``read_json_auto``).
             source_id: ID of the parent source.
-            source_name: Logical name of the parent source (used to compose
-                the source-prefixed table identifier in ``lake.raw``).
             duckdb_conn: DuckDB connection.
             session: SQLAlchemy session.
 
         Returns:
             Result containing StagedTable.
         """
-        from dataraum.core.duckdb_naming import schema_for_layer, table_name_for_source
+        from dataraum.core.duckdb_naming import schema_for_layer, workspace_table_name
         from dataraum.server.storage import LAKE_CATALOG_ALIAS
 
         try:
@@ -143,10 +140,11 @@ class JsonLoader(LoaderBase):
                     seen[normalized] = 1
                 col_mapping.append((original, normalized))
 
-            # Compose the source-prefixed name. The catalog alias is resolved
-            # here so the loader can write directly into ``lake.raw.*``.
+            # Compose the narrow, workspace-unique name (DAT-639 — no source
+            # prefix). The catalog alias is resolved here so the loader can write
+            # directly into ``lake.raw.*``.
             file_table_name = self._sanitize_table_name(uri_stem(source_uri))
-            bare = table_name_for_source(source_name, file_table_name)
+            bare = workspace_table_name(file_table_name)
             raw_target = f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("raw")}."{bare}"'
 
             # Build SELECT: serialize every column to VARCHAR via to_json().

--- a/packages/engine/src/dataraum/sources/parquet/loader.py
+++ b/packages/engine/src/dataraum/sources/parquet/loader.py
@@ -98,7 +98,6 @@ class ParquetLoader(LoaderBase):
         self,
         source_uri: str,
         source_id: str,
-        source_name: str,
         duckdb_conn: duckdb.DuckDBPyConnection,
         session: Session,
     ) -> Result[StagedTable]:
@@ -114,15 +113,13 @@ class ParquetLoader(LoaderBase):
         Args:
             source_uri: URI of the Parquet file (passed straight to ``read_parquet``).
             source_id: ID of the parent source
-            source_name: Logical name of the parent source (used to compose
-                the source-prefixed table identifier in ``lake.raw``).
             duckdb_conn: DuckDB connection
             session: SQLAlchemy session
 
         Returns:
             Result containing StagedTable
         """
-        from dataraum.core.duckdb_naming import schema_for_layer, table_name_for_source
+        from dataraum.core.duckdb_naming import schema_for_layer, workspace_table_name
         from dataraum.server.storage import LAKE_CATALOG_ALIAS
 
         try:
@@ -143,11 +140,12 @@ class ParquetLoader(LoaderBase):
 
                 col_mapping.append((original, normalized, duckdb_type))
 
-            # Compose the source-prefixed name. The catalog alias is resolved
-            # here so the loader can write directly into ``lake.raw.*`` —
-            # avoids a cross-schema move in import_phase.
+            # Compose the narrow, workspace-unique name (DAT-639 — no source
+            # prefix). The catalog alias is resolved here so the loader can write
+            # directly into ``lake.raw.*`` — avoids a cross-schema move in
+            # import_phase.
             file_table_name = self._sanitize_table_name(uri_stem(source_uri))
-            bare = table_name_for_source(source_name, file_table_name)
+            bare = workspace_table_name(file_table_name)
             raw_target = f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("raw")}."{bare}"'
 
             # Build SELECT with aliasing for normalized names

--- a/packages/engine/src/dataraum/sources/parquet/loader.py
+++ b/packages/engine/src/dataraum/sources/parquet/loader.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from dataraum.core.logging import get_logger
 from dataraum.core.models import Result, SourceConfig
-from dataraum.core.uri import uri_basename, uri_stem
+from dataraum.core.uri import uri_basename
 from dataraum.sources.base import ColumnInfo, LoaderBase, normalize_column_name
 from dataraum.sources.csv.models import StagedTable
 from dataraum.storage import Column, Table
@@ -119,8 +119,9 @@ class ParquetLoader(LoaderBase):
         Returns:
             Result containing StagedTable
         """
-        from dataraum.core.duckdb_naming import schema_for_layer, workspace_table_name
+        from dataraum.core.duckdb_naming import schema_for_layer
         from dataraum.server.storage import LAKE_CATALOG_ALIAS
+        from dataraum.sources.base import raw_table_name_for_uri
 
         try:
             # Read schema using DuckDB DESCRIBE
@@ -141,11 +142,11 @@ class ParquetLoader(LoaderBase):
                 col_mapping.append((original, normalized, duckdb_type))
 
             # Compose the narrow, workspace-unique name (DAT-639 — no source
-            # prefix). The catalog alias is resolved here so the loader can write
-            # directly into ``lake.raw.*`` — avoids a cross-schema move in
-            # import_phase.
-            file_table_name = self._sanitize_table_name(uri_stem(source_uri))
-            bare = workspace_table_name(file_table_name)
+            # prefix) via the single canonical derivation the import phase's
+            # collision guard also uses. The catalog alias is resolved here so
+            # the loader can write directly into ``lake.raw.*`` — avoids a
+            # cross-schema move in import_phase.
+            bare = raw_table_name_for_uri(source_uri)
             raw_target = f'{LAKE_CATALOG_ALIAS}.{schema_for_layer("raw")}."{bare}"'
 
             # Build SELECT with aliasing for normalized names

--- a/packages/engine/src/dataraum/storage/models.py
+++ b/packages/engine/src/dataraum/storage/models.py
@@ -90,19 +90,24 @@ class Table(Base):
     """
 
     __tablename__ = "tables"
-    __table_args__ = (
-        UniqueConstraint("source_id", "table_name", "layer", name="uq_source_table_layer"),
-    )
+    # Workspace-unique table identity (DAT-639): the per-workspace DuckLake
+    # catalog IS the namespace, so a workspace holds exactly one ``orders`` raw
+    # table — uniqueness is ``(table_name, layer)``, NOT scoped by source. The
+    # source is an atomic content-keyed wrapper (how the table arrived), never a
+    # disambiguator; two sources cannot each own an ``orders`` (import fails loud
+    # and tells the user to retire the existing one first).
+    __table_args__ = (UniqueConstraint("table_name", "layer", name="uq_table_name_layer"),)
 
     table_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
     source_id: Mapped[str] = mapped_column(ForeignKey("sources.source_id"), nullable=False)
     table_name: Mapped[str] = mapped_column(String, nullable=False)
     layer: Mapped[str] = mapped_column(String, nullable=False)  # 'raw', 'typed', 'quarantine'
-    # Unqualified DuckDB table name (e.g., ``csv_source__orders``). Schema is
-    # derived from ``layer`` via ``dataraum.core.duckdb_naming.schema_for_layer``;
-    # cross-layer SQL composes the full ``"schema.table"`` form via
-    # ``qualified_table(layer, source.name, table_name)``. The catalog alias
-    # (``lake`` in slice 1) is NOT stored here — it's resolved at query time.
+    # Unqualified DuckDB table name — NARROW, workspace-unique (e.g. ``orders``,
+    # no source prefix — DAT-639). Schema is derived from ``layer`` via
+    # ``dataraum.core.duckdb_naming.schema_for_layer``; cross-layer SQL composes
+    # the full ``"schema.table"`` form via ``qualified_table(layer, table_name)``.
+    # The catalog alias (``lake`` in slice 1) is NOT stored here — it's resolved
+    # at query time.
     duckdb_path: Mapped[str | None] = mapped_column(String)
     row_count: Mapped[int | None] = mapped_column(Integer)
     created_at: Mapped[datetime] = mapped_column(

--- a/packages/engine/tests/integration/analysis/statistics/test_statistics.py
+++ b/packages/engine/tests/integration/analysis/statistics/test_statistics.py
@@ -60,7 +60,6 @@ def _stage_csv(
     result = loader._load_single_file(
         source_uri=source_uri,
         source_id=source_id,
-        source_name="simple",
         duckdb_conn=duckdb_conn,
         session=session,
         null_config=load_null_value_config(),

--- a/packages/engine/tests/integration/conftest.py
+++ b/packages/engine/tests/integration/conftest.py
@@ -197,9 +197,9 @@ class PipelineTestHarness:
         ``source_id`` / ``source_name``. The per-URI loop loads each in turn and
         aggregates the per-file ``raw_tables`` into one COMPLETED ``PhaseResult``
         — the same multi-URI shape production now runs (DAT-378). The loader
-        names each raw table ``<source_name>__<file_stem>``, so the loop
-        reproduces the exact multi-table dataset (``small_finance__customers``,
-        ``small_finance__payment_methods``, …). If any per-file load fails, the
+        names each raw table by its NARROW, workspace-unique file stem (DAT-639 —
+        no source prefix), so the loop reproduces the exact multi-table dataset
+        (``customers``, ``payment_methods``, …). If any per-file load fails, the
         aggregate fails with that error.
 
         Args:

--- a/packages/engine/tests/integration/pipeline/test_import_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_import_phase.py
@@ -223,7 +223,8 @@ class TestImportPhase:
 
         stmt = select(Table).where(Table.source_id == source_id, Table.layer == "raw")
         names = {t.table_name for t in session.execute(stmt).scalars().all()}
-        assert names == {"multi__customers", "multi__orders"}
+        # DAT-639: narrow, workspace-unique names — the file stems, no source prefix.
+        assert names == {"customers", "orders"}
 
     def test_import_missing_config(self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection):
         """Empty config: import phase reports the missing identity fields."""

--- a/packages/engine/tests/integration/pipeline/test_materialization_recipe.py
+++ b/packages/engine/tests/integration/pipeline/test_materialization_recipe.py
@@ -62,7 +62,6 @@ def _seed_source(
     load_result = loader._load_single_file(
         source_uri=source_uri,
         source_id=source_id,
-        source_name=session.get(Source, source_id).name,
         duckdb_conn=duckdb_conn,
         session=session,
         null_config=load_null_value_config(),

--- a/packages/engine/tests/integration/pipeline/test_replay_cross_stage.py
+++ b/packages/engine/tests/integration/pipeline/test_replay_cross_stage.py
@@ -75,7 +75,6 @@ def _seed_source(
     load_result = loader._load_single_file(
         source_uri=source_uri,
         source_id=source_id,
-        source_name="seed_source",
         duckdb_conn=duckdb_conn,
         session=session,
         null_config=load_null_value_config(),

--- a/packages/engine/tests/integration/sources/csv/test_loader.py
+++ b/packages/engine/tests/integration/sources/csv/test_loader.py
@@ -49,7 +49,6 @@ def _stage_csv(
     result = loader._load_single_file(
         source_uri=source_uri,
         source_id=source_id,
-        source_name=source_name,
         duckdb_conn=duckdb_conn,
         session=session,
         null_config=load_null_value_config(),
@@ -164,7 +163,6 @@ class TestCSVLoaderIntegration:
         result = loader._load_single_file(
             source_uri=source_uri,
             source_id="src-csv-latin1",
-            source_name="bad_encoding",
             duckdb_conn=duckdb_conn,
             session=session,
             null_config=load_null_value_config(),

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -28,6 +28,7 @@ from sqlalchemy import select, text
 
 from dataraum.core.connections import ConnectionConfig, ConnectionManager
 from dataraum.entropy.db_models import EntropyObjectRecord, EntropyReadinessRecord
+from dataraum.sources.base import raw_table_name_for_uri
 from dataraum.storage import Source, Table
 from dataraum.worker import (
     RunRef,
@@ -379,9 +380,9 @@ def test_per_table_chain_runs(worker_manager: ConnectionManager, small_finance_p
     assert len(raw_ids) == len(files), "each enumerated URI maps to one raw table"
 
     # CALIBRATION GUARD (DAT-378): the per-URI loop must reproduce the EXACT
-    # ``small_finance__<file_stem>`` raw-table set the pre-DAT-389 directory
+    # the NARROW per-file-stem raw-table set the pre-DAT-389 directory
     # branch produced, so dataraum-eval recall baselines do not move. Assert the
-    # raw-table NAME set is byte-identical to ``small_finance__<stem>`` for every
+    # raw-table NAME set is byte-identical to the narrow ``<stem>`` for every
     # enumerated fixture file.
     with worker_manager.session_scope() as session:
         raw_names = {
@@ -390,7 +391,7 @@ def test_per_table_chain_runs(worker_manager: ConnectionManager, small_finance_p
                 select(Table.table_name).where(Table.source_id == source_id, Table.layer == "raw")
             )
         }
-    expected_names = {f"small_finance__{p.stem}" for p in files}
+    expected_names = {raw_table_name_for_uri(str(p)) for p in files}
     assert raw_names == expected_names, (
         "per-URI loop changed the raw-table set — dataraum-eval baselines would move"
     )

--- a/packages/engine/tests/unit/analysis/slicing/test_agent_grounding.py
+++ b/packages/engine/tests/unit/analysis/slicing/test_agent_grounding.py
@@ -31,7 +31,7 @@ def _context() -> dict:
             {
                 "table_name": "journal_lines",
                 "table_id": "tbl_jl",
-                "duckdb_path": "src_x__journal_lines",
+                "duckdb_path": "journal_lines",
                 "enriched_duckdb_path": None,
                 "columns": [
                     {

--- a/packages/engine/tests/unit/core/test_duckdb_naming.py
+++ b/packages/engine/tests/unit/core/test_duckdb_naming.py
@@ -9,7 +9,7 @@ from dataraum.core.duckdb_naming import (
     qualified_table,
     sanitize_identifier,
     schema_for_layer,
-    table_name_for_source,
+    workspace_table_name,
 )
 
 
@@ -47,30 +47,31 @@ class TestSchemaForLayer:
         assert schema_for_layer(layer) == "typed"
 
 
-class TestTableNameForSource:
-    def test_joins_sanitized_components(self):
-        assert table_name_for_source("CSV.Source", "Orders") == "csv_source__orders"
+class TestWorkspaceTableName:
+    def test_is_narrow_no_source_prefix(self):
+        # DAT-639: workspace-unique narrow name — no `{source}__` prefix.
+        assert workspace_table_name("Orders") == "orders"
 
-    def test_handles_collision_risk_consistently(self):
-        # Sanitization is deterministic — same input yields same output every call.
-        a = table_name_for_source("Sales.LT", "Customer")
-        b = table_name_for_source("Sales.LT", "Customer")
-        assert a == b == "sales_lt__customer"
+    def test_sanitizes(self):
+        assert workspace_table_name("Sales.LT Customer") == "sales_lt_customer"
+
+    def test_deterministic(self):
+        assert workspace_table_name("Customer") == workspace_table_name("Customer")
 
 
 class TestQualifiedTable:
-    def test_composes_schema_plus_table(self):
-        assert qualified_table("typed", "csv_src", "orders") == "typed.csv_src__orders"
+    def test_composes_schema_plus_narrow_table(self):
+        assert qualified_table("typed", "orders") == "typed.orders"
 
     def test_uses_raw_schema_for_raw_layer(self):
-        assert qualified_table("raw", "mssql", "Customer") == "raw.mssql__customer"
+        assert qualified_table("raw", "Customer") == "raw.customer"
 
     def test_quarantine_layer_routes_to_quarantine_schema(self):
-        assert qualified_table("quarantine", "csv", "orders") == "quarantine.csv__orders"
+        assert qualified_table("quarantine", "orders") == "quarantine.orders"
 
     def test_view_like_layer_falls_back_to_typed_schema(self):
         # Slice 1 keeps enriched/slicing_view artifacts under the typed schema.
-        assert qualified_table("enriched", "csv", "orders") == "typed.csv__orders"
+        assert qualified_table("enriched", "orders") == "typed.orders"
 
 
 class TestIsReservedSchema:

--- a/packages/engine/tests/unit/entropy/test_cross_table_consistency.py
+++ b/packages/engine/tests/unit/entropy/test_cross_table_consistency.py
@@ -190,7 +190,7 @@ class TestColumnFanOut:
         table = Table(
             table_id="jl",
             source_id="src_v",
-            table_name="src_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa__journal_lines",
+            table_name="journal_lines",  # narrow, workspace-unique (DAT-639)
             layer="typed",
         )
         session.add(table)
@@ -208,7 +208,7 @@ class TestColumnFanOut:
     def _context(self, session, validations: list) -> DetectorContext:  # noqa: ANN001
         ctx = DetectorContext(
             table_id="jl",
-            table_name="src_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa__journal_lines",
+            table_name="journal_lines",
             session=session,
         )
         ctx.analysis_results["validation"] = validations
@@ -217,7 +217,7 @@ class TestColumnFanOut:
     def test_failed_check_bands_its_columns(
         self, detector: CrossTableConsistencyDetector, session
     ) -> None:  # noqa: ANN001
-        """Logical and physical table prefixes both match; foreign tables ignored;
+        """Own-table columns matched by exact narrow name; foreign tables ignored;
         hallucinated columns dropped; column_id rides in evidence."""
         _, ids = self._seed(session)
         ctx = self._context(
@@ -227,8 +227,8 @@ class TestColumnFanOut:
                     severity="critical",
                     details={"check_type": "aggregate", "violation_rate": 0.1},
                     columns_used=[
-                        "journal_lines.credit",  # logical table name
-                        "src_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa__journal_lines.debit",  # physical name
+                        "journal_lines.credit",  # ours
+                        "journal_lines.debit",  # ours
                         "trial_balance.debit_balance",  # other table — not ours
                         "journal_lines.ghost",  # hallucinated column
                     ],
@@ -238,16 +238,10 @@ class TestColumnFanOut:
         objects = detector.detect(ctx)
 
         by_target = {o.target: o for o in objects}
-        assert (
-            "column:src_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa__journal_lines.credit" in by_target
-        )
-        assert (
-            "column:src_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa__journal_lines.debit" in by_target
-        )
+        assert "column:journal_lines.credit" in by_target
+        assert "column:journal_lines.debit" in by_target
         assert len(objects) == 3  # table object + 2 columns (ghost + foreign dropped)
-        credit = by_target[
-            "column:src_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa__journal_lines.credit"
-        ]
+        credit = by_target["column:journal_lines.credit"]
         assert credit.score == 1.0  # critical → categorical
         assert credit.evidence[0]["column_id"] == ids["credit"]
 

--- a/packages/engine/tests/unit/pipeline/test_import_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_import_phase.py
@@ -483,3 +483,99 @@ class TestMultiUriDispatch:
         with factory() as session:
             rows = list(session.execute(select(Table)).scalars())
         assert rows == []
+
+
+class TestWorkspaceNameCollision:
+    """Workspace-unique table identity (DAT-639): a workspace holds exactly one
+    ``orders``. A DIFFERENT source landing on a name an existing source already
+    owns fails loud BEFORE any loader writes — the loader's ``CREATE OR REPLACE``
+    would otherwise overwrite that source's DuckDB table outside the transaction
+    the phase runner rolls back. ``source_id`` here is OWNERSHIP, not naming: the
+    same source re-importing its own name is not a collision (upload replay via
+    ``should_skip`` / db recipe refresh via teardown).
+    """
+
+    @staticmethod
+    def _session():  # noqa: ANN205
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+        from sqlalchemy.pool import StaticPool
+
+        from dataraum.storage import init_database
+
+        engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        init_database(engine)
+        return sessionmaker(bind=engine)()
+
+    def test_cross_source_collision_fails_loud_before_any_loader(self) -> None:
+        from dataraum.storage import Source, Table
+
+        session = self._session()
+        with session:
+            # Source A already owns the raw ``orders`` table.
+            session.add(Source(source_id="src-a", name="alpha", source_type="csv"))
+            session.add(
+                Table(
+                    table_id="t-a",
+                    source_id="src-a",
+                    table_name="orders",
+                    layer="raw",
+                    duckdb_path="orders",
+                )
+            )
+            # Source B (a DIFFERENT source) tries to import a file whose stem also
+            # narrows to ``orders``.
+            session.add(Source(source_id="src-b", name="beta", source_type="csv"))
+            session.commit()
+
+            ctx = PhaseContext(
+                session=session,
+                duckdb_conn=MagicMock(),
+                config={
+                    "source_id": "src-b",
+                    "source_name": "beta",
+                    "source_type": "file",
+                    "source_connection_config": {
+                        "file_uris": ["s3://dataraum-lake/sel/orders.csv"]
+                    },
+                },
+            )
+
+            csv_loader = MagicMock()
+            with patch("dataraum.pipeline.phases.import_phase.CSVLoader", csv_loader):
+                result = ImportPhase()._run(ctx)
+
+            assert result.status == PhaseStatus.FAILED
+            assert "orders" in (result.error or "")
+            assert "retire" in (result.error or "").lower()
+            assert "alpha" in (result.error or "")  # names the owning source
+            csv_loader.assert_not_called()  # guard fired before any load
+
+    def test_same_source_owning_the_name_is_not_a_collision(self) -> None:
+        from dataraum.storage import Source, Table
+
+        session = self._session()
+        with session:
+            session.add(Source(source_id="src-a", name="alpha", source_type="csv"))
+            session.add(
+                Table(
+                    table_id="t-a",
+                    source_id="src-a",
+                    table_name="orders",
+                    layer="raw",
+                    duckdb_path="orders",
+                )
+            )
+            session.commit()
+            ctx = PhaseContext(session=session, duckdb_conn=MagicMock())
+
+            # Same source re-importing its own ``orders`` → ownership, not collision.
+            assert ImportPhase._first_name_collision(ctx, "src-a", ["orders"]) is None
+            # A name no source owns yet → free to create.
+            assert ImportPhase._first_name_collision(ctx, "src-b", ["customers"]) is None
+            # Another source owning the name → fail-loud message.
+            assert ImportPhase._first_name_collision(ctx, "src-b", ["orders"]) is not None

--- a/packages/engine/tests/unit/pipeline/test_typed_tables_scope.py
+++ b/packages/engine/tests/unit/pipeline/test_typed_tables_scope.py
@@ -79,12 +79,14 @@ def test_filter_keeps_typed_tables_across_sources(
 ) -> None:
     """DAT-422: the per-table scope is source-AGNOSTIC — ``table_ids`` spanning two
     sources resolve BOTH (a run is over a set of objects from 1–N sources), with
-    no source boundary to cross.
+    no source boundary to cross. The two tables carry DISTINCT names because table
+    identity is workspace-unique now (DAT-639): a workspace can't hold two
+    ``orders``, so the cross-source set is ``orders`` + ``shipments``.
     """
     src_a = _source(session)
     src_b = _source(session)
     a1 = _table(session, src_a.source_id, "orders", layer="typed")
-    b1 = _table(session, src_b.source_id, "orders", layer="typed")
+    b1 = _table(session, src_b.source_id, "shipments", layer="typed")
 
     resolved = StatisticsPhase()._typed_tables(
         _ctx(session, duckdb_conn, [a1.table_id, b1.table_id])

--- a/packages/engine/tests/unit/pipeline/test_typing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_typing_phase.py
@@ -271,25 +271,18 @@ class TestApplyUnitOverrides:
             select(TypeCandidate).where(TypeCandidate.column_id == col.column_id)
         ).scalar_one()
 
-    def test_qualified_key_patches_best_candidate(self, session: Session) -> None:
-        table, col = self._setup(session, "src_abc123__bank_transactions")
-        config = {"overrides": {"units": {"src_abc123__bank_transactions.amount": {"unit": "EUR"}}}}
+    def test_units_key_patches_best_candidate(self, session: Session) -> None:
+        # DAT-639: table names are narrow, so a teach keys directly on the bare
+        # ``<table>.<column>`` — there is no source-qualified form to also match.
+        table, col = self._setup(session, "bank_transactions")
+        config = {"overrides": {"units": {"bank_transactions.amount": {"unit": "EUR"}}}}
         _apply_unit_overrides(session, config, table)
         tc = self._candidate(session, col)
         assert tc.detected_unit == "EUR"
         assert tc.unit_confidence == 1.0
 
-    def test_raw_name_key_patches_despite_source_prefix(self, session: Session) -> None:
-        # A human teaches the bare table name; the stored raw table is source-qualified.
-        table, col = self._setup(session, "src_deadbeef__bank_transactions")
-        config = {"overrides": {"units": {"bank_transactions.amount": {"unit": "USD"}}}}
-        _apply_unit_overrides(session, config, table)
-        tc = self._candidate(session, col)
-        assert tc.detected_unit == "USD"
-        assert tc.unit_confidence == 1.0
-
     def test_no_matching_key_leaves_candidate_untouched(self, session: Session) -> None:
-        table, col = self._setup(session, "src_x__invoices")
+        table, col = self._setup(session, "invoices")
         config = {"overrides": {"units": {"other.col": {"unit": "EUR"}}}}
         _apply_unit_overrides(session, config, table)
         tc = self._candidate(session, col)
@@ -297,7 +290,7 @@ class TestApplyUnitOverrides:
         assert tc.unit_confidence is None
 
     def test_no_units_section_is_a_noop(self, session: Session) -> None:
-        table, col = self._setup(session, "src_y__payments")
+        table, col = self._setup(session, "payments")
         _apply_unit_overrides(session, {}, table)
         tc = self._candidate(session, col)
         assert tc.detected_unit is None
@@ -309,7 +302,7 @@ class TestApplyUnitOverrides:
         unscoped, the patch hit the prior run while the detect read the current run → None.
         """
         src = _make_source(session)
-        table = _make_table(session, src.source_id, "src_zzz__bank_transactions")
+        table = _make_table(session, src.source_id, "bank_transactions")
         col = Column(
             column_id=str(uuid4()),
             table_id=table.table_id,

--- a/packages/engine/tests/unit/sources/json/test_json_loader.py
+++ b/packages/engine/tests/unit/sources/json/test_json_loader.py
@@ -1,9 +1,10 @@
 """Tests for JSON/JSONL loader.
 
-Post-DAT-341: loader writes to ``lake.raw.<source>__<table>`` via the
-DuckLake-anchored connection. Tests under ``TestLoadSingleFile`` request
-``lake_anchor`` + ``lake_clean`` and open ``connect_session()`` instead of
-a plain ``:memory:`` DuckDB.
+Post-DAT-341: loader writes to ``lake.raw.<table>`` via the DuckLake-anchored
+connection — the physical name is NARROW (the file stem, no source prefix —
+DAT-639). Tests under ``TestLoadSingleFile`` request ``lake_anchor`` +
+``lake_clean`` and open ``connect_session()`` instead of a plain ``:memory:``
+DuckDB.
 """
 
 from __future__ import annotations
@@ -99,9 +100,6 @@ class TestGetSchema:
         assert not result.success
 
 
-_SOURCE_NAME = "test_baseline"  # matches the session fixture's seeded Source.name
-
-
 def _fqn(bare: str) -> str:
     """Return ``lake.raw."<bare>"`` — convenience for assertions."""
     return f'lake.raw."{bare}"'
@@ -123,7 +121,6 @@ class TestLoadSingleFile:
             result = loader._load_single_file(
                 source_uri=str(json_file),
                 source_id=_TEST_SOURCE_ID,
-                source_name=_SOURCE_NAME,
                 duckdb_conn=conn,
                 session=session,
             )
@@ -132,8 +129,8 @@ class TestLoadSingleFile:
             staged = result.unwrap()
             assert staged.row_count == 3
             assert staged.column_count == 3
-            assert staged.table_name == "test_baseline__data"
-            assert staged.raw_table_name == "test_baseline__data"
+            assert staged.table_name == "data"
+            assert staged.raw_table_name == "data"
 
             # Verify all columns are VARCHAR by reading back from lake.raw
             row = conn.execute(f"SELECT * FROM {_fqn(staged.raw_table_name)} LIMIT 1").fetchone()
@@ -157,7 +154,6 @@ class TestLoadSingleFile:
             result = loader._load_single_file(
                 source_uri=str(jsonl_file),
                 source_id=_TEST_SOURCE_ID,
-                source_name=_SOURCE_NAME,
                 duckdb_conn=conn,
                 session=session,
             )
@@ -165,7 +161,7 @@ class TestLoadSingleFile:
             assert result.success
             staged = result.unwrap()
             assert staged.row_count == 2
-            assert staged.table_name == "test_baseline__cities"
+            assert staged.table_name == "cities"
         finally:
             conn.close()
 
@@ -188,7 +184,6 @@ class TestLoadSingleFile:
             result = loader._load_single_file(
                 source_uri=str(path),
                 source_id=_TEST_SOURCE_ID,
-                source_name=_SOURCE_NAME,
                 duckdb_conn=conn,
                 session=session,
             )
@@ -197,8 +192,7 @@ class TestLoadSingleFile:
             # Describe the materialized table directly via PRAGMA so we don't
             # depend on information_schema (DuckLake doesn't expose it cleanly).
             cols = conn.execute(
-                f"SELECT column_name FROM (DESCRIBE {_fqn('test_baseline__weird_cols')}) "
-                "ORDER BY column_name"
+                f"SELECT column_name FROM (DESCRIBE {_fqn('weird_cols')}) ORDER BY column_name"
             ).fetchall()
             col_names = [c[0] for c in cols]
             assert "first_name" in col_names
@@ -230,7 +224,6 @@ class TestLoadSingleFile:
             result = loader._load_single_file(
                 source_uri=str(path),
                 source_id=_TEST_SOURCE_ID,
-                source_name=_SOURCE_NAME,
                 duckdb_conn=conn,
                 session=session,
             )
@@ -266,7 +259,6 @@ class TestLoadSingleFile:
             result = loader._load_single_file(
                 source_uri=str(path),
                 source_id=_TEST_SOURCE_ID,
-                source_name=_SOURCE_NAME,
                 duckdb_conn=conn,
                 session=session,
             )

--- a/packages/engine/tests/unit/sources/parquet/test_parquet_loader.py
+++ b/packages/engine/tests/unit/sources/parquet/test_parquet_loader.py
@@ -95,7 +95,6 @@ def _stage_parquet(
     result = loader._load_single_file(
         source_uri=source_uri,
         source_id=source_id,
-        source_name=source_name,
         duckdb_conn=conn,
         session=session,
     )
@@ -172,9 +171,9 @@ class TestParquetLoader:
         try:
             staged = _stage_parquet(conn, test_session, str(sample_parquet), source_name="sample")
 
-            # Post-DAT-341: bare name is ``<source>__<table>``
-            assert staged.table_name == "sample__sample"
-            assert staged.raw_table_name == "sample__sample"
+            # DAT-639: bare name is NARROW (the file stem, no source prefix).
+            assert staged.table_name == "sample"
+            assert staged.raw_table_name == "sample"
             assert staged.row_count == 3
             assert staged.column_count == 5
 
@@ -184,7 +183,7 @@ class TestParquetLoader:
                 "WHERE database_name = 'lake' AND schema_name = 'raw'"
             ).fetchall()
             table_names = [t[0] for t in tables]
-            assert "sample__sample" in table_names
+            assert "sample" in table_names
         finally:
             conn.close()
 
@@ -196,7 +195,7 @@ class TestParquetLoader:
         try:
             _stage_parquet(conn, test_session, str(sample_parquet), source_name="typed_test")
 
-            schema = conn.execute('DESCRIBE lake.raw."typed_test__sample"').fetchall()
+            schema = conn.execute('DESCRIBE lake.raw."sample"').fetchall()
             # DESCRIBE returns (column_name, column_type, null, key, default, extra)
             type_map = {row[0]: row[1] for row in schema}
             assert type_map["id"] == "BIGINT"
@@ -226,7 +225,7 @@ class TestParquetLoader:
         try:
             _stage_parquet(conn, test_session, str(path), source_name="special_cols")
 
-            schema = conn.execute('DESCRIBE lake.raw."special_cols__special_cols"').fetchall()
+            schema = conn.execute('DESCRIBE lake.raw."special_cols"').fetchall()
             col_names = [row[0] for row in schema]
             assert col_names == ["customer_id", "first_name", "totalamount"]
         finally:
@@ -251,7 +250,6 @@ class TestParquetLoader:
             result = loader._load_single_file(
                 source_uri="nonexistent.parquet",
                 source_id="src-missing",
-                source_name="missing",
                 duckdb_conn=conn,
                 session=test_session,
             )
@@ -284,8 +282,8 @@ class TestParquetLoader:
                 select(Table).where(Table.source_id == source.source_id)
             ).scalar_one()
             assert table.layer == "raw"
-            # Post-DAT-341: table_name is ``<source>__<file_stem>``
-            assert table.table_name == "metadata_test__sample"
+            # DAT-639: table_name is the NARROW file stem (no source prefix).
+            assert table.table_name == "sample"
 
             # Check Column records
             columns = (


### PR DESCRIPTION
## What & why

Completes DAT-506's source-free identity into **physical table naming**. We had removed source as a DB identifier but kept it as the `{source}__` prefix on physical table names — so re-importing byte-identical content under a new source name silently created duplicate parallel tables (the DAT-639 bug: 3 live `smoke_<uuid>` sources, byte-identical config).

The per-workspace DuckLake catalog **is** the namespace, so a workspace holds exactly one `orders` — no prefix.

## Engine

- **Narrow names** (P2): raw/typed/quarantine tables are the file stem / recipe name, sanitized, no `src_<digest>__` / `<source>__` / `raw_` prefix. One canonical derivation `sources.base.raw_table_name_for_uri`, shared by every loader **and** the import collision guard so they can't drift.
- **Workspace-unique constraint** (P3): `tables` uniqueness `(source_id, table_name, layer)` → `(table_name, layer)` (`uq_table_name_layer`).
- **Cross-source fail-loud** (P3): a pre-flight guard fails loud *before any write* if a target name is already owned by a **different** source (`CREATE OR REPLACE` would otherwise clobber that source's DuckDB table outside the rolled-back txn). `source_id` here is **ownership** — same source re-importing its own name is replay (upload `should_skip` / db recipe teardown), not a collision.
- **Dead-strip cleanup** (P4): removed the now-dead `src_<digest>__` strip sites (typing-phase teach lookup, `cross_table_consistency` detector).
- **P1 groundwork**: raised `ducklake_max_retry_count` (a slice of DAT-641; the rest of DAT-641 stays deferred).

## Cockpit

- **"Say no" guard**: `importSources` rejects *before persist/trigger* when an import-set would mint a narrow name that already exists in the workspace (or repeats within the batch) — the friendly pre-check in front of the engine backstop.
- **Dead source-id naming removed**: `displayTableName` → identity; deleted slice-family + `src_<digest>__` prefix machinery. The **live** leak barrier stays (`stripSrcDigests` neutralizes the bare `src_<digest>` source name + upload-URI digests, which still exist by design).

## Behavior change (agreed)

DAT-639 **supersedes** DAT-596's silent db auto-replace: re-pointing a recipe is now caught at the cockpit (name exists → say no) / engine fail-loud, not a silent in-place replace. **Deferred (follow-ups):** db recipe *refresh* (same source, re-run → teardown+re-extract — `should_skip` blocks it today), per-workspace import serialization (the one residual TOCTOU, documented in `_first_name_collision`), DAT-641 proper, smoke-harness content-keying.

## Tests / verification

- Engine: 1666 unit green; schema.sql re-dumped; reviewers APPROVE / COMPLIANT.
- Cockpit: 1393 unit green; tsc + biome clean.
- Migration = **fresh-workspace re-seed** (no in-place path) — documented in `.claude/handoff.md` for eval calibration.
- Not yet smoke-tested against the live cluster (cluster in use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)