### PR TITLE
docs: phase-1 concept spine + docs-wide sober voice

### DIFF
--- a/docs/concepts/approach.md
+++ b/docs/concepts/approach.md
@@ -1,23 +1,22 @@
 # The approach
 
-DataRaum's job is to recover the meaning latent in an organization's data and bind it to
-that data — reliably enough that an LLM can reason over the result. Two design choices make
-that possible: it **blends three kinds of method** instead of betting on one, and it treats
-their **disagreement as the thing to measure** rather than something to paper over.
+DataRaum recovers the meaning latent in an organization's data and binds it to that data.
+Two design choices define the approach: it **blends three kinds of method**, and it treats
+their **disagreement as the quantity to measure**.
 
 ## Why a blend
 
-Each obvious shortcut fails on its own:
+Each method fails on its own:
 
-- **Schema-only** (read the column names, trust them) is fast and wrong. Names lie, are
-  abbreviated, or mean different things in different sources.
-- **LLM-only** (hand everything to the model) is fluent and ungrounded. The model will
-  happily assert what a field means with no way to check it against the data, and no way to
-  tell you how sure it is.
-- **Statistics-only** (mine the data for patterns) is grounded but mute. It can tell you two
-  columns correlate; it can't tell you one is a price and the other a discount.
+- **Schema-only** (read the column names, trust them): names are abbreviated, misleading,
+  or mean different things in different sources.
+- **LLM-only** (hand everything to the model): the model asserts what a field means with no
+  check against the data and no calibrated statement of how sure it is.
+- **Statistics-only** (mine the data for patterns): it can establish that two columns
+  correlate; it cannot establish that one is a price and the other a discount.
 
-So DataRaum uses all three, each where it is authoritative, and makes them check each other.
+DataRaum uses all three, each where it is authoritative, and checks them against each
+other.
 
 | Method | What it does | Authoritative for |
 |---|---|---|
@@ -26,24 +25,23 @@ So DataRaum uses all three, each where it is authoritative, and makes them check
 | **LLM** | Field meaning, concept grounding, composing measures / rules / processes | *Meaning* — what the structure and shape represent in the business |
 
 The deterministic and statistical layers are cheap, reproducible, and certain where the
