### PR TITLE
DAT-277: composite-key rescue of many-to-many fan-out edges (LLM-confirmed)

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,60 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-277 — composite-key rescue of many-to-many fan-out edges (LLM-confirmed)
+
+**Branch:** `refactor/dat-277-composite-key-rescue`.
+
+### What changed (detector + enriched-view shape)
+A fan-trap edge (best single-column join is **many-to-many** → over-counts in
+enriched views) can now be **rescued** by a composite key — the real FK plus a
+shared scoping column (e.g. a tenant `business_id` present on both tables). The
+rescue is a **greedy statistical pre-pass** (parallel to Jaccard) that SURFACES a
+composite candidate; **the LLM (semantic_per_table agent) is the sole judge** and
+confirms it via the new `RelationshipOutput.key_columns`. Nothing is auto-created
+from statistics.
+
+- **New relationship shape:** a confirmed composite is persisted as a **group** of
+  N `relationships` rows sharing `relationship_group_id`, the anchor at
+  `key_position` 0, all carrying the COMPOSITE cardinality (the collapsed value).
+  Two new columns: `relationships.relationship_group_id`, `key_position`. A plain
+  single-column relationship leaves both NULL.
+- **Consumer gate:** `load_defined_relationships` EXCLUDES grouped rows by default
+  (`include_composite_groups=False`) — single-column consumers never fan out on a
+  half-key. Only `enriched_views` opts in and assembles the multi-column join.
+- **Enriched views:** `DimensionJoin.key_pairs` + a multi-column ON clause; a
+  composite join scopes on the full key and stays grain-preserving. Grain
+  verification remains the backstop (a bad join is still dropped).
+- **Fix folded in:** the candidate-dict overlap score is keyed `confidence` (not
+  `join_confidence`); the per-table agent's candidate block previously rendered
+  `overlap=0.00` for every pair — now shows real scores. This changes the LLM
+  input to `semantic_per_table` (relationship confirmation may shift slightly).
+
+### Engine routes / phases affected
+- `analysis/relationships/{evaluator,composite,models,db_models,utils}.py`
+- `analysis/semantic/{processor,agent,models}.py` + `semantic_per_table` prompt
+- `analysis/views/builder.py`, `pipeline/phases/enriched_views_phase.py`
+
+### Calibration to run
+- **Relationship detection / FK confirmation** — verify recall didn't regress now
+  that the agent sees real overlap scores (was 0.00) and a composite hint. The
+  fan-trap cases (DAT-642: drivers empty because real discriminators sit behind an
+  m2m/composite fan-out) are the target win.
+- **Enriched-view grain + downstream metrics** — a previously-fan-trapped fact↔dim
+  pair (e.g. txn↔chart-of-accounts on `account` alone) should now enrich
+  grain-preserving via the composite key; metric grounding behind that dimension
+  should improve. Watch for any view newly built (and grain-verified) where none
+  existed before.
+
+### testdata hints
+The canonical shape: a fact table whose FK recurs across a tenant/scope partition
+(same `account` name under several `business_id`s) joined to a dimension keyed on
+`(account, business_id)`. Single-column join fans out; the composite holds grain.
+A genuine many-to-many (bridge/junction table) is the negative — it must abstain
+(no rescue, flagged fan-trap), never be forced into a composite.
+
+---
+
 ## DAT-641 — concurrent-typing DuckLake commit conflict is now Temporal-retryable
 
 **Branch:** `worktree-dat-641`.

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -317,6 +317,8 @@ export const currentRelationships = metadataSchema
 		toColumnId: varchar("to_column_id"),
 		relationshipType: varchar("relationship_type"),
 		cardinality: varchar(),
+		relationshipGroupId: varchar("relationship_group_id"),
+		keyPosition: integer("key_position"),
 		confidence: doublePrecision(),
 		detectionMethod: varchar("detection_method"),
 		evidence: json(),
@@ -326,7 +328,7 @@ export const currentRelationships = metadataSchema
 		detectedAt: timestamp("detected_at"),
 	})
 	.as(
-		sql`SELECT relationship_id, run_id, from_table_id, from_column_id, to_table_id, to_column_id, relationship_type, cardinality, confidence, detection_method, evidence, is_confirmed, confirmed_at, confirmed_by, detected_at FROM ws_00000000_0000_0000_0000_000000000001.relationships r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
+		sql`SELECT relationship_id, run_id, from_table_id, from_column_id, to_table_id, to_column_id, relationship_type, cardinality, relationship_group_id, key_position, confidence, detection_method, evidence, is_confirmed, confirmed_at, confirmed_by, detected_at FROM ws_00000000_0000_0000_0000_000000000001.relationships r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
 	);
 
 export const currentSemanticAnnotations = metadataSchema

--- a/packages/dataraum-config/llm/prompts/semantic_per_table.yaml
+++ b/packages/dataraum-config/llm/prompts/semantic_per_table.yaml
@@ -98,6 +98,18 @@ system_prompt: |
   Not all candidates are real relationships. You may also add relationships
   not present in the candidate list.
 
