### PR TITLE
fix(cockpit): make the answer agent reliably return a result (emit_result tool) + show/honest no-result

### DIFF
--- a/packages/cockpit/src/prompts/query.ts
+++ b/packages/cockpit/src/prompts/query.ts
@@ -34,7 +34,7 @@ Work through every question in this order:
 2. SEARCH THE KB FIRST — call snippet_search with concepts/statements/graph_ids drawn ONLY from the available vocabulary. The validated snippets are pre-tested, schema-grounded calculations — prefer them, and reproduce a fitting one faithfully (see <reuse>).
 3. COMPOSE — break the answer into standalone steps, one per business concept, then a final_sql that combines them. Reuse snippet steps where they fit (see <reuse>).
 4. VALIDATE — call run_steps with your steps + final_sql to confirm the SQL runs and to read a bounded headline sample. Repair and re-validate if it returns an error.
-5. ANSWER — state the result in plain language, including the headline number(s) from the validated sample.
+5. ANSWER — once run_steps confirms the query, call emit_result with your answer (the headline number(s) from the validated sample, in plain language) — this is how you finish; prose alone is not your answer, only an emit_result call is. If you genuinely cannot validate a query, call emit_result anyway with a short answer explaining why, so the user gets the story rather than nothing.
 </reasoning>
 
 <reuse>
