### PR TITLE
fix(DAT-649): remove silent grounding caps across authoring surfaces

### DIFF
--- a/packages/cockpit/src/tools/look-table.test.ts
+++ b/packages/cockpit/src/tools/look-table.test.ts
@@ -112,7 +112,7 @@ describe("projectColumnReadiness (DAT-350)", () => {
 		expect(out.semantic).toBeNull();
 	});
 
-	it("caps top drivers at 3 (the overview shows the worst few)", () => {
+	it("surfaces ALL top drivers (no cap) — every ranked driver is served (DAT-649)", () => {
 		const many = Array.from({ length: 6 }, (_, i) => ({
 			node: `n${i}`,
 			dimension_path: `p.${i}`,
@@ -121,8 +121,15 @@ describe("projectColumnReadiness (DAT-350)", () => {
 			impact_delta: 0.5 - i * 0.01,
 		}));
 		const out = projectColumnReadiness(row({ topDrivers: many }));
-		expect(out.top_drivers).toHaveLength(3);
-		expect(out.top_drivers.map((d) => d.label)).toEqual(["L0", "L1", "L2"]);
+		expect(out.top_drivers).toHaveLength(6);
+		expect(out.top_drivers.map((d) => d.label)).toEqual([
+			"L0",
+			"L1",
+			"L2",
+			"L3",
+			"L4",
+			"L5",
+		]);
 	});
 
 	it("degrades a malformed JSONB blob to empty rather than throwing", () => {
@@ -357,7 +364,7 @@ describe("projectTableBand (DAT-415)", () => {
 		]);
 	});
 
-	it("caps top drivers at 3", () => {
+	it("surfaces ALL top drivers (no cap) (DAT-649)", () => {
 		const many = Array.from({ length: 6 }, (_, i) => ({
 			node: `n${i}`,
 			dimension_path: `p.${i}`,
@@ -366,8 +373,15 @@ describe("projectTableBand (DAT-415)", () => {
 			impact_delta: 0.5 - i * 0.01,
 		}));
 		const out = projectTableBand(tableRow({ topDrivers: many }));
-		expect(out.top_drivers).toHaveLength(3);
-		expect(out.top_drivers.map((d) => d.label)).toEqual(["L0", "L1", "L2"]);
+		expect(out.top_drivers).toHaveLength(6);
+		expect(out.top_drivers.map((d) => d.label)).toEqual([
+			"L0",
+			"L1",
+			"L2",
+			"L3",
+			"L4",
+			"L5",
+		]);
 	});
 
 	it("degrades a malformed JSONB blob to empty rather than throwing", () => {

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -170,10 +170,6 @@ const LookTableResult = z.object({
 });
 export type LookTableResult = z.infer<typeof LookTableResult>;
 
-// How many of a column's top drivers to surface in the overview (why_column
-// shows the full ranked list).
-const TOP_DRIVERS_SHOWN = 3;
-
 /** One joined (columns ⟕ entropy_readiness ⟕ semantic_annotations) row, as
  * Drizzle returns it. The semantic fields are left-join-nullable — a column with
  * no promoted annotation reads them all null and projects `semantic: null`. */
@@ -250,7 +246,7 @@ export function projectColumnReadiness(row: ReadinessRow): ColumnReadiness {
 				}))
 			: [],
 		top_drivers: drivers.success
-			? drivers.data.slice(0, TOP_DRIVERS_SHOWN).map((d) => ({
+			? drivers.data.map((d) => ({
 					label: d.label,
 					state: d.state,
 					impact_delta: d.impact_delta,
@@ -272,7 +268,7 @@ export interface TableBandRow {
  * Project the table-grain readiness row to the overview shape. Pure (no DB), the
  * table analog of {@link projectColumnReadiness} minus the column identity: the
  * per-intent overview keeps band + risk (drivers are why_table's drill-down), and
- * the top drivers are capped + self-describing. A malformed JSONB blob degrades to
+ * the surfaced drivers are self-describing. A malformed JSONB blob degrades to
  * empty rather than throwing.
  */
 export function projectTableBand(row: TableBandRow): TableReadiness {
@@ -289,7 +285,7 @@ export function projectTableBand(row: TableBandRow): TableReadiness {
 				}))
 			: [],
 		top_drivers: drivers.success
-			? drivers.data.slice(0, TOP_DRIVERS_SHOWN).map((d) => ({
+			? drivers.data.map((d) => ({
 					label: d.label,
 					state: d.state,
 					impact_delta: d.impact_delta,

--- a/packages/cockpit/src/tools/why-metric.test.ts
+++ b/packages/cockpit/src/tools/why-metric.test.ts
@@ -3,7 +3,7 @@
 //
 // What this guards: the found discriminant is the DECLARED artifact (NOT the
 // cross-session-durable snippets), the per-step evidence labels + digest-
-// sanitized SQL, grounded_against rendering, and the MAX_STEPS bound (rule 15).
+// sanitized SQL, grounded_against rendering, and full (uncapped) step serving.
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -188,14 +188,14 @@ describe("projectWhyMetric (DAT-466)", () => {
 		);
 	});
 
-	it("bounds the steps rendered to MAX_STEPS (rule 15)", () => {
+	it("renders ALL steps (no cap) — a large metric DAG is served whole (DAT-649)", () => {
 		const many: MetricSnippetRow[] = Array.from({ length: 60 }, (_, i) => ({
 			...extractSnippet,
 			standardField: `field_${i}`,
 		}));
 		const projected = projectWhyMetric("big", executedArtifact, many, 0);
-		// Capped at 40 rendered, but the true count is reported.
-		expect(projected.steps).toHaveLength(40);
+		// Every persisted step is served — no truncation — and the count matches.
+		expect(projected.steps).toHaveLength(60);
 		expect(projected.snippet_count).toBe(60);
 	});
 });

--- a/packages/cockpit/src/tools/why-metric.ts
+++ b/packages/cockpit/src/tools/why-metric.ts
@@ -27,10 +27,6 @@ import { sqlSnippets } from "../db/metadata/schema";
 import { renderEvidenceDetail, stripSrcDigests } from "../lib/display-names";
 import { metricSnippetSource } from "./look-metric";
 
-// Bound the steps rendered into context/DOM (rule 15). A metric DAG is normally
-// a handful of steps, but the surface must stay usable if a graph is large.
-const MAX_STEPS = 40;
-
 // --- Tool output (mirrors the why_* found/anatomy conventions, keyed on the
 // metric's graph_id).
 
@@ -72,7 +68,7 @@ const WhyMetricResult = z.object({
 	// How many persisted SQL steps back the metric.
 	snippet_count: z.number(),
 	// The per-step SQL fragments — the metric's executable knowledge, the "how it
-	// computes". Bounded (MAX_STEPS).
+	// computes". Every persisted step is served (no cap, DAT-649).
 	steps: z.array(MetricStep),
 	pending_teaches: z.number(),
 });
@@ -120,7 +116,7 @@ export function projectWhyMetric(
 	snippets: MetricSnippetRow[],
 	pendingTeaches: number,
 ): WhyMetricResult {
-	const steps: MetricStep[] = snippets.slice(0, MAX_STEPS).map((s) => ({
+	const steps: MetricStep[] = snippets.map((s) => ({
 		snippet_id: s.snippetId,
 		type: s.snippetType,
 		label: stepLabel(s),

--- a/packages/dataraum-config/phases/statistics.yaml
+++ b/packages/dataraum-config/phases/statistics.yaml
@@ -2,4 +2,4 @@
 # Used by analysis/statistics/profiler.py
 
 # Number of top frequent values to collect per column
-top_k_values: 20
+top_k_values: 200

--- a/packages/dataraum-config/phases/temporal.yaml
+++ b/packages/dataraum-config/phases/temporal.yaml
@@ -32,8 +32,6 @@ gaps:
   # Severity thresholds (multipliers on median gap)
   severity_severe_multiplier: 10.0
   severity_moderate_multiplier: 5.0
-  # Maximum gaps to report
-  max_gaps: 10
 
 # Update frequency and staleness
 staleness:

--- a/packages/engine/src/dataraum/analysis/cycles/context.py
+++ b/packages/engine/src/dataraum/analysis/cycles/context.py
@@ -387,7 +387,7 @@ def _get_value_counts_for_column(
             "count": tv.get("count", 0),
             "percentage": round(tv.get("percentage", 0), 1),
         }
-        for tv in top_values[:10]
+        for tv in top_values
     ]
 
 
@@ -500,13 +500,8 @@ def format_context_for_prompt(context: dict[str, Any]) -> str:
             dims = ", ".join(ev["dimension_tables"]) if ev["dimension_tables"] else "none"
             lines.append(f"- {ev['view_name']}: {ev['fact_table']} + [{dims}]")
             if ev.get("dimension_columns"):
-                cols = ", ".join(ev["dimension_columns"][:8])
-                extra = (
-                    f" (+{len(ev['dimension_columns']) - 8} more)"
-                    if len(ev["dimension_columns"]) > 8
-                    else ""
-                )
-                lines.append(f"  Added columns: {cols}{extra}")
+                cols = ", ".join(ev["dimension_columns"])
+                lines.append(f"  Added columns: {cols}")
         lines.append("")
 
     # Relationships

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -42,7 +42,6 @@ from dataraum.analysis.drivers.tree import (
     DEFAULT_ALPHA,
     DEFAULT_MAX_DEPTH,
     DEFAULT_N_PERM,
-    DEFAULT_TOP_K_SLICES,
     discover_tree,
 )
 from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
@@ -287,7 +286,6 @@ def discover_drivers(
     min_support: int = DEFAULT_MIN_SUPPORT,
     missingness_gate: float = DEFAULT_MISSINGNESS_GATE,
     n_perm: int = DEFAULT_N_PERM,
-    top_k_slices: int = DEFAULT_TOP_K_SLICES,
     icc_threshold: float = DEFAULT_ICC_THRESHOLD,
     min_entities: int = DEFAULT_MIN_ENTITIES,
     max_rows: int = DEFAULT_MAX_ROWS,
@@ -455,7 +453,6 @@ def discover_drivers(
             min_support=min_support,
             missingness_gate=missingness_gate,
             n_perm=n_perm,
-            top_k_slices=top_k_slices,
             icc_threshold=icc_threshold,
             min_entities=min_entities,
         )
@@ -470,7 +467,6 @@ def discover_drivers(
         min_support=min_support,
         missingness_gate=missingness_gate,
         n_perm=n_perm,
-        top_k_slices=top_k_slices,
     )
 
 
@@ -644,7 +640,6 @@ def _routed_ranking(
     min_support: int,
     missingness_gate: float,
     n_perm: int,
-    top_k_slices: int,
     icc_threshold: float,
     min_entities: int,
 ) -> DriverRanking:
@@ -686,7 +681,6 @@ def _routed_ranking(
                     seed=seed + i,
                     alpha=alpha,
                     n_perm=n_perm,
-                    top_k_slices=top_k_slices,
                     min_entities=min_entities,
                 ),
                 "entity",
@@ -706,7 +700,6 @@ def _routed_ranking(
                     min_support=min_support,
                     missingness_gate=missingness_gate,
                     n_perm=n_perm,
-                    top_k_slices=top_k_slices,
                     cluster_key=top_entity if high_icc else None,
                 ),
                 "row",
@@ -744,7 +737,6 @@ def _row_wise_ranking(
     min_support: int,
     missingness_gate: float,
     n_perm: int,
-    top_k_slices: int,
     cluster_key: str | None = None,
 ) -> DriverRanking:
     """Rank ``dims`` row-wise. ``cluster_key`` set → de-mean the measure within entity.
@@ -781,7 +773,6 @@ def _row_wise_ranking(
         min_support=min_support,
         missingness_gate=missingness_gate,
         n_perm=n_perm,
-        top_k_slices=top_k_slices,
     )
 
 
@@ -794,7 +785,6 @@ def _entity_grain_ranking(
     seed: int,
     alpha: float,
     n_perm: int,
-    top_k_slices: int,
     min_entities: int,
 ) -> DriverRanking:
     """Collapse to one row per entity and rank the (pre-partitioned) entity-level dims.
@@ -826,5 +816,4 @@ def _entity_grain_ranking(
         alpha=alpha,
         min_support=min_entities,
         n_perm=n_perm,
-        top_k_slices=top_k_slices,
     )

--- a/packages/engine/src/dataraum/analysis/drivers/tree.py
+++ b/packages/engine/src/dataraum/analysis/drivers/tree.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 DEFAULT_N_PERM = 500
 DEFAULT_ALPHA = 0.05
 DEFAULT_MAX_DEPTH = 2
-DEFAULT_TOP_K_SLICES = 5
 # A child subset must clear this multiple of min_support to be re-gated — too few
 # rows and the per-node null is meaningless (the spike's 4× rule).
 _RECURSE_SUPPORT_MULTIPLE = 4
@@ -102,9 +101,12 @@ def _slices(
     coded: _Coded,
     *,
     min_support: int,
-    top_k: int,
 ) -> tuple[DriverSlice, ...]:
-    """The supported slice values whose target deviates most from the node baseline."""
+    """The supported slice values whose target deviates most from the node baseline.
+
+    The FDR/permutation gate already drops non-significant slices, so every
+    surviving slice is served — no top-k cap (DAT-649).
+    """
     codes, n_codes = coded
     labels = _code_labels(phys, dim_labels, codes, n_codes)
     out = [
@@ -112,7 +114,7 @@ def _slices(
         for code, effect, support in target.group_effects(codes, n_codes, min_support=min_support)
     ]
     out.sort(key=lambda s: abs(s.effect), reverse=True)
-    return tuple(out[:top_k])
+    return tuple(out)
 
 
 def _build_node(
@@ -127,7 +129,6 @@ def _build_node(
     min_support: int,
     missingness_gate: float,
     n_perm: int,
-    top_k: int,
     rng: np.random.Generator,
 ) -> tuple[DriverNode | None, dict[str, float], dict[str, float]]:
     """Build the best split for this subset; recurse into its slice values.
@@ -161,7 +162,6 @@ def _build_node(
         target,
         coded[best],
         min_support=min_support,
-        top_k=top_k,
     )
 
     children: list[tuple[str, DriverNode]] = []
@@ -184,7 +184,6 @@ def _build_node(
                 min_support=min_support,
                 missingness_gate=missingness_gate,
                 n_perm=n_perm,
-                top_k=top_k,
                 rng=rng,
             )
             if child is not None:
@@ -224,7 +223,6 @@ def discover_tree(
     min_support: int = DEFAULT_MIN_SUPPORT,
     missingness_gate: float = DEFAULT_MISSINGNESS_GATE,
     n_perm: int = DEFAULT_N_PERM,
-    top_k_slices: int = DEFAULT_TOP_K_SLICES,
 ) -> DriverRanking:
     """Rank ``dims`` by their permutation-gated gain on ``target`` and build the tree.
 
@@ -244,7 +242,6 @@ def discover_tree(
         min_support=min_support,
         missingness_gate=missingness_gate,
         n_perm=n_perm,
-        top_k=top_k_slices,
         rng=rng,
     )
     ranked = sorted(

--- a/packages/engine/src/dataraum/analysis/relationships/graph_topology.py
+++ b/packages/engine/src/dataraum/analysis/relationships/graph_topology.py
@@ -408,7 +408,7 @@ def format_graph_structure_for_context(structure: GraphStructure) -> str:
     if structure.schema_cycles:
         lines.append("")
         lines.append(f"Schema cycles detected: {len(structure.schema_cycles)}")
-        for i, cycle in enumerate(structure.schema_cycles[:5], 1):  # Limit to 5
+        for i, cycle in enumerate(structure.schema_cycles, 1):
             lines.append(f"  {i}. {' → '.join(cycle.tables)} → {cycle.tables[0]}")
 
     lines.append("")

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -453,7 +453,7 @@ class SemanticAgent(LLMFeature):
             if graph_structure.schema_cycles:
                 cycle_strs = [
                     " → ".join(c.tables) + " → " + c.tables[0]
-                    for c in graph_structure.schema_cycles[:5]
+                    for c in graph_structure.schema_cycles
                 ]
                 lines.append(f"Cycles: {'; '.join(cycle_strs)}")
             lines.append("")
@@ -461,8 +461,6 @@ class SemanticAgent(LLMFeature):
         if not candidates:
             lines.append("No pre-computed relationship candidates available.")
             return "\n".join(lines)
-
-        _MAX_JOIN_COLS = 10
 
         for rel in candidates:
             table1 = rel.get("table1", "?")
@@ -484,22 +482,17 @@ class SemanticAgent(LLMFeature):
             if not join_cols:
                 lines.append("  (none detected)")
             else:
-                # Sort by overlap descending, take top N. The DB candidate-dict wire
-                # format (load_relationship_candidates_for_semantic) keys the overlap
+                # Sort by overlap descending. The DB candidate-dict wire format
+                # (load_relationship_candidates_for_semantic) keys the overlap
                 # score `confidence`, NOT `join_confidence` — reading only the latter
-                # showed the LLM overlap=0.00 for every candidate and truncated the
-                # top-N arbitrarily. Read both so the strongest pairs surface.
+                # showed the LLM overlap=0.00 for every candidate. Read both so the
+                # strongest pairs surface; all pairs are served (no cap, DAT-649).
                 def _overlap(jc: dict[str, Any]) -> float:
                     return float(jc.get("join_confidence", jc.get("confidence", 0.0)))
 
                 sorted_cols = sorted(join_cols, key=_overlap, reverse=True)
-                total_cols = len(sorted_cols)
-                display_cols = sorted_cols[:_MAX_JOIN_COLS]
 
-                if total_cols > _MAX_JOIN_COLS:
-                    lines.append(f"  (showing top {_MAX_JOIN_COLS} of {total_cols} candidates)")
-
-                for jc in display_cols:
+                for jc in sorted_cols:
                     col1 = jc.get("column1", "?")
                     col2 = jc.get("column2", "?")
                     join_conf = _overlap(jc)

--- a/packages/engine/src/dataraum/analysis/statistics/quality.py
+++ b/packages/engine/src/dataraum/analysis/statistics/quality.py
@@ -198,7 +198,10 @@ def detect_outliers_iqr(
         outlier_count = int(outlier_row[0]) if outlier_row else 0
         outlier_ratio = outlier_count / total_count if total_count > 0 else 0.0
 
-        # Step 3: Get sample outliers
+        # Step 3: Get sample outliers. Bounded (DAT-649): these are stored
+        # illustrative samples, NOT LLM grounding context — the full
+        # iqr_outlier_count is persisted separately — so a storage cap is correct
+        # (uncapped would bloat the row, not fail loud). 200 = the value-set margin.
         sample_query = f"""
             SELECT TRY_CAST("{col_name}" AS DOUBLE) as val
             FROM {table_name}
@@ -206,7 +209,7 @@ def detect_outliers_iqr(
             AND (TRY_CAST("{col_name}" AS DOUBLE) < {lower_fence}
                  OR TRY_CAST("{col_name}" AS DOUBLE) > {upper_fence})
             ORDER BY ABS(TRY_CAST("{col_name}" AS DOUBLE) - {(lower_fence + upper_fence) / 2.0}) DESC
-            LIMIT 10
+            LIMIT 200
         """
 
         outlier_samples = [
@@ -295,7 +298,9 @@ def detect_outliers_zscore(
 
         outlier_ratio = outlier_count / total_count if total_count > 0 else 0.0
 
-        # Get sample outliers
+        # Get sample outliers. Bounded (DAT-649): stored illustrative samples, NOT
+        # LLM grounding context — the full outlier_count is persisted separately — so
+        # a storage cap is correct (uncapped would bloat the row). 200 = value-set margin.
         sample_query = f"""
             WITH base AS (
                 SELECT TRY_CAST("{col_name}" AS DOUBLE) AS val
@@ -306,7 +311,7 @@ def detect_outliers_zscore(
             FROM base
             WHERE ABS(0.6745 * (val - {median_val}) / {mad_val}) > {threshold}
             ORDER BY zscore DESC
-            LIMIT 10
+            LIMIT 200
         """
 
         outlier_samples = [

--- a/packages/engine/src/dataraum/analysis/temporal/detection.py
+++ b/packages/engine/src/dataraum/analysis/temporal/detection.py
@@ -204,7 +204,6 @@ def analyze_basic_temporal(
         sig_gap_mult = gap_cfg["significant_gap_multiplier"]
         sev_severe_mult = gap_cfg["severity_severe_multiplier"]
         sev_moderate_mult = gap_cfg["severity_moderate_multiplier"]
-        max_gaps_limit = gap_cfg["max_gaps"]
 
         gaps = []
         if median_gap:
@@ -228,7 +227,6 @@ def analyze_basic_temporal(
                 FROM gaps
                 WHERE gap_seconds > {gap_threshold}
                 ORDER BY gap_seconds DESC
-                LIMIT {max_gaps_limit}
             """
             ).fetchall()
 

--- a/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
+++ b/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
@@ -206,9 +206,7 @@ class EnrichmentAgent(LLMFeature):
             view_name = view.get("view_name", "?")
             fact_table = view.get("fact_table", "?")
             dimensions = view.get("dimension_columns", [])
-            dim_str = ", ".join(dimensions[:5])
-            if len(dimensions) > 5:
-                dim_str += f" ... (+{len(dimensions) - 5} more)"
+            dim_str = ", ".join(dimensions)
 
             lines.append(f"- {view_name}: {fact_table} enriched with [{dim_str}]")
 

--- a/packages/engine/src/dataraum/entropy/detectors/value/slice_conditional_null.py
+++ b/packages/engine/src/dataraum/entropy/detectors/value/slice_conditional_null.py
@@ -40,7 +40,7 @@ logger = get_logger(__name__)
 # A categorical with more distinct values than this is not a slice dimension (an
 # identifier / free text); the Cochran rule already abstains on too-many-tiny-slices,
 # so this only bounds the scan, it does not tune the statistic.
-_MAX_SLICE_CARDINALITY = 50
+_MAX_SLICE_CARDINALITY = 200
 # distinct/total above this ⇒ an identifier (distinct ≈ rowcount) → never a slice.
 _NEAR_UNIQUE_RATIO = 0.99
 # evidence keeps the strongest driving slices only.

--- a/packages/engine/src/dataraum/graphs/field_mapping.py
+++ b/packages/engine/src/dataraum/graphs/field_mapping.py
@@ -162,12 +162,10 @@ def format_mappings_for_prompt(field_mappings: FieldMappings) -> str:
             )
         else:
             lines.append(f"- **{concept}** (multiple candidates):")
-            for c in candidates[:3]:  # Show top 3
+            for c in candidates:
                 lines.append(
                     f"  - `{c.table_name}.{c.column_name}` (confidence: {c.confidence:.2f})"
                 )
-            if len(candidates) > 3:
-                lines.append(f"  - ... and {len(candidates) - 3} more")
 
     lines.append("")
     lines.append(

--- a/packages/engine/src/dataraum/llm/privacy.py
+++ b/packages/engine/src/dataraum/llm/privacy.py
@@ -57,9 +57,8 @@ class DataSampler:
             else:
                 # Use real top values from profile
                 if profile.top_values:
-                    samples[key] = [
-                        vc.value for vc in profile.top_values[: self.config.max_sample_values]
-                    ]
+                    # Serve all stored top values (already bounded upstream, DAT-649).
+                    samples[key] = [vc.value for vc in profile.top_values]
                 else:
                     samples[key] = []
 

--- a/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
@@ -308,7 +308,7 @@ class SlicingPhase(BasePhase):
         """Remove columns that are objectively bad slice candidates.
 
         Mutates context_data in place, removing columns with:
-        - distinct_count > 50 (too high cardinality for slicing)
+        - distinct_count > 200 (too high cardinality for slicing)
         - null_ratio > 0.5 (majority NULL)
         - cardinality_ratio > 0.5 (approaching identifier territory)
 
@@ -337,7 +337,7 @@ class SlicingPhase(BasePhase):
                 card_ratio = col.get("cardinality_ratio")
                 is_enriched = col.get("is_enriched_dimension", False)
 
-                if distinct is not None and distinct > 50:
+                if distinct is not None and distinct > 200:
                     continue
                 if null_ratio is not None and null_ratio > 0.5:
                     continue

--- a/packages/engine/tests/unit/analysis/semantic/test_candidate_overlap_format.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_candidate_overlap_format.py
@@ -2,8 +2,8 @@
 
 The DB candidate-dict wire format (load_relationship_candidates_for_semantic) keys
 the value-overlap score ``confidence``; the formatter previously read only
-``join_confidence`` and rendered ``overlap=0.00`` for every candidate (and truncated
-the top-N arbitrarily), degrading relationship confirmation.
+``join_confidence`` and rendered ``overlap=0.00`` for every candidate, degrading
+relationship confirmation. Every candidate pair is now served (no cap, DAT-649).
 """
 
 from __future__ import annotations
@@ -18,8 +18,18 @@ def _candidates() -> list[dict]:
             "table1": "orders",
             "table2": "customers",
             "join_columns": [
-                {"column1": "customer_id", "column2": "id", "confidence": 0.92, "cardinality": "many-to-one"},
-                {"column1": "region", "column2": "region", "confidence": 0.30, "cardinality": "many-to-many"},
+                {
+                    "column1": "customer_id",
+                    "column2": "id",
+                    "confidence": 0.92,
+                    "cardinality": "many-to-one",
+                },
+                {
+                    "column1": "region",
+                    "column2": "region",
+                    "confidence": 0.30,
+                    "cardinality": "many-to-many",
+                },
             ],
         }
     ]
@@ -33,7 +43,7 @@ def test_overlap_score_is_rendered_from_the_confidence_key() -> None:
 
 
 def test_candidates_are_sorted_by_real_overlap() -> None:
-    """The stronger pair must come first (top-N truncation relies on it)."""
+    """The stronger pair must come first (strongest-overlap-first ordering)."""
     agent = SemanticAgent.__new__(SemanticAgent)
     out = agent._format_relationship_candidates(_candidates())
     assert out.index("customer_id <-> id") < out.index("region <-> region")

--- a/packages/engine/tests/unit/pipeline/test_slicing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_slicing_phase.py
@@ -391,7 +391,7 @@ class TestRunTimeAxisFill:
     ) -> None:
         """A real date axis is high-cardinality and prompt-prefiltered — fill still lands.
 
-        ``_pre_filter_columns`` drops ``distinct_count > 50`` columns as
+        ``_pre_filter_columns`` drops ``distinct_count > 200`` columns as
         slice-DIMENSION candidates, and a time axis is exactly such a column.
         Validating the agent's choice against the filtered list deterministically
         rejected every real enriched date axis (the live DAT-491 false-reject:


### PR DESCRIPTION
## What

Completes the DAT-621 uncapping **beyond the metric agent**. LLM context is 100k+ tokens — silently serving a partial set (with no `+N more` signal) under-grounds every author and can feed *different* slices run-to-run (a contributor to cross-run grounding non-determinism, DAT-638). Policy: **fail loud on real overflow, don't silently cap.**

A two-pass sweep (metadata-production + context-assembly) found a class of `[:N]` / `MAX_*` caps the metric-only DAT-621 never reached — including a **source-level ceiling** (`top_k_values: 20`) that capped cycles/validation/semantic regardless of any downstream re-fetch.

## Remove entirely (small lists)
- **`graphs/field_mapping.py` `candidates[:3]` — confirmed live metric-grounding bug:** candidate confidence is a constant `0.5` fallback, so `[:3]` was an arbitrary cut and the correct column at #4 was invisible *and* unrankable.
- `semantic` join-cols (`_MAX_JOIN_COLS=10`) + `schema_cycles[:5]`; `graph_topology schema_cycles[:5]`
- `cycles` `top_values[:10]` + `dimension_columns[:8]`; `views/enrichment dimensions[:5]`
- `llm/privacy` `top_values[:max_sample_values]`
- `drivers/tree out[:top_k]` — FDR/permutation gate already drops non-significant slices; `top_k_slices` threaded out of `tree.py` + `processor.py`
- cockpit `why-metric MAX_STEPS=40`, `look-table TOP_DRIVERS_SHOWN`; `temporal max_gaps=10`

## Raise to the 200 margin (genuinely-large sets)
- `statistics.yaml top_k_values 20→200` (the source ceiling)
- `slicing_phase distinct>50→200` (kept `null_ratio`/`cardinality_ratio` filters)
- `slice_conditional_null _MAX_SLICE_CARDINALITY 50→200`
- `quality.py` outlier-sample `LIMIT 10→200` (stored sample, not grounding — bounded on purpose; full count persists separately)

## Kept (documented in-code)
Infra bounds (10k/2.4M-row samples, result storage/virtualization) and O(n²) noisy tails (entropy `_TOP_K_PAIRS/_SLICES`).

## Tests
Flipped the tests that asserted the old caps to assert full serving (DAT-621 precedent): `look-table.test.ts`, `why-metric.test.ts`, semantic + slicing unit tests. Engine unit suite + cockpit (biome/vitest/tsc) green.

## Follow-ups
- Calibration: `dataraum-eval` re-baseline (more evidence per author) — not in this PR.
- DAT-650: paginate `look-profile` sample (human-facing, left out of this cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)