### PR TITLE
fix(cockpit): reconcile NULL-conversation runs + retire Temporal-purged runs (DAT-640)

### DIFF
--- a/packages/cockpit/src/db/cockpit/runs.ts
+++ b/packages/cockpit/src/db/cockpit/runs.ts
@@ -97,15 +97,23 @@ export async function recordRun(input: RecordRunInput): Promise<void> {
 }
 
 /**
- * Mark a recorded run terminal (completed | failed) — best-effort. Writers: the
- * completion-watcher's `result()` awaiter (DAT-615, the primary path), the
- * workflow-progress seed route (DAT-461), and the reload-recovery reconcile
- * (DAT-462). No-op if the run isn't recorded.
+ * Mark a recorded run terminal — best-effort. Writers: the completion-watcher's
+ * `result()` awaiter (DAT-615, the primary path), the workflow-progress seed route
+ * (DAT-461), and the reload-recovery reconcile (DAT-462). No-op if the run isn't
+ * recorded.
+ *
+ * `retired` (DAT-640) is a THIRD terminal state, distinct from completed/failed:
+ * the reconcile found NO execution in Temporal for the run's `(workflowId, runId)`.
+ * Temporal never drops a RUNNING workflow, and retention only GCs CLOSED ones, so
+ * an absent execution means the run closed and its history aged out past the
+ * namespace retention TTL — it is terminal (not in-flight) but its OUTCOME is
+ * unrecoverable. We assert neither success nor failure: `retired` is the honest
+ * "closed, outcome no longer knowable" state.
  */
 export async function markRunStatus(
 	workflowId: string,
 	runId: string,
-	status: "completed" | "failed",
+	status: "completed" | "failed" | "retired",
 ): Promise<void> {
 	try {
 		await cockpitDb
@@ -151,10 +159,13 @@ export async function markRunAwaitingInput(
 	}
 }
 
-/** One in-flight run to reconcile on reload. */
+/** One in-flight run to reconcile on reload. `startedAt` lets the sweep tell a
+ * brand-new run (Temporal visibility may briefly lag a just-recorded execution)
+ * from one whose history aged out — only the latter is `retired` (DAT-640). */
 export interface ActiveRun {
 	workflowId: string;
 	runId: string;
+	startedAt: Date;
 }
 
 /**
@@ -173,6 +184,7 @@ export async function listNonTerminalRuns(
 		.select({
 			workflowId: runs.workflowId,
 			runId: runs.runId,
+			startedAt: runs.startedAt,
 		})
 		.from(runs)
 		.where(
@@ -203,6 +215,7 @@ export async function listNonTerminalRunsByWorkspace(
 		.select({
 			workflowId: runs.workflowId,
 			runId: runs.runId,
+			startedAt: runs.startedAt,
 		})
 		.from(runs)
 		.where(and(eq(runs.workspaceId, workspaceId), eq(runs.status, "running")))

--- a/packages/cockpit/src/db/cockpit/runs.ts
+++ b/packages/cockpit/src/db/cockpit/runs.ts
@@ -183,6 +183,34 @@ export async function listNonTerminalRuns(
 }
 
 /**
+ * The WORKSPACE's non-terminal (`running`) runs, newest first, BOUNDED — the
+ * workspace-scoped reconcile (DAT-640) sweeps these against Temporal regardless of
+ * `conversation_id`. The conversation-scoped `listNonTerminalRuns` above is a
+ * partial cover: an ONBOARDING import records with `conversation_id = NULL`
+ * (imports don't narrate, DAT-597), so no chat ever owns it → it is never swept by
+ * the chat-load reconcile and lingers `running` forever (the Runs monitor +
+ * `countRunningRuns` + the briefing's `progress.connect` then misreport in-flight
+ * work indefinitely). This query is the conversation-independent counterpart: every
+ * still-`running` run in the workspace, so the workspace sweep reaches the orphaned
+ * onboarding runs the chat sweep can't. Bounded identically so a stale backlog can't
+ * fan out unboundedly.
+ */
+export async function listNonTerminalRunsByWorkspace(
+	workspaceId: string,
+	limit: number,
+): Promise<Array<ActiveRun>> {
+	return cockpitDb
+		.select({
+			workflowId: runs.workflowId,
+			runId: runs.runId,
+		})
+		.from(runs)
+		.where(and(eq(runs.workspaceId, workspaceId), eq(runs.status, "running")))
+		.orderBy(desc(runs.startedAt))
+		.limit(limit);
+}
+
+/**
  * The DISTINCT stages of the conversation's still-`running` runs — the in-flight
  * set the completion narration must NOT claim finished (DAT-510). Scoped to the
  * conversation (DAT-528): "what ELSE is in flight in THIS chat". Cheap and

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.functions.ts
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/workflows.functions.ts
@@ -14,6 +14,7 @@ import {
 } from "#/db/cockpit/runs";
 import { readStageStaleness } from "#/db/metadata/stage-staleness-read";
 import { currentTypedTableIds } from "#/db/metadata/workspace-state";
+import { reconcileWorkspaceRuns } from "#/temporal/reconcile";
 import { beginSession } from "#/tools/begin-session";
 import { operatingModel } from "#/tools/operating-model";
 import { replay } from "#/tools/replay";
@@ -29,6 +30,11 @@ const AWAITING_LIMIT = 50;
 
 export const loadRuns = createServerFn({ method: "GET" }).handler(async () => {
 	const workspaceId = await resolveActiveWorkspace();
+	// Reconcile the workspace's in-flight runs against Temporal BEFORE the read
+	// (DAT-640) so the monitor reflects terminal state on first paint — including
+	// onboarding imports (`conversation_id = NULL`) the chat-scoped reconcile never
+	// owns. Best-effort (never throws); awaited because the page renders this read.
+	await reconcileWorkspaceRuns(workspaceId);
 	const [runs, awaiting, staleness] = await Promise.all([
 		listRunsByWorkspace(workspaceId, RUN_LIMIT),
 		listAwaitingInput(workspaceId, AWAITING_LIMIT),

--- a/packages/cockpit/src/routes/api/running-runs.ts
+++ b/packages/cockpit/src/routes/api/running-runs.ts
@@ -4,16 +4,28 @@
 // Query `refetchInterval` rather than importing the server module — keeping the
 // cockpit_db client + config out of the client bundle (same pattern as
 // /api/workflow-progress). GET: no input, the workspace is resolved server-side.
+//
+// Reconcile-before-count (DAT-640): this badge poll is the workspace's
+// tab-independent heartbeat, so it's where the workspace sweep lives. An onboarding
+// import (`conversation_id = NULL`) is never swept by the chat-scoped reconcile and
+// would keep `countRunningRuns` (and every other `status='running'` read — the run
+// monitor, `hasRunningRun`, the briefing's `progress.connect`) stale forever. Sweeping
+// here terminates those orphans against Temporal within one poll interval; the heal
+// is a cockpit_db write, so it propagates to ALL of those surfaces, not just this count.
 
 import { createFileRoute } from "@tanstack/react-router";
 import { resolveActiveWorkspace } from "../../db/cockpit/registry";
 import { countRunningRuns } from "../../db/cockpit/runs";
+import { reconcileWorkspaceRuns } from "../../temporal/reconcile";
 
 export const Route = createFileRoute("/api/running-runs")({
 	server: {
 		handlers: {
 			GET: async () => {
 				const workspaceId = await resolveActiveWorkspace();
+				// Best-effort sweep (never throws) BEFORE the count so the badge reflects
+				// reconciled state on this very poll, not the next one.
+				await reconcileWorkspaceRuns(workspaceId);
 				return Response.json({ count: await countRunningRuns(workspaceId) });
 			},
 		},

--- a/packages/cockpit/src/temporal/progress.ts
+++ b/packages/cockpit/src/temporal/progress.ts
@@ -143,6 +143,19 @@ export function isProgressDone(phase: string, status: string): boolean {
 }
 
 /**
+ * True when Temporal has NO execution for the polled `(workflow_id, run_id)` —
+ * `describe()` threw `WorkflowNotFoundError`, the one path that yields the
+ * `PENDING_PROGRESS` sentinel (status `"PENDING"`). Every other path reports a real
+ * describe() status. The reconcile (DAT-640) keys the `retired` decision off this:
+ * an absent execution is either a brand-new run Temporal visibility hasn't caught up
+ * to (the DAT-570 start race) or a closed run whose history aged out past retention —
+ * the caller disambiguates the two by the run's age.
+ */
+export function isWorkflowAbsent(progress: WorkflowProgress): boolean {
+	return progress.status === PENDING_PROGRESS.status;
+}
+
+/**
  * The snapshot returned while a triggered run isn't queryable yet (DAT-570). A
  * stage trigger returns the deterministic workflow id immediately, but the
  * orchestration workflow starts the engine child a beat later (DAT-530/562) — so an

--- a/packages/cockpit/src/temporal/reconcile.test.ts
+++ b/packages/cockpit/src/temporal/reconcile.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("#/db/cockpit/runs", () => ({
 	listNonTerminalRuns: vi.fn(),
+	listNonTerminalRunsByWorkspace: vi.fn(),
 	markRunStatus: vi.fn(),
 }));
 vi.mock("#/temporal/progress", () => ({
@@ -18,16 +19,22 @@ vi.mock("#/temporal/progress", () => ({
 		p.status === "FAILED" ? "failed" : "completed",
 }));
 
-import { listNonTerminalRuns, markRunStatus } from "#/db/cockpit/runs";
+import {
+	listNonTerminalRuns,
+	listNonTerminalRunsByWorkspace,
+	markRunStatus,
+} from "#/db/cockpit/runs";
 import { getWorkflowProgress } from "#/temporal/progress";
-import { reconcileActiveRuns } from "./reconcile";
+import { reconcileActiveRuns, reconcileWorkspaceRuns } from "./reconcile";
 
 const list = vi.mocked(listNonTerminalRuns);
+const listByWs = vi.mocked(listNonTerminalRunsByWorkspace);
 const mark = vi.mocked(markRunStatus);
 const progress = vi.mocked(getWorkflowProgress);
 
 beforeEach(() => {
 	list.mockReset();
+	listByWs.mockReset();
 	mark.mockReset().mockResolvedValue(undefined);
 	progress.mockReset();
 });
@@ -79,6 +86,63 @@ describe("reconcileActiveRuns", () => {
 	it("swallows a listing failure (no marks, no throw)", async () => {
 		list.mockRejectedValue(new Error("db down"));
 		await expect(reconcileActiveRuns("conv-1")).resolves.toBeUndefined();
+		expect(mark).not.toHaveBeenCalled();
+		expect(progress).not.toHaveBeenCalled();
+	});
+});
+
+describe("reconcileWorkspaceRuns (DAT-640 — conversation-independent)", () => {
+	it("marks terminal an orphaned onboarding import (NULL conversation), leaving still-running ones", async () => {
+		// The bug case: an onboarding import (conversation_id = NULL) the chat sweep
+		// never owns. The workspace sweep lists it by workspace and reconciles it.
+		listByWs.mockResolvedValue([
+			{ workflowId: "addsource-ws", runId: "onboarding-r" },
+			{ workflowId: "wf-2", runId: "r-2" },
+		]);
+		progress.mockImplementation(async ({ run_id }) =>
+			run_id === "onboarding-r"
+				? prog(true, "COMPLETED")
+				: prog(false, "RUNNING"),
+		);
+
+		await reconcileWorkspaceRuns("ws-1");
+
+		expect(listByWs).toHaveBeenCalledWith("ws-1", expect.any(Number));
+		expect(mark).toHaveBeenCalledTimes(1);
+		expect(mark).toHaveBeenCalledWith(
+			"addsource-ws",
+			"onboarding-r",
+			"completed",
+		);
+	});
+
+	it("classifies a failed run as failed", async () => {
+		listByWs.mockResolvedValue([{ workflowId: "wf-9", runId: "r-9" }]);
+		progress.mockResolvedValue(prog(true, "FAILED"));
+
+		await reconcileWorkspaceRuns("ws-1");
+
+		expect(mark).toHaveBeenCalledWith("wf-9", "r-9", "failed");
+	});
+
+	it("swallows a per-run query error and still reconciles the others", async () => {
+		listByWs.mockResolvedValue([
+			{ workflowId: "wf-1", runId: "boom" },
+			{ workflowId: "wf-2", runId: "r-2" },
+		]);
+		progress.mockImplementation(async ({ run_id }) => {
+			if (run_id === "boom") throw new Error("run gone");
+			return prog(true, "COMPLETED");
+		});
+
+		await expect(reconcileWorkspaceRuns("ws-1")).resolves.toBeUndefined();
+		expect(mark).toHaveBeenCalledTimes(1);
+		expect(mark).toHaveBeenCalledWith("wf-2", "r-2", "completed");
+	});
+
+	it("swallows a listing failure (no marks, no throw)", async () => {
+		listByWs.mockRejectedValue(new Error("db down"));
+		await expect(reconcileWorkspaceRuns("ws-1")).resolves.toBeUndefined();
 		expect(mark).not.toHaveBeenCalled();
 		expect(progress).not.toHaveBeenCalled();
 	});

--- a/packages/cockpit/src/temporal/reconcile.test.ts
+++ b/packages/cockpit/src/temporal/reconcile.test.ts
@@ -17,7 +17,18 @@ vi.mock("#/temporal/progress", () => ({
 	// terminalRunStatus is exercised by the progress poll + smoke.
 	terminalRunStatus: (p: { status?: string }) =>
 		p.status === "FAILED" ? "failed" : "completed",
+	// Mirror the real sentinel: describe-NotFound surfaces as status "PENDING".
+	isWorkflowAbsent: (p: { status?: string }) => p.status === "PENDING",
 }));
+
+// An ActiveRun fixture — `startedAt` defaults OLD (a year ago) so the absent-run
+// path retires by default; pass a recent date to exercise the start-race grace.
+const OLD = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
+const run = (workflowId: string, runId: string, startedAt: Date = OLD) => ({
+	workflowId,
+	runId,
+	startedAt,
+});
 
 import {
 	listNonTerminalRuns,
@@ -45,10 +56,7 @@ const prog = (done: boolean, status: string) => ({ done, status }) as any;
 
 describe("reconcileActiveRuns", () => {
 	it("marks DONE runs terminal and leaves still-running ones", async () => {
-		list.mockResolvedValue([
-			{ workflowId: "wf-1", runId: "r-1" },
-			{ workflowId: "wf-2", runId: "r-2" },
-		]);
+		list.mockResolvedValue([run("wf-1", "r-1"), run("wf-2", "r-2")]);
 		progress.mockImplementation(async ({ run_id }) =>
 			run_id === "r-1" ? prog(true, "COMPLETED") : prog(false, "RUNNING"),
 		);
@@ -60,7 +68,7 @@ describe("reconcileActiveRuns", () => {
 	});
 
 	it("classifies a failed run as failed", async () => {
-		list.mockResolvedValue([{ workflowId: "wf-9", runId: "r-9" }]);
+		list.mockResolvedValue([run("wf-9", "r-9")]);
 		progress.mockResolvedValue(prog(true, "FAILED"));
 
 		await reconcileActiveRuns("conv-1");
@@ -69,10 +77,7 @@ describe("reconcileActiveRuns", () => {
 	});
 
 	it("swallows a per-run query error and still reconciles the others", async () => {
-		list.mockResolvedValue([
-			{ workflowId: "wf-1", runId: "boom" },
-			{ workflowId: "wf-2", runId: "r-2" },
-		]);
+		list.mockResolvedValue([run("wf-1", "boom"), run("wf-2", "r-2")]);
 		progress.mockImplementation(async ({ run_id }) => {
 			if (run_id === "boom") throw new Error("run gone");
 			return prog(true, "COMPLETED");
@@ -96,8 +101,8 @@ describe("reconcileWorkspaceRuns (DAT-640 — conversation-independent)", () => 
 		// The bug case: an onboarding import (conversation_id = NULL) the chat sweep
 		// never owns. The workspace sweep lists it by workspace and reconciles it.
 		listByWs.mockResolvedValue([
-			{ workflowId: "addsource-ws", runId: "onboarding-r" },
-			{ workflowId: "wf-2", runId: "r-2" },
+			run("addsource-ws", "onboarding-r"),
+			run("wf-2", "r-2"),
 		]);
 		progress.mockImplementation(async ({ run_id }) =>
 			run_id === "onboarding-r"
@@ -117,7 +122,7 @@ describe("reconcileWorkspaceRuns (DAT-640 — conversation-independent)", () => 
 	});
 
 	it("classifies a failed run as failed", async () => {
-		listByWs.mockResolvedValue([{ workflowId: "wf-9", runId: "r-9" }]);
+		listByWs.mockResolvedValue([run("wf-9", "r-9")]);
 		progress.mockResolvedValue(prog(true, "FAILED"));
 
 		await reconcileWorkspaceRuns("ws-1");
@@ -126,10 +131,7 @@ describe("reconcileWorkspaceRuns (DAT-640 — conversation-independent)", () => 
 	});
 
 	it("swallows a per-run query error and still reconciles the others", async () => {
-		listByWs.mockResolvedValue([
-			{ workflowId: "wf-1", runId: "boom" },
-			{ workflowId: "wf-2", runId: "r-2" },
-		]);
+		listByWs.mockResolvedValue([run("wf-1", "boom"), run("wf-2", "r-2")]);
 		progress.mockImplementation(async ({ run_id }) => {
 			if (run_id === "boom") throw new Error("run gone");
 			return prog(true, "COMPLETED");
@@ -145,5 +147,50 @@ describe("reconcileWorkspaceRuns (DAT-640 — conversation-independent)", () => 
 		await expect(reconcileWorkspaceRuns("ws-1")).resolves.toBeUndefined();
 		expect(mark).not.toHaveBeenCalled();
 		expect(progress).not.toHaveBeenCalled();
+	});
+});
+
+describe("reconcileOne — Temporal-absent runs (DAT-640 retire)", () => {
+	it("retires an OLD run whose Temporal execution is gone (history aged out)", async () => {
+		// describe-NotFound → PENDING sentinel; the run is a year old, so it's a
+		// retention purge, not the pre-start race. Temporal is authoritative: an
+		// execution it has no record of is NOT running — but its outcome is lost.
+		listByWs.mockResolvedValue([run("addsource-ws", "gone-r")]);
+		progress.mockResolvedValue(prog(false, "PENDING"));
+
+		await reconcileWorkspaceRuns("ws-1");
+
+		expect(mark).toHaveBeenCalledTimes(1);
+		expect(mark).toHaveBeenCalledWith("addsource-ws", "gone-r", "retired");
+	});
+
+	it("does NOT retire a JUST-STARTED absent run (start-race grace)", async () => {
+		// Same NotFound sentinel, but the run was recorded seconds ago — Temporal
+		// visibility may simply lag. Leave it for the next sweep, don't retire a run
+		// that's actually spinning up.
+		listByWs.mockResolvedValue([run("addsource-ws", "fresh-r", new Date())]);
+		progress.mockResolvedValue(prog(false, "PENDING"));
+
+		await reconcileWorkspaceRuns("ws-1");
+
+		expect(mark).not.toHaveBeenCalled();
+	});
+
+	it("leaves a genuinely RUNNING run alone (not absent, not done)", async () => {
+		listByWs.mockResolvedValue([run("addsource-ws", "live-r")]);
+		progress.mockResolvedValue(prog(false, "RUNNING"));
+
+		await reconcileWorkspaceRuns("ws-1");
+
+		expect(mark).not.toHaveBeenCalled();
+	});
+
+	it("retires via the chat sweep too (reconcileOne is shared)", async () => {
+		list.mockResolvedValue([run("wf-x", "r-x")]);
+		progress.mockResolvedValue(prog(false, "PENDING"));
+
+		await reconcileActiveRuns("conv-1");
+
+		expect(mark).toHaveBeenCalledWith("wf-x", "r-x", "retired");
 	});
 });

--- a/packages/cockpit/src/temporal/reconcile.ts
+++ b/packages/cockpit/src/temporal/reconcile.ts
@@ -23,10 +23,25 @@ import {
 	listNonTerminalRunsByWorkspace,
 	markRunStatus,
 } from "#/db/cockpit/runs";
-import { getWorkflowProgress, terminalRunStatus } from "#/temporal/progress";
+import {
+	getWorkflowProgress,
+	isWorkflowAbsent,
+	terminalRunStatus,
+} from "#/temporal/progress";
 
 /** Cap the per-load sweep so a stale backlog can't fan out unboundedly. */
 export const RECONCILE_LIMIT = 20;
+
+/**
+ * Grace before an ABSENT Temporal execution (describe NotFound) is read as
+ * `retired` rather than left polling (DAT-640). A reconciled run carries its REAL
+ * Temporal execution id (recorded post-start, DAT-595), so its execution existed
+ * when the row was written — an absent describe is therefore retention GC, not the
+ * pre-start DAT-570 race. The grace only absorbs brief post-insert visibility lag;
+ * a few minutes is comfortably past it and nowhere near the 72h retention window
+ * that produces a genuine purge.
+ */
+export const RETIRE_GRACE_MS = 5 * 60 * 1000;
 
 export async function reconcileActiveRuns(
 	conversationId: string,
@@ -74,11 +89,29 @@ async function reconcileOne(run: ActiveRun): Promise<void> {
 			run_id: run.runId,
 		});
 		if (progress.done) {
-			const status = terminalRunStatus(progress);
-			await markRunStatus(run.workflowId, run.runId, status);
+			// Temporal HAS the run and reports it closed — take its verdict verbatim.
+			await markRunStatus(
+				run.workflowId,
+				run.runId,
+				terminalRunStatus(progress),
+			);
+			return;
+		}
+		// Temporal has NO execution for this id. Past the start-race grace that means
+		// the run closed and its history aged out past retention (Temporal never drops
+		// a running workflow; retention GCs only closed ones) — so it is NOT in-flight,
+		// but its outcome is unrecoverable: `retired`, not a guessed completed/failed.
+		// Inside the grace it's a just-recorded run Temporal visibility hasn't caught
+		// up to — leave it for the next sweep.
+		if (
+			isWorkflowAbsent(progress) &&
+			Date.now() - run.startedAt.getTime() > RETIRE_GRACE_MS
+		) {
+			await markRunStatus(run.workflowId, run.runId, "retired");
 		}
 	} catch (err) {
-		// A missing/expired run or a Temporal hiccup — leave it for the next load.
+		// A Temporal hiccup (NOT a clean NotFound — that's handled above) — leave it
+		// for the next load.
 		console.warn(`[cockpit] reconcile: run ${run.runId} skipped: ${err}`);
 	}
 }

