### PR TITLE
docs: phase-0 hygiene — retire stale pre-pivot claims, reframe index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ handling, and the per-workspace topology.
 ## Develop
 
 - **Engine (Python):** `cd packages/engine && uv sync --group dev && uv run pytest --testmon tests/unit -q`. See `packages/engine/README.md` and `packages/engine/CLAUDE.md`.
-- **Cockpit (TypeScript):** `cd packages/cockpit && bun install && bun run dev`. See `packages/cockpit/README.md` and `packages/cockpit/CLAUDE.md`.
+- **Cockpit (TypeScript):** `cd packages/cockpit && bun install && bun --bun run dev` (the `--bun` flag is required). See `packages/cockpit/README.md` and `packages/cockpit/CLAUDE.md`.
 - **Pull the engine metadata schema (cockpit):** `cd packages/cockpit && DATARAUM_WORKSPACE_ID=<id> METADATA_DATABASE_URL=<url> bun run db:pull:metadata`. Re-run after the engine adds/changes SQLAlchemy models.
 
 ## Documentation
@@ -87,4 +87,4 @@ uv run --project packages/engine zensical serve   # run from the repo root
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/docs/adr/0011-measurement-pack.md
+++ b/docs/adr/0011-measurement-pack.md
@@ -1,4 +1,4 @@
-# ADR-0009 — Entropy measurements ship as the 7-piece measurement pack; all numbers live in config
+# ADR-0011 — Entropy measurements ship as the 7-piece measurement pack; all numbers live in config
 
 - **Status:** Accepted
 - **Date:** 2026-06-10

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,19 +24,5 @@ record). When code and an ADR disagree, the code wins and the ADR needs a supers
 - Decisions are immutable once `Accepted`. To change one, write a **new** ADR that
   supersedes it and flip the old one's status to `Superseded by ADR-NNNN`.
 - Link the long-form design (Confluence DD space) and the driving ticket (Jira DAT-*).
-- Add a one-line pointer? No — the directory listing *is* the index. Keep titles descriptive.
-
-## Index
-
-- [0001 — Temporal orchestration: Python workflows + activities on one worker](./0001-temporal-orchestration-python.md)
-- [0002 — Engine is a pure Temporal activity worker (no HTTP / MCP transport)](./0002-engine-no-http-transport.md)
-- [0003 — Postgres schema ownership: engine `ws_<id>`, cockpit `cockpit_db`, never shared](./0003-postgres-schema-ownership.md)
-- [0004 — Agent-tier boundary: agentic LLM in the cockpit, durable pipeline in the engine](./0004-agent-tier-boundary.md)
-- [0005 — Knowledge lives where its consumer reads it (memory / ADRs / Confluence / Jira)](./0005-knowledge-management.md)
-- [0006 — Team-lead operating model: parallel lanes, gates at the intent layer](./0006-team-lead-operating-model.md)
-- [0007 — Frame frozen-artifact contract: concept overlay rows as the engine↔cockpit grounding input](./0007-frame-frozen-artifact-contract.md)
-- [0008 — Promoted reads are enforced by the database (head-joined views + grants), not by reader convention](./0008-promoted-read-views.md)
-- [0010 — Failure contract: (key, run_id) idempotent writers; skips and deletes are exceptions](./0010-failure-contract-idempotent-writers.md)
-- [0009 — Entropy measures disagreement between witnesses; no deterministic semantic overrides](./0009-entropy-as-disagreement.md)
-- [0011 — Entropy measurements ship as the 7-piece measurement pack; all numbers live in config](./0011-measurement-pack.md)
-- [0014 — Cockpit orchestration worker: TS JourneyWorkflow owns stage execution (amends 0001)](./0014-cockpit-orchestration-worker.md)
+- No hand-maintained index — the directory listing *is* the index (a previous hand list
+  here drifted out of date). Keep titles descriptive.

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -6,8 +6,9 @@ after each, the relevant [detectors](measurement.md) update the entropy scores. 
 the map of those phases.
 
 The phases are grouped into the three engine analysis stages. How they are *scheduled* (as
-Temporal workflows and activities) is [orchestration](../platform/orchestration.md); here we
-care about what each one does.
+Temporal workflows and activities) is the
+[platform architecture](../platform/architecture.md)'s concern; here we care about what
+each one does.
 
 ## Two ground rules
 
