### PR TITLE
style(cockpit): set the chart preview apart on a dotted, rounded panel

### DIFF
--- a/packages/cockpit/src/ui/cockpit/widgets/chart-modal.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/chart-modal.tsx
@@ -26,6 +26,7 @@ import {
 	Group,
 	Loader,
 	Modal,
+	Paper,
 	Select,
 	Stack,
 	Text,
@@ -334,27 +335,35 @@ function ChartModalContent({
 				)}
 			</Stack>
 
-			{/* Live preview / empty state. A chart shows only once both axes resolve to
-			    a valid config; otherwise prompt the user toward either path. */}
-			{validConfig ? (
-				<ClientOnly>
-					<ChartView
-						config={validConfig}
-						rows={data.rows}
-						testId="chart-preview"
-					/>
-				</ClientOnly>
-			) : (
-				<Center h={200} data-testid="chart-modal-empty">
-					<Text c="dimmed" size="sm" ta="center" maw={420}>
-						{candidate
-							? validation && !validation.ok
-								? validation.error
-								: "Adjust the mapping to preview a chart."
-							: "Describe the chart above, or map the columns yourself."}
-					</Text>
-				</Center>
-			)}
+			{/* Live preview / empty state, set apart on a tinted, rounded panel so the
+			    chart reads as a distinct surface from the controls. A chart shows only
+			    once both axes resolve to a valid config; otherwise prompt the user. */}
+			<Paper
+				bg="white"
+				radius="md"
+				p="md"
+				style={{ border: "1px dotted var(--mantine-color-gray-4)" }}
+			>
+				{validConfig ? (
+					<ClientOnly>
+						<ChartView
+							config={validConfig}
+							rows={data.rows}
+							testId="chart-preview"
+						/>
+					</ClientOnly>
+				) : (
+					<Center h={200} data-testid="chart-modal-empty">
+						<Text c="dimmed" size="sm" ta="center" maw={420}>
+							{candidate
+								? validation && !validation.ok
+									? validation.error
+									: "Adjust the mapping to preview a chart."
+								: "Describe the chart above, or map the columns yourself."}
+						</Text>
+					</Center>
+				)}
+			</Paper>
 
 			{/* The encoding controls — secondary, collapsed behind a one-line readout
 			    of the current mapping. A generated config seeds this; opening lets the


### PR DESCRIPTION
## What

The chart preview in the authoring modal sat flush against the encoding controls with no visual separation. Wrap it — and its empty/placeholder state, so the frame stays consistent whether or not a chart is showing — in a Mantine `Paper`:

```tsx
<Paper bg="white" radius="md" p="md"
       style={{ border: "1px dotted var(--mantine-color-gray-4)" }}>
  {validConfig ? <ChartView … /> : <Center>…placeholder…</Center>}
</Paper>
```

White fill matches the chart canvas; the dotted, rounded grey border gives the preview its own surface without competing with the white modal background.

## Verification

Driven on the dev server: the preview renders inside the panel (chart and empty state), no console errors, `typecheck` + `check` (biome) clean. Pure presentation — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)