### PR TITLE
fix(cockpit): chart "Describe" input is a 2-line textarea, aligned with Generate

### DIFF
--- a/packages/cockpit/src/ui/cockpit/widgets/chart-modal.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/chart-modal.tsx
@@ -29,6 +29,7 @@ import {
 	Select,
 	Stack,
 	Text,
+	Textarea,
 	TextInput,
 } from "@mantine/core";
 import { ClientOnly } from "@tanstack/react-router";
@@ -296,16 +297,23 @@ function ChartModalContent({
 			    result seeds the manual mapping below, which the user can fine-tune. */}
 			<Stack gap={6}>
 				<Group gap="xs" align="flex-end" wrap="nowrap">
-					<TextInput
+					<Textarea
 						label="Describe the chart"
 						placeholder="e.g. revenue by month as a line, colored by region"
 						value={instruction}
 						size="xs"
+						autosize
+						minRows={2}
+						maxRows={4}
 						style={{ flex: 1 }}
 						data-testid="chart-instruction"
 						onChange={(e) => setInstruction(e.currentTarget.value)}
 						onKeyDown={(e) => {
-							if (e.key === "Enter" && !authoring) authorFromInstruction();
+							// Enter submits; Shift+Enter keeps the newline (it's a textarea).
+							if (e.key === "Enter" && !e.shiftKey) {
+								e.preventDefault();
+								if (!authoring) authorFromInstruction();
+							}
 						}}
 					/>
 					<Button


### PR DESCRIPTION
## What

Small follow-up to the chart-modal refactor (#403). The single-line "Describe the chart" input sat taller than the label-less, `compact-sm` Generate button next to it, so their heights and baselines didn't line up.

Make it an **autosizing 2-line textarea** (`minRows={2}`, grows to `maxRows={4}`):
- gives the chart description some room, and
- the compact Generate button reads as proportionate beside a 2-line field (bottoms align via the existing `flex-end` group).

Enter still submits; **Shift+Enter** now inserts a newline (it's a textarea).

## Verification
- `bun run typecheck` — clean
- `bun run check` (biome) — clean
- Not browser-driven; standard Mantine `Textarea` swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)