--- a/packages/cockpit/src/temporal/reconcile.ts
+++ b/packages/cockpit/src/temporal/reconcile.ts
@@ -1,20 +1,26 @@
 // Reload reconcile (DAT-462) — bridge cockpit_db's in-flight runs to Temporal.
 //
 // On cockpit load, a run may have FINISHED while the tab was closed: its
-// `runs` row still reads "running" but the workflow is long done. This
-// chat's loader fires the sweep for ITS conversation (DAT-528: conversation-scoped
-// — a chat reconciles its own runs); a run in another chat is swept when that chat
-// opens. The progress widget's own re-poll also terminates runs whose conversation
-// is reloaded; this catches ones that finished while the tab was closed.
+// `runs` row still reads "running" but the workflow is long done. Two sweeps cover
+// the two grains:
 //
-// Bounded + best-effort by design: it sweeps at most RECONCILE_LIMIT runs, fans
-// the Temporal queries out in parallel, and swallows every error (a Temporal or
-// db hiccup must never block — or break — the cockpit's first paint). It is fired
-// without await from the bootstrap loader, so it never delays render.
+//   - reconcileActiveRuns(conversationId) — the chat-load sweep (DAT-528): a chat
+//     reconciles ITS OWN runs; a run in another chat is swept when that chat opens.
+//   - reconcileWorkspaceRuns(workspaceId) — the workspace sweep (DAT-640): every
+//     still-`running` run in the workspace, regardless of `conversation_id`. The
+//     conversation sweep was always a PARTIAL cover — an onboarding import records
+//     with `conversation_id = NULL` (DAT-597), so no chat owns it and it lingers
+//     `running` forever. The workspace sweep, fired from the run-monitor load + the
+//     tab-independent liveness poll, is what finally terminates those orphans.
+//
+// Both share `reconcileOne`. Bounded + best-effort by design: each sweeps at most
+// RECONCILE_LIMIT runs, fans the Temporal queries out in parallel, and swallows
+// every error (a Temporal or db hiccup must never block — or break — the cockpit).
 
 import {
 	type ActiveRun,
 	listNonTerminalRuns,
+	listNonTerminalRunsByWorkspace,
 	markRunStatus,
 } from "#/db/cockpit/runs";
 import { getWorkflowProgress, terminalRunStatus } from "#/temporal/progress";
