### PR TITLE
feat(DAT-645): wire vertical conventions into the cockpit Q&A agent

### DIFF
--- a/packages/cockpit/src/prompts/conventions.test.ts
+++ b/packages/cockpit/src/prompts/conventions.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+// conventions.ts imports `config` at module load (env-validated at import) — stub
+// it so the unit test doesn't boot the real Zod env. The pure formatter under test
+// doesn't use config; this just keeps the import side-effect-free.
+vi.mock("#/config", () => ({ config: { dataraumConfigPath: "/unused" } }));
+
+import { formatConventionsBlock } from "./conventions";
+
+const conv = (over: Record<string, unknown> = {}) => [
+	{
+		id: "sign_natural_balance",
+		targets: ["extraction", "validation:sign_conventions", "qa"],
+		statement:
+			"Express every measure in its natural-balance direction so it reads positive.",
+		concept_groups: {
+			credit_normal: ["revenue", "equity"],
+			debit_normal: ["cost_of_goods_sold"],
+		},
+		...over,
+	},
+];
+
+describe("formatConventionsBlock", () => {
+	it("renders the statement + groups verbatim for a qa-targeted convention", () => {
+		const out = formatConventionsBlock(conv());
+		expect(out).toContain("<domain_conventions>");
+		expect(out).toContain("natural-balance direction");
+		expect(out).toContain("credit_normal: revenue, equity");
+		expect(out).toContain("debit_normal: cost_of_goods_sold");
+		expect(out.endsWith("</domain_conventions>")).toBe(true);
+	});
+
+	it("returns '' when no convention targets the consumer", () => {
+		expect(formatConventionsBlock(conv({ targets: ["extraction"] }))).toBe("");
+	});
+
+	it("routes by the target label", () => {
+		// Same convention, asked for the `extraction` consumer instead.
+		expect(formatConventionsBlock(conv(), "extraction")).toContain(
+			"<domain_conventions>",
+		);
+	});
+
+	it("returns '' for non-array / empty / no-statement input", () => {
+		expect(formatConventionsBlock(null)).toBe("");
+		expect(formatConventionsBlock(undefined)).toBe("");
+		expect(formatConventionsBlock([])).toBe("");
+		expect(formatConventionsBlock([{ targets: ["qa"] }])).toBe(""); // statement missing
+	});
+
+	it("narrows untrusted shapes (rule 11) — bad targets/members are skipped", () => {
+		// targets not an array → excluded.
+		expect(formatConventionsBlock([{ targets: "qa", statement: "x" }])).toBe(
+			"",
+		);
+		// a non-array group is dropped, the rest still renders.
+		const out = formatConventionsBlock([
+			{
+				targets: ["qa"],
+				statement: "x",
+				concept_groups: { good: ["a"], bad: "nope" },
+			},
+		]);
+		expect(out).toContain("good: a");
+		expect(out).not.toContain("bad:");
+	});
+});