@@ -20,8 +21,7 @@ the run. This is what lets messy real-world sources in without a brittle import 
 overwriting. A terminal **promote** step flips a per-stage pointer to the new run only once
 the run has succeeded, so a failed or partial run never becomes visible. "The current state"
 is always a clean, complete run. (The mechanics — heads, promoted read views, idempotent
-writers — are [substrate](../platform/substrate.md), per
-[ADR-0008](../adr/0008-promoted-read-views.md) and
+writers — are in [ADR-0008](../adr/0008-promoted-read-views.md) and
 [ADR-0010](../adr/0010-failure-contract-idempotent-writers.md).)
 
 ## add_source — raw sources to typed, annotated data

--- a/docs/concepts/the-journey.md
+++ b/docs/concepts/the-journey.md
@@ -34,7 +34,7 @@ Two things are worth holding onto before the details:
 - **Where each stage runs.** The interactive, agentic stages (**frame**, **answer**) run in
   the cockpit. The heavy analysis stages (**add_source**, **begin_session**,
   **operating_model**) run in the engine as durable Temporal workflows. This split is
-  deliberate — see [orchestration](../platform/orchestration.md).
+  deliberate — see the [platform architecture](../platform/architecture.md).
 - **What persists.** Typed sources, the workspace, and the operating model persist as named
   artifacts. So do your **teaches** — every correction you make survives a stage re-run.
   What does *not* persist is an agent's in-loop reasoning; agents are stateless across runs.
@@ -128,5 +128,5 @@ Re-entering an earlier stage cascades to the stages built on top of it — re-ty
 invalidates the workspace and operating model that were built from it. The cockpit shows the
 cost before you commit, and because **teaches persist**, a re-run reapplies everything you
 previously taught. Going back is a deliberate act with visible consequences, not a silent
