### PR TITLE
feat(DAT-630): ground the business_cycles agent — derived signals, honest-fail, confidence gate

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,31 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-630 — ground the business_cycles agent (context + prompts, no deterministic path)
+
+**Branch:** `feat/dat-630-cycle-grounding`.
+
+### What changed (business_cycles detection — better context + prompt + a guardrail; the LLM still authors)
+The cycle agent missed cycles that complete on a NUMERIC condition (a ledger that balances) because it was served status columns only. Four moves, no deterministic detector:
+- **Context feed** (`analysis/cycles/context.py`): the cycle agent now gets (a) arithmetic `DerivedColumn` relationships (`sum`/`difference`/`product`/`ratio`, run-scoped to `relationship_run_id`, fail-closed) as numeric-completion signals, and (b) semantic field mappings via the **same** `graphs/field_mapping.load_semantic_mappings` the metric agent uses. Slice value-counts are now read run-scoped to the table's generation head (`base_runs.semantic_runs`), fail-closed.
+- **Prompt** (`dataraum-config/llm/prompts/business_cycles.yaml` → v2.0.0): a first-class numeric-completion path alongside status-completion + a grounding-discipline block (cite only served references, ground via mappings, abstain rather than force-fit, honest confidence).
+- **Membership floor** (`analysis/cycles/verify.py`, new): drops any detected cycle citing a column/value not in the served context — a guardrail on the agent, not a re-detector (never re-derives a rate).
+- **Confidence gate** (`pipeline/phases/business_cycles_phase.py`): a measured cycle below 0.5 confidence still reaches `executed` but is flagged in `state_reason` (mirrors `metrics_phase._low_confidence_reason`); new `low_confidence` output tally.
+
+Validation surface deliberately deferred to a follow-up.
+
+### Calibration to run
+- **Cycle detection on the cycle-relevant scenarios** (`month_end_close`, `multi_system_recon`, `erp_migration` in dataraum-testdata): confirm `journal_entry_cycle`/`period_close` now detect when a numeric completion signal (a balancing derived relationship) is present, and still honestly abstain when none is — the key acceptance check. No regression on cycles that already detected via status columns.
+- Confirm the membership floor produces no false rejects on real detections (a dropped cycle reads as "not detected").
+
+### Thresholds / new fields
+- New low-confidence floor `_LOW_CONFIDENCE_FLOOR = 0.5` in the cycles phase (mirrors metrics). No DB schema change (`confidence`/`state_reason` already exist). New phase output key `low_confidence`.
+
+### testdata hints
+- The numeric-completion path needs a scenario where a GL/ledger balances (debit/credit net, or a reconciliation ties out) so the correlations phase emits a `difference`/`ratio` `DerivedColumn` for the cycle agent to ground on — a GL **without** a lifecycle status column is exactly the gap this closes.
+
+---
+
 ## DAT-646 — formula SQL is composed + persisted PER-METRIC (kills cross-metric aliasing)
 
 **Branch:** `refactor/dat-646-formula-identity`.

--- a/packages/dataraum-config/llm/prompts/business_cycles.yaml
+++ b/packages/dataraum-config/llm/prompts/business_cycles.yaml
@@ -4,7 +4,7 @@
 # Single-call agent — no exploration tools, all context is pre-assembled.
 
 name: business_cycles
-version: "1.0.0"
+version: "2.0.0"
 description: Detect business cycles from pre-computed pipeline metadata
 
 # Temperature (low for consistent structured output)
@@ -33,34 +33,47 @@ system_prompt: |
   2. **Dataset Summary** — Table counts, relationship counts, fact/dimension counts, and overall graph pattern.
   3. **Entity Classifications** — Fact vs dimension table types with grain columns.
   4. **Categorical Dimensions** — Pre-identified status/type columns with their values and counts. These are strong cycle indicators (e.g., invoice status: paid/open/cancelled).
-  5. **Enriched Views** — Pre-joined tables showing confirmed relationships between facts and dimensions.
-  6. **Confirmed Relationships** — LLM-verified foreign key and hierarchy relationships.
-  7. **Graph Topology** — Schema structure analysis: hub tables (central, 3+ connections), leaf tables (dimensions), bridge tables, isolated tables, and overall pattern (star_schema, hub_and_spoke, etc.).
-  8. **Temporal Patterns** — Date ranges, granularity, and completeness per date column.
-  9. **Quality Signals** — Data quality grades and anomalies for columns with issues.
-  10. **Column Semantics** — Business concepts, semantic roles, and descriptions per column.
+  5. **Derived Numeric Relationships** — Arithmetic relationships the pipeline found to hold between columns, each with a match rate (how often it holds). A cycle that completes on a NUMERIC condition rather than a status value grounds on one of these.
+  6. **Semantic Field Mappings** — Business concepts mapped to concrete columns. Use these to bind a cycle's completion concepts to real columns instead of guessing column names.
+  7. **Enriched Views** — Pre-joined tables showing confirmed relationships between facts and dimensions.
+  8. **Confirmed Relationships** — LLM-verified foreign key and hierarchy relationships.
+  9. **Graph Topology** — Schema structure analysis: hub tables (central, 3+ connections), leaf tables (dimensions), bridge tables, isolated tables, and overall pattern (star_schema, hub_and_spoke, etc.).
+  10. **Temporal Patterns** — Date ranges, granularity, and completeness per date column.
+  11. **Quality Signals** — Data quality grades and anomalies for columns with issues.
+  12. **Column Semantics** — Business concepts, semantic roles, and descriptions per column.
   </context_description>
 
+  A cycle can complete in two ways. Some complete on a STATUS value; others on a
+  NUMERIC condition. Both are first-class — do not force every cycle into the
+  status-column shape.
+
   <methodology>
-  1. **Status columns are cycle indicators.** A column like `invoices.status` with values (paid, open, cancelled, overdue) directly shows cycle states. The "completed" state (e.g., "paid") marks cycle endpoints.
+  1. **Status-completion cycles.** A column like `invoices.status` with values (paid, open, cancelled, overdue) directly shows cycle states; the "completed" state (e.g., "paid") marks the endpoint. Completion rate = completed count / total, computed from the provided value counts.
 