+  Composite keys (COMPOSITE-KEY RESCUE hint): a candidate may be marked as a
+  fan-out — its best single-column join is many-to-many and silently over-counts
+  — with a measured multi-column key that collapses it to many-to-one/one-to-one.
+  This is the classic shared-scope key: a real FK plus a tenant/partition column
+  present in both tables (e.g. (account, business_id) where account alone recurs
+  across businesses). When the hint is present AND the composite is the genuine
+  key, confirm it: emit ONE relationship for the anchor pair (from_column,
+  to_column) and list the REMAINING component pair(s) in its key_columns. Leave
+  key_columns empty for an ordinary single-column relationship. Only use it when
+  the data shows the composite RESOLVES the fan-out — never to staple together
+  unrelated columns.
+
   Note: Do NOT determine cardinality (one-to-one, many-to-one, etc.) — this is
   computed automatically from actual data after your analysis. Focus on whether
   the relationship is semantically real.

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -506,6 +506,8 @@ CREATE TABLE relationships (
 	to_column_id VARCHAR NOT NULL, 
 	relationship_type VARCHAR NOT NULL, 
 	cardinality VARCHAR, 
+	relationship_group_id VARCHAR, 
+	key_position INTEGER, 
 	confidence FLOAT NOT NULL, 
 	detection_method VARCHAR, 
 	evidence JSON, 
@@ -532,6 +534,8 @@ CREATE INDEX idx_relationships_to ON relationships (to_table_id);
 CREATE INDEX idx_relationships_to_column ON relationships (to_column_id);
 
 CREATE INDEX idx_relationships_to_table_column ON relationships (to_table_id, to_column_id);
+
+CREATE INDEX ix_relationships_relationship_group_id ON relationships (relationship_group_id);
 
 CREATE INDEX ix_relationships_run_id ON relationships (run_id);
 

--- a/packages/engine/src/dataraum/analysis/relationships/composite.py
+++ b/packages/engine/src/dataraum/analysis/relationships/composite.py
@@ -1,0 +1,136 @@
+"""Composite-key rescue of many-to-many fan-out edges (DAT-277).
+
+The structural detector finds every value-overlapping column pair between two
+tables as a separate ``JoinCandidate``. When the best (highest-confidence) pair is
+**many-to-many**, joining on it alone fans out and silently over-counts
+aggregates. The true key is often composite — a real FK plus a shared scoping
+column (e.g. a tenant key present in both tables). This module greedily fuses the
+co-present candidate columns until the composite join collapses out of
+many-to-many, or reports failure (a genuine many-to-many / bridge situation the
+caller must flag and abstain on).
+
+DATA decides, not names: a composite is accepted ONLY when the cardinality
+actually collapses. A greedy miss returns ``None`` (abstain) — never a forced
+join — so the worst case is a missed rescue, never a silent over-count.
+"""
+
+from __future__ import annotations
+
+import duckdb
+
+from dataraum.analysis.relationships.evaluator import compute_composite_cardinality
+from dataraum.analysis.relationships.models import CompositeKey, RelationshipCandidate
+from dataraum.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+_MANY_TO_MANY = "many-to-many"
+
+
+def rescue_fanout_to_composite(
+    candidate: RelationshipCandidate,
+    table1_path: str,
+    table2_path: str,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    *,
+    max_key_columns: int = 4,
+) -> CompositeKey | None:
+    """Greedily fuse co-present join columns to collapse a many-to-many fan-out.
+
+    Anchors on the highest-confidence ``JoinCandidate`` (the real FK we want to keep
+    scopable). If that pair alone is already not many-to-many there is nothing to
+    rescue. Otherwise, repeatedly add the remaining co-present pair that most
+    reduces the join's row multiplication, re-checking the composite cardinality
+    after each add, until the join is no longer many-to-many (rescued) or the
+    candidates / ``max_key_columns`` cap are exhausted (genuine many-to-many).
+
+    Args:
+        candidate: the table-pair candidate carrying all value-overlap join pairs.
+        table1_path: DuckDB path to ``candidate.table1``.
+        table2_path: DuckDB path to ``candidate.table2``.
+        duckdb_conn: DuckDB connection.
+        max_key_columns: cap on composite width (keeps the greedy search bounded).
+
+    Returns:
+        The rescuing :class:`CompositeKey` (cardinality never many-to-many), or
+        ``None`` when nothing needs rescuing or no composite collapses the fan-out.
+    """
+    if len(candidate.join_candidates) < 2:
+        return None  # need at least one scoping column to fuse with the anchor
+
+    ordered = sorted(candidate.join_candidates, key=lambda j: j.join_confidence, reverse=True)
+    anchor = ordered[0]
+    chosen: list[tuple[str, str]] = [(anchor.column1, anchor.column2)]
+    remaining: list[tuple[str, str]] = [(j.column1, j.column2) for j in ordered[1:]]
+
+    card = compute_composite_cardinality(table1_path, table2_path, chosen, duckdb_conn)
+    if card is None or card != _MANY_TO_MANY:
+        return None  # the anchor alone is not a fan-out — nothing to rescue
+
+    while remaining and len(chosen) < max_key_columns:
+        # Add the co-present pair that most reduces the join's row multiplication —
+        # the most-disambiguating scoping column.
+        best_next = min(
+            remaining,
+            key=lambda p: _join_multiplication(table1_path, table2_path, [*chosen, p], duckdb_conn),
+        )
+        chosen.append(best_next)
+        remaining.remove(best_next)
+
+        card = compute_composite_cardinality(table1_path, table2_path, chosen, duckdb_conn)
+        if card is not None and card != _MANY_TO_MANY:
+            logger.info(
+                "composite_key_rescued",
+                table1=candidate.table1,
+                table2=candidate.table2,
+                key_columns=len(chosen),
+                cardinality=card,
+            )
+            return CompositeKey(column_pairs=chosen, cardinality=card)
+
+    return None  # genuine many-to-many — no composite of these columns collapses it
+
+
+def _join_multiplication(
+    table1_path: str,
+    table2_path: str,
+    column_pairs: list[tuple[str, str]],
+    duckdb_conn: duckdb.DuckDBPyConnection,
+) -> float:
+    """Worst-direction match multiplicity for a composite join (1 = unique both ways).
+
+    The largest number of matches a single key-tuple draws, taken over both join
+    directions. Lower means closer to a clean one-to-one — the ranking signal for
+    "which scoping column disambiguates most". Returns ``inf`` on error so a
+    failing candidate is never preferred.
+    """
+    on_clause = " AND ".join(f't1."{a}" = t2."{b}"' for a, b in column_pairs)
+    t1_cols = [a for a, _b in column_pairs]
+    t2_cols = [b for _a, b in column_pairs]
+    t1_not_null = " AND ".join(f'"{a}" IS NOT NULL' for a in t1_cols)
+    t2_not_null = " AND ".join(f'"{b}" IS NOT NULL' for b in t2_cols)
+    t1_group = ", ".join(f't1."{a}"' for a in t1_cols)
+    t2_group = ", ".join(f't2."{b}"' for b in t2_cols)
+    t1_distinct = ", ".join(f'"{a}"' for a in t1_cols)
+    t2_distinct = ", ".join(f'"{b}"' for b in t2_cols)
+
+    try:
+        q = f"""
+            SELECT GREATEST(
+                (SELECT COALESCE(MAX(c), 0) FROM (
+                    SELECT COUNT(*) c
+                    FROM (SELECT DISTINCT {t1_distinct} FROM {table1_path} WHERE {t1_not_null}) t1
+                    INNER JOIN {table2_path} t2 ON {on_clause}
+                    GROUP BY {t1_group})),
+                (SELECT COALESCE(MAX(c), 0) FROM (
+                    SELECT COUNT(*) c
+                    FROM (SELECT DISTINCT {t2_distinct} FROM {table2_path} WHERE {t2_not_null}) t2
+                    INNER JOIN {table1_path} t1 ON {on_clause}
+                    GROUP BY {t2_group}))
+            )
+        """
+        result = duckdb_conn.execute(q).fetchone()
+        return float(result[0]) if result and result[0] is not None else float("inf")
+    except Exception as e:
+        logger.warning("join_multiplication_failed", column_pairs=column_pairs, error=str(e))
+        return float("inf")

--- a/packages/engine/src/dataraum/analysis/relationships/db_models.py
+++ b/packages/engine/src/dataraum/analysis/relationships/db_models.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     Index,
+    Integer,
     String,
     UniqueConstraint,
 )
@@ -84,6 +85,15 @@ class Relationship(Base):
     cardinality: Mapped[str | None] = mapped_column(
         String
     )  # 'one-to-one', 'one-to-many', 'many-to-one', 'many-to-many'
+
+    # Composite key (DAT-277): a multi-column FK is N rows sharing one
+    # ``relationship_group_id``, each carrying one component (from_column_id,
+    # to_column_id) pair at its ``key_position`` (0-based). All rows of a group
+    # share the COMPOSITE ``cardinality`` (the fan-out-resolved value). A plain
+    # single-column relationship leaves both NULL. Born from the composite-key
+    # rescue (a fan-trap edge whose true key is composite) and LLM-confirmed.
+    relationship_group_id: Mapped[str | None] = mapped_column(String, index=True)
+    key_position: Mapped[int | None] = mapped_column(Integer)
 
     # Confidence and evidence
     confidence: Mapped[float] = mapped_column(Float, nullable=False)

--- a/packages/engine/src/dataraum/analysis/relationships/evaluator.py
+++ b/packages/engine/src/dataraum/analysis/relationships/evaluator.py
@@ -115,40 +115,82 @@ def compute_actual_cardinality(
     col2: str,
     duckdb_conn: duckdb.DuckDBPyConnection,
 ) -> str | None:
-    """Compute actual join cardinality from data.
+    """Compute actual single-column join cardinality from data.
 
