### PR TITLE
refactor(DAT-637): move catalogue-grain column semantics to ColumnConcept

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -93,3 +93,24 @@ The collision fail-loud is testable: two sources whose names/files resolve to th
 same narrow table name should now produce one materialized table + one loud
 failure, not two parallel tables. An injection that re-imports identical content
 under a second name is the natural regression for the original duplication bug.
+
+---
+
+## DAT-637 — catalogue-grain column semantics move to ColumnConcept
+
+**What changed.** Single-ownership move: the per-column semantic attributes that need the *composed catalogue* (not one table) were physically removed from `SemanticAnnotation` (object-grain, add_source) and re-homed on a NEW `ColumnConcept` model, authored ONLY by the table agent (`semantic_per_table`, begin_session) and sealed under the workspace **catalogue head**. Moved: `business_concept`, `temporal_behavior` (+`contested`), `unit_source_column`, `derived_formula_hypothesis` (+conf). Also `foreign_key` removed from `SemanticRole`/the column-agent schema (FK-ness is the `Relationship` catalogue's job).
+
+**Engine routes/phases affected.**
+- `semantic_per_table` now emits `TableSynthesisOutput.column_concepts` (new authoring surface) + applies a **near-constant refusal**: never binds a concept to a column whose top value ≥90% (flagged `near_constant` in the feed), and leaves `business_concept` null when no genuine discriminator column exists (→ value-set grounding). Prompt: `dataraum-config/llm/prompts/semantic_per_table.yaml`.
+- The **metric-grounding feed** (`graphs/field_mapping.load_semantic_mappings` + `graphs/context.build_execution_context`) now reads `business_concept`/`temporal_behavior`/`unit_source` from `ColumnConcept` pinned to the **catalogue run** (`base_runs.relationship_run_id`), threaded through `metrics_phase` → `ExecutionContext.with_rich_context`.
+- The `derived_value` / `temporal_behavior` detector inputs (`entropy/detectors/loaders.load_semantic`) now grain-split: object-grain fields from `SemanticAnnotation`, catalogue-grain from `ColumnConcept` at the run — so catalogue fields are present at `session_detect`, ABSENT at add_source `detect` (the intended grain boundary). `entropy/resolve.resolve_temporal_behavior` now writes `ColumnConcept`.
+
+### Calibration to run
+- **BookSQL cold re-seed grounding** — the headline acceptance check: `revenue`/`accounts_payable`/`accounts_receivable` must NO LONGER trap-bind to near-constant flags (`sale`/`ap_paid`/`ar_paid`) — they bind to a genuine discriminator or stay null (value-set grounded). The 11 already-grounding metrics must NOT regress.
+- Driver-discovery `target_type` (reads `ColumnConcept.temporal_behavior` now) — confirm stock/flow target selection is unchanged on the calibration corpora.
+
+### Thresholds / new fields
+No score thresholds changed. New table `column_concepts` (catalogue-grain, `(column_id, run_id)`). `near_constant` is a new boolean hint in the per-table LLM feed only (not a stored field).
+
+### Cross-package
+- **Cockpit drizzle mirror is STALE** until `bun run db:pull:metadata` runs against a migrated DB — `schema.sql` gained `column_concepts` and dropped 5 columns from `semantic_annotations`. The `schema-drift` CI gate will fail until the cockpit mirror is re-pulled.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ External, stack-specific skills:
 
 Dev runs in a sandboxed (SBX) container — the sandbox handles permissions, so agents run **without per-command gating**. Don't add `permissionMode: bypassPermissions`, cd-must-be-relative rules, or `permissions.allow` allowlists to dodge prompts.
 
+**Git hygiene for concurrent agents (this repo runs several at once):**
+- **ALWAYS WORK IN A WORKTREE.** Never edit on a shared checkout's branch — another agent can switch or commit under you, and your work ends up stranded on someone else's branch (or their commits land in your PR). Spawn with `isolation: "worktree"`, or `git worktree add .claude/worktrees/<task> -b <branch>`; commit there.
+- **ALWAYS REBASE/MERGE onto `origin/main` BEFORE PUSHING.** Fetch + rebase first — main moves under long runs. Pushing a stale-base branch forces a non-fast-forward fixup later (or clobbers a teammate's force-push). Rebase clean, re-verify, then push.
+
 ## Dev loop
 
 ```bash

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -62,6 +62,26 @@ export const currentClaimWitnesses = metadataSchema
 		sql`SELECT claim_witness_id, table_id, column_id, run_id, target, claim_field, witness_id, distribution, reliability, detector_id, computed_at, (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.stage::text = 'generation'::text AND h.run_id::text = r.run_id::text AND h.target::text = ('table:'::text || r.table_id::text))) AS via_table_head, (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text AND h.target::text = 'catalog'::text)) AS via_catalog_head, (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.stage::text = 'operating_model'::text AND h.run_id::text = r.run_id::text AND h.target::text = 'catalog'::text)) AS via_operating_model_head FROM ws_00000000_0000_0000_0000_000000000001.claim_witnesses r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.run_id::text = r.run_id::text AND (h.stage::text = 'generation'::text AND h.target::text = ('table:'::text || r.table_id::text) OR h.stage::text = 'catalog'::text AND h.target::text = 'catalog'::text OR h.stage::text = 'operating_model'::text AND h.target::text = 'catalog'::text)))`,
 	);
 
+export const currentColumnConcepts = metadataSchema
+	.view("current_column_concepts", {
+		conceptId: varchar("concept_id"),
+		columnId: varchar("column_id"),
+		runId: varchar("run_id"),
+		businessConcept: varchar("business_concept"),
+		temporalBehavior: varchar("temporal_behavior"),
+		temporalBehaviorContested: boolean("temporal_behavior_contested"),
+		unitSourceColumn: varchar("unit_source_column"),
+		derivedFormulaHypothesis: varchar("derived_formula_hypothesis"),
+		derivedFormulaConfidence: doublePrecision("derived_formula_confidence"),
+		annotationSource: varchar("annotation_source"),
+		annotatedAt: timestamp("annotated_at"),
+		annotatedBy: varchar("annotated_by"),
+		confidence: doublePrecision(),
+	})
+	.as(
+		sql`SELECT concept_id, column_id, run_id, business_concept, temporal_behavior, temporal_behavior_contested, unit_source_column, derived_formula_hypothesis, derived_formula_confidence, annotation_source, annotated_at, annotated_by, confidence FROM ws_00000000_0000_0000_0000_000000000001.column_concepts r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
+	);
+
 export const currentColumnEligibility = metadataSchema
 	.view("current_column_eligibility", {
 		eligibilityId: varchar("eligibility_id", { length: 36 }),
@@ -318,16 +338,10 @@ export const currentSemanticAnnotations = metadataSchema
 		entityType: varchar("entity_type"),
 		businessName: varchar("business_name"),
 		businessDescription: text("business_description"),
-		businessConcept: varchar("business_concept"),
-		temporalBehavior: varchar("temporal_behavior"),
 		temporalBehaviorClaim: varchar("temporal_behavior_claim"),
 		temporalBehaviorClaimConfidence: doublePrecision(
 			"temporal_behavior_claim_confidence",
 		),
-		temporalBehaviorContested: boolean("temporal_behavior_contested"),
-		derivedFormulaHypothesis: varchar("derived_formula_hypothesis"),
-		derivedFormulaConfidence: doublePrecision("derived_formula_confidence"),
-		unitSourceColumn: varchar("unit_source_column"),
 		nullTokens: json("null_tokens"),
 		annotationSource: varchar("annotation_source"),
 		annotatedAt: timestamp("annotated_at"),
@@ -335,7 +349,7 @@ export const currentSemanticAnnotations = metadataSchema
 		confidence: doublePrecision(),
 	})
 	.as(
-		sql`SELECT annotation_id, column_id, run_id, semantic_role, entity_type, business_name, business_description, business_concept, temporal_behavior, temporal_behavior_claim, temporal_behavior_claim_confidence, temporal_behavior_contested, derived_formula_hypothesis, derived_formula_confidence, unit_source_column, null_tokens, annotation_source, annotated_at, annotated_by, confidence FROM ws_00000000_0000_0000_0000_000000000001.semantic_annotations r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.columns c JOIN ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h ON h.target::text = ('table:'::text || c.table_id::text) WHERE c.column_id::text = r.column_id::text AND h.stage::text = 'generation'::text AND h.run_id::text = r.run_id::text))`,
+		sql`SELECT annotation_id, column_id, run_id, semantic_role, entity_type, business_name, business_description, temporal_behavior_claim, temporal_behavior_claim_confidence, null_tokens, annotation_source, annotated_at, annotated_by, confidence FROM ws_00000000_0000_0000_0000_000000000001.semantic_annotations r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.columns c JOIN ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h ON h.target::text = ('table:'::text || c.table_id::text) WHERE c.column_id::text = r.column_id::text AND h.stage::text = 'generation'::text AND h.run_id::text = r.run_id::text))`,
 	);
 
 export const currentSliceDefinitions = metadataSchema

