### PR TITLE
fix: semantic upsert dedups + relationship-overlap + enriched-view column uniqueness

### DIFF
--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -484,12 +484,15 @@ class SemanticAgent(LLMFeature):
             if not join_cols:
                 lines.append("  (none detected)")
             else:
-                # Sort by confidence descending, take top N
-                sorted_cols = sorted(
-                    join_cols,
-                    key=lambda jc: jc.get("join_confidence", 0.0),
-                    reverse=True,
-                )
+                # Sort by overlap descending, take top N. The DB candidate-dict wire
+                # format (load_relationship_candidates_for_semantic) keys the overlap
+                # score `confidence`, NOT `join_confidence` — reading only the latter
+                # showed the LLM overlap=0.00 for every candidate and truncated the
+                # top-N arbitrarily. Read both so the strongest pairs surface.
+                def _overlap(jc: dict[str, Any]) -> float:
+                    return float(jc.get("join_confidence", jc.get("confidence", 0.0)))
+
+                sorted_cols = sorted(join_cols, key=_overlap, reverse=True)
                 total_cols = len(sorted_cols)
                 display_cols = sorted_cols[:_MAX_JOIN_COLS]
 
@@ -499,7 +502,7 @@ class SemanticAgent(LLMFeature):
                 for jc in display_cols:
                     col1 = jc.get("column1", "?")
                     col2 = jc.get("column2", "?")
-                    join_conf = jc.get("join_confidence", 0.0)
+                    join_conf = _overlap(jc)
                     card = jc.get("cardinality", "unknown")
 
                     # Basic info with value overlap score

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -256,6 +256,14 @@ def persist_column_concepts(
             }
         )
 
+    # Dedup on the upsert key (column_id, run_id): the table agent can emit the same
+    # column twice in column_concepts, and Postgres ON CONFLICT cannot touch a row
+    # twice in one batch (CardinalityViolation). Last mention wins.
+    deduped: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in rows:
+        deduped[(row["column_id"], row["run_id"])] = row
+    rows = list(deduped.values())
+
     upsert(session, ConceptModel, rows, index_elements=["column_id", "run_id"])
     return len(rows)
 

