### PR TITLE
refactor(DAT-646): compose & persist formula SQL per-metric (kill cross-metric aliasing)

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,45 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-646 — formula SQL is composed + persisted PER-METRIC (kills cross-metric aliasing)
+
+**Branch:** `refactor/dat-646-formula-identity`.
+
+### What changed (metric SQL composition + snippet persistence — NOT a new response shape)
+The metrics phase warms only leaf EXTRACTs now; a metric's FORMULA/CONSTANT SQL is
+composed **per-metric** from the DAG (`graphs/agent.py` `_compose_metric_from_dag`),
+never warmed or shared by expression shape. The bug this fixes: formula snippets were
+deduped by `normalize_expression`, so same-shape metrics collided — `ebitda/revenue`,
+`net_income/revenue`, `operating_income/revenue` all normalize to `{A}/{B}` and aliased
+to ONE snippet, attributed to whichever metric authored first. The losers either reused
+the wrong numerator's SQL or were left un-composable.
+- Composition is now deterministic per-metric: each step is a CTE in topo order
+  (`compose_formula_sql`/`compose_constant_sql`), so `net_margin` references `net_income`
+  and `ebitda_margin` references `ebitda` — provably distinct.
+- Persistence: formula/constant snippets are saved per-metric in `assemble`
+  (`_save_composed_snippets`), sourced to `graph:{graph_id}` and keyed per-source, not by
+  shape. `find_by_expression` (the shape lookup) is deleted.
+
+### Why eval cares (calibration to run)
+- **The margin family should now EXECUTE with CORRECT, DISTINCT values.** Before, same-
+  shape margins aliased → a margin could compute another margin's numerator over revenue,
+  or fail. Re-run finance metric grounding/execution calibration; focus on
+  `gross_margin` / `ebitda_margin` / `net_margin` / `operating_margin` — expect each to
+  reach `executed` with its OWN value, and aliasing-induced wrong/crashing margins to
+  disappear. Net: more correct margins, fewer ungroundable/wrong ones.
+- **No threshold or response-field change.** The metric output shape (value, assumptions,
+  state/reason) is unchanged; only the composed `final_sql` and the snippet KB rows
+  differ. A metric's numeric value may CHANGE where it was previously aliased to the wrong
+  SQL — that is the fix, not a regression; update any fixed-SQL/value snapshots for the
+  margin metrics.
+
+### Snippet KB shape (if eval inspects `sql_snippets`)
+Formula snippets are now **one row per metric** (sourced `graph:{graph_id}`, sql = the
+whole standalone composition), not one shape-shared row. Extract/constant snippets are
+unchanged (concept- / param-keyed, shared). No schema/column change.
+
+---
+
 ## DAT-645 — vertical sign conventions wired into grounding + validation
 
 **Branch:** `feat/dat-645-vertical-conventions`.

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -245,12 +245,7 @@ class GraphAgent(LLMFeature):
         # cheap, and a per-instance cache would mask the snippet self-heal on a
         # stale-snippet retry (and never hit anyway — one agent, one run, one
         # execution per graph_id).
-        cached_snippets = self._lookup_snippets(
-            session,
-            graph,
-            schema_mapping_id,
-            resolved_params,
-        )
+        cached_snippets = self._lookup_snippets(session, graph, schema_mapping_id)
 
         # Inject inspiration SQL as a hint (from snippet promotion path)
         if inspiration_sql and not cached_snippets:
@@ -350,7 +345,6 @@ class GraphAgent(LLMFeature):
             generated_code=generated_code,
             schema_mapping_id=schema_mapping_id,
             step_results=execution.step_results,
-            resolved_params=resolved_params,
             workspace_id=workspace_id,
         )
 
@@ -402,7 +396,7 @@ class GraphAgent(LLMFeature):
         # (DAT-646): extract leaves come from the warm cache, formulas/constants are
         # composed here. Only extracts are cached now — formulas/constants are not
         # warmed, so the cache holds exactly the metric's extract leaves.
