### PR TITLE
fix(cockpit): close isomorphic-route server-only leak into the client bundle

### DIFF
--- a/packages/cockpit/src/lib/run-context.ts
+++ b/packages/cockpit/src/lib/run-context.ts
@@ -22,7 +22,23 @@ interface ConversationContext {
 	conversationId: string;
 }
 
-const storage = new AsyncLocalStorage<ConversationContext>();
+// Lazy singleton — instantiated on first SERVER call, never at module load. This
+// module is server-only, but it is reachable from a CLIENT graph by a non-route
+// path the `.functions.ts` peel can't cover: `probe.tsx` (client) → the
+// `importSources` server fn's FILE (`server/import-sources.ts`) → `trigger-add-
+// source` → here. The build replaces the server fn with a stub but keeps the
+// FILE's transitively-imported helpers if they aren't tree-shakeable — and a
+// top-level `new AsyncLocalStorage()` is a module side effect prod DCE cannot
+// drop, so it leaked into the client bundle (shimmed-empty `new` → crash). With
+// the `new` deferred into `store()`, this module is side-effect-free and DCE
+// removes it from every client chunk (like `mappers` after the createHash split).
+// See [[feedback_cockpit_isomorphic_import_side_effects]].
+let storage: AsyncLocalStorage<ConversationContext> | null = null;
+
+function store(): AsyncLocalStorage<ConversationContext> {
+	storage ??= new AsyncLocalStorage<ConversationContext>();
+	return storage;
+}
 
 /**
  * Run `fn` with `conversationId` bound for its ENTIRE async call tree — every
@@ -31,7 +47,7 @@ const storage = new AsyncLocalStorage<ConversationContext>();
  * awaited by the caller.
  */
 export function runWithConversation<T>(conversationId: string, fn: () => T): T {
-	return storage.run({ conversationId }, fn);
+	return store().run({ conversationId }, fn);
 }
 
 /**
@@ -41,5 +57,5 @@ export function runWithConversation<T>(conversationId: string, fn: () => T): T {
  * (the completion-watcher filters on a matching conversationId).
  */
 export function currentConversationId(): string | null {
-	return storage.getStore()?.conversationId ?? null;
+	return store().getStore()?.conversationId ?? null;
 }

--- a/packages/cockpit/src/routes/(app)/route.functions.ts
+++ b/packages/cockpit/src/routes/(app)/route.functions.ts
@@ -1,0 +1,18 @@
+// Server functions for the (app) pathless layout route.
+//
+// Peeled out of the route file into `*.functions.ts` (the TanStack Start idiom):
+// a route is ISOMORPHIC, so server-only helpers imported at its top level ride
+// into the CLIENT bundle. Here the helper is imported ONLY inside the
+// `createServerFn` handler; the route imports the fn as an RPC stub and the
+// helper never reaches the client.
+
+import { createServerFn } from "@tanstack/react-start";
+import { resolveActiveWorkspace } from "#/db/cockpit/registry";
+
+// Active workspace id from the cockpit_db registry (DAT-461). The shell needs it
+// so the rail's workspace links resolve on global routes like /settings, which
+// carry no wsId param. Resolved server-side — the registry read never reaches
+// the client bundle.
+export const getActiveWorkspaceId = createServerFn({ method: "GET" }).handler(
+	() => resolveActiveWorkspace(),
+);

--- a/packages/cockpit/src/routes/(app)/route.tsx
+++ b/packages/cockpit/src/routes/(app)/route.tsx
@@ -1,19 +1,10 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
-import { resolveActiveWorkspace } from "#/db/cockpit/registry";
 import { CockpitShell } from "#/ui/app-shell";
+import { getActiveWorkspaceId } from "./route.functions";
 
 // Pathless layout (`(app)` is a route group — it adds no URL segment). Every
 // section page nests under this so the AppShell chrome (rail + top bar +
 // ⌘K palette) renders once and the section fills <Outlet/>.
