### PR TITLE
perf(engine): multi-stage Dockerfile — 2.74GB → 1.39GB

### DIFF
--- a/packages/engine/docker/worker.Dockerfile
+++ b/packages/engine/docker/worker.Dockerfile
@@ -1,21 +1,28 @@
-FROM python:3.14-slim
+# DataRaum engine — Temporal activity worker (DAT-344). Multi-stage:
+#   builder — resolve + install the venv; carries the build toolchain (gcc/g++)
+#             and uv, both discarded with this stage.
+#   runtime — slim image with only the venv + the mssql runtime lib. No gcc/g++,
+#             no uv. The venv stays root-owned/world-readable (NO recursive chown
+#             of /app — that would copy-up the whole ~700MB venv into a duplicate
+#             layer; only the writable runtime dirs are chowned to dataraum).
 
-LABEL org.opencontainers.image.source="https://github.com/dataraum/dataraum"
-LABEL org.opencontainers.image.description="DataRaum engine — Temporal activity worker"
-LABEL org.opencontainers.image.licenses="Apache-2.0"
+# ---------- builder ----------
+FROM python:3.14-slim AS builder
 
-# System deps: gcc/g++ for any source builds. No curl — the engine is a Temporal
-# worker now (DAT-344), not an HTTP service; its health is the worker heartbeat
-# the Temporal server records, checked externally via `temporal worker list`.
-# libgssapi-krb5-2: runtime dependency of the community mssql DuckDB extension
-# (db-recipe backend) — without it LOAD mssql fails with a missing
-# libgssapi_krb5.so.2, both at the pre-bake below and at runtime.
+# gcc/g++ for any source-built wheels during `uv sync` (most deps ship
+# arm64/x86_64 manylinux wheels, but keep the toolchain so a source build never
+# fails the image — it is discarded with this stage, costing the final image 0).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc g++ libgssapi-krb5-2 && \
+    gcc g++ && \
     rm -rf /var/lib/apt/lists/*
 
-# Install uv for fast dependency resolution
+# Install uv for fast dependency resolution (build-only — not in the runtime).
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Pin uv to the system CPython 3.14 (matches the runtime base below) so the venv
+# references /usr/local/bin/python3.14 — present identically in the runtime
+# stage — rather than a managed interpreter that the COPY below wouldn't carry.
+ENV UV_PYTHON_DOWNLOADS=never
 
 WORKDIR /app
 
@@ -23,9 +30,27 @@ WORKDIR /app
 COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --no-dev --frozen --no-install-project
 
-# Now copy the project itself and re-sync to install the package
+# Now copy the project itself and re-sync to install the package (editable — the
+# venv references /app/src, so the runtime stage keeps /app at this same path).
 COPY src/ src/
 RUN uv sync --no-dev --frozen
+
+# ---------- runtime ----------
+FROM python:3.14-slim AS runtime
+
+LABEL org.opencontainers.image.source="https://github.com/dataraum/dataraum"
+LABEL org.opencontainers.image.description="DataRaum engine — Temporal activity worker"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+# libgssapi-krb5-2: runtime dependency of the community mssql DuckDB extension
+# (db-recipe backend) — without it LOAD mssql fails with a missing
+# libgssapi_krb5.so.2, at the pre-bake below and at runtime. No curl: the engine
+# is a Temporal worker (DAT-344), not an HTTP service; its health is the worker
+# heartbeat, checked externally via `temporal worker list`. gcc/g++ and uv are
+# build-only and deliberately absent here (they live in the builder stage).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgssapi-krb5-2 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Engine config root. Config is the standalone `dataraum-config` package, NOT
 # baked into this image — it is bind-mounted at /opt/dataraum/config by compose
@@ -34,14 +59,22 @@ RUN uv sync --no-dev --frozen
 # runtime, so a bare `docker run` without the mount has no config by design.
 ENV DATARAUM_CONFIG_PATH=/opt/dataraum/config
 
-# Non-root runtime user. DuckDB extensions live at a known image path
-# (``/opt/dataraum/duckdb-extensions``) rather than ``$HOME/.duckdb/`` so we
-# don't need to provision a writable home — the path is immutable, predictable,
-# and pre-populated at build time. Pattern adapted from web-app/roboduck.
+# Non-root runtime user. Only the WRITABLE dirs are chowned to dataraum; the venv
+# + source under /app stay root-owned and world-readable (a non-root user
+# reads/executes them fine). Chowning /app would copy-up the entire ~700MB venv
+# into a duplicate layer. DuckDB extensions live at a known image path
+# (/opt/dataraum/duckdb-extensions) — immutable, predictable, pre-populated below
+# — so we don't need a writable home for the system user.
 RUN groupadd -r dataraum && useradd -r -g dataraum -u 1001 dataraum && \
     mkdir -p /var/lib/dataraum/sources /opt/dataraum/duckdb-extensions && \
-    chown -R dataraum:dataraum /app /opt/dataraum /var/lib/dataraum
+    chown -R dataraum:dataraum /opt/dataraum /var/lib/dataraum
 
+# The installed venv + project from the builder. Root-owned, world-readable — no
+# recursive chown, no duplicate layer. The editable install references /app/src,
+# preserved at this same path.
+COPY --from=builder /app /app
+
+WORKDIR /app
 USER dataraum
 
 # Pre-install the DuckDB extensions at image build time. Runtime sets


### PR DESCRIPTION
## Problem

The engine worker image was **2.74GB**. Per-layer inspection found two avoidable causes:

1. **A duplicate ~717MB venv layer.** `chown -R dataraum:dataraum /app` re-owned the entire `.venv` that `uv sync` had just built (~716MB), and overlayfs copy-up wrote a *full second copy* of it as a new layer. That one line nearly doubled the venv's footprint — for nothing, since the venv only needs to be readable/executable by the runtime user, not owned by it.
2. **Build-only tooling shipped in the runtime image.** Single-stage kept `gcc`/`g++` (~251MB) and the `uv` binary (~53MB), neither of which is used at runtime.

## Fix

- **Recursive chown now covers only the writable dirs** (`/opt/dataraum` + `/var/lib/dataraum`). The venv + source arrive via a plain `COPY --from=builder /app /app` — root-owned, world-readable, **no duplicate layer**.
- **Split into `builder` + `runtime` stages.** gcc/g++ + uv live in the builder and are discarded; runtime keeps only `libgssapi-krb5-2` (the mssql extension's runtime dep).
- `UV_PYTHON_DOWNLOADS=never` pins uv to the system CPython 3.14, so the copied venv references `/usr/local/bin/python3.14` — present identically in the runtime base (no managed interpreter that the COPY would miss).

The 195MB DuckDB-extension prebake is unchanged — intentional for air-gapped/proxy deploys.

## Result — verified by building locally

| | Before | After |
|---|---|---|
| **Image size** | 2.74GB | **1.39GB** (−49%) |

Runtime smoke on the built image:
- `import dataraum` resolves from `/app/src/dataraum` — editable install intact
- runs as non-root **uid 1001** (dataraum)
- all six extensions (ducklake/httpfs/postgres/mysql/sqlite/mssql) `LOAD` from the baked `/opt/dataraum/duckdb-extensions` with `DUCKLAKE_SKIP_INSTALL=1` — **no network**

> Cockpit image (1.63GB, dominated by the externalized `@temporalio` worker tree) is a separate, more investigative pass — deferred per discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)