--- a/packages/cockpit/src/tools/look-profile.ts
+++ b/packages/cockpit/src/tools/look-profile.ts
@@ -24,6 +24,7 @@ import { z } from "zod";
 import { metadataDb } from "../db/metadata/client";
 import {
 	columns,
+	currentColumnConcepts,
 	currentDerivedColumns,
 	currentSemanticAnnotations,
 	currentStatisticalProfiles,
@@ -594,14 +595,18 @@ export async function lookProfile(input: {
 async function loadSemantic(columnId: string): Promise<SemanticRow | null> {
 	const [row] = await metadataDb
 		.select({
-			businessConcept: currentSemanticAnnotations.businessConcept,
+			businessConcept: currentColumnConcepts.businessConcept,
 			semanticRole: currentSemanticAnnotations.semanticRole,
 			businessName: currentSemanticAnnotations.businessName,
 			entityType: currentSemanticAnnotations.entityType,
-			temporalBehavior: currentSemanticAnnotations.temporalBehavior,
-			unitSourceColumn: currentSemanticAnnotations.unitSourceColumn,
+			temporalBehavior: currentColumnConcepts.temporalBehavior,
+			unitSourceColumn: currentColumnConcepts.unitSourceColumn,
 		})
 		.from(currentSemanticAnnotations)
+		.leftJoin(
+			currentColumnConcepts,
+			eq(currentColumnConcepts.columnId, currentSemanticAnnotations.columnId),
+		)
 		.where(eq(currentSemanticAnnotations.columnId, columnId))
 		.limit(1);
 	return row ?? null;

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -28,6 +28,7 @@ import {
 import { tableTargetKey } from "../db/metadata/relationship-target";
 import {
 	columns,
+	currentColumnConcepts,
 	currentEntropyReadiness,
 	currentSemanticAnnotations,
 	currentTableEntities,
@@ -459,10 +460,12 @@ async function loadColumnGrid(tableId: string): Promise<ColumnReadiness[]> {
 			columnId: columns.columnId,
 			columnName: columns.columnName,
 			resolvedType: columns.resolvedType,
-			// Light per-column semantics (DAT-476) — begin_session's
-			// `semantic_per_column` annotation, head-resolved by the view. Left-join
-			// nullable: an unannotated column reads all three null → semantic: null.
-			businessConcept: currentSemanticAnnotations.businessConcept,
+			// Light per-column semantics, head-resolved by the views. Object-grain
+			// role/name from currentSemanticAnnotations (generation head);
+			// catalogue-grain business_concept from currentColumnConcepts (catalogue
+			// head, DAT-637). Both left-joins nullable → an unannotated/unbound
+			// column reads null.
+			businessConcept: currentColumnConcepts.businessConcept,
 			semanticRole: currentSemanticAnnotations.semanticRole,
 			businessName: currentSemanticAnnotations.businessName,
 		})
@@ -470,6 +473,10 @@ async function loadColumnGrid(tableId: string): Promise<ColumnReadiness[]> {
 		.leftJoin(
 			currentSemanticAnnotations,
 			eq(currentSemanticAnnotations.columnId, columns.columnId),
+		)
+		.leftJoin(
+			currentColumnConcepts,
+			eq(currentColumnConcepts.columnId, columns.columnId),
 		)
 		.where(eq(columns.tableId, tableId))
 		.orderBy(asc(columns.columnPosition));

--- a/packages/cockpit/src/tools/operating-model-load.ts
+++ b/packages/cockpit/src/tools/operating-model-load.ts
@@ -15,9 +15,9 @@ import { config } from "../config";
 import { metadataDb } from "../db/metadata/client";
 import {
 	columns as columnsView,
+	currentColumnConcepts,
 	currentDriverRankings,
 	currentRelationships,
-	currentSemanticAnnotations,
 	currentValidationResults,
 	sqlSnippets,
 	tables as tablesView,
@@ -85,11 +85,11 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 			),
 		metadataDb
 			.select({
-				concept: currentSemanticAnnotations.businessConcept,
-				columnId: currentSemanticAnnotations.columnId,
+				concept: currentColumnConcepts.businessConcept,
+				columnId: currentColumnConcepts.columnId,
 			})
-			.from(currentSemanticAnnotations)
-			.where(isNotNull(currentSemanticAnnotations.businessConcept)),
+			.from(currentColumnConcepts)
+			.where(isNotNull(currentColumnConcepts.businessConcept)),
 		metadataDb
 			.select({
 				measureColumnId: currentDriverRankings.measureColumnId,

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -31,9 +31,9 @@ import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
 import { metadataDb } from "../db/metadata/client";
 import {
 	columns,
+	currentColumnConcepts,
 	currentDimensionHierarchies,
 	currentRelationships,
-	currentSemanticAnnotations,
 	currentSliceDefinitions,
 	currentTableEntities,
 	sources,
@@ -271,15 +271,18 @@ export async function buildSchemaBlock(): Promise<string> {
 		.innerJoin(sources, eq(sources.sourceId, tables.sourceId))
 		.where(and(isNull(sources.archivedAt), eq(tables.layer, TYPED_LAYER)));
 
+	// Catalogue-grain concepts live on currentColumnConcepts (DAT-637), authored by
+	// the table agent and sealed under the catalogue head — no longer on the
+	// object-grain currentSemanticAnnotations.
 	const conceptRows = await metadataDb
 		.select({
-			columnId: currentSemanticAnnotations.columnId,
-			businessConcept: currentSemanticAnnotations.businessConcept,
-			temporalBehavior: currentSemanticAnnotations.temporalBehavior,
+			columnId: currentColumnConcepts.columnId,
+			businessConcept: currentColumnConcepts.businessConcept,
+			temporalBehavior: currentColumnConcepts.temporalBehavior,
 			temporalBehaviorContested:
-				currentSemanticAnnotations.temporalBehaviorContested,
+				currentColumnConcepts.temporalBehaviorContested,
 		})
-		.from(currentSemanticAnnotations);
+		.from(currentColumnConcepts);
 
 	return formatSchema(
 		typedTables,

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -47,9 +47,11 @@ system_prompt: |
   1. If field_mappings gives a sound `concept → column` (a real discriminator, not near-constant),
      use that column.
   2. Otherwise ground via Value sets + Business Concepts: pick the discriminator column whose
-     values name the concept, select the values that ARE the concept (by MEANING — honor the
-     concept's `exclude` patterns; a value's surface string can contradict its concept), and
-     filter `WHERE "<discriminator>" IN ('<value1>', '<value2>', ...)` over THOSE EXACT values.
+     values name the concept, then from THAT column's served Value-set select the SUBSET of its
+     listed values that ARE the concept (by MEANING — honor the concept's `exclude` patterns; a
+     value's surface string can contradict its concept), and filter `WHERE "<discriminator>" IN
+     ('<value1>', '<value2>', ...)` over THOSE EXACT SERVED values. You are choosing a subset of
+     the listed values — never adding one that is not listed.
   3. If the discriminator lives on a DIMENSION table (a classification, not a value on the fact),
      join to it — see the join-to-dimension blueprint.
   4. Record the grounding in column_mappings_basis (which column, which values, why).
@@ -65,6 +67,13 @@ system_prompt: |
     are one-shot and cannot drill it): do NOT invent a filter on it — join to a dimension that
     HAS a complete value-set, or ABSTAIN.
   - Never invent a value; never use a concept name as a table name.
+  - **Every literal in an `IN (...)` MUST appear VERBATIM in the served Value-set for that
+    column.** Do NOT append a conventional or synonym name because you believe it means the
+    concept — a value that is not in the served list is an INVENTED value (forbidden above),
+    even as an exact string mixed in with valid ones. Picking the real served value AND padding
+    the list with plausible-but-unlisted names is still invention. If NONE of the served values
+    mean the concept, the concept is ABSENT in this dataset — fall loud (NULL, per below); do
+    not construct an `IN (...)` of names you expect to exist.
 
   FALL LOUD — do not guess (this protects against a confidently-wrong number):
   If you cannot ground the concept by rule (1) or (2) — the only complete value-set is opaque

--- a/packages/dataraum-config/llm/prompts/semantic_per_table.yaml
+++ b/packages/dataraum-config/llm/prompts/semantic_per_table.yaml
@@ -32,15 +32,42 @@ system_prompt: |
     non-grain column, and the grain may be a surrogate row key that identifies
     nothing. Emit each with a one-sentence note.
   - Confirm which relationships between tables are real
+  - Author the CATALOGUE-GRAIN per-column semantics (column_concepts): which
+    columns ground an ontology concept, each measure's unit source, and any
+    cross-table derived-formula hypothesis. These need the whole composed
+    catalogue (the ontology, the confirmed relationships, the joined tables), so
+    only you can decide them — the per-column phase could not.
   </role>
 
-  <column_annotations_are_decided>
-  Per-column annotations (roles, business concepts, confidence) have ALREADY been
-  produced and persisted by an earlier phase, and may have been corrected by a
-  human via teach. They are provided to you as READ-ONLY context. Do NOT re-annotate
-  or second-guess individual columns — use them to reason about what each table is
-  and how tables relate. Your output contains tables and relationships only.
-  </column_annotations_are_decided>
+  <grain_split>
+  Per-column OBJECT-grain annotations (structural role, entity label, business
+  term, the stock/flow CLAIM, confidence) were decided by an earlier per-column
+  phase from each table alone, and may have been corrected by a human via teach.
+  They are READ-ONLY context — do NOT re-emit them. But the CATALOGUE-grain
+  semantics below are YOURS to author, because they are properties of the composed
+  catalogue, not of any single table:
+  </grain_split>
+
+  <column_concepts>
+  Emit a column_concepts entry ONLY for columns that carry at least one of these;
+  omit every other column.
+
+  - business_concept: the EXACT ontology concept a column GROUNDS (e.g. 'revenue',
+    'accounts_receivable'). Bind ONLY a genuine discriminator the analyst can
+    filter or aggregate on. NEVER bind a concept to a near-constant column —
+    flagged `near_constant` in the schema (its single most-frequent value covers
+    ≥90% of rows: a status flag like a 99%-true boolean is NOT a discriminator).
+    When a concept has no genuine column
+    in this catalogue (e.g. revenue is SUM of an amount filtered by an
+    account-class value, not any single column), leave business_concept null — it
+    grounds via value-sets, honestly. A wrong binding is worse than none.
+  - unit_source_column: the column defining a measure's unit — same-table name, or
+    'table.column' reachable via a CONFIRMED relationship, or 'dimensionless'.
+  - derived_formula_hypothesis: if a column reads as computed, the arithmetic it
+    should obey (two column names joined by + - * /). Operands MAY live in a JOINED
+    table reachable via a confirmed relationship (use 'table.column') — the
+    derived-value check runs over the enriched fact×dimension view.
+  </column_concepts>
 
   <relationship_evaluation>
   Evaluate the pre-computed relationship candidates and determine:
@@ -80,8 +107,10 @@ system_prompt: |
 
 user_prompt: |
   <task>
-  Classify each table below and confirm the relationships between them. Do not
-  annotate individual columns — those are already decided (shown for context).
+  Classify each table below, confirm the relationships between them, and author
+  the catalogue-grain column_concepts (ontology concept, unit source, derived
+  formula) for the columns that carry them. The OBJECT-grain per-column
+  annotations are shown for context only — do not re-emit them.
   </task>
 
   <schema>

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -351,6 +351,25 @@ CREATE INDEX idx_claim_witness_table ON claim_witnesses (table_id);
 
 CREATE INDEX idx_claim_witness_target ON claim_witnesses (target);
 
+CREATE TABLE column_concepts (
+	concept_id VARCHAR NOT NULL, 
+	column_id VARCHAR NOT NULL, 
+	run_id VARCHAR NOT NULL, 
+	business_concept VARCHAR, 
+	temporal_behavior VARCHAR, 
+	temporal_behavior_contested BOOLEAN, 
+	unit_source_column VARCHAR, 
+	derived_formula_hypothesis VARCHAR, 
+	derived_formula_confidence FLOAT, 
+	annotation_source VARCHAR, 
+	annotated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
+	annotated_by VARCHAR, 
+	confidence FLOAT, 
+	CONSTRAINT pk_column_concepts PRIMARY KEY (concept_id), 
+	CONSTRAINT uq_column_concept UNIQUE (column_id, run_id), 
+	CONSTRAINT fk_column_concepts_column_id_columns FOREIGN KEY(column_id) REFERENCES columns (column_id)
+);
+
 CREATE TABLE derived_columns (
 	derived_id VARCHAR NOT NULL, 
 	run_id VARCHAR NOT NULL, 
@@ -524,14 +543,8 @@ CREATE TABLE semantic_annotations (
 	entity_type VARCHAR, 
 	business_name VARCHAR, 
 	business_description TEXT, 
-	business_concept VARCHAR, 
-	temporal_behavior VARCHAR, 
 	temporal_behavior_claim VARCHAR, 
 	temporal_behavior_claim_confidence FLOAT, 
-	temporal_behavior_contested BOOLEAN, 
-	derived_formula_hypothesis VARCHAR, 
-	derived_formula_confidence FLOAT, 
-	unit_source_column VARCHAR, 
 	null_tokens JSON, 
 	annotation_source VARCHAR, 
 	annotated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 

--- a/packages/engine/schema_read.sql
+++ b/packages/engine/schema_read.sql
@@ -33,6 +33,16 @@ WHERE EXISTS (
 )
 ;
 
+DROP VIEW IF EXISTS __READ__.current_column_concepts;
+CREATE VIEW __READ__.current_column_concepts AS
+SELECT r.* FROM __WS__.column_concepts r
+WHERE EXISTS (
+  SELECT 1 FROM __WS__.metadata_snapshot_head h
+  WHERE h.target = 'catalog'
+    AND h.stage = 'catalog'
+    AND h.run_id = r.run_id
+);
+
 DROP VIEW IF EXISTS __READ__.current_column_eligibility;
 CREATE VIEW __READ__.current_column_eligibility AS
 SELECT r.* FROM __WS__.column_eligibility r

--- a/packages/engine/src/dataraum/analysis/cycles/context.py
+++ b/packages/engine/src/dataraum/analysis/cycles/context.py
@@ -30,6 +30,7 @@ from dataraum.analysis.relationships.graph_topology import (
 )
 from dataraum.analysis.relationships.utils import load_defined_relationships
 from dataraum.analysis.semantic.db_models import SemanticAnnotation, TableEntity
+from dataraum.analysis.semantic.utils import load_column_concepts
 from dataraum.analysis.slicing.db_models import SliceDefinition
 from dataraum.analysis.statistics.db_models import StatisticalProfile
 from dataraum.analysis.temporal.db_models import TemporalColumnProfile
@@ -92,6 +93,13 @@ def build_cycle_detection_context(
             column_by_id[c.column_id] = c
 
     annotations = _load_pinned_annotations(session, tables, base_runs.semantic_runs)
+    # Catalogue-grain concepts (DAT-637) live under the catalogue head, scoped by
+    # the same pinned begin_session run the relationship reads use.
+    concepts = (
+        load_column_concepts(session, [t.table_id for t in tables], base_runs.relationship_run_id)
+        if base_runs.relationship_run_id
+        else {}
+    )
 
     # Row counts from DuckDB
     row_counts: dict[str, int | None] = {}
@@ -116,10 +124,12 @@ def build_cycle_detection_context(
             if ann is not None:
                 col_info["semantic_role"] = ann.semantic_role
                 col_info["entity_type"] = ann.entity_type
-                col_info["business_concept"] = ann.business_concept
-                col_info["temporal_behavior"] = ann.temporal_behavior
                 col_info["business_name"] = ann.business_name
                 col_info["business_description"] = ann.business_description
+            concept = concepts.get(c.column_id)
+            if concept is not None:
+                col_info["business_concept"] = concept.business_concept
+                col_info["temporal_behavior"] = concept.temporal_behavior
             columns.append(col_info)
 
         table_info.append(

--- a/packages/engine/src/dataraum/analysis/drivers/persistence.py
+++ b/packages/engine/src/dataraum/analysis/drivers/persistence.py
@@ -23,7 +23,7 @@ from sqlalchemy import select
 from dataraum.analysis.drivers.db_models import DriverRankingArtifact
 from dataraum.analysis.drivers.models import DriverRanking, Measure
 from dataraum.analysis.drivers.processor import discover_drivers
-from dataraum.analysis.semantic.db_models import SemanticAnnotation
+from dataraum.analysis.semantic.db_models import ColumnConcept, SemanticAnnotation
 from dataraum.core.logging import get_logger
 from dataraum.storage import Column
 from dataraum.storage.upsert import upsert
@@ -75,29 +75,32 @@ def ranking_to_row(
 
 
 def _measure_columns(
-    session: Session, table_ids: list[str]
+    session: Session, table_ids: list[str], *, run_id: str
 ) -> list[tuple[str, str, str, str | None]]:
     """The session's measure-role columns: ``(column_id, table_id, name, behavior)``.
 
-    Read by ``column_id`` without a run filter (the ``slicing_phase`` convention):
-    ``semantic_role`` is stable from add_source generation. Deduped to one row per
-    column so a re-adjudicated annotation can never run discovery twice. UNLIKE
-    slicing (which only reads the stable role), the ``temporal_behavior`` picked here
-    drives ``discover_drivers``' target function — so when a column carries annotations
-    from multiple coexisting runs the pick MUST be deterministic, or a Temporal
-    redelivery could persist a different ranking than the promoted head. The
-    ``run_id`` desc tiebreak makes it stable (a deterministic pick, not a recency
-    claim — ``run_id`` isn't time-ordered; resolving the true per-table semantic head
-    is the value layer's shared gap with slicing, out of scope here).
+    ``semantic_role`` is object-grain (add_source generation) and read by ``column_id``
+    without a run filter (the ``slicing_phase`` convention) — stable across runs, deduped
+    to one row per column. ``temporal_behavior`` is catalogue-grain (``ColumnConcept``,
+    DAT-637) and drives ``discover_drivers``' target function, so it MUST be pinned to
+    THIS begin_session ``run_id``: a column carries one ``ColumnConcept`` per run, and an
+    unscoped join would let a Temporal redelivery pick an arbitrary run's behavior. The
+    outer join keeps a measure with no bound concept (behavior ``None`` → defaults
+    downstream); the ``SemanticAnnotation.run_id`` desc only orders the dedup of the
+    object-grain rows.
     """
     rows = session.execute(
         select(
             Column.column_id,
             Column.table_id,
             Column.column_name,
-            SemanticAnnotation.temporal_behavior,
+            ColumnConcept.temporal_behavior,
         )
         .join(SemanticAnnotation, SemanticAnnotation.column_id == Column.column_id)
+        .outerjoin(
+            ColumnConcept,
+            (ColumnConcept.column_id == Column.column_id) & (ColumnConcept.run_id == run_id),
+        )
         .where(
             Column.table_id.in_(table_ids),
             SemanticAnnotation.semantic_role == "measure",
@@ -130,7 +133,7 @@ def persist_driver_rankings(
     """
     if not table_ids:
         return 0
-    measures = _measure_columns(session, table_ids)
+    measures = _measure_columns(session, table_ids, run_id=run_id)
     if not measures:
         logger.info("driver_rankings_no_measures", table_ids=table_ids)
         return 0

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -10,7 +10,7 @@ Binds the engine (:mod:`tree`) to the begin_session substrate:
   pulled ONCE into memory; the permutation null runs in numpy (the design's "GROUP
   BYs over aggregation views" is moot — ADR-0013 removed those, and 500 shuffles in
   SQL would be hundreds of scans).
-- **Target type** = the measure's ``SemanticAnnotation.temporal_behavior``
+- **Target type** = the measure's ``ColumnConcept.temporal_behavior`` (DAT-637)
   (``additive`` → flow, ``point_in_time`` → stock) via :func:`resolve_target_type`.
 
 On-demand and pure: returns a :class:`DriverRanking`, persists nothing (DAT-546).
@@ -46,7 +46,7 @@ from dataraum.analysis.drivers.tree import (
     discover_tree,
 )
 from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
-from dataraum.analysis.semantic.db_models import SemanticAnnotation, TableEntity
+from dataraum.analysis.semantic.db_models import ColumnConcept, TableEntity
 from dataraum.analysis.slicing.db_models import SliceDefinition
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.core.logging import get_logger
@@ -88,10 +88,12 @@ def resolve_target_type(session: Session, *, column_id: str, run_id: str) -> str
     ``temporal_behavior`` value: a ratio measure is constructed explicitly by the
     caller (computed metric), not resolved here.
     """
+    # temporal_behavior is catalogue-grain (DAT-637): on ColumnConcept, written by
+    # the table agent under THIS begin_session run earlier in the session spine.
     behavior = session.execute(
-        select(SemanticAnnotation.temporal_behavior).where(
-            SemanticAnnotation.column_id == column_id,
-            SemanticAnnotation.run_id == run_id,
+        select(ColumnConcept.temporal_behavior).where(
+            ColumnConcept.column_id == column_id,
+            ColumnConcept.run_id == run_id,
         )
     ).scalar_one_or_none()
     target = _TEMPORAL_TO_TARGET.get(behavior or "", "flow")

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -283,6 +283,7 @@ class SemanticAgent(LLMFeature):
                 annotations=[],
                 entity_detections=entity_detections,
                 relationships=relationships,
+                column_concepts=synthesis.column_concepts,
                 source="llm",
             )
         )
@@ -599,6 +600,16 @@ class SemanticAgent(LLMFeature):
             # Add string stats if available
             if profile.string_stats:
                 col_data["avg_length"] = round(profile.string_stats.avg_length, 1)
+
+            # Near-constant flag (DAT-637): a column whose single most-frequent
+            # value covers ≥90% of rows is a status flag, NOT a discriminator — so
+            # the table agent must never bind a concept to it. Surfaced explicitly
+            # (the same 0.9 fraction the graph-context feed flags it at) rather than
+            # left for the agent to infer from samples.
+            if profile.top_values and profile.total_count:
+                dominant = max((tv.count for tv in profile.top_values), default=0)
+                if dominant / profile.total_count > 0.9:
+                    col_data["near_constant"] = True
 
             tables_data[table_name]["columns"].append(col_data)
 

--- a/packages/engine/src/dataraum/analysis/semantic/db_models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/db_models.py
@@ -62,36 +62,14 @@ class SemanticAnnotation(Base):
     business_name: Mapped[str | None] = mapped_column(String)
     business_description: Mapped[str | None] = mapped_column(Text)
 
-    # Business concept mapping - maps to standard domain concepts
-    # from the active ontology (e.g., 'accounts_receivable', 'revenue', 'fiscal_period')
-    business_concept: Mapped[str | None] = mapped_column(String)
-
-    # Temporal behavior from ontology: 'additive' or 'point_in_time'
-    temporal_behavior: Mapped[str | None] = mapped_column(String)
-
-    # Independent LLM stock/flow read (ADR-0009 / DAT-445), pooled against the
-    # ontology prior above in the temporal_behavior adjudication. The claim
-    # ('stock'/'flow'/'unsure') + its confidence are the LLM witness, written by
-    # semantic_per_column. ``temporal_behavior_contested`` is written back by the
-    # resolved-layer pass (dataraum.entropy.resolve) when the pooled conflict is
-    # non-trivial — it flags the resolved temporal_behavior so a downstream SQL
-    # agent treats a contested stock with caution. None = no claim / not resolved.
+    # Object-grain stock/flow witness (ADR-0009 / DAT-445): the column agent's
+    # INDEPENDENT per-column read ('stock'/'flow'/'unsure') + its confidence,
+    # decidable from one column's name + values, written by semantic_per_column.
+    # The ontology-derived ``temporal_behavior`` it is pooled against is
+    # catalogue-grain and now lives on ``ColumnConcept`` (DAT-637) — owned by the
+    # table agent, never duplicated here.
     temporal_behavior_claim: Mapped[str | None] = mapped_column(String)
     temporal_behavior_claim_confidence: Mapped[float | None] = mapped_column(Float)
-    temporal_behavior_contested: Mapped[bool | None] = mapped_column(Boolean)
-
-    # Independent LLM formula hypothesis (ADR-0009, derived_value second witness):
-    # the within-table arithmetic expression this column SHOULD obey from its
-    # name + concept context (e.g. 'subtotal + tax_amount'), with the LLM's
-    # confidence. Written by semantic_per_column alongside the stock/flow claim;
-    # pooled against the data-discovered formula (correlation phase) in the
-    # derived_value adjudication. None = no hypothesis (the witness abstains).
-    derived_formula_hypothesis: Mapped[str | None] = mapped_column(String)
-    derived_formula_confidence: Mapped[float | None] = mapped_column(Float)
-
-    # Cross-column unit inference: column name that defines the unit for this measure
-    # e.g., 'currency_code' for monetary measures. Set by the per-column phase.
-    unit_source_column: Mapped[str | None] = mapped_column(String)
 
     # Resolved null-marker tokens (ADR-0009 / DAT-457): the rejected tokens the
     # null_semantics adjudication resolved to is-null (pooled posterior past
@@ -112,6 +90,66 @@ class SemanticAnnotation(Base):
 
     # Relationships
     column: Mapped[Column] = relationship(back_populates="semantic_annotation")
+
+
+class ColumnConcept(Base):
+    """Catalogue-grain per-column semantics, owned by the table agent (DAT-637).
+
+    The home for column attributes that CANNOT be decided from a single table —
+    they need the composed catalogue (cross-cutting ontology concepts, the
+    confirmed relationship catalogue, the enriched fact×dimension views). They are
+    authored ONLY by ``semantic_per_table`` (begin_session) and sealed under the
+    workspace **catalogue head**, never by the object-grain per-column agent.
+
+    Single ownership, no copy-forward: these fields were physically removed from
+    ``SemanticAnnotation`` (object-grain, add_source generation head). A reader
+    resolves them through :func:`load_column_concepts`, which DEMANDS the catalogue
+    run — there is no unscoped read, so object-grain code (add_source ``detect``)
+    cannot reach catalogue-grain semantics by construction.
+
+    Fields:
+        business_concept: the standard ontology concept this column grounds
+            (revenue, accounts_receivable). Cross-cutting — a property of the
+            composed catalogue, not one table. None when the column is not a
+            genuine discriminator for any concept (grounds via value-sets).
+        temporal_behavior: the ontology concept's stock/flow ('additive' /
+            'point_in_time'), a function of ``business_concept``.
+        temporal_behavior_contested: set by the resolved-layer pass when the
+            object-grain ``temporal_behavior_claim`` and this ontology behavior
+            pool to a non-trivial conflict.
+        unit_source_column: the column (possibly ``table.column`` via a confirmed
+            FK) that defines this measure's unit.
+        derived_formula_hypothesis / _confidence: the arithmetic this column
+            should obey — operands may span a JOINED table (the derived_value
+            session detector grades it over enriched_views), so it is reasoned
+            from the relationship catalogue, not one table.
+    """
+
+    __tablename__ = "column_concepts"
+    # One row per column PER catalogue run (DAT-637): mirrors SemanticAnnotation's
+    # run-versioned grain so coexisting begin_session runs don't collide; the
+    # catalogue head names the current run.
+    __table_args__ = (UniqueConstraint("column_id", "run_id", name="uq_column_concept"),)
+
+    concept_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    column_id: Mapped[str] = mapped_column(ForeignKey("columns.column_id"), nullable=False)
+    # Snapshot version axis: the begin_session (catalogue head) run that wrote this row.
+    run_id: Mapped[str] = mapped_column(String, nullable=False)
+
+    business_concept: Mapped[str | None] = mapped_column(String)
+    temporal_behavior: Mapped[str | None] = mapped_column(String)
+    temporal_behavior_contested: Mapped[bool | None] = mapped_column(Boolean)
+    unit_source_column: Mapped[str | None] = mapped_column(String)
+    derived_formula_hypothesis: Mapped[str | None] = mapped_column(String)
+    derived_formula_confidence: Mapped[float | None] = mapped_column(Float)
+
+    # Provenance
+    annotation_source: Mapped[str | None] = mapped_column(String)
+    annotated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(UTC)
+    )
+    annotated_by: Mapped[str | None] = mapped_column(String)
+    confidence: Mapped[float | None] = mapped_column(Float)
 
 
 class TableEntity(Base):

--- a/packages/engine/src/dataraum/analysis/semantic/models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/models.py
@@ -35,17 +35,17 @@ class ColumnSemanticOutput(BaseModel):
         description="Exact column name from the provided schema. Must match exactly."
     )
 
-    semantic_role: Literal[
-        "key", "foreign_key", "measure", "dimension", "timestamp", "attribute"
-    ] = Field(
+    semantic_role: Literal["key", "measure", "dimension", "timestamp", "attribute"] = Field(
         description=(
-            "Structural role of the column: "
+            "Structural role of the column, judged from THIS table alone: "
             "'key' = primary identifier (unique, non-null); "
-            "'foreign_key' = references another table's key column; "
             "'measure' = numeric value for aggregation (sum, avg, count); "
             "'dimension' = categorical attribute for grouping/filtering; "
             "'timestamp' = date or datetime for time-based analysis; "
-            "'attribute' = descriptive field not used for aggregation or grouping"
+            "'attribute' = descriptive field not used for aggregation or grouping. "
+            "Do NOT classify foreign keys — whether a column references another "
+            "table is decided later from the confirmed relationship catalogue, not "
+            "from one table."
         )
     )
 
@@ -65,16 +65,6 @@ class ColumnSemanticOutput(BaseModel):
         )
     )
 
-    business_concept: str | None = Field(
-        default=None,
-        description=(
-            "Standard domain concept from the provided ontology concept list. "
-            "Use the EXACT concept name from the list (e.g., 'revenue', 'accounts_receivable', "
-            "'fiscal_period'). Match based on semantic meaning, not just column name patterns. "
-            "Set to null ONLY if no concept in the list applies to this column."
-        ),
-    )
-
     description: str = Field(
         description=(
             "One sentence describing what this column contains and how it's used. "
@@ -91,20 +81,6 @@ class ColumnSemanticOutput(BaseModel):
             "names like 'vendor_id'. Moderate (0.6-0.8) for recognizable abbreviations "
             "like 'amt'. Low (0.2-0.4) for random or encoded names like 'xq_v7kl' — "
             "even if you can infer meaning from the data values."
-        ),
-    )
-
-    unit_source_column: str | None = Field(
-        default=None,
-        description=(
-            "Column that defines the unit for this measure. "
-            "For same-table references, use just the column name (e.g., 'currency_code'). "
-            "For cross-table references via a confirmed FK relationship, use "
-            "'table_name.column_name' (e.g., 'chart_of_accounts.currency'). "
-            "For measures that are inherently dimensionless (ratios, rates, indices, "
-            "percentages, scores), set to 'dimensionless'. "
-            "Only set a column reference when there is a concrete dimension column — "
-            "never guess a unit."
         ),
     )
 
@@ -132,33 +108,6 @@ class ColumnSemanticOutput(BaseModel):
             "unambiguous domain language (balance, payment, revenue, closing_position). "
             "Moderate (0.6–0.8) when the role implies it but the name is ambiguous. Low "
             "(0.2–0.4) for a weak signal. Set this low whenever you answer 'unsure'."
-        ),
-    )
-
-    derived_formula_hypothesis: str | None = Field(
-        default=None,
-        description=(
-            "If this column reads as COMPUTED from two other columns in the SAME table, "
-            "the arithmetic expression it should obey from the business meaning of the "
-            "names: exactly two column names from this table joined by one of + - * / "
-            "(e.g. 'subtotal + tax_amount', 'quantity * unit_price'). Use EXACT column "
-            "names from the schema; no constants, functions, or columns from other "
-            "tables. This is an INDEPENDENT expectation — state what the name says the "
-            "column SHOULD be, even without verifying it against the values. Set to null "
-            "when the column does not read as derived (keys, dimensions, raw measures) "
-            "or when no two plausible source columns exist in this table."
-        ),
-    )
-
-    derived_formula_confidence: float = Field(
-        ge=0.0,
-        le=1.0,
-        description=(
-            "Confidence (0.0–1.0) in derived_formula_hypothesis: how clearly the column "
-            "and source names communicate the formula. High (0.85–1.0) for explicit "
-            "naming ('total_amount' with 'net_amount' + 'tax_amount'). Low (0.2–0.4) "
-            "when guessing among several plausible formulas. Set 0.0 when the "
-            "hypothesis is null."
         ),
     )
 
@@ -287,13 +236,65 @@ class TableEntityOutput(BaseModel):
     )
 
 
-class TableSynthesisOutput(BaseModel):
-    """Per-table synthesis tool output: table entities + cross-table relationships.
+class ColumnConceptOutput(BaseModel):
+    """Catalogue-grain semantics the table agent authors for ONE column (DAT-637).
 
-    Replaces :class:`SemanticAnalysisOutput` for the post-split per-table phase.
-    Column annotations are produced and persisted by the per-column phase; they
-    are provided to this phase as read-only context and are NOT part of this
-    schema.
+    These need the composed catalogue — the cross-cutting ontology, the confirmed
+    relationships, the joined views — so they are decided here, never by the
+    object-grain per-column agent. Only emit a column that carries at least one of
+    these; columns with none are omitted.
+    """
+
+    table_name: str = Field(description="Exact table name from the provided schema.")
+    column_name: str = Field(description="Exact column name from the provided schema.")
+
+    business_concept: str | None = Field(
+        default=None,
+        description=(
+            "The EXACT ontology concept this column GROUNDS (e.g. 'revenue', "
+            "'accounts_receivable'), or null. Bind ONLY a genuine discriminator the "
+            "agent can filter or aggregate on. NEVER bind a concept to a near-constant "
+            "column (one value ≥90% — a status flag like a 99%-true boolean is not a "
+            "discriminator). When a concept has no genuine column in this catalogue "
+            "(e.g. revenue is SUM of an amount filtered by an account-class value, not "
+            "any single column), leave it null — it grounds via value-sets, honestly."
+        ),
+    )
+    unit_source_column: str | None = Field(
+        default=None,
+        description=(
+            "The column defining this measure's unit: a same-table column name, or "
+            "'table_name.column_name' reachable via a CONFIRMED relationship, or "
+            "'dimensionless' for ratios/rates/indices. Null when there is no concrete "
+            "unit column — never guess."
+        ),
+    )
+    derived_formula_hypothesis: str | None = Field(
+        default=None,
+        description=(
+            "If this column reads as COMPUTED, the arithmetic it should obey: exactly "
+            "two column names joined by one of + - * / . Operands may be in a JOINED "
+            "table reachable via a confirmed relationship (use 'table.column' for a "
+            "joined operand) — the derived-value check runs over the enriched view. "
+            "Null when the column does not read as derived."
+        ),
+    )
+    derived_formula_confidence: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Confidence (0.0–1.0) in derived_formula_hypothesis; 0.0 when null.",
+    )
+
+
+class TableSynthesisOutput(BaseModel):
+    """Per-table synthesis tool output: entities, relationships, column concepts.
+
+    The per-table (catalogue-grain) tier. It classifies tables, confirms
+    relationships, AND authors the catalogue-grain per-column semantics
+    (``column_concepts``, DAT-637) that the object-grain per-column agent cannot
+    decide. The object-grain column annotations (role, term, stock/flow claim) are
+    produced by the per-column phase and provided here only as read-only context.
     """
 
     tables: list[TableEntityOutput] = Field(
@@ -306,6 +307,15 @@ class TableSynthesisOutput(BaseModel):
             "Relationships between tables. Evaluate the pre-computed candidates "
             "and include only confirmed relationships. Add any additional "
             "relationships you detect that weren't in the candidates."
+        ),
+    )
+
+    column_concepts: list[ColumnConceptOutput] = Field(
+        default_factory=list,
+        description=(
+            "Catalogue-grain per-column semantics (ontology concept, unit source, "
+            "derived-formula hypothesis). Emit only columns carrying at least one; "
+            "omit the rest."
         ),
     )
 
@@ -406,6 +416,9 @@ class SemanticEnrichmentResult(BaseModel):
     annotations: list[SemanticAnnotation] = Field(default_factory=list)
     entity_detections: list[EntityDetection] = Field(default_factory=list)
     relationships: list[Relationship] = Field(default_factory=list)
+    # Catalogue-grain per-column semantics authored by the table agent (DAT-637),
+    # persisted as ``ColumnConcept`` rows under the catalogue head.
+    column_concepts: list[ColumnConceptOutput] = Field(default_factory=list)
     source: str = "llm"  # 'llm', 'manual', 'override'
 
 
@@ -415,6 +428,7 @@ __all__ = [
     "RelationshipOutput",
     # Per-table synthesis output (DAT-362 Option B)
     "TableEntityOutput",
+    "ColumnConceptOutput",
     "TableSynthesisOutput",
     # Per-column annotation output
     "TableColumnAnnotation",

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -24,6 +24,9 @@ from dataraum.analysis.relationships.evaluator import (
 )
 from dataraum.analysis.semantic.agent import SemanticAgent
 from dataraum.analysis.semantic.db_models import (
+    ColumnConcept as ConceptModel,
+)
+from dataraum.analysis.semantic.db_models import (
     SemanticAnnotation as AnnotationModel,
 )
 from dataraum.analysis.semantic.db_models import (
@@ -31,6 +34,7 @@ from dataraum.analysis.semantic.db_models import (
 )
 from dataraum.analysis.semantic.models import (
     ColumnAnnotationOutput,
+    ColumnConceptOutput,
     SemanticEnrichmentResult,
 )
 from dataraum.analysis.semantic.models import (
@@ -149,29 +153,26 @@ def persist_column_annotations(
     table_ids: list[str],
     *,
     annotated_by: str,
-    ontology_def: Any = None,
     run_id: str | None = None,
 ) -> int:
-    """Persist per-column annotations as ``SemanticAnnotation`` rows (DAT-362).
+    """Persist the OBJECT-grain per-column annotations as ``SemanticAnnotation`` rows.
 
-    The per-column phase's authoritative output. Maps each annotated column to a
-    DB row, backfilling ``temporal_behavior`` from the ontology concept (same as
-    the legacy monolithic path did).
+    The per-column phase's authoritative output — single-table-knowable fields
+    only (role, entity label, term, the stock/flow claim). Catalogue-grain
+    semantics (business_concept, ontology temporal_behavior, unit source, derived
+    formula) are NOT written here: the table agent authors them onto
+    ``ColumnConcept`` under the catalogue head (DAT-637).
 
     Args:
         session: Database session.
         column_output: Per-column tool output (tables -> columns).
         table_ids: Tables the annotations belong to (for column-id resolution).
         annotated_by: Model identifier that produced the annotations.
-        ontology_def: Loaded ontology, for ``temporal_behavior`` backfill.
 
     Returns:
         Number of annotation rows persisted.
     """
     column_map = load_column_mappings(session, table_ids)
-    concept_temporal = (
-        {c.name: c.temporal_behavior for c in ontology_def.concepts} if ontology_def else {}
-    )
 
     rows: list[dict[str, Any]] = []
     for table in column_output.tables:
@@ -179,7 +180,12 @@ def persist_column_annotations(
             column_id = column_map.get((table.table_name, col.column_name))
             if not column_id:
                 continue
-            # PK omitted so the model's Python-side default applies.
+            # PK omitted so the model's Python-side default applies. OBJECT-grain
+            # only (DAT-637): business_concept, ontology temporal_behavior,
+            # unit_source_column, and the derived_formula hypothesis are
+            # catalogue-grain — authored by the table agent onto ``ColumnConcept``,
+            # never here. The stock/flow CLAIM stays (an independent single-column
+            # read).
             rows.append(
                 {
                     "column_id": column_id,
@@ -188,20 +194,8 @@ def persist_column_annotations(
                     "entity_type": col.entity_type,
                     "business_name": col.business_term,
                     "business_description": col.description,
-                    "business_concept": col.business_concept,
-                    "temporal_behavior": concept_temporal.get(col.business_concept)
-                    if col.business_concept
-                    else None,
-                    # Independent LLM stock/flow read (DAT-445) — the second witness,
-                    # stored ALONGSIDE the ontology temporal_behavior, never replacing it.
                     "temporal_behavior_claim": col.temporal_behavior_claim,
                     "temporal_behavior_claim_confidence": col.temporal_behavior_claim_confidence,
-                    # Independent LLM formula hypothesis (derived_value second witness,
-                    # ADR-0009) — graded against the data-discovered formula at detect.
-                    "derived_formula_hypothesis": (col.derived_formula_hypothesis or "").strip()
-                    or None,
-                    "derived_formula_confidence": col.derived_formula_confidence,
-                    "unit_source_column": col.unit_source_column,
                     "annotation_source": DecisionSource.LLM.value,
                     "annotated_by": annotated_by,
                     "confidence": col.confidence,
@@ -212,6 +206,57 @@ def persist_column_annotations(
     # (same run_id) updates the annotation in place instead of duplicating it —
     # which would make the head-resolved loaders' scalar_one_or_none() raise.
     upsert(session, AnnotationModel, rows, index_elements=["column_id", "run_id"])
+    return len(rows)
+
+
+def persist_column_concepts(
+    session: Session,
+    column_concepts: list[ColumnConceptOutput],
+    table_ids: list[str],
+    *,
+    annotated_by: str,
+    ontology_def: Any = None,
+    run_id: str,
+) -> int:
+    """Persist the table agent's catalogue-grain per-column semantics (DAT-637).
+
+    Writes ``ColumnConcept`` rows under the begin_session (catalogue head) run.
+    ``temporal_behavior`` is the ontology concept's stock/flow, derived from the
+    authored ``business_concept`` exactly as the legacy per-column path did — but
+    now at catalogue grain, where the concept is authoritative. Run-scoped upsert
+    on ``(column_id, run_id)``; a column the table agent did not bind this run has
+    no row (absent = no concept), and run-scoped reads never see a prior run's.
+
+    Returns:
+        Number of concept rows persisted.
+    """
+    column_map = load_column_mappings(session, table_ids)
+    concept_temporal = (
+        {c.name: c.temporal_behavior for c in ontology_def.concepts} if ontology_def else {}
+    )
+
+    rows: list[dict[str, Any]] = []
+    for cc in column_concepts:
+        column_id = column_map.get((cc.table_name, cc.column_name))
+        if not column_id:
+            continue
+        rows.append(
+            {
+                "column_id": column_id,
+                "run_id": run_id,
+                "business_concept": cc.business_concept,
+                "temporal_behavior": concept_temporal.get(cc.business_concept)
+                if cc.business_concept
+                else None,
+                "unit_source_column": cc.unit_source_column,
+                "derived_formula_hypothesis": (cc.derived_formula_hypothesis or "").strip() or None,
+                "derived_formula_confidence": cc.derived_formula_confidence,
+                "annotation_source": DecisionSource.LLM.value,
+                "annotated_by": annotated_by,
+            }
+        )
+
+    upsert(session, ConceptModel, rows, index_elements=["column_id", "run_id"])
     return len(rows)
 
 
@@ -247,7 +292,6 @@ def ground_columns(
         ``Result.fail`` with the same messages the phase surfaced before.
     """
     from dataraum.analysis.semantic.column_agent import ColumnAnnotationAgent
-    from dataraum.analysis.semantic.ontology import OntologyLoader
     from dataraum.graphs.config import get_metric_definitions
     from dataraum.graphs.loader import GraphLoader, GraphLoadError
 
@@ -285,7 +329,6 @@ def ground_columns(
     if not annotation_result.success or not annotation_result.value:
         return Result.fail(f"Column annotation failed: {annotation_result.error}")
 
-    ontology_def = OntologyLoader().load(ontology)
     model_name = provider.get_model_for_tier(col_config.model_tier)
 
     count = persist_column_annotations(
@@ -293,7 +336,6 @@ def ground_columns(
         annotation_result.value,
         table_ids,
         annotated_by=model_name,
-        ontology_def=ontology_def,
         run_id=run_id,
     )
     return Result.ok(count)
@@ -460,5 +502,22 @@ def synthesize_and_store_tables(
             "detection_method",
         ],
     )
+
+    # Catalogue-grain per-column semantics (DAT-637): the table agent is the sole
+    # author. Sealed under THIS (begin_session catalogue head) run. ``run_id`` is
+    # always stamped by the workflow before the phase; guard only for the
+    # type-checker / direct test callers.
+    if run_id is not None:
+        annotated_by = agent.provider.get_model_for_tier(
+            agent.config.features.semantic_analysis.model_tier
+        )
+        persist_column_concepts(
+            session,
+            enrichment.column_concepts,
+            table_ids,
+            annotated_by=annotated_by,
+            ontology_def=agent._ontology_loader.load(ontology),
+            run_id=run_id,
+        )
 
     return Result.ok(enrichment)

--- a/packages/engine/src/dataraum/analysis/semantic/utils.py
+++ b/packages/engine/src/dataraum/analysis/semantic/utils.py
@@ -5,8 +5,35 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from dataraum.analysis.semantic.db_models import SemanticAnnotation
+from dataraum.analysis.semantic.db_models import ColumnConcept, SemanticAnnotation
 from dataraum.storage import Column, Table
+
+
+def load_column_concepts(
+    session: Session,
+    table_ids: list[str],
+    catalogue_run_id: str,
+) -> dict[str, ColumnConcept]:
+    """Catalogue-grain per-column semantics for ``table_ids`` at the catalogue head run.
+
+    The ONLY reader of :class:`ColumnConcept` (DAT-637). ``catalogue_run_id`` is
+    **mandatory** — the catalogue-grain fields (business_concept, ontology
+    temporal_behavior, unit_source_column, derived_formula hypothesis) live only
+    under the begin_session catalogue head, so a caller MUST hold that run to read
+    them. Object-grain code (add_source ``detect``) has no catalogue run and so
+    cannot reach these by construction — the cross-grain read is unexpressible.
+
+    Returns ``{column_id: ColumnConcept}`` for the run; columns the table agent did
+    not bind are simply absent.
+    """
+    if not table_ids:
+        return {}
+    stmt = (
+        select(ColumnConcept)
+        .join(Column, ColumnConcept.column_id == Column.column_id)
+        .where(Column.table_id.in_(table_ids), ColumnConcept.run_id == catalogue_run_id)
+    )
+    return {cc.column_id: cc for cc in session.execute(stmt).scalars()}
 
 
 def load_table_mappings(
@@ -55,27 +82,29 @@ def load_persisted_annotations(
 ) -> list[dict[str, Any]]:
     """Load persisted per-column semantic annotations for the given tables.
 
-    The per-table synthesis phase (DAT-362) reads these as read-only context —
-    they are the post-teach column annotations produced + persisted by the
-    per-column phase. Returns one dict per annotated column with the fields the
-    per-table prompt needs to reason about table classification + relationships.
+    The per-table synthesis phase reads these as read-only context — the
+    OBJECT-grain column annotations the per-column agent produced (role, entity
+    label, term, the stock/flow claim). It does NOT include ``business_concept``:
+    that is catalogue-grain and AUTHORED by the table agent itself (DAT-637), so
+    feeding it back would be the dual-ownership we removed. Returns one dict per
+    annotated column, ordered by table then column.
 
     Args:
         session: Database session.
         table_ids: Table IDs whose columns' annotations to load.
 
     Returns:
-        List of ``{table_name, column_name, semantic_role, business_concept,
-        entity_type, confidence}`` dicts, ordered by table then column.
+        List of ``{table_name, column_name, semantic_role, entity_type,
+        confidence, temporal_behavior_claim}`` dicts, ordered by table then column.
     """
     stmt = (
         select(
             Table.table_name,
             Column.column_name,
             SemanticAnnotation.semantic_role,
-            SemanticAnnotation.business_concept,
             SemanticAnnotation.entity_type,
             SemanticAnnotation.confidence,
+            SemanticAnnotation.temporal_behavior_claim,
         )
         .join(Column, SemanticAnnotation.column_id == Column.column_id)
         .join(Table, Column.table_id == Table.table_id)
@@ -88,9 +117,9 @@ def load_persisted_annotations(
             "table_name": table_name,
             "column_name": column_name,
             "semantic_role": semantic_role,
-            "business_concept": business_concept,
             "entity_type": entity_type,
             "confidence": confidence,
+            "temporal_behavior_claim": temporal_behavior_claim,
         }
-        for table_name, column_name, semantic_role, business_concept, entity_type, confidence in rows
+        for table_name, column_name, semantic_role, entity_type, confidence, temporal_behavior_claim in rows
     ]

--- a/packages/engine/src/dataraum/analysis/validation/resolver.py
+++ b/packages/engine/src/dataraum/analysis/validation/resolver.py
@@ -18,7 +18,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
 from dataraum.analysis.relationships.utils import load_defined_relationships
-from dataraum.analysis.semantic.db_models import SemanticAnnotation
+from dataraum.analysis.semantic.db_models import ColumnConcept, SemanticAnnotation
+from dataraum.analysis.semantic.utils import load_column_concepts
 from dataraum.analysis.slicing.db_models import SliceDefinition
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.core.logging import get_logger
@@ -84,6 +85,12 @@ def get_multi_table_schema_for_llm(
         logger.warning("validation_schema_tables_missing", missing_table_ids=missing)
 
     annotations = _load_pinned_annotations(session, tables, base_runs.semantic_runs)
+    # Catalogue-grain concepts (DAT-637), pinned to the same begin_session run.
+    concepts = (
+        load_column_concepts(session, table_ids, base_runs.relationship_run_id)
+        if base_runs.relationship_run_id
+        else {}
+    )
 
     # Build table schemas
     table_schemas = []
@@ -124,7 +131,7 @@ def get_multi_table_schema_for_llm(
                     duckdb_path=table.duckdb_path,
                 )
 
-        schema = _format_table_schema(table, annotations, row_count=row_count)
+        schema = _format_table_schema(table, annotations, concepts, row_count=row_count)
         table_schemas.append(schema)
         table_id_to_name[table.table_id] = table.table_name
 
@@ -275,6 +282,7 @@ def _load_pinned_annotations(
 def _format_table_schema(
     table: Table,
     annotations: dict[str, SemanticAnnotation],
+    concepts: dict[str, ColumnConcept],
     *,
     row_count: int | None = None,
 ) -> dict[str, Any]:
@@ -282,7 +290,8 @@ def _format_table_schema(
 
     Args:
         table: Table ORM object with columns loaded
-        annotations: run-pinned semantic annotations keyed by column_id
+        annotations: run-pinned object-grain semantic annotations keyed by column_id
+        concepts: run-pinned catalogue-grain column concepts keyed by column_id
         row_count: Optional row count from DuckDB
 
     Returns:
@@ -296,14 +305,15 @@ def _format_table_schema(
         }
 
         ann = annotations.get(col.column_id)
-        if ann is not None:
+        concept = concepts.get(col.column_id)
+        if ann is not None or concept is not None:
             col_info["semantic"] = {
-                "role": ann.semantic_role,
-                "entity_type": ann.entity_type,
-                "business_name": ann.business_name,
-                "business_concept": ann.business_concept,
-                "temporal_behavior": ann.temporal_behavior,
-                "business_description": ann.business_description,
+                "role": ann.semantic_role if ann else None,
+                "entity_type": ann.entity_type if ann else None,
+                "business_name": ann.business_name if ann else None,
+                "business_description": ann.business_description if ann else None,
+                "business_concept": concept.business_concept if concept else None,
+                "temporal_behavior": concept.temporal_behavior if concept else None,
             }
 
         columns.append(col_info)

--- a/packages/engine/src/dataraum/core/models/base.py
+++ b/packages/engine/src/dataraum/core/models/base.py
@@ -68,7 +68,9 @@ class SemanticRole(StrEnum):
     MEASURE = "measure"  # Numeric value to aggregate
     DIMENSION = "dimension"  # Categorical grouping
     KEY = "key"  # Primary/business key
-    FOREIGN_KEY = "foreign_key"  # Reference to another table
+    # No FOREIGN_KEY (DAT-637): FK-ness needs the cross-table view the per-column
+    # agent lacks. It is owned by the confirmed ``Relationship`` catalogue, never a
+    # role the object-grain column agent guesses.
     ATTRIBUTE = "attribute"  # Descriptive non-key column
     TIMESTAMP = "timestamp"  # Time dimension
     UNKNOWN = "unknown"

--- a/packages/engine/src/dataraum/core/overlay.py
+++ b/packages/engine/src/dataraum/core/overlay.py
@@ -44,7 +44,7 @@ Registered teach types
   ``indicators`` so the next run's grounding LLM (which reads indicators via
   ``OntologyLoader.format_concepts_for_prompt``) pulls the column to that
   concept. Teach-as-witness, never an override: it steers the grounding
-  input; ``SemanticAnnotation.business_concept`` stays an LLM judgment.
+  input; ``ColumnConcept.business_concept`` (DAT-637) stays an LLM judgment.
   Applied after ``concept`` / ``concept_property`` so it patches the final
   concept state; last rebind per column wins (a later row MOVES the column).
 * ``validation`` — the logical collection ``verticals/<vertical>/validations``

--- a/packages/engine/src/dataraum/entropy/detectors/loaders.py
+++ b/packages/engine/src/dataraum/entropy/detectors/loaders.py
@@ -318,7 +318,7 @@ def load_semantic(
     annotation, read the run the orchestrator pinned for the column's table at
     ``semantic_per_column``; no pin → ``None`` as before.
     """
-    from dataraum.analysis.semantic.db_models import SemanticAnnotation
+    from dataraum.analysis.semantic.db_models import ColumnConcept, SemanticAnnotation
 
     sa_stmt = select(SemanticAnnotation).where(SemanticAnnotation.column_id == column_id)
     if run_id is not None:
@@ -340,28 +340,46 @@ def load_semantic(
     if not sa:
         return None
 
+    # OBJECT-grain fields from the per-column annotation (DAT-637).
     semantic_dict: dict[str, Any] = {
         "semantic_role": sa.semantic_role,
         "entity_type": sa.entity_type,
         "business_name": sa.business_name,
         "business_description": sa.business_description,
         "confidence": sa.confidence,
-        "business_concept": sa.business_concept,
     }
-    if sa.unit_source_column:
-        semantic_dict["unit_source_column"] = sa.unit_source_column
-    if sa.temporal_behavior:
-        semantic_dict["temporal_behavior"] = sa.temporal_behavior
-    # The LLM stock/flow witness (DAT-445), read alongside the ontology prior.
+    # The LLM stock/flow witness (DAT-445), an object-grain single-column read.
     if sa.temporal_behavior_claim:
         semantic_dict["temporal_behavior_claim"] = sa.temporal_behavior_claim
     if sa.temporal_behavior_claim_confidence is not None:
         semantic_dict["temporal_behavior_claim_confidence"] = sa.temporal_behavior_claim_confidence
-    # The LLM formula-hypothesis witness (derived_value second witness, ADR-0009).
-    if sa.derived_formula_hypothesis:
-        semantic_dict["derived_formula_hypothesis"] = sa.derived_formula_hypothesis
-    if sa.derived_formula_confidence is not None:
-        semantic_dict["derived_formula_confidence"] = sa.derived_formula_confidence
+
+    # CATALOGUE-grain fields from ColumnConcept (DAT-637): authored by the table
+    # agent under the begin_session run. At session_detect ``run_id`` IS that run,
+    # so they are present; at add_source detect no ColumnConcept exists under the
+    # add_source run, so the catalogue fields are simply absent — the grain
+    # boundary the architecture enforces, not a lookup miss to paper over.
+    cc = None
+    if run_id is not None:
+        cc = session.execute(
+            select(ColumnConcept).where(
+                ColumnConcept.column_id == column_id,
+                ColumnConcept.run_id == run_id,
+            )
+        ).scalar_one_or_none()
+    if cc is not None:
+        semantic_dict["business_concept"] = cc.business_concept
+        if cc.unit_source_column:
+            semantic_dict["unit_source_column"] = cc.unit_source_column
+        if cc.temporal_behavior:
+            semantic_dict["temporal_behavior"] = cc.temporal_behavior
+        # The LLM formula-hypothesis witness (derived_value second witness, ADR-0009).
+        if cc.derived_formula_hypothesis:
+            semantic_dict["derived_formula_hypothesis"] = cc.derived_formula_hypothesis
+        if cc.derived_formula_confidence is not None:
+            semantic_dict["derived_formula_confidence"] = cc.derived_formula_confidence
+    else:
+        semantic_dict["business_concept"] = None
     return semantic_dict
 
 

--- a/packages/engine/src/dataraum/entropy/detectors/semantic/dimensional_entropy.py
+++ b/packages/engine/src/dataraum/entropy/detectors/semantic/dimensional_entropy.py
@@ -183,6 +183,9 @@ class DimensionalEntropyDetector(EntropyDetector):
         name = (col.column_name or "").lower()
         if name == "id" or name.endswith("_id"):
             return True
+        # "foreign_key" retained for pre-DAT-637 annotation rows; new annotations
+        # cannot carry this role (removed from the column agent's enum — FK-ness is
+        # the Relationship catalogue's job now).
         if semantic.get("semantic_role") in {"key", "foreign_key"}:
             return True
         cardinality = stats_row.get("cardinality_ratio")

--- a/packages/engine/src/dataraum/entropy/measurements/temporal_behavior.py
+++ b/packages/engine/src/dataraum/entropy/measurements/temporal_behavior.py
@@ -167,7 +167,7 @@ def resolved_behaviour(result: PoolResult) -> tuple[str | None, bool]:
     when no witness took a position (total ignorance). ``contested`` is True when the
     pooled conflict is non-trivial: the resolved layer writes the label but flags it
     so a downstream SQL agent treats a contested stock with caution. Inverse of the
-    ontology vocabulary so the resolve write round-trips onto SemanticAnnotation.
+    ontology vocabulary so the resolve write round-trips onto ColumnConcept (DAT-637).
     """
     if not result.posterior:
         return None, False

--- a/packages/engine/src/dataraum/entropy/resolve.py
+++ b/packages/engine/src/dataraum/entropy/resolve.py
@@ -79,7 +79,11 @@ def resolve_temporal_behavior(session: Session, run_id: str | None) -> int:
     are left untouched, preserving the ontology backfill. Idempotent on retry (same
     run_id → same UPDATE). Returns the number of annotations updated.
     """
-    from dataraum.analysis.semantic.db_models import SemanticAnnotation
+    # temporal_behavior + contested are catalogue-grain (DAT-637): on ColumnConcept,
+    # authored by the table agent and resolved here at session_detect (the run that
+    # holds ColumnConcept). At add_source detect no ColumnConcept exists under the
+    # run, so the UPDATE matches nothing — a harmless no-op, the correct grain.
+    from dataraum.analysis.semantic.db_models import ColumnConcept
 
     records = session.execute(
         select(EntropyObjectRecord).where(
@@ -100,10 +104,10 @@ def resolve_temporal_behavior(session: Session, run_id: str | None) -> int:
         if resolved is None:
             continue  # total ignorance — leave the ontology backfill in place
         result: CursorResult[Any] = session.execute(  # type: ignore[assignment]
-            update(SemanticAnnotation)
+            update(ColumnConcept)
             .where(
-                SemanticAnnotation.column_id == record.column_id,
-                SemanticAnnotation.run_id == run_id,
+                ColumnConcept.column_id == record.column_id,
+                ColumnConcept.run_id == run_id,
             )
             .values(
                 temporal_behavior=resolved,

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -118,6 +118,7 @@ class ExecutionContext:
         slice_value: str | None = None,
         vertical: str | None = None,
         om_run_id: str | None = None,
+        catalogue_run_id: str | None = None,
         **kwargs: Any,
     ) -> ExecutionContext:
         """Create ExecutionContext with rich metadata loaded from analysis modules.
@@ -152,6 +153,7 @@ class ExecutionContext:
             slice_value=slice_value,
             vertical=vertical,
             om_run_id=om_run_id,
+            catalogue_run_id=catalogue_run_id,
         )
 
         return cls(

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -357,6 +357,7 @@ def build_execution_context(
     slice_value: str | None = None,
     vertical: str | None = None,
     om_run_id: str | None = None,
+    catalogue_run_id: str | None = None,
 ) -> GraphExecutionContext:
     """Build execution context from all analysis modules.
 
@@ -378,6 +379,11 @@ def build_execution_context(
         om_run_id: Explicit operating_model run for the cycle/validation/health
             reads (the in-run metrics phase passes its current run). Omitted ⇒ the
             promoted operating_model catalog head.
+        catalogue_run_id: The begin_session catalogue head run (DAT-637) — scopes
+            the catalogue-grain ``ColumnConcept`` reads (business_concept, ontology
+            temporal_behavior, unit source). The metrics phase passes
+            ``base_runs.relationship_run_id``. None ⇒ no concepts (object-grain
+            column metadata still loads).
 
     Returns:
         GraphExecutionContext with all relevant metadata
@@ -458,13 +464,23 @@ def build_execution_context(
             if _is_current(metrics):
                 stat_quality[metrics.column_id] = metrics
 
-    # 5. Load semantic annotations
+    # 5. Load semantic annotations — OBJECT-grain (role, entity label, term),
+    # scoped to each table's add_source generation head.
     semantic: dict[str, SemanticAnnotation] = {}
     if column_ids:
         sem_stmt = select(SemanticAnnotation).where(SemanticAnnotation.column_id.in_(column_ids))
         for ann in session.execute(sem_stmt).scalars():
             if _is_current(ann):
                 semantic[ann.column_id] = ann
+
+    # 5b. Load catalogue-grain concepts (DAT-637) from the begin_session catalogue
+    # head — a DIFFERENT run from the add_source column metadata above, so it is
+    # NOT scoped by ``_is_current`` (the generation head); it has its own run.
+    from dataraum.analysis.semantic.utils import load_column_concepts
+
+    concepts = (
+        load_column_concepts(session, table_ids, catalogue_run_id) if catalogue_run_id else {}
+    )
 
     # 6. Load temporal profiles
     temporal: dict[str, TemporalColumnProfile] = {}
@@ -772,8 +788,8 @@ def build_execution_context(
         except Exception as e:
             logger.warning("cycle_health_failed", error=str(e))
 
-    # 14. Load field mappings
-    field_mappings = load_semantic_mappings(session, table_ids)
+    # 14. Load field mappings (catalogue-grain concept → column, DAT-637)
+    field_mappings = load_semantic_mappings(session, table_ids, catalogue_run_id=catalogue_run_id)
 
     # 14b. Load the vertical's concept vocabulary (DAT-616). On long-format data the
     # discriminating measure (`amount`) carries no business_concept, so field_mappings
@@ -892,6 +908,7 @@ def build_execution_context(
             stat_prof = stat_profiles.get(col.column_id)
             quality = stat_quality.get(col.column_id)
             sem_ann = semantic.get(col.column_id)
+            concept = concepts.get(col.column_id)
             temp_profile = temporal.get(col.column_id)
             type_dec = type_decisions.get(col.column_id)
 
@@ -966,11 +983,11 @@ def build_execution_context(
                     data_type=type_dec.decided_type if type_dec else None,
                     semantic_role=sem_ann.semantic_role if sem_ann else None,
                     entity_type=sem_ann.entity_type if sem_ann else None,
-                    business_concept=sem_ann.business_concept if sem_ann else None,
-                    temporal_behavior=sem_ann.temporal_behavior if sem_ann else None,
+                    business_concept=concept.business_concept if concept else None,
+                    temporal_behavior=concept.temporal_behavior if concept else None,
                     business_name=sem_ann.business_name if sem_ann else None,
                     business_description=sem_ann.business_description if sem_ann else None,
-                    unit_source_column=sem_ann.unit_source_column if sem_ann else None,
+                    unit_source_column=concept.unit_source_column if concept else None,
                     null_ratio=null_ratio,
                     cardinality_ratio=cardinality_ratio,
                     outlier_ratio=outlier_ratio,

--- a/packages/engine/src/dataraum/graphs/field_mapping.py
+++ b/packages/engine/src/dataraum/graphs/field_mapping.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from dataraum.analysis.semantic.db_models import SemanticAnnotation
+from dataraum.analysis.semantic.db_models import ColumnConcept, SemanticAnnotation
 from dataraum.storage import Column, Table
 
 if TYPE_CHECKING:
@@ -71,71 +71,65 @@ def load_semantic_mappings(
     session: Session,
     table_ids: list[str],
     *,
-    semantic_runs: dict[str, str] | None = None,
+    catalogue_run_id: str | None = None,
 ) -> FieldMappings:
-    """Load business_concept → column mappings from semantic annotations.
+    """Load business_concept → column mappings from ``ColumnConcept`` (DAT-637).
 
-    Queries the semantic_annotations table for all columns in the specified
-    tables that have a business_concept set, and groups them by concept.
+    ``business_concept`` is catalogue-grain: authored by the table agent and
+    sealed under the begin_session catalogue head. ``catalogue_run_id`` scopes the
+    read to that single run (fail-closed: ``None`` ⇒ no mappings, never a cross-run
+    read). The object-grain role/entity_type garnish is outer-joined from
+    ``SemanticAnnotation`` — a descriptive hint on the candidate, not the
+    grounding decision (which is the concept binding itself).
 
     Args:
-        session: Database session
-        table_ids: Table IDs to load mappings for
-        semantic_runs: Optional ``table_id → begin_session run_id`` pin. When
-            given (the operating_model compose gate threads the run's pinned
-            base-run map), each table contributes ONLY annotations from its
-            pinned run — multi-run isolation, fail-closed: a table absent from
-            the pin contributes nothing, never an arbitrary run's annotations
-            (the ``SemanticAnnotation`` table is run-versioned with a
-            ``(column_id, run_id)`` UNIQUE, so N coexisting runs leave N rows
-            per column). When ``None``, all runs' annotations are read (the
-            legacy cross-run behavior, still used by the graph-context builder).
+        session: Database session.
+        table_ids: Table IDs to load mappings for.
+        catalogue_run_id: The begin_session catalogue head run the concepts live
+            under (``base_runs.relationship_run_id``).
 
     Returns:
-        FieldMappings with business_concept → column mappings
+        FieldMappings with business_concept → column mappings.
     """
-    if not table_ids:
-        return FieldMappings(table_ids=[])
+    if not table_ids or not catalogue_run_id:
+        return FieldMappings(table_ids=table_ids)
 
-    # Query semantic annotations with business_concept set
     stmt = (
-        select(SemanticAnnotation, Column, Table)
-        .join(Column, SemanticAnnotation.column_id == Column.column_id)
+        select(ColumnConcept, Column, Table, SemanticAnnotation)
+        .join(Column, ColumnConcept.column_id == Column.column_id)
         .join(Table, Column.table_id == Table.table_id)
+        .outerjoin(SemanticAnnotation, SemanticAnnotation.column_id == Column.column_id)
         .where(
             Table.table_id.in_(table_ids),
-            SemanticAnnotation.business_concept.isnot(None),
+            ColumnConcept.run_id == catalogue_run_id,
+            ColumnConcept.business_concept.isnot(None),
         )
+        # The SemanticAnnotation garnish (role/entity_type) can fan out across runs;
+        # order so the dedup below keeps a deterministic row, not a DB-arbitrary one.
+        .order_by(SemanticAnnotation.run_id.desc())
     )
 
-    result = session.execute(stmt)
-    rows = result.all()
-
     mappings: dict[str, list[ColumnCandidate]] = {}
+    seen: set[tuple[str, str]] = set()  # (concept, column_id) — outerjoin can fan out
 
-    for annotation, column, table in rows:
-        # Pin to the table's begin_session run when a pin is provided — drop any
-        # annotation from another run (fail-closed for an unpinned table).
-        if semantic_runs is not None and annotation.run_id != semantic_runs.get(table.table_id):
+    for concept_row, column, table, annotation in session.execute(stmt).all():
+        concept = concept_row.business_concept
+        if not concept or (concept, column.column_id) in seen:
             continue
-        concept = annotation.business_concept
-        if not concept:
-            continue
-
-        if concept not in mappings:
-            mappings[concept] = []
-
-        # Use full DuckDB table name with layer prefix
-        duckdb_table_name = f"{table.layer}_{table.table_name}"
-        candidate = ColumnCandidate(
-            column_id=column.column_id,
-            column_name=column.column_name,
-            table_name=duckdb_table_name,
-            confidence=annotation.confidence or 0.5,
-            semantic_role=annotation.semantic_role,
-            entity_type=annotation.entity_type,
+        seen.add((concept, column.column_id))
+        mappings.setdefault(concept, []).append(
+            ColumnCandidate(
+                column_id=column.column_id,
+                column_name=column.column_name,
+                table_name=f"{table.layer}_{table.table_name}",
+                # A concept binding is authoritative, not probabilistic — the table
+                # agent does not author a per-binding confidence, so this is the
+                # constant fallback by design (not a missing feature).
+                confidence=concept_row.confidence or 0.5,
+                semantic_role=annotation.semantic_role if annotation else None,
+                entity_type=annotation.entity_type if annotation else None,
+            )
         )
-        mappings[concept].append(candidate)
 
     return FieldMappings(mappings=mappings, table_ids=table_ids)
 

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -256,8 +256,18 @@ class MetricsPhase(BasePhase):
         # NEVER re-authors, so the same concept can no longer ground different ways
         # across siblings (the within-run divergence DAT-629 only half-fixed —
         # it cached successes but the per-metric path re-authored every miss).
+        # The catalogue head run carries the table agent's ColumnConcept rows
+        # (DAT-637) — the graph context reads concepts/field-mappings from it.
+        catalogue_run_id = base_runs.relationship_run_id
         bindings = _warm_shared_nodes(
-            graphs, ctx, agent, schema_mapping_id, table_ids, vertical, om_run_id=run_id
+            graphs,
+            ctx,
+            agent,
+            schema_mapping_id,
+            table_ids,
+            vertical,
+            om_run_id=run_id,
+            catalogue_run_id=catalogue_run_id,
         )
         _log.info(
             "metrics_authored",
@@ -278,6 +288,7 @@ class MetricsPhase(BasePhase):
                 vertical,
                 bindings,
                 om_run_id=run_id,
+                catalogue_run_id=catalogue_run_id,
             )
         else:
             exec_ctx = ExecutionContext.with_rich_context(
@@ -286,6 +297,7 @@ class MetricsPhase(BasePhase):
                 table_ids=table_ids,
                 schema_mapping_id=schema_mapping_id,
                 om_run_id=run_id,
+                catalogue_run_id=catalogue_run_id,
                 vertical=vertical,
             )
             results = _execute_metrics_serial(
@@ -400,6 +412,7 @@ def _warm_shared_nodes(
     vertical: str,
     *,
     om_run_id: str,
+    catalogue_run_id: str | None = None,
 ) -> dict[NodeKey, NodeDecision]:
     """The authoring pass: decide every unique cache-keyed node ONCE (DAT-636).
 
@@ -441,6 +454,7 @@ def _warm_shared_nodes(
             table_ids,
             vertical,
             om_run_id,
+            catalogue_run_id,
         )
     return _warm_generations_serial(
         generations,
@@ -452,6 +466,7 @@ def _warm_shared_nodes(
         table_ids,
         vertical,
         om_run_id,
+        catalogue_run_id,
     )
 
 
@@ -464,6 +479,7 @@ def _warm_generations_parallel(
     table_ids: list[str],
     vertical: str,
     om_run_id: str,
+    catalogue_run_id: str | None = None,
 ) -> dict[NodeKey, NodeDecision]:
     """Author generations concurrently within each wave, barrier between waves.
 
@@ -501,6 +517,7 @@ def _warm_generations_parallel(
                         table_ids,
                         vertical,
                         om_run_id,
+                        catalogue_run_id,
                     )
                 ] = key
             for future in as_completed(futures):
@@ -523,6 +540,7 @@ def _warm_isolated(
     table_ids: list[str],
     vertical: str,
     om_run_id: str,
+    catalogue_run_id: str | None = None,
 ) -> NodeDecision:
     """Author one node with an isolated session + cursor; return its decision."""
     from dataraum.graphs.agent import ExecutionContext
@@ -536,6 +554,7 @@ def _warm_isolated(
             table_ids=table_ids,
             schema_mapping_id=schema_mapping_id,
             om_run_id=om_run_id,
+            catalogue_run_id=catalogue_run_id,
             vertical=vertical,
         )
         result = agent.execute(session, mini, exec_ctx, workspace_id=schema_mapping_id)
@@ -557,6 +576,7 @@ def _warm_generations_serial(
     table_ids: list[str],
     vertical: str,
     om_run_id: str,
+    catalogue_run_id: str | None = None,
 ) -> dict[NodeKey, NodeDecision]:
     """Serial fallback: shared session + cursor, sequential dependency order."""
     from dataraum.graphs.agent import ExecutionContext
@@ -572,6 +592,7 @@ def _warm_generations_serial(
         table_ids=table_ids,
         schema_mapping_id=schema_mapping_id,
         om_run_id=om_run_id,
+        catalogue_run_id=catalogue_run_id,
         vertical=vertical,
     )
     bindings: dict[NodeKey, NodeDecision] = {}
@@ -633,6 +654,7 @@ def _execute_metrics_parallel(
     bindings: dict[NodeKey, NodeDecision],
     *,
     om_run_id: str,
+    catalogue_run_id: str | None = None,
 ) -> list[MetricResult]:
     """Concurrent path: per-call session + cursor via a ThreadPoolExecutor.
 
@@ -658,6 +680,7 @@ def _execute_metrics_parallel(
                 vertical,
                 bindings,
                 om_run_id,
+                catalogue_run_id,
             ): (graph_id, inspiration_id)
             for graph_id, graph, inspiration_id in prep
         }
@@ -682,6 +705,7 @@ def _execute_isolated(
     vertical: str,
     bindings: dict[NodeKey, NodeDecision],
     om_run_id: str,
+    catalogue_run_id: str | None = None,
 ) -> Result[GraphExecution]:
     """Assemble one metric from the bindings with an isolated session + cursor.
 
@@ -704,6 +728,7 @@ def _execute_isolated(
             table_ids=table_ids,
             schema_mapping_id=schema_mapping_id,
             om_run_id=om_run_id,
+            catalogue_run_id=catalogue_run_id,
             vertical=vertical,
         )
         return agent.assemble(session, graph, exec_ctx, bindings, workspace_id=schema_mapping_id)

--- a/packages/engine/src/dataraum/storage/read_views.py
+++ b/packages/engine/src/dataraum/storage/read_views.py
@@ -73,6 +73,11 @@ _TABLE_GRAIN: tuple[str, ...] = (
 _CATALOG_GRAIN: dict[str, str] = {
     "relationships": "catalog",
     "table_entities": "catalog",
+    # Catalogue-grain per-column semantics authored by the table agent (DAT-637):
+    # carries column_id, but sealed under the begin_session (catalog, "catalog")
+    # head like the other begin_session catalogue tables — NOT the per-table
+    # generation head the object-grain semantic_annotations resolve through.
+    "column_concepts": "catalog",
     "enriched_views": "catalog",
     "slice_definitions": "catalog",
     "dimension_hierarchies": "catalog",  # begin_session dimension_hierarchies (DAT-537)

--- a/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain_e2e.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session
 
 from dataraum.analysis.drivers.models import Measure
 from dataraum.analysis.drivers.processor import discover_drivers
-from dataraum.analysis.semantic.db_models import SemanticAnnotation, TableEntity
+from dataraum.analysis.semantic.db_models import ColumnConcept, SemanticAnnotation, TableEntity
 from dataraum.analysis.slicing.db_models import SliceDefinition
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.storage import Column, Table
@@ -78,10 +78,13 @@ def _seed_catalog(session: Session, dims: list[str] = CL_DIMS) -> str:
                 )
             )
         if name == "measure":
+            # Object-grain role on SemanticAnnotation; catalogue-grain
+            # temporal_behavior on ColumnConcept (DAT-637).
             session.add(
-                SemanticAnnotation(
-                    column_id=col.column_id, run_id=RUN, temporal_behavior="additive"
-                )
+                SemanticAnnotation(column_id=col.column_id, run_id=RUN, semantic_role="measure")
+            )
+            session.add(
+                ColumnConcept(column_id=col.column_id, run_id=RUN, temporal_behavior="additive")
             )
     session.add(
         EnrichedView(

--- a/packages/engine/tests/unit/analysis/drivers/test_persistence.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_persistence.py
@@ -17,8 +17,12 @@ from sqlalchemy.orm import Session
 
 from dataraum.analysis.drivers.db_models import DriverRankingArtifact
 from dataraum.analysis.drivers.models import DriverRanking, DriverSlice, SecondaryDriver
-from dataraum.analysis.drivers.persistence import persist_driver_rankings, ranking_to_row
-from dataraum.analysis.semantic.db_models import SemanticAnnotation, TableEntity
+from dataraum.analysis.drivers.persistence import (
+    _measure_columns,
+    persist_driver_rankings,
+    ranking_to_row,
+)
+from dataraum.analysis.semantic.db_models import ColumnConcept, SemanticAnnotation, TableEntity
 from dataraum.analysis.slicing.db_models import SliceDefinition
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.storage import Column, Table
@@ -84,13 +88,17 @@ def _seed(
             )
         else:  # the measure column
             measure_col_id = col.column_id
+            # Object-grain role on SemanticAnnotation; catalogue-grain
+            # temporal_behavior on ColumnConcept (DAT-637).
             session.add(
                 SemanticAnnotation(
                     column_id=col.column_id,
                     run_id=RUN,
                     semantic_role=measure_role,
-                    temporal_behavior=behavior,
                 )
+            )
+            session.add(
+                ColumnConcept(column_id=col.column_id, run_id=RUN, temporal_behavior=behavior)
             )
     session.add(
         EnrichedView(
@@ -258,3 +266,25 @@ def test_only_session_tables_are_enumerated(
     rows = real_session.execute(select(DriverRankingArtifact)).scalars().all()
     assert len(rows) == 1
     assert rows[0].measure_column_id == in_col
+
+
+def test_temporal_behavior_pinned_to_run_under_coexisting_concepts(
+    real_session: Session,
+) -> None:
+    """A stale ColumnConcept from another run MUST NOT bleed into this run's pick.
+
+    DAT-637 regression guard: ``temporal_behavior`` is catalogue-grain (ColumnConcept,
+    one row per run). A Temporal redelivery after a completed semantic_per_table leaves
+    >1 concept row per column; ``_measure_columns`` must pin to ``run_id`` or it picks an
+    arbitrary run's behaviour and persists a different ranking than the promoted head.
+    """
+    tid, measure_col = _seed(real_session, dims=CL_DIMS, behavior="additive")
+    # A coexisting concept from a DIFFERENT run, the OPPOSITE behaviour.
+    real_session.add(
+        ColumnConcept(column_id=measure_col, run_id="stale-run", temporal_behavior="point_in_time")
+    )
+    real_session.flush()
+
+    measures = _measure_columns(real_session, [tid], run_id=RUN)
+    behaviours = {col_id: beh for col_id, _tid, _name, beh in measures}
+    assert behaviours[measure_col] == "additive"  # THIS run's, not the stale row's

--- a/packages/engine/tests/unit/analysis/drivers/test_processor.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_processor.py
@@ -28,7 +28,7 @@ from dataraum.analysis.drivers.processor import (
     resolve_target_type,
 )
 from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
-from dataraum.analysis.semantic.db_models import SemanticAnnotation
+from dataraum.analysis.semantic.db_models import ColumnConcept
 from dataraum.analysis.slicing.db_models import SliceDefinition
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.storage import Column, Table
@@ -91,9 +91,7 @@ def _seed(
         )
     )
     session.add(
-        SemanticAnnotation(
-            column_id=col_id["measure"], run_id=RUN, temporal_behavior=temporal_behavior
-        )
+        ColumnConcept(column_id=col_id["measure"], run_id=RUN, temporal_behavior=temporal_behavior)
     )
     session.add(
         EnrichedView(

--- a/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
@@ -12,10 +12,12 @@ from sqlalchemy import select
 
 from dataraum.analysis.relationships.db_models import Relationship as RelationshipDB
 from dataraum.analysis.semantic.agent import SemanticAgent
+from dataraum.analysis.semantic.db_models import ColumnConcept as ColumnConceptDB
 from dataraum.analysis.semantic.db_models import SemanticAnnotation as AnnotationDB
 from dataraum.analysis.semantic.db_models import TableEntity
 from dataraum.analysis.semantic.models import (
     ColumnAnnotationOutput,
+    ColumnConceptOutput,
     ColumnSemanticOutput,
     EntityDetection,
     IdentityColumn,
@@ -26,6 +28,7 @@ from dataraum.analysis.semantic.models import (
 )
 from dataraum.analysis.semantic.processor import (
     persist_column_annotations,
+    persist_column_concepts,
     synthesize_and_store_tables,
 )
 from dataraum.core.models.base import RelationshipType, Result
@@ -51,19 +54,17 @@ def _table_with_columns(session, name: str, columns: list[str]) -> Table:
 
 
 def _col(name: str, role: str, **kw) -> ColumnSemanticOutput:
+    # Object-grain only (DAT-637): business_concept / unit_source_column /
+    # derived_formula moved to the table agent's ColumnConceptOutput.
     return ColumnSemanticOutput(
         column_name=name,
         semantic_role=role,
         entity_type=kw.get("entity_type", f"{name}_entity"),
         business_term=kw.get("business_term", name.title()),
-        business_concept=kw.get("business_concept"),
         description=kw.get("description", f"{name} column"),
         confidence=kw.get("confidence", 0.9),
-        unit_source_column=kw.get("unit_source_column"),
         temporal_behavior_claim=kw.get("temporal_behavior_claim", "unsure"),
         temporal_behavior_claim_confidence=kw.get("temporal_behavior_claim_confidence", 0.0),
-        derived_formula_hypothesis=kw.get("derived_formula_hypothesis"),
-        derived_formula_confidence=kw.get("derived_formula_confidence", 0.0),
     )
 
 
@@ -80,8 +81,8 @@ class TestPersistColumnAnnotations:
                 TableColumnAnnotation(
                     table_name="customers",
                     columns=[
-                        _col("customer_id", "key", business_concept="customer"),
-                        _col("revenue", "measure", unit_source_column="currency_code"),
+                        _col("customer_id", "key"),
+                        _col("revenue", "measure"),
                     ],
                 )
             ]
@@ -100,8 +101,10 @@ class TestPersistColumnAnnotations:
         assert count == 2
         assert len(rows) == 2
         by_role = {r.semantic_role: r for r in rows}
-        assert by_role["key"].business_concept == "customer"
-        assert by_role["measure"].unit_source_column == "currency_code"
+        # Object-grain fields only — catalogue-grain (business_concept, unit
+        # source) is the table agent's ColumnConcept, not this writer (DAT-637).
+        assert by_role["key"].business_name == "Customer_Id"
+        assert by_role["measure"].entity_type == "revenue_entity"
         assert all(r.annotation_source == "llm" and r.annotated_by == "test-model" for r in rows)
 
     def test_skips_columns_not_in_the_table(self, session) -> None:
@@ -124,45 +127,86 @@ class TestPersistColumnAnnotations:
         )
         assert count == 1
 
-    def test_persists_derived_formula_hypothesis(self, session) -> None:
-        """The formula-hypothesis witness lands on the annotation row (ADR-0009).
+
+class TestPersistColumnConcepts:
+    """The catalogue-grain authoring the table agent owns (DAT-637)."""
+
+    def test_persists_concept_unit_and_normalizes_formula(self, session) -> None:
+        """business_concept / unit source / derived-formula land on ColumnConcept.
 
         Whitespace-only hypotheses normalize to None so the detector's
         truthiness read ("no hypothesis → witness abstains") holds.
         """
         table = _table_with_columns(session, "orders", ["total", "discount"])
-        output = ColumnAnnotationOutput(
-            tables=[
-                TableColumnAnnotation(
-                    table_name="orders",
-                    columns=[
-                        _col(
-                            "total",
-                            "measure",
-                            derived_formula_hypothesis="subtotal + tax",
-                            derived_formula_confidence=0.85,
-                        ),
-                        _col("discount", "measure", derived_formula_hypothesis="   "),
-                    ],
-                )
-            ]
-        )
+        concepts = [
+            ColumnConceptOutput(
+                table_name="orders",
+                column_name="total",
+                business_concept="revenue",
+                unit_source_column="currency_code",
+                derived_formula_hypothesis="subtotal + tax",
+                derived_formula_confidence=0.85,
+            ),
+            ColumnConceptOutput(
+                table_name="orders",
+                column_name="discount",
+                derived_formula_hypothesis="   ",
+            ),
+        ]
 
-        persist_column_annotations(
+        count = persist_column_concepts(
             session,
-            output,
+            concepts,
             [table.table_id],
             annotated_by="m",
             run_id=baseline_run_id(),
         )
         session.flush()
 
-        rows = {r.column_id: r for r in session.execute(select(AnnotationDB)).scalars()}
+        assert count == 2
+        rows = {r.column_id: r for r in session.execute(select(ColumnConceptDB)).scalars()}
         cols = {c.column_name: c.column_id for c in session.execute(select(Column)).scalars()}
         total = rows[cols["total"]]
+        assert total.business_concept == "revenue"
+        assert total.unit_source_column == "currency_code"
         assert total.derived_formula_hypothesis == "subtotal + tax"
         assert total.derived_formula_confidence == 0.85
         assert rows[cols["discount"]].derived_formula_hypothesis is None
+
+
+class TestNearConstantFeed:
+    """The per-table feed flags near-constant columns (DAT-637 quality fix) so the
+    table agent refuses to bind a concept to a status flag."""
+
+    @staticmethod
+    def _profile(name: str, top: list[tuple[object, int]]):
+        from datetime import UTC, datetime
+
+        from dataraum.analysis.statistics.models import ColumnProfile, ValueCount
+        from dataraum.core.models.base import ColumnRef
+
+        total = sum(c for _v, c in top)
+        return ColumnProfile(
+            column_id=name,
+            column_ref=ColumnRef(table_name="t", column_name=name),
+            profiled_at=datetime.now(UTC),
+            total_count=total,
+            null_count=0,
+            distinct_count=len(top),
+            null_ratio=0.0,
+            cardinality_ratio=len(top) / total,
+            top_values=[ValueCount(value=v, count=c, percentage=100 * c / total) for v, c in top],
+        )
+
+    def test_dominant_value_flagged_balanced_column_not(self) -> None:
+        agent = SemanticAgent.__new__(SemanticAgent)
+        profiles = [
+            self._profile("flag", [(True, 99), (False, 1)]),  # 99% → near-constant
+            self._profile("region", [("a", 40), ("b", 35), ("c", 25)]),  # balanced
+        ]
+        cols = {c["column_name"]: c for c in agent._build_tables_json(profiles, {})[0]["columns"]}
+        assert cols["flag"].get("near_constant") is True
+        assert "near_constant" not in cols["region"]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/engine/tests/unit/entropy/test_loaders.py
+++ b/packages/engine/tests/unit/entropy/test_loaders.py
@@ -149,6 +149,9 @@ class TestLoadSemantic:
         assert "unit_source_column" not in result
 
     def test_includes_unit_source_column(self):
+        # unit_source_column is catalogue-grain (DAT-637): read from ColumnConcept
+        # at the run, not SemanticAnnotation — the loader needs a run_id and a
+        # second (ColumnConcept) query result.
         session = MagicMock()
         sa = MagicMock()
         sa.semantic_role = "measure"
@@ -156,12 +159,22 @@ class TestLoadSemantic:
         sa.business_name = "Amount"
         sa.business_description = ""
         sa.confidence = 0.7
-        sa.business_concept = None
-        sa.unit_source_column = "currency"
+        sa.temporal_behavior_claim = None
+        sa.temporal_behavior_claim_confidence = None
+        cc = MagicMock()
+        cc.business_concept = None
+        cc.unit_source_column = "currency"
+        cc.temporal_behavior = None
+        cc.derived_formula_hypothesis = None
+        cc.derived_formula_confidence = None
 
-        session.execute.return_value.scalars.return_value.first.return_value = sa
+        sa_result = MagicMock()
+        sa_result.scalar_one_or_none.return_value = sa
+        cc_result = MagicMock()
+        cc_result.scalar_one_or_none.return_value = cc
+        session.execute.side_effect = [sa_result, cc_result]
 
-        result = load_semantic(session, "col1")
+        result = load_semantic(session, "col1", run_id="r1")
         assert result is not None
         assert result["unit_source_column"] == "currency"
 

--- a/packages/engine/tests/unit/entropy/test_resolve_temporal_behavior.py
+++ b/packages/engine/tests/unit/entropy/test_resolve_temporal_behavior.py
@@ -18,7 +18,7 @@ from sqlalchemy import create_engine, event, select
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from dataraum.analysis.semantic.db_models import SemanticAnnotation
+from dataraum.analysis.semantic.db_models import ColumnConcept
 from dataraum.entropy.db_models import EntropyObjectRecord
 from dataraum.entropy.resolve import resolve_temporal_behavior
 from dataraum.storage import init_database
@@ -58,13 +58,11 @@ def _seed_annotation(
     *,
     ontology_behaviour: str = "point_in_time",
 ) -> None:
-    """The annotation semantic_per_column wrote, carrying the ONTOLOGY prior."""
+    """The ColumnConcept the table agent wrote, carrying the ONTOLOGY prior (DAT-637)."""
     session.add(
-        SemanticAnnotation(
-            annotation_id=str(uuid4()),
+        ColumnConcept(
             column_id=column_id,
             run_id=run_id,
-            semantic_role="measure",
             temporal_behavior=ontology_behaviour,
         )
     )
@@ -97,11 +95,11 @@ def _seed_object(
     session.flush()
 
 
-def _read(session: Session, column_id: str, run_id: str = _RUN) -> SemanticAnnotation:
+def _read(session: Session, column_id: str, run_id: str = _RUN) -> ColumnConcept:
     return session.execute(
-        select(SemanticAnnotation).where(
-            SemanticAnnotation.column_id == column_id,
-            SemanticAnnotation.run_id == run_id,
+        select(ColumnConcept).where(
+            ColumnConcept.column_id == column_id,
+            ColumnConcept.run_id == run_id,
         )
     ).scalar_one()
 

--- a/packages/engine/tests/unit/graphs/test_context_builder.py
+++ b/packages/engine/tests/unit/graphs/test_context_builder.py
@@ -85,10 +85,12 @@ class TestBuilderExtractsSemanticFields:
     """Verify builder reads business_name, business_description, unit_source_column."""
 
     def test_business_name_from_semantic_annotation(self, session: Session) -> None:
-        from dataraum.analysis.semantic.db_models import SemanticAnnotation
+        from dataraum.analysis.semantic.db_models import ColumnConcept, SemanticAnnotation
 
         source_id, table_id, column_id = _insert_source_table_column(session)
 
+        # Object-grain (business_name/description) on SemanticAnnotation; the
+        # catalogue-grain unit source on ColumnConcept at the catalogue run (DAT-637).
         session.add(
             SemanticAnnotation(
                 annotation_id=_id(),
@@ -96,13 +98,15 @@ class TestBuilderExtractsSemanticFields:
                 semantic_role="measure",
                 business_name="Invoice Amount",
                 business_description="Total value before tax in local currency",
-                unit_source_column="currency_code",
                 confidence=0.9,
             )
         )
+        session.add(
+            ColumnConcept(column_id=column_id, run_id="cat-run", unit_source_column="currency_code")
+        )
         session.flush()
 
-        ctx = build_execution_context(session, [table_id])
+        ctx = build_execution_context(session, [table_id], catalogue_run_id="cat-run")
 
         col = ctx.tables[0].columns[0]
         assert col.business_name == "Invoice Amount"


### PR DESCRIPTION
## What & why
The per-column semantic agent runs **one table at a time**, but was authoring attributes that need the **composed catalogue** (cross-cutting ontology concepts, confirmed relationships, joined enriched views). That grain mismatch is the field-mapping trap (concepts bound to near-constant flags). Fix: a clean **ownership move** — one owner per attribute, **no copy-forward**.

## The move
Deleted from object-grain `SemanticAnnotation` → re-homed on new catalogue-grain **`ColumnConcept`** (authored only by the table agent, sealed under the begin_session **catalogue head**):
- `business_concept`, `temporal_behavior` (+`contested`), `unit_source_column`, `derived_formula_hypothesis` (+confidence)
- `foreign_key` removed from `SemanticRole` (FK-ness is the `Relationship` catalogue's job)

Deleting the fields turned the tree red and **the compiler/tests enumerated every reader** — each repointed with correct run-scoping (catalogue-grain via `base_runs.relationship_run_id`; object-grain stays on the add_source generation head). The sole accessor `load_column_concepts` **requires** the catalogue run, so object-grain code structurally cannot read catalogue semantics.

## Quality fix (the trap)
Table agent authors `column_concepts` with a **near-constant refusal** (explicit `near_constant` feed flag + prompt rule) and **null-when-no-discriminator**. Also tightened the extract prompt: every `IN(...)` literal must be **verbatim from the served value-set** — no padding with un-served conventional names; abstain when none match (closes a silent-empty failure mode seen in the smoke).

## Cross-package
`ColumnConcept` registered on the ADR-0008 read surface; `schema.sql` + `schema_read.sql` + cockpit drizzle mirror regenerated; cockpit consumers (`query-context`, `operating-model-load`, `look-table`, `look-profile`) repointed to `currentColumnConcepts`.

## Verification
- Engine: **mypy 0 · ruff clean · 1721 unit tests**
- Cockpit: **tsc 0 · biome clean · 1401 tests**
- Reviewers: spec-compliance **COMPLIANT** · senior **APPROVE** (required fix + tests landed)
- **Live cascade smoke** (begin_session → operating_model on a real GL dataset): `column_concepts` authored (cross-table `account` bindings), concepts ground on **real joined account-class discriminators** (`account_id__name`, `account_id__account_type='expense'`), **48/48 metrics ground**.

> Follow-up (not in this PR): the extract-prompt tightening above will be smoked on the next grounding run; eval re-runs BookSQL calibration for the `sale`/`ap_paid` trap (this GL dataset has no near-constant flag columns) — see `.claude/handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)