### PR TITLE
chore(release): publish engine + cockpit containers, retire PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     preflight:
         name: Preflight (doc counts)
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         defaults:
             run:
                 working-directory: packages/engine

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,69 +1,36 @@
 name: Release
 
+# Publishes the shippable container images to GHCR on a GitHub Release. The
+# engine is a Temporal activity worker and the cockpit is a TanStack Start
+# server — both consumed as images, never as a PyPI/npm package (the engine's
+# PyPI publish + its `dataraum-mcp` entrypoint died with the MCP surface:
+# DAT-325 retired the transport, DAT-487 deleted the code). The git tag is the
+# single source of version truth: every image is tagged `:{tag}` + `:latest`.
+
 on:
     release:
         types: [published]
 
 jobs:
     preflight:
-        name: Preflight (version match + doc counts)
+        name: Preflight (doc counts)
         runs-on: ubuntu-latest
         defaults:
             run:
                 working-directory: packages/engine
         steps:
             - uses: actions/checkout@v7
-
-            # server.json (the MCP registry manifest) died with the MCP surface —
-            # DAT-325 retired the transport, DAT-487 deleted the code.
-            - name: Check tag == pyproject version
-              run: |
-                  set -e
-                  TAG_VERSION="${GITHUB_REF_NAME#v}"
-                  PYPROJECT_VERSION=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "(.*)"/\1/')
-
-                  echo "tag=$TAG_VERSION  pyproject=$PYPROJECT_VERSION"
-
-                  if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
-                      echo "::error::version mismatch — refusing to publish"
-                      exit 1
-                  fi
-
-            - name: Check doc counts (phases / detectors)
-              run: python scripts/check_doc_counts.py
-
-    pypi:
-        name: Publish to PyPI
-        needs: preflight
-        runs-on: ubuntu-latest
-        environment: pypi
-        defaults:
-            run:
-                working-directory: packages/engine
-        permissions:
-            id-token: write
-            contents: read
-        steps:
-            - uses: actions/checkout@v7
-
-            - name: Install uv
-              uses: astral-sh/setup-uv@v7
 
             - name: Set up Python
               uses: actions/setup-python@v6
               with:
                   python-version: "3.x"
 
-            - name: Build package
-              run: uv build
+            - name: Check doc counts (phases / detectors)
+              run: python scripts/check_doc_counts.py
 
-            - name: Publish to PyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
-              with:
-                  packages-dir: packages/engine/dist
-
-    docker:
-        name: Push to GHCR
+    engine:
+        name: Push engine to GHCR
         needs: preflight
         runs-on: ubuntu-latest
         permissions:
@@ -92,3 +59,50 @@ jobs:
                   tags: |
                       ghcr.io/dataraum/dataraum:${{ steps.version.outputs.version }}
                       ghcr.io/dataraum/dataraum:latest
+
+    cockpit:
+        name: Push cockpit to GHCR
+        needs: preflight
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - uses: actions/checkout@v7
+
+            - name: Log in to GHCR
+              uses: docker/login-action@v4
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract version from tag
+              id: version
+              run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+            # Two images from one Dockerfile: the slim runner serves the app; the
+            # `build` stage carries drizzle-kit + the checked-in cockpit_db
+            # migrations and ships as the one-shot migrate image. The deploy runs
+            # migrate (`bun run db:migrate:cockpit`) before the cockpit serves —
+            # mirroring the `cockpit-migrate` service in docker-compose.yml. The
+            # engine's ws_<id> schema needs no migrate step: the worker
+            # self-bootstraps it at boot.
+            - name: Build and push cockpit (runner)
+              uses: docker/build-push-action@v7
+              with:
+                  context: packages/cockpit
+                  push: true
+                  tags: |
+                      ghcr.io/dataraum/dataraum-cockpit:${{ steps.version.outputs.version }}
+                      ghcr.io/dataraum/dataraum-cockpit:latest
+
+            - name: Build and push cockpit-migrate (build stage)
+              uses: docker/build-push-action@v7
+              with:
+                  context: packages/cockpit
+                  target: build
+                  push: true
+                  tags: |
+                      ghcr.io/dataraum/dataraum-cockpit-migrate:${{ steps.version.outputs.version }}
+                      ghcr.io/dataraum/dataraum-cockpit-migrate:latest

--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ open http://localhost:3000
 
 For UI iteration, run the cockpit dev server outside docker for hot reload — see `packages/cockpit/README.md`.
 
