### PR TITLE
fix(cockpit): stop run-context (node:async_hooks) leaking into the client bundle

### DIFF
--- a/packages/cockpit/src/server/import-sources.test.ts
+++ b/packages/cockpit/src/server/import-sources.test.ts
@@ -184,11 +184,20 @@ describe("runImport (DAT-639) — guard before write", () => {
 		workflow_id: "wf_1",
 		run_id: "run_1",
 	}));
+	// Pass-through stand-in for run-context's AsyncLocalStorage binding (injected,
+	// never statically imported — see ImportDeps). Asserted in the bound-run case.
+	const runWithConversation = vi.fn(
+		(
+			_id: string,
+			start: () => Promise<{ workflow_id: string; run_id: string }>,
+		) => start(),
+	);
 
 	beforeEach(() => {
 		persistRecipeSources.mockClear();
 		persistFileSources.mockClear();
 		triggerAddSource.mockClear();
+		runWithConversation.mockClear();
 	});
 
 	it("rejects on a candidate colliding with an existing workspace table — NO persist, NO trigger", async () => {
@@ -205,6 +214,7 @@ describe("runImport (DAT-639) — guard before write", () => {
 					// `orders.csv` → narrow name `orders`, already live in the workspace.
 					existingRawTableNames: async () => new Set(["orders"]),
 					triggerAddSource,
+					runWithConversation,
 				},
 			),
 		).rejects.toThrow(/already exists in this workspace/);
@@ -233,6 +243,7 @@ describe("runImport (DAT-639) — guard before write", () => {
 				persistFileSources,
 				existingRawTableNames: async () => new Set(["vendors"]),
 				triggerAddSource,
+				runWithConversation,
 			},
 		);
 		expect(persistRecipeSources).toHaveBeenCalledOnce();
@@ -242,5 +253,29 @@ describe("runImport (DAT-639) — guard before write", () => {
 		});
 		expect(result.workflow_id).toBe("wf_1");
 		expect(result.run_id).toBe("run_1");
+	});
+
+	it("binds the trigger to the conversation when one is present", async () => {
+		await runImport(
+			{
+				queries: [],
+				files: [{ file_uri: "s3://b/ws/uploads/aaa/widgets.csv" }],
+			},
+			"conv_42",
+			{
+				persistRecipeSources,
+				persistFileSources,
+				existingRawTableNames: async () => new Set<string>(),
+				triggerAddSource,
+				runWithConversation,
+			},
+		);
+		// The trigger fires INSIDE the conversation binding (run-context), so the
+		// completion-watcher can route this run's progress back to the chat.
+		expect(runWithConversation).toHaveBeenCalledWith(
+			"conv_42",
+			expect.any(Function),
+		);
+		expect(triggerAddSource).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/cockpit/src/server/import-sources.ts
+++ b/packages/cockpit/src/server/import-sources.ts
@@ -20,7 +20,6 @@
 
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-import { runWithConversation } from "#/lib/run-context";
 import type { FileSourceSpec } from "#/select/file-source";
 // `persistRecipeSources` / `persistFileSources` + `triggerAddSource` pull
 // config-bearing modules (duckdb/probe, config) at load. They run ONLY server-side
@@ -28,9 +27,13 @@ import type { FileSourceSpec } from "#/select/file-source";
 // keep THIS module's graph config-free. The probe WIDGET imports this server fn at
 // module scope; a static pull would drag config into every test that eagerly loads
 // the widget registry (the canvas registry is deliberately config-free).
-// `runWithConversation` is just AsyncLocalStorage (config-free), so it stays a
-// normal import. The persist-fn TYPES are erased at build, so importing them as
-// `type` keeps the module graph config-free while the union helper stays typed.
+// `runWithConversation` (run-context) imports `node:async_hooks` — config-free but
+// NOT browser-safe: that Node builtin is shimmed-empty in the client bundle this
+// server fn is reachable from (the probe widget), and accessing it there crashes
+// the route. So it's an injected `ImportDeps` collaborator wired from the handler's
+// dynamic imports, never a static import here. The persist-fn TYPES are erased at
+// build, so importing them as `type` keeps the module graph config-free while the
+// union helper stays typed.
 // `mappers` is config-free (node:crypto + a type + UPLOAD_PREFIX only), so the
 // candidate-name derivation stays a static import — it does NOT drag config into
 // this module's graph the way the persist fns / metadata client do.
@@ -203,6 +206,16 @@ export interface ImportDeps extends ImportSetPersisters {
 	triggerAddSource: (input: {
 		sources: string[];
 	}) => Promise<{ workflow_id: string; run_id: string }>;
+	/** Bind the trigger to its originating conversation (run-context's
+	 * AsyncLocalStorage) so the completion-watcher narrates it. Injected — NOT a
+	 * static import — because run-context pulls `node:async_hooks`, which crashes the
+	 * client bundle this file is reachable from. The server fn wires the real one
+	 * (generic `runWithConversation<T>`, which assigns to this concrete use) via
+	 * dynamic import. Typed to the trigger result it always wraps here. */
+	runWithConversation: (
+		conversationId: string,
+		start: () => Promise<{ workflow_id: string; run_id: string }>,
+	) => Promise<{ workflow_id: string; run_id: string }>;
 }
 
 /**
@@ -235,7 +248,7 @@ export async function runImport(
 	// progress + narration by conversationId). Off-route (no id) → bare trigger,
 	// the null-conversation run the watcher simply doesn't narrate.
 	const run = await (conversationId
-		? runWithConversation(conversationId, () =>
+		? deps.runWithConversation(conversationId, () =>
 				deps.triggerAddSource({ sources: sourceIds }),
 			)
 		: deps.triggerAddSource({ sources: sourceIds }));
@@ -268,6 +281,9 @@ export const importSources = createServerFn({ method: "POST" })
 		const { existingRawTableNames } = await import(
 			"#/db/metadata/workspace-state"
 		);
+		// run-context pulls `node:async_hooks` (server-only) — dynamic-import it here
+		// so it never lands in the probe widget's client bundle.
+		const { runWithConversation } = await import("#/lib/run-context");
 
 		return runImport(
 			{ queries: data.queries, files: data.files },
@@ -277,6 +293,7 @@ export const importSources = createServerFn({ method: "POST" })
 				persistFileSources,
 				existingRawTableNames,
 				triggerAddSource,
+				runWithConversation,
 			},
 		);
 	});


### PR DESCRIPTION
## Symptom

The cockpit route crashed on load with:

> Module \"node:async_hooks\" has been externalized for browser compatibility. Cannot access \"node:async_hooks.AsyncLocalStorage\" in client code.

…firing 6× from `src/lib/run-context.ts`, taking down the probe widget's `<Lazy>` subtree (recovered by the CatchBoundary, hence the page churn).

## Root cause

`server/import-sources.ts` is a `createServerFn` module imported by the **probe widget (client)**. It already keeps its static graph browser-safe by dynamic-importing its config/Temporal deps inside the handler — but it made **one exception**: a top-level

```ts
import { runWithConversation } from "#/lib/run-context";
```

rationalized in its own comment as *"just AsyncLocalStorage (config-free), so it stays a normal import."* That's the bug: **config-free ≠ browser-safe.** `run-context` imports `node:async_hooks`, a Node builtin Vite shims empty in the client bundle — accessing it there crashes the route.

`run-context.ts` itself is fine: it has 5 legitimate server-only importers and is already a clean, side-effect-free server module. This was **one bad importer**, not a module that needs splitting.

## Fix

Make `runWithConversation` an injected `ImportDeps` collaborator, wired from the handler's dynamic imports exactly like `persistFileSources`/`triggerAddSource` already are. `import-sources.ts`'s static graph no longer references `node:async_hooks`.

This matches the codebase's established discipline (`server/active-vertical.ts`, which the file's own comment says it mirrors) and the TanStack Intent `start-core/server-functions` guidance (server-fn modules stay client-safe; node-builtins live behind the handler).

## Tests

`runImport`'s conversation-bound branch was previously **uncovered** (both cases passed `conversationId: null`). It's now injectable, so there's a case asserting the trigger fires *inside* the `runWithConversation` binding.

## Verification

Drove the dev server and mounted the probe widget (the exact leak path: `probe.tsx → import-sources.ts → run-context`):
- **Before:** 6 `node:async_hooks` console errors, page bouncing.
- **After:** 0 console errors, probe widget renders fully.
- `bun run test src/server/import-sources.test.ts` — 12 passed · `typecheck` clean · `check` (biome) clean.

Note: observed on the **vite dev** server; the prod (nitro) build may DCE this differently, but the fix aligns with the codebase discipline regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)