-    Checks join multiplicity in both directions:
-    - For each distinct col1 value in t1, how many t2 rows match?
-    - For each distinct col2 value in t2, how many t1 rows match?
+    Thin wrapper over :func:`compute_composite_cardinality` for the single-pair
+    case (``t1.col1 = t2.col2``).
 
     Returns:
         Cardinality string ("one-to-one", "one-to-many", "many-to-one",
         "many-to-many") or None if inconclusive.
     """
+    return compute_composite_cardinality(table1_path, table2_path, [(col1, col2)], duckdb_conn)
+
+
+def compute_composite_cardinality(
+    table1_path: str,
+    table2_path: str,
+    column_pairs: list[tuple[str, str]],
+    duckdb_conn: duckdb.DuckDBPyConnection,
+) -> str | None:
+    """Compute join cardinality for a (possibly multi-column) key, from data.
+
+    Generalizes :func:`compute_actual_cardinality` to a COMPOSITE key: the join
+    matches on every ``(t1_col, t2_col)`` pair (``t1.a = t2.b AND t1.c = t2.d``),
+    and the key on each side is the column TUPLE. This is the math that lets a
+    single-column many-to-many fan-out be *rescued* — adding a scoping column to
+    the key can collapse it to many-to-one (DAT-277).
+
+    Checks multiplicity in both directions:
+    - For each distinct t1 key-tuple, how many t2 rows match?
+    - For each distinct t2 key-tuple, how many t1 rows match?
+
+    Args:
+        table1_path: DuckDB path to the first table.
+        table2_path: DuckDB path to the second table.
+        column_pairs: ordered ``(table1_column, table2_column)`` key components.
+            A single pair reproduces ``compute_actual_cardinality``.
+        duckdb_conn: DuckDB connection.
+
+    Returns:
+        Cardinality string ("one-to-one", "one-to-many", "many-to-one",
+        "many-to-many") or None if inconclusive / empty key.
+    """
+    if not column_pairs:
+        return None
+
+    t1_cols = [a for a, _b in column_pairs]
+    t2_cols = [b for _a, b in column_pairs]
+    on_clause = " AND ".join(f't1."{a}" = t2."{b}"' for a, b in column_pairs)
+    t1_not_null = " AND ".join(f'"{a}" IS NOT NULL' for a in t1_cols)
+    t2_not_null = " AND ".join(f'"{b}" IS NOT NULL' for b in t2_cols)
+    t1_distinct = ", ".join(f'"{a}"' for a in t1_cols)
+    t2_distinct = ", ".join(f'"{b}"' for b in t2_cols)
+    t1_group = ", ".join(f't1."{a}"' for a in t1_cols)
+    t2_group = ", ".join(f't2."{b}"' for b in t2_cols)
+
     try:
-        # For each distinct col1 value in t1, how many t2 rows match?
-        # If max <= 1, each t1 value maps to at most one t2 row.
+        # For each distinct t1 key-tuple, how many t2 rows match? max <= 1 → unique.
         t1_to_t2_query = f"""
             SELECT MAX(match_count) <= 1
             FROM (
-                SELECT t1."{col1}", COUNT(*) as match_count
-                FROM (SELECT DISTINCT "{col1}" FROM {table1_path} WHERE "{col1}" IS NOT NULL) t1
-                INNER JOIN {table2_path} t2 ON t1."{col1}" = t2."{col2}"
-                GROUP BY t1."{col1}"
+                SELECT COUNT(*) as match_count
+                FROM (SELECT DISTINCT {t1_distinct} FROM {table1_path} WHERE {t1_not_null}) t1
+                INNER JOIN {table2_path} t2 ON {on_clause}
+                GROUP BY {t1_group}
             )
         """
         result1 = duckdb_conn.execute(t1_to_t2_query).fetchone()
         each_t1_has_one_t2 = bool(result1[0]) if result1 and result1[0] is not None else None
 
-        # For each distinct col2 value in t2, how many t1 rows match?
-        # If max <= 1, each t2 value maps to at most one t1 row.
+        # For each distinct t2 key-tuple, how many t1 rows match? max <= 1 → unique.
         t2_to_t1_query = f"""
             SELECT MAX(match_count) <= 1
             FROM (
-                SELECT t2."{col2}", COUNT(*) as match_count
-                FROM (SELECT DISTINCT "{col2}" FROM {table2_path} WHERE "{col2}" IS NOT NULL) t2
-                INNER JOIN {table1_path} t1 ON t2."{col2}" = t1."{col1}"
-                GROUP BY t2."{col2}"
+                SELECT COUNT(*) as match_count
+                FROM (SELECT DISTINCT {t2_distinct} FROM {table2_path} WHERE {t2_not_null}) t2
+                INNER JOIN {table1_path} t1 ON {on_clause}
+                GROUP BY {t2_group}
             )
         """
         result2 = duckdb_conn.execute(t2_to_t1_query).fetchone()
@@ -171,8 +213,7 @@ def compute_actual_cardinality(
     except Exception as e:
         logger.warning(
             "cardinality_computation_failed",
-            col1=col1,
-            col2=col2,
+            column_pairs=column_pairs,
             error=str(e),
         )
         return None

--- a/packages/engine/src/dataraum/analysis/relationships/models.py
+++ b/packages/engine/src/dataraum/analysis/relationships/models.py
@@ -71,6 +71,26 @@ class RelationshipCandidate(BaseModel):
     introduces_duplicates: bool | None = None
 
 
+class CompositeKey(BaseModel):
+    """A multi-column key that rescues a single-column many-to-many fan-out (DAT-277).
+
+    The structural detector finds every value-overlapping column pair between two
+    tables separately; when the best pair is many-to-many (the silent over-count),
+    its true key is often composite — a real FK plus a shared scoping column (a
+    tenant/partition key). Binding them as ONE key collapses the fan-out.
+
+    Attributes:
+        column_pairs: ordered ``(table1_column, table2_column)`` components; the
+            first is the anchor (highest-confidence) join, the rest are the scoping
+            columns added to collapse the fan-out.
+        cardinality: the composite join's cardinality — never ``"many-to-many"``
+            (a non-m2m result IS the rescue-success condition).
+    """
+
+    column_pairs: list[tuple[str, str]]
+    cardinality: str
+
+
 class RelationshipDetectionResult(BaseModel):
     """Result of relationship detection."""
 

--- a/packages/engine/src/dataraum/analysis/relationships/utils.py
+++ b/packages/engine/src/dataraum/analysis/relationships/utils.py
@@ -20,6 +20,7 @@ def load_defined_relationships(
     both_tables: bool = True,
     eager_columns: bool = False,
     min_confidence: float | None = None,
+    include_composite_groups: bool = False,
 ) -> list[Relationship]:
     """The session's **defined** relationships for ``table_ids`` (DAT-408).
 
@@ -36,8 +37,15 @@ def load_defined_relationships(
       joins) vs either endpoint.
     - ``eager_columns``: eager-load from/to columns + their tables.
     - ``min_confidence``: optional confidence floor.
+    - ``include_composite_groups``: composite-key components (DAT-277) are stored
+      as grouped rows (``relationship_group_id IS NOT NULL``) carrying ONLY ONE
+      pair each. A consumer that joins on a single column would silently fan out
+      on them, so they are excluded by default; only the multi-column enrichment
+      path (which assembles the whole key) opts in.
     """
     stmt = select(Relationship).where(Relationship.detection_method != "candidate")
+    if not include_composite_groups:
+        stmt = stmt.where(Relationship.relationship_group_id.is_(None))
     if eager_columns:
         stmt = stmt.options(
             selectinload(Relationship.from_column).selectinload(Column.table),

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -270,6 +270,9 @@ class SemanticAgent(LLMFeature):
                     from_column=rel.from_column,
                     to_table=rel.to_table,
                     to_column=rel.to_column,
+                    # LLM-confirmed composite (DAT-277): additional key columns
+                    # beyond the anchor pair. Empty for a normal single-column join.
+                    key_columns=[(kc.from_column, kc.to_column) for kc in rel.key_columns],
                     relationship_type=rel_type,
                     cardinality=None,  # Set by processor from actual data
                     confidence=rel.confidence,
@@ -477,6 +480,20 @@ class SemanticAgent(LLMFeature):
                 lines.append(f"Join success rate: {join_success:.1f}%")
             if introduces_dups is not None:
                 lines.append(f"Introduces duplicates (fan trap): {introduces_dups}")
+
+            # Composite-key rescue hint (DAT-277): the single-column join fans out
+            # (many-to-many) but a multi-column key collapses it. Surfaced for the
+            # LLM to judge and, if valid, confirm via ``key_columns``.
+            composite = rel.get("composite_key")
+            if composite:
+                pair_strs = [f"{a} <-> {b}" for a, b in composite.get("column_pairs", [])]
+                lines.append(
+                    "COMPOSITE-KEY RESCUE: the best single-column join is many-to-many "
+                    "(fan-out / over-counts). Joining on the full key "
+                    f"[{', '.join(pair_strs)}] is {composite.get('cardinality', '?')}. "
+                    "If this composite is the real key, confirm it: emit ONE relationship "
+                    "for the anchor pair and put the remaining pair(s) in key_columns."
+                )
 
             lines.append("Column pairs with value overlap:")
 

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -501,12 +501,14 @@ class SemanticAgent(LLMFeature):
             if not join_cols:
                 lines.append("  (none detected)")
             else:
-                # Sort by confidence descending, take top N
-                sorted_cols = sorted(
-                    join_cols,
-                    key=lambda jc: jc.get("join_confidence", 0.0),
-                    reverse=True,
-                )
+                # Sort by confidence descending, take top N. The DB candidate-dict
+                # wire format keys the overlap score ``confidence`` (not
+                # ``join_confidence``); read both so the LLM sees real scores and the
+                # top-N truncation keeps the strongest pairs (previously all 0.00).
+                def _overlap(jc: dict[str, Any]) -> float:
+                    return float(jc.get("join_confidence", jc.get("confidence", 0.0)))
+
+                sorted_cols = sorted(join_cols, key=_overlap, reverse=True)
                 total_cols = len(sorted_cols)
                 display_cols = sorted_cols[:_MAX_JOIN_COLS]
 
@@ -516,7 +518,7 @@ class SemanticAgent(LLMFeature):
                 for jc in display_cols:
                     col1 = jc.get("column1", "?")
                     col2 = jc.get("column2", "?")
-                    join_conf = jc.get("join_confidence", 0.0)
+                    join_conf = _overlap(jc)
                     card = jc.get("cardinality", "unknown")
 
                     # Basic info with value overlap score

--- a/packages/engine/src/dataraum/analysis/semantic/models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/models.py
@@ -112,6 +112,13 @@ class ColumnSemanticOutput(BaseModel):
     )
 
 
+class KeyColumnPair(BaseModel):
+    """One ADDITIONAL component of a composite key (DAT-277)."""
+
+    from_column: str = Field(description="Column in the source table.")
+    to_column: str = Field(description="Matching column in the target table.")
+
+
 class RelationshipOutput(BaseModel):
     """A detected relationship between two tables.
 
