### PR TITLE
feat(DAT-645): vertical sign conventions — ground credit-normal measures positive

### DIFF
--- a/.claude-agent-memory/senior-code-reviewer/test_mock_coverage_gap.md
+++ b/.claude-agent-memory/senior-code-reviewer/test_mock_coverage_gap.md
@@ -1,0 +1,12 @@
+---
+name: test-mock-coverage-gap
+description: Graph agent and validation agent tests mock renderer.render_split — they verify context dict keys but never exercise the real template render path
+metadata:
+  type: feedback
+---
+
+`test_prompt_selection.py` and the validation integration conftest both mock `renderer.render_split.return_value = (...)`. This means the assertions prove the context dict is built correctly but never exercise `_prepare_context` or `_render_text`. A mismatched `{placeholder}` vs `inputs:` entry is invisible to these tests.
+
+**Why:** DAT-645 introduced `{vertical_conventions}` in `graph_sql_generation.yaml` but omitted the `inputs:` entry — tests stayed green because the renderer was mocked.
+
+**How to apply:** Add at least one real-render smoke test per prompt template that exercises the actual `PromptRenderer.render_split` path (not mocked), or add a lint test that loads all YAML templates and checks that every `{placeholder}` in `user_prompt`/`system_prompt` is listed in `inputs:`.

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,46 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-645 — vertical sign conventions wired into grounding + validation
+
+**Branch:** `feat/dat-645-vertical-conventions`.
+
+### What changed (grounding INPUT, not a new response shape)
+The finance ontology now declares a `conventions.sign_natural_balance` block
+(`verticals/finance/ontology.yaml`) stating that measures are expressed in their
+natural-balance direction (credit-normal = credit−debit, debit-normal = debit−credit)
+so they read positive. The engine pipes this verbatim into BOTH SQL-authoring agents:
+- **extraction** (`graphs/context.py` → `graphs/agent.py` `_generate_sql` → the
+  `graph_sql_generation` prompt's new `{vertical_conventions}` slot), and
+- **validation** (`validation_phase.py` → `validation/agent.py` → the `validation_sql`
+  prompt's new `{conventions}` slot).
+The engine stays domain-agnostic — it routes an opaque string; only the vertical YAML
+holds credit/debit vocabulary.
+
+### Why eval cares (calibration to run)
+- **Profitability tree should now GROUND and EXECUTE.** Before, `revenue` grounded with
+  a non-deterministic sign (often `SUM(debit)−SUM(credit)` = negative) and failed its
+  declared `value > 0`, cascading 8 dependent metrics to ungroundable. With the sign
+  convention fed in, `revenue` (and other credit-normal measures) should ground positive
+  and the gross_profit/margin/ebitda/net_income tree should reach `executed`. Re-run the
+  finance grounding calibration; expect MORE metrics executed, not fewer.
+- **`sign_conventions` validation SQL changed framing.** It no longer declares its own
+  `credit_normal_types`/`debit_normal_types` lists or expects `revenue ≤ 0` (net-debit).
+  It now consumes the shared convention and checks **natural balance ≥ 0**. If eval holds
+  a fixed ground-truth SQL/snapshot for `sign_conventions`, it will diverge — update it.
+  The pass/fail outcome on clean data is unchanged (still ~0 violations).
+
+### Thresholds / new fields
+None. No score thresholds, no new stored response fields — this changes LLM prompt
+INPUT (an extra `<domain_conventions>` block), not engine output shape.
+
+### testdata hints
+Any finance fixture exercising the profitability tree is the regression: revenue should
+ground positive and the margin metrics should execute. A vertical without a `conventions`
+block is unaffected (the block renders empty).
+
+---
+
 ## DAT-643 — formula/constant authoring is fully deterministic (shadow + LLM fallback retired)
 
 **Branch:** `refactor/dat-643-retire-shadow`.

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -272,3 +272,8 @@ inputs:
     type: "string"
     required: true
     description: "Prior-run honest-fail reason + prior value→concept grounding for this concept (empty string if none)"
+  vertical_conventions:
+    type: "string"
+    required: false
+    default: ""
+    description: "Vertical conventions to apply (verbatim); empty when the vertical declares none"

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -143,6 +143,15 @@ system_prompt: |
   `sum` on a `point_in_time` column), trust `temporal_behavior` and note the reason in assumptions.
   </temporal_signals>
 
+  <domain_conventions>
+  The active vertical may supply authoritative conventions in the <domain_conventions> block of
+  the evidence. When present, they govern how a measure is computed or expressed and OVERRIDE any
+  default you would otherwise assume. Apply every convention whose terms match the concept you are
+  grounding, composing its rule into the SQL; a concept no convention mentions follows the default.
+  These are the vertical's words, not yours — honor them literally rather than substituting your
+  own domain assumptions.
+  </domain_conventions>
+
   <duckdb_dialect>
   CRITICAL DuckDB rules (violations cause runtime errors or silent wrongness):
   1. Table references: ALWAYS use the enriched views (enriched_*) when available in <data_schema>,
@@ -202,6 +211,10 @@ user_prompt: |
   <field_mappings>
   {field_mappings}
   </field_mappings>
+
+  <domain_conventions description="Authoritative vertical conventions to apply when grounding. Empty when the vertical declares none — then use the defaults.">
+  {vertical_conventions}
+  </domain_conventions>
 
   <graph_specification description="The single concept to ground — its standard_field, statement, and aggregation.">
   {graph_yaml}

--- a/packages/dataraum-config/llm/prompts/validation_sql.yaml
+++ b/packages/dataraum-config/llm/prompts/validation_sql.yaml
@@ -60,6 +60,14 @@ system_prompt: |
     Return descriptive column names
   </check_types>
 
+  <domain_conventions>
+  The active vertical may supply authoritative conventions in the <domain_conventions> block of
+  the task. When present, they govern how a measure is computed or expressed and OVERRIDE any
+  default you would otherwise assume. Apply every convention whose terms match the columns/values
+  this check operates on, composing its rule into the SQL. These are the vertical's words, not
+  yours — honor them literally.
+  </domain_conventions>
+
   Use the generate_validation_sql tool to provide your response.
 
 # User prompt - provides context and task
@@ -83,6 +91,10 @@ user_prompt: |
 
   {schema}
   </schema>
+
+  <domain_conventions>
+  {conventions}
+  </domain_conventions>
 
   <instructions>
   1. Identify which columns from the schema are needed for this validation
@@ -126,3 +138,8 @@ inputs:
   schema:
     description: Available tables and columns with types
     required: true
+
+  conventions:
+    description: Vertical conventions to apply (verbatim); empty when none declared
+    required: false
+    default: ""

--- a/packages/dataraum-config/verticals/finance/ontology.yaml
+++ b/packages/dataraum-config/verticals/finance/ontology.yaml
@@ -285,8 +285,11 @@ concepts:
 # consumes this block instead of re-declaring its own account lists, so the
 # extraction and validation paths can no longer disagree about sign.
 conventions:
+    # Scoped routing: ALL extraction (every measure needs a sign), but only the
+    # sign_conventions VALIDATION — a sign rule is noise in unrelated checks like a
+    # raw debit=credit trial-balance test (qa = fast-follow).
   - id: sign_natural_balance
-    targets: [extraction, validation]   # generic consumer labels (qa = fast-follow)
+    targets: [extraction, "validation:sign_conventions"]
     statement: >
       Express every monetary measure in its natural-balance direction so a healthy
       value reads POSITIVE. By account family: asset and expense accounts are

--- a/packages/dataraum-config/verticals/finance/ontology.yaml
+++ b/packages/dataraum-config/verticals/finance/ontology.yaml
@@ -276,3 +276,37 @@ concepts:
     temporal_behavior: point_in_time
     typical_role: measure
     unit_from_concept: currency
+
+# Domain conventions, piped VERBATIM to any SQL-authoring agent (extraction +
+# validation) — DAT-645. The engine parses only the generic envelope (id /
+# targets / statement / concept_groups) and lints that group members are declared
+# concepts; it never interprets "sign" or "credit_normal" — those are opaque
+# labels the LLM reads. Single source of truth: validations/sign_conventions.yaml
+# consumes this block instead of re-declaring its own account lists, so the
+# extraction and validation paths can no longer disagree about sign.
+conventions:
+  - id: sign_natural_balance
+    targets: [extraction, validation]   # generic consumer labels (qa = fast-follow)
+    statement: >
+      Express every monetary measure in its natural-balance direction so a healthy
+      value reads POSITIVE: a credit-normal concept is SUM(credit) - SUM(debit); a
+      debit-normal concept is SUM(debit) - SUM(credit). Exclude contra accounts
+      (names containing accumulated, allowance, contra, reserve) — they legitimately
+      carry the opposite sign. A concept not listed below has no fixed normal balance
+      (raw ledger columns such as debit, credit, transaction_amount, or period
+      balances) — sign it from its account context, not from this rule.
+    concept_groups:
+      credit_normal:
+        - revenue
+        - accounts_payable
+        - current_liabilities
+        - equity
+      debit_normal:
+        - cost_of_goods_sold
+        - operating_expense
+        - depreciation
+        - tax
+        - accounts_receivable
+        - inventory
+        - current_assets
+        - cash

--- a/packages/dataraum-config/verticals/finance/ontology.yaml
+++ b/packages/dataraum-config/verticals/finance/ontology.yaml
@@ -289,11 +289,14 @@ conventions:
     targets: [extraction, validation]   # generic consumer labels (qa = fast-follow)
     statement: >
       Express every monetary measure in its natural-balance direction so a healthy
-      value reads POSITIVE: a credit-normal concept is SUM(credit) - SUM(debit); a
-      debit-normal concept is SUM(debit) - SUM(credit). Exclude contra accounts
-      (names containing accumulated, allowance, contra, reserve) — they legitimately
-      carry the opposite sign. A concept not listed below has no fixed normal balance
-      (raw ledger columns such as debit, credit, transaction_amount, or period
+      value reads POSITIVE. By account family: asset and expense accounts are
+      DEBIT-normal (natural balance = SUM(debit) - SUM(credit)); liability, equity,
+      revenue, and income accounts are CREDIT-normal (natural balance = SUM(credit) -
+      SUM(debit)). Sign a measure by the normal balance of the accounts it is drawn
+      from; the concept groups below list which measures are credit- vs debit-normal.
+      Exclude contra accounts (names containing accumulated, allowance, contra,
+      reserve) — they legitimately invert. A measure not listed has no fixed normal
+      balance (raw ledger columns such as debit, credit, transaction_amount, or period
       balances) — sign it from its account context, not from this rule.
     concept_groups:
       credit_normal:

--- a/packages/dataraum-config/verticals/finance/validations/sign_conventions.yaml
+++ b/packages/dataraum-config/verticals/finance/validations/sign_conventions.yaml
@@ -1,13 +1,18 @@
 # Sign Convention Validation
-# Checks if account balances follow expected sign conventions
+# Checks that account balances follow the vertical's natural-balance convention.
+# DAT-645: the credit-/debit-normal account families are NOT declared here — they
+# come from the single source of truth, the `sign_natural_balance` convention in
+# ontology.yaml (piped into <domain_conventions>). Extraction and validation read the
+# SAME rule, so they can no longer disagree about sign.
 
 validation_id: sign_conventions
 name: Sign Convention Compliance
 description: >
-  Validates that account balances follow standard accounting sign conventions.
-  Assets and Expenses normally have debit (positive) balances.
-  Liabilities, Equity, and Revenue normally have credit (negative or positive) balances.
-  Violations may indicate data entry errors or contra accounts.
+  Validates that each account's NATURAL balance is positive, per the vertical's sign
+  convention: debit-normal accounts (assets, expenses) should have SUM(debit) >=
+  SUM(credit); credit-normal accounts (liabilities, equity, revenue, income) should
+  have SUM(credit) >= SUM(debit). A negative natural balance signals a data-entry
+  error or an unflagged contra account.
 
 category: financial
 severity: warning
@@ -23,34 +28,30 @@ relevant_cycles:
 
 check_type: constraint
 
-parameters:
-  # Expected signs for each account type (debit = positive typically)
-  debit_normal_types: ["asset", "assets", "expense", "expenses"]
-  credit_normal_types: ["liability", "liabilities", "equity", "revenue", "income"]
-
 sql_hints: >
-  IMPORTANT: Check sign conventions on AGGREGATED account balances, not
-  individual transaction lines. Individual journal lines naturally have
-  both debits and credits — that is correct double-entry bookkeeping.
+  Apply the account sign convention from <domain_conventions> — that block is the
+  single source of truth for which account families are credit- vs debit-normal; do
+  not hardcode your own lists.
+
+  IMPORTANT: check on AGGREGATED account balances, not individual transaction lines.
+  Individual journal lines naturally carry both a debit and a credit — that is correct
+  double-entry bookkeeping, not a violation.
 
   Steps:
-  1. Join journal lines with chart of accounts on account_id
-  2. GROUP BY account_id, account_type
-  3. Compute net_balance = SUM(debit) - SUM(credit) per account
-  4. Check the NET BALANCE sign against the expected convention:
-     - Asset/Expense accounts: net_balance should be >= 0 (debit normal)
-     - Liability/Equity/Revenue accounts: net_balance should be <= 0 (credit normal)
-  5. Exclude contra accounts: accounts with names containing 'accumulated',
-     'allowance', 'contra', or 'reserve' — these legitimately have the
-     opposite sign of their account type.
+  1. Join journal lines to chart of accounts on account_id; GROUP BY account_id,
+     account_type.
+  2. Classify each account_type as credit-normal or debit-normal using the convention.
+  3. Compute the NATURAL balance per account: SUM(credit) - SUM(debit) for credit-normal
+     accounts, SUM(debit) - SUM(credit) for debit-normal accounts.
+  4. Flag accounts whose natural balance is NEGATIVE — that is a sign violation.
+  5. Exclude contra accounts (names containing 'accumulated', 'allowance', 'contra',
+     or 'reserve') — they legitimately invert.
 
   Return violating accounts with: account_id, account_name, account_type,
-  net_balance, expected_sign.
-
-  Also return a total_rows column with the total number of accounts checked
-  (for proportional scoring).
+  natural_balance. Also return a total_rows column with the total number of accounts
+  checked (for proportional scoring).
 
 expected_outcome: >
-  Most accounts should follow sign conventions. A small number of
-  violations (1-3) may be acceptable for contra accounts not caught
-  by the name filter. Zero violations on well-structured data.
+  Most accounts should have a positive natural balance. A small number of violations
+  (1-3) may be acceptable for contra accounts not caught by the name filter. Zero
+  violations on well-structured data.

--- a/packages/engine/src/dataraum/analysis/semantic/__init__.py
+++ b/packages/engine/src/dataraum/analysis/semantic/__init__.py
@@ -23,6 +23,7 @@ from dataraum.analysis.semantic.models import (
 )
 from dataraum.analysis.semantic.ontology import (
     OntologyConcept,
+    OntologyConvention,
     OntologyDefinition,
     OntologyLoader,
 )
@@ -43,6 +44,7 @@ __all__ = [
     "OntologyLoader",
     "OntologyDefinition",
     "OntologyConcept",
+    "OntologyConvention",
     # Models
     "SemanticAnnotation",
     "EntityDetection",

--- a/packages/engine/src/dataraum/analysis/semantic/ontology.py
+++ b/packages/engine/src/dataraum/analysis/semantic/ontology.py
@@ -186,29 +186,35 @@ class OntologyLoader:
         return "\n".join(lines)
 
     def format_conventions_for_prompt(
-        self, ontology: OntologyDefinition | None, target: str
+        self, ontology: OntologyDefinition | None, target: str, qualifier: str | None = None
     ) -> str:
         """Render the vertical's conventions for one consumer (DAT-645).
 
         Returns the verbatim ``statement`` plus each ``concept_groups`` entry, for
-        every convention whose ``targets`` include ``target`` (e.g. ``extraction``
-        or ``validation``). The engine routes by the generic ``target`` label only
-        and emits the content as-is — it never interprets the group labels or the
-        statement. Empty string when nothing applies, so the prompt omits the
-        section entirely.
+        every convention whose ``targets`` include this consumer. A target may be
+        BROAD (``"validation"`` — every validation) or SPECIFIC
+        (``"validation:sign_conventions"`` — only that spec); ``qualifier`` carries
+        the specific id so a convention reaches ONLY the consumers it names. This
+        keeps an irrelevant convention (e.g. a sign rule) out of unrelated prompts
+        (e.g. a raw debit=credit check) — relevance is the vertical's call, not the
+        engine's. The engine routes by the generic label only; it never interprets
+        the group labels or the statement. Empty string when nothing applies.
 
         Args:
             ontology: Ontology definition, or None.
-            target: Consumer label to filter conventions by.
+            target: Consumer label (e.g. ``"extraction"``, ``"validation"``).
+            qualifier: Optional specific id (e.g. a validation's id) — a convention
+                also matches if its targets include ``f"{target}:{qualifier}"``.
 
         Returns:
             Formatted conventions text, or "" when none target this consumer.
         """
         if ontology is None or not ontology.conventions:
             return ""
+        specific = f"{target}:{qualifier}" if qualifier else None
         blocks: list[str] = []
         for conv in ontology.conventions:
-            if target not in conv.targets:
+            if target not in conv.targets and (specific is None or specific not in conv.targets):
                 continue
             lines = [conv.statement.strip()]
             for group, members in conv.concept_groups.items():

--- a/packages/engine/src/dataraum/analysis/semantic/ontology.py
+++ b/packages/engine/src/dataraum/analysis/semantic/ontology.py
@@ -7,9 +7,11 @@ through the shared :class:`~dataraum.core.vertical_loader.VerticalLoader`
 Custom ``verticals_dir`` (test fixtures) bypasses the overlay — deterministic.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from dataraum.core.config import get_config_dir
 from dataraum.core.vertical import VerticalKind, resolve_vertical
@@ -30,6 +32,25 @@ class OntologyConcept(BaseModel):
     is_unit_dimension: bool = False  # Whether this concept defines units for measures
 
 
+class OntologyConvention(BaseModel):
+    """A domain convention piped verbatim to SQL-authoring agents (DAT-645).
+
+    Conventions carry vertical-specific guidance that an LLM applies when
+    authoring SQL — e.g. the sign/normalization rule that makes a credit-normal
+    measure read positive. The engine is deliberately agnostic to the *content*:
+    it parses only this generic envelope, validates that ``concept_groups``
+    members are declared concepts, and routes the block by ``targets`` — it never
+    interprets the group labels or the ``statement`` prose (both finance-specific,
+    LLM-facing). Mirrors how ``description`` / ``sql_hints`` are parsed fields
+    whose values are opaque to the engine.
+    """
+
+    id: str
+    targets: list[str] = Field(default_factory=list)  # consumer labels: extraction|validation|qa
+    statement: str  # verbatim LLM-facing guidance — engine never interprets it
+    concept_groups: dict[str, list[str]] = Field(default_factory=dict)  # label -> concept names
+
+
 class OntologyDefinition(BaseModel):
     """A complete ontology definition from YAML."""
 
@@ -37,6 +58,44 @@ class OntologyDefinition(BaseModel):
     version: str = "1.0.0"
     description: str | None = None
     concepts: list[OntologyConcept] = Field(default_factory=list)
+    conventions: list[OntologyConvention] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_conventions(self) -> OntologyDefinition:
+        """Lint conventions against the concept vocabulary (DAT-645), born-loud.
+
+        Generic, vertical-agnostic checks — the engine validates that references
+        *resolve*, never what a group *means*:
+
+        - **resolve:** every concept named in a ``concept_groups`` list must be a
+          declared concept (catches typos / renamed concepts).
+        - **disjoint:** a concept may not appear in two groups of the same
+          convention (e.g. both credit- and debit-normal — a contradiction).
+
+        Coverage ("every measure is grouped") is intentionally NOT enforced: raw
+        ledger columns and period balances legitimately have no fixed group, so
+        full coverage is ill-defined. The per-metric runtime verifier is the
+        backstop for an ungrouped-but-should-be-grouped concept.
+        """
+        if not self.conventions:
+            return self
+        concept_names = {c.name for c in self.concepts}
+        for conv in self.conventions:
+            placed: dict[str, str] = {}  # concept name -> the group it first landed in
+            for group, members in conv.concept_groups.items():
+                for member in members:
+                    if member not in concept_names:
+                        raise ValueError(
+                            f"convention '{conv.id}' group '{group}' references "
+                            f"'{member}', which is not a declared concept"
+                        )
+                    if member in placed:
+                        raise ValueError(
+                            f"convention '{conv.id}' assigns '{member}' to both "
+                            f"'{placed[member]}' and '{group}' — groups must be disjoint"
+                        )
+                    placed[member] = group
+        return self
 
 
 class OntologyLoader:
@@ -126,9 +185,41 @@ class OntologyLoader:
 
         return "\n".join(lines)
 
+    def format_conventions_for_prompt(
+        self, ontology: OntologyDefinition | None, target: str
+    ) -> str:
+        """Render the vertical's conventions for one consumer (DAT-645).
+
+        Returns the verbatim ``statement`` plus each ``concept_groups`` entry, for
+        every convention whose ``targets`` include ``target`` (e.g. ``extraction``
+        or ``validation``). The engine routes by the generic ``target`` label only
+        and emits the content as-is — it never interprets the group labels or the
+        statement. Empty string when nothing applies, so the prompt omits the
+        section entirely.
+
+        Args:
+            ontology: Ontology definition, or None.
+            target: Consumer label to filter conventions by.
+
+        Returns:
+            Formatted conventions text, or "" when none target this consumer.
+        """
+        if ontology is None or not ontology.conventions:
+            return ""
+        blocks: list[str] = []
+        for conv in ontology.conventions:
+            if target not in conv.targets:
+                continue
+            lines = [conv.statement.strip()]
+            for group, members in conv.concept_groups.items():
+                lines.append(f"{group}: {', '.join(members)}")
+            blocks.append("\n".join(lines))
+        return "\n\n".join(blocks)
+
 
 __all__ = [
     "OntologyConcept",
+    "OntologyConvention",
     "OntologyDefinition",
     "OntologyLoader",
 ]

--- a/packages/engine/src/dataraum/analysis/validation/agent.py
+++ b/packages/engine/src/dataraum/analysis/validation/agent.py
@@ -136,6 +136,7 @@ class ValidationAgent(LLMFeature):
         table_ids: list[str],
         spec: ValidationSpec,
         schema: dict[str, Any],
+        conventions: str = "",
     ) -> tuple[GeneratedSQL | None, ValidationResult | None]:
         """``validation.bind`` — ground a declared spec against the workspace.
 
@@ -153,7 +154,7 @@ class ValidationAgent(LLMFeature):
         combined_table_name = ", ".join(table_names)
 
         # Generate SQL via LLM
-        sql_result = self._generate_sql(spec, schema)
+        sql_result = self._generate_sql(spec, schema, conventions=conventions)
 
         if not sql_result.success or not sql_result.value:
             return None, ValidationResult(
@@ -288,6 +289,7 @@ class ValidationAgent(LLMFeature):
         self,
         spec: ValidationSpec,
         schema: dict[str, Any],
+        conventions: str = "",
     ) -> Result[GeneratedSQL]:
         """Generate SQL via LLM using tool-based structured output.
 
@@ -324,6 +326,9 @@ class ValidationAgent(LLMFeature):
             "sql_hints": sql_hints,
             "expected_outcome": expected,
             "schema": schema_text,
+            # DAT-645: the vertical's conventions, piped verbatim (engine never
+            # interprets them) — the same source of truth extraction uses.
+            "conventions": conventions,
         }
 
         # Render prompt using template

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -76,7 +76,9 @@ def _ordered_dep_steps(graph: TransformationGraph, output_step: GraphStep) -> li
         if step_id in done:
             return
         if step_id in on_path:
-            raise ValueError(f"formula '{output_step.step_id}' has a dependency cycle at '{step_id}'")
+            raise ValueError(
+                f"formula '{output_step.step_id}' has a dependency cycle at '{step_id}'"
+            )
         on_path.add(step_id)
         step = graph.steps.get(step_id)
         if step is not None:

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -53,26 +53,37 @@ logger = get_logger(__name__)
 
 
 def _ordered_dep_steps(graph: TransformationGraph, output_step: GraphStep) -> list[str]:
-    """Transitive dependency step ids of ``output_step``, deps-before-dependents.
+    """``output_step``'s transitive dependency subgraph, deps-before-dependents.
 
     Depth-first post-order over ``depends_on`` (DAT-645): a step is appended only
-    after all its own deps, so the resulting list is a valid CTE materialization
-    order for a NESTED formula (an inner formula's snippet references its own
-    extract deps, which must be defined as earlier CTEs). A dep that is not a step
-    in ``graph`` (a leaf snippet supplied only via the cache, e.g. in a unit
-    fixture) is treated as a leaf with no further deps. Excludes ``output_step``.
+    after all its own deps, so the result is a valid CTE materialization order for a
+    NESTED formula (an inner formula's snippet references its own extract deps, which
+    must be defined as earlier CTEs). Visits only the transitive deps of
+    ``output_step`` — the output step itself is never in the list. A dep that is not a
+    step in ``graph`` (a leaf snippet supplied only via the cache, e.g. in a unit
+    fixture) is treated as a leaf with no further deps.
+
+    Raises:
+        ValueError: a ``depends_on`` cycle. The warm DAG already rejects cycles
+            (``node_warming.build_warm_dag``), so this only fires on a malformed graph
+            reaching the composer off that path — born-loud, not a silently-wrong order.
     """
     order: list[str] = []
-    seen: set[str] = set()
+    done: set[str] = set()
+    on_path: set[str] = set()
 
     def visit(step_id: str) -> None:
-        if step_id in seen:
+        if step_id in done:
             return
-        seen.add(step_id)
+        if step_id in on_path:
+            raise ValueError(f"formula '{output_step.step_id}' has a dependency cycle at '{step_id}'")
+        on_path.add(step_id)
         step = graph.steps.get(step_id)
         if step is not None:
             for dep in step.depends_on:
                 visit(dep)
+        on_path.discard(step_id)
+        done.add(step_id)
         order.append(step_id)
 
     for dep in output_step.depends_on:

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -531,6 +531,9 @@ class GraphAgent(LLMFeature):
             # DAT-616: feed back what prior runs learned for this concept — the
             # honest-fail reason + prior value→concept filter decisions.
             "prior_context": self._build_prior_context(session, graph, cached_snippets),
+            # DAT-645: the vertical's conventions (e.g. the sign/natural-balance
+            # rule), piped verbatim — the engine does not interpret them.
+            "vertical_conventions": context.rich_context.conventions,
         }
 
         # Render prompt with system/user split.

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -52,6 +52,34 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _ordered_dep_steps(graph: TransformationGraph, output_step: GraphStep) -> list[str]:
+    """Transitive dependency step ids of ``output_step``, deps-before-dependents.
+
+    Depth-first post-order over ``depends_on`` (DAT-645): a step is appended only
+    after all its own deps, so the resulting list is a valid CTE materialization
+    order for a NESTED formula (an inner formula's snippet references its own
+    extract deps, which must be defined as earlier CTEs). A dep that is not a step
+    in ``graph`` (a leaf snippet supplied only via the cache, e.g. in a unit
+    fixture) is treated as a leaf with no further deps. Excludes ``output_step``.
+    """
+    order: list[str] = []
+    seen: set[str] = set()
+
+    def visit(step_id: str) -> None:
+        if step_id in seen:
+            return
+        seen.add(step_id)
+        step = graph.steps.get(step_id)
+        if step is not None:
+            for dep in step.depends_on:
+                visit(dep)
+        order.append(step_id)
+
+    for dep in output_step.depends_on:
+        visit(dep)
+    return order
+
+
 @dataclass
 class GeneratedCode:
     """LLM-generated SQL for a specific graph + schema combination."""
@@ -1088,8 +1116,14 @@ class GraphAgent(LLMFeature):
         else:  # FORMULA
             if not output_step.expression:
                 raise ValueError(f"formula '{graph.graph_id}' has no expression — cannot compose")
-            deps = output_step.depends_on
-            missing = [d for d in deps if d not in cached_snippets]
+            # Materialize the FULL transitive dependency closure as CTE steps, ordered
+            # deps-before-dependents (DAT-645). A formula may depend on another formula
+            # (e.g. operating_income = gross_profit - operating_expense): the inner
+            # formula's snippet is `(SELECT value FROM revenue) - ...`, so its own
+            # extract deps must also be materialized as CTEs or execution fails with
+            # "Table revenue does not exist". Direct deps alone are not enough.
+            ordered = _ordered_dep_steps(graph, output_step)
+            missing = [d for d in ordered if d not in cached_snippets]
             if missing:
                 raise ValueError(
                     f"formula '{graph.graph_id}' dependency/ies {missing} not grounded — "
@@ -1102,9 +1136,10 @@ class GraphAgent(LLMFeature):
                     "sql": cached_snippets[d]["sql"],
                     "description": cached_snippets[d].get("description", ""),
                 }
-                for d in deps
+                for d in ordered
             ]
-            final_sql = compose_formula_sql(output_step.expression, set(deps))
+            # final_sql references the OUTPUT's direct deps (each a CTE in `steps`).
+            final_sql = compose_formula_sql(output_step.expression, set(output_step.depends_on))
             summary = f"Composed {graph.graph_id}: {output_step.expression}"
 
         return GeneratedCode(

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -339,6 +339,12 @@ class GraphExecutionContext:
     # long-format data where field_mappings is empty. None when no vertical.
     concept_vocabulary: str | None = None
 
+    # Vertical conventions for the extraction consumer (DAT-645): verbatim,
+    # LLM-facing domain guidance (e.g. the sign/natural-balance rule) the SQL
+    # agent applies when authoring a measure. Opaque to the engine — see
+    # OntologyConvention. Empty string when the vertical declares none.
+    conventions: str = ""
+
     # Metadata
     built_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
@@ -796,12 +802,17 @@ def build_execution_context(
     # is empty for the P&L concepts; serving the ontology lets the agent ground which
     # discriminator VALUES are revenue/cogs/opex from the value-sets it's now fed.
     concept_vocabulary: str | None = None
+    # Vertical conventions for the EXTRACTION consumer (DAT-645) — the sign rule
+    # etc. piped verbatim so the SQL agent grounds a credit-normal measure positive.
+    conventions: str = ""
     if vertical:
         try:
             from dataraum.analysis.semantic.ontology import OntologyLoader
 
-            ontology = OntologyLoader().load(vertical)
+            loader = OntologyLoader()
+            ontology = loader.load(vertical)
             concept_vocabulary = _format_concept_vocabulary(ontology)
+            conventions = loader.format_conventions_for_prompt(ontology, "extraction")
         except Exception as e:
             logger.warning("concept_vocabulary_load_failed", vertical=vertical, error=str(e))
 
@@ -1084,6 +1095,7 @@ def build_execution_context(
         enriched_views=enriched_view_contexts,
         field_mappings=field_mappings,
         concept_vocabulary=concept_vocabulary,
+        conventions=conventions,
     )
 
 

--- a/packages/engine/src/dataraum/pipeline/phases/validation_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/validation_phase.py
@@ -175,20 +175,23 @@ class ValidationPhase(BasePhase):
             )
         table_names = ", ".join(t["table_name"] for t in schema.get("tables", []))
 
-        # DAT-645: the vertical's conventions for the VALIDATION consumer, piped
-        # verbatim into every spec's SQL generation. Same source of truth the graph
-        # agent uses for extraction, so validation and extraction can no longer
-        # disagree about (e.g.) account sign. Empty when the vertical declares none.
-        conventions = ""
-        if vertical:
-            loader = OntologyLoader()
-            conventions = loader.format_conventions_for_prompt(loader.load(vertical), "validation")
+        # DAT-645: the vertical's conventions, piped verbatim into the SQL
+        # generation of the validations they target. A convention is routed
+        # PER-SPEC (qualifier = the validation id), so a sign rule reaches only the
+        # validations that name it (e.g. `validation:sign_conventions`) and stays
+        # out of unrelated checks. Same source of truth the graph agent uses for
+        # extraction. Empty when the vertical declares none.
+        ontology_loader = OntologyLoader()
+        ontology = ontology_loader.load(vertical) if vertical else None
 
         # bind → execute per artifact
         results: list[ValidationResult] = []
         for validation_id, spec in specs.items():
             artifact = artifacts[validation_id]
 
+            conventions = ontology_loader.format_conventions_for_prompt(
+                ontology, "validation", qualifier=validation_id
+            )
             generated, bind_failure = agent.bind_validation(
                 ctx.duckdb_conn, table_ids, spec, schema, conventions=conventions
             )

--- a/packages/engine/src/dataraum/pipeline/phases/validation_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/validation_phase.py
@@ -174,13 +174,24 @@ class ValidationPhase(BasePhase):
             )
         table_names = ", ".join(t["table_name"] for t in schema.get("tables", []))
 
+        # DAT-645: the vertical's conventions for the VALIDATION consumer, piped
+        # verbatim into every spec's SQL generation. Same source of truth the graph
+        # agent uses for extraction, so validation and extraction can no longer
+        # disagree about (e.g.) account sign. Empty when the vertical declares none.
+        from dataraum.analysis.semantic.ontology import OntologyLoader
+
+        conventions = ""
+        if vertical:
+            loader = OntologyLoader()
+            conventions = loader.format_conventions_for_prompt(loader.load(vertical), "validation")
+
         # bind → execute per artifact
         results: list[ValidationResult] = []
         for validation_id, spec in specs.items():
             artifact = artifacts[validation_id]
 
             generated, bind_failure = agent.bind_validation(
-                ctx.duckdb_conn, table_ids, spec, schema
+                ctx.duckdb_conn, table_ids, spec, schema, conventions=conventions
             )
             if bind_failure is not None:
                 # Ungroundable: stays declared, reason on the row.

--- a/packages/engine/src/dataraum/pipeline/phases/validation_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/validation_phase.py
@@ -29,6 +29,7 @@ from datetime import UTC, datetime
 from types import ModuleType
 from typing import TYPE_CHECKING, Any
 
+from dataraum.analysis.semantic.ontology import OntologyLoader
 from dataraum.analysis.validation import ValidationAgent
 from dataraum.analysis.validation.config import load_all_validation_specs
 from dataraum.analysis.validation.db_models import ValidationResultRecord
@@ -178,8 +179,6 @@ class ValidationPhase(BasePhase):
         # verbatim into every spec's SQL generation. Same source of truth the graph
         # agent uses for extraction, so validation and extraction can no longer
         # disagree about (e.g.) account sign. Empty when the vertical declares none.
-        from dataraum.analysis.semantic.ontology import OntologyLoader
-
         conventions = ""
         if vertical:
             loader = OntologyLoader()

--- a/packages/engine/tests/integration/analysis/validation/test_agent.py
+++ b/packages/engine/tests/integration/analysis/validation/test_agent.py
@@ -349,6 +349,38 @@ class TestValidationAgentGenerateSQL:
         assert generated.columns_used == ["debit", "credit"]
         assert generated.is_valid is True
 
+    def test_generate_sql_pipes_conventions(self, validation_agent, mock_provider):
+        """DAT-645: the vertical's conventions reach the prompt context verbatim."""
+        spec = ValidationSpec(
+            validation_id="sign_conventions",
+            name="Sign",
+            description="d",
+            category="financial",
+            check_type="constraint",
+        )
+        schema = {
+            "table_name": "transactions",
+            "duckdb_path": "typed_transactions",
+            "columns": [{"column_name": "debit", "data_type": "DECIMAL"}],
+        }
+        mock_provider.converse.return_value = Result.ok(
+            _make_tool_response(
+                {
+                    "sql": "SELECT 1 AS x",
+                    "explanation": "e",
+                    "columns_used": [],
+                    "tables_used": [],
+                    "can_validate": True,
+                    "skip_reason": None,
+                }
+            )
+        )
+
+        validation_agent._generate_sql(spec, schema, conventions="CREDIT-NORMAL = credit - debit")
+
+        rendered_context = validation_agent.renderer.render_split.call_args.args[1]
+        assert rendered_context["conventions"] == "CREDIT-NORMAL = credit - debit"
+
     def test_generate_sql_cannot_validate(self, validation_agent, mock_provider):
         """Test when LLM indicates validation cannot be performed."""
         spec = ValidationSpec(

--- a/packages/engine/tests/integration/graphs/test_agent.py
+++ b/packages/engine/tests/integration/graphs/test_agent.py
@@ -513,6 +513,77 @@ class TestComposeGroundingFree:
         with pytest.raises(ValueError, match="no expression"):
             self._agent()._compose_grounding_free(graph.get_output_step(), graph, {}, {})
 
+    def test_nested_formula_materializes_transitive_extract_ctes(self) -> None:
+        """A formula-over-formula must materialize the INNER formula's extract deps as
+        CTEs too (DAT-645). operating_income = gross_profit - operating_expense, where
+        gross_profit = revenue - cost_of_goods_sold: gross_profit's snippet references
+        revenue/cogs, so those must be earlier CTEs or execution fails 'Table revenue
+        does not exist'. Direct deps alone are not enough."""
+
+        def _ext(sid: str) -> GraphStep:
+            return GraphStep(
+                step_id=sid,
+                step_type=StepType.EXTRACT,
+                source=StepSource(standard_field=sid, statement="income_statement"),
+                aggregation="sum",
+            )
+
+        graph = TransformationGraph(
+            graph_id="operating_income",
+            version="1.0",
+            metadata=GraphMetadata(
+                name="oi", description="", category="profitability", source=GraphSource.SYSTEM
+            ),
+            output=OutputDef(output_type=OutputType.SCALAR),
+            steps={
+                "revenue": _ext("revenue"),
+                "cost_of_goods_sold": _ext("cost_of_goods_sold"),
+                "operating_expense": _ext("operating_expense"),
+                "gross_profit": GraphStep(
+                    step_id="gross_profit",
+                    step_type=StepType.FORMULA,
+                    expression="revenue - cost_of_goods_sold",
+                    depends_on=["revenue", "cost_of_goods_sold"],
+                ),
+                "operating_income": GraphStep(
+                    step_id="operating_income",
+                    step_type=StepType.FORMULA,
+                    expression="gross_profit - operating_expense",
+                    depends_on=["gross_profit", "operating_expense"],
+                    output_step=True,
+                ),
+            },
+        )
+        cached = {
+            "revenue": {"sql": "SELECT 1000 AS value", "description": ""},
+            "cost_of_goods_sold": {"sql": "SELECT 600 AS value", "description": ""},
+            "operating_expense": {"sql": "SELECT 100 AS value", "description": ""},
+            "gross_profit": {
+                "sql": "SELECT ((SELECT value FROM revenue) - "
+                "(SELECT value FROM cost_of_goods_sold)) AS value",
+                "description": "",
+            },
+        }
+
+        code = self._agent()._compose_grounding_free(graph.get_output_step(), graph, cached, {})
+
+        step_ids = [s["step_id"] for s in code.steps]
+        # The full transitive closure is materialized — not just the direct deps.
+        assert set(step_ids) == {
+            "revenue",
+            "cost_of_goods_sold",
+            "operating_expense",
+            "gross_profit",
+        }
+        # The inner formula CTE is defined AFTER its extract deps (valid order).
+        assert step_ids.index("gross_profit") > step_ids.index("revenue")
+        assert step_ids.index("gross_profit") > step_ids.index("cost_of_goods_sold")
+        # final_sql composes the OUTPUT's direct deps (each a materialized CTE).
+        assert code.final_sql == (
+            "SELECT ((SELECT value FROM gross_profit) - "
+            "(SELECT value FROM operating_expense)) AS value"
+        )
+
 
 class TestDeterministicAuthoringEndToEnd:
     """execute() authors a formula/constant deterministically — the LLM is never called

--- a/packages/engine/tests/integration/llm/test_prompt_render_smoke.py
+++ b/packages/engine/tests/integration/llm/test_prompt_render_smoke.py
@@ -1,0 +1,57 @@
+"""Real-render smoke for the SQL-authoring prompts (DAT-645).
+
+The unit tests mock the renderer, so a placeholder in a prompt's body that is NOT
+declared in its `inputs:` section is invisible to them — the renderer drops
+undeclared keys and then raises KeyError at substitution, which the agents swallow
+into a silent Result.fail. These tests render the REAL config prompts with a minimal
+context, proving every declared placeholder substitutes (no inputs/body mismatch) and
+that the conventions block actually reaches the rendered text.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dataraum.llm.prompts import PromptRenderer
+
+_MARKER = "SIGN_RULE_MARKER"
+
+
+def _ctx_for(template, **extra) -> dict[str, str]:
+    """Minimal context satisfying the template's required inputs, plus overrides."""
+    ctx = {name: "x" for name, spec in template.inputs.items() if spec.get("required")}
+    ctx.update(extra)
+    return ctx
+
+
+@pytest.mark.parametrize(
+    ("prompt_name", "conventions_key"),
+    [
+        ("graph_sql_generation", "vertical_conventions"),
+        ("validation_sql", "conventions"),
+    ],
+)
+def test_sql_prompt_renders_and_pipes_conventions(prompt_name: str, conventions_key: str) -> None:
+    renderer = PromptRenderer()
+    template = renderer.load_template(prompt_name)
+    # The conventions key MUST be a declared (optional) input — else it is dropped and
+    # the {placeholder} in the body raises KeyError at render.
+    assert conventions_key in template.inputs, (
+        f"{prompt_name}: '{conventions_key}' placeholder is in the body but not declared "
+        f"in inputs: — the renderer would drop it and KeyError at substitution"
+    )
+    ctx = _ctx_for(template, **{conventions_key: _MARKER})
+
+    system, user, _temperature = renderer.render_split(prompt_name, ctx)
+
+    # Real substitution happened (no KeyError) and the conventions reached the prompt.
+    assert _MARKER in (system + user)
+
+
+@pytest.mark.parametrize("prompt_name", ["graph_sql_generation", "validation_sql"])
+def test_sql_prompt_renders_with_empty_conventions(prompt_name: str) -> None:
+    """The conventions input is optional — rendering with none declared still works."""
+    renderer = PromptRenderer()
+    template = renderer.load_template(prompt_name)
+    # Required-only context (conventions omitted → its default "" fills the slot).
+    renderer.render_split(prompt_name, _ctx_for(template))

--- a/packages/engine/tests/unit/analysis/semantic/test_ontology_loader.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_ontology_loader.py
@@ -175,6 +175,19 @@ class TestConventions:
             ont, "validation", qualifier="sign_conventions"
         )
 
+    def test_broad_target_matches_even_with_qualifier(self) -> None:
+        """A BROAD `validation` target reaches every spec — the qualifier doesn't
+        narrow a convention that already opted into all of them."""
+        loader = OntologyLoader()
+        ont = OntologyDefinition(
+            **self._ontology(
+                [{"id": "c", "targets": ["validation"], "statement": "rule", "concept_groups": {}}]
+            )
+        )
+        # Broad target matches with OR without a qualifier.
+        assert loader.format_conventions_for_prompt(ont, "validation")
+        assert loader.format_conventions_for_prompt(ont, "validation", qualifier="anything")
+
     def test_format_conventions_none(self) -> None:
         assert OntologyLoader().format_conventions_for_prompt(None, "extraction") == ""
 

--- a/packages/engine/tests/unit/analysis/semantic/test_ontology_loader.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_ontology_loader.py
@@ -136,12 +136,44 @@ class TestConventions:
         assert "debit_normal:" in out and "cost_of_goods_sold" in out
 
     def test_conventions_routed_by_target(self) -> None:
-        """A convention only renders for a target listed in its `targets`."""
+        """A convention renders only for a target it lists — broad or specific."""
         loader = OntologyLoader()
         ontology = loader.load("finance")
-        # finance's sign convention targets extraction + validation, not qa.
-        assert loader.format_conventions_for_prompt(ontology, "validation")
+        # finance's sign convention targets `extraction` (broad) + the SPECIFIC
+        # `validation:sign_conventions` — NOT every validation.
+        assert loader.format_conventions_for_prompt(ontology, "extraction")
         assert loader.format_conventions_for_prompt(ontology, "qa") == ""
+        # Broad `validation` (no qualifier) does NOT match the scoped target.
+        assert loader.format_conventions_for_prompt(ontology, "validation") == ""
+        # The named validation gets it; an unrelated one does not.
+        assert loader.format_conventions_for_prompt(
+            ontology, "validation", qualifier="sign_conventions"
+        )
+        assert (
+            loader.format_conventions_for_prompt(ontology, "validation", qualifier="trial_balance")
+            == ""
+        )
+
+    def test_qualifier_matches_specific_target(self) -> None:
+        """A `target:qualifier` target is reached only with the matching qualifier."""
+        loader = OntologyLoader()
+        ont = OntologyDefinition(
+            **self._ontology(
+                [
+                    {
+                        "id": "c",
+                        "targets": ["validation:sign_conventions"],
+                        "statement": "rule",
+                        "concept_groups": {},
+                    }
+                ]
+            )
+        )
+        assert loader.format_conventions_for_prompt(ont, "validation") == ""
+        assert loader.format_conventions_for_prompt(ont, "validation", qualifier="other") == ""
+        assert loader.format_conventions_for_prompt(
+            ont, "validation", qualifier="sign_conventions"
+        )
 
     def test_format_conventions_none(self) -> None:
         assert OntologyLoader().format_conventions_for_prompt(None, "extraction") == ""

--- a/packages/engine/tests/unit/analysis/semantic/test_ontology_loader.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_ontology_loader.py
@@ -2,7 +2,14 @@
 
 from pathlib import Path
 
+import pytest
+
 from dataraum.analysis.semantic import OntologyLoader
+from dataraum.analysis.semantic.ontology import (
+    OntologyConcept,
+    OntologyConvention,
+    OntologyDefinition,
+)
 from dataraum.core.overlay import (
     OverlayRow,
     reset_overlay_resolver_for_tests,
@@ -102,3 +109,101 @@ concepts:
         assert ontology.name == "test_ontology"
         assert len(ontology.concepts) == 1
         assert ontology.concepts[0].name == "test_concept"
+
+
+class TestConventions:
+    """Vertical conventions piped to SQL-authoring agents (DAT-645)."""
+
+    @staticmethod
+    def _ontology(conventions: list[dict]) -> dict:
+        return {
+            "name": "t",
+            "concepts": [
+                {"name": "revenue", "typical_role": "measure"},
+                {"name": "cost_of_goods_sold", "typical_role": "measure"},
+            ],
+            "conventions": conventions,
+        }
+
+    def test_finance_conventions_render_for_extraction(self) -> None:
+        """The shipped finance sign convention loads and renders for extraction."""
+        loader = OntologyLoader()
+        ontology = loader.load("finance")
+        out = loader.format_conventions_for_prompt(ontology, "extraction")
+        assert "natural-balance" in out.lower()
+        # Group labels + members are emitted verbatim for the LLM.
+        assert "credit_normal:" in out and "revenue" in out
+        assert "debit_normal:" in out and "cost_of_goods_sold" in out
+
+    def test_conventions_routed_by_target(self) -> None:
+        """A convention only renders for a target listed in its `targets`."""
+        loader = OntologyLoader()
+        ontology = loader.load("finance")
+        # finance's sign convention targets extraction + validation, not qa.
+        assert loader.format_conventions_for_prompt(ontology, "validation")
+        assert loader.format_conventions_for_prompt(ontology, "qa") == ""
+
+    def test_format_conventions_none(self) -> None:
+        assert OntologyLoader().format_conventions_for_prompt(None, "extraction") == ""
+
+    def test_valid_convention_resolves_and_is_disjoint(self) -> None:
+        ont = OntologyDefinition(
+            **self._ontology(
+                [
+                    {
+                        "id": "sign",
+                        "targets": ["extraction"],
+                        "statement": "rule",
+                        "concept_groups": {
+                            "credit_normal": ["revenue"],
+                            "debit_normal": ["cost_of_goods_sold"],
+                        },
+                    }
+                ]
+            )
+        )
+        assert len(ont.conventions) == 1
+
+    def test_lint_rejects_unknown_concept(self) -> None:
+        """A group member that is not a declared concept fails loud at load."""
+        with pytest.raises(ValueError, match="not a declared concept"):
+            OntologyDefinition(
+                **self._ontology(
+                    [
+                        {
+                            "id": "sign",
+                            "statement": "rule",
+                            "concept_groups": {"credit_normal": ["nonexistent_concept"]},
+                        }
+                    ]
+                )
+            )
+
+    def test_lint_rejects_concept_in_two_groups(self) -> None:
+        """A concept assigned to two groups (contradiction) fails loud."""
+        with pytest.raises(ValueError, match="disjoint"):
+            OntologyDefinition(
+                **self._ontology(
+                    [
+                        {
+                            "id": "sign",
+                            "statement": "rule",
+                            "concept_groups": {
+                                "credit_normal": ["revenue"],
+                                "debit_normal": ["revenue"],
+                            },
+                        }
+                    ]
+                )
+            )
+
+    def test_no_conventions_is_valid(self) -> None:
+        """Verticals without conventions (the common case) load fine."""
+        ont = OntologyDefinition(name="t", concepts=[OntologyConcept(name="x")])
+        assert ont.conventions == []
+
+
+def test_convention_model_defaults() -> None:
+    """A convention needs only id + statement; groups/targets default empty."""
+    conv = OntologyConvention(id="c", statement="s")
+    assert conv.targets == [] and conv.concept_groups == {}

--- a/packages/engine/tests/unit/graphs/test_prompt_selection.py
+++ b/packages/engine/tests/unit/graphs/test_prompt_selection.py
@@ -75,6 +75,7 @@ def test_extract_node_uses_the_grounding_prompt_on_balanced_tier(monkeypatch) ->
     agent._build_prior_context = MagicMock(return_value="")  # type: ignore[method-assign]
     rich = MagicMock()
     rich.field_mappings.mappings = {"revenue": object()}
+    rich.conventions = "CREDIT-NORMAL → credit - debit"  # DAT-645: vertical conventions
     ctx = ExecutionContext(duckdb_conn=MagicMock(), schema_mapping_id="ws", rich_context=rich)
 
     agent._generate_sql(MagicMock(), graph, ctx, {})
@@ -83,3 +84,5 @@ def test_extract_node_uses_the_grounding_prompt_on_balanced_tier(monkeypatch) ->
     assert name == "graph_sql_generation"
     provider.get_model_for_tier.assert_called_with("balanced")
     assert prompt_ctx["rich_context"] == "META" and prompt_ctx["field_mappings"] == "MAPS"
+    # DAT-645: the vertical's conventions are piped verbatim into the prompt context.
+    assert prompt_ctx["vertical_conventions"] == "CREDIT-NORMAL → credit - debit"


### PR DESCRIPTION
## What & why

Fixes the DAT-645 grounding bug: `revenue` (a credit-normal measure) grounded with a **non-deterministic sign** — often `SUM(debit) − SUM(credit)` = −51.77M — and failed its declared `value > 0`, cascading 8 dependent profitability metrics to ungroundable. Root cause: nothing told the grounding LLM which sign convention to use, so a temp>0 sampler coin-flipped it.

The fix keeps the engine a **general analysis platform** — sign is the *vertical's* business, not the engine's. A vertical declares its conventions; the engine pipes them verbatim to its SQL-authoring agents and never interprets them.

## Design

- **Generic, lintable `conventions` schema** in the ontology (`id` / `targets` / `statement` / `concept_groups`). The engine parses the envelope and lints it (members resolve to declared concepts; groups disjoint — coverage deliberately NOT enforced, since raw ledger columns have no fixed sign; the `value > 0` verifier is the backstop). It never reads `credit`/`debit`/`sign` — those are opaque values in the vertical YAML.
- **Wired to both engine SQL agents**, routed by a generic `targets` label: the graph agent (extraction) and the validation agent (validation). The shared prompts get a generic `<domain_conventions>` instruction with **zero finance vocabulary**; the credit/debit specifics ride only in the injected `{vertical_conventions}` / `{conventions}` content.
- **Contradiction killed (a bug):** `sign_conventions.yaml` previously expected `revenue ≤ 0` (net-debit) while the metric expected `value > 0` (report-positive). It now consumes the *same* convention and checks natural-balance-positive — one source of truth, both agents agree.

## Phasing
1. ontology model + lint + finance `sign_natural_balance` block
2. wire into the graph agent (extraction)
3. wire into the validation agent + kill the contradiction
4. review fix: declare `vertical_conventions` in the prompt `inputs:` (a senior-review catch — the placeholder was undeclared, so the renderer dropped it and the `KeyError` was swallowed into a silent `Result.fail`, making extraction inert) + a real-render smoke test that the mocked unit tests can't substitute for

## Verification
- Full engine suite green (1964 passed, 8 skipped); ruff + mypy clean.
- Reviews: spec-compliance **COMPLIANT**; senior **NEEDS WORK → resolved** (the inputs fix + real-render test).
- **Real-LLM e2e acceptance pending** (revenue grounds positive; profitability tree executes; sign_conventions still passes).

## Eval impact
Calibration-relevant (handoff added): the profitability tree should now ground+execute (more metrics executed, not fewer); `sign_conventions` SQL changed framing (natural-balance), so update any fixed ground-truth snapshot — clean-data outcome unchanged. No new response fields/thresholds; this changes prompt INPUT.

Deferred: cockpit Q&A agent (`targets: [qa]` hook); data-inferred per-account polarity for contra accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)