### PR TITLE
refactor(cockpit): lead chart modal with Generate, collapse manual mapping (DAT-626)

### DIFF
--- a/packages/cockpit/src/charts/manual-mapping.test.ts
+++ b/packages/cockpit/src/charts/manual-mapping.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { type ChartDraft, draftToConfig, emptyDraft } from "./manual-mapping";
+import {
+	type ChartDraft,
+	draftToConfig,
+	emptyDraft,
+	summarizeDraft,
+} from "./manual-mapping";
 import { validateChartConfig } from "./validate";
 
 const COLUMNS = ["month", "revenue", "region"];
@@ -59,5 +64,29 @@ describe("draftToConfig", () => {
 		});
 		expect(config?.encoding.y.aggregate).toBeUndefined();
 		expect(config?.title).toBeUndefined();
+	});
+});
+
+describe("summarizeDraft", () => {
+	it("lists mark + every set channel, with the aggregate parenthesized", () => {
+		const draft: ChartDraft = {
+			mark: "bar",
+			x: { field: "month", type: "temporal" },
+			y: { field: "revenue", type: "quantitative", aggregate: "sum" },
+			color: { field: "region", type: "nominal" },
+		};
+		expect(summarizeDraft(draft)).toBe(
+			"bar · X: month · Y: revenue (sum) · color: region",
+		);
+	});
+
+	it("omits unset channels — a blank draft is just its mark", () => {
+		expect(summarizeDraft(emptyDraft("line"))).toBe("line");
+		expect(
+			summarizeDraft({
+				...emptyDraft(),
+				x: { field: "month", type: "nominal" },
+			}),
+		).toBe("bar · X: month");
 	});
 });

--- a/packages/cockpit/src/charts/manual-mapping.ts
+++ b/packages/cockpit/src/charts/manual-mapping.ts
@@ -68,3 +68,24 @@ export function draftToConfig(draft: ChartDraft): ChartConfig | null {
 		...(title ? { title } : {}),
 	};
 }
+
+/**
+ * A compact, human readout of a draft's mapping for the collapsed editor — e.g.
+ * `bar · X: month · Y: revenue (sum) · color: region`. Only set channels appear
+ * (an aggregate shows as `(agg)`); a fully unmapped draft is just its mark. This
+ * is what "show the generated config" surfaces before the user opens the editor.
+ */
+export function summarizeDraft(draft: ChartDraft): string {
+	const channel = (label: string, e: EncodingDraft): string | null =>
+		e.field
+			? `${label}: ${e.field}${e.aggregate ? ` (${e.aggregate})` : ""}`
+			: null;
+	return [
+		draft.mark,
+		channel("X", draft.x),
+		channel("Y", draft.y),
+		channel("color", draft.color),
+	]
+		.filter(Boolean)
+		.join(" · ");
+}

--- a/packages/cockpit/src/db/metadata/snippet-library.ts
+++ b/packages/cockpit/src/db/metadata/snippet-library.ts
@@ -16,8 +16,8 @@
 // the one workspace schema, so this filter is redundant-but-correct today; it
 // becomes load-bearing once workspaces multiply (DAT-357).
 //
-// Producer-side APIs (find_by_key, find_by_expression, save_snippet,
-// record_usage) are intentionally absent: lookup-only here; the write seam is P2a.
+// Producer-side APIs (find_by_key, save_snippet, record_usage) are intentionally
+// absent: lookup-only here; the write seam is P2a.
 
 import { and, eq, inArray, isNotNull, like, or, type SQL } from "drizzle-orm";
 

--- a/packages/cockpit/src/ui/cockpit/widgets/chart-modal.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/chart-modal.tsx
@@ -1,11 +1,13 @@
 // The chart authoring modal (DAT-626 / ADR-0015).
 //
 // Opens to an EMPTY state — no auto/default chart (a type-sniffing heuristic isn't