-        cached_snippets = self._lookup_snippets(session, graph, schema_mapping_id, resolved_params)
+        cached_snippets = self._lookup_snippets(session, graph, schema_mapping_id)
         missing = [
             step_id
             for step_id, step in graph.steps.items()
@@ -431,6 +425,18 @@ class GraphAgent(LLMFeature):
         verdict = verify_execution(graph, execution)
         if not verdict.success:
             return Result.fail(verdict.error or "metric verification failed")
+
+        # Persist THIS metric's composed FORMULA/CONSTANT snippets (DAT-646) AFTER it
+        # executed AND verified — only trustworthy SQL enters the cockpit reuse KB. The
+        # extract leaves were already saved by the warm pass; these have no other home.
+        self._save_composed_snippets(
+            session=session,
+            graph=graph,
+            generated_code=generated_code,
+            schema_mapping_id=schema_mapping_id,
+            resolved_params=resolved_params,
+            workspace_id=workspace_id,
+        )
         return Result.ok(execution)
 
     def _compose_metric_from_dag(
@@ -1100,6 +1106,39 @@ class GraphAgent(LLMFeature):
                         step_id=step_id,
                     )
 
+    @staticmethod
+    def _build_snippet_provenance(
+        generated_code: GeneratedCode, *, repaired: bool
+    ) -> dict[str, Any] | None:
+        """The provenance blob saved alongside a snippet.
+
+        Carries the LLM grounding decisions (field_resolution, column_mappings_basis),
+        a repair flag, and — crucially for the phase confidence gate — the per-input
+        ``assumptions`` (so a metric ASSEMBLED from cache still surfaces its weakest
+        grounding's confidence). Composed FORMULA/CONSTANT snippets have no LLM
+        provenance but DO carry forward their extract leaves' assumptions.
+        """
+        provenance: dict[str, Any] | None = None
+        if generated_code.provenance:
+            prov = generated_code.provenance
+            provenance = {
+                "field_resolution": prov.field_resolution,
+                "was_repaired": repaired,
+                "column_mappings_basis": prov.column_mappings_basis,
+                "llm_reasoning": prov.llm_reasoning,
+            }
+        elif repaired:
+            provenance = {"was_repaired": True}
+
+        if generated_code.assumptions:
+            if provenance is None:
+                provenance = {}
+            provenance["assumptions"] = [
+                {"assumption": a.assumption, "basis": a.basis, "confidence": a.confidence}
+                for a in generated_code.assumptions
+            ]
+        return provenance
+
     def _save_snippets(
         self,
         session: Session,
@@ -1107,147 +1146,128 @@ class GraphAgent(LLMFeature):
         generated_code: GeneratedCode,
         schema_mapping_id: str,
         step_results: list[StepResult] | None = None,
-        resolved_params: dict[str, Any] | None = None,
         *,
         workspace_id: str,
     ) -> None:
-        """Save generated SQL steps as snippets for cross-graph reuse.
+        """Save grounded EXTRACT leaves as snippets for cross-metric reuse.
 
-        Called only from the authoring path (``execute`` on a single-output
-        mini-graph); ``assemble`` never saves — its nodes were already minted here.
-        A FORMULA mini-graph reproduces its dep extract/constant steps, so this loop
-        re-encounters them — that is a harmless no-op: ``save_snippet`` is
-        first-writer-wins, so an existing healthy snippet for the dep concept is KEPT
-        (a hallucinated dep-SQL change can never overwrite a good extract snippet).
+        Called only from the authoring path (``execute`` on a single-output EXTRACT
+        mini-graph — the sole LLM surface, DAT-646). ONLY EXTRACT leaves are saved
+        here: they are the shared, concept-keyed cache. FORMULA/CONSTANT snippets are
+        deterministic and composed per-metric, so they are persisted by
+        ``_save_composed_snippets`` (from ``assemble``) sourced to their own metric —
+        never shared by shape (the aliasing DAT-646 removed).
 
         Called AFTER successful execution so that:
         - Only working SQL is saved (not broken SQL that needs marking as failed)
         - Repair info from step_results can be included in provenance
-
-        Args:
-            session: SQLAlchemy session
-            graph: Graph specification (defines step types and metadata)
-            generated_code: LLM-generated SQL code
-            schema_mapping_id: Schema mapping identifier
-            step_results: Execution results for repair detection
         """
         from dataraum.query.snippet_library import SnippetLibrary
-        from dataraum.query.snippet_utils import normalize_expression
 
         library = SnippetLibrary(session, workspace_id=workspace_id)
-
         source = f"graph:{graph.graph_id}"
 
-        # Build a map of generated step_id -> {sql, description}
         generated_steps: dict[str, dict[str, str]] = {}
         for step_dict in generated_code.steps:
             step_id = step_dict.get("step_id", "")
             if step_id:
                 generated_steps[step_id] = step_dict
 
-        # Build repair lookup from execution results
         repair_by_step: dict[str, StepResult] = {}
         if step_results:
             for sr in step_results:
                 if sr.inputs_used.get("repair_attempts", 0) > 0:
                     repair_by_step[sr.step_id] = sr
 
-        # Build provenance dict from LLM output + repair info + assumptions
-        any_repaired = bool(repair_by_step)
-        provenance_dict: dict[str, Any] | None = None
-        if generated_code.provenance:
-            prov = generated_code.provenance
-            provenance_dict = {
-                "field_resolution": prov.field_resolution,
-                "was_repaired": any_repaired,
-                "column_mappings_basis": prov.column_mappings_basis,
-                "llm_reasoning": prov.llm_reasoning,
-            }
-        elif any_repaired:
-            provenance_dict = {"was_repaired": True}
+        provenance_dict = self._build_snippet_provenance(
+            generated_code, repaired=bool(repair_by_step)
+        )
 
-        # Include assumptions in provenance so they're discoverable via search_snippets
-        if generated_code.assumptions:
-            if provenance_dict is None:
-                provenance_dict = {}
-            provenance_dict["assumptions"] = [
-                {"assumption": a.assumption, "basis": a.basis, "confidence": a.confidence}
-                for a in generated_code.assumptions
-            ]
-
-        # Map graph steps to snippets
         for step_id, graph_step in graph.steps.items():
+            if graph_step.step_type != StepType.EXTRACT or not graph_step.source:
+                continue
             gen_step = generated_steps.get(step_id)
-
-            # The authored grounding-free output's SQL lives in final_sql, not in
-            # `steps`: deterministic authoring (DAT-636 step 3) emits no entry for the
-            # output step, and the LLM tool schema makes `steps` OPTIONAL while
-            # final_sql is REQUIRED. So a FORMULA or CONSTANT output step is persisted
-            # from final_sql even when absent from `steps` — reading it from the
-            # optional `steps` left the node "grounded in the binding map but absent
-            # from the cache", un-assemblable per-metric (DAT-636).
-            is_composed_output = graph_step.output_step and graph_step.step_type in (
-                StepType.FORMULA,
-                StepType.CONSTANT,
-            )
-            if not gen_step and not is_composed_output:
+            if not gen_step:
                 continue
 
-            # The composed output's SQL is ALWAYS final_sql — repair tracks per-step
-            # CTE bodies (by step_id), which are not the composed final statement, so
-            # a repaired formula step must not override the composition. Otherwise:
-            # repaired step SQL if available, else the step's own LLM SQL.
             repaired = repair_by_step.get(step_id)
-            if is_composed_output:
-                sql = generated_code.final_sql
-            elif repaired and repaired.source_query:
-                sql = repaired.source_query
-            else:
-                sql = gen_step.get("sql", "") if gen_step else ""
-            description = gen_step.get("description", "") if gen_step else generated_code.summary
+            sql = (
+                repaired.source_query
+                if (repaired and repaired.source_query)
+                else gen_step.get("sql", "")
+            )
+            description = gen_step.get("description", "") or generated_code.summary
 
-            if graph_step.step_type == StepType.EXTRACT and graph_step.source:
-                # Extract snippet: keyed by standard_field + statement + aggregation.
-                # column_mappings is now PER-CONCEPT (DAT-495 closed): post-DAT-636-P1
-                # _save_snippets is only ever reached via the authoring pass on a
-                # single-output mini-graph, so generated_code.column_mappings describes
-                # this one concept — never the sibling-leaking whole-metric dict the old
-                # whole-graph authoring produced. It is a secondary, graph-level HINT for
-                # the cockpit query agent (NOT a source of truth — the authoritative
-                # per-concept grounding is provenance.column_mappings_basis).
-                library.save_snippet(
-                    snippet_type="extract",
-                    sql=sql,
-                    description=description,
-                    schema_mapping_id=schema_mapping_id,
-                    source=source,
-                    standard_field=graph_step.source.standard_field,
-                    statement=graph_step.source.statement,
-                    aggregation=graph_step.aggregation,
-                    column_mappings=generated_code.column_mappings,
-                    llm_model=generated_code.llm_model,
-                    provenance=provenance_dict,
-                )
+            # Extract snippet: keyed by standard_field + statement + aggregation.
+            # column_mappings is per-concept (DAT-495): execute grounds ONE leaf, so
+            # generated_code describes this single concept — a graph-level HINT for the
+            # cockpit query agent (authoritative per-concept grounding lives in
+            # provenance.column_mappings_basis).
+            library.save_snippet(
+                snippet_type="extract",
+                sql=sql,
+                description=description,
+                schema_mapping_id=schema_mapping_id,
+                source=source,
+                standard_field=graph_step.source.standard_field,
+                statement=graph_step.source.statement,
+                aggregation=graph_step.aggregation,
+                column_mappings=generated_code.column_mappings,
+                llm_model=generated_code.llm_model,
+                provenance=provenance_dict,
+            )
 
-            elif graph_step.step_type == StepType.CONSTANT:
-                # Constant snippet: keyed by parameter name + RESOLVED value. Key off
-                # resolved_params (the same value the deterministic SQL and the later
-                # _lookup_snippets use) — NOT param.default — so a non-default parameter
-                # value can't save under one key and look up under another.
+        logger.debug("saved_snippets", graph_id=graph.graph_id)
+
+    def _save_composed_snippets(
+        self,
+        session: Session,
+        graph: TransformationGraph,
+        generated_code: GeneratedCode,
+        schema_mapping_id: str,
+        resolved_params: dict[str, Any],
+        *,
+        workspace_id: str,
+    ) -> None:
+        """Persist a metric's composed FORMULA/CONSTANT snippets (DAT-646, ``assemble``).
+
+        The warm pass saves only the shared EXTRACT leaves; a metric's formula and
+        constants are composed per-metric here, so they have no other home. Each is
+        sourced to ``graph:{graph_id}`` so the cockpit reuse KB groups it under THIS
+        metric, and FORMULA snippets are keyed PER-SOURCE (not by expression shape),
+        so two same-shape margins never collapse to one row — the bug DAT-646 fixes.
+        Insert-if-not-exists (``save_snippet`` is first-writer-wins) → a re-run is a
+        no-op.
+
+        Only the FORMULA OUTPUT step is persisted, and its ``sql`` is the WHOLE metric
+        as one standalone statement (extract CTEs + the formula) — the cockpit answer
+        agent reproduces ``snippet.sql`` independently (DAT-494), so a bare CTE body
+        referencing sibling CTEs would not be reusable. CONSTANT steps are persisted
+        standalone, keyed by (parameter, value) — a genuinely shared value, not aliased.
+        """
+        from dataraum.query.execution import SQLStep, compose_standalone
+        from dataraum.query.snippet_library import SnippetLibrary
+        from dataraum.query.snippet_utils import normalize_expression
+
+        library = SnippetLibrary(session, workspace_id=workspace_id)
+        source = f"graph:{graph.graph_id}"
+        provenance_dict = self._build_snippet_provenance(generated_code, repaired=False)
+        steps_by_id = {s.get("step_id", ""): s for s in generated_code.steps}
+
+        for step_id, graph_step in graph.steps.items():
+            gen_step = steps_by_id.get(step_id)
+            if gen_step is None:
+                continue
+
+            if graph_step.step_type == StepType.CONSTANT:
                 param_value = None
                 if graph_step.parameter:
-                    resolved = (resolved_params or {}).get(graph_step.parameter)
-                    if resolved is None:  # fall back to the graph default
-                        for param in graph.parameters:
-                            if param.name == graph_step.parameter:
-                                resolved = param.default
-                                break
+                    resolved = resolved_params.get(graph_step.parameter)
                     param_value = str(resolved) if resolved is not None else None
-
                 library.save_snippet(
                     snippet_type="constant",
-                    sql=sql,
-                    description=description,
+                    sql=gen_step.get("sql", ""),
+                    description=gen_step.get("description", "") or generated_code.summary,
                     schema_mapping_id=schema_mapping_id,
                     source=source,
                     standard_field=graph_step.parameter or step_id,
@@ -1256,45 +1276,60 @@ class GraphAgent(LLMFeature):
                     provenance=provenance_dict,
                 )
 
-            elif graph_step.step_type == StepType.FORMULA and graph_step.expression:
-                # Formula template snippet: keyed by normalized expression
-                normalized, sorted_fields, bindings = normalize_expression(graph_step.expression)
-
+            elif (
+                graph_step.step_type == StepType.FORMULA
+                and graph_step.output_step
+                and graph_step.expression
+            ):
+                standalone = compose_standalone(
+                    [
+                        SQLStep(
+                            s.get("step_id", ""),
+                            s.get("sql", ""),
+                            s.get("description", ""),
+                        )
+                        for s in generated_code.steps
+                    ],
+                    generated_code.final_sql,
+                )
+                normalized, input_fields, _ = normalize_expression(graph_step.expression)
                 library.save_snippet(
                     snippet_type="formula",
-                    sql=sql,
-                    description=description,
+                    sql=standalone,
+                    description=generated_code.summary,
                     schema_mapping_id=schema_mapping_id,
                     source=source,
                     normalized_expression=normalized,
-                    input_fields=sorted_fields,
+                    input_fields=input_fields,
+                    column_mappings=generated_code.column_mappings,
                     llm_model=generated_code.llm_model,
                     provenance=provenance_dict,
                 )
 
-        logger.debug("saved_snippets", graph_id=graph.graph_id)
+        logger.debug("saved_composed_snippets", graph_id=graph.graph_id)
 
     def _lookup_snippets(
         self,
         session: Session,
         graph: TransformationGraph,
         schema_mapping_id: str,
-        parameters: dict[str, Any],
     ) -> dict[str, dict[str, Any]]:
         """Look up cached snippets for graph steps before LLM generation.
 
-        For each graph step, check the snippet library for a matching cached SQL.
-        Returns a dict of step_id -> {sql, description, snippet_id, column_mappings}
-        for steps that have cached SQL.
+        Only EXTRACT leaves are looked up (DAT-646): they are the sole shared,
+        cross-metric cache surface. FORMULA/CONSTANT steps are NOT looked up — they
+        are deterministic and composed per-metric in ``_compose_metric_from_dag``,
+        never reused by shape (which is exactly the aliasing DAT-646 removed). The
+        per-metric FORMULA/CONSTANT snippets that DO get saved (``_save_composed_
+        snippets``) exist only for the cockpit reuse KB, not for engine lookup.
 
         Args:
             session: SQLAlchemy session
             graph: Graph specification
             schema_mapping_id: Schema mapping identifier
-            parameters: Resolved parameter values
 
         Returns:
-            Dict mapping step_id to cached snippet info for found snippets
+            Dict mapping EXTRACT step_id to cached snippet info for found snippets
         """
         from dataraum.query.snippet_library import SnippetLibrary
 
@@ -1303,34 +1338,16 @@ class GraphAgent(LLMFeature):
         cached_steps: dict[str, dict[str, Any]] = {}
 
         for step_id, graph_step in graph.steps.items():
-            match = None
+            if graph_step.step_type != StepType.EXTRACT or not graph_step.source:
+                continue
 
-            if graph_step.step_type == StepType.EXTRACT and graph_step.source:
-                match = library.find_by_key(
-                    snippet_type="extract",
-                    schema_mapping_id=schema_mapping_id,
-                    standard_field=graph_step.source.standard_field,
-                    statement=graph_step.source.statement,
-                    aggregation=graph_step.aggregation,
-                )
-
-            elif graph_step.step_type == StepType.CONSTANT:
-                param_value = None
-                if graph_step.parameter and graph_step.parameter in parameters:
-                    param_value = str(parameters[graph_step.parameter])
-
-                match = library.find_by_key(
-                    snippet_type="constant",
-                    schema_mapping_id=schema_mapping_id,
-                    standard_field=graph_step.parameter or step_id,
-                    parameter_value=param_value,
-                )
-
-            elif graph_step.step_type == StepType.FORMULA and graph_step.expression:
-                match = library.find_by_expression(
-                    expression=graph_step.expression,
-                    schema_mapping_id=schema_mapping_id,
-                )
+            match = library.find_by_key(
+                snippet_type="extract",
+                schema_mapping_id=schema_mapping_id,
+                standard_field=graph_step.source.standard_field,
+                statement=graph_step.source.statement,
+                aggregation=graph_step.aggregation,
+            )
 
             if match:
                 cached_steps[step_id] = {

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -266,10 +266,19 @@ class GraphAgent(LLMFeature):
         # warmed, NOT cross-metric shared). So ``execute`` only ever authors a single
         # extract: a cache-assemble when it was already minted on a prior run, else the
         # one LLM grounding call (the sole LLM surface in the pipeline).
-        if cached_snippets and len(cached_snippets) == len(graph.steps):
-            generated_code = self._compose_metric_from_dag(
-                graph, cached_snippets, resolved_params
-            )
+        #
+        # Gate on the EXTRACT leaves specifically — not ``len(cached) == len(steps)``.
+        # FORMULA/CONSTANT steps are recomposed (never cached), and a non-step hint key
+        # (``_inspiration``) inflates the dict count; either makes a raw length compare
+        # mis-route. "Every EXTRACT leaf is cached" is the precise compose precondition.
+        extract_ids = [
+            step_id for step_id, step in graph.steps.items() if step.step_type == StepType.EXTRACT
+        ]
+        all_extracts_cached = bool(extract_ids) and all(
+            step_id in cached_snippets for step_id in extract_ids
+        )
+        if all_extracts_cached:
+            generated_code = self._compose_metric_from_dag(graph, cached_snippets, resolved_params)
             if generated_code:
                 logger.debug(
                     "assembled_from_cache",
@@ -528,7 +537,7 @@ class GraphAgent(LLMFeature):
         """Ground a single leaf EXTRACT to SQL via the LLM (tool-based output).
 
         EXTRACT is the SOLE LLM authoring surface (DAT-643): a FORMULA/CONSTANT is
-        composed deterministically in ``_compose_grounding_free`` and never reaches
+        composed deterministically in ``_compose_metric_from_dag`` and never reaches
         here, so this path only ever grounds one leaf extract against the dataset
         context + field mappings. ``cached_snippets`` feeds the DAT-616 prior context
         (a cached extract is ASSEMBLED upstream, never re-authored), so an extract is a

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -1242,8 +1242,16 @@ class GraphAgent(LLMFeature):
         Only the FORMULA OUTPUT step is persisted, and its ``sql`` is the WHOLE metric
         as one standalone statement (extract CTEs + the formula) — the cockpit answer
         agent reproduces ``snippet.sql`` independently (DAT-494), so a bare CTE body
-        referencing sibling CTEs would not be reusable. CONSTANT steps are persisted
-        standalone, keyed by (parameter, value) — a genuinely shared value, not aliased.
+        referencing sibling CTEs would not be reusable. Intermediate (non-output)
+        FORMULA steps are intentionally NOT persisted: each is captured as a CTE inside
+        the output formula's standalone SQL, so a separate fragment row would be both
+        redundant and un-reproducible. CONSTANT steps are persisted standalone, keyed by
+        (parameter, value) — a genuinely shared value, not aliased.
+
+        A pure-EXTRACT-output metric (output step IS an extract) saves nothing here —
+        its sole snippet is the concept-keyed EXTRACT minted by the warm pass, sourced
+        to the representative metric and discoverable by concept. There is no formula to
+        compose, so a per-metric row would just duplicate that shared extract.
         """
         from dataraum.query.execution import SQLStep, compose_standalone
         from dataraum.query.snippet_library import SnippetLibrary
@@ -1252,7 +1260,7 @@ class GraphAgent(LLMFeature):
         library = SnippetLibrary(session, workspace_id=workspace_id)
         source = f"graph:{graph.graph_id}"
         provenance_dict = self._build_snippet_provenance(generated_code, repaired=False)
-        steps_by_id = {s.get("step_id", ""): s for s in generated_code.steps}
+        steps_by_id = {s["step_id"]: s for s in generated_code.steps if s.get("step_id")}
 
         for step_id, graph_step in graph.steps.items():
             gen_step = steps_by_id.get(step_id)
@@ -1260,6 +1268,9 @@ class GraphAgent(LLMFeature):
                 continue
 
             if graph_step.step_type == StepType.CONSTANT:
+                # resolved_params is always populated by _resolve_parameters before
+                # compose, and compose itself fails (returns None) on a missing value —
+                # so a successful compose guarantees the value is present here.
                 param_value = None
                 if graph_step.parameter:
                     resolved = resolved_params.get(graph_step.parameter)

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -261,41 +261,18 @@ class GraphAgent(LLMFeature):
             }
 
         generated_code: GeneratedCode | None
-        # The authored node's type fixes the path, with NO fallback between them
-        # (DAT-643): a FORMULA/CONSTANT is grounding-free arithmetic over already-decided
-        # nodes, so it is composed DETERMINISTICALLY and can never reach the LLM — a
-        # formula whose deps did not ground honest-fails born-loud (the warm DAG authors
-        # deps first, so a missing dep is a real keying/contract bug, not a cue to
-        # LLM-re-derive a shared extract). An EXTRACT is the SOLE LLM authoring surface
-        # (or a cache-assemble when already minted on a prior run).
-        output_step = graph.get_output_step()
-        if output_step is not None and output_step.step_type in (
-            StepType.FORMULA,
-            StepType.CONSTANT,
-        ):
-            try:
-                generated_code = self._compose_grounding_free(
-                    output_step, graph, cached_snippets, resolved_params
-                )
-            except ValueError as exc:
-                # Deps ungroundable / constant unresolved / malformed expression —
-                # born-loud, never handed to the LLM.
-                return Result.fail(str(exc))
-            self._track_snippet_usage(
-                session=session,
-                execution_id=generated_code.code_id,
-                cached_snippets=cached_snippets or {},
-                generated_steps=generated_code.steps,
-                workspace_id=workspace_id,
-            )
-        # EXTRACT already minted on a prior run → assemble from cache without the LLM.
-        elif cached_snippets and len(cached_snippets) == len(graph.steps):
-            generated_code = self._assemble_from_snippets(
-                graph, context, cached_snippets, resolved_params
+        # DAT-646: the warm DAG warms only leaf EXTRACTs — a FORMULA/CONSTANT is
+        # deterministic and metric-specific, composed per-metric in ``assemble`` (NOT
+        # warmed, NOT cross-metric shared). So ``execute`` only ever authors a single
+        # extract: a cache-assemble when it was already minted on a prior run, else the
+        # one LLM grounding call (the sole LLM surface in the pipeline).
+        if cached_snippets and len(cached_snippets) == len(graph.steps):
+            generated_code = self._compose_metric_from_dag(
+                graph, cached_snippets, resolved_params
             )
             if generated_code:
                 logger.debug(
-                    "assembled_from_snippets",
+                    "assembled_from_cache",
                     graph_id=graph.graph_id,
                     snippet_count=len(cached_snippets),
                 )
@@ -412,19 +389,24 @@ class GraphAgent(LLMFeature):
                 )
                 return Result.fail(f"dependency '{step_id}' is ungroundable: {reason}")
 
-        # Every dependency grounded → assemble from the snippets the pass minted.
+        # Every extract dep grounded → compose the metric PER-METRIC from the DAG
+        # (DAT-646): extract leaves come from the warm cache, formulas/constants are
+        # composed here. Only extracts are cached now — formulas/constants are not
+        # warmed, so the cache holds exactly the metric's extract leaves.
         cached_snippets = self._lookup_snippets(session, graph, schema_mapping_id, resolved_params)
-        if not cached_snippets or len(cached_snippets) != len(graph.steps):
-            missing = len(graph.steps) - len(cached_snippets or {})
+        missing = [
+            step_id
+            for step_id, step in graph.steps.items()
+            if step.step_type == StepType.EXTRACT and step_id not in cached_snippets
+        ]
+        if missing:
             return Result.fail(
-                f"metric '{graph.graph_id}': {missing} step(s) grounded per the binding "
-                "map but absent from the snippet cache"
+                f"metric '{graph.graph_id}': extract leaves {missing} grounded per the "
+                "binding map but absent from the snippet cache"
             )
-        generated_code = self._assemble_from_snippets(
-            graph, context, cached_snippets, resolved_params
-        )
+        generated_code = self._compose_metric_from_dag(graph, cached_snippets, resolved_params)
         if generated_code is None:
-            return Result.fail(f"metric '{graph.graph_id}': failed to assemble cached snippets")
+            return Result.fail(f"metric '{graph.graph_id}': failed to compose from the DAG")
         self._track_snippet_usage(
             session=session,
             execution_id=generated_code.code_id,
@@ -442,77 +424,95 @@ class GraphAgent(LLMFeature):
             return Result.fail(verdict.error or "metric verification failed")
         return Result.ok(execution)
 
-    def _assemble_from_snippets(
+    def _compose_metric_from_dag(
         self,
         graph: TransformationGraph,
-        context: ExecutionContext,
         cached_snippets: dict[str, dict[str, Any]],
-        parameters: dict[str, Any],
+        resolved_params: dict[str, Any],
     ) -> GeneratedCode | None:
-        """Assemble GeneratedCode from cached snippets without LLM call.
+        """Compose a metric's SQL PER-METRIC from the DAG — no cross-metric reuse (DAT-646).
 
-        When ALL graph steps have cached SQL snippets, we can skip the LLM
-        entirely and assemble the generated code from the cache.
+        Every step becomes a CTE, materialized in dependency order
+        (:func:`_ordered_dep_steps` + the output last):
 
-        Args:
-            graph: Graph specification
-            context: Execution context
-            cached_snippets: Dict of step_id -> {sql, description, snippet_id}
-            parameters: Resolved parameter values
+        - an **EXTRACT** leaf uses its warmed, concept-keyed cached snippet (the sole
+          shared / LLM surface — authored once, reused correctly);
+        - a **CONSTANT** is composed here (``compose_constant_sql`` over the resolved
+          parameter value);
+        - a **FORMULA** is composed here (``compose_formula_sql`` over its dep step ids,
+          which are earlier CTEs).
 
-        Returns:
-            GeneratedCode if assembly succeeds, None if not possible
+        Formulas and constants are therefore scoped to THIS metric — two metrics that
+        share an arithmetic shape can no longer alias a formula snippet (the DAT-646
+        ``net_margin``/``ebitda_margin`` collision). ``final_sql`` selects the output
+        CTE. Returns ``None`` when an extract leaf is absent (its dep ungroundable — the
+        caller honest-fails) or a step is malformed.
         """
-        steps = []
-        merged_column_mappings: dict[str, str] = {}
-        # DAT-631: carry each snippet's authored grounding confidence forward.
-        # Cache-assembly skips the LLM, so without this the assembled metric would
-        # reach the phase with no assumptions and look confidently green — exactly
-        # the silent-wrong mode for a metric resting on a 0.35-confidence proxy.
-        assumptions: list[GraphAssumptionOutput] = []
-        for step_id in graph.steps:
-            snippet = cached_snippets.get(step_id)
-            if not snippet:
-                return None  # Missing a step, can't assemble
-            steps.append(
-                {
-                    "step_id": step_id,
-                    "sql": snippet["sql"],
-                    "description": snippet["description"],
-                }
-            )
-            # Merge column_mappings from each snippet
-            snippet_mappings = snippet.get("column_mappings")
-            if isinstance(snippet_mappings, dict):
-                merged_column_mappings.update(snippet_mappings)
-            for a in snippet.get("assumptions") or []:
-                assumptions.append(
-                    GraphAssumptionOutput(
-                        dimension=a.get("dimension", "grounding.cached"),
-                        target=a.get("target", f"step:{step_id}"),
-                        assumption=a.get("assumption", ""),
-                        basis=a.get("basis", "inferred"),
-                        confidence=a.get("confidence", 0.5),
-                    )
-                )
+        from dataraum.graphs.formula_composer import compose_constant_sql, compose_formula_sql
 
-        # Build final_sql by referencing the output step
         output_step = graph.get_output_step()
-        if output_step:
-            final_sql = f"SELECT * FROM {output_step.step_id}"
-        else:
-            # Fallback: select from last step
-            final_sql = f"SELECT * FROM {steps[-1]['step_id']}"
+        if output_step is None:
+            return None
+
+        # Every step, deps-before-dependents, output last.
+        ordered = _ordered_dep_steps(graph, output_step) + [output_step.step_id]
+        steps: list[dict[str, str]] = []
+        column_mappings: dict[str, str] = {}
+        # DAT-631: carry each EXTRACT snippet's authored grounding confidence forward, so
+        # a cache-composed metric still surfaces its weakest input's confidence to the
+        # phase gate instead of looking confidently green.
+        assumptions: list[GraphAssumptionOutput] = []
+        for step_id in ordered:
+            step = graph.steps.get(step_id)
+            if step is None:
+                return None
+            description = step_id
+            try:
+                if step.step_type == StepType.EXTRACT:
+                    snippet = cached_snippets.get(step_id)
+                    if not snippet:
+                        return None  # an extract leaf is missing → dep ungroundable
+                    sql = snippet["sql"]
+                    description = snippet.get("description") or step_id
+                    snippet_mappings = snippet.get("column_mappings")
+                    if isinstance(snippet_mappings, dict):
+                        column_mappings.update(snippet_mappings)
+                    for a in snippet.get("assumptions") or []:
+                        assumptions.append(
+                            GraphAssumptionOutput(
+                                dimension=a.get("dimension", "grounding.cached"),
+                                target=a.get("target", f"step:{step_id}"),
+                                assumption=a.get("assumption", ""),
+                                basis=a.get("basis", "inferred"),
+                                confidence=a.get("confidence", 0.5),
+                            )
+                        )
+                elif step.step_type == StepType.CONSTANT:
+                    value = resolved_params.get(step.parameter) if step.parameter else None
+                    if value is None:
+                        return None
+                    sql = compose_constant_sql(value)
+                elif step.step_type == StepType.FORMULA:
+                    if not step.expression:
+                        return None
+                    sql = compose_formula_sql(step.expression, set(step.depends_on))
+                else:
+                    return None
+            except ValueError:
+                # Malformed expression / non-numeric constant — composer raises; the
+                # metric honest-fails (the caller surfaces None as ungroundable).
+                return None
+            steps.append({"step_id": step_id, "sql": sql, "description": description})
 
         return GeneratedCode(
             code_id=str(uuid4()),
             graph_id=graph.graph_id,
-            summary=f"Assembled from {len(steps)} cached snippets",
+            summary=f"Composed {graph.graph_id} from DAG ({len(steps)} steps)",
             steps=steps,
-            final_sql=final_sql,
-            column_mappings=merged_column_mappings,
-            llm_model="cached",
-            prompt_hash="snippets",
+            final_sql=f"SELECT * FROM {output_step.step_id}",
+            column_mappings=column_mappings,
+            llm_model="composed",
+            prompt_hash="composed",
             generated_at=datetime.now(UTC),
             assumptions=assumptions,
         )
@@ -1090,82 +1090,6 @@ class GraphAgent(LLMFeature):
                         snippet_id=snippet_id,
                         step_id=step_id,
                     )
