### PR TITLE
feat(DAT-631): flag low-confidence metrics with a grounding-confidence badge

### DIFF
--- a/packages/cockpit/src/tools/look-metric.ts
+++ b/packages/cockpit/src/tools/look-metric.ts
@@ -51,7 +51,10 @@ const MetricOverview = z.object({
 	// always paired with `state_reason` (the fail-loud contract).
 	state: z.string(),
 	// WHY the metric stopped short of executed (e.g. "ungroundable: required
-	// field mappings missing") — the engine's reason verbatim; null once executed.
+	// field mappings missing") — the engine's reason verbatim. Also non-null on an
+	// EXECUTED metric when the grounding confidence fell below the engine floor
+	// (the low-confidence caveat, DAT-631) — so on an executed metric a present
+	// reason is the low-confidence flag (GroundingConfidenceBadge).
 	state_reason: z.string().nullable(),
 	// How many persisted SQL snippets back this metric (the per-step fragments the
 	// graph agent saved). 0 when it never composed; >0 once it did — a soft signal

--- a/packages/cockpit/src/ui/cockpit/widgets/lifecycle-badges.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/lifecycle-badges.tsx
@@ -8,7 +8,7 @@
 //
 // The value is the engine's persisted state string — never recomputed here.
 
-import { Badge, Text } from "@mantine/core";
+import { Badge, Text, Tooltip } from "@mantine/core";
 
 // Lifecycle state → Mantine color. A non-executed state in a promoted run always
 // carries a state_reason (the fail-loud contract), so anything short of executed
@@ -49,5 +49,46 @@ export function LifecycleStateBadge({
 		>
 			{state.charAt(0).toUpperCase() + state.slice(1)}
 		</Badge>
+	);
+}
+
+// Grounding-confidence caveat badge (DAT-631) — a metric's quality badge, the
+// analog of the validation pass/fail verdict (the state badge owns PROGRESS,
+// never good/bad; quality rides a separate badge — see validation-badges.tsx).
+//
+// A metric whose SQL composes + verifies still reaches `executed`, but the graph
+// agent records the WEAKEST per-concept grounding confidence and, when it falls
+// below the engine's floor, stamps a caveat onto the EXECUTED artifact's
+// `state_reason` (engine metrics_phase `_low_confidence_reason`). That is the
+// only writer of a reason on an executed metric, so on an executed artifact a
+// present `state_reason` IS the low-confidence flag — no string parsing, an
+// executed metric is silent unless flagged. This surfaces the honesty the engine
+// already produces so a 0.35-confidence proxy stops reading identically to a
+// confidently-grounded metric (the DAT-631 headline). Renders nothing when the
+// metric is confident (executed, no reason) or not yet executed (the state badge
+// carries the why-not) — a dash would be noise next to the state badge.
+export function GroundingConfidenceBadge({
+	state,
+	stateReason,
+}: {
+	state: string | null | undefined;
+	stateReason: string | null | undefined;
+}) {
+	if (state !== "executed" || !stateReason) {
+		return null;
+	}
+	return (
+		<Tooltip label={stateReason} multiline maw={320} withArrow>
+			<Badge
+				color="orange"
+				variant="light"
+				size="sm"
+				tt="none"
+				data-testid="grounding-confidence-badge"
+				styles={{ label: { overflow: "visible" } }}
+			>
+				Low confidence
+			</Badge>
+		</Tooltip>
 	);
 }

--- a/packages/cockpit/src/ui/cockpit/widgets/lifecycle-badges.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/lifecycle-badges.tsx
@@ -78,12 +78,17 @@ export function GroundingConfidenceBadge({
 		return null;
 	}
 	return (
+		// `maw` = max-width (a long reason wraps within 320px), not a fixed width.
 		<Tooltip label={stateReason} multiline maw={320} withArrow>
 			<Badge
 				color="orange"
 				variant="light"
 				size="sm"
 				tt="none"
+				// A Badge renders a non-interactive span; make it focusable so the
+				// reason tooltip is keyboard-reachable, not mouse-only (the full reason
+				// is also always visible in the list's Detail column + the why Alert).
+				tabIndex={0}
 				data-testid="grounding-confidence-badge"
 				styles={{ label: { overflow: "visible" } }}
 			>

--- a/packages/cockpit/src/ui/cockpit/widgets/metric-list.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/metric-list.test.tsx
@@ -45,6 +45,16 @@ const UNGROUNDABLE = {
 	snippet_count: 0,
 };
 
+// Executed, but the graph agent's weakest per-concept confidence fell below the
+// engine floor → the caveat rides on the executed artifact's state_reason (DAT-631).
+const LOW_CONFIDENCE = {
+	graph_id: "gross_margin",
+	state: "executed",
+	state_reason:
+		"low-confidence grounding (0.35 < 0.50): COGS proxy may overstate",
+	snippet_count: 4,
+};
+
 const analyzed: LookMetricResult = {
 	analyzed: true,
 	pending_teaches: 0,
@@ -75,6 +85,20 @@ describe("MetricListWidget (DAT-466)", () => {
 		expect(
 			screen.getByText(/ungroundable: required field mappings missing/),
 		).toBeTruthy();
+	});
+
+	it("flags a low-confidence executed metric amber, but not a confident one (DAT-631)", () => {
+		renderWidget({ ...analyzed, metrics: [EXECUTED, LOW_CONFIDENCE] });
+		// The confident EBITDA row and the low-confidence gross-margin row both read
+		// `executed`; only the low-confidence one carries the caveat badge.
+		const badges = screen.getAllByTestId("grounding-confidence-badge");
+		expect(badges).toHaveLength(1);
+		expect(badges[0].textContent).toBe("Low confidence");
+	});
+
+	it("shows no confidence badge when every executed metric is confident (DAT-631)", () => {
+		renderWidget({ ...analyzed, metrics: [EXECUTED] });
+		expect(screen.queryByTestId("grounding-confidence-badge")).toBeNull();
 	});
 
 	it("renders the not-run state pointing at the operating-model stage", () => {

--- a/packages/cockpit/src/ui/cockpit/widgets/metric-list.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/metric-list.tsx
@@ -10,12 +10,15 @@
 // computed on demand by running the metric, never stored). State / reason /
 // step-count are the engine's persisted values verbatim — never recomputed here.
 
-import { Alert, Anchor, Stack, Table, Text } from "@mantine/core";
+import { Alert, Anchor, Group, Stack, Table, Text } from "@mantine/core";
 import { humanizeIdentifier } from "#/lib/display-names";
 import type { MetricOverview } from "#/tools/look-metric";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
 import { useCockpitActions } from "#/ui/cockpit/cockpit-state";
-import { LifecycleStateBadge } from "#/ui/cockpit/widgets/lifecycle-badges";
+import {
+	GroundingConfidenceBadge,
+	LifecycleStateBadge,
+} from "#/ui/cockpit/widgets/lifecycle-badges";
 import { PendingTeachAlert } from "#/ui/cockpit/widgets/why-detail";
 
 // Cap the rows rendered into the DOM (rule 15). A vertical ships a few dozen
@@ -116,7 +119,17 @@ export function MetricListWidget({
 									</Anchor>
 								</Table.Td>
 								<Table.Td>
-									<LifecycleStateBadge state={m.state} />
+									{/* Progress (state) + quality (grounding confidence) are two
+									    distinct badges — a low-confidence metric is still
+									    `executed` but flags amber rather than reading identical
+									    to a confident one (DAT-631). */}
+									<Group gap="xs" wrap="nowrap">
+										<LifecycleStateBadge state={m.state} />
+										<GroundingConfidenceBadge
+											state={m.state}
+											stateReason={m.state_reason}
+										/>
+									</Group>
 								</Table.Td>
 								<Table.Td>
 									{m.snippet_count > 0 ? (

--- a/packages/cockpit/src/ui/cockpit/widgets/metric-why.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/metric-why.test.tsx
@@ -63,6 +63,14 @@ const UNGROUNDABLE: WhyMetricResult = {
 	steps: [],
 };
 
+// Executed, but the weakest per-concept grounding confidence fell below the
+// engine floor → the caveat rides on the executed artifact's state_reason (DAT-631).
+const LOW_CONFIDENCE: WhyMetricResult = {
+	...EXECUTED,
+	state_reason:
+		"low-confidence grounding (0.35 < 0.50): COGS proxy may overstate",
+};
+
 afterEach(cleanup);
 
 describe("MetricWhyWidget (DAT-466)", () => {
@@ -96,8 +104,23 @@ describe("MetricWhyWidget (DAT-466)", () => {
 		expect(
 			screen.getByText(/SELECT sum\(amount\) FROM lake\.typed\.income/),
 		).toBeTruthy();
-		// No reason alert when the metric executed.
+		// No reason alert, and no low-confidence badge, when the metric executed
+		// confidently (state_reason null — the gate wrote no caveat).
 		expect(screen.queryByTestId("canvas-metric-why-reason")).toBeNull();
+		expect(screen.queryByTestId("grounding-confidence-badge")).toBeNull();
+	});
+
+	it("flags a low-confidence executed metric: badge + first-class reason alert (DAT-631)", () => {
+		renderWidget(LOW_CONFIDENCE);
+		// Still executed — the state badge reads Executed…
+		expect(screen.getByText("Executed")).toBeTruthy();
+		// …but the quality badge flags it, and the caveat is first-class, not a hover.
+		expect(screen.getByTestId("grounding-confidence-badge").textContent).toBe(
+			"Low confidence",
+		);
+		expect(
+			screen.getByTestId("canvas-metric-why-reason").textContent,
+		).toContain("0.35 < 0.50");
 	});
 
 	it("surfaces the pending-teach note", () => {

--- a/packages/cockpit/src/ui/cockpit/widgets/metric-why.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/metric-why.tsx
@@ -16,7 +16,10 @@ import { humanizeIdentifier } from "#/lib/display-names";
 import type { MetricStep } from "#/tools/why-metric";
 import type { CanvasState } from "#/ui/cockpit/canvas-state";
 import { EvidenceDetail } from "#/ui/cockpit/widgets/evidence-detail";
-import { LifecycleStateBadge } from "#/ui/cockpit/widgets/lifecycle-badges";
+import {
+	GroundingConfidenceBadge,
+	LifecycleStateBadge,
+} from "#/ui/cockpit/widgets/lifecycle-badges";
 import { SqlBlock } from "#/ui/cockpit/widgets/sql-block";
 import { PendingTeachAlert } from "#/ui/cockpit/widgets/why-detail";
 
@@ -82,11 +85,19 @@ export function MetricWhyWidget({
 				<Text size="sm" fw={600}>
 					{label}
 				</Text>
-				<LifecycleStateBadge state={why.state} />
+				<Group gap="xs" wrap="nowrap">
+					<LifecycleStateBadge state={why.state} />
+					<GroundingConfidenceBadge
+						state={why.state}
+						stateReason={why.state_reason}
+					/>
+				</Group>
 			</Group>
 
-			{/* The "visibly impossible" surface: WHY the metric stopped short of
-			    executed — the engine's reason verbatim, first-class, never a hover. */}
+			{/* First-class reason surface, never a hover: WHY the metric stopped
+			    short of executed, OR — on an executed metric — the low-confidence
+			    grounding caveat the badge flags (DAT-631). The engine's text
+			    verbatim. */}
 			{why.state_reason && (
 				<Alert color="orange" data-testid="canvas-metric-why-reason">
 					{why.state_reason}


### PR DESCRIPTION
## What

The engine already **gates** on grounding confidence — DAT-631 round-1 (`1dde10f0`) added `_LOW_CONFIDENCE_FLOOR = 0.5` + `_low_confidence_reason()` in `metrics_phase.py`: a metric whose *weakest* per-concept assumption confidence falls below the floor still reaches `executed`, but the caveat rides on its `state_reason` (e.g. *"low-confidence grounding (0.35 < 0.50): …"*).

The **cockpit ignored it.** Every `executed` metric rendered the same blue `LifecycleStateBadge`, so a 0.35-confidence proxy (`gross_margin` / `ebitda` on a weak COGS proxy) read *identically* to a confidently-grounded metric — the DAT-631 headline ("low-confidence proxies render green").

## Change

A shared **`GroundingConfidenceBadge`** in `lifecycle-badges.tsx` — the metric analog of the validation pass/fail verdict badge (the state badge owns *progress*; a separate badge owns *quality*, matching `ValidationVerdictBadge`). It renders an amber **"Low confidence"** flag (full reason on hover) on the metric list + the why drill-down.

**No string-parsing.** On an `executed` metric a present `state_reason` *is* the low-confidence flag — the gate is its only writer there — so the signal is the structured `state === "executed" && state_reason != null`. Also fixes the now-stale `look_metric` "null once executed" invariant comment.

## Scope

Cockpit-only, ~5 files. Engine unchanged (the honest confidence was already produced + gated). Problem 2 of DAT-631 (discriminator / blocked-column / double-count) is **not** in scope — 2a is blocked on DAT-277; see the ticket comment for the full code-verified breakdown. DAT-631 re-homed under DAT-652 (relational grounding) accordingly.

## Test

- `metric-list.test.tsx`: a low-confidence `executed` metric flags amber while a confident one does not; no badge when all executed metrics are confident.
- Full `bun run check` (biome) + `tsc --noEmit` + vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)