-// worth the code; ADR-0015). The user drives, two ways:
-//   - manual column→encoding mapping (deterministic; this phase), and
-//   - a typed instruction to the chart agent (Phase 3, wired into the same draft).
-// Either produces a draft → validated config → LIVE preview. Accept freezes the
-// config; the caller decides what "freeze" means (mint it with a report, etc.).
+// worth the code; ADR-0015). Describing the chart is the PRIMARY path: a typed
+// instruction → the forced-tool chart agent → a config that seeds the draft. The
+// per-encoding controls are the same draft, surfaced behind an "Edit" disclosure
+// that opens to a one-line readout of the current mapping (the deterministic
+// escape hatch + the way to fine-tune a generated config). Either path produces a
+// draft → validated config → LIVE preview. Accept freezes the config; the caller
+// decides what "freeze" means (mint it with a report, etc.).
 //
 // The preview data is ONE capped page from the grid stream (`/api/run-sql`, max
 // GRID_MAX_PAGE rows): charts are for aggregated results, so the cap doubles as the
@@ -20,7 +22,7 @@ import {
 	Alert,
 	Button,
 	Center,
-	Divider,
+	Collapse,
 	Group,
 	Loader,
 	Modal,
@@ -30,7 +32,7 @@ import {
 	TextInput,
 } from "@mantine/core";
 import { ClientOnly } from "@tanstack/react-router";
-import { Sparkles, TriangleAlert } from "lucide-react";
+import { ChevronDown, ChevronUp, Sparkles, TriangleAlert } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
 	AGGREGATES,
@@ -46,6 +48,7 @@ import {
 	draftToConfig,
 	type EncodingDraft,
 	emptyDraft,
+	summarizeDraft,
 } from "#/charts/manual-mapping";
 import { type ChartData, useChartData } from "#/charts/use-chart-data";
 import { validateChartConfig } from "#/charts/validate";
@@ -195,6 +198,9 @@ function ChartModalContent({
 	const [instruction, setInstruction] = useState("");
 	const [authoring, setAuthoring] = useState(false);
 	const [authorError, setAuthorError] = useState<string | null>(null);
+	// The per-encoding controls are secondary — collapsed behind a readout of the
+	// current mapping, opened on demand to fine-tune or to map from scratch.
+	const [editing, setEditing] = useState(false);
 	// Abort an in-flight author when the user cancels/closes or fires a new one —
 	// otherwise the server's forced-tool loop keeps billing Anthropic calls after the
 	// modal is gone (the fetch unmount doesn't close the connection).
@@ -320,57 +326,8 @@ function ChartModalContent({
 				)}
 			</Stack>
 
-			<Divider label="or map columns manually" labelPosition="center" />
-
-			<TextInput
-				label="Title"
-				placeholder="Optional chart title"
-				value={draft.title ?? ""}
-				size="xs"
-				data-testid="chart-title"
-				onChange={(e) =>
-					setDraft((d) => ({ ...d, title: e.currentTarget.value }))
-				}
-			/>
-
-			<Select
-				label="Mark"
-				data={CHART_MARKS.map((m) => ({ value: m, label: m }))}
-				value={draft.mark}
-				allowDeselect={false}
-				size="xs"
-				maw={200}
-				data-testid="chart-mark"
-				onChange={(mark) =>
-					mark && setDraft((d) => ({ ...d, mark: mark as ChartDraft["mark"] }))
-				}
-			/>
-
-			<EncodingControls
-				label="X"
-				draft={draft.x}
-				columns={columnData}
-				suggestFor={suggestFor}
-				onChange={(x) => setDraft((d) => ({ ...d, x }))}
-			/>
-			<EncodingControls
-				label="Y"
-				draft={draft.y}
-				columns={columnData}
-				suggestFor={suggestFor}
-				onChange={(y) => setDraft((d) => ({ ...d, y }))}
-			/>
-			<EncodingControls
-				label="Color"
-				optional
-				draft={draft.color}
-				columns={columnData}
-				suggestFor={suggestFor}
-				onChange={(color) => setDraft((d) => ({ ...d, color }))}
-			/>
-
 			{/* Live preview / empty state. A chart shows only once both axes resolve to
-			    a valid config; otherwise prompt the user. */}
+			    a valid config; otherwise prompt the user toward either path. */}
 			{validConfig ? (
 				<ClientOnly>
 					<ChartView
@@ -386,10 +343,91 @@ function ChartModalContent({
 							? validation && !validation.ok
 								? validation.error
 								: "Adjust the mapping to preview a chart."
-							: "Pick an X and Y column to preview a chart."}
+							: "Describe the chart above, or map the columns yourself."}
 					</Text>
 				</Center>
 			)}
+
+			{/* The encoding controls — secondary, collapsed behind a one-line readout
+			    of the current mapping. A generated config seeds this; opening lets the
+			    user fine-tune it (or map from scratch when there's nothing yet). */}
+			<Stack gap="xs">
+				<Group justify="space-between" wrap="nowrap" gap="xs">
+					<Text
+						size="xs"
+						c="dimmed"
+						truncate
+						style={{ flex: 1, minWidth: 0 }}
+						data-testid="chart-mapping-summary"
+					>
+						{candidate ? summarizeDraft(draft) : "No columns mapped yet"}
+					</Text>
+					<Button
+						variant="subtle"
+						color="gray"
+						size="compact-xs"
+						rightSection={
+							editing ? <ChevronUp size={14} /> : <ChevronDown size={14} />
+						}
+						data-testid="chart-edit-toggle"
+						onClick={() => setEditing((e) => !e)}
+					>
+						{editing ? "Done" : "Edit"}
+					</Button>
+				</Group>
+
+				<Collapse expanded={editing}>
+					<Stack gap="md" pt="xs">
+						<TextInput
+							label="Title"
+							placeholder="Optional chart title"
+							value={draft.title ?? ""}
+							size="xs"
+							data-testid="chart-title"
+							onChange={(e) =>
+								setDraft((d) => ({ ...d, title: e.currentTarget.value }))
+							}
+						/>
+
+						<Select
+							label="Mark"
+							data={CHART_MARKS.map((m) => ({ value: m, label: m }))}
+							value={draft.mark}
+							allowDeselect={false}
+							size="xs"
+							maw={200}
+							data-testid="chart-mark"
+							onChange={(mark) =>
+								mark &&
+								setDraft((d) => ({ ...d, mark: mark as ChartDraft["mark"] }))
+							}
+						/>
+
+						<EncodingControls
+							label="X"
+							draft={draft.x}
+							columns={columnData}
+							suggestFor={suggestFor}
+							onChange={(x) => setDraft((d) => ({ ...d, x }))}
+						/>
+						<EncodingControls
+							label="Y"
+							draft={draft.y}
+							columns={columnData}
+							suggestFor={suggestFor}
+							onChange={(y) => setDraft((d) => ({ ...d, y }))}
+						/>
+						<EncodingControls
+							label="Color"
+							optional
+							draft={draft.color}
+							columns={columnData}
+							suggestFor={suggestFor}
+							onChange={(color) => setDraft((d) => ({ ...d, color }))}
+						/>
+					</Stack>
+				</Collapse>
+			</Stack>
 
 			<Group justify="space-between">
 				<Button


### PR DESCRIPTION
## What

Restructures the chart authoring modal (`chart-modal.tsx`) so the AI **Generate** path leads and the per-encoding controls become a secondary **Edit** disclosure — a follow-up polish on the DAT-626 charts feature (#395).

### Before
The modal opened with "describe → Generate" and the full manual mapper (Title, Mark, and X/Y/Color rows each with Type + Aggregate selects) given equal weight below an "or map columns manually" divider. That front-loads Vega-Lite vocabulary onto the user and undersells the primary (AI) path.

### After
- **Generate leads.** Describe + Generate on top, live preview directly below.
- **Manual mapping collapses behind "Edit."** In place of the divider, a one-line readout of the current mapping — e.g. `bar · X: month · Y: revenue (sum) · color: region` — with an `Edit ▸ / Done ▾` toggle. The full controls live in a `<Collapse>`, closed by default.
- **Generate seeds that readout**, so a generated config is shown to the user; one click opens the editor to fine-tune. Fresh open shows "No columns mapped yet" + Edit as the deterministic escape hatch.
- The editor resets to collapsed on every open (content already remounts per-open via `key`).

No behaviour change to authoring / validation / accept — purely how the modal presents the two paths.

## Implementation notes
- New pure `summarizeDraft()` in `charts/manual-mapping.ts` builds the readout (with unit tests); the component stays render + dispatch (cockpit rule 10).
- This Mantine version's `Collapse` uses `expanded`, not `in`.

## Verification
- `bun run test src/charts/` — 25 passed
- `bun run typecheck` — clean
- `bun run check` (biome) — clean
- Not yet driven in-browser (needs backend stack + a chartable result to open the modal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)