-
-    def _compose_grounding_free(
-        self,
-        output_step: GraphStep,
-        graph: TransformationGraph,
-        cached_snippets: dict[str, dict[str, Any]],
-        resolved_params: dict[str, Any],
-    ) -> GeneratedCode:
-        """Deterministically compose a grounding-free node — FORMULA or CONSTANT, no LLM.
-
-        A formula is pure arithmetic over already-decided dep steps and a constant is a
-        known parameter value — neither carries judgment, so the composer authors them
-        and the LLM is never involved (DAT-643 retired the comparison shadow + the
-        legacy full-graph fallback). ``output_step`` is the node being authored and is
-        already known to be a FORMULA or CONSTANT (``execute`` branches on type).
-
-        Raises:
-            ValueError: a constant has no resolved value, a formula depends on a node
-                that did not ground (absent from ``cached_snippets``), or the expression
-                is malformed — surfaced born-loud so the metric honest-fails rather than
-                the LLM re-deriving a shared extract. The warm DAG authors deps before
-                their dependents, so a missing dep is a real keying/contract bug.
-        """
-        from dataraum.graphs.formula_composer import compose_constant_sql, compose_formula_sql
-
-        steps: list[dict[str, str]]
-        if output_step.step_type == StepType.CONSTANT:
-            value = resolved_params.get(output_step.parameter) if output_step.parameter else None
-            if value is None:
-                raise ValueError(
-                    f"constant '{output_step.parameter or output_step.step_id}' has no resolved "
-                    "value — cannot compose"
-                )
-            final_sql = compose_constant_sql(value)
-            steps = []
-            summary = f"Constant {output_step.parameter} = {value}"
-        else:  # FORMULA
-            if not output_step.expression:
-                raise ValueError(f"formula '{graph.graph_id}' has no expression — cannot compose")
-            # Materialize the FULL transitive dependency closure as CTE steps, ordered
-            # deps-before-dependents (DAT-645). A formula may depend on another formula
-            # (e.g. operating_income = gross_profit - operating_expense): the inner
-            # formula's snippet is `(SELECT value FROM revenue) - ...`, so its own
-            # extract deps must also be materialized as CTEs or execution fails with
-            # "Table revenue does not exist". Direct deps alone are not enough.
-            ordered = _ordered_dep_steps(graph, output_step)
-            missing = [d for d in ordered if d not in cached_snippets]
-            if missing:
-                raise ValueError(
-                    f"formula '{graph.graph_id}' dependency/ies {missing} not grounded — "
-                    "cannot compose (the warm DAG authors deps first; a missing dep is a "
-                    "keying/contract bug, never an LLM-re-derive cue)"
-                )
-            steps = [
-                {
-                    "step_id": d,
-                    "sql": cached_snippets[d]["sql"],
-                    "description": cached_snippets[d].get("description", ""),
-                }
-                for d in ordered
-            ]
-            # final_sql references the OUTPUT's direct deps (each a CTE in `steps`).
-            final_sql = compose_formula_sql(output_step.expression, set(output_step.depends_on))
-            summary = f"Composed {graph.graph_id}: {output_step.expression}"
-
-        return GeneratedCode(
-            code_id=str(uuid4()),
-            graph_id=graph.graph_id,
-            summary=summary,
-            steps=steps,
-            final_sql=final_sql,
-            column_mappings={},
-            llm_model="deterministic",
-            prompt_hash="deterministic",
-            generated_at=datetime.now(UTC),
-        )
 
     def _save_snippets(
         self,

--- a/packages/engine/src/dataraum/graphs/node_warming.py
+++ b/packages/engine/src/dataraum/graphs/node_warming.py
@@ -19,10 +19,12 @@ This module is the **pure** layer — no execution, fully unit-testable:
 * :class:`NodeDecision` — one node's run-scoped authoring outcome (the binding
   map value); the pass itself lives in ``metrics_phase``.
 
-The node key mirrors the snippet cache key *exactly* (extract → standard_field /
-statement / aggregation; constant → parameter / value; formula → normalized
-expression), so authoring mints precisely what the per-metric assembly's
-``_lookup_snippets`` later finds.
+Only **EXTRACT** steps carry a node key (DAT-646: extract → standard_field /
+statement / aggregation) — they are the sole LLM authoring surface and the only
+nodes worth deduping across metrics. FORMULA and CONSTANT steps key to ``None``
+and never enter this DAG: they are deterministic and metric-specific, so the
+per-metric ``assemble`` composes each one fresh from its own dep list rather than
+sharing it by shape (which is exactly the cross-metric aliasing DAT-646 removed).
 """
 
 from __future__ import annotations
@@ -47,11 +49,12 @@ NodeKey = tuple[str | None, ...]
 class WarmNode:
     """A unique cache-keyed node in the cross-metric DAG.
 
-    ``key`` is the global dedup identity (mirrors the snippet cache key, so
-    warming this node mints exactly what a later per-metric lookup finds).
-    ``graph`` / ``step`` are the *representative* occurrence — the first one
-    seen — used to build the warming mini-graph. The snippet is concept-keyed,
-    so which representative we pick does not affect later lookups.
+    ``key`` is the global dedup identity of an EXTRACT leaf (its standard_field /
+    statement / aggregation — DAT-646), so warming this node mints exactly what a
+    later per-metric lookup finds. ``graph`` / ``step`` are the *representative*
+    occurrence — the first one seen — used to build the warming mini-graph. The
+    snippet is concept-keyed, so which representative we pick does not affect later
+    lookups.
     """
 
     key: NodeKey

--- a/packages/engine/src/dataraum/graphs/node_warming.py
+++ b/packages/engine/src/dataraum/graphs/node_warming.py
@@ -34,7 +34,6 @@ from typing import TYPE_CHECKING
 import networkx as nx
 
 from dataraum.graphs.models import StepType
-from dataraum.query.snippet_utils import normalize_expression
 
 if TYPE_CHECKING:
     from dataraum.graphs.models import GraphStep, TransformationGraph
@@ -77,49 +76,25 @@ class NodeDecision:
     reason: str | None = None
 
 
-def _resolve_constant_value(step: GraphStep, graph: TransformationGraph) -> str | None:
-    """Resolve a constant step's parameter default to its string cache value.
-
-    INVARIANT (DAT-636): a constant's resolved value is part of its ``NodeKey``,
-    and the authoring pass keys off the *representative* graph while the per-metric
-    assembly keys off *its own* graph. So two graphs that share a parameter name
-    MUST agree on its default, or the same concept gets two keys and the assembly
-    lookup misses (→ honest-fail "not authored"). Vertical configs use globally
-    consistent defaults today; a divergent default is a config error, surfaced
-    born-loud rather than silently mis-grounded.
-    """
-    if not step.parameter:
-        return None
-    for param in graph.parameters:
-        if param.name == step.parameter:
-            return str(param.default) if param.default is not None else None
-    return None
-
-
 def node_key(step: GraphStep, graph: TransformationGraph) -> NodeKey | None:
-    """Global dedup key for a step, mirroring the snippet cache key.
+    """Cross-metric dedup key for a step — ONLY leaf EXTRACTs warm (DAT-646).
 
-    Returns ``None`` for a step that cannot be cache-keyed (an extract with no
-    source, a formula with no expression) — such a step is never warmed; it
-    falls through to per-metric authoring as before.
+    An EXTRACT is the sole LLM authoring surface and is genuinely shared across
+    metrics (e.g. ``revenue``), so it is warmed ONCE, keyed by its concept. A
+    FORMULA or CONSTANT is deterministic and metric-specific: it is NOT warmed and
+    NOT cross-metric shared — the per-metric ``assemble`` composes it directly from
+    the DAG. (Keying a formula by its normalized SHAPE aliased distinct metrics that
+    share an arithmetic pattern — e.g. every ``x / revenue * 100`` margin collapsed
+    to one snippet, reusing the wrong operand's CTE — DAT-646. The fix is to not
+    share formulas at all, not to refine the key.)
+
+    Returns ``None`` for a step that is never warmed: a FORMULA, a CONSTANT, or an
+    extract with no source.
     """
     if step.step_type == StepType.EXTRACT:
         if not step.source:
             return None
         return ("extract", step.source.standard_field, step.source.statement, step.aggregation)