--- a/packages/engine/src/dataraum/analysis/views/builder.py
+++ b/packages/engine/src/dataraum/analysis/views/builder.py
@@ -76,12 +76,25 @@ def build_enriched_view_sql(
     # Pre-compute aliases for all joins
     join_aliases = [get_unique_alias(join.dim_table_name) for join in dimension_joins]
 
+    # Output column names must be unique by construction — the ``{fact_fk}__{col}``
+    # prefix does NOT guarantee it (two joins can share a fact column), and a
+    # duplicate would violate the enriched-layer ``uq_table_column`` on registration.
+    # Disambiguate with a numeric suffix, mirroring ``get_unique_alias``.
+    used_column_names: dict[str, int] = {}
+
+    def get_unique_column_name(base: str) -> str:
+        if base not in used_column_names:
+            used_column_names[base] = 1
+            return base
+        used_column_names[base] += 1
+        return f"{base}_{used_column_names[base]}"
+
     for join, alias in zip(dimension_joins, join_aliases, strict=True):
         # Use fact FK column as prefix so repeated joins of the same dim table are distinct:
         # e.g. kontonummer_des_gegenkontos__beschriftung vs kontonummer_des_kontos__beschriftung
         col_prefix = join.fact_fk_column
         for col in join.include_columns:
-            qualified_name = f"{col_prefix}__{col}"
+            qualified_name = get_unique_column_name(f"{col_prefix}__{col}")
             select_parts.append(f'{alias}."{col}" AS "{qualified_name}"')
             dimension_column_names.append(qualified_name)
 

--- a/packages/engine/tests/unit/analysis/semantic/test_candidate_overlap_format.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_candidate_overlap_format.py
@@ -1,0 +1,39 @@
+"""The relationship-candidate block must show the LLM real overlap scores.
+
+The DB candidate-dict wire format (load_relationship_candidates_for_semantic) keys
+the value-overlap score ``confidence``; the formatter previously read only
+``join_confidence`` and rendered ``overlap=0.00`` for every candidate (and truncated
+the top-N arbitrarily), degrading relationship confirmation.
+"""
+
+from __future__ import annotations
+
+from dataraum.analysis.semantic.agent import SemanticAgent
+
+
+def _candidates() -> list[dict]:
+    # Exactly the shape load_relationship_candidates_for_semantic emits.
+    return [
+        {
+            "table1": "orders",
+            "table2": "customers",
+            "join_columns": [
+                {"column1": "customer_id", "column2": "id", "confidence": 0.92, "cardinality": "many-to-one"},
+                {"column1": "region", "column2": "region", "confidence": 0.30, "cardinality": "many-to-many"},
+            ],
+        }
+    ]
+
+
+def test_overlap_score_is_rendered_from_the_confidence_key() -> None:
+    agent = SemanticAgent.__new__(SemanticAgent)  # _format_* is self-contained
+    out = agent._format_relationship_candidates(_candidates())
+    assert "overlap=0.92" in out
+    assert "overlap=0.00" not in out  # the regression
+
+
+def test_candidates_are_sorted_by_real_overlap() -> None:
+    """The stronger pair must come first (top-N truncation relies on it)."""
+    agent = SemanticAgent.__new__(SemanticAgent)
+    out = agent._format_relationship_candidates(_candidates())
+    assert out.index("customer_id <-> id") < out.index("region <-> region")

--- a/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
@@ -173,6 +173,33 @@ class TestPersistColumnConcepts:
         assert total.derived_formula_confidence == 0.85
         assert rows[cols["discount"]].derived_formula_hypothesis is None
 
+    def test_duplicate_column_concepts_collapse_to_one_row(self, session) -> None:
+        """The table agent can list the same column twice; the upsert batch must dedup.
+
+        Two ColumnConceptOutput for the same (table, column) share the (column_id,
+        run_id) upsert key — without dedup Postgres raises CardinalityViolation
+        ("ON CONFLICT cannot affect a row twice"). Last mention wins.
+        """
+        table = _table_with_columns(session, "orders", ["total"])
+        concepts = [
+            ColumnConceptOutput(
+                table_name="orders", column_name="total", business_concept="revenue"
+            ),
+            ColumnConceptOutput(
+                table_name="orders", column_name="total", business_concept="net_revenue"
+            ),
+        ]
+
+        count = persist_column_concepts(
+            session, concepts, [table.table_id], annotated_by="m", run_id=baseline_run_id()
+        )
+        session.flush()
+
+        assert count == 1  # collapsed
+        rows = list(session.execute(select(ColumnConceptDB)).scalars())
+        assert len(rows) == 1
+        assert rows[0].business_concept == "net_revenue"  # last mention wins
+
 
 class TestNearConstantFeed:
     """The per-table feed flags near-constant columns (DAT-637 quality fix) so the

--- a/packages/engine/tests/unit/analysis/views/test_builder.py
+++ b/packages/engine/tests/unit/analysis/views/test_builder.py
@@ -83,6 +83,33 @@ class TestBuildEnrichedViewSql:
         assert "product_id__category" in dim_cols
         assert len(dim_cols) == 3
 
+    def test_colliding_column_names_are_made_unique(self):
+        """Two joins sharing a fact-column prefix + a same-named dim column must not
+        collide — the builder disambiguates by construction (uq_table_column safety)."""
+        joins = [
+            DimensionJoin(
+                dim_table_name="customers",
+                dim_duckdb_path='lake.typed."csv__customers"',
+                fact_fk_column="org",  # same prefix on purpose
+                dim_pk_column="org",
+                include_columns=["city"],
+            ),
+            DimensionJoin(
+                dim_table_name="vendors",
+                dim_duckdb_path='lake.typed."csv__vendors"',
+                fact_fk_column="org",  # same prefix on purpose
+                dim_pk_column="org",
+                include_columns=["city"],
+            ),
+        ]
+        _sql, dim_cols = build_enriched_view_sql(
+            view_fqn='lake.typed."enriched_csv__txn"',
+            fact_fqn='lake.typed."csv__txn"',
+            dimension_joins=joins,
+        )
+        assert len(dim_cols) == len(set(dim_cols))  # no duplicates
+        assert dim_cols == ["org__city", "org__city_2"]
+
     def test_same_dim_table_joined_twice_produces_unique_column_names(self):
         """Same dimension table joined via two different FK columns gets distinct column names."""
         joins = [


### PR DESCRIPTION
Three dataset-agnostic engine fixes surfaced while validating on BookSQL + the dataraum-testdata finance set. Each is independently correct and unit-tested; none depend on the parked composite-key work.

## Fixes
1. **`column_concepts` dedup before upsert** — the table agent can emit the same column twice; the rows collide on the `(column_id, run_id)` upsert key and Postgres `ON CONFLICT` cannot touch a row twice in one statement, crashing `semantic_per_table` with `CardinalityViolation`. Dedup the batch (last mention wins).
2. **Relationship candidates showed the LLM `overlap=0.00` for every pair** — `load_relationship_candidates_for_semantic` keys the value-overlap score `confidence`, but `_format_relationship_candidates` read only `join_confidence`, so the table agent never saw real overlap and the top-N truncation was arbitrary. Read the real key.
3. **Enriched-view column names unique by construction** — the `{fact_fk}__{col}` prefix doesn't guarantee uniqueness (two joins can share a fact column); a duplicate violates the enriched-layer `uq_table_column`. Disambiguate with a numeric suffix, mirroring the existing table-alias uniquing.

## Validation
- Unit tests for all three.
- End-to-end on two real datasets (BookSQL; dataraum-testdata `clean` finance): pipeline runs clean, **0** `CardinalityViolation` / `UniqueViolation`, and relationship detection finds the correct single-column surrogate FKs now that the LLM sees real overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)