@@ -75,7 +75,7 @@ Always call run_steps before you answer — pass it your steps (each {name, sql,
 </validation>
 
 <output>
-Your steps + final_sql go to run_steps (above), NOT into this final answer. Return only:
+Your steps + final_sql go to run_steps (above), NOT into emit_result. Call emit_result with:
 - answer: the practitioner-facing reply, in plain language, stating the headline number(s) from the validated sample. No SQL, no tool names, no internal table identifiers in this text.
 - assumptions: the decisions you made to resolve ambiguity, as plain sentences (e.g. "Treated null amounts as zero in the sum.", "Used posting_date for the period."). Empty if the question was unambiguous.
 - concepts_used: the business concepts your answer draws on (for provenance — the names from the schema/snippets).

--- a/packages/cockpit/src/tools/query.test.ts
+++ b/packages/cockpit/src/tools/query.test.ts
@@ -47,6 +47,7 @@ import {
 	componentsToSave,
 	exhaustionDiagnostic,
 	isMissingStructuredResult,
+	noResultNarrative,
 	persistLearnedSnippets,
 	type QueryDraft,
 	readDataQuality,
@@ -433,5 +434,41 @@ describe("exhaustionDiagnostic (no query ever validated)", () => {
 		expect(msg.length).toBeGreaterThan(0);
 		expect(msg).not.toContain("undefined");
 		expect(msg).not.toContain("null");
+	});
+});
+
+describe("noResultNarrative (finalized-but-unvalidated run)", () => {
+	const draft = (answer: string): QueryDraft => ({
+		answer,
+		assumptions: [],
+		concepts_used: [],
+		tables_touched: [],
+	});
+
+	it("keeps the model's own explanation when it wrote one", () => {
+		expect(
+			noResultNarrative(
+				draft("No revenue rows fell in the requested period."),
+				null,
+			),
+		).toBe("No revenue rows fell in the requested period.");
+	});
+
+	it("synthesizes from the last validation failure when the narrative is empty", () => {
+		// The common no-result shape: model finalized a blank answer. Tell the story from
+		// the last state instead of returning nothing.
+		const msg = noResultNarrative(draft("   "), {
+			message: 'Binder Error: column "amount" not found',
+			sql: "SELECT amount FROM lake.typed.invoices",
+			steps: ["revenue"],
+		});
+		expect(msg).toContain('Binder Error: column "amount" not found');
+		expect(msg).toContain("SELECT amount FROM lake.typed.invoices");
+	});
+
+	it("falls back to a generic story when empty AND nothing was even attempted", () => {
+		const msg = noResultNarrative(draft(""), null);
+		expect(msg.length).toBeGreaterThan(0);
+		expect(msg).not.toContain("undefined");
 	});
 });

--- a/packages/cockpit/src/tools/query.test.ts
+++ b/packages/cockpit/src/tools/query.test.ts
@@ -46,7 +46,6 @@ import {
 	classifyComponents,
 	componentsToSave,
 	exhaustionDiagnostic,
-	isMissingStructuredResult,
 	noResultNarrative,
 	persistLearnedSnippets,
 	type QueryDraft,
@@ -360,27 +359,6 @@ describe("persistLearnedSnippets (save-on-clean)", () => {
 });
 
 // --- Exhaustion handling (DAT-608) -----------------------------------------------
-
-describe("isMissingStructuredResult", () => {
-	it("is true for chat()'s finalization error code", () => {
-		const err = Object.assign(new Error("missing structured result"), {
-			code: "structured-output-missing-result",
-		});
-		expect(isMissingStructuredResult(err)).toBe(true);
-		// A bare object carrying the code also matches (defensive).
-		expect(
-			isMissingStructuredResult({ code: "structured-output-missing-result" }),
-		).toBe(true);
-	});
-
-	it("is false for infra errors, aborts, and non-errors (they must propagate)", () => {
-		expect(isMissingStructuredResult(new Error("ECONNREFUSED"))).toBe(false);
-		expect(isMissingStructuredResult({ code: "something-else" })).toBe(false);
-		expect(isMissingStructuredResult(null)).toBe(false);
-		expect(isMissingStructuredResult(undefined)).toBe(false);
-		expect(isMissingStructuredResult("missing structured result")).toBe(false);
-	});
-});
 
 describe("salvageDraft (validated-but-unfinalized run)", () => {
 	it("turns the last validated run into a draft: concepts from components, no guessed tables", () => {

--- a/packages/cockpit/src/tools/query.test.ts
+++ b/packages/cockpit/src/tools/query.test.ts
@@ -438,26 +438,8 @@ describe("exhaustionDiagnostic (no query ever validated)", () => {
 });
 
 describe("noResultNarrative (finalized-but-unvalidated run)", () => {
-	const draft = (answer: string): QueryDraft => ({
-		answer,
-		assumptions: [],
-		concepts_used: [],
-		tables_touched: [],
-	});
-
-	it("keeps the model's own explanation when it wrote one", () => {
-		expect(
-			noResultNarrative(
-				draft("No revenue rows fell in the requested period."),
-				null,
-			),
-		).toBe("No revenue rows fell in the requested period.");
-	});
-
-	it("synthesizes from the last validation failure when the narrative is empty", () => {
-		// The common no-result shape: model finalized a blank answer. Tell the story from
-		// the last state instead of returning nothing.
-		const msg = noResultNarrative(draft("   "), {
+	it("tells the real story from the last validation failure when a query was tried", () => {
+		const msg = noResultNarrative({
 			message: 'Binder Error: column "amount" not found',
 			sql: "SELECT amount FROM lake.typed.invoices",
 			steps: ["revenue"],
@@ -466,9 +448,13 @@ describe("noResultNarrative (finalized-but-unvalidated run)", () => {
 		expect(msg).toContain("SELECT amount FROM lake.typed.invoices");
 	});
 
-	it("falls back to a generic story when empty AND nothing was even attempted", () => {
-		const msg = noResultNarrative(draft(""), null);
+	it("states plainly that no SQL was run when nothing was attempted (NOT a model placeholder)", () => {
+		// The model's `answer` field is deliberately ignored here — it's often a mid-
+		// compose placeholder ("Let me now compose…") that would mislead the reader and
+		// feed the orchestrator a non-fact. State the honest fact instead.
+		const msg = noResultNarrative(null);
 		expect(msg.length).toBeGreaterThan(0);
+		expect(msg).toContain("stopped before");
 		expect(msg).not.toContain("undefined");
 	});
 });

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -552,6 +552,20 @@ export function exhaustionDiagnostic(
 	);
 }
 
+/** The narrative for a finalized-but-unvalidated run (DAT-608 sibling): the model can
+ * satisfy QueryDraftSchema with an empty `answer` and never call run_steps, finalizing a
+ * blank draft — which sails PAST the exhaustion catch (it never threw). Tell the story
+ * instead: keep the model's own explanation if it wrote one, else synthesize it from the
+ * last validation failure (the SQL it tried + why) or a generic "couldn't compose a
+ * query". So a no-result is always self-explaining, never blank. Pure; unit-tested. */
+export function noResultNarrative(
+	draft: QueryDraft,
+	lastError: RunStepsFailure | null,
+): string {
+	const own = draft.answer.trim();
+	return own.length > 0 ? own : exhaustionDiagnostic(lastError);
+}
+
 /**
  * The query sub-agent: ONE nested chat() over [snippet_search, run_steps] with the
  * concrete `QueryDraftSchema`, then deterministic post-processing (the grid +
@@ -655,6 +669,27 @@ export async function querySubAgent(
 	// assembled and is never on the answer's critical path; persistLearnedSnippets
 	// swallows its own errors, so it can neither block nor fail the answer.
 	void persistLearnedSnippets(captured.value);
+
+	// The model can finalize a structured draft WITHOUT validating a runnable query
+	// (captured.value === null): it satisfies QueryDraftSchema with an empty answer and
+	// never calls run_steps, so `chat()` never throws and the exhaustion catch above is
+	// bypassed. Returning assembleAnswer(draft, null) there is the "blank no-result with
+	// no error message" bug — nothing to show, nothing to debug. Instead surface the last
+	// state: a self-explaining narrative for the user + a structured log line carrying the
+	// last validation failure (SQL tried + error) so the run leaves a debuggable trace.
+	if (!captured.value) {
+		console.info("answer_no_result", {
+			had_narrative: draft.answer.trim().length > 0,
+			last_error: captured.lastError?.message ?? null,
+			last_sql: captured.lastError?.sql ?? null,
+			steps_attempted: captured.lastError?.steps ?? [],
+		});
+		return assembleAnswer(
+			{ ...draft, answer: noResultNarrative(draft, captured.lastError) },
+			null,
+			dataQuality,
+		);
+	}
 	return assembleAnswer(draft, captured.value, dataQuality);
 }
 

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -50,11 +50,7 @@ import {
 	QUERY_SUBAGENT_MAX_ITERATIONS,
 } from "../llm";
 import { buildConventionsBlock, getQueryInstructions } from "../prompts";
-import {
-	AgentActionableError,
-	asAgentError,
-	withAgentError,
-} from "./agent-error";
+import { asAgentError, withAgentError } from "./agent-error";
 import { computeGrainNote, loadNearUniqueColumns } from "./grain-note";
 import { listTables } from "./list-tables";
 import { lookValuesTool } from "./look-values";
@@ -203,11 +199,13 @@ export interface RunStepsFailure {
 	steps: string[];
 }
 
-/** The per-invocation capture cell: the last successful validation (for the grid)
- * AND the last failure (for the exhaustion diagnostic). */
+/** The per-invocation capture cell: the last successful run_steps validation (for the
+ * grid), the last failure (for the no-result diagnostic), and the model's final answer
+ * draft once it calls `emit_result`. */
 interface RunStepsCapture {
 	value: ValidatedRun | null;
 	lastError: RunStepsFailure | null;
+	draft: QueryDraft | null;
 }
 
 // --- Reuse classification (CLASSIFY-don't-substitute; informed by the engine's
@@ -487,23 +485,10 @@ export async function persistLearnedSnippets(
 	}
 }
 
-// --- Exhaustion handling (DAT-608): the agent loop can end without the model
-// emitting the final structured answer (it hit the step limit, often after
-// repeatedly mis-grounding columns). `chat()` then throws a finalization error
-// (code `structured-output-missing-result`). Rather than let that surface as an
-// opaque "missing structured result", salvage a validated query if one exists, or
-// return an actionable diagnostic so the OUTER agent retries with a concrete hint.
-
-/** True when a thrown error is `chat()`'s "loop ended without a structured output"
- * finalization error (vs an infra error / abort, which must propagate). Keys on the
- * stable `code`, set by @tanstack/ai's chat finalizer. */
-export function isMissingStructuredResult(err: unknown): boolean {
-	return (
-		typeof err === "object" &&
-		err !== null &&
-		(err as { code?: unknown }).code === "structured-output-missing-result"
-	);
-}
+// --- No-result handling (DAT-608): the agent loop can end without the model emitting
+// an answer (it gave up, or hit the iteration ceiling). `emit_result` not being called
+// is how that surfaces now — captured.draft stays null. We salvage a validated query if
+// one exists, else tell the no-result story from the last state (see noResultNarrative).
 
 /** Synthesize a draft from a validated-but-unfinalized run: the model proved a
  * query via run_steps but ran out of steps before writing the summary. The grid
@@ -615,86 +600,97 @@ export async function querySubAgent(
 		conventionsBlock ? `\n\n${conventionsBlock}` : ""
 	}`;
 
-	// Per-invocation capture cell — the run_steps tool writes the last successful
-	// validation (and the last failure) here, so it's isolated across concurrent
-	// answer calls.
-	const captured: RunStepsCapture = { value: null, lastError: null };
+	// Per-invocation capture cell — run_steps writes the last validation (+ last failure)
+	// and emit_result writes the model's final draft. Isolated across concurrent calls.
+	const captured: RunStepsCapture = {
+		value: null,
+		lastError: null,
+		draft: null,
+	};
 
-	// Combined tools + outputSchema is native for claude-sonnet-4-6 — one call
-	// runs the tool loop and returns the validated structured draft (no separate
-	// finalize round-trip). The concrete schema gives a typed result.
-	let draft: QueryDraft;
-	try {
-		draft = await chat({
-			adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
-			abortController: linkedAbortController(signal),
-			modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
-			agentLoopStrategy: maxIterations(QUERY_SUBAGENT_MAX_ITERATIONS),
-			systemPrompts: [getQueryInstructions()],
-			messages: [{ role: "user", content: userMessage }],
-			tools: [
-				snippetSearchTool,
-				lookValuesTool,
-				makeRunStepsTool(captured, nearUniqueColumns),
-			],
-			// Per-turn LLM telemetry (DAT-600). Logs this nested sub-agent loop
-			// SEPARATELY from the orchestrator; `iterations` exposes its round-trip
-			// depth (the multiplier DAT-605 quantifies).
-			middleware: [llmTelemetryMiddleware("answer_subagent")],
-			outputSchema: QueryDraftSchema,
-		});
-	} catch (err) {
-		// Re-throw everything that ISN'T "loop ended without a structured answer":
-		// infra (network/DB), aborts (DOMException `AbortError` — no `code` prop), AND
-		// `structured-output-validation-failed` (Zod rejected a syntactically valid
-		// model response — rare on the native-combined path). The outer asAgentError
-		// converts these to `{ error }`; only the exhaustion case is handled below.
-		if (!isMissingStructuredResult(err)) throw err;
-		// DAT-608: the agent loop exhausted its step budget without finalizing.
-		if (captured.value) {
-			// A query DID validate — salvage it as the answer (grid + components),
-			// so a near-miss returns the real result instead of failing the turn.
-			const salvaged = salvageDraft(captured.value);
-			const dq = await readDataQuality(salvaged.tables_touched);
-			// Save-on-clean for the salvage path; the success path below is not reached
-			// (this returns), so captured.value is never double-saved.
-			void persistLearnedSnippets(captured.value);
-			return assembleAnswer(salvaged, captured.value, dq);
+	// The structured answer arrives as an EXPLICIT `emit_result` tool call, deliberately
+	// NOT native `chat({ outputSchema })`. Native combined mode (Anthropic 4.x) harvests
+	// the model's FINAL-TURN TEXT as the structured output — so a prose preamble ("Let me
+	// now compose…") emitted before the model means to call run_steps gets harvested as
+	// the `answer`, ending the loop before any SQL runs (the silent no-result bug). A
+	// plain tool can't be finalized by prose: the loop runs until the model EXPLICITLY
+	// emits its answer (or gives up), and run_steps stays a real step in between. Mirrors
+	// frame-family's induceStructured lesson, adapted from one-shot to this tool loop.
+	const emitResult = toolDefinition({
+		name: "emit_result",
+		description:
+			"Return your final answer as this tool's arguments, AFTER validating the query " +
+			"with run_steps. Call this exactly once, as your last action.",
+		inputSchema: QueryDraftSchema,
+	}).server((input) => {
+		captured.draft = input as QueryDraft;
+		return { ok: true };
+	});
+
+	const abortController = linkedAbortController(signal);
+	const stream = await chat({
+		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
+		abortController,
+		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
+		agentLoopStrategy: maxIterations(QUERY_SUBAGENT_MAX_ITERATIONS),
+		systemPrompts: [getQueryInstructions()],
+		messages: [{ role: "user", content: userMessage }],
+		tools: [
+			snippetSearchTool,
+			lookValuesTool,
+			makeRunStepsTool(captured, nearUniqueColumns),
+			emitResult,
+		],
+		// Per-turn LLM telemetry (DAT-600). Logs this nested sub-agent loop SEPARATELY
+		// from the orchestrator; `iterations` exposes its round-trip depth.
+		middleware: [llmTelemetryMiddleware("answer_subagent")],
+	});
+
+	// Drain the agent-loop stream so the tools actually execute. Stop as soon as the
+	// model emits its answer — draining further bills an extra turn that only re-confirms
+	// (abort the in-flight request, then break). If the loop ends with no emit (the model
+	// gave up, or hit the iteration ceiling), captured.draft stays null.
+	for await (const _chunk of stream) {
+		if (captured.draft !== null) {
+			abortController?.abort();
+			break;
 		}
-		// Nothing validated — surface an actionable diagnostic (last error + what it
-		// tried) so the outer agent retries with a concrete hint, not on the opaque
-		// "missing structured result".
-		throw new AgentActionableError(exhaustionDiagnostic(captured.lastError));
 	}
 
-	const dataQuality = await readDataQuality(draft.tables_touched);
-	// Save-on-clean (P2a): grow the snippet library from this answer's fresh/
-	// adapted steps. Fire-and-forget — the learning write runs AFTER the answer is
-	// assembled and is never on the answer's critical path; persistLearnedSnippets
-	// swallows its own errors, so it can neither block nor fail the answer.
+	const dataQuality = await readDataQuality(
+		captured.draft?.tables_touched ?? [],
+	);
+	// Save-on-clean (P2a): grow the snippet library from this answer's fresh/adapted
+	// steps. Fire-and-forget — runs AFTER assembly, never on the critical path.
 	void persistLearnedSnippets(captured.value);
 
-	// The model can finalize a structured draft WITHOUT validating a runnable query
-	// (captured.value === null): it satisfies QueryDraftSchema with an empty answer and
-	// never calls run_steps, so `chat()` never throws and the exhaustion catch above is
-	// bypassed. Returning assembleAnswer(draft, null) there is the "blank no-result with
-	// no error message" bug — nothing to show, nothing to debug. Instead surface the last
-	// state: a self-explaining narrative for the user + a structured log line carrying the
-	// last validation failure (SQL tried + error) so the run leaves a debuggable trace.
-	if (!captured.value) {
-		console.info("answer_no_result", {
-			had_narrative: draft.answer.trim().length > 0,
-			last_error: captured.lastError?.message ?? null,
-			last_sql: captured.lastError?.sql ?? null,
-			steps_attempted: captured.lastError?.steps ?? [],
-		});
-		return assembleAnswer(
-			{ ...draft, answer: noResultNarrative(captured.lastError) },
-			null,
-			dataQuality,
-		);
+	if (captured.value) {
+		// A query validated — that's the answer. Use the model's emitted draft, or salvage
+		// from the validated run if it validated but never emitted (the grid IS the answer,
+		// DAT-608: a near-miss returns the real result rather than failing the turn).
+		const draft = captured.draft ?? salvageDraft(captured.value);
+		return assembleAnswer(draft, captured.value, dataQuality);
 	}
-	return assembleAnswer(draft, captured.value, dataQuality);
+
+	// No validated query → an honest no-result (the last state), never a blank. The
+	// narrative tells the story from facts (the last validation failure, or a plain
+	// "stopped before running any SQL"); the log line leaves a debuggable trace.
+	console.info("answer_no_result", {
+		emitted_answer: captured.draft !== null,
+		last_error: captured.lastError?.message ?? null,
+		last_sql: captured.lastError?.sql ?? null,
+		steps_attempted: captured.lastError?.steps ?? [],
+	});
+	return assembleAnswer(
+		{
+			answer: noResultNarrative(captured.lastError),
+			assumptions: captured.draft?.assumptions ?? [],
+			concepts_used: captured.draft?.concepts_used ?? [],
+			tables_touched: [],
+		},
+		null,
+		dataQuality,
+	);
 }
 
 export const answerTool = toolDefinition({

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -553,17 +553,21 @@ export function exhaustionDiagnostic(
 }
 
 /** The narrative for a finalized-but-unvalidated run (DAT-608 sibling): the model can
- * satisfy QueryDraftSchema with an empty `answer` and never call run_steps, finalizing a
- * blank draft — which sails PAST the exhaustion catch (it never threw). Tell the story
- * instead: keep the model's own explanation if it wrote one, else synthesize it from the
- * last validation failure (the SQL it tried + why) or a generic "couldn't compose a
- * query". So a no-result is always self-explaining, never blank. Pure; unit-tested. */
-export function noResultNarrative(
-	draft: QueryDraft,
-	lastError: RunStepsFailure | null,
-): string {
-	const own = draft.answer.trim();
-	return own.length > 0 ? own : exhaustionDiagnostic(lastError);
+ * satisfy QueryDraftSchema and never call run_steps, finalizing a draft with no validated
+ * query — which sails PAST the exhaustion catch (it never threw). Tell the story from
+ * FACTS we trust, NOT the model's `answer` field: that field is frequently a mid-compose
+ * placeholder ("Let me now compose…") the model finalized prematurely, which both
+ * misleads the reader and feeds the orchestrator a non-fact it hallucinates a cause from.
+ * If a query WAS tried and failed, that's the real story (SQL + validation error); if
+ * none was tried, say so plainly. Pure; unit-tested. */
+export function noResultNarrative(lastError: RunStepsFailure | null): string {
+	if (lastError) return exhaustionDiagnostic(lastError);
+	return (
+		"I couldn't compose a runnable query for this question — I stopped before " +
+		"validating any SQL, so there's no result to show. This usually means the " +
+		"question didn't map cleanly to the staged concepts. Try rephrasing it, or " +
+		"inspect the relevant tables or metrics first."
+	);
 }
 
 /**
@@ -685,7 +689,7 @@ export async function querySubAgent(
 			steps_attempted: captured.lastError?.steps ?? [],
 		});
 		return assembleAnswer(
-			{ ...draft, answer: noResultNarrative(draft, captured.lastError) },
+			{ ...draft, answer: noResultNarrative(captured.lastError) },
 			null,
 			dataQuality,
 		);

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.test.ts
@@ -289,15 +289,18 @@ describe("toolResultToCanvas", () => {
 		});
 	});
 
-	it("leaves the canvas unchanged for a no-grid answer with no narrative, or an agent error", () => {
-		expect(toolResultToCanvas("answer", { grid: null })).toBeNull();
-		expect(toolResultToCanvas("answer", {})).toBeNull();
+	it("leaves the canvas unchanged only for an agent error or a non-object answer result", () => {
+		// An agent error stays a chat-rail chip; a null/drifted non-object carries
+		// nothing to show. Everything that IS an answer result maps to a card (below).
 		expect(toolResultToCanvas("answer", { error: "boom" })).toBeNull();
+		expect(toolResultToCanvas("answer", null)).toBeNull();
+		expect(toolResultToCanvas("answer", "nope")).toBeNull();
 	});
 
-	it("maps a no-grid answer WITH a narrative to an explicit no-result card", () => {
+	it("ALWAYS maps a no-grid answer to a no-result card — clicking 'view' must show it", () => {
 		// The sub-agent couldn't compose a runnable query — a legitimate outcome. Show
-		// it (sql:null + the narrative) rather than a stale/blank canvas.
+		// it (sql:null) rather than a stale/blank canvas, WHETHER OR NOT the tool wrote a
+		// narrative (it usually doesn't — the widget supplies a default message then).
 		expect(
 			toolResultToCanvas("answer", {
 				answer: "I couldn't find revenue accounts to compute that.",
@@ -307,6 +310,19 @@ describe("toolResultToCanvas", () => {
 			kind: "answer-result",
 			sql: null,
 			summary: "I couldn't find revenue accounts to compute that.",
+			confidence: null,
+		});
+		// Empty narrative (the common no-result shape) + the bare {} drift → still a card.
+		expect(toolResultToCanvas("answer", { answer: "", grid: null })).toEqual({
+			kind: "answer-result",
+			sql: null,
+			summary: "",
+			confidence: null,
+		});
+		expect(toolResultToCanvas("answer", {})).toEqual({
+			kind: "answer-result",
+			sql: null,
+			summary: "",
 			confidence: null,
 		});
 	});

--- a/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
+++ b/packages/cockpit/src/ui/cockpit/tool-result-to-canvas.ts
@@ -282,17 +282,22 @@ const PROJECTORS: Record<string, CanvasProjector> = {
 	// (DAT-500) — band, grounded ratio, reuse, assumptions.
 	answer: (result) => {
 		if (isAgentError(result)) return null;
-		const r = result as Record<string, unknown> | null;
+		// A non-object result (null / drifted) carries nothing to show — leave the
+		// canvas unchanged. Any real `answer` tool result IS an object (the AnswerSchema
+		// shape), so this only excludes genuinely malformed output.
+		if (result === null || typeof result !== "object") return null;
+		const r = result as Record<string, unknown>;
 		// The narrative `answer` field, read defensively (cockpit boundary rule): a
 		// drifted result with a non-string answer yields "" rather than throwing.
-		const summary = typeof r?.answer === "string" ? r.answer : "";
-		const grid = (r?.grid ?? null) as { sql?: unknown } | null;
+		const summary = typeof r.answer === "string" ? r.answer : "";
+		const grid = (r.grid ?? null) as { sql?: unknown } | null;
 		if (!grid || typeof grid.sql !== "string" || grid.sql.length === 0) {
-			// No runnable query: show the no-result state when there's a narrative to
-			// explain it; a fully-empty result (no grid, no narrative) maps to nothing.
-			return summary
-				? { kind: "answer-result", sql: null, summary, confidence: null }
-				: null;
+			// No runnable query — a legitimate no-result. ALWAYS surface it as an explicit
+			// no-result card (clicking the answer chip's "view" must show SOMETHING, not a
+			// stale/blank canvas). The narrative is often empty here (the sub-agent gives
+			// up without writing one — the orchestrator explains it in chat instead), so
+			// the widget falls back to a default "couldn't compute that" message.
+			return { kind: "answer-result", sql: null, summary, confidence: null };
 		}
 		return {
 			kind: "answer-result",


### PR DESCRIPTION
## Problem

The analyse chat could return a **blank** result with no error and no way to debug it —
e.g. "compare net, operating, and EBITDA margin" came back empty, and the orchestrator
then *hallucinated* a "blocked columns" cause from the nothing it was handed.

## Root cause

The `answer` sub-agent used native `chat({ outputSchema })`. For Anthropic 4.x that routes
through NATIVE combined tools+schema mode, whose engine **harvests the final-turn TEXT** as
the structured output (confirmed via the `@tanstack/ai` structured-outputs skill). So when
the model emitted a prose preamble ("great, I have all the graph snippets needed. Let me now
compose…") intending to call `run_steps` next, that text was harvested as the `answer` and
the loop **ended before any SQL ran** (telemetry: `steps_attempted: []`, `iterations 2/10`).
It wasn't "giving up" — its preamble was being captured as the answer.

## Fix (three commits)

1. **`emit_result` tool rewire (the root fix).** The structured answer now arrives as an
   explicit `emit_result` tool the model must call (`inputSchema = QueryDraftSchema`), with
   **no `outputSchema`** — the proven `frame-family`/`induceStructured` pattern, adapted from
   one-shot to this tool loop. Prose can't finalize a tool, so the loop runs
   `snippet_search → run_steps → emit_result`; we drain the stream until `emit_result`
   captures (abort+break). Validated query → the emitted draft (or `salvageDraft` if it
   validated but didn't emit); no validated query → an honest no-result. Removed the dead
   native-finalization path (`isMissingStructuredResult`, the `AgentActionableError` throw).
2. **Honest no-result narrative.** When no query was run, tell the story from facts (the last
   validation failure, or "stopped before running any SQL") + a structured `answer_no_result`
   log line (`last_error`/`last_sql`/`steps_attempted`) — never the model's placeholder, which
   is what fed the orchestrator's hallucination.
3. **Canvas always renders the no-result card.** A no-grid answer now always maps to the
   `AnswerNoResult` widget, so clicking the answer chip's "view" shows it (was silently
   dropped when the narrative was empty). The `answer-result` canvas type is sql-discriminated.

## Verified live

The 3-margin question now returns a full grounded result — EBITDA 54.05% / Operating 51.11% /
Net 48.28%, a real grid, **100% grounded, 6 snippets reused** — `iterations` went 2 → 3 (the
model now runs `run_steps`), no crash, 0 console errors.

tsc clean; **1484 cockpit tests pass** (lone red is the pre-existing live-SeaweedFS
integration test, unrelated).

Follow-up (separate ticket): the intermittent ~219s orchestrator / answer-tool context-build
stall — needs timing instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)