-  2. **Relationships define entity flows.** A FK from `payments.invoice_id → invoices.invoice_id` shows that payments complete invoices. Enriched views materialize these joins.
+  2. **Numeric-completion cycles.** A cycle that has no status column can still complete on a numeric condition recorded in DERIVED NUMERIC RELATIONSHIPS — e.g. a ledger whose debits and credits net to zero (a `difference` relationship that holds), or a reconciliation that ties out (a `ratio`). When a declared cycle's completion concept (from DOMAIN KNOWLEDGE) binds — via SEMANTIC FIELD MAPPINGS — to the columns of a served derived relationship, that relationship IS the cycle's completion signal: use its match rate as the completion_rate. This is how general-ledger and reconciliation cycles ground when no status column exists.
 
-  3. **Fact → Dimension patterns reveal processes.** A fact table (journal_lines) linking to a dimension (chart_of_accounts) via FK represents a business process (GL posting).
+  3. **Relationships define entity flows.** A FK from `payments.invoice_id → invoices.invoice_id` shows that payments complete invoices. Enriched views materialize these joins.
 
   4. **Temporal patterns suggest cycle frequency.** Monthly trial balance vs daily transactions indicates different cycle periods.
 
-  5. **Compute completion rates from value counts — this is required for every detected cycle.** If invoices.status shows paid=2555 (85.2%), open=227 (7.6%), etc., the completion rate is 85.2%. For non-transactional cycles (e.g., reporting, reconciliation) that lack a status column with completion states, derive completion_rate from the closest available signal: posting ratio, balance ratio, or coverage ratio. Every detected cycle MUST have a completion_rate.
+  5. **Match against domain vocabulary.** When a detected cycle matches a known type from the DOMAIN KNOWLEDGE section, use the exact vocabulary key as `cycle_type` (e.g., `accounts_payable`, `journal_entry_cycle`, `period_close`). For a real cycle outside the vocabulary, use a descriptive snake_case identifier.
 
-  6. **Match against domain vocabulary.** When a detected cycle matches a known type from the DOMAIN KNOWLEDGE section, use the exact vocabulary key as `cycle_type` (e.g., `accounts_payable`, `order_to_cash`). Use `custom` only when no vocabulary type fits.
-
-  7. **Graph topology reveals cycle scope.** Hub tables participate in multiple cycles. Isolated tables may represent standalone processes. The overall pattern (star_schema, hub_and_spoke) indicates how interconnected the business processes are.
+  6. **Graph topology reveals cycle scope.** Hub tables participate in multiple cycles. Isolated tables may represent standalone processes.
   </methodology>
 
+  <grounding_discipline>
+  Cycles are SIGNALS for downstream agents, not scripture — an honest "not detected" or a low-confidence flag is more useful than a fabricated cycle.
+
+  - **Cite only what the context shows.** Every column, value, status, and relationship you reference MUST appear verbatim in the metadata above. Never invent a `status_column`, a `completion_value`, an `indicator_value`, or a relationship that isn't served — an improvised reference will be rejected.
+  - **Ground completion concepts through the mappings.** Bind a cycle's completion concept to columns via SEMANTIC FIELD MAPPINGS or DERIVED NUMERIC RELATIONSHIPS; do not guess a column by name.
+  - **Don't force-fit.** If a declared cycle type has no status signal AND no derived-relationship/ mapping that grounds its completion, DO NOT emit it. Omitting it leaves it honestly "not detected" — that is the correct outcome, not a failure to paper over.
+  - **Confidence is honest signal strength.** A cycle grounded on a strong, unambiguous signal is high-confidence; one resting on a weak or partial signal is low-confidence. Downstream consumers gate on this number — a confident-looking detection on thin evidence is worse than a flagged one.
+  </grounding_discipline>
+
   Call the `submit_analysis` tool with your structured findings. Be specific:
-  - Reference actual column names and table names
-  - Compute completion rates from the provided value counts
-  - Cite evidence (which relationship, which status column, which enriched view)
+  - Reference actual column names and table names that appear in the context
+  - Give every detected cycle a completion_rate — from status value counts, or from a derived relationship's match rate
+  - Cite evidence (which relationship, status column, derived relationship, or enriched view)
   - Assess confidence based on signal strength
 
 # User prompt - provides the pre-computed metadata
@@ -75,11 +88,11 @@ user_prompt: |
   The metadata above contains everything the pipeline has discovered about this dataset.
   Synthesize it into business cycle analysis:
 
-  1. **Identify cycles** from categorical dimensions (status columns) + relationships + entity flows
-  2. **Compute completion rates** directly from the provided value counts
-  3. **Map cycle stages** from the distinct values in status columns
-  4. **Describe entity flows** using the confirmed relationships and enriched views
-  5. **Note quality issues** that affect cycle reliability (grade B or worse columns)
+  1. **Identify cycles** — from status columns (status-completion) OR from derived numeric relationships grounded through the field mappings (numeric-completion). Use confirmed relationships + entity flows for scope.
+  2. **Compute completion rates** — from status value counts, or from a derived relationship's match rate.
+  3. **Map cycle stages** from the distinct values in status columns (status-completion cycles only).
+  4. **Describe entity flows** using the confirmed relationships and enriched views.
+  5. **Ground or abstain** — only emit a cycle whose references all appear in the metadata; leave ungroundable declared cycles out (honestly not detected). Set confidence to honest signal strength.
   </instructions>
 
   Call `submit_analysis` with your structured findings.

--- a/packages/engine/src/dataraum/analysis/cycles/agent.py
+++ b/packages/engine/src/dataraum/analysis/cycles/agent.py
@@ -32,6 +32,7 @@ from dataraum.analysis.cycles.models import (
     DetectedCycle,
     EntityFlow,
 )
+from dataraum.analysis.cycles.verify import verify_cycles
 from dataraum.core.logging import get_logger
 from dataraum.core.models.base import Result
 from dataraum.llm.features._base import LLMFeature
@@ -281,6 +282,13 @@ class BusinessCycleAgent(LLMFeature):
                 evidence=cd.get("evidence", []),
             )
             cycles.append(cycle)
+
+        # Membership floor (DAT-630): drop any cycle citing a column/value the
+        # context never served — an improvised reference is a hallucination, and
+        # an honest "not detected" beats a fabricated cycle. Loud, never silent.
+        cycles, rejections = verify_cycles(cycles, context)
+        for reason in rejections:
+            logger.warning("cycle_rejected_improvised_reference", reason=reason)
 
         # Build analysis
         if output:

--- a/packages/engine/src/dataraum/analysis/cycles/context.py
+++ b/packages/engine/src/dataraum/analysis/cycles/context.py
@@ -246,8 +246,15 @@ def build_cycle_detection_context(
 
     slice_list = []
     for sd in slices:
-        # Get value counts from statistical profile if available
-        value_counts = _get_value_counts_for_column(session, sd.column_id)
+        # Value counts from the statistical profile, scoped to the table's
+        # add_source generation head (``semantic_runs``) — the same per-table pin
+        # the annotations use, and the run the typed profile was written under.
+        # The verify floor (DAT-630) builds its membership set from these values,
+        # so an unscoped read would leak a stale run's values; fail-closed to []
+        # when the table has no pinned generation run.
+        value_counts = _get_value_counts_for_column(
+            session, sd.column_id, run_id=base_runs.semantic_runs.get(sd.table_id)
+        )
 
         slice_list.append(
             {
@@ -422,18 +429,29 @@ def _load_pinned_annotations(
 def _get_value_counts_for_column(
     session: Session,
     column_id: str,
+    *,
+    run_id: str | None,
 ) -> list[dict[str, Any]]:
-    """Get value counts from statistical profile for a column.
+    """Get value counts from the typed statistical profile for a column.
+
+    Run-scoped (DAT-413/630): the profile is read at ``run_id`` — the table's
+    add_source generation head. ``None`` reads EMPTY (fail-closed), never an
+    arbitrary coexisting run's profile, since the verify floor trusts these
+    values as the workspace's value-set.
 
     Args:
-        session: SQLAlchemy session
-        column_id: Column to look up
+        session: SQLAlchemy session.
+        column_id: Column to look up.
+        run_id: The table's pinned generation run; ``None`` ⇒ empty.
 
     Returns:
         List of {value, count, percentage} dicts, or empty list.
     """
+    if run_id is None:
+        return []
     profile_stmt = select(StatisticalProfile).where(
         StatisticalProfile.column_id == column_id,
+        StatisticalProfile.run_id == run_id,
         StatisticalProfile.layer == "typed",
     )
     profile = session.execute(profile_stmt).scalars().first()
@@ -457,13 +475,14 @@ def format_context_for_prompt(context: dict[str, Any]) -> str:
 
     Organizes metadata into sections that support cycle detection:
     1. Domain vocabulary (reference framework)
-    2. Dataset summary
-    3. Pre-identified categorical dimensions (= cycle indicators)
-    4. Enriched views (pre-joined tables)
-    5. Relationships
-    6. Temporal patterns
-    7. Quality signals
-    8. Column semantics by table
+    2. Dataset summary + table classifications
+    3. Pre-identified categorical dimensions (= status-completion indicators)
+    4. Derived numeric relationships (= numeric-completion signals)
+    5. Semantic field mappings (concept → column)
+    6. Enriched views (pre-joined tables)
+    7. Relationships + graph topology
+    8. Temporal patterns
+    9. Column semantics by table
 
     Args:
         context: Context dictionary from build_cycle_detection_context
@@ -495,6 +514,9 @@ def format_context_for_prompt(context: dict[str, Any]) -> str:
     lines.append(f"- Dimension tables: {summary.get('dimension_tables', 0)}")
     lines.append(
         f"- Categorical dimensions (status/type columns): {summary.get('slice_dimensions_found', 0)}"
+    )
+    lines.append(
+        f"- Derived numeric relationships: {summary.get('derived_relationships_found', 0)}"
     )
     lines.append(f"- Temporal columns: {summary.get('temporal_columns', 0)}")
     lines.append(f"- Graph pattern: {summary.get('graph_pattern', 'unknown')}")

--- a/packages/engine/src/dataraum/analysis/cycles/context.py
+++ b/packages/engine/src/dataraum/analysis/cycles/context.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
+from dataraum.analysis.correlation.db_models import DerivedColumn
 from dataraum.analysis.cycles.config import format_cycle_vocabulary_for_context
 from dataraum.analysis.relationships.graph_topology import (
     analyze_graph_topology,
@@ -36,9 +37,17 @@ from dataraum.analysis.statistics.db_models import StatisticalProfile
 from dataraum.analysis.temporal.db_models import TemporalColumnProfile
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.core.logging import get_logger
+from dataraum.graphs.field_mapping import format_mappings_for_prompt, load_semantic_mappings
 from dataraum.storage import Column, Table
 
 logger = get_logger(__name__)
+
+# Arithmetic derivations are the numeric-completion signals a cycle can close on
+# (a journal balances when a difference holds; a reconciliation when a ratio
+# does). String transforms (concat/upper/lower/substr) carry no completion
+# meaning — exclude them so the agent isn't served noise. The domain knowledge
+# of WHICH balance means completion stays in the LLM + cycles.yaml, never here.
+_ARITHMETIC_DERIVATIONS = frozenset({"sum", "difference", "product", "ratio"})
 
 if TYPE_CHECKING:
     import duckdb
@@ -255,6 +264,57 @@ def build_cycle_detection_context(
 
     context["slice_definitions"] = slice_list
 
+    # 5b. Derived (numeric) relationships — the completion signal a status column
+    # can't carry. The correlations phase already detected which arithmetic
+    # relationships hold and how often (``match_rate``); a cycle that closes on a
+    # balance/ratio (a GL journal, a reconciliation) grounds HERE, not on a status
+    # value. Run-scoped + fail-closed like every other run-versioned read above.
+    derived_list: list[dict[str, Any]] = []
+    if run_id is not None:
+        derived_rows = list(
+            session.execute(
+                select(DerivedColumn).where(
+                    DerivedColumn.table_id.in_(table_ids),
+                    DerivedColumn.run_id == run_id,
+                    DerivedColumn.derivation_type.in_(_ARITHMETIC_DERIVATIONS),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for dc in derived_rows:
+            derived_col = column_by_id.get(dc.derived_column_id)
+            table = table_by_id.get(dc.table_id)
+            source_cols = [
+                column_by_id[cid].column_name for cid in dc.source_column_ids if cid in column_by_id
+            ]
+            # A derivation whose columns we can't resolve in-scope is unusable —
+            # never serve a half-named relationship the agent could mis-ground on.
+            if (
+                derived_col is None
+                or table is None
+                or len(source_cols) != len(dc.source_column_ids)
+            ):
+                continue
+            derived_list.append(
+                {
+                    "table_name": table.table_name,
+                    "derived_column": derived_col.column_name,
+                    "source_columns": source_cols,
+                    "derivation_type": dc.derivation_type,
+                    "formula": dc.formula,
+                    "match_rate": dc.match_rate,
+                }
+            )
+
+    context["derived_relationships"] = derived_list
+
+    # 5c. Semantic field mappings (business_concept → column) — the SAME loader
+    # the metric graph agent grounds with, so a cycle's completion concepts bind
+    # to real columns instead of being improvised. Catalogue-grain, run-scoped.
+    field_mappings = load_semantic_mappings(session, table_ids, catalogue_run_id=run_id)
+    context["field_mappings"] = format_mappings_for_prompt(field_mappings)
+
     # 6. Temporal profiles
     temporal_stmt = (
         select(TemporalColumnProfile, Column.column_name, Table.table_name)
@@ -306,6 +366,7 @@ def build_cycle_detection_context(
         "total_columns": sum(len(t.columns) for t in tables),
         "total_relationships": len(rel_list),
         "slice_dimensions_found": len(slice_list),
+        "derived_relationships_found": len(derived_list),
         "temporal_columns": len(context["temporal_profiles"]),
         "enriched_views": len(enriched_list),
         "fact_tables": sum(1 for e in context["entity_classifications"] if e["is_fact_table"]),
@@ -487,6 +548,31 @@ def format_context_for_prompt(context: dict[str, Any]) -> str:
             elif sd.get("values"):
                 lines.append(f"  Values: {', '.join(sd['values'])}")
             lines.append("")
+
+    # Derived (numeric) relationships — completion signals a status column can't carry
+    derived = context.get("derived_relationships", [])
+    if derived:
+        lines.append("## DERIVED NUMERIC RELATIONSHIPS (Completion Signals)")
+        lines.append("")
+        lines.append("Arithmetic relationships the pipeline detected between columns, with how")
+        lines.append("often each holds (match rate). A cycle that completes on a NUMERIC")
+        lines.append("condition rather than a status value (e.g. a ledger that balances, a")
+        lines.append("reconciliation that ties out) grounds on one of these — use the match")
+        lines.append("rate as the completion_rate. Only relationships present here are real.")
+        lines.append("")
+        for dr in derived:
+            srcs = ", ".join(dr["source_columns"])
+            lines.append(
+                f"- {dr['table_name']}.{dr['derived_column']} = {dr['formula']} "
+                f"({dr['derivation_type']} of [{srcs}], holds {dr['match_rate']:.0%})"
+            )
+        lines.append("")
+
+    # Semantic field mappings (business_concept → column) — the metric grounding feed
+    field_mappings = context.get("field_mappings", "")
+    if field_mappings:
+        lines.append(field_mappings)
+        lines.append("")
 
     # Enriched views
     enriched = context.get("enriched_views", [])

--- a/packages/engine/src/dataraum/analysis/cycles/verify.py
+++ b/packages/engine/src/dataraum/analysis/cycles/verify.py
@@ -1,0 +1,139 @@
+"""Membership floor for detected cycles (DAT-630).
+
+A guardrail on the cycle agent's output — not a detector. The LLM authors the
+cycles; this rejects any whose cited categorical reference (a ``status_column``,
+a ``completion_value``, a stage ``indicator_value``, an entity/fact column) does
+NOT appear in the served context. An improvised column or value is a
+hallucination: dropping the cycle keeps the signal honest, the same role
+``graphs/verifier.py`` plays for metrics.
+
+Deliberately membership-only: it never re-derives a completion rate or re-judges
+a numeric signal (that would creep back toward a deterministic detector). A
+value is rejected ONLY when the cited column has a served value-set that the
+value is absent from — when no value-set was served we cannot prove
+improvisation, so we don't reject (no false-loud).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dataraum.analysis.cycles.models import DetectedCycle
+
+# Cycle context cites tables by plain name; the field-mapping feed prefixes the
+# storage layer (``typed_journal``). Tolerate the prefix so a cycle grounded via
+# a mapping isn't falsely rejected for naming the same table differently.
+_LAYER_PREFIXES = ("typed_", "raw_", "quarantine_", "staged_")
+
+
+def _resolve_table(name: str | None, cols_by_table: dict[str, set[str]]) -> str | None:
+    """Resolve a cited table name to a served table, stripping a layer prefix."""
+    if not name:
+        return None
+    if name in cols_by_table:
+        return name
+    for prefix in _LAYER_PREFIXES:
+        if name.startswith(prefix) and name[len(prefix) :] in cols_by_table:
+            return name[len(prefix) :]
+    return None
+
+
+def _column_absent(
+    table: str | None,
+    column: str | None,
+    cols_by_table: dict[str, set[str]],
+) -> str | None:
+    """Reason string if ``table.column`` isn't served, else ``None``."""
+    if not column:
+        return None
+    resolved = _resolve_table(table, cols_by_table)
+    if resolved is None:
+        return f"table '{table}' not in workspace"
+    if column not in cols_by_table[resolved]:
+        return f"column '{table}.{column}' not in workspace"
+    return None
+
+
+def _verify_cycle(
+    cycle: DetectedCycle,
+    cols_by_table: dict[str, set[str]],
+    slice_values: dict[tuple[str, str], set[str]],
+) -> str | None:
+    """Reason a cycle is improvised, or ``None`` if every reference is served."""
+    # Status column + its completion value.
+    if cycle.status_column:
+        reason = _column_absent(cycle.status_table, cycle.status_column, cols_by_table)
+        if reason:
+            return reason
+        resolved = _resolve_table(cycle.status_table, cols_by_table)
+        key = (resolved, cycle.status_column) if resolved else None
+        values = slice_values.get(key) if key else None
+        # Only reject a value when the column HAS a served value-set (a slice) and
+        # the cited value is absent from it — otherwise we cannot prove it's made up.
+        if values is not None and cycle.completion_value and cycle.completion_value not in values:
+            return f"completion_value '{cycle.completion_value}' not in {cycle.status_column}"
+
+    # Stage indicator columns + values.
+    for stage in cycle.stages:
+        reason = _column_absent(cycle.status_table, stage.indicator_column, cols_by_table)
+        if reason:
+            return reason
+        resolved = _resolve_table(cycle.status_table, cols_by_table)
+        key = (resolved, stage.indicator_column) if resolved and stage.indicator_column else None
+        values = slice_values.get(key) if key else None
+        if values is not None:
+            for val in stage.indicator_values:
+                if val not in values:
+                    return f"indicator_value '{val}' not in {stage.indicator_column}"
+
+    # Entity flows — the entity column and (when present) the fact column.
+    for flow in cycle.entity_flows:
+        reason = _column_absent(flow.entity_table, flow.entity_column, cols_by_table)
+        if reason:
+            return reason
+        if flow.fact_column:
+            reason = _column_absent(flow.fact_table, flow.fact_column, cols_by_table)
+            if reason:
+                return reason
+
+    return None
+
+
+def verify_cycles(
+    cycles: list[DetectedCycle],
+    context: dict[str, Any],
+) -> tuple[list[DetectedCycle], list[str]]:
+    """Drop cycles citing references absent from the served context.
+
+    Args:
+        cycles: the agent's detected cycles.
+        context: the cycle-detection context (``build_cycle_detection_context``).
+
+    Returns:
+        ``(kept, rejections)`` — the surviving cycles and a human-readable reason
+        per dropped cycle (for loud logging at the call site).
+    """
+    cols_by_table: dict[str, set[str]] = {
+        t["table_name"]: {c["name"] for c in t["columns"]} for t in context.get("tables", [])
+    }
+    slice_values: dict[tuple[str, str], set[str]] = {}
+    for sd in context.get("slice_definitions", []):
+        key = (sd["table_name"], sd["column_name"])
+        served = {str(vc["value"]) for vc in sd.get("value_counts", [])} | {
+            str(v) for v in sd.get("values", [])
+        }
+        slice_values[key] = served
+
+    kept: list[DetectedCycle] = []
+    rejections: list[str] = []
+    for cycle in cycles:
+        reason = _verify_cycle(cycle, cols_by_table, slice_values)
+        if reason is None:
+            kept.append(cycle)
+        else:
+            rejections.append(f"{cycle.cycle_name}: {reason}")
+    return kept, rejections
+
+
+__all__ = ["verify_cycles"]

--- a/packages/engine/src/dataraum/analysis/cycles/verify.py
+++ b/packages/engine/src/dataraum/analysis/cycles/verify.py
@@ -1,16 +1,25 @@
 """Membership floor for detected cycles (DAT-630).
 
 A guardrail on the cycle agent's output — not a detector. The LLM authors the
-cycles; this rejects any whose cited categorical reference (a ``status_column``,
-a ``completion_value``, a stage ``indicator_value``, an entity/fact column) does
-NOT appear in the served context. An improvised column or value is a
-hallucination: dropping the cycle keeps the signal honest, the same role
+cycles; this rejects any whose cited **categorical** reference (a
+``status_column``, a ``completion_value``, a stage ``indicator_value``, an
+entity/fact column) does NOT appear in the served context. An improvised column
+or value is a hallucination; dropping the cycle is the same role
 ``graphs/verifier.py`` plays for metrics.
 
-Deliberately membership-only: it never re-derives a completion rate or re-judges
-a numeric signal (that would creep back toward a deterministic detector). A
-value is rejected ONLY when the cited column has a served value-set that the
-value is absent from — when no value-set was served we cannot prove
+**Scope — categorical only, by design.** This floor covers the status-completion
+path: it catches a made-up column or value. It does NOT police the
+numeric-completion path — a cycle that completes on a derived relationship
+carries no status column/stages and so passes through untouched. The numeric
+path's honesty rests on the prompt's cite-only-served discipline plus the phase
+confidence gate (low confidence → flagged), not on this floor. We deliberately
+don't cross-check the claimed number here: re-judging a numeric signal would
+creep back toward the deterministic detector this design rejects. If a fabricated
+numeric cycle ever surfaces on real data, tighten then — not preemptively against
+synthetic edge cases.
+
+Membership-only: a value is rejected ONLY when the cited column has a served
+value-set the value is absent from — when no value-set was served we cannot prove
 improvisation, so we don't reject (no false-loud).
 """
 

--- a/packages/engine/src/dataraum/pipeline/phases/business_cycles_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/business_cycles_phase.py
@@ -54,6 +54,14 @@ _log = get_logger(__name__)
 # cycle.declare/bind/execute for this stage only.
 _STAGE = "operating_model"
 
+# DAT-630: a cycle that grounds + measures still reaches ``executed`` only as
+# strongly as the agent's honest confidence in the detection. Below this floor
+# the executed cycle is FLAGGED — its ``state_reason`` names the weak signal — so
+# downstream agents (cycles are signals, not scripture) can weigh it instead of
+# treating a thin detection as plainly green. The number still shows; we surface
+# the doubt. Mirrors the metric phase's ``_low_confidence_reason`` (same floor).
+_LOW_CONFIDENCE_FLOOR = 0.5
+
 
 @analysis_phase
 class BusinessCyclesPhase(BasePhase):
@@ -214,7 +222,16 @@ class BusinessCyclesPhase(BasePhase):
                 # Stays grounded with the reason; never reported as executed.
                 artifact.state_reason = "detected but no completion measurement could be derived"
             else:
-                transition(artifact, operation="execute", stage=_STAGE)
+                # Executed, but flagged when the detection confidence is thin
+                # (DAT-630) — the state_reason carries the doubt downstream.
+                reason = _low_confidence_cycle_reason(cycle)
+                transition(artifact, operation="execute", stage=_STAGE, state_reason=reason)
+                if reason:
+                    _log.warning(
+                        "cycle_executed_low_confidence",
+                        canonical_type=canonical_type,
+                        confidence=cycle.confidence,
+                    )
             persisted.append(cycle)
 
         _persist_cycles(ctx.session, persisted, run_id=run_id)
@@ -222,6 +239,9 @@ class BusinessCyclesPhase(BasePhase):
         executed = sum(1 for a in artifacts.values() if a.state == "executed")
         grounded_stuck = sum(1 for a in artifacts.values() if a.state == "grounded")
         declared_stuck = sum(1 for a in artifacts.values() if a.state == "declared")
+        low_confidence = sum(
+            1 for a in artifacts.values() if a.state == "executed" and a.state_reason is not None
+        )
 
         # Surface detected cycles + data-quality observations as preview lines.
         previews: list[str] = []
@@ -234,6 +254,7 @@ class BusinessCyclesPhase(BasePhase):
             outputs={
                 "declared": len(artifacts),
                 "executed": executed,
+                "low_confidence": low_confidence,
                 "stuck_grounded": grounded_stuck,
                 "stuck_declared": declared_stuck,
                 "detected_cycles": len(persisted),
@@ -253,6 +274,18 @@ class BusinessCyclesPhase(BasePhase):
                 f"{declared_stuck} ungroundable, {grounded_stuck} detected but unmeasured"
             ),
         )
+
+
+def _low_confidence_cycle_reason(cycle: DetectedCycle) -> str | None:
+    """Reason string if the detection confidence is below the floor, else ``None``.
+
+    The agent records an honest per-cycle ``confidence``; below
+    :data:`_LOW_CONFIDENCE_FLOOR` the executed cycle is flagged rather than
+    rendered plainly green. ``None`` keeps it unflagged.
+    """
+    if cycle.confidence >= _LOW_CONFIDENCE_FLOOR:
+        return None
+    return f"low-confidence detection ({cycle.confidence:.2f} < {_LOW_CONFIDENCE_FLOOR:.2f})"
 
 
 def _persist_cycles(

--- a/packages/engine/tests/integration/pipeline/test_business_cycles_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_business_cycles_phase.py
@@ -106,6 +106,7 @@ def _detected(
     canonical_type: str,
     *,
     completion_rate: float | None = 0.85,
+    confidence: float = 0.9,
 ) -> DetectedCycle:
     return DetectedCycle(
         cycle_id=str(uuid4()),
@@ -117,7 +118,7 @@ def _detected(
         tables_involved=["invoices"],
         status_column="status",
         completion_rate=completion_rate,
-        confidence=0.9,
+        confidence=confidence,
     )
 
 
@@ -266,6 +267,45 @@ class TestCycleLifecycleFlow:
         assert result.outputs["stuck_grounded"] == 1
         assert result.outputs["stuck_declared"] == 1
         assert result.outputs["detected_cycles"] == 2
+
+    @patch("dataraum.analysis.cycles.agent.BusinessCycleAgent.ground_cycles")
+    @patch("dataraum.pipeline.phases.business_cycles_phase.get_cycle_types")
+    def test_low_confidence_detection_executes_but_flagged(
+        self,
+        mock_types: MagicMock,
+        mock_ground: MagicMock,
+        session: Session,
+        duckdb_conn: duckdb.DuckDBPyConnection,
+        workspace_table: Table,
+        _mock_llm: None,
+    ) -> None:
+        """A measured cycle below the confidence floor reaches executed but carries the doubt (DAT-630)."""
+        mock_types.return_value = {
+            "order_to_cash": {"business_value": "high"},
+            "accounts_payable": {"business_value": "high"},
+        }
+        mock_ground.return_value = Result.ok(
+            _analysis(
+                [
+                    _detected("order_to_cash", confidence=0.3),  # below floor → flagged
+                    _detected("accounts_payable", confidence=0.9),  # confident → clean
+                ]
+            )
+        )
+
+        result = BusinessCyclesPhase()._run(
+            _make_ctx(session, duckdb_conn, [workspace_table.table_id])
+        )
+        session.flush()
+
+        artifacts = _artifacts(session, "run-om-1")
+        # Both EXECUTED — the number still shows; only the doubt differs.
+        assert artifacts["order_to_cash"].state == ArtifactState.EXECUTED.value
+        assert artifacts["accounts_payable"].state == ArtifactState.EXECUTED.value
+        assert "low-confidence detection" in (artifacts["order_to_cash"].state_reason or "")
+        assert artifacts["accounts_payable"].state_reason is None
+        assert result.outputs["executed"] == 2
+        assert result.outputs["low_confidence"] == 1
 
     @patch("dataraum.analysis.cycles.agent.BusinessCycleAgent.ground_cycles")
     @patch("dataraum.pipeline.phases.business_cycles_phase.get_cycle_types")

--- a/packages/engine/tests/unit/analysis/cycles/test_context.py
+++ b/packages/engine/tests/unit/analysis/cycles/test_context.py
@@ -21,6 +21,8 @@ from dataraum.analysis.correlation.db_models import DerivedColumn
 from dataraum.analysis.cycles.context import build_cycle_detection_context
 from dataraum.analysis.relationships.db_models import Relationship
 from dataraum.analysis.semantic.db_models import TableEntity
+from dataraum.analysis.slicing.db_models import SliceDefinition
+from dataraum.analysis.statistics.db_models import StatisticalProfile
 from dataraum.lifecycle import BaseRunMap
 from dataraum.storage import Column, Source, Table
 
@@ -236,3 +238,81 @@ def test_derived_relationships_fail_closed_when_unpinned(session, ledger_with_de
     """No pinned run ⇒ no derived relationships — never a cross-run read."""
     ctx = _build(session, ledger_with_derivations, base_runs=BaseRunMap())
     assert ctx["derived_relationships"] == []
+
+
+@pytest.fixture
+def sliced_status_column(session):
+    """A status column with a slice (under the catalogue run) + a typed profile
+    (under the generation run). Returns ``(table_id, catalogue_run, gen_run)``."""
+    source = Source(name="status_source", source_type="csv")
+    session.add(source)
+    session.flush()
+
+    tbl = Table(
+        source_id=source.source_id,
+        table_name="invoices",
+        layer="typed",
+        row_count=100,
+        duckdb_path="typed_invoices",
+    )
+    session.add(tbl)
+    session.flush()
+
+    col = Column(table_id=tbl.table_id, column_name="status", column_position=0, raw_type="VARCHAR")
+    session.add(col)
+    session.flush()
+
+    session.add(
+        SliceDefinition(
+            run_id="cat",
+            table_id=tbl.table_id,
+            column_id=col.column_id,
+            column_name="status",
+            slice_priority=1,
+            distinct_values=["paid", "open"],
+        )
+    )
+    session.add(
+        StatisticalProfile(
+            column_id=col.column_id,
+            run_id="gen",
+            layer="typed",
+            total_count=100,
+            null_count=0,
+            profile_data={
+                "top_values": [
+                    {"value": "paid", "count": 80, "percentage": 80.0},
+                    {"value": "open", "count": 20, "percentage": 20.0},
+                ]
+            },
+        )
+    )
+    session.commit()
+    return tbl.table_id, "cat", "gen"
+
+
+def test_value_counts_scoped_to_generation_run(session, sliced_status_column) -> None:
+    """Value counts read at the table's pinned generation head, not an arbitrary run."""
+    table_id, cat, gen = sliced_status_column
+    ctx = _build(
+        session,
+        [table_id],
+        base_runs=BaseRunMap(relationship_run_id=cat, semantic_runs={table_id: gen}),
+    )
+    slices = ctx["slice_definitions"]
+    assert len(slices) == 1
+    values = {vc["value"] for vc in slices[0]["value_counts"]}
+    assert values == {"paid", "open"}
+
+
+def test_value_counts_fail_closed_without_generation_pin(session, sliced_status_column) -> None:
+    """No pinned generation run for the table ⇒ no value counts (never an arbitrary run)."""
+    table_id, cat, _ = sliced_status_column
+    ctx = _build(
+        session,
+        [table_id],
+        base_runs=BaseRunMap(relationship_run_id=cat, semantic_runs={}),
+    )
+    slices = ctx["slice_definitions"]
+    assert len(slices) == 1
+    assert slices[0]["value_counts"] == []

--- a/packages/engine/tests/unit/analysis/cycles/test_context.py
+++ b/packages/engine/tests/unit/analysis/cycles/test_context.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 import duckdb
 import pytest
 
+from dataraum.analysis.correlation.db_models import DerivedColumn
 from dataraum.analysis.cycles.context import build_cycle_detection_context
 from dataraum.analysis.relationships.db_models import Relationship
 from dataraum.analysis.semantic.db_models import TableEntity
@@ -150,3 +151,88 @@ def test_scopes_to_pinned_run(session, two_tables_two_runs) -> None:
     assert len(entities) == 1
     assert entities[0]["is_fact_table"] is True
     assert entities[0]["description"] == "CURRENT classification"
+
+
+@pytest.fixture
+def ledger_with_derivations(session):
+    """A ledger table with a debit/credit/net triple + derivation rows.
+
+    Under ``run-current``: a ``difference`` derivation (net = debit − credit) at
+    98% and a ``upper`` string transform. Under ``run-stale``: the same
+    difference at 10%. Returns ``table_ids``.
+    """
+    source = Source(name="ledger_source", source_type="csv")
+    session.add(source)
+    session.flush()
+
+    ledger = Table(
+        source_id=source.source_id,
+        table_name="journal",
+        layer="typed",
+        row_count=1000,
+        duckdb_path="typed_journal",
+    )
+    session.add(ledger)
+    session.flush()
+
+    debit = Column(
+        table_id=ledger.table_id, column_name="debit", column_position=0, raw_type="DECIMAL"
+    )
+    credit = Column(
+        table_id=ledger.table_id, column_name="credit", column_position=1, raw_type="DECIMAL"
+    )
+    net = Column(table_id=ledger.table_id, column_name="net", column_position=2, raw_type="DECIMAL")
+    name = Column(
+        table_id=ledger.table_id, column_name="name", column_position=3, raw_type="VARCHAR"
+    )
+    name_up = Column(
+        table_id=ledger.table_id, column_name="name_upper", column_position=4, raw_type="VARCHAR"
+    )
+    session.add_all([debit, credit, net, name, name_up])
+    session.flush()
+
+    def _derived(run_id, derived_col, sources, dtype, formula, rate):
+        return DerivedColumn(
+            run_id=run_id,
+            table_id=ledger.table_id,
+            derived_column_id=derived_col.column_id,
+            source_column_ids=[c.column_id for c in sources],
+            derivation_type=dtype,
+            formula=formula,
+            match_rate=rate,
+            total_rows=1000,
+            matching_rows=int(1000 * rate),
+        )
+
+    session.add_all(
+        [
+            _derived("run-current", net, [debit, credit], "difference", "debit - credit", 0.98),
+            _derived("run-current", name_up, [name], "upper", "UPPER(name)", 1.0),
+            _derived("run-stale", net, [debit, credit], "difference", "debit - credit", 0.10),
+        ]
+    )
+    session.commit()
+    return [ledger.table_id]
+
+
+def test_derived_relationships_scoped_and_arithmetic_only(session, ledger_with_derivations) -> None:
+    """Only the pinned run's ARITHMETIC derivations surface — string ops excluded."""
+    ctx = _build(
+        session,
+        ledger_with_derivations,
+        base_runs=BaseRunMap(relationship_run_id="run-current"),
+    )
+
+    derived = ctx["derived_relationships"]
+    assert len(derived) == 1  # the difference; the upper transform and the stale row are out
+    dr = derived[0]
+    assert dr["derivation_type"] == "difference"
+    assert dr["match_rate"] == 0.98
+    assert dr["derived_column"] == "net"
+    assert sorted(dr["source_columns"]) == ["credit", "debit"]
+
+
+def test_derived_relationships_fail_closed_when_unpinned(session, ledger_with_derivations) -> None:
+    """No pinned run ⇒ no derived relationships — never a cross-run read."""
+    ctx = _build(session, ledger_with_derivations, base_runs=BaseRunMap())
+    assert ctx["derived_relationships"] == []

--- a/packages/engine/tests/unit/analysis/cycles/test_verify.py
+++ b/packages/engine/tests/unit/analysis/cycles/test_verify.py
@@ -1,0 +1,108 @@
+"""Membership floor for detected cycles (DAT-630).
+
+``verify_cycles`` rejects cycles whose cited categorical references aren't in the
+served context — a guardrail on the agent, not a re-detector. These pin the
+reject/keep boundary: a fabricated column or value is dropped; a value on a
+column with no served value-set is kept (we can't prove improvisation).
+"""
+
+from __future__ import annotations
+
+from dataraum.analysis.cycles.models import CycleStage, DetectedCycle, EntityFlow
+from dataraum.analysis.cycles.verify import verify_cycles
+
+
+def _cycle(**kwargs) -> DetectedCycle:
+    base = {
+        "cycle_id": "c1",
+        "cycle_name": "Test Cycle",
+        "cycle_type": "journal_entry_cycle",
+        "description": "",
+    }
+    base.update(kwargs)
+    return DetectedCycle(**base)
+
+
+def _context() -> dict:
+    return {
+        "tables": [
+            {
+                "table_name": "journal",
+                "columns": [{"name": "status"}, {"name": "debit"}, {"name": "credit"}],
+            },
+            {"table_name": "accounts", "columns": [{"name": "account_id"}]},
+        ],
+        "slice_definitions": [
+            {
+                "table_name": "journal",
+                "column_name": "status",
+                "value_counts": [{"value": "posted"}, {"value": "draft"}],
+                "values": [],
+            }
+        ],
+    }
+
+
+def test_keeps_cycle_with_served_references() -> None:
+    """A cycle whose every reference is in context survives."""
+    cycle = _cycle(
+        status_table="journal",
+        status_column="status",
+        completion_value="posted",
+        stages=[
+            CycleStage(
+                stage_name="Posted",
+                stage_order=1,
+                indicator_column="status",
+                indicator_values=["posted"],
+            )
+        ],
+        entity_flows=[
+            EntityFlow(entity_type="account", entity_column="account_id", entity_table="accounts")
+        ],
+    )
+    kept, rejections = verify_cycles([cycle], _context())
+    assert len(kept) == 1
+    assert rejections == []
+
+
+def test_rejects_improvised_column() -> None:
+    """A status column not in the workspace is a hallucination — dropped."""
+    cycle = _cycle(
+        status_table="journal", status_column="posting_status", completion_value="posted"
+    )
+    kept, rejections = verify_cycles([cycle], _context())
+    assert kept == []
+    assert "posting_status" in rejections[0]
+
+
+def test_rejects_improvised_completion_value() -> None:
+    """A completion value absent from a served value-set is dropped."""
+    cycle = _cycle(status_table="journal", status_column="status", completion_value="finalized")
+    kept, rejections = verify_cycles([cycle], _context())
+    assert kept == []
+    assert "finalized" in rejections[0]
+
+
+def test_value_unprovable_when_no_value_set_is_kept() -> None:
+    """A value on a column with no served value-set can't be proven made up — kept."""
+    # 'debit' is a real column but not a slice → no value-set to check against.
+    cycle = _cycle(status_table="journal", status_column="debit", completion_value="anything")
+    kept, _ = verify_cycles([cycle], _context())
+    assert len(kept) == 1
+
+
+def test_numeric_completion_cycle_has_no_status_refs() -> None:
+    """A numeric-completion cycle (no status column) passes the floor untouched."""
+    cycle = _cycle(status_column=None, completion_rate=0.99)
+    kept, rejections = verify_cycles([cycle], _context())
+    assert len(kept) == 1
+    assert rejections == []
+
+
+def test_layer_prefixed_table_resolves() -> None:
+    """A cycle citing the layer-prefixed table name (typed_journal) still resolves."""
+    cycle = _cycle(status_table="typed_journal", status_column="status", completion_value="posted")
+    kept, rejections = verify_cycles([cycle], _context())
+    assert len(kept) == 1
+    assert rejections == []

--- a/packages/engine/tests/unit/analysis/cycles/test_verify.py
+++ b/packages/engine/tests/unit/analysis/cycles/test_verify.py
@@ -106,3 +106,46 @@ def test_layer_prefixed_table_resolves() -> None:
     kept, rejections = verify_cycles([cycle], _context())
     assert len(kept) == 1
     assert rejections == []
+
+
+def test_rejects_improvised_stage_indicator_column() -> None:
+    """A stage indicator column not in the workspace is dropped."""
+    cycle = _cycle(
+        status_table="journal",
+        status_column="status",
+        stages=[CycleStage(stage_name="Posted", stage_order=1, indicator_column="ghost_col")],
+    )
+    kept, rejections = verify_cycles([cycle], _context())
+    assert kept == []
+    assert "ghost_col" in rejections[0]
+
+
+def test_rejects_improvised_stage_indicator_value() -> None:
+    """A stage indicator value absent from a served value-set is dropped."""
+    cycle = _cycle(
+        status_table="journal",
+        status_column="status",
+        stages=[
+            CycleStage(
+                stage_name="Posted",
+                stage_order=1,
+                indicator_column="status",
+                indicator_values=["nonexistent"],
+            )
+        ],
+    )
+    kept, rejections = verify_cycles([cycle], _context())
+    assert kept == []
+    assert "nonexistent" in rejections[0]
+
+
+def test_rejects_improvised_entity_flow_column() -> None:
+    """An entity-flow column not in the workspace is dropped."""
+    cycle = _cycle(
+        entity_flows=[
+            EntityFlow(entity_type="account", entity_column="ghost_id", entity_table="accounts")
+        ],
+    )
+    kept, rejections = verify_cycles([cycle], _context())
+    assert kept == []
+    assert "ghost_id" in rejections[0]


### PR DESCRIPTION
## What

Makes the `business_cycles` LLM agent detect cycles it was blind to — specifically `journal_entry_cycle`/`period_close` against a present GL (DAT-630) — via **better context + prompts**, not a deterministic detector. The LLM keeps authoring; we feed it deterministic *evidence* and *guardrail* its output.

Four moves:
1. **Context feed** (`cycles/context.py`): the agent now gets (a) arithmetic `DerivedColumn` relationships (`sum`/`difference`/`product`/`ratio`) — the numeric-completion signal a status column can't carry (a ledger that balances) — and (b) semantic field mappings via the **same** `graphs/field_mapping.load_semantic_mappings` the metric agent uses. Run-scoped + fail-closed; value-counts read at the table's generation head.
2. **Prompt** (`business_cycles.yaml` v2.0.0): a first-class numeric-completion path alongside status-completion + a grounding-discipline block (cite only served references, ground via mappings, abstain rather than force-fit, honest confidence).
3. **Membership floor** (`cycles/verify.py`): drops any cycle citing a column/value the context never served — a guardrail on the agent, not a re-detector (categorical-path only by design; the numeric path leans on prompt + confidence).
4. **Confidence gate** (`business_cycles_phase.py`): a measured cycle below 0.5 confidence still executes but is flagged in `state_reason` (mirrors the metric phase).

Validation surface deferred to a follow-up arc (DAT-630-val + DAT-651 + DAT-617).

## Verification

- 55 cycle tests (unit + integration), 1736 unit suite — green; ruff + mypy clean.
- Reviewers: senior **APPROVE**, spec **COMPLIANT**, strict **NEEDS-WORK** addressed (docstring scoped honestly; two hardening findings deferred as fix-if-a-real-bug-surfaces).
- **End-to-end smoke** (8-table finance operating_model): `journal_entry_cycle`/`period_close`/`accounts_payable`/`bank_reconciliation` detect; **`period_close` grounded via the new numeric path (no status column, rate 0.97)** — proving the feed reaches the agent. Absent cycles abstain honestly; no false flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)