-    if step.step_type == StepType.CONSTANT:
-        # Mirror _save_snippets/_lookup_snippets: keyed by parameter name (or the
-        # local step_id when there is no parameter) + the resolved value. The
-        # step_id fallback is graph-local, so two graphs sharing a step_id but
-        # different values could in principle collide — that's the EXISTING cache
-        # keying (we mirror it exactly so warming mints what lookup finds); it
-        # does not arise in practice (parameterized constants carry a parameter).
-        return ("constant", step.parameter or step.step_id, _resolve_constant_value(step, graph))
-    if step.step_type == StepType.FORMULA:
-        if not step.expression:
-            return None
-        normalized, _, _ = normalize_expression(step.expression)
-        return ("formula", normalized)
     return None
 
 
@@ -179,39 +154,6 @@ def warming_generations(dag: nx.DiGraph) -> list[list[NodeKey]]:
     Nodes within a generation are independent — safe to warm concurrently.
     """
     return [list(generation) for generation in nx.topological_generations(dag)]
-
-
-def ungroundable_dep_reason(node: WarmNode, bindings: dict[NodeKey, NodeDecision]) -> str | None:
-    """First dependency of ``node`` that did not ground, or ``None`` if all did.
-
-    Gates formula/composite authoring (DAT-636): a node whose dependency is
-    ungroundable must NOT reach the LLM. The composition prompt is told to
-    reproduce each dependency step EXACTLY — given an ABSENT dependency it
-    fabricates one instead (e.g. a `dio` formula over an ungroundable
-    `cost_of_goods_sold` emitted ``SELECT 30 AS value``, copying the
-    days_in_period constant), and the save path then persists that fabrication
-    as a healthy extract snippet: a cross-run precision landmine. Honest-fail
-    the node here instead — symmetric to the per-metric assembly's guard.
-
-    The barrier between warming generations guarantees every dependency is
-    already decided in ``bindings`` by the time its dependent node is gated — so
-    a dependency that is missing, un-keyable, or not grounded is treated as
-    ungroundable (fail loud), never silently passed through (which would hand the
-    LLM a dep it can only fabricate).
-    """
-    graph = node.graph
-    for dep_id in node.step.depends_on:
-        dep_step = graph.steps.get(dep_id)
-        if dep_step is None:
-            return f"dependency '{dep_id}' is ungroundable: not defined in the graph"
-        dep_key = node_key(dep_step, graph)
-        if dep_key is None:
-            return f"dependency '{dep_id}' is ungroundable: has no cache key (never authored)"
-        decision = bindings.get(dep_key)
-        if decision is None or not decision.grounded:
-            reason = decision.reason if decision and decision.reason else "not authored"
-            return f"dependency '{dep_id}' is ungroundable: {reason}"
-    return None
 
 
 def build_mini_graph(node: WarmNode) -> TransformationGraph:

--- a/packages/engine/src/dataraum/graphs/node_warming.py
+++ b/packages/engine/src/dataraum/graphs/node_warming.py
@@ -160,33 +160,18 @@ def warming_generations(dag: nx.DiGraph) -> list[list[NodeKey]]:
 
 
 def build_mini_graph(node: WarmNode) -> TransformationGraph:
-    """Minimal single-output graph for warming one node.
+    """Minimal single-output graph for warming one EXTRACT leaf.
 
-    The representative step plus its transitive dependency steps (taken from the
-    representative graph, original local step ids preserved so ``depends_on``
-    resolves), with **only** the warmed node marked as the output step. The
-    deps are already warm by the time a later-generation node is warmed, so the
-    agent assembles them from cache and only authors this node.
+    Post-DAT-646 the warm DAG holds ONLY edge-less EXTRACT leaves — formulas and
+    constants are composed per-metric and never warmed — so a node has no dependency
+    steps to carry: the mini-graph is exactly the one extract, marked as the output.
+    The representative ``graph_id`` is preserved so the minted snippet is sourced to
+    that metric (``graph:{graph_id}``); a concept shared across metrics is decided once
+    under whichever metric warmed it first.
 
-    Steps are **copied** (:func:`dataclasses.replace`) — the originals belong to
-    the real metric graphs that execute later in the phase; warming must never
-    mutate their ``output_step`` flag.
+    The step is **copied** (:func:`dataclasses.replace`) — the original belongs to the
+    real metric graph that executes later in the phase; warming must never mutate its
+    ``output_step`` flag.
     """
-    graph = node.graph
-    needed: dict[str, GraphStep] = {}
-    stack = [node.step.step_id]
-    while stack:
-        step_id = stack.pop()
-        if step_id in needed:
-            continue
-        step = graph.steps.get(step_id)
-        if step is None:
-            continue
-        needed[step_id] = step
-        stack.extend(step.depends_on)
-
-    mini_steps = {
-        step_id: dataclasses.replace(step, output_step=(step_id == node.step.step_id))
-        for step_id, step in needed.items()
-    }
-    return dataclasses.replace(graph, steps=mini_steps)
+    mini_step = dataclasses.replace(node.step, output_step=True)
+    return dataclasses.replace(node.graph, steps={node.step.step_id: mini_step})

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -491,22 +491,17 @@ def _warm_generations_parallel(
     grounded. Returns the run-scoped binding map; a node that raises is recorded
     ungroundable so its dependent metrics honest-fail born-loud at assembly.
     """
-    from dataraum.graphs.node_warming import NodeDecision, ungroundable_dep_reason
+    from dataraum.graphs.node_warming import NodeDecision
 
     bindings: dict[NodeKey, NodeDecision] = {}
     with ThreadPoolExecutor(
         max_workers=_MAX_CONCURRENT_METRICS, thread_name_prefix="metric-warm"
     ) as pool:
         for generation in generations:
-            # Gate before authoring: a node whose dependency did not ground is
-            # recorded ungroundable WITHOUT an LLM call — never let the composition
-            # prompt fabricate the missing dep and poison the snippet cache (DAT-636).
+            # Only leaf EXTRACTs warm now (DAT-646) — they have no dependencies, so
+            # there is no dep-gate: each is authored once, concept-keyed.
             futures: dict[Future[NodeDecision], NodeKey] = {}
             for key in generation:
-                reason = ungroundable_dep_reason(nodes[key], bindings)
-                if reason is not None:
-                    bindings[key] = NodeDecision(grounded=False, reason=reason)
-                    continue
                 futures[
                     pool.submit(
                         _warm_isolated,
@@ -580,11 +575,7 @@ def _warm_generations_serial(
 ) -> dict[NodeKey, NodeDecision]:
     """Serial fallback: shared session + cursor, sequential dependency order."""
     from dataraum.graphs.agent import ExecutionContext
-    from dataraum.graphs.node_warming import (
-        NodeDecision,
-        build_mini_graph,
-        ungroundable_dep_reason,
-    )
+    from dataraum.graphs.node_warming import NodeDecision, build_mini_graph
 
     exec_ctx = ExecutionContext.with_rich_context(
         session=session,
@@ -598,11 +589,7 @@ def _warm_generations_serial(
     bindings: dict[NodeKey, NodeDecision] = {}
     for generation in generations:
         for key in generation:
-            # Gate before authoring — see _warm_generations (DAT-636 cache-poison guard).
-            reason = ungroundable_dep_reason(nodes[key], bindings)
-            if reason is not None:
-                bindings[key] = NodeDecision(grounded=False, reason=reason)
-                continue
+            # Only leaf EXTRACTs warm (DAT-646) — no deps, so no dep-gate.
             try:
                 result = agent.execute(
                     session, build_mini_graph(nodes[key]), exec_ctx, workspace_id=schema_mapping_id

--- a/packages/engine/src/dataraum/query/snippet_library.py
+++ b/packages/engine/src/dataraum/query/snippet_library.py
@@ -1,15 +1,17 @@
 """SQL Snippet Library — the engine-owned snippet Knowledge Base substrate.
 
 Manages snippet lifecycle for the LIVE producer path (the GraphAgent in
-``graphs/agent.py`` + ``metrics_phase``): upsert, exact-key + expression-pattern
-discovery, and usage/failure tracking. The natural-language CONSUMER discovery
-surface — key-based graph search, full-graph injection, vocabulary, stats — moved
-to the cockpit TS tier (the ``answer`` sub-agent, DAT-485/494) and was removed in
-DAT-487; the cockpit reads the same ``sql_snippets`` substrate directly via Drizzle.
+``graphs/agent.py`` + ``metrics_phase``): upsert, exact-key discovery, and
+usage/failure tracking. The natural-language CONSUMER discovery surface — key-based
+graph search, full-graph injection, vocabulary, stats — moved to the cockpit TS tier
+(the ``answer`` sub-agent, DAT-485/494) and was removed in DAT-487; the cockpit reads
+the same ``sql_snippets`` substrate directly via Drizzle.
 
 Discovery (graph agent only):
-1. Exact key match — extract/constant steps (``find_by_key``, O(1) with index)
-2. Expression pattern match — formula steps (``find_by_expression``, O(N), N < 100)
+1. Exact key match — EXTRACT leaves (``find_by_key``, O(1) with index). EXTRACTs are
+   the sole shared, cross-metric cache. FORMULA/CONSTANT snippets are NOT discovered
+   here (DAT-646): they are composed per-metric and persisted source-scoped only for
+   the cockpit reuse KB — never reused by expression shape (the old aliasing bug).
 
 Usage:
     library = SnippetLibrary(session, workspace_id=workspace_id)
@@ -47,7 +49,6 @@ from sqlalchemy import select, update
 
 from dataraum.core.logging import get_logger
 from dataraum.query.snippet_models import SnippetUsageRecord, SQLSnippetRecord
-from dataraum.query.snippet_utils import normalize_expression
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -61,7 +62,7 @@ class SnippetMatch:
 
     snippet: SQLSnippetRecord
     match_confidence: float  # 0.0-1.0
-    match_strategy: str  # "exact_key" | "expression_pattern"
+    match_strategy: str  # "exact_key"
 
 
 class SnippetLibrary:
@@ -209,40 +210,6 @@ class SnippetLibrary:
 
         return self.session.execute(stmt).scalar_one_or_none()
 
-    def find_by_expression(
-        self,
-        expression: str,
-        schema_mapping_id: str,
-    ) -> SnippetMatch | None:
-        """Find formula snippet by normalized expression pattern.
-
-        Used by the graph agent for formula steps.
-
-        Args:
-            expression: Formula expression to match
-            schema_mapping_id: Schema mapping identifier
-
-        Returns:
-            SnippetMatch if found, None otherwise
-        """
-        normalized, sorted_fields, _ = normalize_expression(expression)
-
-        stmt = select(SQLSnippetRecord).where(
-            SQLSnippetRecord.snippet_type == "formula",
-            SQLSnippetRecord.schema_mapping_id == schema_mapping_id,
-            SQLSnippetRecord.normalized_expression == normalized,
-        )
-
-        record = self.session.execute(stmt).scalar_one_or_none()
-        if record is None:
-            return None
-
-        return SnippetMatch(
-            snippet=record,
-            match_confidence=0.9,
-            match_strategy="expression_pattern",
-        )
-
     # --- Persistence ---
 
     def save_snippet(
@@ -301,10 +268,15 @@ class SnippetLibrary:
                 parameter_value=parameter_value,
             )
         elif snippet_type == "formula" and normalized_expression:
-            # Check for existing formula with same expression
+            # Per-metric identity (DAT-646): a formula snippet is unique per SOURCE
+            # (``graph:{graph_id}``) + expression, NOT by expression alone. Two metrics
+            # that share an arithmetic shape (``ebitda/revenue`` vs ``net_income/revenue``)
+            # must NOT collapse to one row — that shape-keyed dedup was the cross-metric
+            # aliasing bug. ``normalized_expression`` is retained as internal metadata.
             stmt = select(SQLSnippetRecord).where(
                 SQLSnippetRecord.snippet_type == "formula",
                 SQLSnippetRecord.schema_mapping_id == schema_mapping_id,
+                SQLSnippetRecord.source == source,
                 SQLSnippetRecord.normalized_expression == normalized_expression,
             )
             existing = self.session.execute(stmt).scalar_one_or_none()

--- a/packages/engine/src/dataraum/query/snippet_library.py
+++ b/packages/engine/src/dataraum/query/snippet_library.py
@@ -279,7 +279,15 @@ class SnippetLibrary:
                 SQLSnippetRecord.source == source,
                 SQLSnippetRecord.normalized_expression == normalized_expression,
             )
-            existing = self.session.execute(stmt).scalar_one_or_none()
+            # ``.first()``, NOT ``scalar_one_or_none()``: formula rows have all-NULL
+            # semantic-key columns, so ``uq_snippet_semantic_key`` (which backstops
+            # extract/constant dedup) never fires for them — Postgres treats NULLs as
+            # distinct. Under at-least-once activity redelivery two concurrent sessions
+            # could each miss-then-insert the SAME (source, expression), leaving two
+            # rows; ``scalar_one_or_none`` would then raise ``MultipleResultsFound`` on
+            # the next save. These snippets are cockpit-KB-only (the engine never reads
+            # them back), so taking any existing row is correct and crash-free.
+            existing = self.session.execute(stmt).scalars().first()
 
         if existing and existing.failure_count > 0:
             # Replace failed snippet with fresh generation

--- a/packages/engine/src/dataraum/query/snippet_models.py
+++ b/packages/engine/src/dataraum/query/snippet_models.py
@@ -5,13 +5,17 @@ Snippets are keyed SQL fragments that grow through usage by both the
 Graph Agent (producer) and Query Agent (consumer).
 
 Snippet types:
-- extract: Level 1 graph steps (keyed by standard_field + statement + aggregation)
-- constant: Parameter-derived values (keyed by parameter_name + parameter_value)
-- formula: Level 2+ formulas (keyed by normalized expression pattern)
-- query: Query-agent-derived patterns (keyed by semantic hash)
+- extract: Level 1 graph steps (keyed by standard_field + statement + aggregation) —
+  the sole shared, cross-metric cache the graph agent discovers by key.
+- constant: Parameter-derived values (keyed by parameter_name + parameter_value).
+- formula: a metric's composed computation, persisted PER-METRIC (keyed by source +
+  expression, DAT-646) — never shared across metrics by expression shape. The cockpit
+  reuse KB groups it by ``source`` (``graph:{graph_id}``); the engine does not look it
+  up by shape.
+- query: Query-agent-derived patterns (keyed by semantic hash).
 
-Discovery uses term-based vocabulary matching against standard_field,
-statement, aggregation, and graph_id values.
+Cockpit consumer discovery groups snippets by ``source`` and matches term-based
+vocabulary against standard_field, statement, and aggregation values.
 """
 
 from __future__ import annotations

--- a/packages/engine/tests/integration/graphs/test_agent.py
+++ b/packages/engine/tests/integration/graphs/test_agent.py
@@ -635,6 +635,173 @@ class TestComposeMetricFromDag:
         assert res_b.value.output_value == pytest.approx(300 / 600)
 
 
+class TestSaveComposedSnippets:
+    """Per-metric FORMULA/CONSTANT persistence for the cockpit reuse KB (DAT-646 P2).
+
+    The warm pass saves only shared EXTRACT leaves; a metric's composed formula/constants
+    are persisted here, sourced to ``graph:{graph_id}`` so the cockpit groups them under
+    THIS metric — and formulas are keyed per-source so two same-shape margins never alias."""
+
+    @staticmethod
+    def _agent() -> GraphAgent:
+        return GraphAgent(config=MagicMock(), provider=MagicMock(), prompt_renderer=MagicMock())
+
+    @staticmethod
+    def _ext(sid: str) -> GraphStep:
+        return GraphStep(
+            step_id=sid,
+            step_type=StepType.EXTRACT,
+            source=StepSource(standard_field=sid, statement="income_statement"),
+            aggregation="sum",
+        )
+
+    def _metric(self, graph_id: str, steps: dict[str, GraphStep]) -> TransformationGraph:
+        return TransformationGraph(
+            graph_id=graph_id,
+            version="1.0",
+            metadata=GraphMetadata(
+                name=graph_id, description="", category="profitability", source=GraphSource.SYSTEM
+            ),
+            output=OutputDef(output_type=OutputType.SCALAR),
+            steps=steps,
+        )
+
+    def _margin(self, graph_id: str, numerator: str) -> TransformationGraph:
+        return self._metric(
+            graph_id,
+            {
+                numerator: self._ext(numerator),
+                "revenue": self._ext("revenue"),
+                "m": GraphStep(
+                    step_id="m",
+                    step_type=StepType.FORMULA,
+                    expression=f"{numerator} / revenue",
+                    depends_on=[numerator, "revenue"],
+                    output_step=True,
+                ),
+            },
+        )
+
+    def _compose_and_save(self, agent, session, graph, cached, resolved_params=None) -> None:
+        code = agent._compose_metric_from_dag(graph, cached, resolved_params or {})
+        assert code is not None
+        agent._save_composed_snippets(
+            session=session,
+            graph=graph,
+            generated_code=code,
+            schema_mapping_id="schema_abc",
+            resolved_params=resolved_params or {},
+            workspace_id=baseline_run_id(),
+        )
+        session.flush()
+
+    def test_same_shape_metrics_persist_distinct_sourced_snippets(self, session: Session):
+        from sqlalchemy import select
+
+        from dataraum.query.snippet_models import SQLSnippetRecord
+
+        agent = self._agent()
+        self._compose_and_save(
+            agent,
+            session,
+            self._margin("ebitda_margin", "ebitda"),
+            {
+                "ebitda": {"sql": "SELECT SUM(amount) AS value FROM t WHERE k='ebitda'"},
+                "revenue": {"sql": "SELECT SUM(amount) AS value FROM t"},
+            },
+        )
+        self._compose_and_save(
+            agent,
+            session,
+            self._margin("net_margin", "net_income"),
+            {
+                "net_income": {"sql": "SELECT SUM(amount) AS value FROM t WHERE k='net_income'"},
+                "revenue": {"sql": "SELECT SUM(amount) AS value FROM t"},
+            },
+        )
+
+        formulas = list(
+            session.execute(
+                select(SQLSnippetRecord).where(SQLSnippetRecord.snippet_type == "formula")
+            ).scalars()
+        )
+        assert len(formulas) == 2
+        by_source = {f.source: f for f in formulas}
+        assert set(by_source) == {"graph:ebitda_margin", "graph:net_margin"}
+        # Each metric's snippet sql is its OWN standalone computation (extract CTEs + the
+        # formula), with no operand from the sibling metric — the no-alias guarantee.
+        assert "ebitda" in by_source["graph:ebitda_margin"].sql
+        assert "net_income" not in by_source["graph:ebitda_margin"].sql
+        assert "net_income" in by_source["graph:net_margin"].sql
+        assert "ebitda" not in by_source["graph:net_margin"].sql
+        # The formula snippet is the WHOLE metric as one statement (a WITH composition).
+        assert by_source["graph:ebitda_margin"].sql.startswith("WITH")
+
+    def test_resave_is_idempotent(self, session: Session):
+        from sqlalchemy import func, select
+
+        from dataraum.query.snippet_models import SQLSnippetRecord
+
+        agent = self._agent()
+        graph = self._margin("net_margin", "net_income")
+        cached = {
+            "net_income": {"sql": "SELECT 1 AS value"},
+            "revenue": {"sql": "SELECT 2 AS value"},
+        }
+        self._compose_and_save(agent, session, graph, cached)
+        self._compose_and_save(agent, session, graph, cached)  # re-run = no-op
+
+        total = session.scalar(
+            select(func.count())
+            .select_from(SQLSnippetRecord)
+            .where(SQLSnippetRecord.snippet_type == "formula")
+        )
+        assert total == 1
+
+    def test_constant_step_persisted_keyed_by_param_value(self, session: Session):
+        from sqlalchemy import select
+
+        from dataraum.query.snippet_models import SQLSnippetRecord
+
+        agent = self._agent()
+        graph = self._metric(
+            "dso",
+            {
+                "ar": self._ext("accounts_receivable"),
+                "revenue": self._ext("revenue"),
+                "dip": GraphStep(
+                    step_id="dip",
+                    step_type=StepType.CONSTANT,
+                    parameter="days_in_period",
+                ),
+                "m": GraphStep(
+                    step_id="m",
+                    step_type=StepType.FORMULA,
+                    expression="ar / revenue * dip",
+                    depends_on=["ar", "revenue", "dip"],
+                    output_step=True,
+                ),
+            },
+        )
+        self._compose_and_save(
+            agent,
+            session,
+            graph,
+            {
+                "ar": {"sql": "SELECT 100 AS value"},
+                "revenue": {"sql": "SELECT 1000 AS value"},
+            },
+            resolved_params={"days_in_period": 30},
+        )
+
+        const = session.execute(
+            select(SQLSnippetRecord).where(SQLSnippetRecord.snippet_type == "constant")
+        ).scalar_one()
+        assert const.standard_field == "days_in_period"
+        assert const.parameter_value == "30"
+        assert const.source == "graph:dso"
+
+
 class TestGraphAgentSnippets:
     """Tests for GraphAgent snippet lifecycle."""
 
@@ -847,7 +1014,7 @@ class TestGraphAgentSnippets:
         )
 
         # Access internal _lookup_snippets to verify column_mappings are returned
-        cached = agent._lookup_snippets(session, sample_graph, "test-mapping", {})
+        cached = agent._lookup_snippets(session, sample_graph, "test-mapping")
 
         assert "value" in cached
         assert cached["value"]["column_mappings"] == {"test_field": "amount"}

--- a/packages/engine/tests/integration/graphs/test_agent.py
+++ b/packages/engine/tests/integration/graphs/test_agent.py
@@ -374,171 +374,129 @@ class TestGraphAgentVerifier:
         assert result.value.output_value == 0
 
 
-def _formula_graph() -> TransformationGraph:
-    """A single-output FORMULA graph whose composed SQL lives in final_sql.
+class TestComposeMetricFromDag:
+    """Per-metric composition from the DAG — no cross-metric formula reuse (DAT-646).
 
-    The expression is a bare constant (no operands) so it is self-consistent with
-    the empty depends_on and self-contained final_sql the round-trip test uses —
-    composer correctness over real multi-operand formulas is covered exhaustively
-    in test_formula_composer.py; this fixture only exercises the save-path.
-    """
-    return TransformationGraph(
-        graph_id="gross_profit",
-        version="1.0",
-        metadata=GraphMetadata(
-            name="Gross Profit",
-            description="",
-            category="test",
-            source=GraphSource.SYSTEM,
-            tags=[],
-        ),
-        output=OutputDef(output_type=OutputType.SCALAR, metric_id="gp"),
-        parameters=[],
-        steps={
-            "gp": GraphStep(
-                step_id="gp",
-                step_type=StepType.FORMULA,
-                expression="42",
-                depends_on=[],
-                output_step=True,
-            ),
-        },
-        interpretation=None,
-    )
-
-
-def _formula_with_deps(expression: str, depends_on: list[str]) -> TransformationGraph:
-    """A single formula output step (deps supplied via generated_code, not graph steps)."""
-    return TransformationGraph(
-        graph_id="margin",
-        version="1.0",
-        metadata=GraphMetadata(
-            name="Margin", description="", category="test", source=GraphSource.SYSTEM, tags=[]
-        ),
-        output=OutputDef(output_type=OutputType.SCALAR, metric_id="m"),
-        parameters=[],
-        steps={
-            "out": GraphStep(
-                step_id="out",
-                step_type=StepType.FORMULA,
-                expression=expression,
-                depends_on=depends_on,
-                output_step=True,
-            ),
-        },
-        interpretation=None,
-    )
-
-
-def _constant_graph() -> TransformationGraph:
-    """A single CONSTANT output step over a `days_in_period` parameter."""
-    from dataraum.graphs.models import ParameterDef
-
-    return TransformationGraph(
-        graph_id="dip",
-        version="1.0",
-        metadata=GraphMetadata(
-            name="DIP", description="", category="test", source=GraphSource.SYSTEM, tags=[]
-        ),
-        output=OutputDef(output_type=OutputType.SCALAR, metric_id="dip"),
-        parameters=[ParameterDef(name="days_in_period", param_type="integer", default=30)],
-        steps={
-            "out": GraphStep(
-                step_id="out",
-                step_type=StepType.CONSTANT,
-                parameter="days_in_period",
-                output_step=True,
-            ),
-        },
-        interpretation=None,
-    )
-
-
-class TestComposeGroundingFree:
-    """Deterministic composition — formula + constant, no LLM (DAT-643).
-
-    ``_compose_grounding_free`` is the SOLE formula/constant authoring path: it
-    composes from already-grounded deps or fails born-loud — it NEVER falls back to
-    the LLM (``execute`` only ever calls it for a FORMULA/CONSTANT output step)."""
+    Formulas/constants are composed HERE, not warmed or cached: an EXTRACT leaf uses
+    its warmed cached snippet; a FORMULA/CONSTANT is composed from THIS metric's graph.
+    So two metrics that share an arithmetic shape can no longer alias a formula snippet
+    (the net_margin/ebitda_margin collision). The composer returns ``None`` on a missing
+    leaf / malformed step (the caller honest-fails) — never the LLM."""
 
     @staticmethod
     def _agent() -> GraphAgent:
         return GraphAgent(config=MagicMock(), provider=MagicMock(), prompt_renderer=MagicMock())
 
-    def test_formula_composed_from_cached_deps(self) -> None:
-        graph = _formula_with_deps(
-            "revenue - cost_of_goods_sold", ["revenue", "cost_of_goods_sold"]
+    @staticmethod
+    def _ext(sid: str) -> GraphStep:
+        return GraphStep(
+            step_id=sid,
+            step_type=StepType.EXTRACT,
+            source=StepSource(standard_field=sid, statement="income_statement"),
+            aggregation="sum",
+        )
+
+    def _metric(self, graph_id: str, steps: dict[str, GraphStep]) -> TransformationGraph:
+        return TransformationGraph(
+            graph_id=graph_id,
+            version="1.0",
+            metadata=GraphMetadata(
+                name=graph_id, description="", category="profitability", source=GraphSource.SYSTEM
+            ),
+            output=OutputDef(output_type=OutputType.SCALAR),
+            steps=steps,
+        )
+
+    def test_formula_composed_from_cached_extract_leaves(self) -> None:
+        graph = self._metric(
+            "gross_profit",
+            {
+                "revenue": self._ext("revenue"),
+                "cost_of_goods_sold": self._ext("cost_of_goods_sold"),
+                "gp": GraphStep(
+                    step_id="gp",
+                    step_type=StepType.FORMULA,
+                    expression="revenue - cost_of_goods_sold",
+                    depends_on=["revenue", "cost_of_goods_sold"],
+                    output_step=True,
+                ),
+            },
         )
         cached = {
             "revenue": {"sql": "SELECT 1000 AS value", "description": ""},
             "cost_of_goods_sold": {"sql": "SELECT 600 AS value", "description": ""},
         }
-        code = self._agent()._compose_grounding_free(
-            graph.get_output_step(), graph, cached, {}
-        )
-        assert code.llm_model == "deterministic"
-        assert code.final_sql == (
+        code = self._agent()._compose_metric_from_dag(graph, cached, {})
+        assert code is not None
+        assert code.llm_model == "composed"
+        # Extract leaves use their cached snippet; the formula is COMPOSED, not looked up.
+        by_id = {s["step_id"]: s["sql"] for s in code.steps}
+        assert by_id["revenue"] == "SELECT 1000 AS value"
+        assert by_id["gp"] == (
             "SELECT ((SELECT value FROM revenue) - (SELECT value FROM cost_of_goods_sold)) AS value"
         )
-        assert {s["step_id"] for s in code.steps} == {"revenue", "cost_of_goods_sold"}
+        assert code.final_sql == "SELECT * FROM gp"
 
-    def test_formula_with_missing_dep_fails_loud(self) -> None:
-        graph = _formula_with_deps(
-            "revenue - cost_of_goods_sold", ["revenue", "cost_of_goods_sold"]
+    def test_missing_extract_leaf_returns_none(self) -> None:
+        graph = self._metric(
+            "gross_profit",
+            {
+                "revenue": self._ext("revenue"),
+                "cost_of_goods_sold": self._ext("cost_of_goods_sold"),
+                "gp": GraphStep(
+                    step_id="gp",
+                    step_type=StepType.FORMULA,
+                    expression="revenue - cost_of_goods_sold",
+                    depends_on=["revenue", "cost_of_goods_sold"],
+                    output_step=True,
+                ),
+            },
         )
-        # cost_of_goods_sold not cached → born-loud ValueError, NEVER an LLM fallback.
+        # cost_of_goods_sold leaf absent → None (the caller honest-fails it as ungroundable).
         cached = {"revenue": {"sql": "SELECT 1000 AS value", "description": ""}}
-        with pytest.raises(ValueError, match="cost_of_goods_sold"):
-            self._agent()._compose_grounding_free(graph.get_output_step(), graph, cached, {})
+        assert self._agent()._compose_metric_from_dag(graph, cached, {}) is None
 
     def test_constant_composed_from_resolved_param(self) -> None:
-        graph = _constant_graph()
-        code = self._agent()._compose_grounding_free(
-            graph.get_output_step(), graph, {}, {"days_in_period": 30}
+        graph = self._metric(
+            "dip",
+            {
+                "out": GraphStep(
+                    step_id="out",
+                    step_type=StepType.CONSTANT,
+                    parameter="days_in_period",
+                    output_step=True,
+                )
+            },
         )
-        assert code.llm_model == "deterministic"
-        assert code.final_sql == "SELECT 30 AS value"
-        assert code.steps == []
+        code = self._agent()._compose_metric_from_dag(graph, {}, {"days_in_period": 30})
+        assert code is not None
+        assert code.steps[0]["sql"] == "SELECT 30 AS value"
+        assert code.final_sql == "SELECT * FROM out"
 
-    def test_constant_without_resolved_value_fails_loud(self) -> None:
-        graph = _constant_graph()
-        # No resolved value for the parameter → born-loud, not a silent None.
-        with pytest.raises(ValueError, match="days_in_period"):
-            self._agent()._compose_grounding_free(graph.get_output_step(), graph, {}, {})
+    def test_constant_without_value_returns_none(self) -> None:
+        graph = self._metric(
+            "dip",
+            {"out": GraphStep(step_id="out", step_type=StepType.CONSTANT, parameter="d", output_step=True)},
+        )
+        assert self._agent()._compose_metric_from_dag(graph, {}, {}) is None
 
-    def test_formula_without_expression_fails_loud(self) -> None:
-        # A FORMULA step with no expression is a malformed graph (loader defect) —
-        # born-loud, never a silent fall-through to the LLM.
-        graph = _formula_with_deps("", [])
-        with pytest.raises(ValueError, match="no expression"):
-            self._agent()._compose_grounding_free(graph.get_output_step(), graph, {}, {})
+    def test_formula_without_expression_returns_none(self) -> None:
+        graph = self._metric(
+            "bad",
+            {"out": GraphStep(step_id="out", step_type=StepType.FORMULA, expression="", output_step=True)},
+        )
+        assert self._agent()._compose_metric_from_dag(graph, {}, {}) is None
 
-    def test_nested_formula_materializes_transitive_extract_ctes(self) -> None:
-        """A formula-over-formula must materialize the INNER formula's extract deps as
-        CTEs too (DAT-645). operating_income = gross_profit - operating_expense, where
-        gross_profit = revenue - cost_of_goods_sold: gross_profit's snippet references
-        revenue/cogs, so those must be earlier CTEs or execution fails 'Table revenue
-        does not exist'. Direct deps alone are not enough."""
-
-        def _ext(sid: str) -> GraphStep:
-            return GraphStep(
-                step_id=sid,
-                step_type=StepType.EXTRACT,
-                source=StepSource(standard_field=sid, statement="income_statement"),
-                aggregation="sum",
-            )
-
-        graph = TransformationGraph(
-            graph_id="operating_income",
-            version="1.0",
-            metadata=GraphMetadata(
-                name="oi", description="", category="profitability", source=GraphSource.SYSTEM
-            ),
-            output=OutputDef(output_type=OutputType.SCALAR),
-            steps={
-                "revenue": _ext("revenue"),
-                "cost_of_goods_sold": _ext("cost_of_goods_sold"),
-                "operating_expense": _ext("operating_expense"),
+    def test_nested_formula_composes_inner_formula_per_metric(self) -> None:
+        """A formula-over-formula composes the INNER formula per-metric (DAT-646): the
+        intermediate gross_profit is composed HERE (not from a shared cache), and its
+        extract CTEs are materialized before it."""
+        graph = self._metric(
+            "operating_income",
+            {
+                "revenue": self._ext("revenue"),
+                "cost_of_goods_sold": self._ext("cost_of_goods_sold"),
+                "operating_expense": self._ext("operating_expense"),
                 "gross_profit": GraphStep(
                     step_id="gross_profit",
                     step_type=StepType.FORMULA,
@@ -554,72 +512,63 @@ class TestComposeGroundingFree:
                 ),
             },
         )
+        # Only the EXTRACT leaves are cached — gross_profit is NOT (composed per-metric).
         cached = {
             "revenue": {"sql": "SELECT 1000 AS value", "description": ""},
             "cost_of_goods_sold": {"sql": "SELECT 600 AS value", "description": ""},
             "operating_expense": {"sql": "SELECT 100 AS value", "description": ""},
-            "gross_profit": {
-                "sql": "SELECT ((SELECT value FROM revenue) - "
-                "(SELECT value FROM cost_of_goods_sold)) AS value",
-                "description": "",
-            },
         }
-
-        code = self._agent()._compose_grounding_free(graph.get_output_step(), graph, cached, {})
-
+        code = self._agent()._compose_metric_from_dag(graph, cached, {})
+        assert code is not None
         step_ids = [s["step_id"] for s in code.steps]
-        # The full transitive closure is materialized — not just the direct deps.
-        assert set(step_ids) == {
-            "revenue",
-            "cost_of_goods_sold",
-            "operating_expense",
-            "gross_profit",
-        }
-        # The inner formula CTE is defined AFTER its extract deps (valid order).
+        assert step_ids[-1] == "operating_income"  # output last
+        # The inner formula CTE is composed AFTER its extract deps (valid order).
         assert step_ids.index("gross_profit") > step_ids.index("revenue")
         assert step_ids.index("gross_profit") > step_ids.index("cost_of_goods_sold")
-        # final_sql composes the OUTPUT's direct deps (each a materialized CTE).
-        assert code.final_sql == (
+        by_id = {s["step_id"]: s["sql"] for s in code.steps}
+        assert by_id["gross_profit"] == (
+            "SELECT ((SELECT value FROM revenue) - (SELECT value FROM cost_of_goods_sold)) AS value"
+        )
+        assert by_id["operating_income"] == (
             "SELECT ((SELECT value FROM gross_profit) - "
             "(SELECT value FROM operating_expense)) AS value"
         )
+        assert code.final_sql == "SELECT * FROM operating_income"
 
+    def test_same_shape_metrics_compose_distinctly_no_alias(self) -> None:
+        """THE DAT-646 fix: two margins with the SAME arithmetic shape compose their own
+        SQL — no cross-metric formula aliasing (was: net_margin reused ebitda's CTE)."""
 
-class TestDeterministicAuthoringEndToEnd:
-    """execute() authors a formula/constant deterministically — the LLM is never called
-    (DAT-643 retired both the comparison shadow and the legacy whole-graph fallback)."""
+        def _margin(graph_id: str, numerator: str) -> TransformationGraph:
+            return self._metric(
+                graph_id,
+                {
+                    numerator: self._ext(numerator),
+                    "revenue": self._ext("revenue"),
+                    "m": GraphStep(
+                        step_id="m",
+                        step_type=StepType.FORMULA,
+                        expression=f"{numerator} / revenue",
+                        depends_on=[numerator, "revenue"],
+                        output_step=True,
+                    ),
+                },
+            )
 
-    @staticmethod
-    def _formula_snippets(session: Session) -> list:
-        from sqlalchemy import select
-
-        from dataraum.query.snippet_models import SQLSnippetRecord
-
-        return [
-            s
-            for s in session.execute(select(SQLSnippetRecord)).scalars().all()
-            if s.snippet_type == "formula"
-        ]
-
-    def test_formula_authored_deterministically_never_calls_the_llm(
-        self, session: Session, duckdb_with_data
-    ):
-        # The LLM mock would emit "SELECT 42 AS value"; the DETERMINISTIC path wins and
-        # composes the expression itself → "SELECT 42.0 AS value", llm_model=deterministic.
-        agent = _agent_with_sql(steps=[], final_sql="SELECT 42 AS value")
-        context = _make_execution_context(duckdb_with_data)
-
-        result = agent.execute(session, _formula_graph(), context, workspace_id=baseline_run_id())
-
-        assert result.success
-        formulas = self._formula_snippets(session)
-        assert len(formulas) == 1
-        assert formulas[0].llm_model == "deterministic"
-        assert formulas[0].sql == "SELECT 42.0 AS value"
-        assert formulas[0].normalized_expression
-        # The structural guarantee: no LLM call at all for a formula — no shadow, no
-        # fallback. (The mock provider would have served SQL had it been asked.)
-        agent.provider.converse.assert_not_called()
+        agent = self._agent()
+        leaf = {"sql": "SELECT 1 AS value", "description": ""}
+        code_a = agent._compose_metric_from_dag(
+            _margin("ebitda_margin", "ebitda"), {"ebitda": leaf, "revenue": leaf}, {}
+        )
+        code_b = agent._compose_metric_from_dag(
+            _margin("net_margin", "net_income"), {"net_income": leaf, "revenue": leaf}, {}
+        )
+        assert code_a is not None and code_b is not None
+        a_sql = next(s["sql"] for s in code_a.steps if s["step_id"] == "m")
+        b_sql = next(s["sql"] for s in code_b.steps if s["step_id"] == "m")
+        # Each references its OWN numerator — no aliasing to the other metric's operand.
+        assert "ebitda" in a_sql and "net_income" not in a_sql
+        assert "net_income" in b_sql and "ebitda" not in b_sql
 
 
 class TestGraphAgentSnippets:

--- a/packages/engine/tests/integration/graphs/test_agent.py
+++ b/packages/engine/tests/integration/graphs/test_agent.py
@@ -476,14 +476,22 @@ class TestComposeMetricFromDag:
     def test_constant_without_value_returns_none(self) -> None:
         graph = self._metric(
             "dip",
-            {"out": GraphStep(step_id="out", step_type=StepType.CONSTANT, parameter="d", output_step=True)},
+            {
+                "out": GraphStep(
+                    step_id="out", step_type=StepType.CONSTANT, parameter="d", output_step=True
+                )
+            },
         )
         assert self._agent()._compose_metric_from_dag(graph, {}, {}) is None
 
     def test_formula_without_expression_returns_none(self) -> None:
         graph = self._metric(
             "bad",
-            {"out": GraphStep(step_id="out", step_type=StepType.FORMULA, expression="", output_step=True)},
+            {
+                "out": GraphStep(
+                    step_id="out", step_type=StepType.FORMULA, expression="", output_step=True
+                )
+            },
         )
         assert self._agent()._compose_metric_from_dag(graph, {}, {}) is None
 
@@ -569,6 +577,62 @@ class TestComposeMetricFromDag:
         # Each references its OWN numerator — no aliasing to the other metric's operand.
         assert "ebitda" in a_sql and "net_income" not in a_sql
         assert "net_income" in b_sql and "ebitda" not in b_sql
+
+    def test_composed_metric_executes_through_duckdb(self, duckdb_with_data) -> None:
+        """End-to-end: a composed extract+formula metric runs through DuckDB to the right
+        number — the multi-CTE composition is valid SQL, not just a well-formed string.
+
+        Two same-shape margins (numerator / revenue) compose AND execute distinctly: each
+        yields its own value, proving the DAT-646 no-alias fix survives real execution, not
+        only string assembly."""
+
+        def _margin(graph_id: str, numerator: str) -> TransformationGraph:
+            return self._metric(
+                graph_id,
+                {
+                    numerator: self._ext(numerator),
+                    "revenue": self._ext("revenue"),
+                    "m": GraphStep(
+                        step_id="m",
+                        step_type=StepType.FORMULA,
+                        expression=f"{numerator} / revenue",
+                        depends_on=[numerator, "revenue"],
+                        output_step=True,
+                    ),
+                },
+            )
+
+        agent = self._agent()
+        context = _make_execution_context(duckdb_with_data)
+        # test_data amounts: id1=100, id2=200, id3=300 (total 600).
+        revenue = {"sql": "SELECT SUM(amount) AS value FROM test_data", "description": ""}  # 600
+
+        # margin_a = id1 / total = 100/600; margin_b = (id1+id2) / total = 300/600.
+        graph_a = _margin("margin_a", "part_a")
+        code_a = agent._compose_metric_from_dag(
+            graph_a,
+            {
+                "part_a": {"sql": "SELECT SUM(amount) AS value FROM test_data WHERE id = 1"},
+                "revenue": revenue,
+            },
+            {},
+        )
+        graph_b = _margin("margin_b", "part_b")
+        code_b = agent._compose_metric_from_dag(
+            graph_b,
+            {
+                "part_b": {"sql": "SELECT SUM(amount) AS value FROM test_data WHERE id <= 2"},
+                "revenue": revenue,
+            },
+            {},
+        )
+        assert code_a is not None and code_b is not None
+
+        res_a = agent._execute_sql(code_a, context, graph_a)
+        res_b = agent._execute_sql(code_b, context, graph_b)
+        assert res_a.success and res_b.success
+        assert res_a.value.output_value == pytest.approx(100 / 600)
+        assert res_b.value.output_value == pytest.approx(300 / 600)
 
 
 class TestGraphAgentSnippets:

--- a/packages/engine/tests/integration/pipeline/test_metrics_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_metrics_phase.py
@@ -534,3 +534,22 @@ class TestWarmingPrimesCache:
 
         assert r_gross.success and r_net.success
         assert authored == [], "assembly must make the per-metric fan-out LLM-free"
+
+        # DAT-646 P2: assemble persists each metric's composed FORMULA snippet sourced
+        # to ITS OWN graph — the cockpit reuse KB groups by source, and two metrics must
+        # never share a formula row. (This drives the real assemble → _save_composed_
+        # snippets wiring, not the unit-level call.)
+        session.flush()
+        formulas = [
+            s
+            for s in session.execute(select(SQLSnippetRecord)).scalars().all()
+            if s.snippet_type == "formula"
+        ]
+        by_source = {s.source: s for s in formulas}
+        assert by_source.keys() == {"graph:gross_profit", "graph:net_income"}
+        # Each metric's snippet is the WHOLE standalone composition (a WITH chain), not a
+        # shared shape — distinct rows, distinct SQL.
+        assert (
+            by_source["graph:gross_profit"].snippet_id != by_source["graph:net_income"].snippet_id
+        )
+        assert by_source["graph:gross_profit"].sql.lstrip().startswith("WITH")

--- a/packages/engine/tests/unit/graphs/test_node_warming.py
+++ b/packages/engine/tests/unit/graphs/test_node_warming.py
@@ -1,13 +1,12 @@
-"""Unit tests for the topo-warm DAG builder (DAT-629).
+"""Unit tests for the topo-warm DAG builder (DAT-629 / DAT-646).
 
-The pure layer: dedup every metric step to its global cache key, wire edges from
-``depends_on``, fail loud on a cycle, and order into dependency waves. No
-execution here — just the graph the warmer will walk.
+The pure layer: warm ONLY leaf EXTRACTs (the sole shared LLM surface), dedup each
+to its concept key, and order into waves. FORMULA/CONSTANT are NOT warmed — they are
+deterministic and metric-specific, composed per-metric in ``assemble`` (DAT-646), so
+they never become warm nodes. No execution here — just the graph the warmer walks.
 """
 
 from __future__ import annotations
-
-import pytest
 
 from dataraum.graphs.models import (
     GraphMetadata,
@@ -21,11 +20,9 @@ from dataraum.graphs.models import (
     TransformationGraph,
 )
 from dataraum.graphs.node_warming import (
-    NodeDecision,
     build_mini_graph,
     build_warm_dag,
     node_key,
-    ungroundable_dep_reason,
     warming_generations,
 )
 
@@ -65,35 +62,22 @@ def _graph(graph_id: str, steps: dict[str, GraphStep], **kw: object) -> Transfor
 class TestNodeKey:
     def test_extract_key_mirrors_cache_key(self) -> None:
         g = _graph("m", {"e": _extract("e", "revenue", aggregation="sum")})
-        assert node_key(g.steps["e"], g) == (
-            "extract",
-            "revenue",
-            "income_statement",
-            "sum",
-        )
+        assert node_key(g.steps["e"], g) == ("extract", "revenue", "income_statement", "sum")
 
-    def test_formula_key_is_normalized_expression(self) -> None:
+    def test_formula_is_not_keyed(self) -> None:
+        """A FORMULA is never warmed (DAT-646) — keying it by shape aliased metrics."""
         g = _graph("m", {"f": _formula("f", "revenue - cogs", ["a", "b"])})
-        key = node_key(g.steps["f"], g)
-        assert key is not None and key[0] == "formula"
-        # Identical expressions in different graphs collapse to one node (field
-        # names → placeholders, order-preserving for subtraction).
-        g2 = _graph("m2", {"f": _formula("f", "revenue - cogs", ["a", "b"])})
-        assert node_key(g2.steps["f"], g2) == key
-        # ...but differing whitespace is a DIFFERENT key — normalize_expression
-        # is whitespace-sensitive (DAT-629: formula-string consistency is a
-        # separate validation concern, explicitly out of scope here).
-        g3 = _graph("m3", {"f": _formula("f", "revenue  -  cogs", ["a", "b"])})
-        assert node_key(g3.steps["f"], g3) != key
+        assert node_key(g.steps["f"], g) is None
 
-    def test_constant_key_uses_parameter_and_value(self) -> None:
+    def test_constant_is_not_keyed(self) -> None:
+        """A CONSTANT is composed per-metric, not warmed (DAT-646)."""
         step = GraphStep(step_id="c", step_type=StepType.CONSTANT, parameter="days_in_period")
         g = _graph(
             "m",
             {"c": step},
             parameters=[ParameterDef(name="days_in_period", param_type="integer", default=365)],
         )
-        assert node_key(step, g) == ("constant", "days_in_period", "365")
+        assert node_key(step, g) is None
 
     def test_extract_without_source_is_unkeyable(self) -> None:
         step = GraphStep(step_id="e", step_type=StepType.EXTRACT, aggregation="sum")
@@ -102,14 +86,31 @@ class TestNodeKey:
 
 
 class TestBuildWarmDag:
-    def test_shared_extract_dedups_across_graphs(self) -> None:
-        """Two metrics each extracting cost_of_goods_sold → ONE node."""
+    def test_only_extracts_are_warmed(self) -> None:
+        """A metric's formula steps are NOT nodes — only its leaf extracts (DAT-646)."""
         gross = _graph(
             "gross_margin",
             {
                 "rev": _extract("rev", "revenue"),
                 "cogs": _extract("cogs", "cost_of_goods_sold"),
-                "gp": _formula("gp", "revenue - cogs", ["rev", "cogs"]),
+                "gp": _formula("gp", "rev - cogs", ["rev", "cogs"]),
+            },
+        )
+        _, nodes = build_warm_dag({"gross_margin": gross})
+        assert set(nodes) == {
+            ("extract", "revenue", "income_statement", "sum"),
+            ("extract", "cost_of_goods_sold", "income_statement", "sum"),
+        }
+        assert all(k[0] == "extract" for k in nodes)
+
+    def test_shared_extract_dedups_across_graphs(self) -> None:
+        """Two metrics each extracting cost_of_goods_sold + revenue → deduped to one each."""
+        gross = _graph(
+            "gross_margin",
+            {
+                "rev": _extract("rev", "revenue"),
+                "cogs": _extract("cogs", "cost_of_goods_sold"),
+                "gp": _formula("gp", "rev - cogs", ["rev", "cogs"]),
             },
         )
         net = _graph(
@@ -118,68 +119,35 @@ class TestBuildWarmDag:
                 "rev2": _extract("rev2", "revenue"),
                 "cogs2": _extract("cogs2", "cost_of_goods_sold"),
                 "opex": _extract("opex", "operating_expense"),
-                "ni": _formula("ni", "revenue - cogs - opex", ["rev2", "cogs2", "opex"]),
+                "ni": _formula("ni", "rev2 - cogs2 - opex", ["rev2", "cogs2", "opex"]),
             },
         )
+        _, nodes = build_warm_dag({"gross_margin": gross, "net_income": net})
+        # 3 distinct extract concepts, deduped across the two metrics; no formula nodes.
+        assert set(nodes) == {
+            ("extract", "revenue", "income_statement", "sum"),
+            ("extract", "cost_of_goods_sold", "income_statement", "sum"),
+            ("extract", "operating_expense", "income_statement", "sum"),
+        }
 
-        dag, nodes = build_warm_dag({"gross_margin": gross, "net_income": net})
-
-        cogs_key = ("extract", "cost_of_goods_sold", "income_statement", "sum")
-        rev_key = ("extract", "revenue", "income_statement", "sum")
-        assert cogs_key in nodes
-        assert rev_key in nodes
-        # revenue + cogs + opex extracts + 2 distinct formula expressions = 5 nodes.
-        extract_nodes = [k for k in nodes if k[0] == "extract"]
-        assert len(extract_nodes) == 3  # rev, cogs, opex — deduped
-        formula_nodes = [k for k in nodes if k[0] == "formula"]
-        assert len(formula_nodes) == 2  # the two distinct expressions
-
-    def test_edges_follow_depends_on(self) -> None:
+    def test_extracts_are_leaves_no_edges_one_generation(self) -> None:
+        """Extracts have no deps → the DAG is edgeless and warms in ONE wave."""
         gross = _graph(
             "gross_margin",
             {
                 "rev": _extract("rev", "revenue"),
                 "cogs": _extract("cogs", "cost_of_goods_sold"),
-                "gp": _formula("gp", "revenue - cogs", ["rev", "cogs"]),
+                "gp": _formula("gp", "rev - cogs", ["rev", "cogs"]),
             },
         )
         dag, _ = build_warm_dag({"gross_margin": gross})
-
-        rev_key = ("extract", "revenue", "income_statement", "sum")
-        cogs_key = ("extract", "cost_of_goods_sold", "income_statement", "sum")
-        formula_keys = [k for k in dag.nodes if k[0] == "formula"]
-        assert len(formula_keys) == 1
-        gp_key = formula_keys[0]
-        assert dag.has_edge(rev_key, gp_key)
-        assert dag.has_edge(cogs_key, gp_key)
-
-    def test_generations_order_extracts_before_formula(self) -> None:
-        gross = _graph(
-            "gross_margin",
-            {
-                "rev": _extract("rev", "revenue"),
-                "cogs": _extract("cogs", "cost_of_goods_sold"),
-                "gp": _formula("gp", "revenue - cogs", ["rev", "cogs"]),
-            },
-        )
-        dag, _ = build_warm_dag({"gross_margin": gross})
+        assert dag.number_of_edges() == 0
         gens = warming_generations(dag)
-
-        assert len(gens) == 2
-        gen0 = set(gens[0])
-        assert gen0 == {
+        assert len(gens) == 1
+        assert set(gens[0]) == {
             ("extract", "revenue", "income_statement", "sum"),
             ("extract", "cost_of_goods_sold", "income_statement", "sum"),
         }
-        assert gens[1][0][0] == "formula"
-
-    def test_cycle_is_fail_loud(self) -> None:
-        # Two formulas depending on each other (pathological) → cycle.
-        a = _formula("a", "x_one - y_two", ["b"])
-        b = _formula("b", "y_two - x_one", ["a"])
-        g = _graph("cyclic", {"a": a, "b": b})
-        with pytest.raises(ValueError, match="cycle"):
-            build_warm_dag({"cyclic": g})
 
     def test_unkeyable_steps_are_skipped(self) -> None:
         g = _graph(
@@ -190,8 +158,7 @@ class TestBuildWarmDag:
             },
         )
         _, nodes = build_warm_dag({"m": g})
-        assert len(nodes) == 1
-        assert ("extract", "revenue", "income_statement", "sum") in nodes
+        assert set(nodes) == {("extract", "revenue", "income_statement", "sum")}
 
 
 class TestBuildMiniGraph:
@@ -206,28 +173,6 @@ class TestBuildMiniGraph:
         assert mini.steps["cogs"].output_step is True
         assert mini.get_output_step() is mini.steps["cogs"]
 
-    def test_formula_node_includes_transitive_deps(self) -> None:
-        g = _graph(
-            "gross_margin",
-            {
-                "rev": _extract("rev", "revenue"),
-                "cogs": _extract("cogs", "cost_of_goods_sold"),
-                "gp": _formula("gp", "revenue - cogs", ["rev", "cogs"]),
-            },
-        )
-        _, nodes = build_warm_dag({"gross_margin": g})
-        formula_key = next(k for k in nodes if k[0] == "formula")
-
-        mini = build_mini_graph(nodes[formula_key])
-
-        # Formula + both dep extracts, with only the formula as output.
-        assert set(mini.steps) == {"rev", "cogs", "gp"}
-        assert mini.steps["gp"].output_step is True
-        assert mini.steps["rev"].output_step is False
-        assert mini.steps["cogs"].output_step is False
-        # depends_on preserved so the agent assembles deps from the warm cache.
-        assert set(mini.steps["gp"].depends_on) == {"rev", "cogs"}
-
     def test_originals_are_not_mutated(self) -> None:
         """The warmed node's output_step flip must not touch the real graph."""
         rev = _extract("rev", "revenue")  # output_step defaults to False
@@ -240,99 +185,3 @@ class TestBuildMiniGraph:
         assert mini.steps["rev"].output_step is True
         assert rev.output_step is False  # original untouched
         assert g.steps["rev"].output_step is False
-
-
-class TestUngroundableDepReason:
-    """The cache-poison guard (DAT-636): a formula whose dependency did not
-    ground must be honest-failed BEFORE authoring, so the composition prompt is
-    never handed an absent dep to fabricate (e.g. ``SELECT 30 AS value``)."""
-
-    def test_formula_with_ungroundable_dep_is_gated(self) -> None:
-        g = _graph(
-            "gross_margin",
-            {
-                "rev": _extract("rev", "revenue"),
-                "cogs": _extract("cogs", "cost_of_goods_sold"),
-                "gp": _formula("gp", "rev - cogs", ["rev", "cogs"]),
-            },
-        )
-        _, nodes = build_warm_dag({"gross_margin": g})
-        formula_key = next(k for k in nodes if k[0] == "formula")
-        rev_key = node_key(g.steps["rev"], g)
-        cogs_key = node_key(g.steps["cogs"], g)
-        # rev grounded, cogs ungroundable (BookSQL genuinely lacks COGS).
-        bindings = {
-            rev_key: NodeDecision(grounded=True),
-            cogs_key: NodeDecision(grounded=False, reason="no support"),
-        }
-
-        reason = ungroundable_dep_reason(nodes[formula_key], bindings)
-
-        assert reason is not None
-        assert "cogs" in reason and "no support" in reason
-
-    def test_formula_with_all_deps_grounded_authors(self) -> None:
-        g = _graph(
-            "gross_margin",
-            {
-                "rev": _extract("rev", "revenue"),
-                "cogs": _extract("cogs", "cost_of_goods_sold"),
-                "gp": _formula("gp", "rev - cogs", ["rev", "cogs"]),
-            },
-        )
-        _, nodes = build_warm_dag({"gross_margin": g})
-        formula_key = next(k for k in nodes if k[0] == "formula")
-        bindings = {
-            node_key(g.steps["rev"], g): NodeDecision(grounded=True),
-            node_key(g.steps["cogs"], g): NodeDecision(grounded=True),
-        }
-
-        assert ungroundable_dep_reason(nodes[formula_key], bindings) is None
-
-    def test_dep_absent_from_bindings_is_gated(self) -> None:
-        """A dep not yet in the map (should not happen given the barrier) is
-        treated as ungroundable rather than silently authored."""
-        g = _graph(
-            "gross_margin",
-            {
-                "rev": _extract("rev", "revenue"),
-                "cogs": _extract("cogs", "cost_of_goods_sold"),
-                "gp": _formula("gp", "rev - cogs", ["rev", "cogs"]),
-            },
-        )
-        _, nodes = build_warm_dag({"gross_margin": g})
-        formula_key = next(k for k in nodes if k[0] == "formula")
-
-        reason = ungroundable_dep_reason(nodes[formula_key], {})
-
-        assert reason is not None and "not authored" in reason
-
-    def test_leaf_extract_has_no_deps_to_gate(self) -> None:
-        g = _graph("gross_margin", {"rev": _extract("rev", "revenue")})
-        _, nodes = build_warm_dag({"gross_margin": g})
-        node = nodes[("extract", "revenue", "income_statement", "sum")]
-
-        assert ungroundable_dep_reason(node, {}) is None
-
-    def test_unkeyable_dep_is_gated(self) -> None:
-        """A formula dep with no cache key (e.g. an extract missing its source) is
-        gated, NOT silently passed through — else the LLM gets a dep it can only
-        fabricate (the guard's invariant must hold for un-keyable deps too)."""
-        bad = GraphStep(step_id="bad", step_type=StepType.EXTRACT, aggregation="sum")  # no source
-        g = _graph("m", {"bad": bad, "gp": _formula("gp", "bad - x", ["bad"])})
-        _, nodes = build_warm_dag({"m": g})
-        formula_key = next(k for k in nodes if k[0] == "formula")
-
-        reason = ungroundable_dep_reason(nodes[formula_key], {})
-
-        assert reason is not None and "no cache key" in reason
-
-    def test_dep_not_defined_in_graph_is_gated(self) -> None:
-        """A formula depending on a step id that is not defined is gated, not skipped."""
-        g = _graph("m", {"gp": _formula("gp", "ghost - x", ["ghost"])})
-        _, nodes = build_warm_dag({"m": g})
-        formula_key = next(k for k in nodes if k[0] == "formula")
-
-        reason = ungroundable_dep_reason(nodes[formula_key], {})
-
-        assert reason is not None and "not defined" in reason

--- a/packages/engine/tests/unit/pipeline/test_metrics_confidence_gate.py
+++ b/packages/engine/tests/unit/pipeline/test_metrics_confidence_gate.py
@@ -60,20 +60,38 @@ def test_weakest_below_floor_is_flagged() -> None:
     assert "COGS proxied via transaction_type" in reason
 
 
-def test_assemble_from_snippets_propagates_confidence() -> None:
-    """Cache-assembly must carry snippet assumptions forward (the gate's fuel)."""
-    from unittest.mock import MagicMock
-
+def test_compose_metric_from_dag_propagates_confidence() -> None:
+    """Per-metric composition must carry each EXTRACT leaf's assumptions forward — the
+    gate's fuel (DAT-646: extract leaves come from the warm cache with their authored
+    confidence; the formula/constant CTEs are composed on top)."""
     from dataraum.graphs.agent import GraphAgent
+    from dataraum.graphs.models import (
+        GraphMetadata,
+        GraphSource,
+        GraphStep,
+        OutputDef,
+        OutputType,
+        StepSource,
+        StepType,
+        TransformationGraph,
+    )
 
-    # Minimal graph: one step keyed by step_id, output step.
-    step = MagicMock()
-    step.step_id = "cost_of_goods_sold"
-    graph = MagicMock()
-    graph.steps = {"cost_of_goods_sold": step}
-    graph.graph_id = "gross_profit"
-    graph.get_output_step.return_value = step
-
+    step = GraphStep(
+        step_id="cost_of_goods_sold",
+        step_type=StepType.EXTRACT,
+        source=StepSource(standard_field="cost_of_goods_sold", statement="income_statement"),
+        aggregation="sum",
+        output_step=True,
+    )
+    graph = TransformationGraph(
+        graph_id="gross_profit",
+        version="1.0",
+        metadata=GraphMetadata(
+            name="g", description="", category="profitability", source=GraphSource.SYSTEM
+        ),
+        output=OutputDef(output_type=OutputType.SCALAR),
+        steps={"cost_of_goods_sold": step},
+    )
     cached = {
         "cost_of_goods_sold": {
             "sql": "SELECT SUM(amount) AS value FROM v WHERE x IN ('a')",
@@ -91,7 +109,7 @@ def test_assemble_from_snippets_propagates_confidence() -> None:
     }
 
     agent = GraphAgent.__new__(GraphAgent)  # bypass __init__; method is pure
-    code = agent._assemble_from_snippets(graph, MagicMock(), cached, {})
+    code = agent._compose_metric_from_dag(graph, cached, {})
 
     assert code is not None
     assert len(code.assumptions) == 1

--- a/packages/engine/tests/unit/pipeline/test_metrics_dispatch.py
+++ b/packages/engine/tests/unit/pipeline/test_metrics_dispatch.py
@@ -447,7 +447,7 @@ class _StubCtx:
 
 
 class TestWarmSharedNodes:
-    def test_shared_extract_warmed_once_extracts_before_formulas(
+    def test_only_extracts_warmed_deduped_no_formulas(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(
@@ -483,16 +483,14 @@ class TestWarmSharedNodes:
             om_run_id="run-test",
         )
 
-        # cost_of_goods_sold + revenue each warmed exactly once (deduped).
+        # Only leaf EXTRACTs warm (DAT-646), each shared concept exactly once.
         assert agent.warmed.count("extract:cost_of_goods_sold") == 1
         assert agent.warmed.count("extract:revenue") == 1
         assert agent.warmed.count("extract:operating_expense") == 1
-        # The two distinct formula expressions warmed once each.
-        formulas = [w for w in agent.warmed if w.startswith("formula:")]
-        assert len(formulas) == 2
-        # Every extract is warmed before any formula (dependency order).
-        first_formula = next(i for i, w in enumerate(agent.warmed) if w.startswith("formula:"))
-        assert all(w.startswith("extract:") for w in agent.warmed[:first_formula])
+        # FORMULAS are NOT warmed — they are composed per-metric in `assemble`.
+        assert not any(w.startswith("formula:") for w in agent.warmed)
+        # Exactly the three distinct extract concepts, nothing else.
+        assert len(agent.warmed) == 3
 
     def test_cyclic_metric_set_is_best_effort_no_raise(
         self, monkeypatch: pytest.MonkeyPatch

--- a/packages/engine/tests/unit/pipeline/test_metrics_dispatch.py
+++ b/packages/engine/tests/unit/pipeline/test_metrics_dispatch.py
@@ -492,21 +492,24 @@ class TestWarmSharedNodes:
         # Exactly the three distinct extract concepts, nothing else.
         assert len(agent.warmed) == 3
 
-    def test_cyclic_metric_set_is_best_effort_no_raise(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_formula_only_metric_warms_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A metric with no EXTRACT leaves contributes no warm nodes (DAT-646).
+
+        Formulas are not keyed and never enter the warm DAG, so a degenerate
+        formula-only set — including a formula cycle that earlier exercised the
+        warm-DAG cycle guard — now simply warms nothing rather than being tolerated.
+        (The real dep-cycle guard moved to ``_ordered_dep_steps`` at compose time.)"""
         monkeypatch.setattr(
             "dataraum.graphs.agent.ExecutionContext.with_rich_context",
             classmethod(lambda cls, **kw: MagicMock()),
         )
         a = _real_formula("a", "x_one - y_two", ["b"])
         b = _real_formula("b", "y_two - x_one", ["a"])
-        cyclic = _real_graph("cyclic", {"a": a, "b": b})
+        formula_only = _real_graph("formula_only", {"a": a, "b": b})
         agent = _RecordingWarmAgent()
 
-        # A cyclic set must not raise — warming is skipped, execute surfaces it.
         bindings = gep._warm_shared_nodes(
-            {"cyclic": cyclic},
+            {"formula_only": formula_only},
             _StubCtx(),  # type: ignore[arg-type]
             agent,  # type: ignore[arg-type]
             _WORKSPACE_ID,

--- a/packages/engine/tests/unit/query/test_snippet_library.py
+++ b/packages/engine/tests/unit/query/test_snippet_library.py
@@ -304,60 +304,67 @@ class TestSnippetLibrarySave:
         assert fetched.column_mappings == {"revenue": "Betrag", "type": "Kontoart"}
 
 
-class TestSnippetLibraryFindByExpression:
-    """Tests for formula pattern matching."""
+class TestSnippetLibraryFormulaPerMetric:
+    """Formula snippets are identified PER-METRIC by source, not by shape (DAT-646)."""
 
-    def test_find_formula(self, session):
-        """Find a formula by normalized expression."""
-        from dataraum.query.snippet_utils import normalize_expression
+    _COMMON = {
+        "snippet_type": "formula",
+        "description": "margin",
+        "schema_mapping_id": "schema_abc",
+        "normalized_expression": "{A} / {B}",
+        "input_fields": ["a", "b"],
+    }
+
+    def test_same_shape_different_source_are_distinct_rows(self, session):
+        """Two metrics sharing an arithmetic shape each get their OWN formula row — no
+        cross-metric aliasing (was: net_margin reused ebitda_margin's formula snippet)."""
+        from sqlalchemy import func, select
 
         library = SnippetLibrary(session, workspace_id=WORKSPACE_ID)
 
-        # Normalize the expression the same way find_by_expression will
-        expr = "(accounts_receivable / revenue) * days_in_period"
-        normalized, sorted_fields, bindings = normalize_expression(expr)
-
-        library.save_snippet(
-            snippet_type="formula",
-            sql="SELECT (SELECT value FROM ar) / (SELECT value FROM rev) * 30",
-            description="DSO formula",
-            schema_mapping_id="schema_abc",
-            source="graph:dso",
-            normalized_expression=normalized,
-            input_fields=sorted_fields,
+        a = library.save_snippet(
+            sql="WITH ebitda AS (SELECT 1) SELECT 1 AS value",
+            source="graph:ebitda_margin",
+            **self._COMMON,
+        )
+        b = library.save_snippet(
+            sql="WITH net_income AS (SELECT 1) SELECT 1 AS value",
+            source="graph:net_margin",
+            **self._COMMON,
         )
         session.flush()
 
-        match = library.find_by_expression(
-            expression=expr,
-            schema_mapping_id="schema_abc",
+        assert a.snippet_id != b.snippet_id
+        total = session.scalar(
+            select(func.count())
+            .select_from(SQLSnippetRecord)
+            .where(SQLSnippetRecord.snippet_type == "formula")
         )
+        assert total == 2
 
-        assert match is not None
-        assert match.match_confidence == 0.9
-        assert match.match_strategy == "expression_pattern"
+    def test_same_source_same_expression_is_idempotent(self, session):
+        """Re-saving a metric's own formula is a no-op (insert-if-not-exists, first wins)."""
+        from sqlalchemy import func, select
 
-    def test_find_formula_no_match(self, session):
-        """No formula for a different expression."""
         library = SnippetLibrary(session, workspace_id=WORKSPACE_ID)
 
-        library.save_snippet(
-            snippet_type="formula",
-            sql="SELECT 1",
-            description="test",
-            schema_mapping_id="schema_abc",
-            source="graph:test",
-            normalized_expression="({A} / {B}) * {C}",
-            input_fields=["a", "b", "c"],
+        first = library.save_snippet(
+            sql="SELECT 1 AS value", source="graph:net_margin", **self._COMMON
+        )
+        session.flush()
+        again = library.save_snippet(
+            sql="SELECT 2 AS value", source="graph:net_margin", **self._COMMON
         )
         session.flush()
 
-        # Different expression
-        match = library.find_by_expression(
-            expression="x + y",
-            schema_mapping_id="schema_abc",
+        assert again.snippet_id == first.snippet_id
+        assert again.sql == "SELECT 1 AS value"  # first writer won
+        total = session.scalar(
+            select(func.count())
+            .select_from(SQLSnippetRecord)
+            .where(SQLSnippetRecord.snippet_type == "formula")
         )
-        assert match is None
+        assert total == 1
 
 
 class TestSnippetLibraryRecordUsage:


### PR DESCRIPTION
## Problem

Formula snippets were deduped by `normalize_expression`, so metrics that share an
arithmetic shape **aliased to one snippet**, attributed to whichever metric authored
first. `ebitda/revenue`, `net_income/revenue`, `operating_income/revenue` all normalize
to `100*{A}/{B}` → only one wins; the others reuse the wrong numerator or fail to compose.
Corrupted both the engine's formula reuse and the cockpit Q&A reuse KB.

## Fix (clean cut, two phases)

**Phase 1 — compose per-metric.** The metrics phase warms only leaf EXTRACTs (the sole
LLM surface); a metric's FORMULA/CONSTANT SQL is composed deterministically per-metric
from the DAG (`_compose_metric_from_dag`, each step a CTE in topo order). Same-shape
metrics can no longer alias — each references its own operands by construction.

**Phase 2 — persist per-metric.** Re-added formula/constant snippet saving in `assemble`
(`_save_composed_snippets`), sourced to `graph:{graph_id}` and keyed per-source (not by
shape), so the cockpit reuse KB gets one row per metric. The formula snippet's `sql` is
the whole standalone composition (DAT-494 — the cockpit reproduces `snippet.sql`
independently). Deleted the shape-keyed reuse: `find_by_expression`, the
`normalized_expression`-only dedup, and the FORMULA/CONSTANT branches of
`_lookup_snippets`/`_save_snippets` (now EXTRACT-only). Also streamlined `build_mini_graph`
(the dep traversal is dead now that only edge-less extract leaves are warmed).

## Reviews & tests

- Three reviewers (senior / strict / spec-compliance) run on **both** phases; all findings
  addressed (incl. crash-safe formula dedup via `.scalars().first()` and an extract-aware
  compose gate).
- Full engine suite green (**1963 passed, 8 skipped**); new tests cover per-metric identity,
  idempotency, composed-snippet persistence, and an end-to-end DuckDB execution of a
  composed metric.

## Smoke (real LLM, BookSQL-style finance data)

Re-grounded the operating model on the branch engine. **Before:** `net_margin` +
`operating_margin` failed ("Step failed"); only `ebitda_margin` had a snippet. **After:**
all four margins `executed`, each with its own per-source snippet referencing its own
numerator (`net_income` / `operating_income` / `ebitda`). The cockpit analysis chat reads
net_margin's per-metric composition correctly (full standalone `WITH … net_margin` SQL).

Eval handoff updated (`.claude/handoff.md`): margin family should recalibrate to
executed-with-correct-distinct-values; no response-shape/threshold change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)