-
-// Active workspace id from the cockpit_db registry (DAT-461). The shell needs it
-// so the rail's workspace links resolve on global routes like /settings, which
-// carry no wsId param. Resolved server-side — the registry read never reaches
-// the client bundle.
-const getActiveWorkspaceId = createServerFn({ method: "GET" }).handler(() =>
-	resolveActiveWorkspace(),
-);
 
 export const Route = createFileRoute("/(app)")({
 	loader: () => getActiveWorkspaceId(),

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.functions.ts
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.functions.ts
@@ -1,0 +1,116 @@
+// Server functions for the $conversationId chat route (DAT-528).
+//
+// Peeled out of the route file into `*.functions.ts` (the TanStack Start idiom):
+// a route is ISOMORPHIC, so server-only helpers imported at its top level ride
+// into the CLIENT bundle (in dev there is no tree-shaking, so a helper that pulls
+// a browser-throwing node builtin — e.g. run-context's `node:async_hooks` via
+// `listRunningStages` — crashes the route). Here those helpers are imported ONLY
+// inside `createServerFn` handlers; "static imports of server functions are safe —
+// the build replaces implementations with RPC stubs in client bundles" (TanStack
+// start-core/server-functions). So the route imports these as RPC stubs and the
+// helpers never reach the client. See [[feedback_cockpit_isomorphic_import_side_effects]].
+
+import { createServerFn } from "@tanstack/react-start";
+import {
+	type ConversationKind,
+	createConversation,
+	getConversation,
+	loadDisplayMessages,
+} from "#/db/cockpit/conversations";
+import { resolveActiveWorkspace } from "#/db/cockpit/registry";
+import { listRunningStages } from "#/db/cockpit/runs";
+import { loadUiState, saveUiState } from "#/db/cockpit/ui-state";
+import { buildWorkspaceBriefing } from "#/db/metadata/briefing";
+import { hasImportedTables } from "#/db/metadata/workspace-state";
+import { chatReadiness } from "#/lib/chat-readiness";
+import { reconcileActiveRuns } from "#/temporal/reconcile";
+
+// Mint a fresh typed conversation (server-side workspace read never reaches the
+// client bundle; the plugin strips this handler from the client).
+export const createTypedConversation = createServerFn({ method: "POST" })
+	.inputValidator((kind: ConversationKind) => kind)
+	.handler(async ({ data }) => {
+		const workspaceId = await resolveActiveWorkspace();
+		return createConversation(workspaceId, data);
+	});
+
+// A specific chat (DAT-528), hydrated by its id from the URL. The conversation's
+// transcript + restored UI state seed `useChat`/the canvas on reload (DAT-462);
+// an unknown id 404s rather than mounting an orphan chat. Reconcile is now
+// CONVERSATION-scoped (DAT-528): this chat's own in-flight runs are swept against
+// Temporal so a run that finished while the tab was closed doesn't linger.
+//
+// `strict: { output: false }` opts out of the OUTPUT serialization TYPE guard:
+// UIMessage's parts carry `unknown` metadata the guard flags, but the values ARE
+// plain JSON (they round-trip out of the conversation_messages jsonb column).
+// Resilient: a cockpit_db hiccup degrades to an unhydrated chat (the /api/chat
+// degraded path still serves the turn) rather than erroring the route; only a
+// genuinely unknown id 404s.
+export const loadChat = createServerFn({
+	method: "GET",
+	strict: { output: false },
+})
+	.inputValidator((conversationId: string) => conversationId)
+	.handler(async ({ data: conversationId }) => {
+		try {
+			const conversation = await getConversation(conversationId);
+			if (!conversation) return { notFound: true as const };
+			// Readiness inputs (DAT-534) alongside hydration — both soft (a read blip
+			// just drops the advisory banner, never the chat).
+			// The chat-open Workspace Briefing (DAT-634) — the landing canvas for a
+			// fresh stage/analyse chat. Connect keeps its probe hub and discards the
+			// briefing, so don't pay the read there. Soft: a blip drops the landing
+			// orientation (falls back to empty), never the chat.
+			const briefingPromise =
+				conversation.kind === "connect"
+					? Promise.resolve(null)
+					: buildWorkspaceBriefing().catch(() => null);
+			const [initialMessages, uiState, hasTables, runningStages, briefing] =
+				await Promise.all([
+					loadDisplayMessages(conversationId),
+					loadUiState(conversationId),
+					hasImportedTables().catch(() => false),
+					listRunningStages(conversationId).catch(() => []),
+					briefingPromise,
+				]);
+			void reconcileActiveRuns(conversationId);
+			return {
+				notFound: false as const,
+				conversationId,
+				kind: conversation.kind,
+				title: conversation.title,
+				initialMessages,
+				uiState,
+				briefing,
+				readiness: chatReadiness(conversation.kind, {
+					hasTables,
+					hasActiveRun: runningStages.length > 0,
+				}),
+			};
+		} catch (err) {
+			console.error(
+				"[cockpit] chat hydration failed — mounting an unhydrated chat:",
+				err,
+			);
+			return {
+				notFound: false as const,
+				conversationId,
+				kind: null,
+				title: null,
+				initialMessages: undefined,
+				uiState: null,
+				briefing: null,
+				readiness: null,
+			};
+		}
+	});
+
+// Persist the canvas-focus pin (DAT-462) so a reload returns to the same view.
+// Best-effort (saveUiState swallows); the client fires it without awaiting.
+export const persistPin = createServerFn({ method: "POST" })
+	.inputValidator(
+		(input: { conversationId: string; pinnedCallId: string | null }) => input,
+	)
+	.handler(({ data }) =>
+		saveUiState(data.conversationId, { pinnedCallId: data.pinnedCallId }),
+	);

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/$conversationId.tsx
@@ -6,116 +6,20 @@ import {
 	useMatch,
 	useNavigate,
 } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
-import {
-	type ConversationKind,
-	createConversation,
-	getConversation,
-	loadDisplayMessages,
-} from "#/db/cockpit/conversations";
-import { resolveActiveWorkspace } from "#/db/cockpit/registry";
-import { listRunningStages } from "#/db/cockpit/runs";
-import { loadUiState, saveUiState } from "#/db/cockpit/ui-state";
-import { buildWorkspaceBriefing } from "#/db/metadata/briefing";
-import { hasImportedTables } from "#/db/metadata/workspace-state";
-import { chatReadiness } from "#/lib/chat-readiness";
-import { reconcileActiveRuns } from "#/temporal/reconcile";
 import { ChatReadinessBanner } from "#/ui/cockpit/chat-readiness-banner";
 import type { ChatTypeNav } from "#/ui/cockpit/chat-switcher";
 import { CockpitProvider } from "#/ui/cockpit/cockpit-state";
 import { CockpitView } from "#/ui/cockpit/cockpit-view";
+import {
+	createTypedConversation,
+	loadChat,
+	persistPin,
+} from "./$conversationId.functions";
 
 // The cockpit layout route, whose loader carries the switcher data (availability
 // + latest-by-kind). Read here via useMatch so the composer's type drop-up can
 // resume-or-create without re-querying.
 const COCKPIT_LAYOUT_ROUTE = "/(app)/workspace/$wsId/cockpit";
-
-// Mint a fresh typed conversation (server-side workspace read never reaches the
-// client bundle; the plugin strips this handler from the client).
-const createTypedConversation = createServerFn({ method: "POST" })
-	.inputValidator((kind: ConversationKind) => kind)
-	.handler(async ({ data }) => {
-		const workspaceId = await resolveActiveWorkspace();
-		return createConversation(workspaceId, data);
-	});
-
-// A specific chat (DAT-528), hydrated by its id from the URL. The conversation's
-// transcript + restored UI state seed `useChat`/the canvas on reload (DAT-462);
-// an unknown id 404s rather than mounting an orphan chat. Reconcile is now
-// CONVERSATION-scoped (DAT-528): this chat's own in-flight runs are swept against
-// Temporal so a run that finished while the tab was closed doesn't linger.
-//
-// `strict: { output: false }` opts out of the OUTPUT serialization TYPE guard:
-// UIMessage's parts carry `unknown` metadata the guard flags, but the values ARE
-// plain JSON (they round-trip out of the conversation_messages jsonb column).
-// Resilient: a cockpit_db hiccup degrades to an unhydrated chat (the /api/chat
-// degraded path still serves the turn) rather than erroring the route; only a
-// genuinely unknown id 404s.
-const loadChat = createServerFn({ method: "GET", strict: { output: false } })
-	.inputValidator((conversationId: string) => conversationId)
-	.handler(async ({ data: conversationId }) => {
-		try {
-			const conversation = await getConversation(conversationId);
-			if (!conversation) return { notFound: true as const };
-			// Readiness inputs (DAT-534) alongside hydration — both soft (a read blip
-			// just drops the advisory banner, never the chat).
-			// The chat-open Workspace Briefing (DAT-634) — the landing canvas for a
-			// fresh stage/analyse chat. Connect keeps its probe hub and discards the
-			// briefing, so don't pay the read there. Soft: a blip drops the landing
-			// orientation (falls back to empty), never the chat.
-			const briefingPromise =
-				conversation.kind === "connect"
-					? Promise.resolve(null)
-					: buildWorkspaceBriefing().catch(() => null);
-			const [initialMessages, uiState, hasTables, runningStages, briefing] =
-				await Promise.all([
-					loadDisplayMessages(conversationId),
-					loadUiState(conversationId),
-					hasImportedTables().catch(() => false),
-					listRunningStages(conversationId).catch(() => []),
-					briefingPromise,
-				]);
-			void reconcileActiveRuns(conversationId);
-			return {
-				notFound: false as const,
-				conversationId,
-				kind: conversation.kind,
-				title: conversation.title,
-				initialMessages,
-				uiState,
-				briefing,
-				readiness: chatReadiness(conversation.kind, {
-					hasTables,
-					hasActiveRun: runningStages.length > 0,
-				}),
-			};
-		} catch (err) {
-			console.error(
-				"[cockpit] chat hydration failed — mounting an unhydrated chat:",
-				err,
-			);
-			return {
-				notFound: false as const,
-				conversationId,
-				kind: null,
-				title: null,
-				initialMessages: undefined,
-				uiState: null,
-				briefing: null,
-				readiness: null,
-			};
-		}
-	});
-
-// Persist the canvas-focus pin (DAT-462) so a reload returns to the same view.
-// Best-effort (saveUiState swallows); the client fires it without awaiting.
-const persistPin = createServerFn({ method: "POST" })
-	.inputValidator(
-		(input: { conversationId: string; pinnedCallId: string | null }) => input,
-	)
-	.handler(({ data }) =>
-		saveUiState(data.conversationId, { pinnedCallId: data.pinnedCallId }),
-	);
 
 export const Route = createFileRoute(
 	"/(app)/workspace/$wsId/cockpit/$conversationId",

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/index.functions.ts
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/index.functions.ts
@@ -1,0 +1,47 @@
+// Server functions for the cockpit landing route (DAT-528/534).
+//
+// Peeled out of the route file into `*.functions.ts` (the TanStack Start idiom):
+// a route is ISOMORPHIC, so server-only helpers imported at its top level ride
+// into the CLIENT bundle. Here those helpers are imported ONLY inside the
+// `createServerFn` handlers; the route imports the fns as RPC stubs and the
+// helpers never reach the client.
+
+import { createServerFn } from "@tanstack/react-start";
+import {
+	type ConversationKind,
+	createConversation,
+	listConversations,
+} from "#/db/cockpit/conversations";
+import { resolveActiveWorkspace } from "#/db/cockpit/registry";
+import { hasImportedTables } from "#/db/metadata/workspace-state";
+import { chatTypesFromState } from "#/lib/chat-availability";
+import { classifyOpeningMessage } from "#/lib/nav-agent";
+
+export const loadHistory = createServerFn({ method: "GET" }).handler(
+	async () => {
+		const workspaceId = await resolveActiveWorkspace();
+		return { conversations: await listConversations(workspaceId) };
+	},
+);
+
+export const startConversation = createServerFn({ method: "POST" })
+	.inputValidator((kind: ConversationKind) => kind)
+	.handler(async ({ data }) => {
+		const workspaceId = await resolveActiveWorkspace();
+		return createConversation(workspaceId, data);
+	});
+
+// The "tell" entry (DAT-534): classify the opening message into a kind (Haiku,
+// best-effort, biased by what's startable), then create that typed chat. The
+// caller seeds the message into the new chat client-side (router state).
+export const routeOpeningMessage = createServerFn({ method: "POST" })
+	.inputValidator((message: string) => message)
+	.handler(async ({ data: message }) => {
+		const workspaceId = await resolveActiveWorkspace();
+		const hasTables = await hasImportedTables().catch(() => false);
+		const available = chatTypesFromState({ hasTables })
+			.filter((t) => t.available)
+			.map((t) => t.kind);
+		const kind = await classifyOpeningMessage(message, available);
+		return { conversationId: await createConversation(workspaceId, kind) };
+	});

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/index.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/index.tsx
@@ -1,48 +1,17 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
-import {
-	type ConversationKind,
-	createConversation,
-	listConversations,
-} from "#/db/cockpit/conversations";
-import { resolveActiveWorkspace } from "#/db/cockpit/registry";
-import { hasImportedTables } from "#/db/metadata/workspace-state";
-import { chatTypesFromState } from "#/lib/chat-availability";
-import { classifyOpeningMessage } from "#/lib/nav-agent";
+import type { ConversationKind } from "#/db/cockpit/conversations";
 import { CockpitHome } from "#/ui/cockpit/cockpit-home";
+import {
+	loadHistory,
+	routeOpeningMessage,
+	startConversation,
+} from "./index.functions";
 
 // The cockpit landing (DAT-528 + DAT-534): "tell or click". The free composer
 // (tell) routes through the Haiku nav-agent → a typed chat seeded with the
 // message; the type chips (click) create a typed chat deterministically. Both
 // server fns resolve the active workspace server-side (the registry read never
 // reaches the client bundle); the plugin strips these handlers from the client.
-
-const loadHistory = createServerFn({ method: "GET" }).handler(async () => {
-	const workspaceId = await resolveActiveWorkspace();
-	return { conversations: await listConversations(workspaceId) };
-});
-
-const startConversation = createServerFn({ method: "POST" })
-	.inputValidator((kind: ConversationKind) => kind)
-	.handler(async ({ data }) => {
-		const workspaceId = await resolveActiveWorkspace();
-		return createConversation(workspaceId, data);
-	});
-
-// The "tell" entry (DAT-534): classify the opening message into a kind (Haiku,
-// best-effort, biased by what's startable), then create that typed chat. The
-// caller seeds the message into the new chat client-side (router state).
-const routeOpeningMessage = createServerFn({ method: "POST" })
-	.inputValidator((message: string) => message)
-	.handler(async ({ data: message }) => {
-		const workspaceId = await resolveActiveWorkspace();
-		const hasTables = await hasImportedTables().catch(() => false);
-		const available = chatTypesFromState({ hasTables })
-			.filter((t) => t.available)
-			.map((t) => t.kind);
-		const kind = await classifyOpeningMessage(message, available);
-		return { conversationId: await createConversation(workspaceId, kind) };
-	});
 
 export const Route = createFileRoute("/(app)/workspace/$wsId/cockpit/")({
 	loader: () => loadHistory(),

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/route.functions.ts
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/route.functions.ts
@@ -1,0 +1,40 @@
+// Server functions for the cockpit layout route (DAT-528/533).
+//
+// Peeled out of the route file into `*.functions.ts` (the TanStack Start idiom):
+// a route is ISOMORPHIC, so server-only helpers imported at its top level ride
+// into the CLIENT bundle. Here those helpers are imported ONLY inside the
+// `createServerFn` handler; the route imports the fn as an RPC stub and the
+// helpers never reach the client.
+
+import { createServerFn } from "@tanstack/react-start";
+import {
+	type ConversationKind,
+	listConversations,
+} from "#/db/cockpit/conversations";
+import { resolveActiveWorkspace } from "#/db/cockpit/registry";
+import { hasImportedTables } from "#/db/metadata/workspace-state";
+import {
+	type ChatTypeAvailability,
+	chatTypesFromState,
+} from "#/lib/chat-availability";
+
+// Switcher data (DAT-533): per-kind availability (drives the dimming) + the most
+// recent conversation id per kind (drives resume-or-create). Consumed by the chat
+// route's composer drop-up. Both reads degrade soft — a failure dims the
+// data-dependent types / falls back to create — the drop-up never blocks a route.
+export const loadSwitcher = createServerFn({ method: "GET" }).handler(
+	async () => {
+		const workspaceId = await resolveActiveWorkspace();
+		const [hasTables, conversations] = await Promise.all([
+			hasImportedTables().catch(() => false),
+			listConversations(workspaceId).catch(() => []),
+		]);
+		// listConversations is lastActiveAt-desc, so the FIRST per kind is its latest.
+		const latestByKind: Partial<Record<ConversationKind, string>> = {};
+		for (const c of conversations) latestByKind[c.kind] ??= c.id;
+		return {
+			availability: chatTypesFromState({ hasTables }) as ChatTypeAvailability[],
+			latestByKind,
+		};
+	},
+);

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/route.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/cockpit/route.tsx
@@ -1,41 +1,12 @@
 import { Box } from "@mantine/core";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
-import {
-	type ConversationKind,
-	listConversations,
-} from "#/db/cockpit/conversations";
-import { resolveActiveWorkspace } from "#/db/cockpit/registry";
-import { hasImportedTables } from "#/db/metadata/workspace-state";
-import {
-	type ChatTypeAvailability,
-	chatTypesFromState,
-} from "#/lib/chat-availability";
+import { loadSwitcher } from "./route.functions";
 
 // Cockpit layout (DAT-528 route split; DAT-533 nav). A FIXED-HEIGHT shell around
 // the history/landing index and a specific chat. The chat-type drop-up now lives
 // in the COMPOSER (the chat route reads THIS loader via useMatch and threads it to
 // the composer as `typeNav`) — so the layout just pins the height and renders the
 // Outlet, no top strip, no header switcher.
-
-// Switcher data (DAT-533): per-kind availability (drives the dimming) + the most
-// recent conversation id per kind (drives resume-or-create). Consumed by the chat
-// route's composer drop-up. Both reads degrade soft — a failure dims the
-// data-dependent types / falls back to create — the drop-up never blocks a route.
-const loadSwitcher = createServerFn({ method: "GET" }).handler(async () => {
-	const workspaceId = await resolveActiveWorkspace();
-	const [hasTables, conversations] = await Promise.all([
-		hasImportedTables().catch(() => false),
-		listConversations(workspaceId).catch(() => []),
-	]);
-	// listConversations is lastActiveAt-desc, so the FIRST per kind is its latest.
-	const latestByKind: Partial<Record<ConversationKind, string>> = {};
-	for (const c of conversations) latestByKind[c.kind] ??= c.id;
-	return {
-		availability: chatTypesFromState({ hasTables }) as ChatTypeAvailability[],
-		latestByKind,
-	};
-});
 
 export const Route = createFileRoute("/(app)/workspace/$wsId/cockpit")({
 	loader: () => loadSwitcher(),

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/governance.functions.ts
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/governance.functions.ts
@@ -1,0 +1,28 @@
+// Server functions for the governance route (DAT-633). Peeled out of the
+// isomorphic route file so the server-only postgres reads never ride into the
+// client bundle — static imports of these are RPC stubs there, the helpers move
+// with them. See $conversationId.functions.ts for the full rationale.
+
+import { createServerFn } from "@tanstack/react-start";
+import { createConversation } from "#/db/cockpit/conversations";
+import { resolveActiveWorkspace } from "#/db/cockpit/registry";
+import { buildWorkspaceBriefing } from "#/db/metadata/briefing";
+
+// No wsId param: single-active-workspace; DAT-357 will add per-request scoping
+// here (mirrors briefing/build.ts). The $wsId route param stays decorative.
+export const loadBriefing = createServerFn({ method: "GET" }).handler(
+	async () => {
+		return buildWorkspaceBriefing();
+	},
+);
+
+// Mint a Stage chat to act on a governance item — the server-side workspace read
+// never reaches the client bundle (the plugin strips this handler); the client
+// navigates to the new chat with the seed in router state. Same flow as the run
+// monitor's "Needs you" resolve (workflows.tsx).
+export const openStageChat = createServerFn({ method: "POST" }).handler(
+	async () => {
+		const workspaceId = await resolveActiveWorkspace();
+		return createConversation(workspaceId, "stage");
+	},
+);

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/governance.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/governance.tsx
@@ -8,27 +8,9 @@
 
 import { Center, Loader, Stack, Text } from "@mantine/core";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
-import { createConversation } from "#/db/cockpit/conversations";
-import { resolveActiveWorkspace } from "#/db/cockpit/registry";
-import { buildWorkspaceBriefing } from "#/db/metadata/briefing";
 import { GovernanceOverview } from "#/ui/governance/governance-overview";
 import { REPLAY_SEED } from "#/ui/governance/governance-target";
-
-// No wsId param: single-active-workspace; DAT-357 will add per-request scoping
-// here (mirrors briefing/build.ts). The $wsId route param stays decorative.
-const loadBriefing = createServerFn({ method: "GET" }).handler(async () => {
-	return buildWorkspaceBriefing();
-});
-
-// Mint a Stage chat to act on a governance item — the server-side workspace read
-// never reaches the client bundle (the plugin strips this handler); the client
-// navigates to the new chat with the seed in router state. Same flow as the run
-// monitor's "Needs you" resolve (workflows.tsx).
-const openStageChat = createServerFn({ method: "POST" }).handler(async () => {
-	const workspaceId = await resolveActiveWorkspace();
-	return createConversation(workspaceId, "stage");
-});
+import { loadBriefing, openStageChat } from "./governance.functions";
 
 export const Route = createFileRoute("/(app)/workspace/$wsId/governance")({
 	loader: () => loadBriefing(),

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/operating-model.functions.ts
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/operating-model.functions.ts
@@ -1,0 +1,13 @@
+// Server function for the operating-model route (DAT-591).
+//
+// Peeled out of the route file into `*.functions.ts` (the TanStack Start idiom):
+// the route is ISOMORPHIC, so the metadata Drizzle read would otherwise ride into
+// the CLIENT bundle. Here it lives ONLY inside the `createServerFn` handler; the
+// route imports this as an RPC stub and the helper never reaches the client.
+
+import { createServerFn } from "@tanstack/react-start";
+import { loadOperatingModelGraph } from "#/tools/operating-model-load";
+
+export const loadModel = createServerFn({ method: "GET" }).handler(() =>
+	loadOperatingModelGraph(),
+);

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/operating-model.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/operating-model.tsx
@@ -5,15 +5,10 @@
 
 import { Box, Center, Stack, Text } from "@mantine/core";
 import { ClientOnly, createFileRoute } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
 
-import { loadOperatingModelGraph } from "#/tools/operating-model-load";
 import { ModelIcon } from "#/ui/cockpit/operating-model/nodes";
 import { OperatingModelCanvas } from "#/ui/cockpit/operating-model/operating-model-canvas";
-
-const loadModel = createServerFn({ method: "GET" }).handler(() =>
-	loadOperatingModelGraph(),
-);
+import { loadModel } from "./operating-model.functions";
 
 export const Route = createFileRoute("/(app)/workspace/$wsId/operating-model")({
 	loader: () => loadModel(),

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/reports/$reportId.functions.ts
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/reports/$reportId.functions.ts
@@ -1,0 +1,67 @@
+// Server functions for the report-detail route (DAT-624 / DAT-625).
+//
+// Peeled out of the route file into `*.functions.ts` (the TanStack Start idiom):
+// the route is ISOMORPHIC, so server-only helpers (cockpit_db + lake reads) imported
+// at its top level would ride into the CLIENT bundle. Here they live ONLY inside
+// `createServerFn` handlers; the route imports these as RPC stubs and the helpers
+// never reach the client.
+
+import { notFound } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import {
+	getReport,
+	renameReport,
+	setReportFingerprint,
+	softDeleteReport,
+	updateReportSummary,
+} from "#/db/cockpit/reports";
+import { computeReportFingerprint } from "#/duckdb/report-fingerprint-read";
+import { regenerateSummary } from "#/lib/report-summary-agent";
+
+export const loadReport = createServerFn({ method: "GET" })
+	.inputValidator((reportId: string) => reportId)
+	.handler(async ({ data: reportId }) => {
+		const report = await getReport(reportId);
+		if (!report) return null;
+		let outdated = false;
+		try {
+			const { fingerprint } = await computeReportFingerprint(report.sql);
+			if (report.summaryFingerprint === null) {
+				// First time we can fingerprint this report — backfill, don't badge.
+				await setReportFingerprint(report.id, fingerprint);
+			} else {
+				outdated = report.summaryFingerprint !== fingerprint;
+			}
+		} catch (err) {
+			// Best-effort: if the live result can't be fingerprinted (a since-broken
+			// SQL, a lake hiccup), don't badge — the grid surfaces the real error.
+			console.error("[reports] drift check failed — not flagging:", err);
+		}
+		return { report, outdated };
+	});
+
+export const renameReportFn = createServerFn({ method: "POST" })
+	.inputValidator((data: { id: string; title: string }) => data)
+	.handler(async ({ data }) => {
+		await renameReport(data.id, data.title);
+	});
+
+export const deleteReportFn = createServerFn({ method: "POST" })
+	.inputValidator((reportId: string) => reportId)
+	.handler(async ({ data: reportId }) => {
+		await softDeleteReport(reportId);
+	});
+
+// Regenerate (DAT-625): re-run the SQL, hand the old summary + fresh result to Haiku,
+// and persist the new summary together with the fresh fingerprint — the one path that
+// mutates `summary`. A throw here (missing report, LLM failure) propagates to the
+// caller, which keeps the old summary + outdated badge rather than half-applying.
+export const regenerateSummaryFn = createServerFn({ method: "POST" })
+	.inputValidator((reportId: string) => reportId)
+	.handler(async ({ data: reportId }) => {
+		const report = await getReport(reportId);
+		if (!report) throw notFound();
+		const { fingerprint, result } = await computeReportFingerprint(report.sql);
+		const summary = await regenerateSummary(report.summary, result);
+		await updateReportSummary(reportId, summary, fingerprint);
+	});

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/reports/$reportId.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/reports/$reportId.tsx
@@ -14,7 +14,7 @@ import {
 	useNavigate,
 	useRouter,
 } from "@tanstack/react-router";
-import { createServerFn, useServerFn } from "@tanstack/react-start";
+import { useServerFn } from "@tanstack/react-start";
 import {
 	Check,
 	Pencil,
@@ -24,17 +24,14 @@ import {
 	X,
 } from "lucide-react";
 import { useState } from "react";
-import {
-	getReport,
-	renameReport,
-	setReportFingerprint,
-	softDeleteReport,
-	updateReportSummary,
-} from "#/db/cockpit/reports";
-import { computeReportFingerprint } from "#/duckdb/report-fingerprint-read";
-import { regenerateSummary } from "#/lib/report-summary-agent";
 import { ConfidenceStrip } from "#/ui/cockpit/widgets/answer-result";
 import { ResultGridWidget } from "#/ui/cockpit/widgets/result-grid";
+import {
+	deleteReportFn,
+	loadReport,
+	regenerateSummaryFn,
+	renameReportFn,
+} from "./$reportId.functions";
 
 // Report detail (DAT-624 / DAT-625) — the frozen artifact rendered over LIVE data:
 // the SQL is re-run on every open through the same result-grid stream, so numbers
@@ -47,56 +44,9 @@ import { ResultGridWidget } from "#/ui/cockpit/widgets/result-grid";
 // it's badged "outdated". A null stored fingerprint (pre-DAT-625 report, or a failed
 // mint-time fingerprint) is lazy-backfilled here — start tracking, show clean.
 //
-// The loader + action server fns are defined inline (the cockpit route convention)
-// so the plugin strips their cockpit_db + lake handlers from the client bundle.
-
-const loadReport = createServerFn({ method: "GET" })
-	.inputValidator((reportId: string) => reportId)
-	.handler(async ({ data: reportId }) => {
-		const report = await getReport(reportId);
-		if (!report) return null;
-		let outdated = false;
-		try {
-			const { fingerprint } = await computeReportFingerprint(report.sql);
-			if (report.summaryFingerprint === null) {
-				// First time we can fingerprint this report — backfill, don't badge.
-				await setReportFingerprint(report.id, fingerprint);
-			} else {
-				outdated = report.summaryFingerprint !== fingerprint;
-			}
-		} catch (err) {
-			// Best-effort: if the live result can't be fingerprinted (a since-broken
-			// SQL, a lake hiccup), don't badge — the grid surfaces the real error.
-			console.error("[reports] drift check failed — not flagging:", err);
-		}
-		return { report, outdated };
-	});
-
-const renameReportFn = createServerFn({ method: "POST" })
-	.inputValidator((data: { id: string; title: string }) => data)
-	.handler(async ({ data }) => {
-		await renameReport(data.id, data.title);
-	});
-
-const deleteReportFn = createServerFn({ method: "POST" })
-	.inputValidator((reportId: string) => reportId)
-	.handler(async ({ data: reportId }) => {
-		await softDeleteReport(reportId);
-	});
-
-// Regenerate (DAT-625): re-run the SQL, hand the old summary + fresh result to Haiku,
-// and persist the new summary together with the fresh fingerprint — the one path that
-// mutates `summary`. A throw here (missing report, LLM failure) propagates to the
-// caller, which keeps the old summary + outdated badge rather than half-applying.
-const regenerateSummaryFn = createServerFn({ method: "POST" })
-	.inputValidator((reportId: string) => reportId)
-	.handler(async ({ data: reportId }) => {
-		const report = await getReport(reportId);
-		if (!report) throw notFound();
-		const { fingerprint, result } = await computeReportFingerprint(report.sql);
-		const summary = await regenerateSummary(report.summary, result);
-		await updateReportSummary(reportId, summary, fingerprint);
-	});
+// The loader + action server fns live in the sibling `$reportId.functions.ts`
+// (the cockpit route convention) so their cockpit_db + lake handlers are stripped
+// from the client bundle.
 
 export const Route = createFileRoute(
 	"/(app)/workspace/$wsId/reports/$reportId",

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/reports/index.functions.ts
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/reports/index.functions.ts
@@ -1,0 +1,17 @@
+// Server function for the reports-gallery route (DAT-624).
+//
+// Peeled out of the route file into `*.functions.ts` (the TanStack Start idiom):
+// the route is ISOMORPHIC, so the cockpit_db helpers would otherwise ride into the
+// CLIENT bundle. Here they live ONLY inside the `createServerFn` handler; the route
+// imports this as an RPC stub and the helpers never reach the client.
+
+import { createServerFn } from "@tanstack/react-start";
+import { resolveActiveWorkspace } from "#/db/cockpit/registry";
+import { listReports } from "#/db/cockpit/reports";
+
+export const loadReports = createServerFn({ method: "GET" }).handler(
+	async () => {
+		const workspaceId = await resolveActiveWorkspace();
+		return listReports(workspaceId);
+	},
+);

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/reports/index.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/reports/index.tsx
@@ -1,22 +1,15 @@
 import { Card, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
 import { Library } from "lucide-react";
-import { resolveActiveWorkspace } from "#/db/cockpit/registry";
-import { listReports } from "#/db/cockpit/reports";
 import { BandBadge } from "#/ui/cockpit/widgets/band-badge";
+import { loadReports } from "./index.functions";
 
 // The reports gallery (DAT-624) — a workspace's library of minted widgets. Each
 // card links to the detail view, which re-runs the frozen SQL live. The list is
 // bounded server-side (REPORTS_LIMIT); cards are lightweight, so the page scrolls.
 //
-// The loader's server fn is defined inline (the cockpit route convention) so the
-// plugin strips its cockpit_db handler from the client bundle.
-
-const loadReports = createServerFn({ method: "GET" }).handler(async () => {
-	const workspaceId = await resolveActiveWorkspace();
-	return listReports(workspaceId);
-});
+// The loader's server fn lives in the sibling `index.functions.ts` (the cockpit
+// route convention) so the plugin strips its cockpit_db handler from the client bundle.
 
 export const Route = createFileRoute("/(app)/workspace/$wsId/reports/")({
 	loader: () => loadReports(),

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.functions.ts
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.functions.ts
@@ -1,0 +1,81 @@
+// Server functions for the run-monitor route (DAT-550). Peeled out of the
+// isomorphic route file so the server-only cockpit_db reads + engine tool calls
+// never ride into the client bundle — static imports of these are RPC stubs
+// there. See $conversationId.functions.ts for the full rationale.
+
+import { createServerFn } from "@tanstack/react-start";
+import { config } from "#/config";
+import { createConversation } from "#/db/cockpit/conversations";
+import { resolveActiveWorkspace } from "#/db/cockpit/registry";
+import {
+	listAwaitingInput,
+	listRunsByWorkspace,
+	type RunStage,
+} from "#/db/cockpit/runs";
+import { readStageStaleness } from "#/db/metadata/stage-staleness-read";
+import { currentTypedTableIds } from "#/db/metadata/workspace-state";
+import { beginSession } from "#/tools/begin-session";
+import { operatingModel } from "#/tools/operating-model";
+import { replay } from "#/tools/replay";
+
+// The native run monitor (DAT-550) — a workspace-wide view of stage runs read from
+// cockpit_db — with the "Needs you" inbox (DAT-553) above it: the ACTIVE worklist
+// over runs the grounding loop parked `awaiting_input`, vs the monitor's PASSIVE
+// "Needs input" row. Workspace resolved server-side (mirrors loadHistory), not the
+// route param. Bounded to the latest N.
+const RUN_LIMIT = 100;
+// The inbox is a worklist, not a log — a tighter bound than the run monitor.
+const AWAITING_LIMIT = 50;
+
+export const loadRuns = createServerFn({ method: "GET" }).handler(async () => {
+	const workspaceId = await resolveActiveWorkspace();
+	const [runs, awaiting, staleness] = await Promise.all([
+		listRunsByWorkspace(workspaceId, RUN_LIMIT),
+		listAwaitingInput(workspaceId, AWAITING_LIMIT),
+		readStageStaleness(),
+	]);
+	return {
+		runs,
+		awaiting,
+		staleness,
+		temporalUiUrl: config.temporalUiUrl,
+		limit: RUN_LIMIT,
+	};
+});
+
+// Mint a Stage chat to resolve a "Needs you" item (DAT-553). The server-side
+// workspace read never reaches the client bundle (the plugin strips this handler);
+// the client navigates to the new chat with the seed in router state.
+export const openStageChat = createServerFn({ method: "POST" }).handler(
+	async () => {
+		const workspaceId = await resolveActiveWorkspace();
+		return createConversation(workspaceId, "stage");
+	},
+);
+
+// One-click re-run of a stale stage (DAT-531) — routes to the affected stage via
+// the SAME journey signals the agent tools use (no new orchestration). Re-runs the
+// CURRENT session; the run records with a null conversationId (no originating chat),
+// so it surfaces in the monitor rather than narrating. `replay` is the DAT-551
+// add_source path for grounding-stale; begin_session / operating_model re-run
+// in-session (the cheap case).
+export const rerunStage = createServerFn({ method: "POST" })
+	.inputValidator((stage: RunStage) => stage)
+	.handler(async ({ data: stage }) => {
+		let result: unknown;
+		if (stage === "operating_model") {
+			result = await operatingModel();
+		} else if (stage === "begin_session") {
+			// begin_session stages over the workspace's current typed table set.
+			result = await beginSession({ table_ids: await currentTypedTableIds() });
+		} else {
+			// add_source — the DAT-551 full replay path (re-runs the workspace sources).
+			result = await replay({});
+		}
+		// The tool fns return an { error } envelope for their born-loud guards (e.g.
+		// operating_model's "begin_session still running"). Surface it as a throw so
+		// the client handler shows the failure instead of a silent no-op re-run.
+		if (result && typeof result === "object" && "error" in result) {
+			throw new Error(String((result as { error: unknown }).error));
+		}
+	});

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.tsx
@@ -4,85 +4,12 @@ import {
 	useNavigate,
 	useRouter,
 } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
-import { config } from "#/config";
-import { createConversation } from "#/db/cockpit/conversations";
-import { resolveActiveWorkspace } from "#/db/cockpit/registry";
-import {
-	type AwaitingInputItem,
-	listAwaitingInput,
-	listRunsByWorkspace,
-	type RunStage,
-} from "#/db/cockpit/runs";
-import { readStageStaleness } from "#/db/metadata/stage-staleness-read";
-import { currentTypedTableIds } from "#/db/metadata/workspace-state";
-import { beginSession } from "#/tools/begin-session";
-import { operatingModel } from "#/tools/operating-model";
-import { replay } from "#/tools/replay";
+import type { AwaitingInputItem, RunStage } from "#/db/cockpit/runs";
 import { resolveSeed } from "#/ui/runs/needs-you";
 import { NeedsYouPanel } from "#/ui/runs/needs-you-panel";
 import { RunMonitor } from "#/ui/runs/run-monitor";
 import { StaleStagesPanel } from "#/ui/runs/stale-stages-panel";
-
-// The native run monitor (DAT-550) — a workspace-wide view of stage runs read from
-// cockpit_db — with the "Needs you" inbox (DAT-553) above it: the ACTIVE worklist
-// over runs the grounding loop parked `awaiting_input`, vs the monitor's PASSIVE
-// "Needs input" row. Workspace resolved server-side (mirrors loadHistory), not the
-// route param. Bounded to the latest N.
-const RUN_LIMIT = 100;
-// The inbox is a worklist, not a log — a tighter bound than the run monitor.
-const AWAITING_LIMIT = 50;
-
-const loadRuns = createServerFn({ method: "GET" }).handler(async () => {
-	const workspaceId = await resolveActiveWorkspace();
-	const [runs, awaiting, staleness] = await Promise.all([
-		listRunsByWorkspace(workspaceId, RUN_LIMIT),
-		listAwaitingInput(workspaceId, AWAITING_LIMIT),
-		readStageStaleness(),
-	]);
-	return {
-		runs,
-		awaiting,
-		staleness,
-		temporalUiUrl: config.temporalUiUrl,
-		limit: RUN_LIMIT,
-	};
-});
-
-// Mint a Stage chat to resolve a "Needs you" item (DAT-553). The server-side
-// workspace read never reaches the client bundle (the plugin strips this handler);
-// the client navigates to the new chat with the seed in router state.
-const openStageChat = createServerFn({ method: "POST" }).handler(async () => {
-	const workspaceId = await resolveActiveWorkspace();
-	return createConversation(workspaceId, "stage");
-});
-
-// One-click re-run of a stale stage (DAT-531) — routes to the affected stage via
-// the SAME journey signals the agent tools use (no new orchestration). Re-runs the
-// CURRENT session; the run records with a null conversationId (no originating chat),
-// so it surfaces in the monitor rather than narrating. `replay` is the DAT-551
-// add_source path for grounding-stale; begin_session / operating_model re-run
-// in-session (the cheap case).
-const rerunStage = createServerFn({ method: "POST" })
-	.inputValidator((stage: RunStage) => stage)
-	.handler(async ({ data: stage }) => {
-		let result: unknown;
-		if (stage === "operating_model") {
-			result = await operatingModel();
-		} else if (stage === "begin_session") {
-			// begin_session stages over the workspace's current typed table set.
-			result = await beginSession({ table_ids: await currentTypedTableIds() });
-		} else {
-			// add_source — the DAT-551 full replay path (re-runs the workspace sources).
-			result = await replay({});
-		}
-		// The tool fns return an { error } envelope for their born-loud guards (e.g.
-		// operating_model's "begin_session still running"). Surface it as a throw so
-		// the client handler shows the failure instead of a silent no-op re-run.
-		if (result && typeof result === "object" && "error" in result) {
-			throw new Error(String((result as { error: unknown }).error));
-		}
-	});
+import { loadRuns, openStageChat, rerunStage } from "./workflows.functions";
 
 export const Route = createFileRoute("/(app)/workspace/$wsId/workflows")({
 	loader: () => loadRuns(),

--- a/packages/cockpit/src/routes/index.functions.ts
+++ b/packages/cockpit/src/routes/index.functions.ts
@@ -1,0 +1,16 @@
+// Server function for the `/` redirect route. Peeled out of the isomorphic route
+// file so the cockpit_db registry read (and the server-only config it seeds from)
+// never rides into the client bundle — the static import is an RPC stub there.
+// See routes/(app)/.../$conversationId.functions.ts for the full rationale.
+
+import { createServerFn } from "@tanstack/react-start";
+import { resolveActiveWorkspace } from "#/db/cockpit/registry";
+
+// `/` resolves the active workspace and sends the user straight to its
+// cockpit. The id comes from the cockpit_db workspace registry (DAT-461),
+// seeded from DATARAUM_WORKSPACE_ID; once multi-workspace lands (DAT-357) this
+// becomes a real picker. Resolved server-side — the registry read (and the
+// server-only config it seeds from) never reaches the client bundle.
+export const getActiveWorkspaceId = createServerFn({ method: "GET" }).handler(
+	() => resolveActiveWorkspace(),
+);

--- a/packages/cockpit/src/routes/index.tsx
+++ b/packages/cockpit/src/routes/index.tsx
@@ -1,15 +1,5 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
-import { resolveActiveWorkspace } from "#/db/cockpit/registry";
-
-// `/` resolves the active workspace and sends the user straight to its
-// cockpit. The id comes from the cockpit_db workspace registry (DAT-461),
-// seeded from DATARAUM_WORKSPACE_ID; once multi-workspace lands (DAT-357) this
-// becomes a real picker. Resolved server-side — the registry read (and the
-// server-only config it seeds from) never reaches the client bundle.
-const getActiveWorkspaceId = createServerFn({ method: "GET" }).handler(() =>
-	resolveActiveWorkspace(),
-);
+import { getActiveWorkspaceId } from "./index.functions";
 
 export const Route = createFileRoute("/")({
 	beforeLoad: async () => {

--- a/packages/cockpit/src/select/file-source.ts
+++ b/packages/cockpit/src/select/file-source.ts
@@ -14,7 +14,8 @@
 // `triggerAddSource` over the union so a heterogeneous import set (files + queries)
 // imports as one coherent run.
 
-import { contentKeyedSourceName, sourceTypeForUri } from "./mappers";
+import { sourceTypeForUri } from "./mappers";
+import { contentKeyedSourceName } from "./source-content-hash";
 import { upsertSource } from "./source-write";
 
 /** One staged upload the user chose to import — its `s3://` URI. */

--- a/packages/cockpit/src/select/mappers.test.ts
+++ b/packages/cockpit/src/select/mappers.test.ts
@@ -13,14 +13,16 @@ vi.mock("#/config", () => ({ config: { s3Bucket: "dataraum-lake" } }));
 import type { ConnectSchema } from "#/duckdb/connect";
 import {
 	connectTablesToRecipeTables,
-	contentKeyedSourceName,
-	recipeContentHash,
 	recipeSqlForDisplayName,
 	reservedSourceNamePrefix,
 	sanitizeRecipeName,
 	sourceTypeForUri,
 	uploadTableName,
 } from "./mappers";
+import {
+	contentKeyedSourceName,
+	recipeContentHash,
+} from "./source-content-hash";
 
 // A real 40-char sha-1 hex digest (the digest of the empty string) — the shape
 // upload/digest.ts produces; `src_` + 40 = 44 chars, a valid source name.

--- a/packages/cockpit/src/select/mappers.ts
+++ b/packages/cockpit/src/select/mappers.ts
@@ -26,10 +26,7 @@
 //     non-default-schema table still resolves, with identifier quoting treated
 //     as a (low) injection surface and escaped.
 
-import { createHash } from "node:crypto";
-
 import type { ConnectSchema } from "../duckdb/connect";
-import { UPLOAD_PREFIX } from "../upload/policy";
 
 // THE source-name rule — this pattern is the authority (DAT-430 deleted the
 // engine's legacy `SourceManager` and its `_NAME_PATTERN`; `select` is the only
@@ -74,57 +71,11 @@ export { sourceTypeForUri } from "../upload/policy";
 
 // --- content-keyed file sources (DAT-422) ------------------------------------
 
-// Each uploaded FILE is its own source, keyed by its content digest (the model:
-// one file = one content-keyed source, DD/30900226 v2). A staged upload's object
-// key is the locked `<ws>/uploads/<digest>/<filename>` shape (upload/policy.ts
-// buildUploadKey, DAT-505) whose digest segment IS the file's content digest, so
-// the source name is `src_<digest>`: identical bytes (same digest → same key →
-// same name) UPSERT one row (re-upload dedup), and two distinct files never
-// collide on a source — even when their basenames match — because the digests
-// differ. The name is engine-valid by construction (a 40-char sha-1 hex digest →
-// `src_` + 40 = 44 chars, lowercase, letter-led).
-const CONTENT_SOURCE_PREFIX = "src_";
-
-/**
- * The content-keyed source NAME (`src_<digest>`) for a staged upload URI.
- *
- * Parses the content digest from the locked `s3://<bucket>/<ws>/uploads/<digest>/
- * <filename>` upload shape (upload/policy.ts, DAT-505). A URI that is NOT
- * upload-shaped — a bare bucket key, or a prefix-enumerated object that was never
- * content-addressed — cannot be content-keyed and is a loud failure here: content
- * identity requires the upload digest, and the bucket/prefix connector is a
- * separate future concern (DAT-390), not a silently path-keyed source. The
- * returned name is asserted against `SOURCE_NAME_PATTERN` so a malformed digest
- * segment fails loud rather than persisting an unusable row.
- */
-export function contentKeyedSourceName(uri: string): string {
-	const path = uri.replace(/^s3:\/\/[^/]+\//, "");
-	const segments = path.split("/").filter(Boolean);
-	// Exactly `<ws>/uploads/<digest>/<filename>` — the workspace prefix, then the
-	// locked upload triple. Locate the `uploads` marker rather than hard-coding an
-	// index so the workspace segment (which can itself be a dashed UUID) is robust.
-	const uploadsAt = segments.indexOf(UPLOAD_PREFIX);
-	const digest = uploadsAt >= 0 ? segments[uploadsAt + 1] : undefined;
-	const filename = uploadsAt >= 0 ? segments[uploadsAt + 2] : undefined;
-	if (uploadsAt !== 1 || segments.length !== 4 || !digest || !filename) {
-		throw new Error(
-			`Cannot content-key '${uri}' — a file source must be a staged upload ` +
-				`(s3://<bucket>/<ws>/${UPLOAD_PREFIX}/<digest>/<filename>). A bucket/prefix ` +
-				"source is not content-addressed (a future connector).",
-		);
-	}
-	// SHA-1 hex (what digestBytes produces) is already lowercase; toLowerCase() is
-	// defensive so a non-canonical digest segment still yields an engine-valid name.
-	const name = `${CONTENT_SOURCE_PREFIX}${digest.toLowerCase()}`;
-	if (!SOURCE_NAME_PATTERN.test(name)) {
-		throw new Error(
-			`Content key '${name}' for '${uri}' is not a valid source name ` +
-				"(lowercase, letter-led, 2–49 chars of [a-z0-9_]) — the upload digest " +
-				"segment is malformed.",
-		);
-	}
-	return name;
-}
+// `contentKeyedSourceName` (`src_<digest>`) and `recipeContentHash` moved to the
+// server-only `select/source-content-hash.ts`: they use `node:crypto`, and this
+// module must stay crypto-free so it can ride into the CLIENT graph (the connect
+// canvas → import flow) without crashing the browser bundle. The naming helpers
+// below are pure and stay here.
 
 // --- narrow raw-table name a file upload loads into (DAT-639) ----------------
 
@@ -162,42 +113,8 @@ export interface RecipeTable {
 	sql: string;
 }
 
-/**
- * The recipe content hash (`connection_config.recipe_hash`) — sha256 over the
- * canonical `{backend, tables}` JSON (DAT-430).
- *
- * Canonical = `JSON.stringify` of a `{backend, tables}` object: key order is
- * fixed by construction (this literal + the `{name, sql}` entries) and array
- * order follows the connected schema's table order, so a re-select of the SAME
- * pick serializes — and hashes — identically. The backend is PART of the
- * identity: the recipe SQL is interpreted against the connected backend, so the
- * same table names against a DIFFERENT backend are a different recipe — without
- * it, re-selecting a source name against another DBMS with identical table
- * names would match the import witness and silently skip over raw tables
- * extracted from the old backend. The engine treats the value as an OPAQUE
- * token: it never recomputes it, only copies it to `imported_recipe_hash` at
- * import success and compares the two on a later run
- * (`ImportPhase.should_skip`) — so no cross-language canonicalization contract
- * exists beyond this one function. This is what kills the silent-staleness
- * hole for name-keyed db sources: a re-pointed recipe stops matching the
- * import witness and the run fails loud instead of presence-skipping over the
- * old raw tables.
- */
-export function recipeContentHash(
-	backend: string,
-	tables: RecipeTable[],
-	credentialSource?: string,
-): string {
-	// `credentialSource` (DAT-592) is part of the recipe identity when present: a
-	// query-source reads through a named connection, so re-pointing it (same SQL,
-	// different DB) is a DIFFERENT recipe. Omitted for the table-pick path (a source
-	// that is its own credential), keeping that path's hash byte-identical.
-	const canonical =
-		credentialSource === undefined
-			? { backend, tables }
-			: { backend, credential_source: credentialSource, tables };
-	return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
-}
+// `recipeContentHash` (sha256 over `{backend, tables}`) moved to the server-only
+// `select/source-content-hash.ts` — see the note above.
 
 /** Quote a single SQL identifier segment, doubling embedded double-quotes.
  *

--- a/packages/cockpit/src/select/recipe-source.integration.test.ts
+++ b/packages/cockpit/src/select/recipe-source.integration.test.ts
@@ -15,7 +15,7 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { recipeContentHash } from "./mappers";
+import { recipeContentHash } from "./source-content-hash";
 
 const STACK_AVAILABLE = !!process.env.METADATA_DATABASE_URL;
 

--- a/packages/cockpit/src/select/recipe-source.test.ts
+++ b/packages/cockpit/src/select/recipe-source.test.ts
@@ -9,7 +9,8 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { recipeContentHash, sanitizeRecipeName } from "./mappers";
+import { sanitizeRecipeName } from "./mappers";
+import { recipeContentHash } from "./source-content-hash";
 
 // recipe-source pulls SUPPORTED_BACKENDS from `#/duckdb/probe`, which imports
 // config at module load — stub it so the unit test needs no real env (same as

--- a/packages/cockpit/src/select/recipe-source.ts
+++ b/packages/cockpit/src/select/recipe-source.ts
@@ -19,11 +19,11 @@
 import { SUPPORTED_BACKENDS } from "../duckdb/probe";
 import {
 	RESERVED_SOURCE_NAME_PREFIXES,
-	recipeContentHash,
 	reservedSourceNamePrefix,
 	SOURCE_NAME_PATTERN,
 	sanitizeRecipeName,
 } from "./mappers";
+import { recipeContentHash } from "./source-content-hash";
 import { importedRecipeHash, upsertSource } from "./source-write";
 
 /** One staged query the user chose to import as its own source. */

--- a/packages/cockpit/src/select/source-content-hash.ts
+++ b/packages/cockpit/src/select/source-content-hash.ts
@@ -1,0 +1,108 @@
+// Content-hashing for source IDENTITY (DAT-422 / DAT-430) — split out of
+// select/mappers so the pure shape helpers there stay client-safe.
+//
+// SERVER-ONLY: these two functions use `node:crypto` (createHash). mappers.ts is
+// (transitively) reachable from a CLIENT graph — the select/import flow is driven
+// from the connect canvas — so a `node:crypto` import there crashes the browser
+// bundle (prod: shimmed empty; dev: Vite's throwing browser-external stub on the
+// import line). Hashing has exactly two server callers (file-source / recipe-
+// source), so it lives here behind the server-only marker; the crypto-free naming
+// helpers stay in mappers. Mirrors the earlier `sourceTypeForUri → upload/policy`
+// move (mappers.ts) and the run-context cut. See
+// [[feedback_cockpit_isomorphic_import_side_effects]].
+
+import "@tanstack/react-start/server-only";
+
+import { createHash } from "node:crypto";
+
+import { UPLOAD_PREFIX } from "../upload/policy";
+import { type RecipeTable, SOURCE_NAME_PATTERN } from "./mappers";
+
+// Each uploaded FILE is its own source, keyed by its content digest (the model:
+// one file = one content-keyed source, DD/30900226 v2). A staged upload's object
+// key is the locked `<ws>/uploads/<digest>/<filename>` shape (upload/policy.ts
+// buildUploadKey, DAT-505) whose digest segment IS the file's content digest, so
+// the source name is `src_<digest>`: identical bytes (same digest → same key →
+// same name) UPSERT one row (re-upload dedup), and two distinct files never
+// collide on a source — even when their basenames match — because the digests
+// differ. The name is engine-valid by construction (a 40-char sha-1 hex digest →
+// `src_` + 40 = 44 chars, lowercase, letter-led).
+const CONTENT_SOURCE_PREFIX = "src_";
+
+/**
+ * The content-keyed source NAME (`src_<digest>`) for a staged upload URI.
+ *
+ * Parses the content digest from the locked `s3://<bucket>/<ws>/uploads/<digest>/
+ * <filename>` upload shape (upload/policy.ts, DAT-505). A URI that is NOT
+ * upload-shaped — a bare bucket key, or a prefix-enumerated object that was never
+ * content-addressed — cannot be content-keyed and is a loud failure here: content
+ * identity requires the upload digest, and the bucket/prefix connector is a
+ * separate future concern (DAT-390), not a silently path-keyed source. The
+ * returned name is asserted against `SOURCE_NAME_PATTERN` so a malformed digest
+ * segment fails loud rather than persisting an unusable row.
+ */
+export function contentKeyedSourceName(uri: string): string {
+	const path = uri.replace(/^s3:\/\/[^/]+\//, "");
+	const segments = path.split("/").filter(Boolean);
+	// Exactly `<ws>/uploads/<digest>/<filename>` — the workspace prefix, then the
+	// locked upload triple. Locate the `uploads` marker rather than hard-coding an
+	// index so the workspace segment (which can itself be a dashed UUID) is robust.
+	const uploadsAt = segments.indexOf(UPLOAD_PREFIX);
+	const digest = uploadsAt >= 0 ? segments[uploadsAt + 1] : undefined;
+	const filename = uploadsAt >= 0 ? segments[uploadsAt + 2] : undefined;
+	if (uploadsAt !== 1 || segments.length !== 4 || !digest || !filename) {
+		throw new Error(
+			`Cannot content-key '${uri}' — a file source must be a staged upload ` +
+				`(s3://<bucket>/<ws>/${UPLOAD_PREFIX}/<digest>/<filename>). A bucket/prefix ` +
+				"source is not content-addressed (a future connector).",
+		);
+	}
+	// SHA-1 hex (what digestBytes produces) is already lowercase; toLowerCase() is
+	// defensive so a non-canonical digest segment still yields an engine-valid name.
+	const name = `${CONTENT_SOURCE_PREFIX}${digest.toLowerCase()}`;
+	if (!SOURCE_NAME_PATTERN.test(name)) {
+		throw new Error(
+			`Content key '${name}' for '${uri}' is not a valid source name ` +
+				"(lowercase, letter-led, 2–49 chars of [a-z0-9_]) — the upload digest " +
+				"segment is malformed.",
+		);
+	}
+	return name;
+}
+
+/**
+ * The recipe content hash (`connection_config.recipe_hash`) — sha256 over the
+ * canonical `{backend, tables}` JSON (DAT-430).
+ *
+ * Canonical = `JSON.stringify` of a `{backend, tables}` object: key order is
+ * fixed by construction (this literal + the `{name, sql}` entries) and array
+ * order follows the connected schema's table order, so a re-select of the SAME
+ * pick serializes — and hashes — identically. The backend is PART of the
+ * identity: the recipe SQL is interpreted against the connected backend, so the
+ * same table names against a DIFFERENT backend are a different recipe — without
+ * it, re-selecting a source name against another DBMS with identical table
+ * names would match the import witness and silently skip over raw tables
+ * extracted from the old backend. The engine treats the value as an OPAQUE
+ * token: it never recomputes it, only copies it to `imported_recipe_hash` at
+ * import success and compares the two on a later run
+ * (`ImportPhase.should_skip`) — so no cross-language canonicalization contract
+ * exists beyond this one function. This is what kills the silent-staleness
+ * hole for name-keyed db sources: a re-pointed recipe stops matching the
+ * import witness and the run fails loud instead of presence-skipping over the
+ * old raw tables.
+ */
+export function recipeContentHash(
+	backend: string,
+	tables: RecipeTable[],
+	credentialSource?: string,
+): string {
+	// `credentialSource` (DAT-592) is part of the recipe identity when present: a
+	// query-source reads through a named connection, so re-pointing it (same SQL,
+	// different DB) is a DIFFERENT recipe. Omitted for the table-pick path (a source
+	// that is its own credential), keeping that path's hash byte-identical.
+	const canonical =
+		credentialSource === undefined
+			? { backend, tables }
+			: { backend, credential_source: credentialSource, tables };
+	return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}


### PR DESCRIPTION
## Problem
The specific-conversation chat route crashed in the **prod container** (`AsyncLocalStorage is not a constructor`), and every route crashed under `vite dev`. TanStack Start route files are **isomorphic** (compiled into client + server bundles), but they inlined `createServerFn` *and* imported server-only helpers at the top level. Those helper imports rode into the **client** bundle and crash when a helper transitively pulls a browser-throwing node builtin (`node:async_hooks`, `node:crypto.createHash`). Prod tree-shakes the side-effect-free ones; `run-context`'s module-scope `new AsyncLocalStorage()` defeats DCE and leaked to prod. Dev tree-shakes nothing → crashed broadly.

## Fix (TanStack Start idiom — Intent skills `start-core/{execution-model,server-functions}`)
1. **Peel** every inline `createServerFn` out of the 11 isomorphic routes into a sibling `*.functions.ts`. Routes import server **functions** (RPC stubs, stripped from the client in dev *and* prod) — helpers never reach the browser.
2. **Split** the one mixed helper: `mappers.ts` keeps the pure naming helpers (client-safe); `createHash` content-hashing → new server-only `select/source-content-hash.ts`.
3. **Lazy-init** `run-context`'s `AsyncLocalStorage` singleton → import-side-effect-free, so DCE drops it from every client chunk. Covers the non-route leak path (a client widget importing the `importSources` server-fn *file*, which chains to `run-context`).

No widget changes (components are isomorphic by design), no markers, no `await import()` workarounds. **API routes unchanged** — they're server routes reached over HTTP, not imported, so already off the client graph (and `.server` renames would break file-based routing).

## Verification
- Prod container `.output/public`: **0** `AsyncLocalStorage`, **0** `createHash`.
- Prod (:3000) browser smoke: connect chat, governance, workflows, operating-model, reports — all render, **0 console errors**.
- `tsc` clean · `biome` clean · **1393/1393** unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)