--- a/packages/cockpit/src/prompts/conventions.ts
+++ b/packages/cockpit/src/prompts/conventions.ts
@@ -1,0 +1,91 @@
+// Vertical conventions for the cockpit Q&A agent (DAT-645).
+//
+// The TS mirror of the engine's `OntologyLoader.format_conventions_for_prompt`
+// (`packages/engine/.../analysis/semantic/ontology.py`). The engine pipes a
+// vertical's conventions verbatim into its two SQL-authoring agents (extraction +
+// validation); the cockpit Q&A agent is the third SQL author (`targets: [..., qa]`)
+// and gets the same rule here. The cockpit NEVER interprets the content — it reads
+// the bind-mounted `verticals/<v>/ontology.yaml`, routes by the generic `target`
+// label, and emits the `statement` + `concept_groups` as-is for the LLM. The
+// finance-specific sign/credit/debit vocabulary lives only in the YAML.
+//
+// Q&A only ever uses the BROAD `qa` target (no per-spec qualifier), so the match is
+// a plain membership test — unlike validation, which routes per spec.
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { config } from "../config";
+
+// Untrusted shape off disk (rule 11) — narrowed below, never trusted.
+type ConventionDoc = {
+	targets?: unknown;
+	statement?: unknown;
+	concept_groups?: unknown;
+};
+
+function asStringArray(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((v): v is string => typeof v === "string")
+		: [];
+}
+
+/**
+ * Pure render of a parsed ontology's `conventions` list into a
+ * `<domain_conventions>` block for consumers whose label is `target`. Untrusted
+ * input (rule 11) — narrows every field. Returns "" when nothing applies (caller
+ * omits the section). Q&A uses the broad `qa` target, so this is a plain membership
+ * test (no per-spec qualifier, unlike the engine's validation routing).
+ */
+export function formatConventionsBlock(
+	conventions: unknown,
+	target = "qa",
+): string {
+	if (!Array.isArray(conventions)) return "";
+	const blocks: string[] = [];
+	for (const raw of conventions as ConventionDoc[]) {
+		if (typeof raw?.statement !== "string") continue;
+		if (!asStringArray(raw.targets).includes(target)) continue;
+		const lines = [raw.statement.trim()];
+		const groups = raw.concept_groups;
+		if (groups && typeof groups === "object") {
+			for (const [label, members] of Object.entries(
+				groups as Record<string, unknown>,
+			)) {
+				const names = asStringArray(members);
+				if (names.length > 0) lines.push(`${label}: ${names.join(", ")}`);
+			}
+		}
+		blocks.push(lines.join("\n"));
+	}
+	if (blocks.length === 0) return "";
+	return `<domain_conventions>\n${blocks.join("\n\n")}\n</domain_conventions>`;
+}
+
+/**
+ * Read the vertical's conventions and render those targeting `target` (default
+ * `qa`) for the Q&A agent's user turn. "" when the vertical is null, the ontology
+ * is missing/unparseable, or none target this consumer — best-effort, never throws
+ * (a config-read blip must not fail an answer). The cockpit never interprets the
+ * content; it routes by label and emits the YAML's statement + groups as-is.
+ */
+export async function buildConventionsBlock(
+	vertical: string | null,
+	target = "qa",
+): Promise<string> {
+	if (!vertical) return "";
+	try {
+		const text = await readFile(
+			join(config.dataraumConfigPath, "verticals", vertical, "ontology.yaml"),
+			"utf8",
+		);
+		// Bun's YAML, imported lazily (mirrors list-verticals.ts): a static import
+		// of "bun" would make merely importing this module pull "bun", which the
+		// node-run vitest workers can't resolve.
+		const { YAML } = await import("bun");
+		const doc = (YAML.parse(text) ?? null) as { conventions?: unknown } | null;
+		return formatConventionsBlock(doc?.conventions, target);
+	} catch {
+		return "";
+	}
+}