-data is certain. The LLM layer is reserved for the one thing only language understanding
-can supply — meaning — and is kept on a short leash (the
-[closed teach surface](learnable-surface.md) and the [firewall](measurement.md#the-goodhart-firewall)).
+data is certain. The LLM layer supplies the one thing only language understanding can —
+meaning — under the constraints of the [closed teach surface](learnable-surface.md) and
+the [firewall](measurement.md#the-goodhart-firewall).
 
 ## Disagreement is the signal
 
-The blend's real power is what happens when the methods **disagree**. A field named
-`created` that never holds a parseable date; a column the model calls an identifier that the
-data shows is highly repeated; a join the structure proposes that the values don't support —
-each is a *disagreement between witnesses*, and disagreement is exactly where understanding
-is missing.
+A field named `created` that never holds a parseable date; a column the model calls an
+identifier that the data shows is highly repeated; a join the structure proposes that the
+values don't support — each is a disagreement between witnesses, and disagreement marks
+where understanding is missing.
 
-DataRaum makes this literal. For each question worth asking about the data ("is this a
-date?", "does this token mean *missing*?", "is this column a stock or a flow?"), several
-**witnesses** weigh in — one reading the field name, one reading the data, one reading what
-you've taught — and a detector measures how much they **conflict** and how much **ignorance**
-remains (nobody qualified weighed in). That combined uncertainty is **entropy**. It is the
-one measurement primitive; there is no separate "data quality" score beside it.
+For each question worth asking about the data ("is this a date?", "does this token mean
+*missing*?", "is this column a stock or a flow?"), several **witnesses** weigh in — one
+reading the field name, one reading the data, one reading what you've taught — and a
+detector measures how much they **conflict** and how much **ignorance** remains (nobody
+qualified weighed in). That combined uncertainty is **entropy**. It is the one measurement
+primitive; there is no separate "data quality" score beside it.
 
 This is why no method is trusted alone: a witness that only reads the column name and a
 witness that only reads the data can be wrong in the same direction, so at least one witness
@@ -71,20 +69,16 @@ flowchart LR
 The phases themselves are covered in [the pipeline](pipeline.md); the stages a *user* walks
 through (which group the phases into bigger steps) are [the journey](the-journey.md).
 
-## Why the LLM stays honest
+## Constraints on the LLM
 
-Two mechanisms make the blend trustworthy with an LLM in the loop:
+Two mechanisms bound the LLM's role in the blend:
 
-- **A closed, typed surface.** The LLM can only fill in a fixed vocabulary — concepts,
-  measures, rules, and a handful of *teaches* — never extend it, and its free text is
-  recorded *alongside* a measurement, never allowed to change it. A correction re-enters
-  analysis as one more **witness** to be weighed, not as an edit to the score: it cannot make
-  a problem disappear by describing it. This is the **Goodhart firewall** — see
-  [the learnable surface](learnable-surface.md).
-- **Calibration against ground truth.** A detector's reliability is *measured*, not asserted:
-  each is run against datasets with injected issues and a recorded answer key and must show
-  recall and precision before its signal counts. That is why the readiness numbers mean
-  something — see [measurement & detectors](measurement.md).
-
-Together they give the system the property everything else rests on: **it cannot make false
-progress by hiding what it doesn't understand.**
+- **A closed, typed surface.** The LLM fills in a fixed vocabulary — concepts, measures,
+  rules, and a fixed set of *teaches* — and cannot extend it. Its free text is recorded
+  alongside a measurement and does not enter the score computation. A correction re-enters
+  analysis as one more **witness**, weighed with the others. This is the **Goodhart
+  firewall** — see [the learnable surface](learnable-surface.md).
+- **Calibration against ground truth.** A detector's reliability is measured: each is run
+  against datasets with injected issues and a recorded answer key, and must show recall and
+  precision before its signal enters readiness — see
+  [measurement & detectors](measurement.md).

--- a/docs/concepts/frame-ground-teach.md
+++ b/docs/concepts/frame-ground-teach.md
@@ -1,0 +1,90 @@
+# Frame, ground, teach
+
+Everything DataRaum knows about your organization arrived through one cycle: you **frame**
+what should be true, the engine **grounds** it in the data, and you **teach** it where
+it's wrong — which re-enters the next grounding as evidence. This page is that cycle: the
+three verbs, and why the system is built around them.
+
+```mermaid
+flowchart LR
+    F["<b>frame</b><br/>declare the vocabulary"]
+    G["<b>ground</b><br/>bind it to the data"]
+    T["<b>teach</b><br/>correct with evidence"]
+    F --> G
+    G -->|"measured, with gaps shown"| T
+    T -->|"re-enters as a witness"| G
+    style F fill:#fafafa
+    style G fill:#e8f5e9
+    style T fill:#e3f2fd
+```
+
+## Frame — declare what should be true
+
+Framing turns intent into vocabulary. You describe, in plain language, what your
+organization deals in and what you want to understand; that becomes **declared**
+artifacts — concepts, and the metrics, validations, and cycles built on them. Declared
+means exactly that: named and typed, with a target shape, and *no data backing yet*.
+
+Nothing about your domain is pre-configured. The concepts you frame **are** your
+workspace's vocabulary — and a bundle of framed knowledge can be shipped and reused as a
+[vertical](learnable-surface.md#verticals-reusable-starting-points), so a domain's
+accumulated understanding can seed a new workspace instead of starting from a blank page.
+
+Frame deliberately runs *before* the data is touched. The declaration is the standard the
+data gets measured against — not a summary written after the fact to fit whatever was
+found.
+
+## Ground — bind it to the data
+
+Grounding is the engine's half: walking the declarations and binding each one to actual
+columns, tables, and views. A concept grounds to the columns that carry it; a metric's
+extracts ground through concepts to real data; a validation grounds to the columns it
+constrains.
+
+Grounding is **earned, not asserted**. A declaration's name and indicators steer where to
+look — the data decides what holds. And the outcome is always visible, in both
+directions:
+
+- what grounds, grounds with **evidence** and a measured confidence behind it,
+- what doesn't stays **declared**, with the reason recorded — *"the data does not support
+  this"* is a first-class result, not a silent omission.
+
+The states an artifact moves through — declared → grounded → executed — are the
+[operating model's lifecycle](operating-model.md#the-lifecycle).
+
+## Teach — correct with evidence
+
+Grounding will get things wrong, and data needs interpretation no analysis can supply: a
+placeholder token that means *missing*, the unit a column is measured in, a join the
+engine didn't see, a concept bound to the wrong column. When that happens, you **teach** —
+a small, typed correction from a
+[closed set of teach types](learnable-surface.md#the-teach-types).
+
+The property that makes teaching safe is the one the whole system leans on: **a teach is
+evidence, not an override.** It does not edit a result or move a score. It re-enters the
+next run as one more *witness* — weighed against what the data itself says — and the
+grounding is re-earned with the new evidence in the pool. You cannot assert the system
+into agreeing; you can only give it better evidence. (This is the no-override half of the
+**Goodhart firewall**; the other half is
+[measurement it can't game](measurement.md#the-goodhart-firewall).)
+
+Teaches are also the most durable thing you create: they persist across every future run.
+Re-running a stage — even rebuilding the workspace from scratch — reapplies everything you
+ever taught.
+
+## The cycle in motion
+
+In practice the cycle runs as a loop against the readiness signal:
+
+1. the system **measures** what it doesn't yet understand and shows you where
+   (*ready / investigate / blocked*),
+2. you ask **why** — and get the disagreement behind the score, with the teaches that
+   would resolve it,
+3. you **teach**, the affected work re-runs, and the score moves — because the
+   understanding moved, not because anyone edited a number.
+
+That last clause is the point of the whole shape. Declaration, adjudication, and
+correction are kept structurally apart — the human declares and corrects, the data
+adjudicates, and nobody (human, agent, or the system itself) can write the conclusion
+directly. It is what lets an LLM do the heavy lifting while the result stays something
+you can trust.

--- a/docs/concepts/frame-ground-teach.md
+++ b/docs/concepts/frame-ground-teach.md
@@ -1,90 +1,73 @@
 # Frame, ground, teach
 
-Everything DataRaum knows about your organization arrived through one cycle: you **frame**
-what should be true, the engine **grounds** it in the data, and you **teach** it where
-it's wrong — which re-enters the next grounding as evidence. This page is that cycle: the
-three verbs, and why the system is built around them.
+Knowledge enters a workspace through three operations: **frame** declares the vocabulary,
+**ground** binds it to the data, **teach** corrects it. Corrections feed the next
+grounding, which closes the loop.
 
 ```mermaid
 flowchart LR
     F["<b>frame</b><br/>declare the vocabulary"]
-    G["<b>ground</b><br/>bind it to the data"]
-    T["<b>teach</b><br/>correct with evidence"]
+    G["<b>ground</b><br/>bind to the data"]
+    T["<b>teach</b><br/>typed correction"]
     F --> G
-    G -->|"measured, with gaps shown"| T
-    T -->|"re-enters as a witness"| G
+    G -->|"measured, gaps reported"| T
+    T -->|"enters the next run as a witness"| G
     style F fill:#fafafa
     style G fill:#e8f5e9
     style T fill:#e3f2fd
 ```
 
-## Frame — declare what should be true
+## Frame
 
-Framing turns intent into vocabulary. You describe, in plain language, what your
-organization deals in and what you want to understand; that becomes **declared**
-artifacts — concepts, and the metrics, validations, and cycles built on them. Declared
-means exactly that: named and typed, with a target shape, and *no data backing yet*.
+Framing records what the workspace is about: concepts, and the metrics, validations, and
+cycles defined over them. You describe this in plain language; the cockpit turns it into
+**declared** artifacts — typed entries with a name and a target shape, not yet bound to
+data. In storage terms this is an ontology-style configuration: concept names, indicator
+patterns, and artifact definitions, written as overlay rows the engine reads.
 
-Nothing about your domain is pre-configured. The concepts you frame **are** your
-workspace's vocabulary — and a bundle of framed knowledge can be shipped and reused as a
-[vertical](learnable-surface.md#verticals-reusable-starting-points), so a domain's
-accumulated understanding can seed a new workspace instead of starting from a blank page.
+Framing happens before import; the engine grounds incoming data against it. A framed
+vocabulary can be exported and reused as a
+[vertical](learnable-surface.md#verticals-reusable-starting-points) — a shipped vertical
+(finance exists today) seeds a workspace with the same artifact types a user would
+declare by hand.
 
-Frame deliberately runs *before* the data is touched. The declaration is the standard the
-data gets measured against — not a summary written after the fact to fit whatever was
-found.
+## Ground
 
-## Ground — bind it to the data
+Grounding is the engine's part: binding each declared artifact to columns, tables, or
+views. Names and indicator patterns select candidates; profiling and data evidence decide
+the binding. Each artifact ends in one of two states:
 
-Grounding is the engine's half: walking the declarations and binding each one to actual
-columns, tables, and views. A concept grounds to the columns that carry it; a metric's
-extracts ground through concepts to real data; a validation grounds to the columns it
-constrains.
+- bound, with the evidence and a measured confidence recorded, or
+- not bound — it stays declared, and the reason is recorded.
 
-Grounding is **earned, not asserted**. A declaration's name and indicators steer where to
-look — the data decides what holds. And the outcome is always visible, in both
-directions:
+The state sequence — declared → grounded → executed — is described with
+[the operating model](operating-model.md#the-lifecycle).
 
-- what grounds, grounds with **evidence** and a measured confidence behind it,
-- what doesn't stays **declared**, with the reason recorded — *"the data does not support
-  this"* is a first-class result, not a silent omission.
+## Teach
 
-The states an artifact moves through — declared → grounded → executed — are the
-[operating model's lifecycle](operating-model.md#the-lifecycle).
+A teach is a typed correction: a token that means *missing*, a column's unit, a type
+pattern, a concept binding, a relationship the detection missed. The set of teach types
+is fixed — see [the learnable surface](learnable-surface.md#the-teach-types).
 
-## Teach — correct with evidence
+Applying a teach writes one row to the workspace's overlay; the affected stage re-runs
+and the measurements are recomputed. Two properties matter in practice:
 
-Grounding will get things wrong, and data needs interpretation no analysis can supply: a
-placeholder token that means *missing*, the unit a column is measured in, a join the
-engine didn't see, a concept bound to the wrong column. When that happens, you **teach** —
-a small, typed correction from a
-[closed set of teach types](learnable-surface.md#the-teach-types).
+- **A teach is input, not output.** It changes what the next run reads — an indicator
+  list, a null-token set — and enters the measurement pool as one more witness alongside
+  the data evidence. It does not write a result or move a score directly; teach appliers
+  write to configuration inputs only. The pooling that weighs witnesses is described in
+  [measurement & detectors](measurement.md#the-goodhart-firewall).
+- **Teaches persist.** They survive re-runs, including a full rebuild of the workspace; a
+  re-run reapplies them.
 
-The property that makes teaching safe is the one the whole system leans on: **a teach is
-evidence, not an override.** It does not edit a result or move a score. It re-enters the
-next run as one more *witness* — weighed against what the data itself says — and the
-grounding is re-earned with the new evidence in the pool. You cannot assert the system
-into agreeing; you can only give it better evidence. (This is the no-override half of the
-**Goodhart firewall**; the other half is
-[measurement it can't game](measurement.md#the-goodhart-firewall).)
+## The loop
 
-Teaches are also the most durable thing you create: they persist across every future run.
-Re-running a stage — even rebuilding the workspace from scratch — reapplies everything you
-ever taught.
+Readiness (*ready / investigate / blocked*) marks where measured understanding is weak.
+Asking *why* returns the disagreement behind a score and the teach types that would
+address it. After a teach, the affected work re-runs and the score is recomputed from the
+new evidence.
 
-## The cycle in motion
-
-In practice the cycle runs as a loop against the readiness signal:
-
-1. the system **measures** what it doesn't yet understand and shows you where
-   (*ready / investigate / blocked*),
-2. you ask **why** — and get the disagreement behind the score, with the teaches that
-   would resolve it,
-3. you **teach**, the affected work re-runs, and the score moves — because the
-   understanding moved, not because anyone edited a number.
-
-That last clause is the point of the whole shape. Declaration, adjudication, and
-correction are kept structurally apart — the human declares and corrects, the data
-adjudicates, and nobody (human, agent, or the system itself) can write the conclusion
-directly. It is what lets an LLM do the heavy lifting while the result stays something
-you can trust.
+Declaration, adjudication, and correction are separate operations: users and agents
+declare and correct; scores are computed from the pooled evidence. The constraints that
+keep these separate are described in [the learnable surface](learnable-surface.md) and
+[measurement & detectors](measurement.md).

--- a/docs/concepts/learnable-surface.md
+++ b/docs/concepts/learnable-surface.md
@@ -1,29 +1,26 @@
 # The learnable surface
 
-The learnable surface is the set of things DataRaum can be taught about an organization. It
-is what lets the LLM contribute *and* keeps it from running off the rails: a small, **typed,
-closed** vocabulary that the agent — and you — can only **fill in**, never extend. This is
-the closed-vocabulary half of the **Goodhart firewall** (the measurement half is in
+The learnable surface is the set of things DataRaum can be taught about an organization: a
+small, **typed, closed** vocabulary that agents and users fill in but cannot extend. This
+is the closed-vocabulary half of the **Goodhart firewall** (the measurement half is in
 [measurement & detectors](measurement.md)).
 
-## Closed for use, the firewall
+## Closed for use
 
-An agent in the loop cannot invent a new *kind* of thing to assert. It can declare that a
-column grounds a concept, or that a token means *missing*, but it cannot create a new species
-of claim that escapes measurement. You, reviewing its proposals, see the same fixed set of
-types. The system, the agent, and the user share one vocabulary.
+An agent in the loop cannot invent a new *kind* of claim. It can declare that a column
+grounds a concept, or that a token means *missing*; it cannot create a claim type outside
+the registered set — a teach of an unregistered type fails. Users reviewing an agent's
+proposals see the same fixed set of types.
 
-This is the **firewall**: the agent can only optimize against signals the closed set was
-designed to surface, and — critically — **its words never move a score**. When an agent adds
-context to a high-uncertainty result ("this column is sparse because the field is only
-collected for a subset"), that context is recorded *alongside* the measurement; the
-uncertainty stays exactly as measured. Legitimate corrections happen by **teaching**, which
-re-enters analysis as evidence (a *witness*), not as an override. (This is the same
-disagreement model as [measurement](measurement.md); the principle is
+Free text does not move a score. When an agent attaches context to a high-uncertainty
+result ("this column is sparse because the field is only collected for a subset"), the
+context is recorded alongside the measurement; the measured value is unchanged.
+Corrections happen by **teaching**, which enters the next analysis run as a witness. (The
+disagreement model is in [measurement](measurement.md); the principle is
 [ADR-0009](../adr/0009-entropy-as-disagreement.md).)
 
-Adding a new teach *type* is a deliberate change to the platform, made out-of-band by the
-people building it — never an in-loop action.
+Adding a new teach *type* is a change to the platform, made by the people building it —
+not an in-loop action.
 
 ## The teach types
 
@@ -45,14 +42,13 @@ a witness. The live set:
 | | `metric` | A measure, expressed as a calculation graph |
 
 A teach is applied by writing one row to the workspace's overlay, after which the affected
-phase re-runs and the scores re-measure. You teach; the engine reapplies; the readiness
-moves — and your teach persists across every future run.
+phase re-runs and the scores are recomputed. Teaches persist across every future run.
 
 ## Verticals — reusable starting points
 
 A **vertical** is a bundle of concepts, rules, processes, and measures for a domain,
-expressed in the same teach types you'd produce by hand. It is a *head start*, not a
-configuration the platform depends on:
+expressed in the same teach types you'd produce by hand. It is a starting bundle; the
+platform does not depend on it:
 
 - You create one simply by [framing](the-journey.md#frame) your concepts — the concepts you
   declare *are* your workspace's vertical.

--- a/docs/concepts/learnable-surface.md
+++ b/docs/concepts/learnable-surface.md
@@ -70,33 +70,10 @@ A declared **concept** becomes real when columns are bound to it. The catalogue-
 by a single phase (`semantic_per_table`, in begin_session) and recorded per run, so there is
 one authoritative place a concept's grounding lives, not copies drifting across stages.
 
-## The artifact lifecycle
+## From taught to executed
 
-Model artifacts — validations, cycles, metrics — are not one-shot writes. Each moves through
-explicit states, recorded per run:
-
-```mermaid
-flowchart LR
-    D["<b>declared</b><br/>named, no data backing"]
-    G["<b>grounded</b><br/>bound to concrete data"]
-    E["<b>executed</b><br/>has run successfully"]
-    D --> G --> E
-    style D fill:#fafafa
-    style G fill:#e8f5e9
-    style E fill:#e3f2fd
-```
-
-- **declared** — created from intent in [frame](the-journey.md#frame): a name and a target
-  shape, no data backing.
-- **grounded** — bound to concrete columns/tables by [operating_model](the-journey.md#operating_model).
-- **executed** — has produced output at least once against the data, with the pipeline
-  running cleanly.
-
-These three are **system states** — they describe what the system has done, and they are
-live today.
-
-!!! note "canonical and endorsement are not built"
-    The design adds a fourth, **canonical** — an *organizational* state meaning "endorsed as
-    the version we use" — reached through an endorsement workflow. Neither the state nor the
-    workflow is implemented today; a strictness parameter is recorded on artifacts but does
-    not yet gate anything. They live in the [vision](../vision/architecture-future.md) only.
+What you teach and frame doesn't stay declared: model artifacts move through an explicit
+lifecycle — **declared → grounded → executed**, recorded per run — as the engine binds
+them to real data. The lifecycle lives with
+[the operating model](operating-model.md#the-lifecycle); the loop that drives it —
+declare, ground, correct — is [frame, ground, teach](frame-ground-teach.md).

--- a/docs/concepts/measurement.md
+++ b/docs/concepts/measurement.md
@@ -1,10 +1,9 @@
 # Measurement & detectors
 
-DataRaum's deliverable is **understood data** — and "understood" is not a figure of speech,
-it is a measured quantity. After every phase, detectors quantify *how much the system does
-not yet know* about each column, relationship, table, and view, and report it as a signal
-you can act on. This page explains what that quantity is, why it's expressed as **entropy**,
-and why the way it's computed makes it hard to game.
+After every phase, detectors quantify *how much the system does not yet know* about each
+column, relationship, table, and view, and report it as a signal you can act on. This page
+explains what that quantity is, why it is expressed as **entropy**, and which properties of
+the computation keep it independent of the parties being measured.
 
 ## Why entropy
 
@@ -25,8 +24,8 @@ call for different actions:
 
 ## Witnesses and the claim space
 
-The system never asks one oracle for the answer. For each claim, several **witnesses** each
-emit a distribution over the claim space, and each carries a **reliability** `r ∈ [0,1]`:
+No single source answers a claim. For each claim, several **witnesses** each emit a
+distribution over the claim space, and each carries a **reliability** `r ∈ [0,1]`:
 
 - a witness reading the **field name**,
 - a witness reading the **data** (at least one per claim *must* — see the firewall below),
@@ -73,26 +72,22 @@ the pool.)
 ## The Goodhart firewall
 
 Goodhart's law: *when a measure becomes a target, it stops being a good measure.* An agent
-optimizing against entropy — or a user impatient to turn something green — is a direct
-Goodhart threat. The pooling shape is what neutralizes it:
+optimizing against entropy, or a user trying to turn something green, are both cases of it.
+Four properties of the pooling address it:
 
-- **Corrections enter as witnesses, never as overrides.** A teach is one more reliability-
-  weighted opinion in the pool, not a write to the score. You cannot *assert* a column into
-  being understood.
-- **Reliability is resolution-only.** Conflict is provably weight-robust: two one-hot
-  witnesses disagreeing give `C = 1` for *any* reliabilities. So a wrong or self-serving
-  reliability can mis-*resolve* which answer wins — it can never *hide a disagreement*. The
-  flag stands even if the weighting is off.
-- **At least one witness must read the data.** If every witness read the column *name*, they
-  would agree confidently and be wrong together — name-correlated witnesses fail in lockstep
-  (this is measured, not assumed). A data-reading witness is what makes disagreement
-  detectable.
-- **Words don't enter the pool.** Free-text context an agent attaches to a result is recorded
-  *alongside* the measurement; it has no distribution and no reliability, so it cannot move
+- **Corrections enter as witnesses.** A teach is one more reliability-weighted opinion in
+  the pool, not a write to the score.
+- **Reliability is resolution-only.** Conflict is weight-robust: two one-hot witnesses
+  disagreeing give `C = 1` for *any* reliabilities. A wrong or self-serving reliability can
+  mis-resolve which answer wins; it cannot hide the disagreement.
+- **At least one witness per claim reads the data.** Witnesses that all read the column
+  *name* agree confidently and fail together (measured in calibration, not assumed). A
+  data-reading witness is what makes disagreement detectable.
+- **Free text does not enter the pool.** Context an agent attaches to a result is recorded
+  alongside the measurement; it has no distribution and no reliability, so it cannot move
   `q`, `C`, or `U`.
 
-The result is the property the whole system leans on: **it cannot make false progress by
-hiding what it doesn't understand.** (Framework: [ADR-0009](../adr/0009-entropy-as-disagreement.md).)
+(Framework: [ADR-0009](../adr/0009-entropy-as-disagreement.md).)
 
 ## The detectors
 
@@ -108,10 +103,9 @@ what it measures.
 | **Computational** | derived & cross-table | derived-value (formula) · stock/flow behaviour · cross-table consistency |
 
 About sixteen run today, across four **granularities** — column, relationship, table, view —
-that readiness rolls up over. A few are kept as **informative** signals: surfaced for context
-but deliberately *not* fed into readiness, because calibration showed they don't predict real
-problems well enough to act on. Earning a place on the readiness path is something a detector
-has to prove.
+that readiness rolls up over. A few are kept as **informative** signals: surfaced for
+context but not fed into readiness, because calibration showed they don't predict real
+problems well enough to act on.
 
 ## From entropy to readiness
 
@@ -129,21 +123,21 @@ The weights and thresholds live in configuration, not code, so the *how-much-it-
 judgement is tunable from data without touching detector logic. (An earlier Bayesian-network
 rollup was removed in favour of these explicit per-intent loss tables.)
 
-## Calibration is what makes the numbers mean something
+## Calibration
 
-A readiness score is only worth trusting if low scores track usable data and high scores
-track real problems. DataRaum establishes that empirically: detectors run against datasets
-with **deliberately injected issues and a recorded answer key**, and each must show both
-**recall** (catches the injection) and **precision** (doesn't cry wolf on clean data). The
-witness reliabilities are measured by the same rig.
+A readiness score is useful if low scores track usable data and high scores track real
+problems. That is established empirically: detectors run against datasets with **injected
+issues and a recorded answer key**, and each must show both **recall** (catches the
+injection) and **precision** (no false alarms on clean data). The witness reliabilities are
+measured by the same rig.
 
-To keep it honest, every measurement ships in one fixed shape — claim space, witness
-extractors, detector shell, config rows, write-back, teach applier, eval entry — with **no
-tuned numbers in detector code at all**: every threshold, weight, and reliability lives in
-config with provenance. Implementation and calibration are separate activities on separate
-artifacts, so nobody nudges a constant to make a test pass.
+Every measurement ships in one fixed shape — claim space, witness extractors, detector
+shell, config rows, write-back, teach applier, eval entry — with no tuned numbers in
+detector code: every threshold, weight, and reliability lives in config with provenance.
+Implementation and calibration are separate activities on separate artifacts.
 ([ADR-0011](../adr/0011-measurement-pack.md).)
 
-When a score is elevated, the **why** view surfaces the witnesses, the contested claim, and a
-ranked list of teaches that would resolve it. You teach; the affected phase re-runs; the
-score moves — or it doesn't, and you've learned the problem is real.
+When a score is elevated, the **why** view surfaces the witnesses, the contested claim, and
+a ranked list of teaches that would resolve it. After a teach, the affected phase re-runs
+and the score is recomputed; a score that does not move indicates the problem is in the
+data itself.

--- a/docs/concepts/operating-model.md
+++ b/docs/concepts/operating-model.md
@@ -1,107 +1,93 @@
 # The operating model
 
-The operating model is what DataRaum exists to produce: the concepts, relationships, rules,
-processes, and measures an organization runs on — recovered from its data, bound to that
-data, and executable against it. Everything else in these docs serves this artifact. This
-page is what it actually is: its parts, its shape, and the lifecycle every part moves
-through.
+The operating model is the artifact DataRaum produces: the workspace's concepts,
+relationships, validations, business cycles, metrics, and driver rankings, bound to the
+workspace's data and computed from it. This page describes its parts, its structure, and
+the lifecycle its artifacts move through.
 
-## Executable, not documented
+## Definitions are computable
 
-Most organizations have their operating model written down somewhere — a wiki, a metrics
-catalog, a diagram. Those documents *describe*; they don't *run*, and nothing tells you
-when they stop being true. DataRaum's operating model is executable knowledge: every part
-of it is either computed from your actual data or explicitly, visibly not.
+Each artifact is stored in a form the engine can execute against the data:
 
-Executable means something concrete for each part:
+- A **metric** is a dependency graph of extracts, constants, and formulas. It compiles to
+  SQL; the SQL is stored with the artifact and can be inspected.
+- A **validation** is a rule with executable SQL and a verdict — *passed* or *failed*.
+  The verdict is computed from the data at read time, not stored, so it reflects the data
+  as it is now.
+- A **cycle** is a business process as ordered stages; completion is counted over the
+  records that move through them.
 
-- a **metric** is not a definition in prose; it is a calculation that runs against your
-  sources, with the SQL there to inspect,
-- a **validation** is not a policy statement; it is a check with a verdict — *passed* or
-  *failed* — recomputed from the data when you look, never stored and left to rot,
-- a **cycle** is not a process diagram; it is a set of ordered stages whose completion is
-  measured in the records themselves.
+Each artifact also carries the confidence of its grounding. A metric that executes
+cleanly but has a weakly grounded input is flagged low-confidence, with the reason
+recorded. How confidence is measured is covered in
+[measurement & detectors](measurement.md).
 
-And each part carries its measured confidence with it. A metric is only as trustworthy as
-its weakest grounded input — and it says so, rather than presenting a clean number over a
-shaky binding. How that confidence is measured is
-[measurement & detectors](measurement.md); that it *cannot be gamed* is the
-[Goodhart firewall](learnable-surface.md).
+## Structure
 
-## The shape: concepts are the hub
+The operating model is a graph. Its central node type is the **concept**: a business term
+from the workspace's vocabulary, together with its binding to the columns that carry it.
+The term itself is a convention — what the model stores is the mapping and the evidence
+for it. The edge types:
 
-The operating model is a graph, and its hub is the **concept** — a business term made
-real. Everything meets at concepts:
-
-- metrics and cycles **reference** the concepts they are built from,
-- each concept **grounds** to the actual columns that carry it,
+- metrics and cycles **reference** the concepts they are defined over,
+- a concept **grounds** to columns,
 - columns **relate** to each other through confirmed joins,
-- validations **check** the columns they constrain,
-- **drivers** point at the measures whose variation they explain.
+- a validation **checks** the columns it constrains,
+- a **driver** points at the measure whose variation it explains.
 
-Artifacts never bind to raw columns directly — the path is always *artifact → concept →
-column*. That indirection is what makes the model durable: when the data moves, the
-grounding is re-earned per concept, and everything built on the concept follows.
+Artifacts do not bind to columns directly; the path is artifact → concept → column. When
+the data changes, grounding is re-established per concept, and the artifacts referencing
+that concept follow without being redefined.
 
-This graph is not an illustration; it is the model itself, and the cockpit's **Model**
-surface renders it exactly — concepts in the middle, your real tables and columns on one
-side, the declared artifacts on the other.
+The cockpit's **Model** page renders this graph.
 
 ## The parts
 
-**Concepts** — the vocabulary: what a *customer*, an *invoice*, *revenue* mean here, each
-grounded in the columns that carry it.
+**Concepts** — the vocabulary the workspace is described in (*customer*, *invoice*,
+*revenue*), each mapped to the columns that carry it.
 
-**Relationships** — how tables fit together: discovered from the data, confirmed
-semantically, correctable by [teaching](frame-ground-teach.md).
+**Relationships** — joins between tables: detected from value overlap and cardinality,
+confirmed semantically, correctable by [teaching](frame-ground-teach.md).
 
-**Validations** — rules the data must satisfy, each executed as a check with a verdict.
-The verdict (*passed* / *failed*) is distinct from the artifact's lifecycle state: a
-validation can be fully grounded and executing, and failing — that is the validation doing
-its job.
+**Validations** — rules the data must satisfy. The verdict is separate from the
+artifact's lifecycle state: a validation can be grounded, executing, and failing.
 
-**Business cycles** — the processes the organization runs (order-to-cash, procure-to-pay),
-as ordered stages with completion measured against the records that flow through them.
+**Business cycles** — processes such as order-to-cash, as ordered stages with completion
+measured against the records.
 
-**Metrics** — measures as small dependency graphs: extracts of grounded concepts,
-constants, and formulas over them, composed into runnable SQL. A metric's definition and
-its execution are the same thing.
+**Metrics** — measures as dependency graphs, compiled to SQL.
 
-**Drivers** — for each measure, the dimensions that actually explain its variation,
-ranked against the dataset's own noise floor. Unlike the families above, drivers are not
-declared — they are discovered during [ingestion](the-journey.md#begin_session) and ride
-along as the model's empirical layer.
+**Drivers** — per measure, the dimensions that explain its variation, ranked against a
+noise floor computed from the dataset itself. Drivers are not declared; they are computed
+during [ingestion](the-journey.md#begin_session).
 
 ## The lifecycle
 
-Model artifacts — validations, cycles, metrics — are not one-shot writes. Each moves
-through explicit states, recorded per run:
+Validations, cycles, and metrics move through explicit states, recorded per run:
 
 ```mermaid
 flowchart LR
-    D["<b>declared</b><br/>named, no data backing"]
+    D["<b>declared</b><br/>named, no data binding"]
     G["<b>grounded</b><br/>bound to concrete data"]
-    E["<b>executed</b><br/>has run successfully"]
+    E["<b>executed</b><br/>ran in a clean run"]
     D --> G --> E
     style D fill:#fafafa
     style G fill:#e8f5e9
     style E fill:#e3f2fd
 ```
 
-- **declared** — created from intent in [frame](the-journey.md#frame): a name and a target
-  shape, no data backing.
+- **declared** — created in [frame](the-journey.md#frame): a name and a target shape, no
+  data binding.
 - **grounded** — bound to concrete columns and views by
   [operating_model](the-journey.md#operating_model).
-- **executed** — has produced output at least once against the data, with the run
-  completing cleanly.
+- **executed** — produced output against the data in a cleanly completed run.
 
-The state an artifact *fails* to reach is as much a part of the model as the state it
-holds: an artifact the data cannot support stays **declared**, with the reason recorded —
-visibly unmet, never silently absent and never silently invented.
+An artifact the data cannot support stays **declared**, and the reason is recorded on the
+artifact. It remains visible in that state; it is not removed.
 
-The model is also **run-versioned**: a re-run writes a fresh version and becomes visible
-only when it completes cleanly, so what you see is always a whole, consistent model —
-never a half-updated one.
+Artifacts are versioned by run: a re-run writes a new version under a new run id, and the
+new version becomes visible only when the run completes. A failed or partial run is not
+shown.
 
 !!! note "canonical and endorsement are not built"
     The design adds a fourth state, **canonical** — an *organizational* state meaning
@@ -109,9 +95,8 @@ never a half-updated one.
     the state nor the workflow is implemented today; they live in the
     [vision](../vision/architecture-future.md) only.
 
-## Where you meet it
+## Where it appears
 
-The model is built by the [journey](the-journey.md) — framed, grounded, executed — and
-from then on it is the thing you work *with*: the **Model** surface renders the graph, and
-every answer the Analyse chat gives is grounded in it, carrying the model's confidence
-rather than a bare number.
+The **Model** page renders the graph. Answers in the Analyse chat resolve against the
+operating model and report which artifacts and concepts they used, with the grounding
+confidence.

--- a/docs/concepts/operating-model.md
+++ b/docs/concepts/operating-model.md
@@ -1,0 +1,117 @@
+# The operating model
+
+The operating model is what DataRaum exists to produce: the concepts, relationships, rules,
+processes, and measures an organization runs on — recovered from its data, bound to that
+data, and executable against it. Everything else in these docs serves this artifact. This
+page is what it actually is: its parts, its shape, and the lifecycle every part moves
+through.
+
+## Executable, not documented
+
+Most organizations have their operating model written down somewhere — a wiki, a metrics
+catalog, a diagram. Those documents *describe*; they don't *run*, and nothing tells you
+when they stop being true. DataRaum's operating model is executable knowledge: every part
+of it is either computed from your actual data or explicitly, visibly not.
+
+Executable means something concrete for each part:
+
+- a **metric** is not a definition in prose; it is a calculation that runs against your
+  sources, with the SQL there to inspect,
+- a **validation** is not a policy statement; it is a check with a verdict — *passed* or
+  *failed* — recomputed from the data when you look, never stored and left to rot,
+- a **cycle** is not a process diagram; it is a set of ordered stages whose completion is
+  measured in the records themselves.
+
+And each part carries its measured confidence with it. A metric is only as trustworthy as
+its weakest grounded input — and it says so, rather than presenting a clean number over a
+shaky binding. How that confidence is measured is
+[measurement & detectors](measurement.md); that it *cannot be gamed* is the
+[Goodhart firewall](learnable-surface.md).
+
+## The shape: concepts are the hub
+
+The operating model is a graph, and its hub is the **concept** — a business term made
+real. Everything meets at concepts:
+
+- metrics and cycles **reference** the concepts they are built from,
+- each concept **grounds** to the actual columns that carry it,
+- columns **relate** to each other through confirmed joins,
+- validations **check** the columns they constrain,
+- **drivers** point at the measures whose variation they explain.
+
+Artifacts never bind to raw columns directly — the path is always *artifact → concept →
+column*. That indirection is what makes the model durable: when the data moves, the
+grounding is re-earned per concept, and everything built on the concept follows.
+
+This graph is not an illustration; it is the model itself, and the cockpit's **Model**
+surface renders it exactly — concepts in the middle, your real tables and columns on one
+side, the declared artifacts on the other.
+
+## The parts
+
+**Concepts** — the vocabulary: what a *customer*, an *invoice*, *revenue* mean here, each
+grounded in the columns that carry it.
+
+**Relationships** — how tables fit together: discovered from the data, confirmed
+semantically, correctable by [teaching](frame-ground-teach.md).
+
+**Validations** — rules the data must satisfy, each executed as a check with a verdict.
+The verdict (*passed* / *failed*) is distinct from the artifact's lifecycle state: a
+validation can be fully grounded and executing, and failing — that is the validation doing
+its job.
+
+**Business cycles** — the processes the organization runs (order-to-cash, procure-to-pay),
+as ordered stages with completion measured against the records that flow through them.
+
+**Metrics** — measures as small dependency graphs: extracts of grounded concepts,
+constants, and formulas over them, composed into runnable SQL. A metric's definition and
+its execution are the same thing.
+
+**Drivers** — for each measure, the dimensions that actually explain its variation,
+ranked against the dataset's own noise floor. Unlike the families above, drivers are not
+declared — they are discovered during [ingestion](the-journey.md#begin_session) and ride
+along as the model's empirical layer.
+
+## The lifecycle
+
+Model artifacts — validations, cycles, metrics — are not one-shot writes. Each moves
+through explicit states, recorded per run:
+
+```mermaid
+flowchart LR
+    D["<b>declared</b><br/>named, no data backing"]
+    G["<b>grounded</b><br/>bound to concrete data"]
+    E["<b>executed</b><br/>has run successfully"]
+    D --> G --> E
+    style D fill:#fafafa
+    style G fill:#e8f5e9
+    style E fill:#e3f2fd
+```
+
+- **declared** — created from intent in [frame](the-journey.md#frame): a name and a target
+  shape, no data backing.
+- **grounded** — bound to concrete columns and views by
+  [operating_model](the-journey.md#operating_model).
+- **executed** — has produced output at least once against the data, with the run
+  completing cleanly.
+
+The state an artifact *fails* to reach is as much a part of the model as the state it
+holds: an artifact the data cannot support stays **declared**, with the reason recorded —
+visibly unmet, never silently absent and never silently invented.
+
+The model is also **run-versioned**: a re-run writes a fresh version and becomes visible
+only when it completes cleanly, so what you see is always a whole, consistent model —
+never a half-updated one.
+
+!!! note "canonical and endorsement are not built"
+    The design adds a fourth state, **canonical** — an *organizational* state meaning
+    "endorsed as the version we use" — reached through an endorsement workflow. Neither
+    the state nor the workflow is implemented today; they live in the
+    [vision](../vision/architecture-future.md) only.
+
+## Where you meet it
+
+The model is built by the [journey](the-journey.md) — framed, grounded, executed — and
+from then on it is the thing you work *with*: the **Model** surface renders the graph, and
+every answer the Analyse chat gives is grounded in it, carrying the model's confidence
+rather than a bare number.

--- a/docs/concepts/the-journey.md
+++ b/docs/concepts/the-journey.md
@@ -1,11 +1,10 @@
 # The journey
 
-The journey is how scattered sources become an executable
-[operating model](operating-model.md) — and then answers you can trust. You drive it from
-the cockpit in three kinds of chat — **Connect**, **Stage**, **Analyse** — and beneath
-them the system runs five stages, each producing an artifact the next one builds on, each
-driven by an agent with a bounded job and a bounded view of the world. This page walks the
-arc in both vocabularies: the chat you're in, and the stage doing the work.
+The journey is the sequence from raw sources to an executable
+[operating model](operating-model.md) and query answers. You drive it from the cockpit in
+three kinds of chat — **Connect**, **Stage**, **Analyse** — and beneath them the system
+runs five stages, each producing an artifact the next one builds on. This page walks the
+sequence in both vocabularies: the chat you're in, and the stage doing the work.
 
 ```mermaid
 flowchart LR
@@ -32,22 +31,22 @@ flowchart LR
     style Q fill:#f3e5f5
 ```
 
-Two things are worth holding onto before the details:
+Two facts apply across all stages:
 
-- **Where each stage runs.** The interactive, agentic stages (**frame**, **answer**) run in
-  the cockpit. The heavy analysis stages (**add_source**, **begin_session**,
-  **operating_model**) run in the engine as durable Temporal workflows — a run survives
-  restarts and finishes without you watching it. This split is deliberate — see the
+- **Where each stage runs.** The interactive stages (**frame**, **answer**) run in the
+  cockpit. The analysis stages (**add_source**, **begin_session**, **operating_model**)
+  run in the engine as durable Temporal workflows: a run survives restarts and completes
+  without the browser open. See the
   [platform architecture](../platform/architecture.md).
-- **What persists.** Typed sources, the workspace, and the operating model persist as named
-  artifacts. So do your **teaches** — every correction you make survives a stage re-run.
-  What does *not* persist is an agent's in-loop reasoning; agents are stateless across runs.
+- **What persists.** Typed sources, the workspace, and the operating model persist as
+  named artifacts, as do **teaches** — corrections survive stage re-runs. An agent's
+  in-loop reasoning does not persist; agents are stateless across runs.
 
 ## Connect — bring data in
 
-The Connect chat is where a workspace acquires both of its inputs: what the data is
-*about*, and the data itself. Declaring comes first — the frame is the standard the
-incoming data is measured against.
+The Connect chat covers the workspace's two inputs: the declaration of what the data is
+about (**frame**) and the data itself (**add_source**). Framing comes first; import
+grounds against it.
 
 ### frame
 
@@ -59,11 +58,10 @@ want to understand and decide. The cockpit turns that into two things:
   graph of extracts and formulas, a validation a rule over them, each node depending on the
   concepts (and other nodes) beneath it.
 
-Together they are the *target* operating model: what you want to be true and computable,
-declared before any data is touched. Nothing about your domain is pre-configured — the
-ontology and DAG you frame *are* your workspace's vertical. Everything here is
-**declared**: named, with a target shape, no data backing yet. The rest of the journey is
-what binds it to the data.
+Together they form the target operating model: what should be computable, declared before
+any data is imported. Nothing about the domain is pre-configured — the ontology and DAG
+you frame are the workspace's vertical. Everything here is **declared**: named, with a
+target shape, no data binding yet. The rest of the journey binds it to the data.
 
 - **Runs in:** the cockpit. **Produces:** a declared ontology + metric/validation DAG,
   written as the frozen grounding contract the engine reads
@@ -72,10 +70,10 @@ what binds it to the data.
 ### add_source
 
 **Turns raw sources into typed, profiled, grounded data.** You bring in sources — a
-database, an API export, a spreadsheet, a file. The engine loads everything as text (so a
-bad value is never a crash), infers types (failed casts go to a quarantine table, not the
-floor), profiles each column statistically, and grounds each column semantically against
-the framed concepts — the first place the frame meets the data.
+database, an API export, a spreadsheet, a file. The engine loads everything as text,
+infers types (a value that fails its cast goes to a quarantine table; the run continues),
+profiles each column statistically, and grounds each column semantically against the
+framed concepts.
 
 Once typed and profiled, a source joins the workspace's library and is available to any
 later session.
@@ -85,9 +83,9 @@ later session.
 
 ## Stage — build the model
 
-The Stage chat is where separately-imported sources become one model. It is also where the
-deeper teaching happens — what a column *means*, how tables relate — because this is the
-pass that puts that meaning to work.
+The Stage chat composes the separately imported sources into one model and grounds the
+framed target in it. Catalogue-grain teaching — what a column means, how tables relate —
+also happens here, because these passes consume it.
 
 ### begin_session
 
@@ -97,27 +95,20 @@ own; this stage is where they become one coherent, queryable model. The engine d
 how tables **relate** (value overlap, cardinality, join paths), classifies them (fact vs
 dimension, grain), builds grain-preserving **enriched join views**, identifies the
 **dimensions** you can slice by, reconciles measures across tables, and ranks the
-**drivers** behind each measure. This is where *many sources become one model*.
+**drivers** behind each measure.
 
-It is the most analysis-intensive stage, and the investment pays off: everything
-downstream runs cheaply against a well-built workspace.
+It is the most analysis-intensive stage; later stages query its outputs.
 
 - **Runs in:** the engine (`begin_session`). **Produces:** relationships, enriched views,
   slice dimensions, driver rankings — the analytical workspace.
 
 ### operating_model
 
-**Grounds the framed target in the actual data.** This is the other half of `frame`. Frame
-declared *what you want* — the ontology and the metric/validation DAG. `operating_model` is
-where that target meets the ingested data: walking the DAG, it **binds** each declared node
-(a measure, a rule, a process) to concrete columns and views, then **executes** it — or
-reports it as visibly impossible. You get a clear *"the data does not support this measure"*
-rather than a silently wrong number.
-
-That reconciliation is the heart of the stage: the frame says what *should* be computable;
-the workspace says what the data actually supports; `operating_model` makes every declared
-node either executed against real data or honestly marked as unmet. As it goes, each
-artifact moves **declared → grounded → executed** — the
+**Grounds the framed target in the data.** Frame declared the ontology and the
+metric/validation DAG; this stage binds each declared node (a measure, a rule, a process)
+to concrete columns and views, then executes it. A node the data cannot support is
+reported as unmet, with the reason recorded — it stays declared rather than producing a
+number from a wrong binding. Each artifact moves **declared → grounded → executed** — the
 [operating model's lifecycle](operating-model.md#the-lifecycle).
 
 - **Runs in:** the engine (`operating_model`). **Produces:** validations, business cycles,
@@ -139,8 +130,7 @@ provenance to a specific executed artifact, or it is surfaced as ungrounded.
 ## Going back
 
 Re-entering an earlier stage cascades to the stages built on top of it — re-typing a source
-invalidates the workspace and operating model that were built from it. The cockpit shows the
-cost before you commit, and because **teaches persist**, a re-run reapplies everything you
-previously taught. Going back is a deliberate act with visible consequences, not a silent
-reset. How that cascade is actually executed is covered in the
+invalidates the workspace and operating model that were built from it. The cockpit shows
+the cost before you commit, and because teaches persist, a re-run reapplies everything you
+previously taught. How the cascade is executed is covered in the
 [platform architecture](../platform/architecture.md).

--- a/docs/concepts/the-journey.md
+++ b/docs/concepts/the-journey.md
@@ -1,48 +1,58 @@
 # The journey
 
-The journey is the sequence of stages your data moves through, from raw sources to grounded
-answers. Each stage produces an artifact the next one builds on, and each is driven by an
-agent with a bounded job and a bounded view of the world.
+The journey is how scattered sources become an executable
+[operating model](operating-model.md) — and then answers you can trust. You drive it from
+the cockpit in three kinds of chat — **Connect**, **Stage**, **Analyse** — and beneath
+them the system runs five stages, each producing an artifact the next one builds on, each
+driven by an agent with a bounded job and a bounded view of the world. This page walks the
+arc in both vocabularies: the chat you're in, and the stage doing the work.
 
 ```mermaid
 flowchart LR
-    F["<b>frame</b><br/>intent → concepts"]
-    A["<b>connect / add_source</b><br/>raw sources → typed, profiled"]
-    B["<b>begin_session</b><br/>tables → analytical workspace"]
-    O["<b>operating_model</b><br/>workspace → rules,<br/>processes, measures"]
-    AN["<b>answer</b><br/>question → grounded answer"]
-
-    F --> B
-    A --> B
-    B --> O
-    O --> AN
-
+    subgraph C["<b>Connect</b> — bring data in"]
+        direction TB
+        F["frame<br/>intent → declared concepts"]
+        A["add_source<br/>raw → typed, profiled, grounded"]
+        F --> A
+    end
+    subgraph S["<b>Stage</b> — build the model"]
+        direction TB
+        B["begin_session<br/>tables → one analytical model"]
+        O["operating_model<br/>declared → grounded, executed"]
+        B --> O
+    end
+    subgraph AN["<b>Analyse</b> — ask"]
+        Q["answer<br/>question → grounded answer"]
+    end
+    C --> S --> AN
     style F fill:#fafafa
     style A fill:#e8f5e9
     style B fill:#fff8e1
     style O fill:#e3f2fd
-    style AN fill:#f3e5f5
+    style Q fill:#f3e5f5
 ```
-
-It is not a strict chain. **frame** and **add_source** are independent upstream stages —
-one captures intent, the other brings in data; neither needs the other. They join at
-**begin_session**, after which the path is sequential through **operating_model** to
-**answer**.
 
 Two things are worth holding onto before the details:
 
 - **Where each stage runs.** The interactive, agentic stages (**frame**, **answer**) run in
   the cockpit. The heavy analysis stages (**add_source**, **begin_session**,
-  **operating_model**) run in the engine as durable Temporal workflows. This split is
-  deliberate — see the [platform architecture](../platform/architecture.md).
+  **operating_model**) run in the engine as durable Temporal workflows — a run survives
+  restarts and finishes without you watching it. This split is deliberate — see the
+  [platform architecture](../platform/architecture.md).
 - **What persists.** Typed sources, the workspace, and the operating model persist as named
   artifacts. So do your **teaches** — every correction you make survives a stage re-run.
   What does *not* persist is an agent's in-loop reasoning; agents are stateless across runs.
 
-## frame
+## Connect — bring data in
+
+The Connect chat is where a workspace acquires both of its inputs: what the data is
+*about*, and the data itself. Declaring comes first — the frame is the standard the
+incoming data is measured against.
+
+### frame
 
 **Turns intent into a target operating model.** You describe, in plain language, what you
-want to understand and decide. The cockpit's agent turns that into two things:
+want to understand and decide. The cockpit turns that into two things:
 
 - an **ontology** — the business concepts that matter and how they relate, and
 - a **DAG of metrics and validations** built on those concepts — a metric is a dependency
@@ -51,49 +61,51 @@ want to understand and decide. The cockpit's agent turns that into two things:
 
 Together they are the *target* operating model: what you want to be true and computable,
 declared before any data is touched. Nothing about your domain is pre-configured — the
-ontology and DAG you frame *are* your workspace's vertical. Everything here is **declared**:
-named, with a target shape, no data backing yet. The stages downstream are what bind it to
-the data.
+ontology and DAG you frame *are* your workspace's vertical. Everything here is
+**declared**: named, with a target shape, no data backing yet. The rest of the journey is
+what binds it to the data.
 
 - **Runs in:** the cockpit. **Produces:** a declared ontology + metric/validation DAG,
   written as the frozen grounding contract the engine reads
   ([ADR-0007](../adr/0007-frame-frozen-artifact-contract.md)).
 
-## connect / add_source
+### add_source
 
-**Turns raw sources into typed, profiled, annotated data.** You bring in sources — a
+**Turns raw sources into typed, profiled, grounded data.** You bring in sources — a
 database, an API export, a spreadsheet, a file. The engine loads everything as text (so a
 bad value is never a crash), infers types (failed casts go to a quarantine table, not the
-floor), profiles each column statistically, and annotates each column semantically against
-the framed concepts.
+floor), profiles each column statistically, and grounds each column semantically against
+the framed concepts — the first place the frame meets the data.
 
-Because it doesn't depend on frame, a source can be added speculatively; once typed and
-profiled it joins the workspace's library and is available to any later session.
+Once typed and profiled, a source joins the workspace's library and is available to any
+later session.
 
 - **Runs in:** the engine (`add_source`, with a per-table child workflow). **Produces:**
-  typed tables + per-column semantics; grounds concepts by binding them to columns.
+  typed tables + per-column semantics; concepts grounded to columns.
 
-## begin_session — really *ingest*
+## Stage — build the model
 
-!!! note "A name we never fixed"
-    `begin_session` is a historical misnomer. What this stage actually does is **ingest**:
-    it takes the separately-typed sources and ingests them into *one* analytical model. Read
-    the name as "ingest" everywhere.
+The Stage chat is where separately-imported sources become one model. It is also where the
+deeper teaching happens — what a column *means*, how tables relate — because this is the
+pass that puts that meaning to work.
 
-**Composes typed sources into a single analytical workspace.** `add_source` typed each source
-on its own; this stage is where they become one coherent, queryable model. The engine
-discovers how tables **relate** (value overlap, cardinality, join paths), classifies them
-(fact vs dimension, grain), builds grain-preserving **enriched join views**, identifies the
-**dimensions** you can slice by, reconciles measures across tables, and ranks the **drivers**
-behind each measure. This is where *many sources become one model*.
+### begin_session
 
-It is the most analysis-intensive stage, and the investment pays off: everything downstream
-runs cheaply against a well-built workspace.
+**Composes typed sources into a single analytical workspace.** (`begin_session` is the
+engine's name for this pass; read it as *ingest*.) `add_source` typed each source on its
+own; this stage is where they become one coherent, queryable model. The engine discovers
+how tables **relate** (value overlap, cardinality, join paths), classifies them (fact vs
+dimension, grain), builds grain-preserving **enriched join views**, identifies the
+**dimensions** you can slice by, reconciles measures across tables, and ranks the
+**drivers** behind each measure. This is where *many sources become one model*.
+
+It is the most analysis-intensive stage, and the investment pays off: everything
+downstream runs cheaply against a well-built workspace.
 
 - **Runs in:** the engine (`begin_session`). **Produces:** relationships, enriched views,
   slice dimensions, driver rankings — the analytical workspace.
 
-## operating_model
+### operating_model
 
 **Grounds the framed target in the actual data.** This is the other half of `frame`. Frame
 declared *what you want* — the ontology and the metric/validation DAG. `operating_model` is
@@ -104,23 +116,25 @@ rather than a silently wrong number.
 
 That reconciliation is the heart of the stage: the frame says what *should* be computable;
 the workspace says what the data actually supports; `operating_model` makes every declared
-node either executed against real data or honestly marked as unmet. As it goes, each artifact
-moves **declared → grounded → executed**, recorded explicitly (see
-[the learnable surface](learnable-surface.md)).
+node either executed against real data or honestly marked as unmet. As it goes, each
+artifact moves **declared → grounded → executed** — the
+[operating model's lifecycle](operating-model.md#the-lifecycle).
 
 - **Runs in:** the engine (`operating_model`). **Produces:** validations, business cycles,
   and metrics — the framed DAG, now bound to data and executed against it.
 
-## answer
+## Analyse — ask
+
+### answer
 
 **Responds to questions, grounded in the operating model.** You ask in plain language; the
-cockpit's agent resolves the question against the operating model — which measure answers it,
-which slice narrows it — composes SQL, runs it against the data lake, and returns the result
-with the SQL and a confidence behind it. Every number traces back through provenance to a
-specific executed artifact, or it is surfaced as ungrounded.
+cockpit's agent resolves the question against the operating model — which measure answers
+it, which slice narrows it — composes SQL, runs it against the data lake, and returns the
+result with the SQL and a confidence behind it. Every number traces back through
+provenance to a specific executed artifact, or it is surfaced as ungrounded.
 
-- **Runs in:** the cockpit. **Produces:** answers — SQL, tables, narrative — each tied to the
-  artifacts it draws from.
+- **Runs in:** the cockpit. **Produces:** answers — SQL, tables, narrative — each tied to
+  the artifacts it draws from.
 
 ## Going back
 

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -72,8 +72,8 @@ flowchart LR
 - **Connect** — declare what the workspace is about, then bring data in. You describe
   what you want to understand and the cockpit records the *concepts* that matter as the
   grounding target (**frame**); then the engine loads your sources as text, infers types
-  (failed casts go to quarantine, never a crash), profiles each column, and grounds it
-  against the framed concepts (**add_source**).
+  (failed casts go to a quarantine table; the run continues), profiles each column, and
+  grounds it against the framed concepts (**add_source**).
 - **Stage** — teach meaning, then build the model. The engine composes your typed tables
   into one analytical workspace — relationships, enriched join views, slice dimensions,
   drivers (**begin_session**) — then reconciles the framed target with what the data

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -17,10 +17,10 @@ know is how **yours** works: which fields carry which meaning, how your sources 
 a given value represents, which tables describe the same thing. That knowledge is latent in
 the data — it has to be recovered, then bound to the data, not assumed.
 
-The result is an **operating model** that is *executable*: your concepts, processes, rules,
-and measures, computed from your actual data with a measured confidence behind each one — and
-an LLM kept honest about all of it by a [closed vocabulary it can't escape](#the-approach)
-and [measurements it can't game](#how-understanding-is-measured).
+The result is an executable **operating model**: your concepts, processes, rules, and
+measures, computed from your data, each with a measured confidence. The LLM in the loop
+works against a [fixed vocabulary](#the-approach) and
+[measurements computed from independent evidence](#how-understanding-is-measured).
 
 ## The approach
 
@@ -28,8 +28,9 @@ DataRaum doesn't index schemas and it doesn't hand everything to the LLM. It run
 through a **pipeline of phases**, each using the right method for the job, and blends three
 kinds of evidence:
 
-- **Deterministic** — exact structure: type inference and casting (failed casts go to
-  quarantine, never a crash), key and relationship detection, join-path analysis.
+- **Deterministic** — exact structure: type inference and casting (failed casts go to a
+  quarantine table; the run continues), key and relationship detection, join-path
+  analysis.
 - **Statistical** — what the shape of the data reveals: profiles, distributions, outliers,
   Benford's law, correlations, temporal granularity and drift.
 - **LLM** — business meaning: what a column *is*, which concept it grounds, how to compose

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -41,43 +41,46 @@ below and [The approach](../concepts/approach.md) for the full treatment).
 
 ## The journey
 
-Your data moves through a sequence of stages. Each stage produces an artifact the next one
-builds on, and each is driven by an agent with a bounded job.
+You drive the journey from the cockpit in three kinds of chat; beneath them the system
+runs five stages, each producing an artifact the next one builds on.
 
 ```mermaid
 flowchart LR
-    F["<b>frame</b><br/>intent → concepts"]
-    A["<b>connect / add_source</b><br/>raw data → typed, profiled"]
-    B["<b>begin_session</b><br/>tables → analytical workspace"]
-    O["<b>operating_model</b><br/>workspace → validations,<br/>cycles, metrics"]
-    AN["<b>answer</b><br/>question → grounded answer"]
-
-    F --> B
-    A --> B
-    B --> O
-    O --> AN
-
+    subgraph C["<b>Connect</b> — bring data in"]
+        direction TB
+        F["frame"]
+        A["add_source"]
+        F --> A
+    end
+    subgraph S["<b>Stage</b> — build the model"]
+        direction TB
+        B["begin_session"]
+        O["operating_model"]
+        B --> O
+    end
+    subgraph AN["<b>Analyse</b> — ask"]
+        Q["answer"]
+    end
+    C --> S --> AN
     style F fill:#fafafa
     style A fill:#e8f5e9
     style B fill:#fff8e1
     style O fill:#e3f2fd
-    style AN fill:#f3e5f5
+    style Q fill:#f3e5f5
 ```
 
-- **frame** — you describe what you want to understand; the cockpit induces the *concepts*
-  that matter and records them as the grounding target.
-- **connect / add_source** — you bring in sources: a database, an API export, a
-  spreadsheet, a file. The engine loads everything as text, infers types (failed casts go
-  to quarantine, never a crash), profiles each column statistically, and annotates it
-  semantically with the LLM.
-- **begin_session** — the engine composes your typed tables into an analytical workspace:
-  it discovers relationships, builds enriched join views, identifies slice dimensions, and
-  ranks the drivers behind each measure.
-- **operating_model** — the engine reconciles the framed concepts with what the data can
-  actually support, producing **validations**, **business cycles**, and **metrics** that
-  are bound to your data and executed against it.
-- **answer** — you ask questions in plain language; the cockpit's agent composes SQL
-  grounded in the operating model and returns the answer with its provenance.
+- **Connect** — declare what the workspace is about, then bring data in. You describe
+  what you want to understand and the cockpit records the *concepts* that matter as the
+  grounding target (**frame**); then the engine loads your sources as text, infers types
+  (failed casts go to quarantine, never a crash), profiles each column, and grounds it
+  against the framed concepts (**add_source**).
+- **Stage** — teach meaning, then build the model. The engine composes your typed tables
+  into one analytical workspace — relationships, enriched join views, slice dimensions,
+  drivers (**begin_session**) — then reconciles the framed target with what the data
+  actually supports, producing **validations**, **business cycles**, and **metrics** bound
+  to your data and executed against it (**operating_model**).
+- **Analyse** — ask questions in plain language; the cockpit's agent composes SQL grounded
+  in the operating model and returns the answer with its provenance (**answer**).
 
 ## How understanding is measured
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,8 @@
 **Ground your organization's operating model in its own data.** Every organization runs on
 an operating model — the entities it deals in, the processes it runs, the rules that must
 hold, the measures it watches. That model usually lives scattered across tools, documents,
-and people, disconnected from the data underneath it. DataRaum brings the two together: it
-turns the structured data an organization already has into an **executable operating
-model**, with an LLM held to a closed vocabulary and to measurements it cannot fake.
+and people, disconnected from the data underneath it. DataRaum turns the structured data an
+organization already has into an **executable operating model**.
 
 A semantic layer tells BI tools what columns are *called*. DataRaum learns what they *mean*
 — the concepts, relationships, rules, and measures of the organization — and grounds each
@@ -25,33 +24,25 @@ durable artifact at the end: the concepts, processes, rules, and measures that u
 in scattered tools and tribal knowledge, now expressed as something you can run, measure,
 and ask questions against.
 
-The deliverable is not a cleaned table or a dashboard. It is that model **plus a measured
-account of how well the system comprehends each part of your data** — solid here, shaky
-there — carried alongside it, so you always know how far to trust it. That is *data
-understanding* in a literal sense, and it is why we call DataRaum an **understanding
-layer**: the layer between your data and an LLM that holds what the system understands —
-and how well.
+The deliverable is the model plus a measured account of how well each part of it is
+grounded in the data, carried alongside it. This is why we call DataRaum an
+**understanding layer**: it sits between the data and an LLM, and holds what the system
+understands about the data — and how well.
 
-## Why you can trust the LLM here
+## Constraints on the LLM
 
-An LLM is what makes grounding an organization this way possible — and an LLM left to its own
-devices is exactly what you can't put in charge of decisions that matter. Two mechanisms keep
-it honest:
+An LLM supplies the one thing only language understanding can: what fields and tables mean
+in business terms. Two constraints bound its role:
 
-- **A closed vocabulary it can't escape.** The LLM can't invent new *kinds* of claim. It
-  works against a small, typed surface — concepts, measures, rules, processes, and a handful
-  of *teaches* — and can only fill those in. Even a correction enters as *evidence to be
-  weighed*, never as a direct edit to a result: it cannot make a problem disappear by
-  describing it. (This is the **Goodhart firewall** — see
-  [the learnable surface](concepts/learnable-surface.md).)
-- **Measurement it can't game.** The system continuously measures its own uncertainty — as
-  **entropy**, the disagreement between independent witnesses — and reports it as a plain
-  readiness signal: *ready*, *investigate*, *blocked*. Those numbers aren't vibes; the
-  detectors behind them are **calibrated against known ground truth**, so a low score really
-  does track usable data and a high one really does mean *look here*. See
-  [measurement & detectors](concepts/measurement.md).
-
-The effect is a system that can't make false progress by hiding what it doesn't know.
+- **A fixed vocabulary.** The LLM fills in a typed set of claims — concepts, measures,
+  rules, processes, and a fixed set of *teaches* — and cannot add new kinds. Corrections
+  enter the next analysis run as evidence, weighed with the rest; they do not edit
+  results. (See [the learnable surface](concepts/learnable-surface.md).)
+- **Independent measurement.** The system measures its own uncertainty as **entropy** —
+  disagreement between independent witnesses, at least one of which reads the data itself —
+  and reports it as a readiness signal: *ready*, *investigate*, *blocked*. Detector
+  reliabilities are calibrated against datasets with known, injected issues. (See
+  [measurement & detectors](concepts/measurement.md).)
 
 ## How it gets there
 
@@ -63,9 +54,9 @@ blends three kinds of evidence:
 - **Statistical** — what the shape of the data reveals: distributions, outliers, drift.
 - **LLM** — meaning: what a field *is*, which concept it grounds, how a measure is composed.
 
-No single method is trusted on its own. Where they **disagree** — the field's name claims
-one thing, the data shows another — that disagreement is the signal the **detectors**
-measure, and it's what turns into the readiness you can act on.
+No single method is trusted on its own. Where they disagree — the field's name claims one
+thing, the data shows another — the **detectors** measure the disagreement, and readiness
+is computed from it.
 
 ```mermaid
 flowchart TB
@@ -101,26 +92,24 @@ picture, not over one source at a time.
 
 ## How you use it
 
-You work in a **workspace** through the web cockpit. Nothing about your domain is baked in:
-you describe what you care about in plain language, and DataRaum builds the model with you.
-The work happens in three kinds of chat, each pairing an agent with a working canvas:
+You work in a **workspace** through the web cockpit. Nothing about your domain is
+pre-configured: you describe it in plain language. The work happens in three kinds of chat,
+each pairing an agent with a working canvas:
 
 - **Connect** — bring data in. Assemble an import set (upload files, probe a database),
-  **frame** your domain — declare the concepts you care about, or adopt a shipped vertical
-  as a head start — and import. An autonomous grounding loop types and re-grounds what it
-  can on its own, surfacing only the gaps that need you.
+  **frame** your domain — declare the concepts you care about, or adopt a shipped
+  vertical — and import. A grounding loop types and re-grounds what it can on its own,
+  surfacing the gaps that need you.
 - **Stage** — teach the model what things *mean*, then run an analytical session over the
   typed tables — relationships, dimensions, drivers — and build the operating model
   (validations, cycles, metrics) over the combined picture.
-- **Analyse** — ask questions in plain language. Answers come back grounded: the SQL that
-  produced them, the concepts they touched, and a confidence you can inspect — never a bare
-  number.
+- **Analyse** — ask questions in plain language. Answers return with the SQL that produced
+  them, the concepts they touched, and the grounding confidence.
 
 Around the chats sit the standing surfaces: the **Model** graph (the operating model as a
-navigable graph over your actual columns), **Governance** (the workspace's state of the
-union), **Runs** (everything in flight, and what needs you), and **Reports** (a frozen
-answer whose SQL re-runs live on every open — and which tells you when the data has moved
-under it).
+navigable graph over your columns), **Governance** (the workspace's overall state),
+**Runs** (work in flight, and what needs your input), and **Reports** (saved answers whose
+SQL re-runs on open, flagged when the data has changed since the summary was written).
 
 See the [Overview](getting-started/overview.md) for the whole arc, and
 [Running the stack](getting-started/running-the-stack.md) to bring it up.

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,12 +129,15 @@ See the [Overview](getting-started/overview.md) for the whole arc, and
 
 - **The concept, in depth** — [The approach](concepts/approach.md) (how the methods
   combine), [the journey](concepts/the-journey.md), the
-  [pipeline & phases](concepts/pipeline.md), the
-  [learnable surface](concepts/learnable-surface.md) (the closed vocabulary), and
-  [measurement & detectors](concepts/measurement.md) (entropy, witnesses, calibration).
+  [operating model](concepts/operating-model.md) (the deliverable itself),
+  [frame, ground, teach](concepts/frame-ground-teach.md) (how knowledge enters and
+  improves), the [learnable surface](concepts/learnable-surface.md) (the closed
+  vocabulary), and [measurement & detectors](concepts/measurement.md) (entropy,
+  witnesses, calibration).
 - **Using it** — [Overview](getting-started/overview.md) and
   [Running the stack](getting-started/running-the-stack.md).
 - **Under the hood** — the [platform architecture](platform/architecture.md), the
+  [pipeline & phases](concepts/pipeline.md), the
   [decision records](adr/README.md), and [Deployment](operations/deployment.md) for
   running released images.
 - **The design intent** (north-star, not current state) —

--- a/zensical.toml
+++ b/zensical.toml
@@ -14,12 +14,14 @@ nav = [
   { "Concepts" = [
     "concepts/approach.md",
     "concepts/the-journey.md",
-    "concepts/pipeline.md",
+    "concepts/operating-model.md",
+    "concepts/frame-ground-teach.md",
     "concepts/learnable-surface.md",
     "concepts/measurement.md",
   ] },
   { "Under the hood" = [
     "platform/architecture.md",
+    "concepts/pipeline.md",
   ] },
   { "Operations" = [
     "operations/deployment.md",


### PR DESCRIPTION
Phase 1 of the documentation overhaul (follows #425): the concept spine.

## New pages

- **`concepts/operating-model.md`** — the product's central noun gets a home. Covers: executable-not-documented (a metric runs, a validation has a verdict recomputed when you look, a cycle's completion is measured); the graph shape with **concepts as the hub** (artifact → concept → column, mirroring exactly what the Model surface renders); the six artifact families; the **declared → grounded → executed lifecycle** — including the honesty stance that an unsupported artifact stays declared *with the reason recorded*. The lifecycle section moved here from `learnable-surface.md` (which now points at it) — it belongs with the deliverable, not the vocabulary.
- **`concepts/frame-ground-teach.md`** — the knowledge cycle, named as a concept: **frame** declares (before the data is touched — the declaration is the standard, not a post-hoc summary), **ground** binds (earned, not asserted; unmet is visible in both directions), **teach** corrects (**as evidence, not an override** — the no-override half of the Goodhart firewall). Ends on the design point: declaration, adjudication, and correction are structurally separated.

## Rewrites

- **`the-journey.md`** — now chats-first: **Connect / Stage / Analyse** as the structure, the five engine stages beneath each. Inbound anchors (`#frame`, `#operating_model`, `#begin_session`) preserved. Two content fixes:
  - The old page claimed frame and add_source are independent and "join at begin_session" — contradicting its own add_source section and ADR-0007 (add_source grounds framed concepts per-column). Diagram and prose now match reality.
  - The "a name we never fixed" contributor aside replaced with a neutral naming note (`begin_session` = read as *ingest*).
- **`overview.md`** — journey section refit to the same three-chat arc, so index → overview → journey all speak one vocabulary, with engine stage names introduced as the under-the-hood mapping.

## Nav

- Two new pages under Concepts (ordered: approach → journey → operating model → frame/ground/teach → learnable surface → measurement).
- `pipeline.md` moved from Concepts to **Under the hood** — it's engine internals, not a user concept.

## Verification

- Zensical build clean — including its anchor validation (caught one wrong anchor id during authoring, fixed).
- All relative links verified.

Phase 2 next: measurement split (user trust page + math deep-dive), relationships & aggregation page, unified firewall treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)