### PR TITLE
docs: phase-2 depth — relationships & aggregation, stage-authorization gate

### DIFF
--- a/docs/concepts/learnable-surface.md
+++ b/docs/concepts/learnable-surface.md
@@ -2,8 +2,10 @@
 
 The learnable surface is the set of things DataRaum can be taught about an organization: a
 small, **typed, closed** vocabulary that agents and users fill in but cannot extend. This
-is the closed-vocabulary half of the **Goodhart firewall** (the measurement half is in
-[measurement & detectors](measurement.md)).
+is one of the **Goodhart firewall**'s three enforcement points; the others are the
+measurement pooling ([measurement & detectors](measurement.md)) and the stage
+authorization of lifecycle operations
+([the operating model](operating-model.md#the-lifecycle)).
 
 ## Closed for use
 

--- a/docs/concepts/operating-model.md
+++ b/docs/concepts/operating-model.md
@@ -89,6 +89,15 @@ Artifacts are versioned by run: a re-run writes a new version under a new run id
 new version becomes visible only when the run completes. A failed or partial run is not
 shown.
 
+Lifecycle operations are **stage-authorized**: each operation (declare, bind, compose,
+execute, endorse) is permitted only from specific journey stages, and an operation from
+any other stage is rejected. The check is fail-closed — a stage not explicitly authorized
+is denied. `endorse`, the transition to canonical, is authorized for no stage, so no
+artifact can reach canonical regardless of what an agent requests. This is the third
+enforcement point of the **Goodhart firewall**, alongside the
+[closed vocabulary](learnable-surface.md) and the
+[measurement pooling](measurement.md#the-goodhart-firewall).
+
 !!! note "canonical and endorsement are not built"
     The design adds a fourth state, **canonical** — an *organizational* state meaning
     "endorsed as the version we use" — reached through an endorsement workflow. Neither

--- a/docs/concepts/relationships-and-aggregation.md
+++ b/docs/concepts/relationships-and-aggregation.md
@@ -1,0 +1,69 @@
+# Relationships & aggregation
+
+Two structural questions decide whether cross-table analysis is safe: how tables join, and
+how a measure may be aggregated. Both are answered from the data, as pooled claims with
+measured uncertainty — the same model as every other
+[measurement](measurement.md).
+
+## Relationships
+
+A join between two tables is established in three steps, each recorded:
+
+1. **Candidates from values.** Column pairs are proposed by value overlap — containment
+   and Jaccard similarity, computed exactly or by sampling on large columns — together
+   with per-column uniqueness, which yields the candidate cardinality (one-to-one,
+   one-to-many, many-to-many).
+2. **Evaluation against the data.** Before any semantic step, each candidate is measured:
+   referential integrity in both directions, orphan counts, whether the join verifies its
+   claimed cardinality, and whether it introduces duplicate rows.
+3. **Semantic confirmation.** An LLM reads the evaluated candidates in table context and
+   confirms a subset. Confirmed relationships persist, alongside relationships you teach.
+
+The standing claim — *do these columns join?* — is then adjudicated by a pooled
+measurement with four witnesses: value overlap (the data witness), the LLM's judgment,
+manual curation (a `relationship` teach), and keeper retention (a join you chose to keep).
+A confident LLM witness over a weak data witness raises conflict, and the relationship is
+flagged for investigation rather than silently kept or dropped.
+
+Confirmed relationships feed three consumers: **enriched join views** (grain-preserving
+joins of a fact table with its dimensions — a view whose row count differs from the fact's
+is dropped, because the join changed the grain), the **Model** graph's *relates* edges,
+and the SQL composed at answer time.
+
+## Aggregation
+
+The claim: is a measure column a **flow** (a per-period movement, summable across periods)
+or a **stock** (a carried-forward level, like a balance)? The distinction decides how the
+column may be aggregated — summing a stock across periods double-counts it.
+
+Three witnesses pool over the claim space {stock, flow}:
+
+- **the concept's declared temporal behaviour** — the ontology prior, with its strength
+  scaled by the grounding confidence: a contested grounding weakens the prior instead of
+  hiding the contest,
+- **the LLM's independent read** of the column — name, table context, sample values,
+- **structural reconciliation** — the data witness. Where a measure aggregates an event
+  table, the engine compares the measure's period series `y[t]` with the per-period net
+  movement `m[t]` aggregated independently from the events. A flow satisfies
+  `y[t] ≈ m[t]`; a stock satisfies `Δy[t] ≈ m[t]`. Scale-free residuals decide between
+  the two. The witness abstains when both residuals are large (which indicates a wrong
+  anchor — wrong entity, wrong join, wrong period — rather than a verdict), when the
+  series is shorter than four periods, or when too few entities agree.
+
+The data witness exists because the other two read the name: on ambiguously named columns
+they fail together, and calibration shows their accuracy falls to chance there. Only a
+witness whose input is the data can dissent in that case.
+
+The pooled verdict is recorded on the column — `additive` or `point_in_time`, with a
+contested flag when witnesses disagree — and aggregation follows it: metrics and
+[drivers](operating-model.md#the-parts) sum a flow over the period and take a stock at the
+period's level. The same reconciliation pass also checks sum-consistency across fact
+tables that share a slice dimension, so a measure reported by two sources is compared
+per slice value and period rather than assumed to agree.
+
+## Correcting either
+
+Both claims accept teaches: a `relationship` teach adds or confirms a join; a
+`concept_property` or `rebind` teach corrects a column's temporal behaviour. As with every
+teach, the correction enters the pool as a witness and the claim is re-adjudicated on the
+next run — see [frame, ground, teach](frame-ground-teach.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,8 +121,10 @@ See the [Overview](getting-started/overview.md) for the whole arc, and
   [operating model](concepts/operating-model.md) (the deliverable itself),
   [frame, ground, teach](concepts/frame-ground-teach.md) (how knowledge enters and
   improves), the [learnable surface](concepts/learnable-surface.md) (the closed
-  vocabulary), and [measurement & detectors](concepts/measurement.md) (entropy,
-  witnesses, calibration).
+  vocabulary), [measurement & detectors](concepts/measurement.md) (entropy, witnesses,
+  calibration), and
+  [relationships & aggregation](concepts/relationships-and-aggregation.md) (joins,
+  stock vs. flow).
 - **Using it** — [Overview](getting-started/overview.md) and
   [Running the stack](getting-started/running-the-stack.md).
 - **Under the hood** — the [platform architecture](platform/architecture.md), the

--- a/zensical.toml
+++ b/zensical.toml
@@ -18,6 +18,7 @@ nav = [
     "concepts/frame-ground-teach.md",
     "concepts/learnable-surface.md",
     "concepts/measurement.md",
+    "concepts/relationships-and-aggregation.md",
   ] },
   { "Under the hood" = [
     "platform/architecture.md",


### PR DESCRIPTION
Phase 2 of the documentation overhaul (follows #425, #426). Written in the sober register.

## New page

**`concepts/relationships-and-aggregation.md`** — the two structural claims that decide whether cross-table analysis is safe, previously the thinnest area of the docs:

- **Relationships**: value-overlap candidates → referential-integrity/cardinality/duplicate evaluation → LLM confirmation → four-witness adjudication (value overlap, LLM judgment, manual curation, keeper retention), and what consumes the result (enriched views with the grain check, the Model graph, answer-time SQL).
- **Aggregation**: the stock/flow claim and its three witnesses, including the structural-reconciliation data witness (`y[t] ≈ m[t]` vs `Δy[t] ≈ m[t]`, scale-free residuals, abstain on wrong anchor / short series / split votes) and why a data witness exists at all: name-reading witnesses fail together on ambiguous names. The verdict (`additive` / `point_in_time`, contested flag) and how aggregation follows it.

Mechanics verified against `analysis/relationships/`, `analysis/lineage/reconcile.py`, and `entropy/measurements/` before writing.

## Firewall: the missing gate

The stage authorization of lifecycle operations was the firewall's only undocumented enforcement point (`lifecycle/transitions.py`: fail-closed per journey stage; `endorse` authorized for no stage, so canonical is unreachable). Now documented in `operating-model.md`'s lifecycle section; `learnable-surface.md`'s intro names all three enforcement points instead of "two halves".

## Plan change

The measurement split (user trust page + math deep-dive) is dropped: the sober rework resolved the audience mixing it was meant to fix. index/overview carry the user-level view; `measurement.md` stays the deep treatment.

## Verification

Zensical build clean (anchor validation included); links verified.

Remaining from the original plan: Phase 3 (ADR user-readiness sweep), and the deliberate screenshot shot-list once you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)