### PR TITLE
chore(infra): pin Temporal images to floating major tags

### DIFF
--- a/packages/infra/.env.example
+++ b/packages/infra/.env.example
@@ -51,9 +51,13 @@ ANTHROPIC_API_KEY=sk-ant-placeholder-replace-me
 # temporalio/samples-server compose/docker-compose-postgres.yml (the canonical
 # non-deprecated path; temporalio/auto-setup is retired). The Temporal DBs
 # (temporal + temporal_visibility) are created in the shared `postgres` service.
-TEMPORAL_VERSION=1.31.0
-TEMPORAL_ADMINTOOLS_VERSION=1.31.0
-TEMPORAL_UI_VERSION=2.49.1
+# Pinned to floating MAJOR tags so rebuilds pick up patch/minor fixes within the
+# major without manual bumps. The UI image publishes no bare-major (`2`) or
+# minor-float (`2.51`) tag — only `latest` (unbounded, could cross a major) or
+# fully-pinned patches — so it carries an explicit patch pin, bumped manually.
+TEMPORAL_VERSION=1
+TEMPORAL_ADMINTOOLS_VERSION=1
+TEMPORAL_UI_VERSION=2.51.1
 
 # Temporal client settings. Read by the engine activity worker (DAT-344 P2) and
 # the cockpit Temporal client (E4b). In-container values: the worker reaches the


### PR DESCRIPTION
## What

Pin the Temporal service images to floating **major** tags so rebuilds pick up patch/minor fixes within the major without manual version bumps — matching how the stack already treats `postgres:18`, `oven/bun:1`, and `python:3.14-slim`.

| Image | Before | After |
|---|---|---|
| `temporalio/server` | `1.31.0` | **`1`** |
| `temporalio/admin-tools` | `1.31.0` | **`1`** |
| `temporalio/ui` | `2.49.1` | **`2.51.1`** |

## Why the UI is different

`temporalio/ui` publishes **no** bare-major (`2`) tag and **no** minor-float (`2.51`) tag — verified against Docker Hub. The only floating option is `latest`, which is unbounded and could silently cross into a future v3 and desync from a `1`-pinned server. So the UI keeps an explicit patch pin (bumped from the current `2.49.1` to the latest `2.51.1`), to be advanced manually.

Only `packages/infra/.env.example` (the committed template) changes — `.env` is gitignored. **Local dev: sync your `packages/infra/.env`** to match (`TEMPORAL_VERSION=1`, `TEMPORAL_ADMINTOOLS_VERSION=1`, `TEMPORAL_UI_VERSION=2.51.1`).

Verified `docker compose config` resolves all three image refs correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)