@@ -30,6 +36,29 @@ export async function reconcileActiveRuns(
 		runs = await listNonTerminalRuns(conversationId, RECONCILE_LIMIT);
 	} catch (err) {
 		console.warn(`[cockpit] reconcile: listing in-flight runs failed: ${err}`);
+		return;
+	}
+	await Promise.all(runs.map((run) => reconcileOne(run)));
+}
+
+/**
+ * Sweep every still-`running` run in the workspace against Temporal (DAT-640) —
+ * the conversation-independent reconcile that reaches onboarding imports
+ * (`conversation_id = NULL`) the chat-scoped sweep can never own. Fired from the
+ * run-monitor load and the liveness-badge poll so a completed/failed workflow is
+ * reflected terminal in cockpit_db within a bounded time, regardless of which chat
+ * (if any) started it. Same bound + best-effort contract as the chat sweep.
+ */
+export async function reconcileWorkspaceRuns(
+	workspaceId: string,
+): Promise<void> {
+	let runs: Array<ActiveRun>;
+	try {
+		runs = await listNonTerminalRunsByWorkspace(workspaceId, RECONCILE_LIMIT);
+	} catch (err) {
+		console.warn(
+			`[cockpit] reconcile: listing workspace in-flight runs failed: ${err}`,
+		);
 		return;
 	}
 	await Promise.all(runs.map((run) => reconcileOne(run)));

--- a/packages/cockpit/src/ui/runs/run-row.test.ts
+++ b/packages/cockpit/src/ui/runs/run-row.test.ts
@@ -20,11 +20,15 @@ describe("run-row presentation (DAT-550)", () => {
 		expect(statusTone("failed")).toBe("red");
 		// The grounding loop's human-handoff state (DAT-551) — amber, not gray.
 		expect(statusTone("awaiting_input")).toBe("yellow");
+		// Aged-out-past-retention terminal (DAT-640) — neutral grey.
+		expect(statusTone("retired")).toBe("gray");
 		expect(statusTone("future_status")).toBe("gray");
 	});
 
-	it("labels awaiting_input as a call to action, others verbatim (DAT-551)", () => {
+	it("labels awaiting_input as a call to action, others verbatim (DAT-551, DAT-640)", () => {
 		expect(statusLabel("awaiting_input")).toBe("Needs input");
+		// retired stays verbatim, consistent with the other terminal states.
+		expect(statusLabel("retired")).toBe("retired");
 		expect(statusLabel("running")).toBe("running");
 		expect(statusLabel("completed")).toBe("completed");
 	});

--- a/packages/cockpit/src/ui/runs/run-row.ts
+++ b/packages/cockpit/src/ui/runs/run-row.ts
@@ -25,13 +25,19 @@ export function statusTone(status: string): RunStatusTone {
 		// The grounding-teach loop parked it for a human judgement teach (DAT-551).
 		case "awaiting_input":
 			return "yellow";
+		// Closed in Temporal but aged out past retention — terminal, outcome unknown
+		// (DAT-640). Neutral grey: not a success, not a failure.
+		case "retired":
+			return "gray";
 		default:
 			return "gray";
 	}
 }
 
-/** Human label for a run status — most are shown verbatim; awaiting_input reads as
- * a call to action ("Needs input") rather than the raw enum. */
+/** Human label for a run status — shown verbatim (running/completed/failed/retired)
+ * except awaiting_input, which reads as a call to action ("Needs input") rather than
+ * the raw enum. `retired` (DAT-640) stays verbatim, consistent with the other
+ * terminal states. */
 export function statusLabel(status: string): string {
 	return status === "awaiting_input" ? "Needs input" : status;
 }


### PR DESCRIPTION
Fixes [DAT-640](https://real-dataraum.atlassian.net/browse/DAT-640) — the Runs monitor shows workflows as `running` that Temporal long since closed.

## Root cause
Onboarding `add_source` runs record with `conversation_id = NULL` (imports don't narrate, DAT-597). Every path that marks a run terminal in `cockpit_db` was **conversation-scoped** — the chat-load reconcile (`reconcileActiveRuns`) and the completion-watcher — both filtering `eq(runs.conversationId, X)`, which never matches NULL. So onboarding runs were never reconciled and lingered `status='running'` forever, while every workspace-scoped read (`countRunningRuns`, `hasRunningRun`, the briefing's `progress.connect`, the run monitor) faithfully misreported them as in-flight (Connect badge stuck "Running" on a workspace whose imports finished yesterday).

## The fix (two parts)

**1. Workspace-scoped reconcile** (`30e59641`) — conversation-independent:
- `listNonTerminalRunsByWorkspace(workspaceId, limit)` — every still-`running` run in the workspace, regardless of `conversation_id`.
- `reconcileWorkspaceRuns(workspaceId)` — sweeps them against Temporal, sharing `reconcileOne` with the chat sweep (same bound, best-effort, exact `(workflowId, runId)` execution pin from DAT-595).
- Fired from the **liveness-badge poll** (`/api/running-runs`) as the tab-independent periodic healer, and from the **Runs-monitor loader** for first-paint correctness. The heal is a `cockpit_db` write, so it propagates to *all* `status='running'` readers, not just the count.

**2. `retired` — fully Temporal-authoritative** (`2ec65e81`):
Temporal never drops a *running* workflow, but retention (72h) GCs *closed* histories — so `describe()` returns `WorkflowNotFoundError` for an old completed run, which the reconcile mapped to PENDING and left `running` forever. A run Temporal has no execution for is **not in-flight**, but once history is purged its outcome is unrecoverable — so we assert neither `completed` nor `failed`. New third terminal status **`retired`** = "closed, outcome no longer knowable":
- `reconcileOne`: Temporal HAS the run → take its verdict verbatim; else absent (`isWorkflowAbsent`) AND older than `RETIRE_GRACE_MS` (5 min — past the DAT-570 start race / visibility lag, far short of the 72h purge floor) → `retired`.
- `runs.status` is `varchar` → no migration. `retired` is excluded from every `status='running'` read, rendered as a neutral grey badge.

## Verification
- **1401/1401 tests** pass (+7), `tsc` clean, `biome` clean.
- Senior + spec-compliance reviewers: **APPROVE / COMPLIANT**.
- **Live-stack (prod container), all three paths:**
  - Heal: injected `running` + NULL-conversation row on a real completed exec → swept to `completed`, count `0`.
  - Retire: injected year-old `running` row with a valid-but-nonexistent UUID exec → `describe()` NotFound → `retired`, excluded from count.
  - Safe error path: malformed run_id → `ServiceError` logged and **skipped** (left `running`, no crash) — only a clean NotFound retires.

## Scope
Cockpit-only (control plane / run lifecycle). No engine, no schema migration, no eval/testdata handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)