### PR TITLE
feat(DAT-631): teach the grounding agent to down-rank blocked columns

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,18 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-631 — metric grounding: teach the agent to down-rank blocked columns
+
+**Branch:** `feat/dat-631-grounding-quality`. **Re-verify metric grounding confidence; no schema/field change.**
+
+Prompt-only (`graph_sql_generation` → v5.1). A new `<column_reliability>` block: when the agent grounds a concept on a `⛔ blocked` column (readiness flagged it unreliable), it now MUST record an inferred assumption + set confidence LOW (≤0.4) — mirroring the existing `<data_trust>` pattern. Previously the agent saw the `⛔` marker but had no instruction, so it summed blocked columns at ~0.5 and the metric read confidently green. The LOW confidence feeds the existing DAT-631 gate (`metrics_phase._low_confidence_reason`, floor 0.5) → the metric flags low-confidence-executed instead.
+
+**Why eval cares (RE-VERIFY):** grounding confidence shifts — metrics resting on blocked columns now flag low-confidence rather than plain executed. Expect MORE low-confidence flags (intended honesty, not a regression). No detector surface, no new fields; it's grounding quality. It's informative/interpretable (a blocked column may still be the right measure), so the agent may still ground on it — just at lower confidence.
+
+_(The double-count half of DAT-631 Problem 2 — a concept-boundary prompt + a deterministic overlap flag — was explored and DROPPED: value-set overlap is a symptom needing interpretation, not a deterministic per-metric signal; the real fix is interpretive-at-compose or a global vocabulary invariant, deferred under DAT-652.)_
+
+---
+
 ## DAT-617 — validation verdict on demand from a contracted SQL output (ADR-0017)
 
 **Branch:** `feat/dat-617-validation-on-demand-p1`. **Re-verify `cross_table_consistency`; do NOT recalibrate blind.**

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -1,5 +1,5 @@
 name: "graph_sql_generation"
-version: "5.0"
+version: "5.1"
 description: "Ground ONE business concept to an executable DuckDB extract. The LLM grounds; it is fed deterministic evidence (ADR-0016). Formula composition is a separate prompt."
 temperature: 0.0
 
@@ -123,6 +123,21 @@ system_prompt: |
   untrustworthy because the source data failed a foundational validation. Do not assume which
   constraints exist — read them from the Validation Results.)
   </data_trust>
+
+  <column_reliability>
+  A column annotated `⛔ blocked` in <dataset_context> was flagged by the readiness stage as
+  unreliable for analysis (e.g. heavy nulls, mixed/ambiguous semantics). It is NOT forbidden —
+  sometimes the blocked column is the only measure that expresses the concept, and you may still
+  aggregate it. But a value summed from a blocked column carries a reliability risk that MUST
+  propagate: if you ground a concept on a `⛔ blocked` column, record an "inferred" assumption
+  naming the column and why it is blocked, AND set that assumption's `confidence` LOW (≤ 0.4).
+
+  Read `confidence` here the same way as in <data_trust>: it is TRUST IN THE RESULTING METRIC
+  VALUE, lowered because a foundational input is flagged unreliable — NOT your certainty that the
+  column is blocked. Weigh it in context: a column blocked for one intent may still be the right
+  measure for this metric, so this is a caveat to surface, not a hard refusal — lower the
+  confidence so the metric is flagged rather than rendered confidently green.
+  </column_reliability>
 
   <aggregation_types>
   The graph step specifies an aggregation that determines HOW to extract the value:


### PR DESCRIPTION
DAT-631 Problem 2, reduced to the one piece that's genuinely sound and domain-agnostic.

## What
The readiness stage flags unreliable columns (`⛔ blocked`) and `context.py` renders the marker, but the grounding prompt never mentioned blocked columns — the agent saw the emoji and summed the column anyway at ~0.5, so a metric resting on a blocked measure read confidently green.

`<column_reliability>` block in `graph_sql_generation` (→ v5.1), mirroring the existing `<data_trust>` pattern: grounding on a blocked column is allowed (it may be the only measure) but MUST record an inferred assumption + set confidence LOW (≤0.4). The LOW confidence feeds the **existing** DAT-631 gate (`metrics_phase._low_confidence_reason`, floor 0.5) → the metric flags low-confidence-executed instead of plain green. **Informative, interpretable — not a hard gate.** Pure prompt; no engine code, no schema, no new fields.

## Why this is the right pattern
Blocked-ness is a **deterministic, domain-agnostic per-column fact** (from readiness) fed to the agent as **evidence** that the agent **interprets** into its confidence. Evidence → agent → guardrail — no finance assumptions, generalizes beyond finance.

## What was dropped (and why)
The double-count half of Problem 2 (a `<concept_boundaries>` prompt + a deterministic value-set-overlap flag) was built, reviewed, then **cut**: value-set overlap is a *symptom* with several causes (grounding pollution vs. legitimate multi-label vs. real double-count) that a bare set-intersection can't distinguish — it needs interpretation, and it's a *global* vocabulary property, not a per-metric fact. A deterministic per-metric flag over-fires (worse outside finance, where categorical values collide). The real fix is interpretive-at-compose (Tier-2b) or a global disjoint-vocabulary invariant (Tier-2c) — deferred under DAT-652, not faked with determinism.

## Validation
Prompt-only → efficacy is a calibration question (shifts the grounding confidence distribution: more low-confidence flags = intended honesty). Handoff entry included. **Not** validated against BookSQL (its enriched_views are wrong pending DAT-277). 224 engine graph tests green; prompt YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)