### PR TITLE
fix(engine): make concurrent-typing DuckLake commit conflict Temporal-retryable (DAT-641)

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,34 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-641 — concurrent-typing DuckLake commit conflict is now Temporal-retryable
+
+**Branch:** `worktree-dat-641`.
+
+### What changed (run behavior, NOT a detector/response shape)
+The typing phase's "all tables failed" failure message now **folds in the per-table
+error detail** (`typing_phase.py`, mirroring statistics/correlations_phase) instead
+of the bare `"No tables were successfully typed"`. That surfaces a DuckLake
+optimistic-commit conflict signature into `PhaseRun.error`, where the worker's
+`_is_transient_commit_conflict` classifier (already present, DAT-641 part 1 +
+`ducklake_max_retry_count` bump) turns it into a **retryable** `TransientPhaseFailure`
+rather than a fatal `PhaseFailed`. Net effect: a wide concurrent replay (≥~20 tables
+fanned out) that lost a commit race used to fail the whole run; it now retries the
+losing table activity and completes.
+
+### Calibration to run
+**None — calibration-neutral.** No detector logic, threshold, or output shape
+changed; this only affects the FAILURE path (a previously-fatal transient race now
+retries to success). Recall/precision cannot move. If anything it removes spurious
+run failures from wide-replay eval scenarios.
+
+### testdata hints
+A wide multi-table replay (≥~20 tables typed concurrently) is the natural regression
+that used to trip the commit race — it should now complete without a fatal
+`PhaseFailed: No tables were successfully typed`.
+
+---
+
 ## DAT-639 — narrow, workspace-unique table names (no `src_<digest>__` prefix)
 
 **Branch:** `fix/dat-639-narrow-table-identity`.

--- a/packages/engine/src/dataraum/pipeline/phases/typing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/typing_phase.py
@@ -346,7 +346,19 @@ class TypingPhase(BasePhase):
                 )
 
         if not typed_tables:
-            return PhaseResult.failed("No tables were successfully typed")
+            # Surface the per-table failure detail (DAT-641). A DuckLake commit
+            # conflict from resolve_types lands in ``warnings``; the worker's
+            # ``_is_transient_commit_conflict`` keys off the PhaseRun.error STRING to
+            # make the concurrent-typing race Temporal-retryable. A bare "No tables
+            # were successfully typed" hides that signature, so a transient race
+            # failed the whole replay non-retryably. Fold the warnings in (as
+            # statistics/correlations_phase already do) so the classifier sees it.
+            detail = "; ".join(warnings)
+            return PhaseResult.failed(
+                f"No tables were successfully typed: {detail}"
+                if detail
+                else "No tables were successfully typed"
+            )
 
         # Link the run to the tables it just typed (DAT-407) so the run's source
         # is derivable without a stored ``source_id``. Written here — a side-effect

--- a/packages/engine/tests/unit/pipeline/test_typing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_typing_phase.py
@@ -19,6 +19,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import duckdb
+import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -336,3 +337,56 @@ class TestApplyUnitOverrides:
             ).scalars()
         }
         assert landed == {"run_current": "EUR", "run_prior": None}
+
+
+class TestCommitConflictIsRetryable:
+    """DAT-641: a DuckLake commit conflict during typing must surface in the phase
+    error STRING so the worker's ``_is_transient_commit_conflict`` classifies it as
+    the retryable ``TransientPhaseFailure`` — not the permanent ``PhaseFailed`` that
+    killed the whole concurrent replay. The classifier reads the error text, so the
+    bare "No tables were successfully typed" (which hid the signature) was the bug;
+    the fix folds the per-table failure detail back in. This is the typing→worker
+    seam the original classifier commit (975473fc) never exercised end-to-end.
+    """
+
+    def test_commit_conflict_failure_carries_the_retryable_signature(
+        self,
+        session: Session,
+        duckdb_conn: duckdb.DuckDBPyConnection,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from dataraum.core.models.base import Result
+        from dataraum.pipeline.base import PhaseStatus
+        from dataraum.pipeline.phases import typing_phase as tp
+        from dataraum.worker.activities import _is_transient_commit_conflict
+
+        src = _make_source(session)
+        table = _make_table(session, src.source_id, "vendor_table")
+
+        # Inference succeeds (its payload is unused before resolution); resolution
+        # loses the commit race — the exact string resolve_types returns on a
+        # DuckLake optimistic-concurrency conflict (resolution.py).
+        monkeypatch.setattr(tp, "infer_type_candidates", lambda **_: Result.ok([]))
+        monkeypatch.setattr(
+            tp,
+            "resolve_types",
+            lambda **_: Result.fail(
+                "SQL execution failed: TransactionContext Error: "
+                "Failed to commit DuckLake transaction."
+            ),
+        )
+
+        result = tp.TypingPhase()._run(
+            PhaseContext(
+                session=session,
+                duckdb_conn=duckdb_conn,
+                table_ids=[table.table_id],
+                run_id="run-1",
+            )
+        )
+
+        assert result.status is PhaseStatus.FAILED
+        # The seam: typing must produce a string the worker recognises as a
+        # transient, retryable conflict — otherwise the run fails non-retryably.
+        assert result.error is not None
+        assert _is_transient_commit_conflict(result.error) is True


### PR DESCRIPTION
Fixes [DAT-641](https://real-dataraum.atlassian.net/browse/DAT-641) — a wide concurrent replay fails non-retryably on a DuckLake commit conflict (`PhaseFailed: No tables were successfully typed`, typing pills stuck at `0 / N`).

## Root cause — a wiring gap, not missing machinery

Both fixes the ticket proposed were **already on `main`**:
1. `ducklake_max_retry_count` bump (`core/connections.py`, "DAT-641 groundwork").
2. The Temporal-retryable classifier — `_is_transient_commit_conflict(run.error)` → `TransientPhaseFailure` (retryable, max 5 attempts), landed in `975473fc`.

But the classifier keys off the `PhaseRun.error` **string**, and the typing phase starved it. On a `resolve_types` commit conflict, `typing_phase` swallowed the detail into a `warnings` list and returned the bare `"No tables were successfully typed"` — so the conflict signature (`"Failed to commit DuckLake transaction"`) never reached `run.error`. The classifier returned `False` → the transient race failed the whole `add_source`/`replay` permanently. `975473fc` shipped a unit test feeding the classifier a crafted error, but nothing exercised the **typing → worker seam** end-to-end.

## The fix (one line + the missing test)

Fold the per-table failure detail into the message — exactly as `statistics_phase` / `correlations_phase` already do:

```python
detail = "; ".join(warnings)
return PhaseResult.failed(
    f"No tables were successfully typed: {detail}" if detail
    else "No tables were successfully typed"
)
```

Now the conflict signature reaches `run.error`, the existing classifier fires, and Temporal retries the losing table activity (typing is idempotent on `(column_id, run_id)`) — the wide replay completes.

Adds the integration test the original commit lacked: a commit conflict in `resolve_types` yields a typing `PhaseResult.failed` whose `error` `_is_transient_commit_conflict` recognises.

## Scope / safety
- Engine only — `pipeline/phases/typing_phase.py` + its test, plus a `handoff.md` note.
- **Calibration-neutral:** failure-path + retry classification only — no detector logic, threshold, or output shape changes. Recall/precision cannot move; it only removes a spurious fatal failure from wide-replay runs.
- Scanned the other add_source phases — typing was the lone gap (the rest are precondition guards that fire before any commit, or already propagate `str(exc)`).

## Verification
- New seam test + 13/13 typing tests + 9/9 worker classifier tests green; ruff + mypy clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)