@@ -129,6 +136,20 @@ class RelationshipOutput(BaseModel):
 
     to_column: str = Field(
         description="Column in the target table being referenced (usually a key)."
+    )
+
+    key_columns: list[KeyColumnPair] = Field(
+        default_factory=list,
+        description=(
+            "ADDITIONAL key columns beyond (from_column, to_column), making the key "
+            "COMPOSITE. Leave EMPTY for a normal single-column relationship. Use this "
+            "for a fan-trap edge whose single-column join OVER-COUNTS but whose "
+            "multi-column key joins cleanly — typically a shared tenant/scope column "
+            "present in both tables. The full key is (from_column, to_column) plus "
+            "these. Only confirm a composite when the candidate evidence shows it "
+            "RESOLVES the fan-out (composite cardinality many-to-one / one-to-one, "
+            "not many-to-many)."
+        ),
     )
 
     relationship_type: Literal["foreign_key", "hierarchy"] = Field(
@@ -401,6 +422,12 @@ class Relationship(BaseModel):
     from_column: str
     to_table: str
     to_column: str
+
+    # ADDITIONAL composite-key components beyond (from_column, to_column), the
+    # LLM's confirmed composite (DAT-277). Empty = single-column. When present,
+    # the full key is (from_column, to_column) plus these pairs; the processor
+    # persists the whole set as ONE relationship group.
+    key_columns: list[tuple[str, str]] = Field(default_factory=list)
 
     relationship_type: RelationshipType
     cardinality: str | None = None  # Using Cardinality from base

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -6,6 +6,7 @@ Orchestrates semantic analysis using the SemanticAgent and stores results.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 import duckdb
 from sqlalchemy import delete
@@ -16,12 +17,15 @@ if TYPE_CHECKING:
     from dataraum.llm.prompts import PromptRenderer
     from dataraum.llm.providers.base import LLMProvider
 
+from dataraum.analysis.relationships.composite import rescue_fanout_to_composite
 from dataraum.analysis.relationships.db_models import Relationship as RelationshipModel
 from dataraum.analysis.relationships.evaluator import (
     compute_actual_cardinality,
+    compute_composite_cardinality,
     compute_introduces_duplicates,
     compute_ri_metrics,
 )
+from dataraum.analysis.relationships.models import JoinCandidate, RelationshipCandidate
 from dataraum.analysis.semantic.agent import SemanticAgent
 from dataraum.analysis.semantic.db_models import (
     ColumnConcept as ConceptModel,
@@ -341,6 +345,136 @@ def ground_columns(
     return Result.ok(count)
 
 
+def _lake_path(table_name: str) -> str:
+    """Collision-safe DuckLake FQN for a typed table (matches the RI/cardinality paths)."""
+    return f'lake.typed."{table_name}"'
+
+
+def _augment_candidates_with_composite_rescue(
+    relationship_candidates: list[dict[str, Any]],
+    duckdb_conn: duckdb.DuckDBPyConnection,
+) -> None:
+    """Surface composite-key rescues to the LLM judge (DAT-277), in place.
+
+    The structural detector emits each value-overlapping column pair separately;
+    when the best pair joins many-to-many it silently over-counts. For each such
+    candidate this runs the greedy rescue — does fusing co-present columns collapse
+    the fan-out? — and, when it does, attaches a ``composite_key`` hint to the
+    candidate dict. The LLM (the only judge, never bypassed) sees the hint and may
+    confirm it via ``RelationshipOutput.key_columns``. A miss attaches nothing.
+    """
+    for cand in relationship_candidates:
+        table1 = cand.get("table1")
+        table2 = cand.get("table2")
+        join_cols = cand.get("join_columns") or []
+        if not table1 or not table2 or len(join_cols) < 2:
+            continue
+
+        candidate = RelationshipCandidate(
+            table1=table1,
+            table2=table2,
+            join_candidates=[
+                JoinCandidate(
+                    column1=jc.get("column1", ""),
+                    column2=jc.get("column2", ""),
+                    join_confidence=jc.get("join_confidence", 0.0),
+                    cardinality=jc.get("cardinality", "unknown"),
+                )
+                for jc in join_cols
+                if jc.get("column1") and jc.get("column2")
+            ],
+        )
+        try:
+            key = rescue_fanout_to_composite(
+                candidate, _lake_path(table1), _lake_path(table2), duckdb_conn
+            )
+        except Exception as e:  # never let a rescue probe break synthesis
+            logger.warning("composite_rescue_failed", table1=table1, table2=table2, error=str(e))
+            continue
+
+        if key is not None:
+            cand["composite_key"] = {
+                "column_pairs": [list(pair) for pair in key.column_pairs],
+                "cardinality": key.cardinality,
+            }
+
+
+def _build_composite_group_rows(
+    *,
+    rel: SemanticRelationship,
+    from_table_id: str | None,
+    from_col_id: str | None,
+    to_table_id: str | None,
+    to_col_id: str | None,
+    column_map: dict[tuple[str, str], str],
+    evidence: dict[str, Any],
+    run_id: str | None,
+    duckdb_conn: duckdb.DuckDBPyConnection | None,
+) -> list[dict[str, Any]] | None:
+    """The N component rows of an LLM-confirmed composite key, or None (DAT-277).
+
+    Returns ``None`` when ``rel`` is single-column (no ``key_columns``) or any
+    component column is unresolvable — the caller then persists the single-column
+    anchor as usual. Otherwise returns the anchor (position 0) plus one row per
+    additional pair, all sharing a fresh ``relationship_group_id`` and the
+    COMPOSITE cardinality (computed from data over the full key; the rescue already
+    proved it collapses the fan-out).
+    """
+    if not rel.key_columns:
+        return None
+
+    components: list[tuple[str, str]] = [(from_col_id or "", to_col_id or "")]
+    pairs: list[tuple[str, str]] = [(rel.from_column, rel.to_column)]
+    for from_name, to_name in rel.key_columns:
+        comp_from = column_map.get((rel.from_table, from_name))
+        comp_to = column_map.get((rel.to_table, to_name))
+        if not comp_from or not comp_to:
+            logger.warning(
+                "composite_key_column_unresolved",
+                from_table=rel.from_table,
+                to_table=rel.to_table,
+                from_column=from_name,
+                to_column=to_name,
+            )
+            return None
+        components.append((comp_from, comp_to))
+        pairs.append((from_name, to_name))
+
+    composite_cardinality = rel.cardinality
+    if duckdb_conn is not None:
+        try:
+            composite_cardinality = compute_composite_cardinality(
+                _lake_path(rel.from_table), _lake_path(rel.to_table), pairs, duckdb_conn
+            )
+        except Exception as e:
+            logger.warning(
+                "composite_cardinality_failed",
+                from_table=rel.from_table,
+                to_table=rel.to_table,
+                error=str(e),
+            )
+
+    group_id = str(uuid4())
+    group_evidence = {**evidence, "composite_key_columns": len(components)}
+    return [
+        {
+            "run_id": run_id,
+            "from_table_id": from_table_id,
+            "from_column_id": comp_from,
+            "to_table_id": to_table_id,
+            "to_column_id": comp_to,
+            "relationship_type": rel.relationship_type.value,
+            "cardinality": composite_cardinality,
+            "confidence": rel.confidence,
+            "detection_method": "llm",
+            "evidence": group_evidence,
+            "relationship_group_id": group_id,
+            "key_position": position,
+        }
+        for position, (comp_from, comp_to) in enumerate(components)
+    ]
+
+
 def synthesize_and_store_tables(
     session: Session,
     agent: SemanticAgent,
@@ -362,6 +496,11 @@ def synthesize_and_store_tables(
     Returns:
         Result with the ``SemanticEnrichmentResult`` (entities + relationships).
     """
+    # Composite-key rescue (DAT-277): probe each fan-out candidate for a composite
+    # that collapses it and surface the hint to the LLM judge before it decides.
+    if relationship_candidates and duckdb_conn is not None:
+        _augment_candidates_with_composite_rescue(relationship_candidates, duckdb_conn)
+
     llm_result = agent.synthesize_tables(
         session=session,
         table_ids=table_ids,
@@ -470,6 +609,28 @@ def synthesize_and_store_tables(
                     error=str(e),
                 )
 
+        # Composite key (DAT-277): the LLM confirmed ADDITIONAL key columns that
+        # collapse the single-column fan-out. Persist the whole key as ONE group —
+        # N component rows sharing a ``relationship_group_id`` and the COMPOSITE
+        # cardinality, the anchor at position 0. Resolve every component's column
+        # ids; if any is unresolvable we cannot honour the composite, so fall back
+        # to the single-column anchor (m2m, marked avoid) rather than persist a
+        # half key.
+        composite_rows = _build_composite_group_rows(
+            rel=rel,
+            from_table_id=from_table_id,
+            from_col_id=from_col_id,
+            to_table_id=to_table_id,
+            to_col_id=to_col_id,
+            column_map=column_map,
+            evidence=evidence,
+            run_id=run_id,
+            duckdb_conn=duckdb_conn,
+        )
+        if composite_rows is not None:
+            rel_rows.extend(composite_rows)
+            continue
+
         rel_rows.append(
             {
                 "run_id": run_id,
@@ -482,6 +643,8 @@ def synthesize_and_store_tables(
                 "confidence": rel.confidence,
                 "detection_method": "llm",
                 "evidence": evidence,
+                "relationship_group_id": None,
+                "key_position": None,
             }
         )
 

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -377,7 +377,10 @@ def _augment_candidates_with_composite_rescue(
                 JoinCandidate(
                     column1=jc.get("column1", ""),
                     column2=jc.get("column2", ""),
-                    join_confidence=jc.get("join_confidence", 0.0),
+                    # The DB candidate-dict wire format keys it ``confidence``
+                    # (load_relationship_candidates_for_semantic); tolerate both so
+                    # the anchor (highest-confidence pair) is picked correctly.
+                    join_confidence=jc.get("join_confidence", jc.get("confidence", 0.0)),
                     cardinality=jc.get("cardinality", "unknown"),
                 )
                 for jc in join_cols
@@ -425,6 +428,11 @@ def _build_composite_group_rows(
 
     components: list[tuple[str, str]] = [(from_col_id or "", to_col_id or "")]
     pairs: list[tuple[str, str]] = [(rel.from_column, rel.to_column)]
+    # Component column-id pairs already in the key — the upsert key is
+    # (run_id, from_column_id, to_column_id, detection_method), so a duplicate
+    # component (e.g. the LLM echoes the anchor pair in key_columns) would collide
+    # within this one INSERT batch. Skip dups defensively.
+    seen_component_ids: set[tuple[str, str]] = {components[0]}
     for from_name, to_name in rel.key_columns:
         comp_from = column_map.get((rel.from_table, from_name))
         comp_to = column_map.get((rel.to_table, to_name))
@@ -437,8 +445,14 @@ def _build_composite_group_rows(
                 to_column=to_name,
             )
             return None
+        if (comp_from, comp_to) in seen_component_ids:
+            continue  # LLM repeated the anchor or a prior component — already in the key
+        seen_component_ids.add((comp_from, comp_to))
         components.append((comp_from, comp_to))
         pairs.append((from_name, to_name))
+
+    if len(components) < 2:
+        return None  # only the anchor survived dedup — not actually composite
 
     composite_cardinality = rel.cardinality
     if duckdb_conn is not None:

--- a/packages/engine/src/dataraum/analysis/views/builder.py
+++ b/packages/engine/src/dataraum/analysis/views/builder.py
@@ -12,7 +12,15 @@ from dataclasses import dataclass, field
 
 @dataclass
 class DimensionJoin:
-    """Specification for a single dimension table join."""
+    """Specification for a single dimension table join.
+
+    ``fact_fk_column`` / ``dim_pk_column`` are the anchor pair — the join's
+    identity and the column-name prefix. For a composite key (DAT-277),
+    ``key_pairs`` holds the FULL ``(fact_column, dim_column)`` set (anchor first);
+    when present the ON clause ANDs every pair so the join scopes correctly and
+    does not fan out. Empty ``key_pairs`` = a plain single-column join on the
+    anchor pair.
+    """
 
     dim_table_name: str
     dim_duckdb_path: str
@@ -20,6 +28,11 @@ class DimensionJoin:
     dim_pk_column: str
     include_columns: list[str] = field(default_factory=list)
     relationship_id: str = ""
+    key_pairs: list[tuple[str, str]] = field(default_factory=list)
+
+    def _on_pairs(self) -> list[tuple[str, str]]:
+        """The (fact_column, dim_column) pairs the ON clause joins on."""
+        return self.key_pairs if self.key_pairs else [(self.fact_fk_column, self.dim_pk_column)]
 
 
 def build_enriched_view_sql(
@@ -87,13 +100,14 @@ def build_enriched_view_sql(
 
     select_clause = ",\n    ".join(select_parts)
 
-    # Build FROM + JOIN clauses
+    # Build FROM + JOIN clauses. A composite key (DAT-277) ANDs every component
+    # pair so the join scopes on the full key and stays grain-preserving.
     join_clauses = []
     for join, alias in zip(dimension_joins, join_aliases, strict=True):
-        join_clauses.append(
-            f"LEFT JOIN {join.dim_duckdb_path} AS {alias} "
-            f'ON f."{join.fact_fk_column}" = {alias}."{join.dim_pk_column}"'
+        on_clause = " AND ".join(
+            f'f."{fact_col}" = {alias}."{dim_col}"' for fact_col, dim_col in join._on_pairs()
         )
+        join_clauses.append(f"LEFT JOIN {join.dim_duckdb_path} AS {alias} ON {on_clause}")
 
     joins_sql = "\n".join(join_clauses)
 

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -155,13 +155,23 @@ class EnrichedViewsPhase(BasePhase):
             )
 
         # The session's defined relationships (not candidate) touching these tables.
+        # Include composite-key groups (DAT-277): their component rows are folded
+        # into ONE multi-column join keyed on the anchor (key_position 0); the
+        # scope rows (key_position > 0) are NOT standalone joins.
         all_relationships = load_defined_relationships(
             ctx.session,
             table_ids,
             run_id=ctx.run_id,
             both_tables=False,
             min_confidence=_MIN_CONFIDENCE,
+            include_composite_groups=True,
         )
+        # Composite components grouped by relationship_group_id, so an anchor row
+        # can recover its full key. Plain rows (group_id None) are not grouped.
+        composite_groups: dict[str, list[Relationship]] = {}
+        for r in all_relationships:
+            if r.relationship_group_id is not None:
+                composite_groups.setdefault(r.relationship_group_id, []).append(r)
 
         # Build column lookups
         cols_stmt = select(Column).where(Column.table_id.in_(table_ids))
@@ -185,11 +195,20 @@ class EnrichedViewsPhase(BasePhase):
         col_id_by_name: dict[tuple[str, str], str] = {
             (c.table_id, c.column_name): c.column_id for c in all_columns
         }
+        name_by_col_id: dict[str, str] = {c.column_id: c.column_name for c in all_columns}
+        table_by_col_id: dict[str, str] = {c.column_id: c.table_id for c in all_columns}
         # Per fact: the relationships touching it, keyed by directional column pair (the
-        # cross-run-stable identity; relationship_id is a per-run uuid4).
+        # cross-run-stable identity; relationship_id is a per-run uuid4). A composite
+        # group contributes ONLY its anchor (key_position 0) here — the scope rows are
+        # folded into the anchor's multi-column key, never standalone single-col joins.
+        anchor_group_by_pair: dict[tuple[str, str], list[Relationship]] = {}
         rels_touching: dict[str, dict[tuple[str, str], Relationship]] = {}
         for r in all_relationships:
+            if r.relationship_group_id is not None and r.key_position != 0:
+                continue  # scope row — represented by its anchor
             pair = (r.from_column_id, r.to_column_id)
+            if r.relationship_group_id is not None:
+                anchor_group_by_pair[pair] = composite_groups[r.relationship_group_id]
             for tid in (r.from_table_id, r.to_table_id):
                 if tid in tables_by_id:
                     rels_touching.setdefault(tid, {})[pair] = r
@@ -276,6 +295,9 @@ class EnrichedViewsPhase(BasePhase):
                             dim_pk_column=spec["dim_pk_column"],
                             include_columns=list(spec["include_columns"]),
                             relationship_id=cand_by_pair[pair].relationship_id,
+                            # Composite key (DAT-277): inherited verbatim from the sticky
+                            # shape, not re-derived (DAT-516).
+                            key_pairs=[(a, b) for a, b in spec.get("key_pairs", [])],
                         ),
                         pair,
                     )
@@ -296,11 +318,27 @@ class EnrichedViewsPhase(BasePhase):
                         if new_pair in inherited_pairs:
                             continue  # already inherited — never double-add a pair
                         inherited_pairs.add(new_pair)
+                        new_join = replace(
+                            join, relationship_id=cand_by_pair[new_pair].relationship_id
+                        )
+                        # Composite key (DAT-277): expand the anchor join to its full
+                        # multi-column key so the ON clause scopes correctly and the
+                        # join stays grain-preserving.
+                        group = anchor_group_by_pair.get(new_pair)
+                        if group is not None:
+                            kp = self._composite_key_pairs(
+                                group, fact_id, name_by_col_id, table_by_col_id
+                            )
+                            if kp:
+                                new_join = replace(
+                                    new_join,
+                                    key_pairs=kp,
+                                    fact_fk_column=kp[0][0],
+                                    dim_pk_column=kp[0][1],
+                                )
                         joins_with_ids.append(
                             (
-                                replace(
-                                    join, relationship_id=cand_by_pair[new_pair].relationship_id
-                                ),
+                                new_join,
                                 new_pair,
                             )
                         )
@@ -464,6 +502,9 @@ class EnrichedViewsPhase(BasePhase):
                     "dim_pk_column": j.dim_pk_column,
                     "dim_table_name": j.dim_table_name,
                     "include_columns": list(j.include_columns),
+                    # Composite key (DAT-277): the full multi-column key, persisted so
+                    # the sticky shape inherits it verbatim next run. [] = single-column.
+                    "key_pairs": [[a, b] for a, b in j.key_pairs],
                 }
                 for j, pair in joins_with_ids
             ]
@@ -525,6 +566,37 @@ class EnrichedViewsPhase(BasePhase):
             if cand in cand_by_pair:
                 return cand
         return None
+
+    @staticmethod
+    def _composite_key_pairs(
+        group_rows: list[Relationship],
+        fact_id: str,
+        name_by_col_id: dict[str, str],
+        table_by_col_id: dict[str, str],
+    ) -> list[tuple[str, str]]:
+        """Fact→dim ``(column_name, column_name)`` pairs for a composite key (DAT-277).
+
+        Anchor (``key_position`` 0) first. Each component relationship is between the
+        fact and a dimension; the fact-side column is whichever endpoint sits on
+        ``fact_id``. Returns ``[]`` if any component can't be oriented onto the fact or
+        a name is missing — the caller then degrades to the single anchor pair rather
+        than emit a malformed ON clause.
+        """
+        ordered = sorted(group_rows, key=lambda r: r.key_position or 0)
+        pairs: list[tuple[str, str]] = []
+        for r in ordered:
+            if table_by_col_id.get(r.from_column_id) == fact_id:
+                fact_col_id, dim_col_id = r.from_column_id, r.to_column_id
+            elif table_by_col_id.get(r.to_column_id) == fact_id:
+                fact_col_id, dim_col_id = r.to_column_id, r.from_column_id
+            else:
+                return []
+            fact_name = name_by_col_id.get(fact_col_id)
+            dim_name = name_by_col_id.get(dim_col_id)
+            if not fact_name or not dim_name:
+                return []
+            pairs.append((fact_name, dim_name))
+        return pairs
 
     def _register_and_profile_dim_columns(
         self,

--- a/packages/engine/tests/integration/analysis/views/test_enriched_views.py
+++ b/packages/engine/tests/integration/analysis/views/test_enriched_views.py
@@ -77,6 +77,64 @@ class TestEnrichedViewsIntegration:
         assert result[0][5] == "US"  # customers__country
         assert result[1][4] == "Bob"  # customers__name
 
+    def test_composite_key_join_collapses_fanout(self, duckdb_conn):
+        """The BookSQL shape (DAT-277): account alone fans out; (account, business_id) holds grain.
+
+        Joining the txn fact to the chart-of-accounts on ``account`` alone multiplies
+        rows (the same account name recurs across businesses → many-to-many). The
+        composite key scopes the join to the right tenant, so the enriched view keeps
+        the fact's row count exactly.
+        """
+        duckdb_conn.execute(
+            "CREATE TABLE typed_txn (txn_id INTEGER, account VARCHAR, business_id VARCHAR, amount DOUBLE)"
+        )
+        duckdb_conn.execute(
+            "INSERT INTO typed_txn VALUES "
+            "(1,'Sales','B1',10),(2,'Sales','B1',20),(3,'COGS','B1',5),"
+            "(4,'Sales','B2',30),(5,'COGS','B2',7)"
+        )
+        duckdb_conn.execute(
+            "CREATE TABLE typed_coa (account_name VARCHAR, business_id VARCHAR, account_type VARCHAR)"
+        )
+        duckdb_conn.execute(
+            "INSERT INTO typed_coa VALUES "
+            "('Sales','B1','revenue'),('COGS','B1','expense'),"
+            "('Sales','B2','revenue'),('COGS','B2','expense')"
+        )
+
+        # Single-column join fans out: 'Sales' matches both B1 and B2 rows in coa.
+        single = [
+            DimensionJoin(
+                dim_table_name="coa",
+                dim_duckdb_path="typed_coa",
+                fact_fk_column="account",
+                dim_pk_column="account_name",
+                include_columns=["account_type"],
+            )
+        ]
+        sql, _ = build_enriched_view_sql('"enriched_single"', "typed_txn", single)
+        duckdb_conn.execute(sql)
+        assert duckdb_conn.execute('SELECT COUNT(*) FROM "enriched_single"').fetchone()[0] > 5
+
+        # Composite (account, business_id) join preserves grain (5 fact rows).
+        composite = [
+            DimensionJoin(
+                dim_table_name="coa",
+                dim_duckdb_path="typed_coa",
+                fact_fk_column="account",
+                dim_pk_column="account_name",
+                include_columns=["account_type"],
+                key_pairs=[("account", "account_name"), ("business_id", "business_id")],
+            )
+        ]
+        sql, _ = build_enriched_view_sql('"enriched_composite"', "typed_txn", composite)
+        duckdb_conn.execute(sql)
+        rows = duckdb_conn.execute(
+            'SELECT account__account_type FROM "enriched_composite" ORDER BY txn_id'
+        ).fetchall()
+        assert len(rows) == 5  # grain preserved
+        assert [r[0] for r in rows] == ["revenue", "revenue", "expense", "revenue", "expense"]
+
     def test_view_with_no_match_uses_null(self, duckdb_conn):
         """Test that LEFT JOIN produces NULLs for unmatched rows."""
         duckdb_conn.execute("""

--- a/packages/engine/tests/unit/analysis/relationships/test_composite.py
+++ b/packages/engine/tests/unit/analysis/relationships/test_composite.py
@@ -1,0 +1,178 @@
+"""Composite-key rescue math (DAT-277) — proven on small, varied fixtures.
+
+The confidence in the rescue comes from this matrix, NOT from one big dataset:
+each fixture is a few rows that exercise one cardinality shape deterministically.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import duckdb
+import pytest
+
+from dataraum.analysis.relationships.composite import (
+    _join_multiplication,
+    rescue_fanout_to_composite,
+)
+from dataraum.analysis.relationships.evaluator import compute_composite_cardinality
+from dataraum.analysis.relationships.models import JoinCandidate, RelationshipCandidate
+
+
+@pytest.fixture
+def con() -> Iterator[duckdb.DuckDBPyConnection]:
+    c = duckdb.connect()
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def _candidate(
+    table1: str, table2: str, pairs: list[tuple[str, str, float]]
+) -> RelationshipCandidate:
+    """A table-pair candidate carrying its value-overlap join columns (col1, col2, confidence)."""
+    return RelationshipCandidate(
+        table1=table1,
+        table2=table2,
+        join_candidates=[
+            JoinCandidate(column1=a, column2=b, join_confidence=conf, cardinality="unknown")
+            for a, b, conf in pairs
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_composite_cardinality — the multi-column primitive
+# ---------------------------------------------------------------------------
+
+
+def test_single_pair_matches_actual_cardinality(con) -> None:
+    con.execute("CREATE TABLE f (fk VARCHAR)")
+    con.execute("INSERT INTO f VALUES ('a'),('a'),('b')")
+    con.execute("CREATE TABLE d (pk VARCHAR)")
+    con.execute("INSERT INTO d VALUES ('a'),('b')")
+    # each f.fk → one d.pk; each d.pk → many f → many-to-one
+    assert compute_composite_cardinality("f", "d", [("fk", "pk")], con) == "many-to-one"
+
+
+def test_empty_key_is_none(con) -> None:
+    assert compute_composite_cardinality("f", "d", [], con) is None
+
+
+# ---------------------------------------------------------------------------
+# The rescue matrix
+# ---------------------------------------------------------------------------
+
+
+def test_spurious_m2m_rescued_by_one_scoping_col(con) -> None:
+    """The BookSQL shape: account recurs across tenants; (account, business_id) is the real key."""
+    con.execute("CREATE TABLE txn (account VARCHAR, business_id VARCHAR, amount INT)")
+    con.execute(
+        "INSERT INTO txn VALUES "
+        "('Sales','B1',10),('Sales','B1',20),('COGS','B1',5),"
+        "('Sales','B2',30),('COGS','B2',7),('COGS','B2',8)"
+    )
+    con.execute(
+        "CREATE TABLE coa (account_name VARCHAR, business_id VARCHAR, account_type VARCHAR)"
+    )
+    con.execute(
+        "INSERT INTO coa VALUES "
+        "('Sales','B1','revenue'),('COGS','B1','expense'),"
+        "('Sales','B2','revenue'),('COGS','B2','expense')"
+    )
+
+    # account alone fans out across tenants; the composite collapses it.
+    assert (
+        compute_composite_cardinality("txn", "coa", [("account", "account_name")], con)
+        == "many-to-many"
+    )
+    assert (
+        compute_composite_cardinality(
+            "txn", "coa", [("account", "account_name"), ("business_id", "business_id")], con
+        )
+        == "many-to-one"
+    )
+
+    cand = _candidate(
+        "txn", "coa", [("account", "account_name", 0.9), ("business_id", "business_id", 0.7)]
+    )
+    key = rescue_fanout_to_composite(cand, "txn", "coa", con)
+    assert key is not None
+    assert set(key.column_pairs) == {("account", "account_name"), ("business_id", "business_id")}
+    assert key.cardinality == "many-to-one"
+
+
+def test_spurious_m2m_needs_two_scoping_cols(con) -> None:
+    """A 3-column key: neither (a) nor (a,b) collapses; (a,b,c) does."""
+    con.execute("CREATE TABLE f (a VARCHAR, b VARCHAR, c VARCHAR, v INT)")
+    con.execute(
+        "INSERT INTO f VALUES ('X','1','P',1),('X','1','P',2),('X','1','Q',3),('Y','1','P',4)"
+    )
+    con.execute("CREATE TABLE d (a VARCHAR, b VARCHAR, c VARCHAR)")
+    con.execute("INSERT INTO d VALUES ('X','1','P'),('X','1','Q'),('X','2','P'),('Y','1','P')")
+
+    assert compute_composite_cardinality("f", "d", [("a", "a")], con) == "many-to-many"
+    assert compute_composite_cardinality("f", "d", [("a", "a"), ("b", "b")], con) == "many-to-many"
+    assert (
+        compute_composite_cardinality("f", "d", [("a", "a"), ("b", "b"), ("c", "c")], con)
+        == "many-to-one"
+    )
+
+    cand = _candidate("f", "d", [("a", "a", 0.9), ("b", "b", 0.6), ("c", "c", 0.5)])
+    key = rescue_fanout_to_composite(cand, "f", "d", con)
+    assert key is not None
+    assert set(key.column_pairs) == {("a", "a"), ("b", "b"), ("c", "c")}
+    assert key.cardinality == "many-to-one"
+
+
+def test_genuine_m2m_is_not_rescued(con) -> None:
+    """A real many-to-many: no composite of the shared columns collapses it → abstain (None)."""
+    con.execute("CREATE TABLE a (tag VARCHAR, color VARCHAR, x INT)")
+    con.execute("INSERT INTO a VALUES ('r','red',1),('r','red',2),('b','blue',3)")
+    con.execute("CREATE TABLE b (tag VARCHAR, color VARCHAR, y INT)")
+    con.execute("INSERT INTO b VALUES ('r','red',1),('r','red',2),('b','blue',3)")
+
+    assert (
+        compute_composite_cardinality("a", "b", [("tag", "tag"), ("color", "color")], con)
+        == "many-to-many"
+    )
+
+    cand = _candidate("a", "b", [("tag", "tag", 0.9), ("color", "color", 0.6)])
+    assert rescue_fanout_to_composite(cand, "a", "b", con) is None
+
+
+def test_clean_m2o_anchor_is_not_rescued(con) -> None:
+    """The best pair is already many-to-one → nothing to rescue, even with a fusable second column."""
+    con.execute("CREATE TABLE f (cust_id VARCHAR, region VARCHAR, v INT)")
+    con.execute("INSERT INTO f VALUES ('c1','N',1),('c1','N',2),('c2','S',3)")
+    con.execute("CREATE TABLE d (id VARCHAR, region VARCHAR, name VARCHAR)")
+    con.execute("INSERT INTO d VALUES ('c1','N','A'),('c2','S','B')")
+
+    assert compute_composite_cardinality("f", "d", [("cust_id", "id")], con) == "many-to-one"
+    cand = _candidate("f", "d", [("cust_id", "id", 0.95), ("region", "region", 0.5)])
+    assert rescue_fanout_to_composite(cand, "f", "d", con) is None
+
+
+def test_single_candidate_cannot_fuse(con) -> None:
+    """A lone m2m candidate has nothing to fuse with → None (the caller flags the fan-trap)."""
+    con.execute("CREATE TABLE a (tag VARCHAR)")
+    con.execute("INSERT INTO a VALUES ('r'),('r'),('b')")
+    con.execute("CREATE TABLE b (tag VARCHAR)")
+    con.execute("INSERT INTO b VALUES ('r'),('r'),('b')")
+    cand = _candidate("a", "b", [("tag", "tag", 0.9)])
+    assert rescue_fanout_to_composite(cand, "a", "b", con) is None
+
+
+def test_join_multiplication_ranks_disambiguation(con) -> None:
+    """The greedy ranking: adding the scoping column drops the worst-direction multiplicity."""
+    con.execute("CREATE TABLE txn (account VARCHAR, business_id VARCHAR)")
+    con.execute("INSERT INTO txn VALUES ('Sales','B1'),('Sales','B1'),('Sales','B2'),('COGS','B1')")
+    con.execute("CREATE TABLE coa (account_name VARCHAR, business_id VARCHAR)")
+    con.execute("INSERT INTO coa VALUES ('Sales','B1'),('Sales','B2'),('COGS','B1')")
+
+    single = _join_multiplication("txn", "coa", [("account", "account_name")], con)
+    composite = _join_multiplication(
+        "txn", "coa", [("account", "account_name"), ("business_id", "business_id")], con
+    )
+    assert composite < single  # the scoping column reduces the fan-out

--- a/packages/engine/tests/unit/analysis/semantic/test_composite_persist.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_composite_persist.py
@@ -1,0 +1,153 @@
+"""LLM-confirmed composite-key persistence + consumer exclusion (DAT-277 B2a).
+
+The rescue surfaces a composite to the LLM; when the LLM confirms it via
+``RelationshipOutput.key_columns`` the processor persists the whole key as ONE
+group (N component rows sharing a ``relationship_group_id`` + the composite
+cardinality). Single-column consumers must NOT see those grouped rows (they join
+on one column and would fan out), so ``load_defined_relationships`` excludes them
+by default — the multi-column enrichment path opts in.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from dataraum.analysis.relationships.db_models import Relationship
+from dataraum.analysis.relationships.utils import load_defined_relationships
+from dataraum.analysis.semantic.models import Relationship as SemanticRelationship
+from dataraum.analysis.semantic.processor import _build_composite_group_rows
+from dataraum.core.models.base import RelationshipType
+from dataraum.storage import Column, Source, Table
+
+
+def _composite_rel(key_columns: list[tuple[str, str]]) -> SemanticRelationship:
+    return SemanticRelationship(
+        relationship_id="r1",
+        from_table="txn",
+        from_column="account",
+        to_table="coa",
+        to_column="account_name",
+        key_columns=key_columns,
+        relationship_type=RelationshipType.FOREIGN_KEY,
+        cardinality="many-to-many",
+        confidence=0.9,
+        detection_method="llm_tool",
+    )
+
+
+def _column_map() -> dict[tuple[str, str], str]:
+    return {
+        ("txn", "account"): "txn_account",
+        ("txn", "business_id"): "txn_biz",
+        ("coa", "account_name"): "coa_name",
+        ("coa", "business_id"): "coa_biz",
+    }
+
+
+def test_single_column_relationship_is_not_a_group() -> None:
+    """No key_columns → None, so the caller persists the plain single-column row."""
+    rows = _build_composite_group_rows(
+        rel=_composite_rel([]),
+        from_table_id="tt",
+        from_col_id="txn_account",
+        to_table_id="tc",
+        to_col_id="coa_name",
+        column_map=_column_map(),
+        evidence={},
+        run_id="run-A",
+        duckdb_conn=None,
+    )
+    assert rows is None
+
+
+def test_composite_persists_as_one_group() -> None:
+    """Anchor at position 0 + each key column, all sharing one group id + cardinality."""
+    rows = _build_composite_group_rows(
+        rel=_composite_rel([("business_id", "business_id")]),
+        from_table_id="tt",
+        from_col_id="txn_account",
+        to_table_id="tc",
+        to_col_id="coa_name",
+        column_map=_column_map(),
+        evidence={"source": "table_synthesis"},
+        run_id="run-A",
+        duckdb_conn=None,  # no lake → composite cardinality falls back to rel.cardinality
+    )
+    assert rows is not None
+    assert len(rows) == 2
+    group_ids = {r["relationship_group_id"] for r in rows}
+    assert len(group_ids) == 1 and None not in group_ids
+    by_pos = {r["key_position"]: r for r in rows}
+    assert by_pos[0]["from_column_id"] == "txn_account"
+    assert by_pos[0]["to_column_id"] == "coa_name"
+    assert by_pos[1]["from_column_id"] == "txn_biz"
+    assert by_pos[1]["to_column_id"] == "coa_biz"
+    # every component row carries the composite cardinality + the component count
+    assert all(r["cardinality"] == "many-to-many" for r in rows)
+    assert all(r["evidence"]["composite_key_columns"] == 2 for r in rows)
+
+
+def test_unresolvable_key_column_falls_back_to_single() -> None:
+    """A composite component that doesn't map to a column id → None (persist anchor only)."""
+    rows = _build_composite_group_rows(
+        rel=_composite_rel([("ghost", "phantom")]),
+        from_table_id="tt",
+        from_col_id="txn_account",
+        to_table_id="tc",
+        to_col_id="coa_name",
+        column_map=_column_map(),
+        evidence={},
+        run_id="run-A",
+        duckdb_conn=None,
+    )
+    assert rows is None
+
+
+def _seed(session: Session) -> None:
+    session.add(Source(source_id="s1", name="s1", source_type="csv"))
+    session.add(Table(table_id="t1", source_id="s1", table_name="txn", layer="typed"))
+    session.add(Table(table_id="t2", source_id="s1", table_name="coa", layer="typed"))
+    for cid in ("txn_account", "txn_biz"):
+        session.add(Column(column_id=cid, table_id="t1", column_name=cid, column_position=0))
+    for cid in ("coa_name", "coa_biz"):
+        session.add(Column(column_id=cid, table_id="t2", column_name=cid, column_position=0))
+    session.flush()
+
+
+def _add_rel(session: Session, frm: str, to: str, group_id: str | None, position: int | None) -> None:
+    session.add(
+        Relationship(
+            run_id="run-A",
+            from_table_id="t1",
+            from_column_id=frm,
+            to_table_id="t2",
+            to_column_id=to,
+            relationship_type="foreign_key",
+            cardinality="many-to-one",
+            relationship_group_id=group_id,
+            key_position=position,
+            confidence=0.9,
+            detection_method="llm",
+        )
+    )
+
+
+def test_load_defined_relationships_excludes_composite_groups_by_default(session: Session) -> None:
+    """Grouped component rows are hidden from single-column consumers; opt-in shows them."""
+    _seed(session)
+    # A plain single-column relationship on a DISTINCT pair (the unique key is
+    # (run_id, from_column_id, to_column_id, detection_method) — an anchor never
+    # collides with a real single-column row because the LLM emits one or the other).
+    _add_rel(session, "txn_biz", "coa_name", group_id=None, position=None)  # plain
+    _add_rel(session, "txn_account", "coa_name", group_id="g1", position=0)  # composite anchor
+    _add_rel(session, "txn_biz", "coa_biz", group_id="g1", position=1)  # composite scope
+    session.flush()
+
+    default = load_defined_relationships(session, ["t1", "t2"], run_id="run-A")
+    assert {r.relationship_group_id for r in default} == {None}
+    assert len(default) == 1
+
+    with_groups = load_defined_relationships(
+        session, ["t1", "t2"], run_id="run-A", include_composite_groups=True
+    )
+    assert len(with_groups) == 3

--- a/packages/engine/tests/unit/analysis/semantic/test_composite_persist.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_composite_persist.py
@@ -87,6 +87,48 @@ def test_composite_persists_as_one_group() -> None:
     assert all(r["evidence"]["composite_key_columns"] == 2 for r in rows)
 
 
+def test_anchor_echoed_in_key_columns_does_not_duplicate() -> None:
+    """The LLM echoing the anchor pair in key_columns must not produce a colliding row.
+
+    Two component rows sharing (run_id, from_column_id, to_column_id, 'llm') would
+    violate the upsert unique key. With only the anchor + an echo, the result is a
+    plain single-column relationship (None) — never a duplicate-component group.
+    """
+    rows = _build_composite_group_rows(
+        rel=_composite_rel([("account", "account_name")]),  # == the anchor pair
+        from_table_id="tt",
+        from_col_id="txn_account",
+        to_table_id="tc",
+        to_col_id="coa_name",
+        column_map=_column_map(),
+        evidence={},
+        run_id="run-A",
+        duckdb_conn=None,
+    )
+    assert rows is None
+
+
+def test_anchor_echo_plus_real_scope_keeps_only_the_scope() -> None:
+    """An echoed anchor alongside a genuine scope column yields a clean 2-row group."""
+    rows = _build_composite_group_rows(
+        rel=_composite_rel([("account", "account_name"), ("business_id", "business_id")]),
+        from_table_id="tt",
+        from_col_id="txn_account",
+        to_table_id="tc",
+        to_col_id="coa_name",
+        column_map=_column_map(),
+        evidence={},
+        run_id="run-A",
+        duckdb_conn=None,
+    )
+    assert rows is not None
+    assert len(rows) == 2
+    assert {(r["from_column_id"], r["to_column_id"]) for r in rows} == {
+        ("txn_account", "coa_name"),
+        ("txn_biz", "coa_biz"),
+    }
+
+
 def test_unresolvable_key_column_falls_back_to_single() -> None:
     """A composite component that doesn't map to a column id → None (persist anchor only)."""
     rows = _build_composite_group_rows(

--- a/packages/engine/tests/unit/analysis/views/test_builder.py
+++ b/packages/engine/tests/unit/analysis/views/test_builder.py
@@ -83,6 +83,32 @@ class TestBuildEnrichedViewSql:
         assert "product_id__category" in dim_cols
         assert len(dim_cols) == 3
 
+    def test_composite_key_join_ands_every_pair(self):
+        """A composite key (DAT-277) ANDs all component pairs in the ON clause."""
+        joins = [
+            DimensionJoin(
+                dim_table_name="coa",
+                dim_duckdb_path='lake.typed."csv__coa"',
+                fact_fk_column="account",
+                dim_pk_column="account_name",
+                include_columns=["account_type"],
+                relationship_id="rel-1",
+                key_pairs=[("account", "account_name"), ("business_id", "business_id")],
+            )
+        ]
+
+        sql, dim_cols = build_enriched_view_sql(
+            view_fqn='lake.typed."enriched_csv__txn"',
+            fact_fqn='lake.typed."csv__txn"',
+            dimension_joins=joins,
+        )
+
+        assert 'f."account" = ' in sql
+        assert ' AND ' in sql
+        assert 'f."business_id" = ' in sql
+        # the column prefix still uses the anchor fact column
+        assert dim_cols == ["account__account_type"]
+
     def test_same_dim_table_joined_twice_produces_unique_column_names(self):
         """Same dimension table joined via two different FK columns gets distinct column names."""
         joins = [

--- a/packages/engine/tests/unit/pipeline/test_composite_key_pairs.py
+++ b/packages/engine/tests/unit/pipeline/test_composite_key_pairs.py
@@ -1,0 +1,61 @@
+"""Composite-key orientation for enriched-view joins (DAT-277 B2b).
+
+``_composite_key_pairs`` turns a stored composite relationship group into the
+fact→dim ``(column_name, column_name)`` pairs the multi-column ON clause needs,
+regardless of which way each component relationship was stored.
+"""
+
+from __future__ import annotations
+
+from dataraum.analysis.relationships.db_models import Relationship
+from dataraum.pipeline.phases.enriched_views_phase import EnrichedViewsPhase
+from dataraum.storage.base import load_all_models
+
+# Constructing a mapped Relationship configures the ORM mappers, which reference
+# models across modules (TemporalColumnProfile, …); register them all first.
+load_all_models()
+
+
+def _rel(frm_col: str, frm_tbl: str, to_col: str, to_tbl: str, position: int) -> Relationship:
+    return Relationship(
+        run_id="r",
+        from_table_id=frm_tbl,
+        from_column_id=frm_col,
+        to_table_id=to_tbl,
+        to_column_id=to_col,
+        relationship_type="foreign_key",
+        cardinality="many-to-one",
+        relationship_group_id="g1",
+        key_position=position,
+        confidence=0.9,
+        detection_method="llm",
+    )
+
+
+_NAMES = {
+    "fa": "account",
+    "fb": "business_id",
+    "da": "account_name",
+    "db": "business_id",
+}
+_TABLES = {"fa": "fact", "fb": "fact", "da": "dim", "db": "dim"}
+
+
+def test_anchor_first_fact_to_dim_orientation() -> None:
+    """Anchor (position 0) leads; each pair is oriented fact-column → dim-column."""
+    # Anchor stored fact→dim, scope stored dim→fact (mixed orientation on purpose).
+    group = [
+        _rel("fa", "fact", "da", "dim", 0),
+        _rel("db", "dim", "fb", "fact", 1),
+    ]
+    pairs = EnrichedViewsPhase._composite_key_pairs(group, "fact", _NAMES, _TABLES)
+    assert pairs == [("account", "account_name"), ("business_id", "business_id")]
+
+
+def test_unorientable_component_yields_empty() -> None:
+    """A component touching neither side of the fact → [] (caller degrades to anchor)."""
+    group = [
+        _rel("fa", "fact", "da", "dim", 0),
+        _rel("xx", "other", "yy", "elsewhere", 1),
+    ]
+    assert EnrichedViewsPhase._composite_key_pairs(group, "fact", _NAMES, _TABLES) == []


### PR DESCRIPTION
## What & why

A fan-trap edge — where the best single-column join between a fact and a dimension is **many-to-many** — silently over-counts aggregates in enriched views. The true key is often **composite**: the real FK plus a shared scoping column (a tenant `business_id` present on both tables). Example (BookSQL): `account` recurs across businesses, so txn↔chart-of-accounts on `account` alone fans out; `(account, business_id)` is many-to-one.

This adds a **composite-key rescue**: an overly-greedy statistical pre-pass (the Jaccard analog) that SURFACES a composite candidate, with the **LLM as the sole judge** that confirms it. The rescue never bypasses the LLM and never auto-creates a relationship.

## How it works

- **B1 — math:** `compute_composite_cardinality` (multi-column ON, both-direction multiplicity) + greedy `rescue_fanout_to_composite` (anchor on the strongest pair; fuse co-present columns until the m2m collapses, or **abstain** — a genuine m2m / bridge returns `None`, never a forced join). Proven on an 8-case fixture matrix.
- **B2a — surface + persist:** the rescue attaches a hint to the candidate block; the `semantic_per_table` agent confirms via `RelationshipOutput.key_columns`. A confirmed composite is persisted as a **relationship group** (N rows sharing `relationship_group_id`, anchor at `key_position` 0, all carrying the collapsed cardinality). `load_defined_relationships` **excludes grouped rows by default** so single-column consumers never fan out (behavior-preserving).
- **B2b — activate:** `DimensionJoin.key_pairs` + a multi-column ON clause; the enriched-views phase folds a group into one grain-preserving join, persisted into the DAT-516 sticky shape and inherited verbatim. Grain verification stays the backstop.

**Single-owner respected:** the composite KEY is decided by the semantic agent; the enrichment agent only picks which dims/columns to expose.

## Schema

Two new columns on `relationships`: `relationship_group_id`, `key_position`. `schema.sql` + the cockpit drizzle mirror regenerated in lockstep.

## Review

- spec-compliance: **COMPLIANT** (all hard requirements traced, zero scope creep).
- senior review: 2 real bugs caught + fixed (candidate-dict `confidence`/`join_confidence` key mismatch that broke anchor selection & made the LLM see `overlap=0.00`; anchor-echo upsert collision). Both have regression tests.

## Verification

mypy 0 · ruff clean · 1700+ unit tests green · new unit + integration tests (incl. a BookSQL-shape proof that the composite collapses the fan-out to exact grain) · eval/testdata handoff written.

Closes DAT-277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)