+### Run a released version (published images)
+
+The quick start above **builds** the engine and cockpit from source. To run the
+published release images instead — a deploy host, no build toolchain — layer the release
+overlay and name the version:
+
+```bash
+export DATARAUM_VERSION=1.2.3          # any tag from a GitHub Release
+docker compose \
+  -f packages/infra/docker-compose.yml -f packages/infra/docker-compose.release.yml \
+  --env-file packages/infra/.env up -d --wait --no-build
+```
+
+This pulls `ghcr.io/dataraum/{dataraum, dataraum-cockpit, dataraum-cockpit-migrate}` at
+that tag. See [Deployment](docs/operations/deployment.md) for the images, schema/migration
+handling, and the per-workspace topology.
+
 ## Develop
 
 - **Engine (Python):** `cd packages/engine && uv sync --group dev && uv run pytest --testmon tests/unit -q`. See `packages/engine/README.md` and `packages/engine/CLAUDE.md`.

--- a/docs/getting-started/running-the-stack.md
+++ b/docs/getting-started/running-the-stack.md
@@ -1,0 +1,93 @@
+# Running the stack
+
+This page brings DataRaum up **locally, built from source** — the dev and evaluation path.
+To run pinned release images on a deploy host instead, see [Deployment](../operations/deployment.md).
+
+## Prerequisites
+
+- **Docker** with Compose v2. That's the only hard requirement — the engine (Python) and
+  cockpit (TypeScript) images build inside the stack; you don't need `uv` or `bun` on the
+  host just to run it. (You do for [developing](../platform/architecture.md) either package;
+  see the package READMEs.)
+- An **Anthropic API key**. Semantic analysis and the chat agent need it; the substrate
+  boots without it, but the pipeline can't complete.
+
+## Bring it up
+
+Run from the workspace root:
+
+```bash
+# One-time: seed the env file and set the LLM key
+cp packages/infra/.env.example packages/infra/.env
+echo "ANTHROPIC_API_KEY=sk-ant-..." >> packages/infra/.env
+
+# Build + start Postgres, the object store, Temporal, the engine worker, and the cockpit
+docker compose -f packages/infra/docker-compose.yml --env-file packages/infra/.env up -d --wait
+```
+
+or, equivalently, `make up` from the root.
+
+The first run builds both app images and pulls the substrate images, so it takes a few
+minutes; subsequent runs reuse the layers. `--wait` blocks until every service is healthy
+(and the one-shot `cockpit-migrate` has applied the `cockpit_db` migrations).
+
+## Verify
+
+The engine is a **Temporal activity worker** with no HTTP surface — its health is the
+worker heartbeat, not a port. Check it through Temporal:
+
+```bash
+docker compose -f packages/infra/docker-compose.yml run --rm --no-deps \
+  --entrypoint temporal temporal-admin-tools \
+  worker list --namespace default --address temporal:7233
+# → Status: Running   (on the engine-<workspace-id> task queue)
+```
+
+Then open the cockpit — the only surface you interact with:
+
+```
+open http://localhost:3000
+```
+
+The Temporal web UI is at <http://localhost:8080> if you want to watch workflows run.
+
+## Everyday operations
+
+```bash
+make logs                    # tail all services  (or: docker compose … logs -f)
+make down                    # stop the stack
+```
+
+- **Iterating on the cockpit UI?** Skip the cockpit container and run the dev server
+  outside docker for hot reload — bring up only the backend deps and `bun --bun run dev`.
+  See [`packages/cockpit/README.md`](https://github.com/dataraum/dataraum/blob/main/packages/cockpit/README.md).
+- **Changed engine or cockpit code and want it in the container?** A plain `up` reuses the
+  cached image. Rebuild and recreate the affected service:
+
+  ```bash
+  docker compose -f packages/infra/docker-compose.yml up -d --build --force-recreate cockpit
+  ```
+
+  This matters for the cockpit's orchestration worker in particular: its workflow bundle is
+  baked into the image at build time, so without `--build --force-recreate` the old bundle
+  keeps running and your change silently never lands.
+
+## Multiple workspaces
+
+A [workspace](../platform/architecture.md#the-per-workspace-model) is the unit of isolation
+— its own engine container, Temporal queue, Postgres schema, catalog, and object-store
+prefix. The default stack runs one. To bring up a second engine worker side by side (for a
+two-workspace smoke), enable the profile:
+
+```bash
+docker compose -f packages/infra/docker-compose.yml --profile multi-workspace up -d --wait
+```
+
+The cockpit is a single app that serves all workspaces, routing each request to the right
+one via the registry.
+
+## Next
+
+- [Deployment](../operations/deployment.md) — run pinned release images on a host, no build.
+- [Platform architecture](../platform/architecture.md) — the two-tier split, the substrate,
+  and how a run flows.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -1,0 +1,99 @@
+# Deployment
+
+There are two ways to run DataRaum, and they differ only in where the engine and
+cockpit images come from:
+
+- **Build from source** — the default `docker-compose.yml` builds both images from this
+  checkout. This is the dev / CI / local-smoke path (see the package READMEs).
+- **Run published images** — a release publishes versioned images to GHCR; a deploy host
+  pulls them and needs no build toolchain or source tree. That is what this page covers.
+
+## The published images
+
+A [GitHub Release](https://github.com/dataraum/dataraum/releases) (tag `vX.Y.Z`) triggers
+the `Release` workflow, which builds and pushes three images to the GitHub Container
+Registry. Each is tagged with the release version **and** `latest`:
+
+| Image | Role |
+|---|---|
+| `ghcr.io/dataraum/dataraum` | the engine analysis worker (one container per workspace) |
+| `ghcr.io/dataraum/dataraum-cockpit` | the web app + its co-located orchestration worker |
+| `ghcr.io/dataraum/dataraum-cockpit-migrate` | one-shot: applies the `cockpit_db` migrations, then exits |
+
+The engine is **not** published to PyPI and the cockpit is **not** published to npm — the
+containers are the only distribution artifact. The substrate dependencies
+(`postgres`, `temporal*`, `seaweedfs`) are stock upstream images, pinned in the base
+compose file; they need no override.
+
+## Run a released version
+
+The base compose file builds; a thin overlay, `docker-compose.release.yml`, swaps the
+three app services over to the published tags (`pull_policy: always`). Layer it on top and
+name the version you want:
+
+```bash
+cp packages/infra/.env.example packages/infra/.env
+echo "ANTHROPIC_API_KEY=sk-ant-..." >> packages/infra/.env
+export DATARAUM_VERSION=1.2.3          # any tag the Release workflow pushed
+
+docker compose \
+  -f packages/infra/docker-compose.yml \
+  -f packages/infra/docker-compose.release.yml \
+  --env-file packages/infra/.env \
+  up -d --wait --no-build
+```
+
+- **`DATARAUM_VERSION` is required** by the overlay — a deploy must name the tag it runs
+  (no implicit `latest`). Set it in the environment or uncomment it in `.env`.
+- **`--no-build` is load-bearing.** The base file's `build:` sections still merge in, so
+  without it a failed pull could silently build from whatever source is on the host. With
+  it, an unreachable or misspelled tag fails loud instead.
+- The engine has **no HTTP healthcheck** — its health is the Temporal worker heartbeat:
+
+  ```bash
+  docker compose -f packages/infra/docker-compose.yml run --rm --no-deps \
+    --entrypoint temporal temporal-admin-tools \
+    worker list --namespace default --address temporal:7233   # → Status: Running
+  ```
+
+Only the two compose files, `.env`, and the read-only config tree
+(`packages/dataraum-config/`, bind-mounted at `/opt/dataraum/config`) are needed on the
+host — no source checkout, no build tools.
+
+## Schema on startup
+
+The two databases are provisioned differently, and neither needs a manual step:
+
+- **`cockpit_db`** (Drizzle-owned) — the `cockpit-migrate` container runs
+  `db:migrate:cockpit` **once** before the cockpit serves; the cockpit's start gates on its
+  successful completion. This is why the migrate image ships separately: the slim cockpit
+  runner carries no `drizzle-kit`.
+- **Engine `ws_<id>`** (SQLAlchemy-owned) — the engine worker **self-bootstraps** its
+  workspace schema at boot. There is no migration step and no migrate image for it.
+
+## Version-lock the app images
+
+The cockpit bakes its typed read-mirror of the engine schema at build time, so an engine
+and a cockpit from different releases can drift at runtime. The release tags all three
+images from one commit, and the overlay pins every app service to the **same**
+`DATARAUM_VERSION` — deploy one version across the stack; do not hand-pin different tags
+per service.
+
+## Scaling: one engine per workspace
+
+A [workspace](../platform/architecture.md#the-per-workspace-model) is the unit of
+isolation — its own engine container, Temporal queue (`engine-<id>`), Postgres schema
+(`ws_<id>`), DuckLake catalog DB, and `s3://bucket/<id>/` prefix. The
+`x-engine-worker-base` anchor in `docker-compose.yml` is the per-workspace template:
+adding a workspace is a registry row plus one more engine service that merges the anchor
+and overrides the four routing knobs (workspace id, queue, catalog DB, lake prefix). The
+cockpit is a **single** app that routes each request to the right workspace by the
+registry.
+
+The images are plain OCI containers — the compose overlay is the reference topology, not a
+requirement. Run them under any orchestrator that gives them the same substrate (one
+Postgres, one S3-compatible object store, one Temporal, the config mount, and
+`ANTHROPIC_API_KEY`).
+
+See [Platform architecture](../platform/architecture.md) for how these pieces fit
+together and why the engine↔cockpit seam is Postgres + Temporal rather than HTTP.

--- a/packages/cockpit/scripts/pull-metadata.sh
+++ b/packages/cockpit/scripts/pull-metadata.sh
@@ -17,7 +17,7 @@ cd "$(dirname "$0")/.." # packages/cockpit
 
 WORKSPACE_ID="${DATARAUM_WORKSPACE_ID:-00000000-0000-0000-0000-000000000001}"
 SCHEMA_NAME="ws_${WORKSPACE_ID//-/_}"
-PG_IMAGE="postgres:17" # keep in lockstep with packages/infra/docker-compose.yml
+PG_IMAGE="postgres:18" # keep in lockstep with packages/infra/docker-compose.yml
 # Unique per run (parallel lanes regen concurrently); port is docker-assigned.
 CONTAINER="dataraum-schema-scratch-$$"
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -1,11 +1,7 @@
 # DataRaum Context Engine
 
-[![PyPI version](https://img.shields.io/pypi/v/dataraum)](https://pypi.org/project/dataraum/)
-[![Python](https://img.shields.io/pypi/pyversions/dataraum)](https://pypi.org/project/dataraum/)
 [![License](https://img.shields.io/github/license/dataraum/dataraum)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/dataraum/dataraum/ci.yml?branch=main)](https://github.com/dataraum/dataraum/actions)
-
-<!-- mcp-name: io.github.dataraum/dataraum -->
 
 A rich metadata context engine for AI-driven data analytics.
 

--- a/packages/infra/.env.example
+++ b/packages/infra/.env.example
@@ -1,6 +1,12 @@
 # Copy to .env on first compose-up: `cp .env.example .env`
 # All values here are dev defaults; override for any non-local environment.
 
+# Release image tag (GHCR) — ONLY used with the docker-compose.release.yml
+# overlay on a deploy host, where it selects which published engine + cockpit
+# tag to run (the overlay requires it). Irrelevant to a local build-from-source
+# `up`, which ignores it. See docker-compose.release.yml.
+# DATARAUM_VERSION=0.2.2
+
 # Postgres (platform + DuckLake catalog + cockpit_db)
 POSTGRES_USER=dataraum
 POSTGRES_PASSWORD=dataraum

--- a/packages/infra/docker-compose.release.yml
+++ b/packages/infra/docker-compose.release.yml
@@ -1,0 +1,43 @@
+# Release overlay — run the PUBLISHED engine + cockpit images instead of building
+# from this checkout. Layer it ON TOP of docker-compose.yml on a deploy host (no
+# build toolchain, no source needed beyond these two compose files + .env):
+#
+#   export DATARAUM_VERSION=1.2.3            # a tag the Release workflow pushed
+#   docker compose \
+#     -f packages/infra/docker-compose.yml \
+#     -f packages/infra/docker-compose.release.yml \
+#     --env-file packages/infra/.env \
+#     up -d --wait --no-build
+#
+# Each app service here pins `image: ghcr.io/dataraum/...:${DATARAUM_VERSION}`
+# and `pull_policy: always`, so `up` fetches the published tag every time. The
+# `--no-build` flag is what makes this pull-ONLY: the base file's `build:`
+# sections still merge in (a compose overlay can't reliably delete them), so
+# WITHOUT --no-build a failed pull could silently build from whatever source
+# happens to be on the host — the wrong code if it isn't checked out at this
+# tag. With --no-build a missing/unreachable tag fails loud instead. The base
+# compose alone (dev / CI / local smoke) is untouched and still builds from
+# source. The infra images (postgres/temporal/seaweedfs) are already pinned in
+# the base file and need no override.
+#
+# DATARAUM_VERSION has no default here on purpose: a deploy must name the tag it
+# runs. (The base file's .env.example documents the var.)
+
+services:
+  engine-worker:
+    image: ghcr.io/dataraum/dataraum:${DATARAUM_VERSION:?set DATARAUM_VERSION to a released tag}
+    pull_policy: always
+
+  # Present only under the multi-workspace profile, but pin it too so a
+  # profile-enabled deploy runs the same published engine image.
+  engine-worker-2:
+    image: ghcr.io/dataraum/dataraum:${DATARAUM_VERSION:?set DATARAUM_VERSION to a released tag}
+    pull_policy: always
+
+  cockpit-migrate:
+    image: ghcr.io/dataraum/dataraum-cockpit-migrate:${DATARAUM_VERSION:?set DATARAUM_VERSION to a released tag}
+    pull_policy: always
+
+  cockpit:
+    image: ghcr.io/dataraum/dataraum-cockpit:${DATARAUM_VERSION:?set DATARAUM_VERSION to a released tag}
+    pull_policy: always

--- a/packages/infra/docker-compose.yml
+++ b/packages/infra/docker-compose.yml
@@ -1,5 +1,13 @@
 # DataRaum platform stack — Postgres + Temporal + engine activity worker (Python) + cockpit (TanStack Start).
 #
+# This file BUILDS the engine + cockpit images from this checkout — it is the
+# dev / CI / local-smoke face. To run the PUBLISHED release images instead (a
+# deploy host, no build toolchain), overlay docker-compose.release.yml, which
+# pins the app services to `image: ghcr.io/dataraum/...:$DATARAUM_VERSION`:
+#   DATARAUM_VERSION=1.2.3 docker compose \
+#     -f packages/infra/docker-compose.yml -f packages/infra/docker-compose.release.yml \
+#     up -d --wait --no-build
+#
 # Run from workspace root:
 #   docker compose -f packages/infra/docker-compose.yml --env-file packages/infra/.env up -d --wait
 # Or via the root Makefile:

--- a/zensical.toml
+++ b/zensical.toml
@@ -9,6 +9,7 @@ nav = [
   "index.md",
   { "Getting Started" = [
     "getting-started/overview.md",
+    "getting-started/running-the-stack.md",
   ] },
   { "Concepts" = [
     "concepts/approach.md",

--- a/zensical.toml
+++ b/zensical.toml
@@ -20,6 +20,9 @@ nav = [
   { "Under the hood" = [
     "platform/architecture.md",
   ] },
+  { "Operations" = [
+    "operations/deployment.md",
+  ] },
   { "Vision" = [
     "vision/architecture-future.md",
   ] },


### PR DESCRIPTION
## What

Turns the release into a **pure multi-image GHCR publish** off one git tag, and retires the dead PyPI path.

The engine ships as a container (Temporal worker), never a pip package — its PyPI publish + tag-vs-pyproject preflight existed only for the dead `dataraum-mcp` distribution (DAT-325/487). The git tag is now the single version source; every image is tagged `:{tag}` + `:latest`.

### Release workflow → three images off one tag
| Image | From | Role |
|---|---|---|
| `ghcr.io/dataraum/dataraum` | `worker.Dockerfile` | engine worker (unchanged) |
| `ghcr.io/dataraum/dataraum-cockpit` | cockpit runner stage | the app |
| `ghcr.io/dataraum/dataraum-cockpit-migrate` | cockpit `build` stage | one-shot `cockpit_db` migrator |

Preflight keeps only the doc-count check. The engine's `ws_<id>` schema needs no migrate step (the worker self-bootstraps at boot); `cockpit_db` migrations run from the migrate image before the cockpit serves, mirroring the existing `cockpit-migrate` compose service.

### Deploy story — new `docker-compose.release.yml` overlay
The base `docker-compose.yml` **still builds from source** (dev / CI / local smoke untouched — no stale-image footgun). A new overlay pins the app services to the published tags (`pull_policy: always`) for deploy hosts:

```
DATARAUM_VERSION=1.2.3 docker compose \
  -f packages/infra/docker-compose.yml -f packages/infra/docker-compose.release.yml \
  --env-file packages/infra/.env up -d --wait --no-build
```

`--no-build` makes it pull-only (fails loud on a bad tag instead of silently building). `DATARAUM_VERSION` is required by the overlay and documented in `.env.example`. All app services share one `DATARAUM_VERSION`, so the cockpit's baked read-mirror can't drift from the deployed engine.

### Also
- Drop the two dead PyPI README badges + the stale `mcp-name` manifest comment.
- Pin the schema-drift scratch Postgres to `18` (was `17`) to match compose/prod — the gate now introspects the same PG version it ships. Regenerated with zero diff.

## Verification
- Base compose resolves with **0** ghcr refs (builds from source); overlay pulls all three tags and **fails loud** without `DATARAUM_VERSION` (dry-run confirmed pull-only under `--no-build`).
- `release.yml` parses (jobs: preflight → engine, cockpit).
- `db:pull:metadata` on PG 18 → no drift in `schema.sql` / `schema_read.sql` / `src/db/metadata/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)