--- a/packages/cockpit/src/prompts/conventions.ts
+++ b/packages/cockpit/src/prompts/conventions.ts
@@ -73,7 +73,9 @@ export async function buildConventionsBlock(
 	vertical: string | null,
 	target = "qa",
 ): Promise<string> {
-	if (!vertical) return "";
+	// `_adhoc` (and any framed `_…` vertical) ships no conventions — skip the read
+	// entirely, mirroring list-verticals.ts's `startsWith("_")` guard.
+	if (!vertical || vertical.startsWith("_")) return "";
 	try {
 		const text = await readFile(
 			join(config.dataraumConfigPath, "verticals", vertical, "ontology.yaml"),

--- a/packages/cockpit/src/prompts/index.ts
+++ b/packages/cockpit/src/prompts/index.ts
@@ -3,6 +3,7 @@
 // with the agents that use them. Per-agent prompt builders export from their own
 // module.
 
+export { buildConventionsBlock } from "./conventions";
 export {
 	getFrameCyclesInstructions,
 	getFrameInstructions,

--- a/packages/cockpit/src/tools/query.test.ts
+++ b/packages/cockpit/src/tools/query.test.ts
@@ -9,6 +9,12 @@ vi.mock("#/config", () => ({
 	config: { dataraumWorkspaceId: "ws-test", anthropicApiKey: "k" },
 }));
 vi.mock("#/db/metadata/client", () => ({ metadataDb: {} }));
+// query.ts reads the workspace vertical (for DAT-645 conventions) via the cockpit
+// registry, which transitively pulls the bun-SQL client — stub it so the unit
+// import stays node-resolvable.
+vi.mock("#/db/cockpit/registry", () => ({
+	resolveActiveWorkspaceRow: async () => ({ vertical: "finance" }),
+}));
 
 // findById drives reuse classification; the other library exports exist only so
 // snippet-search (pulled via query.ts) imports cleanly.

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -33,6 +33,7 @@ import { createAnthropicChat } from "@tanstack/ai-anthropic";
 import { z } from "zod";
 
 import { config } from "../config";
+import { resolveActiveWorkspaceRow } from "../db/cockpit/registry";
 import { findById } from "../db/metadata/snippet-library";
 import { saveQuerySnippet } from "../db/metadata/snippet-writer";
 import {
@@ -48,7 +49,7 @@ import {
 	MODEL,
 	QUERY_SUBAGENT_MAX_ITERATIONS,
 } from "../llm";
-import { getQueryInstructions } from "../prompts";
+import { buildConventionsBlock, getQueryInstructions } from "../prompts";
 import {
 	AgentActionableError,
 	asAgentError,
@@ -571,6 +572,7 @@ export async function querySubAgent(
 		driversBlock,
 		vocabularyBlock,
 		nearUniqueColumns,
+		workspace,
 	] = await Promise.all([
 		buildSchemaBlock(),
 		buildEntitiesBlock(),
@@ -579,9 +581,20 @@ export async function querySubAgent(
 		buildDriversBlock(),
 		buildVocabularyBlock(),
 		loadNearUniqueColumns(),
+		resolveActiveWorkspaceRow(),
 	]);
 
-	const userMessage = `<question>\n${question}\n</question>\n\n${schemaBlock}\n\n${entitiesBlock}\n\n${catalogBlock}\n\n${relationshipsBlock}\n\n${driversBlock}\n\n${vocabularyBlock}`;
+	// DAT-645: the vertical's conventions (e.g. the sign / natural-balance rule),
+	// piped verbatim — the same source of truth the engine's extraction/validation
+	// agents use, now reaching the third SQL author. Empty (section omitted) when
+	// the vertical declares none or none target `qa`. Reused snippets are already
+	// sign-correct from extraction; this steers NEW SQL composed for a concept that
+	// has no snippet yet.
+	const conventionsBlock = await buildConventionsBlock(workspace.vertical);
+
+	const userMessage = `<question>\n${question}\n</question>\n\n${schemaBlock}\n\n${entitiesBlock}\n\n${catalogBlock}\n\n${relationshipsBlock}\n\n${driversBlock}\n\n${vocabularyBlock}${
+		conventionsBlock ? `\n\n${conventionsBlock}` : ""
+	}`;
 
 	// Per-invocation capture cell — the run_steps tool writes the last successful
 	// validation (and the last failure) here, so it's isolated across concurrent

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -589,7 +589,8 @@ export async function querySubAgent(
 	// agents use, now reaching the third SQL author. Empty (section omitted) when
 	// the vertical declares none or none target `qa`. Reused snippets are already
 	// sign-correct from extraction; this steers NEW SQL composed for a concept that
-	// has no snippet yet.
+	// has no snippet yet. Sequenced after the Promise.all: it needs workspace.vertical
+	// from that batch (cheap local file read, not worth threading into the parallel set).
 	const conventionsBlock = await buildConventionsBlock(workspace.vertical);
 
 	const userMessage = `<question>\n${question}\n</question>\n\n${schemaBlock}\n\n${entitiesBlock}\n\n${catalogBlock}\n\n${relationshipsBlock}\n\n${driversBlock}\n\n${vocabularyBlock}${

--- a/packages/dataraum-config/verticals/finance/ontology.yaml
+++ b/packages/dataraum-config/verticals/finance/ontology.yaml
@@ -285,11 +285,12 @@ concepts:
 # consumes this block instead of re-declaring its own account lists, so the
 # extraction and validation paths can no longer disagree about sign.
 conventions:
-    # Scoped routing: ALL extraction (every measure needs a sign), but only the
-    # sign_conventions VALIDATION — a sign rule is noise in unrelated checks like a
-    # raw debit=credit trial-balance test (qa = fast-follow).
+    # Scoped routing: ALL extraction (every measure needs a sign), the
+    # sign_conventions VALIDATION (a sign rule is noise in unrelated checks like a
+    # raw debit=credit trial-balance test), and the cockpit Q&A agent (qa) — which
+    # composes new SQL for free-form questions and needs the same sign rule.
   - id: sign_natural_balance
-    targets: [extraction, "validation:sign_conventions"]
+    targets: [extraction, "validation:sign_conventions", qa]
     statement: >
       Express every monetary measure in its natural-balance direction so a healthy
       value reads POSITIVE. By account family: asset and expense accounts are

--- a/packages/engine/tests/unit/analysis/semantic/test_ontology_loader.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_ontology_loader.py
@@ -139,10 +139,11 @@ class TestConventions:
         """A convention renders only for a target it lists — broad or specific."""
         loader = OntologyLoader()
         ontology = loader.load("finance")
-        # finance's sign convention targets `extraction` (broad) + the SPECIFIC
-        # `validation:sign_conventions` — NOT every validation.
+        # finance's sign convention targets `extraction` (broad) + `qa` (broad, the
+        # cockpit Q&A agent) + the SPECIFIC `validation:sign_conventions` — NOT every
+        # validation.
         assert loader.format_conventions_for_prompt(ontology, "extraction")
-        assert loader.format_conventions_for_prompt(ontology, "qa") == ""
+        assert loader.format_conventions_for_prompt(ontology, "qa")
         # Broad `validation` (no qualifier) does NOT match the scoped target.
         assert loader.format_conventions_for_prompt(ontology, "validation") == ""
         # The named validation gets it; an unrelated one does not.


### PR DESCRIPTION
## What & why

Completes DAT-645's "third SQL author." The engine pipes a vertical's sign/natural-balance convention into its **extraction** and **validation** agents (merged in #398); the cockpit **Q&A agent** composes new SQL for free-form questions and is the remaining surface. Now it gets the same rule, routed by the generic `qa` target.

## Changes
- `verticals/finance/ontology.yaml`: convention `targets` → `[extraction, "validation:sign_conventions", qa]`.
- `cockpit/src/prompts/conventions.ts`: `formatConventionsBlock` (pure, unit-tested) + `buildConventionsBlock` (reads `verticals/<v>/ontology.yaml` via the cockpit's existing `readFile` + lazy `bun` YAML pattern; best-effort, never throws). The cockpit **never interprets** the content — it routes by the `qa` label and emits the YAML `statement` + `concept_groups` verbatim, exactly mirroring the engine's `format_conventions_for_prompt`.
- `cockpit/src/tools/query.ts`: `querySubAgent` resolves the workspace vertical and appends the `<domain_conventions>` block to the user turn (section omitted when nothing targets `qa`).

## Scope / notes
- **Narrow payoff by design:** the Q&A agent already **reuses the engine's snippets**, which are sign-correct from the extraction fix — so conventions only steer **new** SQL composed for a concept that has no snippet yet. Still the right place to close the loop.
- **Cockpit-only, eval-neutral** (no engine detector/phase/shape change; no handoff).
- Domain-agnostic: zero finance vocabulary in cockpit code; it all rides in the YAML.

## Verification
- `formatConventionsBlock` unit tests (render, target routing, empty/untrusted-shape narrowing).
- Full cockpit unit suite green (1429 tests); `tsc` clean; biome clean (450 files).
- **Acceptance pending:** a real-LLM Q&A smoke (ask a margin question, confirm the agent composes sign-correct SQL for an ungrounded concept) — I'll run it with your OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)