-reset. How that cascade is actually executed is covered in
-[orchestration](../platform/orchestration.md).
+reset. How that cascade is actually executed is covered in the
+[platform architecture](../platform/architecture.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,10 +25,12 @@ durable artifact at the end: the concepts, processes, rules, and measures that u
 in scattered tools and tribal knowledge, now expressed as something you can run, measure,
 and ask questions against.
 
-What it produces is **data understanding** in a literal sense — and that is why we call it
-that. The deliverable is not a cleaned table or a dashboard; it is a *measured account of how
-well the system comprehends each part of your data* — solid here, shaky there — carried
-alongside the model so you always know how far to trust it.
+The deliverable is not a cleaned table or a dashboard. It is that model **plus a measured
+account of how well the system comprehends each part of your data** — solid here, shaky
+there — carried alongside it, so you always know how far to trust it. That is *data
+understanding* in a literal sense, and it is why we call DataRaum an **understanding
+layer**: the layer between your data and an LLM that holds what the system understands —
+and how well.
 
 ## Why you can trust the LLM here
 
@@ -99,12 +101,29 @@ picture, not over one source at a time.
 
 ## How you use it
 
-You work in a **workspace** through a web cockpit. Nothing about your domain is baked in:
-you **describe what you care about in plain language**, and DataRaum builds the model with
-you. The journey is short — describe your domain (**frame**), **connect** your sources,
-**stage** an analytical session, build the **operating model**, then **ask** questions in
-plain language and get answers grounded in that model, with the SQL and the confidence
-shown. See the [Overview](getting-started/overview.md) for the whole arc.
+You work in a **workspace** through the web cockpit. Nothing about your domain is baked in:
+you describe what you care about in plain language, and DataRaum builds the model with you.
+The work happens in three kinds of chat, each pairing an agent with a working canvas:
+
+- **Connect** — bring data in. Assemble an import set (upload files, probe a database),
+  **frame** your domain — declare the concepts you care about, or adopt a shipped vertical
+  as a head start — and import. An autonomous grounding loop types and re-grounds what it
+  can on its own, surfacing only the gaps that need you.
+- **Stage** — teach the model what things *mean*, then run an analytical session over the
+  typed tables — relationships, dimensions, drivers — and build the operating model
+  (validations, cycles, metrics) over the combined picture.
+- **Analyse** — ask questions in plain language. Answers come back grounded: the SQL that
+  produced them, the concepts they touched, and a confidence you can inspect — never a bare
+  number.
+
+Around the chats sit the standing surfaces: the **Model** graph (the operating model as a
+navigable graph over your actual columns), **Governance** (the workspace's state of the
+union), **Runs** (everything in flight, and what needs you), and **Reports** (a frozen
+answer whose SQL re-runs live on every open — and which tells you when the data has moved
+under it).
+
+See the [Overview](getting-started/overview.md) for the whole arc, and
+[Running the stack](getting-started/running-the-stack.md) to bring it up.
 
 ## Where to go next
 
@@ -113,10 +132,10 @@ shown. See the [Overview](getting-started/overview.md) for the whole arc.
   [pipeline & phases](concepts/pipeline.md), the
   [learnable surface](concepts/learnable-surface.md) (the closed vocabulary), and
   [measurement & detectors](concepts/measurement.md) (entropy, witnesses, calibration).
-- **Using it** — [Overview](getting-started/overview.md),
-  [Running the stack](getting-started/running-the-stack.md), and
-  [the Cockpit](cockpit/cockpit.md).
+- **Using it** — [Overview](getting-started/overview.md) and
+  [Running the stack](getting-started/running-the-stack.md).
 - **Under the hood** — the [platform architecture](platform/architecture.md), the
-  [substrate](platform/substrate.md), and [orchestration](platform/orchestration.md).
+  [decision records](adr/README.md), and [Deployment](operations/deployment.md) for
+  running released images.
 - **The design intent** (north-star, not current state) —
   [Architecture (vision)](vision/architecture-future.md).

--- a/docs/platform/architecture.md
+++ b/docs/platform/architecture.md
@@ -73,8 +73,9 @@ flowchart LR
 **Object store (S3)** — the data lake lives here, not on a local disk. The engine writes
 typed/staged data as parquet under the workspace's lake prefix; file uploads land under an
 `uploads/` prefix in the same bucket. In dev this is a single-node **SeaweedFS** S3
-gateway; in production it is a real object store with real IAM. ([Substrate](substrate.md)
-covers DuckLake-on-S3 in detail.)
+gateway; in production it is a real object store with real IAM. (The per-workspace lake
+prefix and catalog layout are in
+[ADR-0012](../adr/0012-per-workspace-tenancy.md).)
 
 **Temporal** — the durable orchestration backbone. Both workers poll it; it guarantees
 long-running analysis survives restarts and is retried correctly.
@@ -89,8 +90,9 @@ Because there is no HTTP between them, the seam is two channels, and only two:
 The cockpit triggers analysis by starting **engine workflows** by name on the workspace's
 task queue. The engine worker bundles three analysis workflows
 (`add_source`, `begin_session`, `operating_model`) plus a per-table child workflow. The
-cockpit never runs analysis itself. See [orchestration](orchestration.md) for the full run
-flow.
+cockpit never runs analysis itself. The full orchestration model is in
+[ADR-0001](../adr/0001-temporal-orchestration-python.md) and
+[ADR-0014](../adr/0014-cockpit-orchestration-worker.md).
 
 ### 2. Metadata flows through promoted Postgres views
 
@@ -163,6 +165,6 @@ per-workspace template.
 
 ## Next
 
-- [Substrate](substrate.md) — Postgres, DuckLake-on-S3, and the run-versioning model.
-- [Orchestration](orchestration.md) — how a run actually flows through Temporal.
+- [Decision records](../adr/README.md) — the settled architecture decisions and the *why*
+  behind each one.
 - [How it works](../concepts/the-journey.md) — the journey and the model behind it.

--- a/docs/vision/architecture-future.md
+++ b/docs/vision/architecture-future.md
@@ -85,9 +85,16 @@ The learnable surface is the set of things the system can be taught about a spec
 | **concept_property** | A patch to a column's semantic annotation (role, concept, unit) |
 | **explanation** | Domain context attached to an entropy observation, an artifact, or a validation result, optionally with evidence SQL. Explanations annotate; they do not adjudicate — they cannot suppress observations, alter scores, or affect groundedness. |
 
+!!! note "How this maps to the live set"
+    The **implemented** vocabulary is documented in
+    [the learnable surface](../concepts/learnable-surface.md), and it differs from this
+    target list in both directions: `validation_exception` and `explanation` are **not
+    built yet**, while three types that exist today — `unit`, `rebind`,
+    `expected_dependency` — postdate this list.
+
 The set is closed *for the agent in the loop*. An agent cannot invent a new kind of thing to teach; it can only fill in the types that exist. A user reviewing the agent's proposals sees the same types. The system, the agent, and the user share one vocabulary. This is the **Goodhart firewall**: the agent can only optimize against signals the closed set was designed to surface.
 
-Adding a teach type is a deliberate architectural act, not an in-loop action. The current ten types are well-shaped for finance and operations; other domains may require first-class types that do not fit, and adding them is handled at the architecture level.
+Adding a teach type is a deliberate architectural act, not an in-loop action. These types are well-shaped for finance and operations; other domains may require first-class types that do not fit, and adding them is handled at the architecture level.
 
 ### The artifact lifecycle
 

--- a/packages/cockpit/CLAUDE.md
+++ b/packages/cockpit/CLAUDE.md
@@ -53,7 +53,7 @@ bun run test                         # vitest
 
 ## Stack
 
-TanStack **Start** (React 19) · **Router** / **Query** · **Mantine v9** + **Tailwind v4** · **Drizzle** + `postgres` · **Temporal** (`@temporalio/client` triggers the Python engine workflows; `@temporalio/worker` runs the co-located TS **orchestration** worker — DAT-529) · **Biome** · **Vitest** · strict TypeScript. The wider ecosystem (TanStack AI, xyflow, ECharts, CodeMirror, Arrow JS) lands as widgets need it — see the [Tech Stack](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/18153474) page.
+TanStack **Start** (React 19) · **Router** / **Query** · **Mantine v9** + **Tailwind v4** · **Drizzle** + `postgres` · **Temporal** (`@temporalio/client` triggers the Python engine workflows; `@temporalio/worker` runs the co-located TS **orchestration** worker — DAT-529) · **Biome** · **Vitest** · strict TypeScript. The wider ecosystem (TanStack AI, xyflow, Vega-Lite — charting per [ADR-0015](../../docs/adr/0015-charting-library-vega-lite.md), NOT ECharts — CodeMirror, Arrow JS) lands as widgets need it — see the [Tech Stack](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/18153474) page.
 
 ## How it fits together
 

--- a/packages/cockpit/README.md
+++ b/packages/cockpit/README.md
@@ -1,10 +1,10 @@
 # cockpit
 
-The DataRaum cockpit — TanStack Start app that hosts the chat surface and renders the agentic UI. One of three packages in the [dataraum](https://github.com/dataraum/dataraum) monorepo (`engine`, `cockpit`, `infra`).
+The DataRaum cockpit — the TanStack Start web app you actually use. One of four packages in the [dataraum](https://github.com/dataraum/dataraum) monorepo (`engine`, `cockpit`, `dataraum-config`, `infra`).
 
-## Status
+## What it is
 
-Read surfaces (sources, tables, snippets) land in Phase 1 of the [DAT-339 pivot](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/23363586) — wired via Drizzle direct against the engine's metadata schema. The chat surface (`/api/chat`) streams via the Anthropic SDK; tool wiring lands alongside the read surfaces in Phase 1+.
+The cockpit is the product surface: typed chats (**Connect** / **Stage** / **Analyse**) with an agent canvas, plus the standing views — the operating-**Model** graph, **Governance**, **Runs**, and minted **Reports**. It hosts the chat agent (streaming via the Anthropic SDK), reads engine metadata straight from Postgres, and drives the engine's durable analysis by starting Temporal workflows. It also runs its own co-located TS **orchestration worker** for control-plane workflows (grounding loop, session cascade) — analysis itself stays in the Python engine.
 
 ## Stack
 
@@ -18,26 +18,28 @@ Read surfaces (sources, tables, snippets) land in Phase 1 of the [DAT-339 pivot]
 - **Vitest** — tests
 - **TypeScript** only, strict
 
-The full ecosystem pick (TanStack AI, xyflow, ECharts, CodeMirror, sql-formatter, marked, Arrow JS, etc.) lands as the corresponding widgets get built. See [Web UI: Tech Stack](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/18153474).
+Also in the stack: **TanStack AI** (the agent loop + tool streaming), **xyflow / React Flow** (the operating-model canvas), **Vega-Lite** (agent-authored charts, [ADR-0015](../../docs/adr/0015-charting-library-vega-lite.md)), **CodeMirror** (SQL editing), **marked** (chat markdown).
 
 ## Architecture
 
 ```
-Browser  ──── /api/chat (SSE) ────→  TanStack Start (this app)
-                                       ├── Anthropic streaming
-                                       ├── Tool registry (TS fns calling kernel verbs + metadata Drizzle)
-                                       └── cockpit_db (Drizzle → shared Postgres)
+Browser ── /api/chat + /api/chat-stream (SSE) ──→ TanStack Start (this app)
+                                                    ├── Anthropic streaming (TanStack AI agent loop)
+                                                    ├── Tool registry (TS fns over Drizzle metadata + Temporal)
+                                                    ├── cockpit_db (Drizzle → chat, reports, control plane)
+                                                    └── co-located TS orchestration worker (@temporalio/worker)
 
-TanStack Start ──── metadata reads ───────→  engine's ws_<id> schema  (Drizzle, src/db/metadata/)
-               ──── /measure SSE, /query Arrow, /probe SQL ───→  Starlette kernel (engine REST)
+TanStack Start ── metadata reads ──→ engine's ws_<id> schema (Drizzle, src/db/metadata/)
+               ── workflow starts ──→ Temporal ──→ engine worker (Python, the analysis)
 ```
 
-The engine exposes three verbs (`/measure`, `/query`, `/probe`) plus `/health` over a Starlette shell. Metadata is consumed directly via Drizzle introspection — no OpenAPI, no codegen anymore (retired in the DAT-339 pivot).
+The engine has **no HTTP surface** ([ADR-0002](../../docs/adr/0002-engine-no-http-transport.md)): the seam is Postgres + Temporal, nothing else. Metadata is consumed via a generated Drizzle mirror — no OpenAPI, no codegen.
 
 ## Sibling packages
 
-- `../engine` — Python engine + Starlette kernel shell at `src/dataraum/server/`
-- `../infra` — docker-compose orchestrating engine + cockpit + postgres
+- `../engine` — Python analysis engine, a Temporal activity worker (no HTTP)
+- `../dataraum-config` — YAML data (entropy config, LLM prompts, verticals); bind-mounted, never imported
+- `../infra` — docker-compose orchestrating postgres + object store + Temporal + engine + cockpit
 
 ## Develop
 
@@ -82,4 +84,4 @@ Two clients in one package:
 - `src/db/cockpit/{schema,client,registry,runs}.ts` — hand-written cockpit_db (generate/migrate target); committed migrations in `drizzle/cockpit/`
 - `src/db/metadata/{schema,relations,client}.ts` — generated from the engine substrate by `bun run db:pull:metadata`; the cockpit reads, never pushes
 
-cockpit_db is the cockpit's control plane (DAT-461): `workspaces` / `sessions` / `session_runs` / `actors` — additive to the engine's `investigation_sessions` run anchor. Migrations apply on the compose stack via the `cockpit-migrate` one-shot service; registry/actor rows seed lazily on first resolve. More tables land as needed (conversations + conversation_messages are the next addition, DAT-462).
+cockpit_db is the cockpit's own persistence: the control plane (`workspaces` / `sessions` / `session_runs` / `actors`) plus the chat transcript (`conversations` / `conversation_messages`) and reports — additive to the engine's `investigation_sessions` run anchor. Migrations apply on the compose stack via the `cockpit-migrate` one-shot service; registry/actor rows seed lazily on first resolve.

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -1,141 +1,101 @@
-# DataRaum Context Engine
+# DataRaum Engine
 
-[![License](https://img.shields.io/github/license/dataraum/dataraum)](LICENSE)
+[![License](https://img.shields.io/github/license/dataraum/dataraum)](../../LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/dataraum/dataraum/ci.yml?branch=main)](https://github.com/dataraum/dataraum/actions)
 
-A rich metadata context engine for AI-driven data analytics.
+The Python half of [DataRaum](../../README.md) — the durable analysis engine. It runs as a
+**Temporal activity worker** with no HTTP surface: the cockpit starts its workflows by name
+and reads the metadata it writes straight from Postgres. What DataRaum is and why it works
+this way is in the [platform docs](../../docs/index.md); this README is the package-level
+map.
 
-Traditional semantic layers tell BI tools "what things are called." DataRaum tells AI "what the data means, how it behaves, how it relates, and what you can compute from it."
+## What it does
 
-The core insight: AI agents don't need tools to discover metadata at runtime. They need **rich, pre-computed context** delivered in a format optimized for LLM consumption.
+The engine owns the three durable analysis stages of the journey, each a Temporal workflow:
 
-## Status — transitioning to v1
+- **`add_source`** — imports sources VARCHAR-first (failed casts go to quarantine tables,
+  never fail the run), infers types, profiles statistics, and grounds per-column meaning
+  with an LLM.
+- **`begin_session`** — works out how the tables relate (value overlap → referential-
+  integrity evaluation → LLM confirmation), builds enriched join views, finds sliceable
+  dimensions and hierarchies, reconciles measures across facts (stock vs. flow), and ranks
+  drivers.
+- **`operating_model`** — grounds and executes the declared model: validations, business
+  cycles, and metrics (LLM-authored SQL over deterministic grounding evidence,
+  [ADR-0016](../../docs/adr/0016-metric-sql-grounding-llm-authoring.md)).
 
-DataRaum is mid-pivot. v0.2.x exposed a 12-tool MCP server over HTTP for use from Claude Code / Claude Desktop. **That transport is gone.** This package is one of four in the monorepo:
+After each stage a terminal detector pass measures **entropy** — disagreement between
+independent witnesses — and rolls it up into per-intent readiness (*ready / investigate /
+blocked*). Every run is versioned: phases append run-stamped rows, and a promote step makes
+a run visible only once it has fully succeeded.
 
-- **engine** (this package) — Python pipeline + thin FastAPI REST shell
-- **`../cockpit`** — TanStack Start web UI that hosts the chat surface and renders the agentic widgets
-- **`../api`** — OpenAPI contract generated from the engine, consumed by the cockpit
-- **`../infra`** — docker-compose orchestration
+Concepts in depth: [pipeline & phases](../../docs/concepts/pipeline.md) ·
+[measurement & detectors](../../docs/concepts/measurement.md) ·
+[the journey](../../docs/concepts/the-journey.md) ·
+[platform architecture](../../docs/platform/architecture.md).
 
-Today the engine runs as a **Temporal activity worker** (no HTTP surface): it bootstraps the substrate, then serves the bundled `AddSourceWorkflow` + phase activities; the cockpit triggers workflows via the Temporal Client and reads metadata via Drizzle. **No end-user surface yet** — if you need v0.2.x MCP behavior, pin `dataraum==0.2.2`.
+## How it fits the monorepo
 
-## Quick Start (substrate + cockpit — v1 surface in development)
+One of four packages (see the [root README](../../README.md)):
 
-Run from the workspace root.
+- **engine** (this package) — Python pipeline, detectors, Temporal activity worker.
+- **`../cockpit`** — TanStack Start web app: the chat agent, the canvas, and a co-located
+  TS orchestration worker.
+- **`../dataraum-config`** — YAML data (entropy contracts, LLM prompts, verticals);
+  bind-mounted, never imported.
+- **`../infra`** — docker-compose orchestration.
+
+The engine↔cockpit seam is **Postgres + Temporal, nothing else** — no HTTP, no OpenAPI, no
+codegen ([ADR-0002](../../docs/adr/0002-engine-no-http-transport.md)). The engine owns the
+workspace's `ws_<id>` Postgres schema (SQLAlchemy); the cockpit reads it through a generated
+Drizzle mirror. `schema.sql` in this package is the generated offline DDL dump of all
+models — regenerate with `uv run python -m dataraum.storage.dump_ddl`, never hand-edit
+(CI fails on drift).
+
+## Run it
+
+From the workspace root — full walkthrough in
+[Running the stack](../../docs/getting-started/running-the-stack.md):
 
 ```bash
-# Set the LLM key (the engine needs it; the substrate boot does not)
-cp packages/infra/.env.example packages/infra/.env
-echo "ANTHROPIC_API_KEY=sk-ant-..." >> packages/infra/.env
-
-# Bring up Postgres + Temporal + engine worker + cockpit
 docker compose -f packages/infra/docker-compose.yml up -d --wait
-
-# Verify the engine worker — its health is the Temporal heartbeat (no HTTP):
+# Engine health = the Temporal worker heartbeat (there is no HTTP endpoint):
 docker compose -f packages/infra/docker-compose.yml run --rm --no-deps \
   --entrypoint temporal temporal-admin-tools \
-  worker list --namespace default --address temporal:7233
-# → Status: Running   (on the dataraum-pipeline task queue)
-
-# Open the cockpit
-open http://localhost:3000
+  worker list --namespace default --address temporal:7233   # → Status: Running
 ```
 
-For UI iteration, skip the cockpit container and run the dev server outside
-docker for hot reload (see `../cockpit/README.md`). The compose cockpit
-service is for end-to-end smoke and prod-like serving.
-
-The engine runs a 19-phase analysis pipeline. The 12 tools the v1 cockpit exposes (also the shape the engine REST will publish, route by route):
-
-| Tool | Description |
-|------|-------------|
-| `add_source` | Register a data source (CSV, Parquet, JSON, directory, or MSSQL recipe yaml) |
-| `list_sources` | List sources registered in the workspace |
-| `begin_session` | Start an investigation session bound to one registered source |
-| `resume_session` | List archived sessions; restore one and make it active again |
-| `look` | Explore data structure, relationships, and semantic metadata |
-| `measure` | Measure entropy scores, readiness, and data quality |
-| `why` | Explain elevated entropy and propose teach suggestions |
-| `teach` | Extend the operation model — sole write tool (concepts, metrics, validations, ...) |
-| `query` | Natural language query against the data |
-| `run_sql` | Execute SQL directly with export support |
-| `search_snippets` | Discover reusable SQL patterns from prior queries and graph execution |
-| `end_session` | Archive workspace and end the session |
-
-### Typical Workflow (the shape the v1 cockpit will surface)
-
-```
-add_source(name="accounting", path="/var/lib/dataraum/sources/accounting")
-  → begin_session(source="accounting",
-                  intent="explore data quality",
-                  contract="exploratory_analysis")
-  → look()                    # Understand the data
-  → measure()                 # Check quality scores and readiness
-  → query("total revenue?")   # Ask questions
-  → run_sql(sql="...", export_format="csv", export_name="report")
-  → end_session(outcome="delivered")
-```
-
-Each session is bound to **one** registered source. The engine logic that powered these tools in v0.2.x lives in `src/dataraum/mcp/server.py`; the v1 plan extracts it into FastAPI route handlers as the cockpit needs each route.
-
-## What It Produces
-
-DataRaum analyzes your data and generates:
-
-- **Statistical metadata** — distributions, cardinality, null rates, patterns
-- **Semantic metadata** — column roles, entity types, business terms (LLM-powered)
-- **Topological metadata** — relationships, join paths, hierarchies
-- **Temporal metadata** — granularity, gaps, seasonality, trends
-- **Quality metadata** — rules, scores, anomalies
-- **Entropy scores** — uncertainty quantification across all dimensions
-- **Ontological context** — domain-specific interpretation (financial, marketing, etc.)
-
-## LLM Configuration
-
-Semantic analysis requires an Anthropic API key. Set `ANTHROPIC_API_KEY` in your `.env` before `docker compose up`. The container reads it from the compose env.
-
-Configure the LLM provider in `config/llm/config.yaml`. See [Configuration](docs/configuration.md) for details.
+`ANTHROPIC_API_KEY` is a hard dependency of the analysis pipeline — set it in
+`packages/infra/.env` before bringing the stack up. LLM provider and prompt configuration
+live in `packages/dataraum-config/llm/`.
 
 ## Development
 
 Run from this package directory (`packages/engine/`).
 
 ```bash
-# Install with dev dependencies (using uv)
-uv sync --group dev
-
-# Run tests
-uv run pytest --testmon tests/unit -q
-
-# Type check
-uv run mypy src/
-
-# Lint
-uv run ruff check src/
+uv sync --group dev                     # install with dev dependencies
+uv run pytest --testmon tests/unit -q   # tests (testmon re-runs only what's affected)
+uv run mypy src/                        # type check
+uv run ruff check src/                  # lint
 uv run ruff format --check src/
+```
 
-# Run the engine activity worker locally (without docker; needs a reachable Temporal)
-export DUCKLAKE_CATALOG_URL=postgresql://...
-export DUCKLAKE_DATA_PATH=/var/lib/dataraum/lake
-export DATABASE_URL=postgresql://...
-export DATARAUM_HOME=/var/lib/dataraum/workspace
-export DATARAUM_WORKSPACE_ID=00000000-0000-0000-0000-000000000001
-export ANTHROPIC_API_KEY=sk-ant-...
-export TEMPORAL_HOST=localhost:7233 TEMPORAL_NAMESPACE=default TEMPORAL_TASK_QUEUE=dataraum-pipeline
+To run the worker directly against an already-running substrate (Postgres, Temporal, object
+store), export the env the compose file wires for the `engine-worker` service —
+`packages/infra/docker-compose.yml` is the authoritative list (`DATABASE_URL`,
+`DUCKLAKE_*`, `DATARAUM_WORKSPACE_ID`, `TEMPORAL_*` with the workspace's task queue per
+[ADR-0012](../../docs/adr/0012-per-workspace-tenancy.md), `ANTHROPIC_API_KEY`) — then:
+
+```bash
 uv run python -m dataraum.worker.main
 ```
 
-## Documentation
-
-Platform docs live at the workspace root in [`docs/`](../../docs/index.md) (published via
-Zensical). The engine's pipeline, entropy/measurement model, and journey are covered there:
-
-- [Pipeline & phases](../../docs/concepts/pipeline.md)
-- [Measurement & detectors](../../docs/concepts/measurement.md)
-- [The journey](../../docs/concepts/the-journey.md)
-- [Platform architecture](../../docs/platform/architecture.md)
+Two things to know before testing: **e2e tests make real LLM calls** — don't run them
+casually; and detector correctness is proven by **calibration** against ground-truth data
+(recall on known injections, precision on clean data) in the separate `dataraum-eval`
+repo, not by unit tests alone.
 
 ## License
 
-Apache 2.0 — see [LICENSE](LICENSE).
+Apache 2.0 — see [LICENSE](../../LICENSE).

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "DataRaum"
-site_description = "The understanding layer that grounds a business's operating model in its own data"
+site_description = "The understanding layer that grounds an organization's operating model in its own data"
 site_url = "https://dataraum.github.io/dataraum"
 docs_dir = "docs"
 


### PR DESCRIPTION
Phase 0 of the documentation overhaul: stop the bleeding before restructuring. The published site's story was largely sound; the periphery contradicted it.

## Fixes

- **engine README** — rewritten against the current architecture. It still sold the pre-pivot world: the 12-tool MCP server, a planned FastAPI/REST surface (rejected by ADR-0002), the retired `../api` package, "one source per session", and a `dataraum-pipeline` task queue. Now: Temporal activity worker, the three analysis workflows, the Postgres+Temporal seam, calibration note.
- **License contradiction** — the `LICENSE` file is **Apache 2.0**; the root README claimed MIT. Fixed in that direction (engine pyproject already says Apache-2.0).
- **cockpit README** — the Architecture section described Starlette "kernel verbs" (`/measure`, `/query`, `/probe`) that were never built. Replaced with the real seam (Drizzle metadata reads + Temporal workflow starts + the co-located TS orchestration worker) and the shipped surface (Connect/Stage/Analyse chats, Model/Governance/Runs/Reports).
- **ECharts ghost** — charting is Vega-Lite per ADR-0015; the implementation matches (`src/charts/` lifts a thin zod subset to a compiled Vega-Lite spec). Two stale pre-decision "ecosystem" lists still named ECharts — fixed (cockpit README + CLAUDE.md).
- **ADR housekeeping** — `docs/adr/README.md`'s hand-written index had drifted (missing 0012–0017, misordered); deleted per the file's own "the directory listing *is* the index" rule. ADR-0011's H1 wrongly said "ADR-0009" — fixed.
- **Dangling links** — `platform/substrate.md`, `platform/orchestration.md`, and `cockpit/cockpit.md` were linked from 4 pages but never written. Retargeted to the platform architecture page and the covering ADRs (0001, 0012, 0014). Dedicated deep pages can come later if wanted.
- **Built-vs-planned reconciliation** — the vision doc's 10-type teach table now carries a note mapping it to the live 11-type set (`validation_exception`/`explanation` unbuilt; `unit`/`rebind`/`expected_dependency` postdate the list).

## The reframe (judge the voice here)

**`docs/index.md`** — two deliberate changes:
1. The "understanding layer" coin is now **earned as a conclusion** (after the deliverable + trust story) instead of asserted as a category the reader should recognize.
2. "How you use it" now speaks the **cockpit's vocabulary** — Connect/Stage/Analyse chats plus the standing surfaces (Model, Governance, Runs, Reports) — instead of engine stage names. The engine vocabulary stays in the concepts/under-the-hood pages.

Also unified the site description ("an organization's", matching the README one-liner).

## Verification

- Zensical build: clean, no issues.
- All relative `.md` links across `docs/` + READMEs verified to resolve.

Phases 1–3 (concept pages: operating model, teach/frame/ground, relationships & aggregation, measurement split; ADR user-readiness sweep) follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)