### PR TITLE
feat(DAT-591): Model page as a metric composition graph

### DIFF
--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -263,11 +263,12 @@ export const currentLifecycleArtifacts = metadataSchema
 		strictness: doublePrecision(),
 		groundedAgainst: json("grounded_against"),
 		teaches: json(),
+		graphDefinition: json("graph_definition"),
 		createdAt: timestamp("created_at"),
 		stateChangedAt: timestamp("state_changed_at"),
 	})
 	.as(
-		sql`SELECT artifact_id, artifact_type, artifact_key, run_id, state, state_reason, stage, strictness, grounded_against, teaches, created_at, state_changed_at FROM ws_00000000_0000_0000_0000_000000000001.lifecycle_artifacts r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'operating_model'::text AND h.run_id::text = r.run_id::text))`,
+		sql`SELECT artifact_id, artifact_type, artifact_key, run_id, state, state_reason, stage, strictness, grounded_against, teaches, graph_definition, created_at, state_changed_at FROM ws_00000000_0000_0000_0000_000000000001.lifecycle_artifacts r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'operating_model'::text AND h.run_id::text = r.run_id::text))`,
 	);
 
 export const currentMaterializationRecipes = metadataSchema

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/operating-model.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/operating-model.tsx
@@ -1,7 +1,9 @@
-// The Model section (DAT-591) — a standing page rendering the workspace's
-// concept-spine operating-model DAG. Data is read server-side (the metadata
-// Drizzle client never reaches the client bundle); the xyflow canvas is rendered
-// client-only (React Flow measures the DOM, so it must not run during SSR).
+// The Model section (DAT-591) — a standing page rendering the workspace's metric
+// composition graph (metric → metric → measure → table). Data is read server-side
+// (the metadata Drizzle client never reaches the client bundle); the xyflow canvas is
+// rendered client-only (React Flow measures the DOM, so it must not run during SSR).
+// (Validation/cycle/driver get their own graphs in a follow-up — this page is
+// metrics-only.)
 
 import { Box, Center, Code, ScrollArea, Stack, Text } from "@mantine/core";
 import {
@@ -30,9 +32,8 @@ function ModelError({ error }: ErrorComponentProps) {
 				<ModelIcon size={32} color="var(--mantine-color-red-6)" />
 				<Text fw={600}>Couldn't load the operating model</Text>
 				<Text size="sm" c="dimmed" ta="center">
-					The concept-spine data failed to load. This is usually a metadata read
-					error — check the run, or that the cockpit build matches the engine
-					schema.
+					The metric graph failed to load. This is usually a metadata read error
+					— check the run, or that the cockpit build matches the engine schema.
 				</Text>
 				<ScrollArea.Autosize mah={200} w="100%">
 					<Code block>{error.message}</Code>
@@ -63,7 +64,7 @@ function ModelSection() {
 		return (
 			<EmptyState
 				title="No operating model yet"
-				detail="Run the operating model over a framed session to populate the concept-spine canvas — metrics, cycles, validations and their drivers."
+				detail="Run the operating model over a framed session to populate the metric graph — every metric, the measures it reads, and how the metrics compose."
 			/>
 		);
 	}

--- a/packages/cockpit/src/routes/(app)/workspace/$wsId/operating-model.tsx
+++ b/packages/cockpit/src/routes/(app)/workspace/$wsId/operating-model.tsx
@@ -3,8 +3,12 @@
 // Drizzle client never reaches the client bundle); the xyflow canvas is rendered
 // client-only (React Flow measures the DOM, so it must not run during SSR).
 
-import { Box, Center, Stack, Text } from "@mantine/core";
-import { ClientOnly, createFileRoute } from "@tanstack/react-router";
+import { Box, Center, Code, ScrollArea, Stack, Text } from "@mantine/core";
+import {
+	ClientOnly,
+	createFileRoute,
+	type ErrorComponentProps,
+} from "@tanstack/react-router";
 
 import { ModelIcon } from "#/ui/cockpit/operating-model/nodes";
 import { OperatingModelCanvas } from "#/ui/cockpit/operating-model/operating-model-canvas";
@@ -13,7 +17,30 @@ import { loadModel } from "./operating-model.functions";
 export const Route = createFileRoute("/(app)/workspace/$wsId/operating-model")({
 	loader: () => loadModel(),
 	component: ModelSection,
+	// A loader failure (e.g. a metadata read against a drifted view) must degrade
+	// to a readable error, never a white screen — the route renders server-side,
+	// so an unhandled loader throw would otherwise blank the page.
+	errorComponent: ModelError,
 });
+
+function ModelError({ error }: ErrorComponentProps) {
+	return (
+		<Center h="100%">
+			<Stack gap="xs" align="center" maw={560}>
+				<ModelIcon size={32} color="var(--mantine-color-red-6)" />
+				<Text fw={600}>Couldn't load the operating model</Text>
+				<Text size="sm" c="dimmed" ta="center">
+					The concept-spine data failed to load. This is usually a metadata read
+					error — check the run, or that the cockpit build matches the engine
+					schema.
+				</Text>
+				<ScrollArea.Autosize mah={200} w="100%">
+					<Code block>{error.message}</Code>
+				</ScrollArea.Autosize>
+			</Stack>
+		</Center>
+	);
+}
 
 function EmptyState({ title, detail }: { title: string; detail: string }) {
 	return (
@@ -50,7 +77,16 @@ function ModelSection() {
 	}
 
 	return (
-		<Box h="100%">
+		// React Flow needs a DEFINITE height. AppShell.Main only sets min-height
+		// (its `height` is auto), so `h="100%"` here resolves to 0 and the canvas
+		// renders blank. Size the container to the viewport minus the header offset
+		// (--app-shell-header-offset, 3rem) and the Main's 1rem top + 1rem bottom
+		// padding — a concrete height the flow pane and its children resolve against.
+		<Box
+			style={{
+				height: "calc(100dvh - var(--app-shell-header-offset, 3rem) - 2rem)",
+			}}
+		>
 			<ClientOnly fallback={<EmptyState title="Loading canvas…" detail="" />}>
 				<OperatingModelCanvas graph={graph} />
 			</ClientOnly>

--- a/packages/cockpit/src/tools/operating-model-graph.test.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.test.ts
@@ -6,7 +6,6 @@ import {
 	buildOperatingModelGraph,
 	computeVisibleGraph,
 	type DriverInput,
-	extractConceptsFromDag,
 	filterGraph,
 	OM_PRESET_KINDS,
 	type OMNodeKind,
@@ -81,58 +80,6 @@ const ids = (g: { nodes: { id: string }[] }) =>
 const edgeKinds = (g: {
 	edges: { source: string; target: string; kind: string }[];
 }) => new Set(g.edges.map((e) => `${e.source}->${e.target}:${e.kind}`));
-
-describe("extractConceptsFromDag", () => {
-	// gross_margin: two extract leaves (revenue, cost_of_goods_sold) + two formula
-	// steps. The reliable metric→concept linkage is the extract leaves — the formulas
-	// carry no standard_field. This is exactly the gap the snippet-provenance derivation
-	// missed (gross_margin reused shared revenue/cogs snippets → no edge).
-	const grossMarginDag = {
-		revenue: {
-			type: "extract",
-			source: { standard_field: "revenue", statement: "income_statement" },
-			aggregation: "sum",
-		},
-		cost_of_goods_sold: {
-			type: "extract",
-			source: {
-				standard_field: "cost_of_goods_sold",
-				statement: "income_statement",
-			},
-			aggregation: "sum",
-		},
-		gross_profit: {
-			type: "formula",
-			expression: "revenue - cost_of_goods_sold",
-			depends_on: ["revenue", "cost_of_goods_sold"],
-		},
-		gross_margin: {
-			type: "formula",
-			expression: "gross_profit / revenue",
-			depends_on: ["gross_profit", "revenue"],
-			output_step: true,
-		},
-	};
-
-	it("returns the standard_fields of the extract leaves only", () => {
-		expect(extractConceptsFromDag(grossMarginDag).sort()).toEqual([
-			"cost_of_goods_sold",
-			"revenue",
-		]);
-	});
-
-	it("ignores formula/constant steps and tolerates malformed input", () => {
-		expect(extractConceptsFromDag(null)).toEqual([]);
-		expect(extractConceptsFromDag("nope")).toEqual([]);
-		expect(
-			extractConceptsFromDag({
-				k: { type: "constant", value: 30 },
-				f: { type: "formula", expression: "a/b", depends_on: ["a", "b"] },
-				bad: { type: "extract" }, // no source → skipped, no throw
-			}),
-		).toEqual([]);
-	});
-});
 
 describe("buildOperatingModelGraph", () => {
 	it("wires the concept-spine: artifact → concept → column, driver and FK", () => {

--- a/packages/cockpit/src/tools/operating-model-graph.test.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.test.ts
@@ -11,6 +11,7 @@ import {
 	type OMNodeKind,
 	type OperatingModelGraphInput,
 	parseMetricDag,
+	resolveGrounding,
 } from "./operating-model-graph";
 
 // --- DAG fixture builders (mirror the persisted graph_definition shape) --------
@@ -133,6 +134,7 @@ const CCC = metric("cash_conversion_cycle", "Cash Conversion Cycle", "days", {
 const ev = { tableId: "ev1", tableName: "enriched_journal_lines" };
 const grounded = (field: string): MeasureGroundingInput => ({
 	standardField: field,
+	grounded: true,
 	sql: `-- extract sql for ${field}`,
 	enrichedView: ev,
 	baseTables: [
@@ -140,9 +142,11 @@ const grounded = (field: string): MeasureGroundingInput => ({
 		{ tableId: "t2", tableName: "chart_of_accounts" },
 	],
 });
+// A failed extract: NOT grounded, no table — but its attempted SQL is still carried.
 const ungrounded = (field: string): MeasureGroundingInput => ({
 	standardField: field,
-	sql: null,
+	grounded: false,
+	sql: `-- attempted (no support) sql for ${field}`,
 	enrichedView: null,
 	baseTables: [],
 });
@@ -263,20 +267,24 @@ describe("buildOperatingModelGraph", () => {
 			kind: "table",
 			layer: "enriched",
 		});
-		expect(g.nodes.find((n) => n.id === "table:t1")?.parent).toBe("table:ev1");
+		expect(g.nodes.find((n) => n.id === "table:t1")?.parents).toEqual([
+			"table:ev1",
+		]);
 	});
 
-	it("leaves an ungrounded measure as a leaf with no table edge", () => {
+	it("flags an ungrounded measure as a leaf but still carries its attempted SQL", () => {
 		const g = buildOperatingModelGraph(base());
 		expect(ids(g)).toContain("measure:inventory");
 		expect(
 			[...edgeKeys(g)].some((k) => k.startsWith("measure:inventory->")),
 		).toBe(false);
+		// grounded=false, but the failed extract's SQL is still shown (not dropped).
 		expect(
 			g.nodes.find((n) => n.id === "measure:inventory")?.data,
 		).toMatchObject({
 			kind: "measure",
 			grounded: false,
+			sql: "-- attempted (no support) sql for inventory",
 		});
 	});
 
@@ -312,16 +320,14 @@ describe("buildOperatingModelGraph", () => {
 });
 
 describe("computeVisibleGraph (collapse base tables under the enriched view)", () => {
-	it("hides base tables and re-points their edges to the enriched view", () => {
+	it("hides base tables and drops their derives edges (no fabricated re-point)", () => {
 		const full = buildOperatingModelGraph(base());
 		const v = computeVisibleGraph(full, new Set());
 		expect(ids(v)).not.toContain("table:t1");
 		expect(ids(v)).not.toContain("table:t2");
 		expect(ids(v)).toContain("table:ev1");
-		// the derives edge (enriched→its own hidden base) self-loops → dropped.
-		expect(
-			[...edgeKeys(v)].some((k) => k === "table:ev1->table:ev1:derives"),
-		).toBe(false);
+		// derives edges into a hidden base are dropped — never a self-loop or view→view.
+		expect([...edgeKeys(v)].some((k) => k.includes(":derives"))).toBe(false);
 		// measure→enriched still stands.
 		expect(edgeKeys(v)).toContain("measure:revenue->table:ev1:grounds");
 	});
@@ -331,6 +337,148 @@ describe("computeVisibleGraph (collapse base tables under the enriched view)", (
 		const v = computeVisibleGraph(full, new Set(["table:ev1"]));
 		expect(ids(v)).toContain("table:t1");
 		expect(edgeKeys(v)).toContain("table:ev1->table:t1:derives");
+	});
+
+	it("handles a base table shared by two enriched views without fabricating edges", () => {
+		const shared = { tableId: "coa", tableName: "chart_of_accounts" };
+		const gv = (
+			field: string,
+			viewId: string,
+			viewName: string,
+			ownBase: { tableId: string; tableName: string },
+		): MeasureGroundingInput => ({
+			standardField: field,
+			grounded: true,
+			sql: null,
+			enrichedView: { tableId: viewId, tableName: viewName },
+			baseTables: [ownBase, shared],
+		});
+		const one = metric("m_rev", "Rev", "currency", {
+			revenue: extract("revenue", "income_statement"),
+			m_rev: formula("revenue", ["revenue"], true),
+		});
+		const two = metric("m_cash", "Cash", "currency", {
+			cash: extract("cash", "balance_sheet"),
+			m_cash: formula("cash", ["cash"], true),
+		});
+		const g = buildOperatingModelGraph({
+			metrics: [one, two],
+			grounding: [
+				gv("revenue", "ev1", "enriched_journal_lines", {
+					tableId: "jl",
+					tableName: "journal_lines",
+				}),
+				gv("cash", "ev2", "enriched_bank_transactions", {
+					tableId: "bt",
+					tableName: "bank_transactions",
+				}),
+			],
+		});
+		// The shared table records BOTH views as parents.
+		expect(g.nodes.find((n) => n.id === "table:coa")?.parents).toEqual([
+			"table:ev1",
+			"table:ev2",
+		]);
+		// Collapsed: shared hidden, and NO fabricated view→view edge appears.
+		const collapsed = computeVisibleGraph(g, new Set());
+		expect(ids(collapsed)).not.toContain("table:coa");
+		expect(
+			[...edgeKeys(collapsed)].some((k) => /table:ev\d->table:ev\d/.test(k)),
+		).toBe(false);
+		// Expanding EITHER owning view reveals the shared table (multi-parent).
+		expect(ids(computeVisibleGraph(g, new Set(["table:ev2"])))).toContain(
+			"table:coa",
+		);
+	});
+});
+
+describe("resolveGrounding", () => {
+	const views = [
+		{
+			viewName: "enriched_journal_lines",
+			viewTableId: "ev1",
+			baseTableIds: ["t1", "t2"],
+		},
+	];
+	const names = new Map([
+		["t1", "journal_lines"],
+		["t2", "chart_of_accounts"],
+	]);
+	const ex = (
+		standardField: string,
+		sql: string | null,
+		failureCount: number,
+		columnMappingsText = "{}",
+	) => ({ standardField, sql, columnMappingsText, failureCount });
+
+	it("grounds an accepted extract via its SQL FROM clause (not column_mappings)", () => {
+		const [g] = resolveGrounding(
+			[ex("revenue", "SELECT sum(x) FROM enriched_journal_lines jl", 0)],
+			views,
+			names,
+		);
+		expect(g).toMatchObject({ standardField: "revenue", grounded: true });
+		expect(g.enrichedView).toEqual({
+			tableId: "ev1",
+			tableName: "enriched_journal_lines",
+		});
+		expect(g.baseTables).toEqual([
+			{ tableId: "t1", tableName: "journal_lines" },
+			{ tableId: "t2", tableName: "chart_of_accounts" },
+		]);
+	});
+
+	it("marks a FAILED extract ungrounded (no table) but keeps its SQL", () => {
+		const [g] = resolveGrounding(
+			[ex("inventory", "SELECT sum(x) FROM enriched_journal_lines WHERE …", 1)],
+			views,
+			names,
+		);
+		expect(g).toMatchObject({ standardField: "inventory", grounded: false });
+		expect(g.enrichedView).toBeNull();
+		expect(g.sql).toContain("enriched_journal_lines"); // still carried through
+	});
+
+	it("resolves the view from column_mappings when the SQL lacks it", () => {
+		const [g] = resolveGrounding(
+			[ex("revenue", null, 0, '{"revenue":"enriched_journal_lines.x"}')],
+			views,
+			names,
+		);
+		expect(g.enrichedView?.tableName).toBe("enriched_journal_lines");
+	});
+
+	it("prefers the longest matching view name (no shorter-name shadowing)", () => {
+		const [g] = resolveGrounding(
+			[ex("x", "FROM enriched_journal_lines_detail", 0)],
+			[
+				{
+					viewName: "enriched_journal_lines",
+					viewTableId: "a",
+					baseTableIds: [],
+				},
+				{
+					viewName: "enriched_journal_lines_detail",
+					viewTableId: "b",
+					baseTableIds: [],
+				},
+			],
+			new Map(),
+		);
+		expect(g.enrichedView?.tableName).toBe("enriched_journal_lines_detail");
+	});
+
+	it("dedupes by standard_field (first/newest row wins)", () => {
+		const g = resolveGrounding(
+			[
+				ex("revenue", "FROM enriched_journal_lines", 0),
+				ex("revenue", "FROM other", 1),
+			],
+			views,
+			names,
+		);
+		expect(g).toHaveLength(1);
+		expect(g[0].grounded).toBe(true);
 	});
 });
 

--- a/packages/cockpit/src/tools/operating-model-graph.test.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.test.ts
@@ -10,6 +10,7 @@ import {
 	OM_PRESET_KINDS,
 	type OMNodeKind,
 	type OperatingModelGraphInput,
+	parseMetricDag,
 } from "./operating-model-graph";
 
 const driver = (measureColumnId: string, label: string): DriverInput => ({
@@ -27,6 +28,38 @@ const driver = (measureColumnId: string, label: string): DriverInput => ({
 	},
 });
 
+// gross_margin's effective DAG: two extracts (revenue, cost_of_goods_sold) feed one
+// output formula. The shape the engine persists onto the metric lifecycle row
+// (graph_definition) — the cockpit's one source for the metric's step structure.
+const grossMarginDag = () => ({
+	graph_id: "gross_margin",
+	output: { type: "scalar", unit: "percentage", decimal_places: 1 },
+	dependencies: {
+		revenue: {
+			level: 1,
+			type: "extract",
+			source: { standard_field: "revenue", statement: "income_statement" },
+			aggregation: "sum",
+		},
+		cost_of_goods_sold: {
+			level: 1,
+			type: "extract",
+			source: {
+				standard_field: "cost_of_goods_sold",
+				statement: "income_statement",
+			},
+			aggregation: "sum",
+		},
+		gross_margin: {
+			level: 2,
+			type: "formula",
+			expression: "(revenue - cost_of_goods_sold) / revenue * 100",
+			depends_on: ["revenue", "cost_of_goods_sold"],
+			output_step: true,
+		},
+	},
+});
+
 const base = (): OperatingModelGraphInput => ({
 	metrics: [
 		{
@@ -35,9 +68,9 @@ const base = (): OperatingModelGraphInput => ({
 			stateReason: null,
 			snippetCount: 3,
 			sql: "SELECT sum(amount) FROM sales",
+			dag: grossMarginDag(),
 		},
 	],
-	metricConcepts: [{ graphId: "gross_margin", concept: "revenue" }],
 	cycles: [
 		{
 			canonicalType: "revenue",
@@ -81,21 +114,78 @@ const edgeKinds = (g: {
 	edges: { source: string; target: string; kind: string }[];
 }) => new Set(g.edges.map((e) => `${e.source}->${e.target}:${e.kind}`));
 
+describe("parseMetricDag", () => {
+	it("narrows the persisted json into typed steps + output metadata", () => {
+		const dag = parseMetricDag(grossMarginDag());
+		expect(dag?.unit).toBe("percentage");
+		expect(dag?.decimalPlaces).toBe(1);
+		const byId = new Map(dag?.steps.map((s) => [s.stepId, s]));
+		expect(byId.get("revenue")).toMatchObject({
+			kind: "extract",
+			standardField: "revenue",
+			statement: "income_statement",
+			aggregation: "sum",
+		});
+		expect(byId.get("gross_margin")).toMatchObject({
+			kind: "formula",
+			expression: "(revenue - cost_of_goods_sold) / revenue * 100",
+			dependsOn: ["revenue", "cost_of_goods_sold"],
+			outputStep: true,
+		});
+	});
+
+	it("returns null on a non-object, a missing dependencies, or an empty DAG", () => {
+		expect(parseMetricDag(null)).toBeNull();
+		expect(parseMetricDag("nope")).toBeNull();
+		expect(parseMetricDag({ output: {} })).toBeNull();
+		expect(parseMetricDag({ dependencies: {} })).toBeNull();
+	});
+
+	it("stringifies a constant's numeric default (value ?? default)", () => {
+		const dag = parseMetricDag({
+			dependencies: {
+				n: { type: "constant", parameter: "days_in_period", default: 30 },
+			},
+		});
+		expect(dag?.steps[0]).toMatchObject({
+			kind: "constant",
+			parameter: "days_in_period",
+			value: "30",
+		});
+	});
+});
+
 describe("buildOperatingModelGraph", () => {
-	it("wires the concept-spine: artifact → concept → column, driver and FK", () => {
+	it("unfolds the metric DAG: metric → formula → extract → concept → column", () => {
 		const g = buildOperatingModelGraph(base());
 		const nodeIds = ids(g);
 		expect(nodeIds).toContain("metric:gross_margin");
+		expect(nodeIds).toContain("formula:gross_margin:gross_margin");
+		expect(nodeIds).toContain("extract:gross_margin:revenue");
+		expect(nodeIds).toContain("extract:gross_margin:cost_of_goods_sold");
 		expect(nodeIds).toContain("concept:revenue");
 		expect(nodeIds).toContain("column:c1");
-		expect(nodeIds).toContain("column:c2");
 		expect(nodeIds).toContain("table:t1");
 		expect(nodeIds).toContain("driver:c1");
 		expect(nodeIds).toContain("validation:margin_positive");
 		expect(nodeIds).toContain("cycle:revenue");
 
 		const edges = edgeKinds(g);
-		expect(edges).toContain("metric:gross_margin->concept:revenue:references");
+		// The metric roots at its output formula (nothing depends on it).
+		expect(edges).toContain(
+			"metric:gross_margin->formula:gross_margin:gross_margin:computes",
+		);
+		// The formula computes from each input extract.
+		expect(edges).toContain(
+			"formula:gross_margin:gross_margin->extract:gross_margin:revenue:computes",
+		);
+		expect(edges).toContain(
+			"formula:gross_margin:gross_margin->extract:gross_margin:cost_of_goods_sold:computes",
+		);
+		// The extract references its concept; the concept grounds to the column.
+		expect(edges).toContain(
+			"extract:gross_margin:revenue->concept:revenue:references",
+		);
 		expect(edges).toContain("concept:revenue->column:c1:grounds");
 		expect(edges).toContain("driver:c1->column:c1:drives");
 		expect(edges).toContain("column:c1->column:c2:relates");
@@ -103,6 +193,75 @@ describe("buildOperatingModelGraph", () => {
 		expect(edges).toContain("validation:margin_positive->column:c1:checks");
 		// cycle canonical_type matches a known concept → cycle → concept edge.
 		expect(edges).toContain("cycle:revenue->concept:revenue:references");
+		// No shortcut metric→concept edge — the path runs through the steps now.
+		expect(edges).not.toContain(
+			"metric:gross_margin->concept:revenue:references",
+		);
+	});
+
+	it("roots a metric at its output formula and leaves a constant a leaf", () => {
+		const input = base();
+		input.metrics = [
+			{
+				graphId: "dso",
+				state: "executed",
+				stateReason: null,
+				snippetCount: 4,
+				sql: null,
+				dag: {
+					output: { unit: "days", decimal_places: 1 },
+					dependencies: {
+						accounts_receivable: {
+							type: "extract",
+							source: {
+								standard_field: "accounts_receivable",
+								statement: "balance_sheet",
+							},
+							aggregation: "sum",
+						},
+						revenue: {
+							type: "extract",
+							source: {
+								standard_field: "revenue",
+								statement: "income_statement",
+							},
+							aggregation: "sum",
+						},
+						days_in_period: {
+							type: "constant",
+							parameter: "days_in_period",
+							default: 30,
+						},
+						dso: {
+							type: "formula",
+							expression: "(accounts_receivable / revenue) * days_in_period",
+							depends_on: ["accounts_receivable", "revenue", "days_in_period"],
+							output_step: true,
+						},
+					},
+				},
+			},
+		];
+		const g = buildOperatingModelGraph(input);
+		const nodeIds = ids(g);
+		expect(nodeIds).toContain("extract:dso:accounts_receivable");
+		expect(nodeIds).toContain("constant:dso:days_in_period");
+		expect(nodeIds).toContain("formula:dso:dso");
+
+		const edges = edgeKinds(g);
+		expect(edges).toContain("metric:dso->formula:dso:dso:computes");
+		expect(edges).toContain(
+			"formula:dso:dso->constant:dso:days_in_period:computes",
+		);
+		expect(edges).toContain(
+			"formula:dso:dso->extract:dso:accounts_receivable:computes",
+		);
+		// A constant is a leaf — nothing flows out of it.
+		expect(
+			[...edges].some((e) => e.startsWith("constant:dso:days_in_period->")),
+		).toBe(false);
+		const c = g.nodes.find((n) => n.id === "constant:dso:days_in_period");
+		expect(c?.data).toMatchObject({ kind: "constant", value: "30" });
 	});
 
 	it("emits only columns that participate in an edge (c3 is unused → absent)", () => {
@@ -119,11 +278,12 @@ describe("buildOperatingModelGraph", () => {
 		const g = buildOperatingModelGraph(input);
 		expect(ids(g)).not.toContain("column:ghost");
 		expect([...edgeKinds(g)].some((e) => e.includes("ghost"))).toBe(false);
-		// The metric/concept nodes still exist — only the bad edge is dropped.
+		// The concept node still exists (the extract references it) — only the bad
+		// grounding edge is dropped.
 		expect(ids(g)).toContain("concept:revenue");
 	});
 
-	it("keeps an ungrounded metric as a node with no concept edge", () => {
+	it("keeps a metric with no persisted DAG as a bare node (no step edges)", () => {
 		const input = base();
 		input.metrics.push({
 			graphId: "lonely",
@@ -131,6 +291,7 @@ describe("buildOperatingModelGraph", () => {
 			stateReason: "no fields mapped",
 			snippetCount: 0,
 			sql: null,
+			dag: null,
 		});
 		const g = buildOperatingModelGraph(input);
 		expect(ids(g)).toContain("metric:lonely");
@@ -139,14 +300,11 @@ describe("buildOperatingModelGraph", () => {
 		);
 	});
 
-	it("dedupes nodes and edges across repeated inputs", () => {
-		const input = base();
-		input.metricConcepts.push({ graphId: "gross_margin", concept: "revenue" });
-		const g = buildOperatingModelGraph(input);
-		const metricConceptEdges = g.edges.filter(
-			(e) => e.id === "metric:gross_margin->concept:revenue:references",
-		);
-		expect(metricConceptEdges).toHaveLength(1);
+	it("dedupes a concept shared by an extract reference and a grounding", () => {
+		const g = buildOperatingModelGraph(base());
+		// concept:revenue is both referenced by the extract AND grounded by
+		// conceptColumns — it must be a single node.
+		expect(g.nodes.filter((n) => n.id === "concept:revenue")).toHaveLength(1);
 	});
 });
 
@@ -191,20 +349,31 @@ describe("filterGraph (kind toggles + hide-orphans)", () => {
 	it("keeps only enabled kinds and prunes edges to dropped kinds", () => {
 		const full = buildOperatingModelGraph(base());
 		const g = filterGraph(full, {
-			kinds: kinds("metric", "concept"),
+			kinds: kinds("extract", "concept"),
 			hideOrphans: false,
 		});
-		expect(ids(g)).toEqual(new Set(["metric:gross_margin", "concept:revenue"]));
-		// The metric→concept edge survives (both endpoints kept); concept→column is
-		// pruned because the column kind is filtered out.
+		// Both extracts + both concepts survive; the extract→concept edges are kept.
+		expect(ids(g)).toEqual(
+			new Set([
+				"extract:gross_margin:revenue",
+				"extract:gross_margin:cost_of_goods_sold",
+				"concept:revenue",
+				"concept:cost_of_goods_sold",
+			]),
+		);
+		// formula→extract (formula dropped) and concept→column (column dropped) are pruned.
 		expect(edgeKinds(g)).toEqual(
-			new Set(["metric:gross_margin->concept:revenue:references"]),
+			new Set([
+				"extract:gross_margin:revenue->concept:revenue:references",
+				"extract:gross_margin:cost_of_goods_sold->concept:cost_of_goods_sold:references",
+			]),
 		);
 	});
 
 	it("hideOrphans drops nodes left with zero edges", () => {
 		const full = buildOperatingModelGraph(base());
-		// metric + cycle both linked ONLY to concept — remove concept and they orphan.
+		// metric links only to its formula, cycle only to concept — both orphan when
+		// those kinds are filtered out.
 		const opts = { kinds: kinds("metric", "cycle") };
 		expect(ids(filterGraph(full, { ...opts, hideOrphans: false }))).toEqual(
 			new Set(["metric:gross_margin", "cycle:revenue"]),
@@ -212,6 +381,19 @@ describe("filterGraph (kind toggles + hide-orphans)", () => {
 		expect(
 			filterGraph(full, { ...opts, hideOrphans: true }).nodes,
 		).toHaveLength(0);
+	});
+
+	it("the metrics preset carries the metric's step spine (formula/extract/constant)", () => {
+		const full = buildOperatingModelGraph(base());
+		const g = filterGraph(full, {
+			kinds: new Set(OM_PRESET_KINDS.metrics),
+			hideOrphans: true,
+		});
+		const nodeIds = ids(g);
+		expect(nodeIds).toContain("metric:gross_margin");
+		expect(nodeIds).toContain("formula:gross_margin:gross_margin");
+		expect(nodeIds).toContain("extract:gross_margin:revenue");
+		expect(nodeIds).not.toContain("validation:margin_positive");
 	});
 
 	it("the cycles preset isolates the cycle spine (no metric/validation/driver)", () => {

--- a/packages/cockpit/src/tools/operating-model-graph.test.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.test.ts
@@ -6,6 +6,9 @@ import {
 	buildOperatingModelGraph,
 	computeVisibleGraph,
 	type DriverInput,
+	filterGraph,
+	OM_PRESET_KINDS,
+	type OMNodeKind,
 	type OperatingModelGraphInput,
 } from "./operating-model-graph";
 
@@ -179,5 +182,50 @@ describe("computeVisibleGraph (progressive disclosure)", () => {
 		expect(edges).toContain("table:t1->column:c1:contains");
 		// c1→c2: c1 visible, c2 collapsed → c1 relates to table t2.
 		expect(edges).toContain("column:c1->table:t2:relates");
+	});
+});
+
+describe("filterGraph (kind toggles + hide-orphans)", () => {
+	const kinds = (...ks: OMNodeKind[]): Set<OMNodeKind> => new Set(ks);
+
+	it("keeps only enabled kinds and prunes edges to dropped kinds", () => {
+		const full = buildOperatingModelGraph(base());
+		const g = filterGraph(full, {
+			kinds: kinds("metric", "concept"),
+			hideOrphans: false,
+		});
+		expect(ids(g)).toEqual(new Set(["metric:gross_margin", "concept:revenue"]));
+		// The metric→concept edge survives (both endpoints kept); concept→column is
+		// pruned because the column kind is filtered out.
+		expect(edgeKinds(g)).toEqual(
+			new Set(["metric:gross_margin->concept:revenue:references"]),
+		);
+	});
+
+	it("hideOrphans drops nodes left with zero edges", () => {
+		const full = buildOperatingModelGraph(base());
+		// metric + cycle both linked ONLY to concept — remove concept and they orphan.
+		const opts = { kinds: kinds("metric", "cycle") };
+		expect(ids(filterGraph(full, { ...opts, hideOrphans: false }))).toEqual(
+			new Set(["metric:gross_margin", "cycle:revenue"]),
+		);
+		expect(
+			filterGraph(full, { ...opts, hideOrphans: true }).nodes,
+		).toHaveLength(0);
+	});
+
+	it("the cycles preset isolates the cycle spine (no metric/validation/driver)", () => {
+		const full = buildOperatingModelGraph(base());
+		const g = filterGraph(full, {
+			kinds: new Set(OM_PRESET_KINDS.cycles),
+			hideOrphans: true,
+		});
+		const nodeIds = ids(g);
+		expect(nodeIds).toContain("cycle:revenue");
+		expect(nodeIds).toContain("concept:revenue");
+		expect(nodeIds).not.toContain("metric:gross_margin");
+		expect(nodeIds).not.toContain("validation:margin_positive");
+		expect(nodeIds).not.toContain("driver:c1");
+		expect(edgeKinds(g)).toContain("cycle:revenue->concept:revenue:references");
 	});
 });

--- a/packages/cockpit/src/tools/operating-model-graph.test.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.test.ts
@@ -1,345 +1,336 @@
 import { describe, expect, it } from "vitest";
 
-// The module under test is now PURE (no DB/config imports) — the IO loader lives in
+// The module under test is PURE (no DB/config imports) — the IO loader lives in
 // operating-model-load.ts — so no mocks are needed to import it.
 import {
 	buildOperatingModelGraph,
 	computeVisibleGraph,
-	type DriverInput,
 	filterGraph,
-	OM_PRESET_KINDS,
+	type MeasureGroundingInput,
+	type MetricInput,
 	type OMNodeKind,
 	type OperatingModelGraphInput,
 	parseMetricDag,
 } from "./operating-model-graph";
 
-const driver = (measureColumnId: string, label: string): DriverInput => ({
-	measureColumnId,
-	ranking: {
-		measureLabel: label,
-		targetType: "flow",
-		grain: "row",
-		entity: null,
-		nRows: 100,
-		rankedDimensions: [{ dimension: "region", gain: 0.4 }],
-		driverPaths: [["region"]],
-		interestingSlices: [],
-		secondaryDimensions: [],
-	},
+// --- DAG fixture builders (mirror the persisted graph_definition shape) --------
+const extract = (field: string, statement: string) => ({
+	type: "extract",
+	level: 1,
+	source: { standard_field: field, statement },
+	aggregation: "sum",
+});
+const constant = (parameter: string, value: number) => ({
+	type: "constant",
+	level: 1,
+	parameter,
+	default: value,
+});
+const formula = (expression: string, dependsOn: string[], output = false) => ({
+	type: "formula",
+	level: 2,
+	expression,
+	depends_on: dependsOn,
+	...(output ? { output_step: true } : {}),
+});
+const dag = (
+	graphId: string,
+	name: string,
+	unit: string,
+	deps: Record<string, unknown>,
+) => ({
+	graph_id: graphId,
+	output: { unit },
+	metadata: { name, category: "test" },
+	dependencies: deps,
 });
 
-// gross_margin's effective DAG: two extracts (revenue, cost_of_goods_sold) feed one
-// output formula. The shape the engine persists onto the metric lifecycle row
-// (graph_definition) — the cockpit's one source for the metric's step structure.
-const grossMarginDag = () => ({
-	graph_id: "gross_margin",
-	output: { type: "scalar", unit: "percentage", decimal_places: 1 },
-	dependencies: {
-		revenue: {
-			level: 1,
-			type: "extract",
-			source: { standard_field: "revenue", statement: "income_statement" },
-			aggregation: "sum",
-		},
-		cost_of_goods_sold: {
-			level: 1,
-			type: "extract",
-			source: {
-				standard_field: "cost_of_goods_sold",
-				statement: "income_statement",
-			},
-			aggregation: "sum",
-		},
-		gross_margin: {
-			level: 2,
-			type: "formula",
-			expression: "(revenue - cost_of_goods_sold) / revenue * 100",
-			depends_on: ["revenue", "cost_of_goods_sold"],
-			output_step: true,
-		},
-	},
+const metric = (
+	graphId: string,
+	name: string,
+	unit: string,
+	deps: Record<string, unknown>,
+): MetricInput => ({
+	graphId,
+	state: "grounded",
+	stateReason: null,
+	dag: dag(graphId, name, unit, deps),
+	sql: `-- flattened sql for ${graphId}`,
+});
+
+const DSO = metric("dso", "Days Sales Outstanding", "days", {
+	accounts_receivable: extract("accounts_receivable", "balance_sheet"),
+	revenue: extract("revenue", "income_statement"),
+	days_in_period: constant("days_in_period", 30),
+	dso: formula(
+		"(accounts_receivable / revenue) * days_in_period",
+		["accounts_receivable", "revenue", "days_in_period"],
+		true,
+	),
+});
+const DIO = metric("dio", "Days Inventory Outstanding", "days", {
+	inventory: extract("inventory", "balance_sheet"),
+	cost_of_goods_sold: extract("cost_of_goods_sold", "income_statement"),
+	days_in_period: constant("days_in_period", 30),
+	dio: formula(
+		"(inventory / cost_of_goods_sold) * days_in_period",
+		["inventory", "cost_of_goods_sold", "days_in_period"],
+		true,
+	),
+});
+const DPO = metric("dpo", "Days Payable Outstanding", "days", {
+	accounts_payable: extract("accounts_payable", "balance_sheet"),
+	cost_of_goods_sold: extract("cost_of_goods_sold", "income_statement"),
+	days_in_period: constant("days_in_period", 30),
+	dpo: formula(
+		"(accounts_payable / cost_of_goods_sold) * days_in_period",
+		["accounts_payable", "cost_of_goods_sold", "days_in_period"],
+		true,
+	),
+});
+const GROSS_PROFIT = metric("gross_profit", "Gross Profit", "currency", {
+	revenue: extract("revenue", "income_statement"),
+	cost_of_goods_sold: extract("cost_of_goods_sold", "income_statement"),
+	gross_profit: formula(
+		"revenue - cost_of_goods_sold",
+		["revenue", "cost_of_goods_sold"],
+		true,
+	),
+});
+// Self-contained: inlines dso/dio/dpo as formula steps (DAT-646). Its output composes
+// them by name — the cockpit follows the standalone metrics, not the inlined copies.
+const CCC = metric("cash_conversion_cycle", "Cash Conversion Cycle", "days", {
+	accounts_receivable: extract("accounts_receivable", "balance_sheet"),
+	revenue: extract("revenue", "income_statement"),
+	inventory: extract("inventory", "balance_sheet"),
+	cost_of_goods_sold: extract("cost_of_goods_sold", "income_statement"),
+	accounts_payable: extract("accounts_payable", "balance_sheet"),
+	days_in_period: constant("days_in_period", 30),
+	dso: formula("(accounts_receivable / revenue) * days_in_period", [
+		"accounts_receivable",
+		"revenue",
+		"days_in_period",
+	]),
+	dio: formula("(inventory / cost_of_goods_sold) * days_in_period", [
+		"inventory",
+		"cost_of_goods_sold",
+		"days_in_period",
+	]),
+	dpo: formula("(accounts_payable / cost_of_goods_sold) * days_in_period", [
+		"accounts_payable",
+		"cost_of_goods_sold",
+		"days_in_period",
+	]),
+	cash_conversion_cycle: formula(
+		"dso + dio - dpo",
+		["dso", "dio", "dpo"],
+		true,
+	),
+});
+
+// Grounding: enriched_journal_lines (ev1) ← {journal_lines(t1), chart_of_accounts(t2)}.
+// inventory is UNGROUNDED (no enriched view) — the visible "not grounded" case.
+const ev = { tableId: "ev1", tableName: "enriched_journal_lines" };
+const grounded = (field: string): MeasureGroundingInput => ({
+	standardField: field,
+	sql: `-- extract sql for ${field}`,
+	enrichedView: ev,
+	baseTables: [
+		{ tableId: "t1", tableName: "journal_lines" },
+		{ tableId: "t2", tableName: "chart_of_accounts" },
+	],
+});
+const ungrounded = (field: string): MeasureGroundingInput => ({
+	standardField: field,
+	sql: null,
+	enrichedView: null,
+	baseTables: [],
 });
 
 const base = (): OperatingModelGraphInput => ({
-	metrics: [
-		{
-			graphId: "gross_margin",
-			state: "executed",
-			stateReason: null,
-			snippetCount: 3,
-			sql: "SELECT sum(amount) FROM sales",
-			dag: grossMarginDag(),
-		},
-	],
-	cycles: [
-		{
-			canonicalType: "revenue",
-			cycleName: "Revenue cycle",
-			state: "executed",
-			completionRate: 0.8,
-			completedCycles: 8,
-			totalRecords: 10,
-		},
-	],
-	validations: [
-		{
-			validationId: "margin_positive",
-			state: "executed",
-			passed: true,
-			severity: "error",
-			status: "passed",
-			sqlUsed: "SELECT 1",
-			columnsUsed: ["sales.amount"],
-		},
-	],
-	drivers: [driver("c1", "net revenue")],
-	conceptColumns: [{ concept: "revenue", columnId: "c1" }],
-	relationships: [{ fromColumnId: "c1", toColumnId: "c2" }],
-	columns: [
-		{ columnId: "c1", tableId: "t1", columnName: "amount" },
-		{ columnId: "c2", tableId: "t2", columnName: "customer_id" },
-		{ columnId: "c3", tableId: "t1", columnName: "unused" },
-	],
-	tables: [
-		// Content-keyed physical name: the validation→column match must resolve via the
-		// DISPLAY name ("sales"), since columns_used arrives digest-stripped.
-		{ tableId: "t1", tableName: "sales" },
-		{ tableId: "t2", tableName: "customers" },
+	metrics: [GROSS_PROFIT, DSO, DIO, DPO, CCC],
+	grounding: [
+		grounded("revenue"),
+		grounded("cost_of_goods_sold"),
+		grounded("accounts_receivable"),
+		grounded("accounts_payable"),
+		ungrounded("inventory"),
 	],
 });
 
 const ids = (g: { nodes: { id: string }[] }) =>
 	new Set(g.nodes.map((n) => n.id));
-const edgeKinds = (g: {
+const edgeKeys = (g: {
 	edges: { source: string; target: string; kind: string }[];
 }) => new Set(g.edges.map((e) => `${e.source}->${e.target}:${e.kind}`));
 
 describe("parseMetricDag", () => {
-	it("narrows the persisted json into typed steps + output metadata", () => {
-		const dag = parseMetricDag(grossMarginDag());
-		expect(dag?.unit).toBe("percentage");
-		expect(dag?.decimalPlaces).toBe(1);
-		const byId = new Map(dag?.steps.map((s) => [s.stepId, s]));
+	it("narrows the persisted json into typed steps + display metadata", () => {
+		const d = parseMetricDag(
+			dag("dso", "Days Sales Outstanding", "days", DSO_DEPS()),
+		);
+		expect(d?.name).toBe("Days Sales Outstanding");
+		expect(d?.unit).toBe("days");
+		const byId = new Map(d?.steps.map((s) => [s.stepId, s]));
 		expect(byId.get("revenue")).toMatchObject({
 			kind: "extract",
 			standardField: "revenue",
 			statement: "income_statement",
-			aggregation: "sum",
 		});
-		expect(byId.get("gross_margin")).toMatchObject({
+		expect(byId.get("days_in_period")).toMatchObject({
+			kind: "constant",
+			value: "30",
+		});
+		expect(byId.get("dso")).toMatchObject({
 			kind: "formula",
-			expression: "(revenue - cost_of_goods_sold) / revenue * 100",
-			dependsOn: ["revenue", "cost_of_goods_sold"],
 			outputStep: true,
 		});
 	});
 
-	it("returns null on a non-object, a missing dependencies, or an empty DAG", () => {
+	it("returns null on non-object / missing dependencies / empty DAG", () => {
 		expect(parseMetricDag(null)).toBeNull();
-		expect(parseMetricDag("nope")).toBeNull();
+		expect(parseMetricDag("x")).toBeNull();
 		expect(parseMetricDag({ output: {} })).toBeNull();
 		expect(parseMetricDag({ dependencies: {} })).toBeNull();
 	});
-
-	it("stringifies a constant's numeric default (value ?? default)", () => {
-		const dag = parseMetricDag({
-			dependencies: {
-				n: { type: "constant", parameter: "days_in_period", default: 30 },
-			},
-		});
-		expect(dag?.steps[0]).toMatchObject({
-			kind: "constant",
-			parameter: "days_in_period",
-			value: "30",
-		});
-	});
 });
+function DSO_DEPS() {
+	return {
+		accounts_receivable: extract("accounts_receivable", "balance_sheet"),
+		revenue: extract("revenue", "income_statement"),
+		days_in_period: constant("days_in_period", 30),
+		dso: formula(
+			"(accounts_receivable / revenue) * days_in_period",
+			["accounts_receivable", "revenue", "days_in_period"],
+			true,
+		),
+	};
+}
 
 describe("buildOperatingModelGraph", () => {
-	it("unfolds the metric DAG: metric → formula → extract → concept → column", () => {
-		const g = buildOperatingModelGraph(base());
-		const nodeIds = ids(g);
-		expect(nodeIds).toContain("metric:gross_margin");
-		expect(nodeIds).toContain("formula:gross_margin:gross_margin");
-		expect(nodeIds).toContain("extract:gross_margin:revenue");
-		expect(nodeIds).toContain("extract:gross_margin:cost_of_goods_sold");
-		expect(nodeIds).toContain("concept:revenue");
-		expect(nodeIds).toContain("column:c1");
-		expect(nodeIds).toContain("table:t1");
-		expect(nodeIds).toContain("driver:c1");
-		expect(nodeIds).toContain("validation:margin_positive");
-		expect(nodeIds).toContain("cycle:revenue");
-
-		const edges = edgeKinds(g);
-		// The metric roots at its output formula (nothing depends on it).
-		expect(edges).toContain(
-			"metric:gross_margin->formula:gross_margin:gross_margin:computes",
-		);
-		// The formula computes from each input extract.
-		expect(edges).toContain(
-			"formula:gross_margin:gross_margin->extract:gross_margin:revenue:computes",
-		);
-		expect(edges).toContain(
-			"formula:gross_margin:gross_margin->extract:gross_margin:cost_of_goods_sold:computes",
-		);
-		// The extract references its concept; the concept grounds to the column.
-		expect(edges).toContain(
-			"extract:gross_margin:revenue->concept:revenue:references",
-		);
-		expect(edges).toContain("concept:revenue->column:c1:grounds");
-		expect(edges).toContain("driver:c1->column:c1:drives");
-		expect(edges).toContain("column:c1->column:c2:relates");
-		expect(edges).toContain("table:t1->column:c1:contains");
-		expect(edges).toContain("validation:margin_positive->column:c1:checks");
-		// cycle canonical_type matches a known concept → cycle → concept edge.
-		expect(edges).toContain("cycle:revenue->concept:revenue:references");
-		// No shortcut metric→concept edge — the path runs through the steps now.
-		expect(edges).not.toContain(
-			"metric:gross_margin->concept:revenue:references",
-		);
-	});
-
-	it("roots a metric at its output formula and leaves a constant a leaf", () => {
-		const input = base();
-		input.metrics = [
-			{
-				graphId: "dso",
-				state: "executed",
-				stateReason: null,
-				snippetCount: 4,
-				sql: null,
-				dag: {
-					output: { unit: "days", decimal_places: 1 },
-					dependencies: {
-						accounts_receivable: {
-							type: "extract",
-							source: {
-								standard_field: "accounts_receivable",
-								statement: "balance_sheet",
-							},
-							aggregation: "sum",
-						},
-						revenue: {
-							type: "extract",
-							source: {
-								standard_field: "revenue",
-								statement: "income_statement",
-							},
-							aggregation: "sum",
-						},
-						days_in_period: {
-							type: "constant",
-							parameter: "days_in_period",
-							default: 30,
-						},
-						dso: {
-							type: "formula",
-							expression: "(accounts_receivable / revenue) * days_in_period",
-							depends_on: ["accounts_receivable", "revenue", "days_in_period"],
-							output_step: true,
-						},
-					},
-				},
-			},
-		];
-		const g = buildOperatingModelGraph(input);
-		const nodeIds = ids(g);
-		expect(nodeIds).toContain("extract:dso:accounts_receivable");
-		expect(nodeIds).toContain("constant:dso:days_in_period");
-		expect(nodeIds).toContain("formula:dso:dso");
-
-		const edges = edgeKinds(g);
-		expect(edges).toContain("metric:dso->formula:dso:dso:computes");
-		expect(edges).toContain(
-			"formula:dso:dso->constant:dso:days_in_period:computes",
-		);
-		expect(edges).toContain(
-			"formula:dso:dso->extract:dso:accounts_receivable:computes",
-		);
-		// A constant is a leaf — nothing flows out of it.
-		expect(
-			[...edges].some((e) => e.startsWith("constant:dso:days_in_period->")),
-		).toBe(false);
-		const c = g.nodes.find((n) => n.id === "constant:dso:days_in_period");
-		expect(c?.data).toMatchObject({ kind: "constant", value: "30" });
-	});
-
-	it("emits only columns that participate in an edge (c3 is unused → absent)", () => {
-		const g = buildOperatingModelGraph(base());
-		expect(ids(g)).not.toContain("column:c3");
-	});
-
-	it("drops a dangling edge when its column is unknown, without throwing", () => {
-		const input = base();
-		input.conceptColumns = [{ concept: "revenue", columnId: "ghost" }];
-		input.relationships = [];
-		input.drivers = [];
-		input.validations = [];
-		const g = buildOperatingModelGraph(input);
-		expect(ids(g)).not.toContain("column:ghost");
-		expect([...edgeKinds(g)].some((e) => e.includes("ghost"))).toBe(false);
-		// The concept node still exists (the extract references it) — only the bad
-		// grounding edge is dropped.
-		expect(ids(g)).toContain("concept:revenue");
-	});
-
-	it("keeps a metric with no persisted DAG as a bare node (no step edges)", () => {
-		const input = base();
-		input.metrics.push({
-			graphId: "lonely",
-			state: "declared",
-			stateReason: "no fields mapped",
-			snippetCount: 0,
-			sql: null,
-			dag: null,
+	it("builds metric → measure/constant with the output formula on the metric node", () => {
+		const g = buildOperatingModelGraph({
+			metrics: [DSO],
+			grounding: base().grounding,
 		});
-		const g = buildOperatingModelGraph(input);
-		expect(ids(g)).toContain("metric:lonely");
-		expect([...edgeKinds(g)].some((e) => e.startsWith("metric:lonely->"))).toBe(
+		expect(ids(g)).toContain("metric:dso");
+		const m = g.nodes.find((n) => n.id === "metric:dso");
+		expect(m?.label).toBe("Days Sales Outstanding");
+		expect(m?.data).toMatchObject({
+			kind: "metric",
+			formula: "(accounts_receivable / revenue) * days_in_period",
+			unit: "days",
+			sql: "-- flattened sql for dso",
+		});
+		const e = edgeKeys(g);
+		expect(e).toContain("metric:dso->measure:accounts_receivable:reads");
+		expect(e).toContain("metric:dso->measure:revenue:reads");
+		expect(e).toContain("metric:dso->constant:days_in_period:uses");
+	});
+
+	it("composes metric→metric by name, NOT inlining the self-contained copies", () => {
+		const g = buildOperatingModelGraph(base());
+		const e = edgeKeys(g);
+		// ccc composes the three metrics...
+		expect(e).toContain("metric:cash_conversion_cycle->metric:dso:composes");
+		expect(e).toContain("metric:cash_conversion_cycle->metric:dio:composes");
+		expect(e).toContain("metric:cash_conversion_cycle->metric:dpo:composes");
+		// ...and does NOT read ccc's inlined leaves directly (dso owns those).
+		expect(e).not.toContain(
+			"metric:cash_conversion_cycle->measure:revenue:reads",
+		);
+		// dio (a real metric here) owns its own leaves.
+		expect(e).toContain("metric:dio->measure:inventory:reads");
+	});
+
+	it("dedupes a measure/constant shared across many metrics into one node", () => {
+		const g = buildOperatingModelGraph(base());
+		// revenue is read by dso, gross_profit, (ccc's dso inline — but that's composed) →
+		// still ONE measure node.
+		expect(g.nodes.filter((n) => n.id === "measure:revenue")).toHaveLength(1);
+		expect(
+			g.nodes.filter((n) => n.id === "constant:days_in_period"),
+		).toHaveLength(1);
+	});
+
+	it("grounds a measure to its enriched view → base tables", () => {
+		const g = buildOperatingModelGraph(base());
+		const e = edgeKeys(g);
+		expect(e).toContain("measure:revenue->table:ev1:grounds");
+		expect(e).toContain("table:ev1->table:t1:derives");
+		expect(e).toContain("table:ev1->table:t2:derives");
+		expect(g.nodes.find((n) => n.id === "table:ev1")?.data).toMatchObject({
+			kind: "table",
+			layer: "enriched",
+		});
+		expect(g.nodes.find((n) => n.id === "table:t1")?.parent).toBe("table:ev1");
+	});
+
+	it("leaves an ungrounded measure as a leaf with no table edge", () => {
+		const g = buildOperatingModelGraph(base());
+		expect(ids(g)).toContain("measure:inventory");
+		expect(
+			[...edgeKeys(g)].some((k) => k.startsWith("measure:inventory->")),
+		).toBe(false);
+		expect(
+			g.nodes.find((n) => n.id === "measure:inventory")?.data,
+		).toMatchObject({
+			kind: "measure",
+			grounded: false,
+		});
+	});
+
+	it("inlines a non-metric formula dependency (dio missing from the metric set)", () => {
+		// dio is NOT a standalone metric here → ccc must inline its formula to reach leaves.
+		const g = buildOperatingModelGraph({
+			metrics: [GROSS_PROFIT, DSO, DPO, CCC],
+			grounding: base().grounding,
+		});
+		const e = edgeKeys(g);
+		expect(e).toContain("metric:cash_conversion_cycle->metric:dso:composes");
+		expect(e).toContain("metric:cash_conversion_cycle->metric:dpo:composes");
+		// dio has no metric node → its leaves fold onto ccc directly.
+		expect(ids(g)).not.toContain("metric:dio");
+		expect(e).toContain(
+			"metric:cash_conversion_cycle->measure:inventory:reads",
+		);
+		expect(e).toContain(
+			"metric:cash_conversion_cycle->constant:days_in_period:uses",
+		);
+	});
+
+	it("keeps a metric with no persisted DAG as a bare node", () => {
+		const g = buildOperatingModelGraph({
+			metrics: [{ ...DSO, dag: null }],
+			grounding: [],
+		});
+		expect(ids(g)).toContain("metric:dso");
+		expect([...edgeKeys(g)].some((k) => k.startsWith("metric:dso->"))).toBe(
 			false,
 		);
-	});
-
-	it("dedupes a concept shared by an extract reference and a grounding", () => {
-		const g = buildOperatingModelGraph(base());
-		// concept:revenue is both referenced by the extract AND grounded by
-		// conceptColumns — it must be a single node.
-		expect(g.nodes.filter((n) => n.id === "concept:revenue")).toHaveLength(1);
 	});
 });
 
-describe("computeVisibleGraph (progressive disclosure)", () => {
-	it("hides columns under collapsed tables and re-points their edges to the table", () => {
+describe("computeVisibleGraph (collapse base tables under the enriched view)", () => {
+	it("hides base tables and re-points their edges to the enriched view", () => {
 		const full = buildOperatingModelGraph(base());
-		const visible = computeVisibleGraph(full, new Set());
-		const nodeIds = ids(visible);
-		// No column nodes when nothing is expanded; tables remain.
-		expect(nodeIds).not.toContain("column:c1");
-		expect(nodeIds).not.toContain("column:c2");
-		expect(nodeIds).toContain("table:t1");
-		expect(nodeIds).toContain("table:t2");
-		const edges = edgeKinds(visible);
-		// concept→column collapses to concept→table; FK c1→c2 becomes table t1→t2.
-		expect(edges).toContain("concept:revenue->table:t1:grounds");
-		expect(edges).toContain("driver:c1->table:t1:drives");
-		expect(edges).toContain("table:t1->table:t2:relates");
-		// The contains edge (table→its own hidden column) self-loops → dropped.
-		expect([...edges].some((e) => e === "table:t1->table:t1:contains")).toBe(
-			false,
-		);
+		const v = computeVisibleGraph(full, new Set());
+		expect(ids(v)).not.toContain("table:t1");
+		expect(ids(v)).not.toContain("table:t2");
+		expect(ids(v)).toContain("table:ev1");
+		// the derives edge (enriched→its own hidden base) self-loops → dropped.
+		expect(
+			[...edgeKeys(v)].some((k) => k === "table:ev1->table:ev1:derives"),
+		).toBe(false);
+		// measure→enriched still stands.
+		expect(edgeKeys(v)).toContain("measure:revenue->table:ev1:grounds");
 	});
 
-	it("reveals a table's columns and precise edges when it is expanded", () => {
+	it("reveals base tables when the enriched view is expanded", () => {
 		const full = buildOperatingModelGraph(base());
-		const visible = computeVisibleGraph(full, new Set(["table:t1"]));
-		const nodeIds = ids(visible);
-		expect(nodeIds).toContain("column:c1"); // t1 expanded
-		expect(nodeIds).not.toContain("column:c2"); // t2 still collapsed
-		const edges = edgeKinds(visible);
-		expect(edges).toContain("concept:revenue->column:c1:grounds");
-		expect(edges).toContain("table:t1->column:c1:contains");
-		// c1→c2: c1 visible, c2 collapsed → c1 relates to table t2.
-		expect(edges).toContain("column:c1->table:t2:relates");
+		const v = computeVisibleGraph(full, new Set(["table:ev1"]));
+		expect(ids(v)).toContain("table:t1");
+		expect(edgeKeys(v)).toContain("table:ev1->table:t1:derives");
 	});
 });
 
@@ -349,65 +340,28 @@ describe("filterGraph (kind toggles + hide-orphans)", () => {
 	it("keeps only enabled kinds and prunes edges to dropped kinds", () => {
 		const full = buildOperatingModelGraph(base());
 		const g = filterGraph(full, {
-			kinds: kinds("extract", "concept"),
+			kinds: kinds("metric"),
 			hideOrphans: false,
 		});
-		// Both extracts + both concepts survive; the extract→concept edges are kept.
-		expect(ids(g)).toEqual(
-			new Set([
-				"extract:gross_margin:revenue",
-				"extract:gross_margin:cost_of_goods_sold",
-				"concept:revenue",
-				"concept:cost_of_goods_sold",
-			]),
+		// only metric nodes; metric→metric composition edges survive, metric→measure gone.
+		expect([...ids(g)].every((id) => id.startsWith("metric:"))).toBe(true);
+		expect(edgeKeys(g)).toContain(
+			"metric:cash_conversion_cycle->metric:dso:composes",
 		);
-		// formula→extract (formula dropped) and concept→column (column dropped) are pruned.
-		expect(edgeKinds(g)).toEqual(
-			new Set([
-				"extract:gross_margin:revenue->concept:revenue:references",
-				"extract:gross_margin:cost_of_goods_sold->concept:cost_of_goods_sold:references",
-			]),
-		);
+		expect([...edgeKeys(g)].some((k) => k.includes("measure:"))).toBe(false);
 	});
 
 	it("hideOrphans drops nodes left with zero edges", () => {
 		const full = buildOperatingModelGraph(base());
-		// metric links only to its formula, cycle only to concept — both orphan when
-		// those kinds are filtered out.
-		const opts = { kinds: kinds("metric", "cycle") };
-		expect(ids(filterGraph(full, { ...opts, hideOrphans: false }))).toEqual(
-			new Set(["metric:gross_margin", "cycle:revenue"]),
-		);
-		expect(
-			filterGraph(full, { ...opts, hideOrphans: true }).nodes,
-		).toHaveLength(0);
-	});
-
-	it("the metrics preset carries the metric's step spine (formula/extract/constant)", () => {
-		const full = buildOperatingModelGraph(base());
+		// keep only tables → base tables connect to enriched (derives), but with metrics
+		// gone the measures/metrics vanish; enriched view orphans (its only inbound was a
+		// measure). Its base tables keep it connected via derives.
 		const g = filterGraph(full, {
-			kinds: new Set(OM_PRESET_KINDS.metrics),
+			kinds: kinds("table"),
 			hideOrphans: true,
 		});
-		const nodeIds = ids(g);
-		expect(nodeIds).toContain("metric:gross_margin");
-		expect(nodeIds).toContain("formula:gross_margin:gross_margin");
-		expect(nodeIds).toContain("extract:gross_margin:revenue");
-		expect(nodeIds).not.toContain("validation:margin_positive");
-	});
-
-	it("the cycles preset isolates the cycle spine (no metric/validation/driver)", () => {
-		const full = buildOperatingModelGraph(base());
-		const g = filterGraph(full, {
-			kinds: new Set(OM_PRESET_KINDS.cycles),
-			hideOrphans: true,
-		});
-		const nodeIds = ids(g);
-		expect(nodeIds).toContain("cycle:revenue");
-		expect(nodeIds).toContain("concept:revenue");
-		expect(nodeIds).not.toContain("metric:gross_margin");
-		expect(nodeIds).not.toContain("validation:margin_positive");
-		expect(nodeIds).not.toContain("driver:c1");
-		expect(edgeKinds(g)).toContain("cycle:revenue->concept:revenue:references");
+		// ev1 ↔ t1/t2 derives edges keep all three tables connected.
+		expect(ids(g)).toContain("table:ev1");
+		expect(ids(g)).toContain("table:t1");
 	});
 });

--- a/packages/cockpit/src/tools/operating-model-graph.test.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.test.ts
@@ -6,6 +6,7 @@ import {
 	buildOperatingModelGraph,
 	computeVisibleGraph,
 	type DriverInput,
+	extractConceptsFromDag,
 	filterGraph,
 	OM_PRESET_KINDS,
 	type OMNodeKind,
@@ -80,6 +81,58 @@ const ids = (g: { nodes: { id: string }[] }) =>
 const edgeKinds = (g: {
 	edges: { source: string; target: string; kind: string }[];
 }) => new Set(g.edges.map((e) => `${e.source}->${e.target}:${e.kind}`));
+
+describe("extractConceptsFromDag", () => {
+	// gross_margin: two extract leaves (revenue, cost_of_goods_sold) + two formula
+	// steps. The reliable metric→concept linkage is the extract leaves — the formulas
+	// carry no standard_field. This is exactly the gap the snippet-provenance derivation
+	// missed (gross_margin reused shared revenue/cogs snippets → no edge).
+	const grossMarginDag = {
+		revenue: {
+			type: "extract",
+			source: { standard_field: "revenue", statement: "income_statement" },
+			aggregation: "sum",
+		},
+		cost_of_goods_sold: {
+			type: "extract",
+			source: {
+				standard_field: "cost_of_goods_sold",
+				statement: "income_statement",
+			},
+			aggregation: "sum",
+		},
+		gross_profit: {
+			type: "formula",
+			expression: "revenue - cost_of_goods_sold",
+			depends_on: ["revenue", "cost_of_goods_sold"],
+		},
+		gross_margin: {
+			type: "formula",
+			expression: "gross_profit / revenue",
+			depends_on: ["gross_profit", "revenue"],
+			output_step: true,
+		},
+	};
+
+	it("returns the standard_fields of the extract leaves only", () => {
+		expect(extractConceptsFromDag(grossMarginDag).sort()).toEqual([
+			"cost_of_goods_sold",
+			"revenue",
+		]);
+	});
+
+	it("ignores formula/constant steps and tolerates malformed input", () => {
+		expect(extractConceptsFromDag(null)).toEqual([]);
+		expect(extractConceptsFromDag("nope")).toEqual([]);
+		expect(
+			extractConceptsFromDag({
+				k: { type: "constant", value: 30 },
+				f: { type: "formula", expression: "a/b", depends_on: ["a", "b"] },
+				bad: { type: "extract" }, // no source → skipped, no throw
+			}),
+		).toEqual([]);
+	});
+});
 
 describe("buildOperatingModelGraph", () => {
 	it("wires the concept-spine: artifact → concept → column, driver and FK", () => {

--- a/packages/cockpit/src/tools/operating-model-graph.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.ts
@@ -60,9 +60,12 @@ interface MeasureData {
 	/** Which statement the measure is drawn from (income_statement / balance_sheet). */
 	statement: string | null;
 	aggregation: string | null;
-	/** Whether the measure resolved to a table — false ⇒ visibly ungrounded (no table edge). */
+	/** Whether the engine ACCEPTED the extract (composed SQL with support). False ⇒ the
+	 *  extract failed (e.g. its filter matched no rows) — flagged, no table edge, but its
+	 *  attempted SQL is still shown. */
 	grounded: boolean;
-	/** The extract's flattened SQL (execution layer); null when ungrounded. */
+	/** The extract's flattened SQL (execution layer) — present even when NOT grounded, so
+	 *  the failed-but-attempted query is visible; null only when no snippet exists. */
 	sql: string | null;
 }
 interface ConstantData {
@@ -81,8 +84,10 @@ export interface OMNode {
 	id: string;
 	kind: OMNodeKind;
 	label: string;
-	/** Base tables carry their enriched-view node id — the UI collapses them under it. */
-	parent?: string;
+	/** Base tables carry the enriched-view node id(s) they derive from — the UI collapses
+	 *  them under those views. A shared dimension table (e.g. chart_of_accounts) can derive
+	 *  from several views, so this is a set, not a single parent. */
+	parents?: string[];
 	data: OMNodeData;
 }
 
@@ -119,9 +124,12 @@ export interface GroundedTable {
 /** One measure concept's grounding, resolved server-side (keyed by standard_field). */
 export interface MeasureGroundingInput {
 	standardField: string;
-	/** The extract's flattened SQL, or null when ungrounded. */
+	/** Whether the engine accepted the extract (failure_count == 0) — the reliable
+	 *  grounding signal, independent of whether the view name could be parsed out. */
+	grounded: boolean;
+	/** The extract's flattened SQL (present even when NOT grounded), or null when no snippet. */
 	sql: string | null;
-	/** The enriched view the measure's SQL reads, or null when ungrounded. */
+	/** The enriched view the measure's SQL reads, or null when ungrounded/unresolved. */
 	enrichedView: GroundedTable | null;
 	/** The base fact/dim tables the enriched view derives from. */
 	baseTables: GroundedTable[];
@@ -234,6 +242,71 @@ const measureNodeId = (standardField: string) => `measure:${standardField}`;
 const constantNodeId = (parameter: string) => `constant:${parameter}`;
 const tableNodeId = (tableId: string) => `table:${tableId}`;
 
+// --- Grounding resolution (measure → enriched view → base tables) -----------
+
+/** One extract snippet's fields the resolver needs (the loader stringifies the
+ *  column_mappings json; failure_count comes straight from the snippet row). */
+export interface ExtractSnippetInput {
+	standardField: string;
+	sql: string | null;
+	columnMappingsText: string;
+	failureCount: number;
+}
+/** One enriched view + the base fact/dim table ids it derives from. */
+export interface EnrichedViewInput {
+	viewName: string;
+	viewTableId: string;
+	baseTableIds: string[];
+}
+
+/**
+ * Resolve each measure concept's grounding from its extract snippet. Pure → unit-tested.
+ *  - `grounded` = the engine accepted the extract (`failure_count == 0`) — the reliable
+ *    signal. `column_mappings` is only an OPTIONAL engine hint (graphs/agent.py), so it
+ *    is NOT used to decide grounding: an accepted extract can carry an empty map, and a
+ *    failed one (e.g. inventory — filter matched no rows) can still name a view in SQL.
+ *  - The enriched VIEW is read from the SQL's `FROM <view>` (a hard prompt contract) or
+ *    the column_mappings text, by LONGEST known-view-name match (so `enriched_invoices`
+ *    isn't shadowed by a shorter `enriched_inv`). Resolved only for grounded measures.
+ *  - `sql` is always carried through, so a failed extract still shows its attempted query.
+ * First snippet per standard_field wins (the loader passes rows newest-first).
+ */
+export function resolveGrounding(
+	extracts: ExtractSnippetInput[],
+	views: EnrichedViewInput[],
+	tableNames: ReadonlyMap<string, string>,
+): MeasureGroundingInput[] {
+	const viewByName = new Map(views.map((v) => [v.viewName, v]));
+	const viewNames = [...viewByName.keys()].sort((a, b) => b.length - a.length);
+
+	const byField = new Map<string, MeasureGroundingInput>();
+	for (const ex of extracts) {
+		if (byField.has(ex.standardField)) continue;
+		const grounded = ex.failureCount === 0;
+		let enrichedView: GroundedTable | null = null;
+		let baseTables: GroundedTable[] = [];
+		if (grounded) {
+			const hay = `${ex.sql ?? ""} ${ex.columnMappingsText}`;
+			const viewName = viewNames.find((n) => hay.includes(n)) ?? null;
+			const view = viewName ? viewByName.get(viewName) : undefined;
+			if (view) {
+				enrichedView = { tableId: view.viewTableId, tableName: view.viewName };
+				baseTables = view.baseTableIds
+					.filter((id) => tableNames.has(id))
+					.map((id) => ({ tableId: id, tableName: tableNames.get(id) ?? id }));
+			}
+		}
+		byField.set(ex.standardField, {
+			standardField: ex.standardField,
+			grounded,
+			sql: ex.sql,
+			enrichedView,
+			baseTables,
+		});
+	}
+	return [...byField.values()];
+}
+
 /**
  * Assemble the metric dependency graph from already-fetched rows. Pure: no DB, no IO.
  * Contracts:
@@ -264,34 +337,35 @@ export function buildOperatingModelGraph(
 		if (!edges.has(id)) edges.set(id, { id, source, target, kind });
 	};
 
-	/** Ground a measure to its enriched view + the base tables it derives from. */
+	/** Ground a measure to its enriched view + the base tables it derives from. A base
+	 *  table shared by several views accrues each as a parent (first-write-wins on the
+	 *  node, but parents are merged) so the collapse UI can't lock it under one view. */
 	const groundMeasure = (standardField: string): void => {
 		const g = groundingByField.get(standardField);
 		if (!g?.enrichedView) return;
+		const viewId = tableNodeId(g.enrichedView.tableId);
 		addNode({
-			id: tableNodeId(g.enrichedView.tableId),
+			id: viewId,
 			kind: "table",
 			label: g.enrichedView.tableName,
 			data: { kind: "table", layer: "enriched" },
 		});
-		addEdge(
-			measureNodeId(standardField),
-			tableNodeId(g.enrichedView.tableId),
-			"grounds",
-		);
+		addEdge(measureNodeId(standardField), viewId, "grounds");
 		for (const base of g.baseTables) {
-			addNode({
-				id: tableNodeId(base.tableId),
-				kind: "table",
-				label: base.tableName,
-				parent: tableNodeId(g.enrichedView.tableId),
-				data: { kind: "table", layer: "base" },
-			});
-			addEdge(
-				tableNodeId(g.enrichedView.tableId),
-				tableNodeId(base.tableId),
-				"derives",
-			);
+			const baseId = tableNodeId(base.tableId);
+			const existing = nodes.get(baseId);
+			if (existing?.parents) {
+				if (!existing.parents.includes(viewId)) existing.parents.push(viewId);
+			} else {
+				addNode({
+					id: baseId,
+					kind: "table",
+					label: base.tableName,
+					parents: [viewId],
+					data: { kind: "table", layer: "base" },
+				});
+			}
+			addEdge(viewId, baseId, "derives");
 		}
 	};
 
@@ -339,7 +413,7 @@ export function buildOperatingModelGraph(
 							kind: "measure",
 							statement: step.statement,
 							aggregation: step.aggregation,
-							grounded: Boolean(g?.enrichedView),
+							grounded: g?.grounded ?? false,
 							sql: g?.sql ?? null,
 						},
 					});
@@ -374,41 +448,31 @@ export function buildOperatingModelGraph(
 // --- Progressive disclosure: collapse base tables under their enriched view ---
 
 /**
- * Collapse base fact/dim tables under their enriched view unless it is expanded. A
- * hidden base table's edges re-point to the enriched view; self-loops drop, edges
- * dedupe. Pure → unit-tested. `expandedTableIds` holds enriched-view NODE ids
- * (`table:<id>`), matching a base table's `parent`.
+ * Collapse base fact/dim tables under their enriched view(s) unless one is expanded. A
+ * base table is hidden while NONE of its parent views is expanded; hiding it drops the
+ * table and its `derives` edges (which only ever come from a parent view — collapsing
+ * into the view). No edge re-pointing: base tables have no other edges, so a shared
+ * dimension under two views can't fabricate a view→view edge. Pure → unit-tested.
+ * `expandedTableIds` holds enriched-view NODE ids (`table:<id>`), matching a base
+ * table's `parents`.
  */
 export function computeVisibleGraph(
 	graph: OperatingModelGraph,
 	expandedTableIds: ReadonlySet<string>,
 ): OperatingModelGraph {
-	const parentOf = new Map<string, string | undefined>();
+	const hidden = new Set<string>();
 	for (const n of graph.nodes) {
-		if (n.kind === "table" && (n.data as TableData).layer === "base") {
-			parentOf.set(n.id, n.parent);
+		if (n.kind !== "table" || (n.data as TableData).layer !== "base") continue;
+		const parents = n.parents ?? [];
+		if (parents.length > 0 && !parents.some((p) => expandedTableIds.has(p))) {
+			hidden.add(n.id);
 		}
 	}
-	const isHidden = (id: string): boolean => {
-		if (!parentOf.has(id)) return false;
-		const parent = parentOf.get(id);
-		return parent !== undefined && !expandedTableIds.has(parent);
-	};
-	const remap = (id: string): string | null => {
-		if (!isHidden(id)) return id;
-		return parentOf.get(id) ?? null;
-	};
-
-	const nodes = graph.nodes.filter((n) => !isHidden(n.id));
-	const edges = new Map<string, OMEdge>();
-	for (const e of graph.edges) {
-		const source = remap(e.source);
-		const target = remap(e.target);
-		if (source === null || target === null || source === target) continue;
-		const id = `${source}->${target}:${e.kind}`;
-		if (!edges.has(id)) edges.set(id, { id, source, target, kind: e.kind });
-	}
-	return { nodes, edges: [...edges.values()] };
+	const nodes = graph.nodes.filter((n) => !hidden.has(n.id));
+	const edges = graph.edges.filter(
+		(e) => !hidden.has(e.source) && !hidden.has(e.target),
+	);
+	return { nodes, edges };
 }
 
 // --- Filtering: node-kind toggles + hide-unconnected --------------------------

--- a/packages/cockpit/src/tools/operating-model-graph.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.ts
@@ -1,151 +1,87 @@
-// Operating-model canvas graph model + assembly (DAT-591 Phase 1) — the PURE,
-// client-safe half. The concept-spine DAG for the Model page is built here from
-// already-fetched plain rows; the server IO that fetches them lives in
-// `operating-model-load.ts` (server-only — it imports the metadata DB client).
-// Keeping this module free of the DB/config imports is load-bearing: the xyflow
-// canvas (a client component) imports the types + `computeVisibleGraph` from here,
-// so any server-only import would trip TanStack's client/server import protection.
+// Operating-model METRIC graph — the PURE, client-safe assembly (DAT-591). Builds
+// the metric dependency graph for the Model page's Metrics view from already-fetched
+// rows; the server IO that fetches them lives in `operating-model-load.ts`. Keeping
+// this module DB/config-free is load-bearing: the xyflow canvas (a client component)
+// imports the types + pure transforms from here, so any server-only import would trip
+// TanStack's client/server boundary.
 //
-// THE SHAPE: concepts are the hub. The real, queryable edges are artifact → concept
-// → column (NOT artifact → artifact, which doesn't exist in the data):
-//   - metric  → step    : `lifecycle_artifacts.graph_definition` (the effective, overlay-
-//                          inclusive DAG) unfolds into formula / extract / constant step
-//                          nodes so the canvas shows HOW a metric is computed (DAT-591)
-//   - extract → concept : an extract step's `source.standard_field` (which concept it pulls)
-//   - concept → column  : `semantic_annotations.business_concept` (the GROUNDED column —
-//                          the actual column, not the pre-grounding YAML hint)
-//   - column  → column  : `current_relationships` (FK)
-//   - driver  → column  : `driver_rankings.measure_column_id`
-//   - cycle   → concept : `detected_business_cycles.canonical_type` matches a concept
-//   - validation → column: `validation_results.columns_used` ("table.column", best-effort)
-// A metric and its driver meet at the shared measure-column node — so the metric×driver
-// drill (DAT-611) is spatial. The metric→column edge is drawn THROUGH the concept hub;
-// the direct `column_mappings`/SQL path (the pre-grounding hint trap) is Phase 2.
-
-import { displayTableName, stripSrcDigests } from "../lib/display-names";
+// THE ONTOLOGY (grounded in finance/ontology.yaml + the persisted graph_definition):
+//   - metric   — a derived measure with a formula + context (DSO, CCC, gross_profit).
+//                Its output formula is a DATA ATTRIBUTE, never a node. It composes
+//                OTHER metrics and/or measures.
+//   - measure  — an ontology `role: measure` concept a metric extracts (revenue, AR,
+//                COGS). Grounds to a table. (What earlier code mislabeled "extract".)
+//   - constant — a declared parameter (days_in_period).
+//   - table    — the grounding target: the enriched view a measure reads, and the base
+//                fact/dim tables it derives from. Raw columns/measures (credit/debit/
+//                net_amount) are NOT nodes — they live in each node's flattened SQL.
+//
+// TWO LAYERS: STRUCTURE (this node/edge graph, for visualization) and EXECUTION (each
+// metric/measure node carries its flattened runnable SQL, shown in the detail panel).
+//
+// COMPOSITION is resolved by the naming convention: a metric's output-step `depends_on`
+// name that matches a known metric graph_id IS a reference to that metric (we follow
+// that metric's own definition, ignoring the inlined self-contained copy). A name that
+// is an extract step is a measure; a constant step is a constant; a non-metric formula
+// step is inlined (recursed) — the one case today is `dio` before its metric exists.
 
 // --- Graph model -----------------------------------------------------------
 
-export type OMNodeKind =
-	| "concept"
-	| "metric"
-	| "formula"
-	| "extract"
-	| "constant"
-	| "validation"
-	| "cycle"
-	| "table"
-	| "column"
-	| "driver";
+export type OMNodeKind = "metric" | "measure" | "constant" | "table";
 
 /** Every node kind, in a stable order — the source of truth for filter UIs. */
 export const OM_NODE_KINDS: readonly OMNodeKind[] = [
 	"metric",
-	"formula",
-	"extract",
+	"measure",
 	"constant",
-	"validation",
-	"cycle",
-	"driver",
-	"concept",
 	"table",
-	"column",
 ] as const;
 
 export type OMEdgeKind =
-	| "references" // extract → concept, cycle → concept
-	| "computes" // metric → step, formula → input step (a metric's internal DAG)
-	| "grounds" // concept → column
-	| "relates" // column → column (FK)
-	| "drives" // driver → column
-	| "contains" // table → column
-	| "checks"; // validation → column
+	| "composes" // metric → metric (a metric's formula references another metric)
+	| "reads" // metric → measure (a metric extracts a measure concept)
+	| "uses" // metric → constant (a metric's formula uses a parameter)
+	| "grounds" // measure → table (the enriched view the measure's SQL reads)
+	| "derives"; // table(enriched view) → table(base fact/dim it is built from)
 
-interface ConceptData {
-	kind: "concept";
-}
 interface MetricData {
 	kind: "metric";
 	state: string;
 	stateReason: string | null;
-	snippetCount: number;
-	/** The metric's validated snippet SQL bodies, joined as steps (null when none). */
+	/** The output formula expression (e.g. "dso + dio - dpo") — a data attribute. */
+	formula: string | null;
+	unit: string | null;
+	category: string | null;
+	/** The metric's flattened runnable SQL (execution layer); null when not composed. */
 	sql: string | null;
 }
-/** One `extract` step of a metric's DAG — the SQL snippet that pulls a concept. */
-interface ExtractData {
-	kind: "extract";
-	graphId: string;
-	stepId: string;
-	/** The concept this extract pulls (source.standard_field); null when it reads a
-	 *  raw table.column instead — then it grounds to no concept node. */
-	standardField: string | null;
+interface MeasureData {
+	kind: "measure";
+	/** Which statement the measure is drawn from (income_statement / balance_sheet). */
 	statement: string | null;
 	aggregation: string | null;
+	/** Whether the measure resolved to a table — false ⇒ visibly ungrounded (no table edge). */
+	grounded: boolean;
+	/** The extract's flattened SQL (execution layer); null when ungrounded. */
+	sql: string | null;
 }
-/** One `formula` step — an expression combining the steps it depends on. */
-interface FormulaData {
-	kind: "formula";
-	graphId: string;
-	stepId: string;
-	expression: string | null;
-	/** True on the metric's output formula (its result is the metric's value). */
-	outputStep: boolean;
-}
-/** One `constant` step — a fixed value / declared parameter default. */
 interface ConstantData {
 	kind: "constant";
-	graphId: string;
-	stepId: string;
-	parameter: string | null;
 	/** The resolved value/default, stringified for display (null when neither set). */
 	value: string | null;
 }
-interface ValidationData {
-	kind: "validation";
-	state: string;
-	passed: boolean | null;
-	severity: string | null;
-	status: string | null;
-	sqlUsed: string | null;
-}
-interface CycleData {
-	kind: "cycle";
-	state: string;
-	completionRate: number | null;
-	completedCycles: number | null;
-	totalRecords: number | null;
-}
 interface TableData {
 	kind: "table";
+	/** enriched view vs base fact/dim table — drives styling + progressive collapse. */
+	layer: "enriched" | "base";
 }
-interface ColumnData {
-	kind: "column";
-	tableId: string;
-}
-interface DriverData {
-	kind: "driver";
-	targetType: string;
-	grain: string;
-	topDimensions: string[];
-}
-export type OMNodeData =
-	| ConceptData
-	| MetricData
-	| ExtractData
-	| FormulaData
-	| ConstantData
-	| ValidationData
-	| CycleData
-	| TableData
-	| ColumnData
-	| DriverData;
+export type OMNodeData = MetricData | MeasureData | ConstantData | TableData;
 
 export interface OMNode {
 	id: string;
 	kind: OMNodeKind;
 	label: string;
-	/** Column nodes carry their table node id — the UI groups/collapses by parent. */
+	/** Base tables carry their enriched-view node id — the UI collapses them under it. */
 	parent?: string;
 	data: OMNodeData;
 }
@@ -168,92 +104,33 @@ export interface MetricInput {
 	graphId: string;
 	state: string;
 	stateReason: string | null;
-	snippetCount: number;
-	/** Joined snippet SQL bodies for the metric, or null when it has no snippets. */
-	sql: string | null;
-	/** The engine-persisted effective DAG (`graph_definition` json) — parsed into
-	 *  typed step nodes. `unknown` at the DB boundary; null when the metric row
-	 *  predates the column or carries no definition. */
+	/** The engine-persisted effective DAG (`graph_definition` json) — `unknown` at the
+	 *  DB boundary; parsed here for structure + display name/category/unit. Null when
+	 *  the row carries no definition (metric shows as a bare node). */
 	dag: unknown;
+	/** The metric's flattened runnable SQL (the `formula` snippet), or null. */
+	sql: string | null;
 }
-export interface CycleInput {
-	canonicalType: string;
-	cycleName: string | null;
-	state: string;
-	completionRate: number | null;
-	completedCycles: number | null;
-	totalRecords: number | null;
-}
-export interface ValidationInput {
-	validationId: string;
-	state: string;
-	passed: boolean | null;
-	severity: string | null;
-	status: string | null;
-	sqlUsed: string | null;
-	/** "table.column" strings the validation SQL touched (best-effort linkage). */
-	columnsUsed: string[];
-}
-/** A persisted `current_driver_rankings` row (JSON columns are `unknown`). */
-export interface DriverRankingRow {
-	measureLabel: string | null;
-	targetType: string | null;
-	grain: string | null;
-	entity: string | null;
-	nRows: number | null;
-	rankedDimensions: unknown;
-	driverPaths: unknown;
-	interestingSlices: unknown;
-	secondaryDimensions: unknown;
-}
-export interface DriverInput {
-	measureColumnId: string;
-	ranking: DriverRankingRow;
-}
-/** A grounded concept → column mapping (table resolved via the columns lookup). */
-export interface ConceptColumnInput {
-	concept: string;
-	columnId: string;
-}
-export interface RelationshipInput {
-	fromColumnId: string;
-	toColumnId: string;
-}
-export interface ColumnInput {
-	columnId: string;
-	tableId: string;
-	columnName: string;
-}
-export interface TableInput {
+/** A resolved grounding target (enriched view or base table). */
+export interface GroundedTable {
 	tableId: string;
 	tableName: string;
+}
+/** One measure concept's grounding, resolved server-side (keyed by standard_field). */
+export interface MeasureGroundingInput {
+	standardField: string;
+	/** The extract's flattened SQL, or null when ungrounded. */
+	sql: string | null;
+	/** The enriched view the measure's SQL reads, or null when ungrounded. */
+	enrichedView: GroundedTable | null;
+	/** The base fact/dim tables the enriched view derives from. */
+	baseTables: GroundedTable[];
 }
 
 export interface OperatingModelGraphInput {
 	metrics: MetricInput[];
-	cycles: CycleInput[];
-	validations: ValidationInput[];
-	drivers: DriverInput[];
-	conceptColumns: ConceptColumnInput[];
-	relationships: RelationshipInput[];
-	columns: ColumnInput[];
-	tables: TableInput[];
+	grounding: MeasureGroundingInput[];
 }
-
-// --- Node id namespacing (kind-prefixed so kinds never collide) -------------
-
-const conceptNodeId = (name: string) => `concept:${name}`;
-const metricNodeId = (graphId: string) => `metric:${graphId}`;
-const validationNodeId = (id: string) => `validation:${id}`;
-const cycleNodeId = (canonical: string) => `cycle:${canonical}`;
-const tableNodeId = (id: string) => `table:${id}`;
-const columnNodeId = (id: string) => `column:${id}`;
-const driverNodeId = (measureColumnId: string) => `driver:${measureColumnId}`;
-// Step nodes are namespaced by their owning metric — the same step name (e.g.
-// "revenue") is a distinct extract in every metric that pulls it, possibly with a
-// different aggregation, so it must not collapse to one shared node.
-const stepNodeId = (graphId: string, kind: MetricStepKind, stepId: string) =>
-	`${kind}:${graphId}:${stepId}`;
 
 // --- Metric DAG parsing (the engine-persisted effective graph) --------------
 
@@ -263,14 +140,11 @@ export type MetricStepKind = "extract" | "formula" | "constant";
 export interface MetricStep {
 	stepId: string;
 	kind: MetricStepKind;
-	/** extract: which concept it pulls (source.standard_field) + from where/how. */
 	standardField: string | null;
 	statement: string | null;
 	aggregation: string | null;
-	/** formula: the expression and the step ids it combines. */
 	expression: string | null;
 	dependsOn: string[];
-	/** constant: the parameter name and its resolved value/default (stringified). */
 	parameter: string | null;
 	value: string | null;
 	outputStep: boolean;
@@ -278,9 +152,10 @@ export interface MetricStep {
 
 /** A metric's parsed effective DAG — from the persisted `graph_definition` json. */
 export interface MetricDag {
-	steps: MetricStep[];
+	name: string | null;
+	category: string | null;
 	unit: string | null;
-	decimalPlaces: number | null;
+	steps: MetricStep[];
 }
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>
@@ -293,13 +168,10 @@ const asStepKind = (v: unknown): MetricStepKind =>
 	v === "formula" || v === "constant" ? v : "extract";
 
 /**
- * Parse the engine-persisted effective DAG (`current_lifecycle_artifacts.
- * graph_definition`, a `metric`-row-only json) into the typed steps the canvas
- * renders. The json is `unknown` at the DB boundary (React idiom 11) — every
- * field is narrowed, an unparseable / step-less shape yields null (the metric
- * then shows as a bare node, born-loud, never a throw). Mirrors the engine
- * loader's step read (`graphs/loader.py::_parse_step`): type default extract,
- * value falls back to default.
+ * Parse the engine-persisted effective DAG (`graph_definition` json) into typed
+ * steps + display metadata. `unknown` at the DB boundary — every field is narrowed;
+ * an unparseable / step-less shape yields null. Mirrors the engine loader's step read
+ * (`graphs/loader.py::_parse_step`): type default extract, value falls back to default.
  */
 export function parseMetricDag(raw: unknown): MetricDag | null {
 	if (!isRecord(raw)) return null;
@@ -323,107 +195,66 @@ export function parseMetricDag(raw: unknown): MetricDag | null {
 				: [],
 			parameter: asString(stepRaw.parameter),
 			value:
-				typeof rawValue === "number"
+				typeof rawValue === "number" || typeof rawValue === "boolean"
 					? String(rawValue)
-					: typeof rawValue === "boolean"
-						? String(rawValue)
-						: asString(rawValue),
+					: asString(rawValue),
 			outputStep: stepRaw.output_step === true,
 		});
 	}
 	if (steps.length === 0) return null;
 
 	const output = isRecord(raw.output) ? raw.output : null;
-	const decimals = output?.decimal_places;
+	const metadata = isRecord(raw.metadata) ? raw.metadata : null;
 	return {
-		steps,
+		name: metadata ? asString(metadata.name) : null,
+		category: metadata ? asString(metadata.category) : null,
 		unit: output ? asString(output.unit) : null,
-		decimalPlaces: typeof decimals === "number" ? decimals : null,
+		steps,
 	};
 }
 
-/** Build the typed canvas node for one metric step (label + kind-specific data). */
-function stepNode(graphId: string, s: MetricStep): OMNode {
-	const id = stepNodeId(graphId, s.kind, s.stepId);
-	switch (s.kind) {
-		case "extract":
-			return {
-				id,
-				kind: "extract",
-				label: s.standardField ?? s.stepId,
-				data: {
-					kind: "extract",
-					graphId,
-					stepId: s.stepId,
-					standardField: s.standardField,
-					statement: s.statement,
-					aggregation: s.aggregation,
-				},
-			};
-		case "formula":
-			return {
-				id,
-				kind: "formula",
-				label: s.expression ?? s.stepId,
-				data: {
-					kind: "formula",
-					graphId,
-					stepId: s.stepId,
-					expression: s.expression,
-					outputStep: s.outputStep,
-				},
-			};
-		case "constant":
-			return {
-				id,
-				kind: "constant",
-				label: s.parameter ?? s.stepId,
-				data: {
-					kind: "constant",
-					graphId,
-					stepId: s.stepId,
-					parameter: s.parameter,
-					value: s.value,
-				},
-			};
-	}
+/**
+ * The output step of a metric's DAG — the one flagged `output_step`, falling back to
+ * a root (a step nothing else depends on) so a malformed DAG still resolves. Returns
+ * null only when the DAG has no steps at all (already excluded by parseMetricDag).
+ */
+function outputStepOf(dag: MetricDag): MetricStep | null {
+	const flagged = dag.steps.find((s) => s.outputStep);
+	if (flagged) return flagged;
+	const dependedOn = new Set(dag.steps.flatMap((s) => s.dependsOn));
+	return (
+		dag.steps.find((s) => !dependedOn.has(s.stepId)) ?? dag.steps[0] ?? null
+	);
 }
 
-/** The strongest driver dimensions' names (digest-stripped), defensively narrowed. */
-function topDimensionNames(rankedDimensions: unknown): string[] {
-	if (!Array.isArray(rankedDimensions)) return [];
-	const names: string[] = [];
-	for (const r of rankedDimensions) {
-		if (
-			r &&
-			typeof r === "object" &&
-			typeof (r as { dimension?: unknown }).dimension === "string"
-		) {
-			names.push(stripSrcDigests((r as { dimension: string }).dimension));
-		}
-	}
-	return names;
-}
+// --- Node id namespacing (semantic identity ⇒ dedup by construction) --------
+
+const metricNodeId = (graphId: string) => `metric:${graphId}`;
+const measureNodeId = (standardField: string) => `measure:${standardField}`;
+const constantNodeId = (parameter: string) => `constant:${parameter}`;
+const tableNodeId = (tableId: string) => `table:${tableId}`;
 
 /**
- * Assemble the concept-spine DAG from already-fetched rows. Pure: no DB, no IO —
- * the whole node/edge derivation is unit-testable. Contracts:
- *  - Concepts are the union of metric `standard_field`s and grounded `business_concept`s.
- *  - Only columns that participate in ≥1 edge are emitted (grounded / measure / FK /
- *    validation-checked), plus the tables that own them — the graph stays focused.
- *  - An edge whose column target is missing from the `columns` lookup is dropped
- *    (born-loud absence over a dangling edge), never throwing.
+ * Assemble the metric dependency graph from already-fetched rows. Pure: no DB, no IO.
+ * Contracts:
+ *  - Every declared metric is a node (label = display name), carrying its output
+ *    formula + flattened SQL as data. Composition edges follow the naming convention.
+ *  - measure / constant nodes are deduped by their semantic identity (concept /
+ *    parameter) — the same measure referenced by N metrics is ONE node.
+ *  - A measure grounds to its enriched view (→ base fact/dim tables); an UNGROUNDED
+ *    measure has no table edge — born-loud, the visible "not grounded" signal.
+ *  - A non-metric formula dependency is inlined (recursed) so the metric still connects
+ *    to its real leaves; never throws on a malformed/dangling reference.
  */
 export function buildOperatingModelGraph(
 	input: OperatingModelGraphInput,
 ): OperatingModelGraph {
-	const columnById = new Map(input.columns.map((c) => [c.columnId, c]));
-	const tableByIdMap = new Map(input.tables.map((t) => [t.tableId, t]));
-
 	const nodes = new Map<string, OMNode>();
 	const edges = new Map<string, OMEdge>();
-	const participatingColumns = new Set<string>();
-	const concepts = new Set<string>();
+	const groundingByField = new Map(
+		input.grounding.map((g) => [g.standardField, g]),
+	);
+	const metricNames = new Set(input.metrics.map((m) => m.graphId));
 
 	const addNode = (node: OMNode) => {
 		if (!nodes.has(node.id)) nodes.set(node.id, node);
@@ -432,213 +263,121 @@ export function buildOperatingModelGraph(
 		const id = `${source}->${target}:${kind}`;
 		if (!edges.has(id)) edges.set(id, { id, source, target, kind });
 	};
-	/** Mark a column as participating; returns false if it's unknown (edge dropped). */
-	const markColumn = (rawColumnId: string): boolean => {
-		if (!columnById.has(rawColumnId)) return false;
-		participatingColumns.add(rawColumnId);
-		return true;
-	};
-	const addConcept = (name: string) => {
-		if (concepts.has(name)) return;
-		concepts.add(name);
+
+	/** Ground a measure to its enriched view + the base tables it derives from. */
+	const groundMeasure = (standardField: string): void => {
+		const g = groundingByField.get(standardField);
+		if (!g?.enrichedView) return;
 		addNode({
-			id: conceptNodeId(name),
-			kind: "concept",
-			label: name,
-			data: { kind: "concept" },
+			id: tableNodeId(g.enrichedView.tableId),
+			kind: "table",
+			label: g.enrichedView.tableName,
+			data: { kind: "table", layer: "enriched" },
 		});
+		addEdge(
+			measureNodeId(standardField),
+			tableNodeId(g.enrichedView.tableId),
+			"grounds",
+		);
+		for (const base of g.baseTables) {
+			addNode({
+				id: tableNodeId(base.tableId),
+				kind: "table",
+				label: base.tableName,
+				parent: tableNodeId(g.enrichedView.tableId),
+				data: { kind: "table", layer: "base" },
+			});
+			addEdge(
+				tableNodeId(g.enrichedView.tableId),
+				tableNodeId(base.tableId),
+				"derives",
+			);
+		}
 	};
 
-	// Metrics + their effective DAG (DAT-591). Every metric is a node; its
-	// persisted graph_definition unfolds into typed step nodes — formula / extract
-	// / constant — so the canvas shows HOW a metric is computed and WHICH extracts
-	// reach a grounded concept, not an undifferentiated "concept" pile. The DAG is
-	// persisted at declare time (before grounding), so an ungroundable metric still
-	// shows its structure: an extract whose concept never grounds is visibly a leaf
-	// with no column beneath it.
 	for (const m of input.metrics) {
+		const dag = parseMetricDag(m.dag);
+		const output = dag ? outputStepOf(dag) : null;
 		addNode({
 			id: metricNodeId(m.graphId),
 			kind: "metric",
-			label: m.graphId,
+			label: dag?.name || m.graphId,
 			data: {
 				kind: "metric",
 				state: m.state,
 				stateReason: m.stateReason,
-				snippetCount: m.snippetCount,
+				formula: output?.expression ?? null,
+				unit: dag?.unit ?? null,
+				category: dag?.category ?? null,
 				sql: m.sql,
 			},
 		});
+		if (!dag || !output) continue;
 
-		const dag = parseMetricDag(m.dag);
-		if (!dag) continue;
 		const stepById = new Map(dag.steps.map((s) => [s.stepId, s]));
-		const nodeIdOf = (s: MetricStep) => stepNodeId(m.graphId, s.kind, s.stepId);
+		const seen = new Set<string>(); // guard against a depends_on cycle while recursing
 
-		// One node per step; an extract step references its concept (standard_field)
-		// — the seam onto the shared concept → column grounding spine.
-		for (const s of dag.steps) {
-			addNode(stepNode(m.graphId, s));
-			if (s.kind === "extract" && s.standardField) {
-				addConcept(s.standardField);
-				addEdge(nodeIdOf(s), conceptNodeId(s.standardField), "references");
+		// Resolve a metric's dependency NAMES into edges, following the naming
+		// convention: a name that is a metric composes; an extract is a measure; a
+		// constant is used; a non-metric formula is inlined (recursed into its own deps).
+		const resolveDeps = (depNames: string[]): void => {
+			for (const name of depNames) {
+				if (name !== m.graphId && metricNames.has(name)) {
+					addEdge(metricNodeId(m.graphId), metricNodeId(name), "composes");
+					continue;
+				}
+				const step = stepById.get(name);
+				if (!step) continue; // dangling reference — drop, never throw
+				if (step.kind === "extract" && step.standardField) {
+					const field = step.standardField;
+					const g = groundingByField.get(field);
+					addNode({
+						id: measureNodeId(field),
+						kind: "measure",
+						label: field,
+						data: {
+							kind: "measure",
+							statement: step.statement,
+							aggregation: step.aggregation,
+							grounded: Boolean(g?.enrichedView),
+							sql: g?.sql ?? null,
+						},
+					});
+					addEdge(metricNodeId(m.graphId), measureNodeId(field), "reads");
+					groundMeasure(field);
+				} else if (step.kind === "constant" && step.parameter) {
+					addNode({
+						id: constantNodeId(step.parameter),
+						kind: "constant",
+						label: step.parameter,
+						data: { kind: "constant", value: step.value },
+					});
+					addEdge(
+						metricNodeId(m.graphId),
+						constantNodeId(step.parameter),
+						"uses",
+					);
+				} else if (step.kind === "formula" && !seen.has(step.stepId)) {
+					// Non-metric intermediate formula (e.g. `dio` before its metric exists):
+					// inline it so the metric still reaches its real leaves.
+					seen.add(step.stepId);
+					resolveDeps(step.dependsOn);
+				}
 			}
-		}
-
-		// Intra-metric computation edges: a formula computes FROM each input step.
-		for (const s of dag.steps) {
-			if (s.kind !== "formula") continue;
-			for (const dep of s.dependsOn) {
-				const depStep = stepById.get(dep);
-				if (depStep) addEdge(nodeIdOf(s), nodeIdOf(depStep), "computes");
-			}
-		}
-
-		// The metric computes from its root step(s) — those nothing else depends on
-		// (the output formula is a root; a stray disconnected step roots too, so it
-		// never floats free of the metric). Robust without trusting output_step.
-		const dependedOn = new Set(dag.steps.flatMap((s) => s.dependsOn));
-		for (const s of dag.steps) {
-			if (!dependedOn.has(s.stepId))
-				addEdge(metricNodeId(m.graphId), nodeIdOf(s), "computes");
-		}
-	}
-
-	// concept → column (the grounded, actual column).
-	for (const cc of input.conceptColumns) {
-		if (!markColumn(cc.columnId)) continue;
-		addConcept(cc.concept);
-		addEdge(conceptNodeId(cc.concept), columnNodeId(cc.columnId), "grounds");
-	}
-
-	// Drivers: one node per measure column; driver → its measure column.
-	for (const d of input.drivers) {
-		addNode({
-			id: driverNodeId(d.measureColumnId),
-			kind: "driver",
-			label: stripSrcDigests(d.ranking.measureLabel ?? "") || "driver",
-			data: {
-				kind: "driver",
-				targetType: d.ranking.targetType ?? "",
-				grain: d.ranking.grain ?? "row",
-				topDimensions: topDimensionNames(d.ranking.rankedDimensions),
-			},
-		});
-		if (markColumn(d.measureColumnId)) {
-			addEdge(
-				driverNodeId(d.measureColumnId),
-				columnNodeId(d.measureColumnId),
-				"drives",
-			);
-		}
-	}
-
-	// column → column (FK relationships).
-	for (const r of input.relationships) {
-		if (!markColumn(r.fromColumnId) || !markColumn(r.toColumnId)) continue;
-		addEdge(
-			columnNodeId(r.fromColumnId),
-			columnNodeId(r.toColumnId),
-			"relates",
-		);
-	}
-
-	// Validations: node + best-effort validation → column via "table.column" names.
-	// `columns_used` arrives digest-stripped (lookValidation runs stripSrcDigests), so
-	// the key must use the DISPLAY table name too — otherwise content-keyed sources
-	// (`src_<digest>__orders`) never match and the linkage is silently empty. Two
-	// same-stem tables from different sources can collide here; acceptable for a
-	// best-effort edge.
-	const columnIdByName = new Map<string, string>();
-	for (const c of input.columns) {
-		const t = tableByIdMap.get(c.tableId);
-		if (t) {
-			columnIdByName.set(
-				`${displayTableName(t.tableName)}.${c.columnName}`,
-				c.columnId,
-			);
-		}
-	}
-	for (const v of input.validations) {
-		addNode({
-			id: validationNodeId(v.validationId),
-			kind: "validation",
-			label: v.validationId,
-			data: {
-				kind: "validation",
-				state: v.state,
-				passed: v.passed,
-				severity: v.severity,
-				status: v.status,
-				sqlUsed: v.sqlUsed,
-			},
-		});
-		for (const ref of v.columnsUsed) {
-			const cid = columnIdByName.get(ref);
-			if (cid && markColumn(cid)) {
-				addEdge(validationNodeId(v.validationId), columnNodeId(cid), "checks");
-			}
-		}
-	}
-
-	// Cycles: node + cycle → concept when its canonical_type names a concept.
-	for (const c of input.cycles) {
-		addNode({
-			id: cycleNodeId(c.canonicalType),
-			kind: "cycle",
-			label: c.cycleName || c.canonicalType,
-			data: {
-				kind: "cycle",
-				state: c.state,
-				completionRate: c.completionRate,
-				completedCycles: c.completedCycles,
-				totalRecords: c.totalRecords,
-			},
-		});
-		if (concepts.has(c.canonicalType)) {
-			addEdge(
-				cycleNodeId(c.canonicalType),
-				conceptNodeId(c.canonicalType),
-				"references",
-			);
-		}
-	}
-
-	// Emit participating columns + their tables, with table → column containment.
-	for (const cid of participatingColumns) {
-		const col = columnById.get(cid);
-		if (!col) continue;
-		const table = tableByIdMap.get(col.tableId);
-		if (table) {
-			addNode({
-				id: tableNodeId(table.tableId),
-				kind: "table",
-				label: table.tableName,
-				data: { kind: "table" },
-			});
-		}
-		addNode({
-			id: columnNodeId(cid),
-			kind: "column",
-			label: col.columnName,
-			parent: table ? tableNodeId(table.tableId) : undefined,
-			data: { kind: "column", tableId: col.tableId },
-		});
-		if (table)
-			addEdge(tableNodeId(table.tableId), columnNodeId(cid), "contains");
+		};
+		resolveDeps(output.dependsOn);
 	}
 
 	return { nodes: [...nodes.values()], edges: [...edges.values()] };
 }
 
+// --- Progressive disclosure: collapse base tables under their enriched view ---
+
 /**
- * Progressive disclosure: collapse columns under their table unless the table is
- * expanded. A hidden column's edges are RE-POINTED to its table node (so the
- * grounding/driver/FK structure stays connected at the collapsed level — e.g. two
- * columns' FK becomes a table→table edge, a concept→column becomes concept→table),
- * then self-loops are dropped and edges deduped. Pure → unit-tested.
- *
- * `expandedTableIds` holds table NODE ids (`table:<id>`), matching `column.parent`.
+ * Collapse base fact/dim tables under their enriched view unless it is expanded. A
+ * hidden base table's edges re-point to the enriched view; self-loops drop, edges
+ * dedupe. Pure → unit-tested. `expandedTableIds` holds enriched-view NODE ids
+ * (`table:<id>`), matching a base table's `parent`.
  */
 export function computeVisibleGraph(
 	graph: OperatingModelGraph,
@@ -646,19 +385,21 @@ export function computeVisibleGraph(
 ): OperatingModelGraph {
 	const parentOf = new Map<string, string | undefined>();
 	for (const n of graph.nodes) {
-		if (n.kind === "column") parentOf.set(n.id, n.parent);
+		if (n.kind === "table" && (n.data as TableData).layer === "base") {
+			parentOf.set(n.id, n.parent);
+		}
 	}
-	const isHiddenColumn = (id: string): boolean => {
-		if (!parentOf.has(id)) return false; // not a column
+	const isHidden = (id: string): boolean => {
+		if (!parentOf.has(id)) return false;
 		const parent = parentOf.get(id);
 		return parent !== undefined && !expandedTableIds.has(parent);
 	};
 	const remap = (id: string): string | null => {
-		if (!isHiddenColumn(id)) return id;
-		return parentOf.get(id) ?? null; // collapse to the owning table
+		if (!isHidden(id)) return id;
+		return parentOf.get(id) ?? null;
 	};
 
-	const nodes = graph.nodes.filter((n) => !isHiddenColumn(n.id));
+	const nodes = graph.nodes.filter((n) => !isHidden(n.id));
 	const edges = new Map<string, OMEdge>();
 	for (const e of graph.edges) {
 		const source = remap(e.source);
@@ -675,18 +416,14 @@ export function computeVisibleGraph(
 export interface GraphFilter {
 	/** Node kinds to keep. A node of any other kind (and its edges) is dropped. */
 	kinds: ReadonlySet<OMNodeKind>;
-	/** Drop nodes left with zero edges (the finance vertical's ~8 declared-but-not-
-	 *  detected cycles are degree-0 floaters — this clears them without special-casing
-	 *  their state). Orphans have no edges by definition, so removal never re-orphans
-	 *  another node: a single pass is correct. */
+	/** Drop nodes left with zero edges (e.g. an ungrounded measure with no table). */
 	hideOrphans: boolean;
 }
 
 /**
- * Filter the (already column-collapsed) graph by node kind, then optionally drop
+ * Filter the (already table-collapsed) graph by node kind, then optionally drop
  * unconnected nodes. Pure → unit-tested. Runs AFTER `computeVisibleGraph` so orphan
- * degree is measured on what's actually on screen (collapsed columns re-pointed to
- * their table). Edges survive only when BOTH endpoints survive the kind filter.
+ * degree is measured on what's on screen. Edges survive only when BOTH endpoints do.
  */
 export function filterGraph(
 	graph: OperatingModelGraph,
@@ -706,24 +443,3 @@ export function filterGraph(
 	}
 	return { nodes: nodes.filter((n) => connected.has(n.id)), edges };
 }
-
-/** Named lenses for the filter bar — a preset sets the enabled node kinds. The
- *  connective kinds (concept / table / column) ride along in every non-empty lens
- *  so the spine stays intact; `column` is gated further by table expansion. */
-export type OMPreset = "full" | "metrics" | "validations" | "cycles";
-
-export const OM_PRESET_KINDS: Record<OMPreset, readonly OMNodeKind[]> = {
-	full: OM_NODE_KINDS,
-	metrics: [
-		"metric",
-		"formula",
-		"extract",
-		"constant",
-		"driver",
-		"concept",
-		"table",
-		"column",
-	],
-	validations: ["validation", "concept", "table", "column"],
-	cycles: ["cycle", "concept", "table", "column"],
-};

--- a/packages/cockpit/src/tools/operating-model-graph.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.ts
@@ -8,7 +8,10 @@
 //
 // THE SHAPE: concepts are the hub. The real, queryable edges are artifact → concept
 // → column (NOT artifact → artifact, which doesn't exist in the data):
-//   - concept → metric  : `sql_snippets` (graph:<id> source) keyed by standard_field
+//   - metric  → step    : `lifecycle_artifacts.graph_definition` (the effective, overlay-
+//                          inclusive DAG) unfolds into formula / extract / constant step
+//                          nodes so the canvas shows HOW a metric is computed (DAT-591)
+//   - extract → concept : an extract step's `source.standard_field` (which concept it pulls)
 //   - concept → column  : `semantic_annotations.business_concept` (the GROUNDED column —
 //                          the actual column, not the pre-grounding YAML hint)
 //   - column  → column  : `current_relationships` (FK)
@@ -26,6 +29,9 @@ import { displayTableName, stripSrcDigests } from "../lib/display-names";
 export type OMNodeKind =
 	| "concept"
 	| "metric"
+	| "formula"
+	| "extract"
+	| "constant"
 	| "validation"
 	| "cycle"
 	| "table"
@@ -35,6 +41,9 @@ export type OMNodeKind =
 /** Every node kind, in a stable order — the source of truth for filter UIs. */
 export const OM_NODE_KINDS: readonly OMNodeKind[] = [
 	"metric",
+	"formula",
+	"extract",
+	"constant",
 	"validation",
 	"cycle",
 	"driver",
@@ -44,7 +53,8 @@ export const OM_NODE_KINDS: readonly OMNodeKind[] = [
 ] as const;
 
 export type OMEdgeKind =
-	| "references" // metric → concept, cycle → concept
+	| "references" // extract → concept, cycle → concept
+	| "computes" // metric → step, formula → input step (a metric's internal DAG)
 	| "grounds" // concept → column
 	| "relates" // column → column (FK)
 	| "drives" // driver → column
@@ -61,6 +71,35 @@ interface MetricData {
 	snippetCount: number;
 	/** The metric's validated snippet SQL bodies, joined as steps (null when none). */
 	sql: string | null;
+}
+/** One `extract` step of a metric's DAG — the SQL snippet that pulls a concept. */
+interface ExtractData {
+	kind: "extract";
+	graphId: string;
+	stepId: string;
+	/** The concept this extract pulls (source.standard_field); null when it reads a
+	 *  raw table.column instead — then it grounds to no concept node. */
+	standardField: string | null;
+	statement: string | null;
+	aggregation: string | null;
+}
+/** One `formula` step — an expression combining the steps it depends on. */
+interface FormulaData {
+	kind: "formula";
+	graphId: string;
+	stepId: string;
+	expression: string | null;
+	/** True on the metric's output formula (its result is the metric's value). */
+	outputStep: boolean;
+}
+/** One `constant` step — a fixed value / declared parameter default. */
+interface ConstantData {
+	kind: "constant";
+	graphId: string;
+	stepId: string;
+	parameter: string | null;
+	/** The resolved value/default, stringified for display (null when neither set). */
+	value: string | null;
 }
 interface ValidationData {
 	kind: "validation";
@@ -93,6 +132,9 @@ interface DriverData {
 export type OMNodeData =
 	| ConceptData
 	| MetricData
+	| ExtractData
+	| FormulaData
+	| ConstantData
 	| ValidationData
 	| CycleData
 	| TableData
@@ -129,11 +171,10 @@ export interface MetricInput {
 	snippetCount: number;
 	/** Joined snippet SQL bodies for the metric, or null when it has no snippets. */
 	sql: string | null;
-}
-/** One (metric, concept) pair from a `graph:<id>` snippet's `standard_field`. */
-export interface MetricConceptInput {
-	graphId: string;
-	concept: string;
+	/** The engine-persisted effective DAG (`graph_definition` json) — parsed into
+	 *  typed step nodes. `unknown` at the DB boundary; null when the metric row
+	 *  predates the column or carries no definition. */
+	dag: unknown;
 }
 export interface CycleInput {
 	canonicalType: string;
@@ -190,7 +231,6 @@ export interface TableInput {
 
 export interface OperatingModelGraphInput {
 	metrics: MetricInput[];
-	metricConcepts: MetricConceptInput[];
 	cycles: CycleInput[];
 	validations: ValidationInput[];
 	drivers: DriverInput[];
@@ -209,6 +249,145 @@ const cycleNodeId = (canonical: string) => `cycle:${canonical}`;
 const tableNodeId = (id: string) => `table:${id}`;
 const columnNodeId = (id: string) => `column:${id}`;
 const driverNodeId = (measureColumnId: string) => `driver:${measureColumnId}`;
+// Step nodes are namespaced by their owning metric — the same step name (e.g.
+// "revenue") is a distinct extract in every metric that pulls it, possibly with a
+// different aggregation, so it must not collapse to one shared node.
+const stepNodeId = (graphId: string, kind: MetricStepKind, stepId: string) =>
+	`${kind}:${graphId}:${stepId}`;
+
+// --- Metric DAG parsing (the engine-persisted effective graph) --------------
+
+export type MetricStepKind = "extract" | "formula" | "constant";
+
+/** One parsed step of a metric's effective DAG (a `dependencies` entry). */
+export interface MetricStep {
+	stepId: string;
+	kind: MetricStepKind;
+	/** extract: which concept it pulls (source.standard_field) + from where/how. */
+	standardField: string | null;
+	statement: string | null;
+	aggregation: string | null;
+	/** formula: the expression and the step ids it combines. */
+	expression: string | null;
+	dependsOn: string[];
+	/** constant: the parameter name and its resolved value/default (stringified). */
+	parameter: string | null;
+	value: string | null;
+	outputStep: boolean;
+}
+
+/** A metric's parsed effective DAG — from the persisted `graph_definition` json. */
+export interface MetricDag {
+	steps: MetricStep[];
+	unit: string | null;
+	decimalPlaces: number | null;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+	typeof v === "object" && v !== null && !Array.isArray(v);
+
+const asString = (v: unknown): string | null =>
+	typeof v === "string" ? v : null;
+
+const asStepKind = (v: unknown): MetricStepKind =>
+	v === "formula" || v === "constant" ? v : "extract";
+
+/**
+ * Parse the engine-persisted effective DAG (`current_lifecycle_artifacts.
+ * graph_definition`, a `metric`-row-only json) into the typed steps the canvas
+ * renders. The json is `unknown` at the DB boundary (React idiom 11) — every
+ * field is narrowed, an unparseable / step-less shape yields null (the metric
+ * then shows as a bare node, born-loud, never a throw). Mirrors the engine
+ * loader's step read (`graphs/loader.py::_parse_step`): type default extract,
+ * value falls back to default.
+ */
+export function parseMetricDag(raw: unknown): MetricDag | null {
+	if (!isRecord(raw)) return null;
+	const deps = raw.dependencies;
+	if (!isRecord(deps)) return null;
+
+	const steps: MetricStep[] = [];
+	for (const [stepId, stepRaw] of Object.entries(deps)) {
+		if (!isRecord(stepRaw)) continue;
+		const source = isRecord(stepRaw.source) ? stepRaw.source : null;
+		const rawValue = stepRaw.value ?? stepRaw.default;
+		steps.push({
+			stepId,
+			kind: asStepKind(stepRaw.type),
+			standardField: source ? asString(source.standard_field) : null,
+			statement: source ? asString(source.statement) : null,
+			aggregation: asString(stepRaw.aggregation),
+			expression: asString(stepRaw.expression),
+			dependsOn: Array.isArray(stepRaw.depends_on)
+				? stepRaw.depends_on.filter((d): d is string => typeof d === "string")
+				: [],
+			parameter: asString(stepRaw.parameter),
+			value:
+				typeof rawValue === "number"
+					? String(rawValue)
+					: typeof rawValue === "boolean"
+						? String(rawValue)
+						: asString(rawValue),
+			outputStep: stepRaw.output_step === true,
+		});
+	}
+	if (steps.length === 0) return null;
+
+	const output = isRecord(raw.output) ? raw.output : null;
+	const decimals = output?.decimal_places;
+	return {
+		steps,
+		unit: output ? asString(output.unit) : null,
+		decimalPlaces: typeof decimals === "number" ? decimals : null,
+	};
+}
+
+/** Build the typed canvas node for one metric step (label + kind-specific data). */
+function stepNode(graphId: string, s: MetricStep): OMNode {
+	const id = stepNodeId(graphId, s.kind, s.stepId);
+	switch (s.kind) {
+		case "extract":
+			return {
+				id,
+				kind: "extract",
+				label: s.standardField ?? s.stepId,
+				data: {
+					kind: "extract",
+					graphId,
+					stepId: s.stepId,
+					standardField: s.standardField,
+					statement: s.statement,
+					aggregation: s.aggregation,
+				},
+			};
+		case "formula":
+			return {
+				id,
+				kind: "formula",
+				label: s.expression ?? s.stepId,
+				data: {
+					kind: "formula",
+					graphId,
+					stepId: s.stepId,
+					expression: s.expression,
+					outputStep: s.outputStep,
+				},
+			};
+		case "constant":
+			return {
+				id,
+				kind: "constant",
+				label: s.parameter ?? s.stepId,
+				data: {
+					kind: "constant",
+					graphId,
+					stepId: s.stepId,
+					parameter: s.parameter,
+					value: s.value,
+				},
+			};
+	}
+}
 
 /** The strongest driver dimensions' names (digest-stripped), defensively narrowed. */
 function topDimensionNames(rankedDimensions: unknown): string[] {
@@ -270,7 +449,13 @@ export function buildOperatingModelGraph(
 		});
 	};
 
-	// Metrics (all of them — ungrounded metrics show their state, just no concept edges).
+	// Metrics + their effective DAG (DAT-591). Every metric is a node; its
+	// persisted graph_definition unfolds into typed step nodes — formula / extract
+	// / constant — so the canvas shows HOW a metric is computed and WHICH extracts
+	// reach a grounded concept, not an undifferentiated "concept" pile. The DAG is
+	// persisted at declare time (before grounding), so an ungroundable metric still
+	// shows its structure: an extract whose concept never grounds is visibly a leaf
+	// with no column beneath it.
 	for (const m of input.metrics) {
 		addNode({
 			id: metricNodeId(m.graphId),
@@ -284,13 +469,39 @@ export function buildOperatingModelGraph(
 				sql: m.sql,
 			},
 		});
-	}
 
-	// concept → metric (metric references the concept via standard_field).
-	for (const mc of input.metricConcepts) {
-		if (!nodes.has(metricNodeId(mc.graphId))) continue;
-		addConcept(mc.concept);
-		addEdge(metricNodeId(mc.graphId), conceptNodeId(mc.concept), "references");
+		const dag = parseMetricDag(m.dag);
+		if (!dag) continue;
+		const stepById = new Map(dag.steps.map((s) => [s.stepId, s]));
+		const nodeIdOf = (s: MetricStep) => stepNodeId(m.graphId, s.kind, s.stepId);
+
+		// One node per step; an extract step references its concept (standard_field)
+		// — the seam onto the shared concept → column grounding spine.
+		for (const s of dag.steps) {
+			addNode(stepNode(m.graphId, s));
+			if (s.kind === "extract" && s.standardField) {
+				addConcept(s.standardField);
+				addEdge(nodeIdOf(s), conceptNodeId(s.standardField), "references");
+			}
+		}
+
+		// Intra-metric computation edges: a formula computes FROM each input step.
+		for (const s of dag.steps) {
+			if (s.kind !== "formula") continue;
+			for (const dep of s.dependsOn) {
+				const depStep = stepById.get(dep);
+				if (depStep) addEdge(nodeIdOf(s), nodeIdOf(depStep), "computes");
+			}
+		}
+
+		// The metric computes from its root step(s) — those nothing else depends on
+		// (the output formula is a root; a stray disconnected step roots too, so it
+		// never floats free of the metric). Robust without trusting output_step.
+		const dependedOn = new Set(dag.steps.flatMap((s) => s.dependsOn));
+		for (const s of dag.steps) {
+			if (!dependedOn.has(s.stepId))
+				addEdge(metricNodeId(m.graphId), nodeIdOf(s), "computes");
+		}
 	}
 
 	// concept → column (the grounded, actual column).
@@ -503,7 +714,16 @@ export type OMPreset = "full" | "metrics" | "validations" | "cycles";
 
 export const OM_PRESET_KINDS: Record<OMPreset, readonly OMNodeKind[]> = {
 	full: OM_NODE_KINDS,
-	metrics: ["metric", "driver", "concept", "table", "column"],
+	metrics: [
+		"metric",
+		"formula",
+		"extract",
+		"constant",
+		"driver",
+		"concept",
+		"table",
+		"column",
+	],
 	validations: ["validation", "concept", "table", "column"],
 	cycles: ["cycle", "concept", "table", "column"],
 };

--- a/packages/cockpit/src/tools/operating-model-graph.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.ts
@@ -227,33 +227,6 @@ function topDimensionNames(rankedDimensions: unknown): string[] {
 }
 
 /**
- * The concepts a metric CONSUMES — the `standard_field` of every EXTRACT leaf in its
- * computation DAG (`dependencies`, untrusted YAML shape → rule-11 narrowed here). This
- * is the RELIABLE metric→concept linkage (DAT-591): the prior derivation keyed on
- * `sql_snippets` PROVENANCE (`source=graph:<id>`), but extract snippets are shared and
- * attributed to whichever metric first minted them — so a metric that reused a cached
- * extract (e.g. `gross_margin` reusing `revenue`/`cost_of_goods_sold`) got NO edge. The
- * DAG is authoritative + complete: every metric links to all its extract concepts.
- * Pure → unit-tested.
- */
-export function extractConceptsFromDag(dependencies: unknown): string[] {
-	if (!dependencies || typeof dependencies !== "object") return [];
-	const out: string[] = [];
-	for (const step of Object.values(dependencies as Record<string, unknown>)) {
-		if (!step || typeof step !== "object") continue;
-		const s = step as Record<string, unknown>;
-		if (s.type !== "extract") continue;
-		const source =
-			s.source && typeof s.source === "object"
-				? (s.source as Record<string, unknown>)
-				: {};
-		if (typeof source.standard_field === "string" && source.standard_field)
-			out.push(source.standard_field);
-	}
-	return out;
-}
-
-/**
  * Assemble the concept-spine DAG from already-fetched rows. Pure: no DB, no IO —
  * the whole node/edge derivation is unit-testable. Contracts:
  *  - Concepts are the union of metric `standard_field`s and grounded `business_concept`s.

--- a/packages/cockpit/src/tools/operating-model-graph.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.ts
@@ -227,6 +227,33 @@ function topDimensionNames(rankedDimensions: unknown): string[] {
 }
 
 /**
+ * The concepts a metric CONSUMES — the `standard_field` of every EXTRACT leaf in its
+ * computation DAG (`dependencies`, untrusted YAML shape → rule-11 narrowed here). This
+ * is the RELIABLE metric→concept linkage (DAT-591): the prior derivation keyed on
+ * `sql_snippets` PROVENANCE (`source=graph:<id>`), but extract snippets are shared and
+ * attributed to whichever metric first minted them — so a metric that reused a cached
+ * extract (e.g. `gross_margin` reusing `revenue`/`cost_of_goods_sold`) got NO edge. The
+ * DAG is authoritative + complete: every metric links to all its extract concepts.
+ * Pure → unit-tested.
+ */
+export function extractConceptsFromDag(dependencies: unknown): string[] {
+	if (!dependencies || typeof dependencies !== "object") return [];
+	const out: string[] = [];
+	for (const step of Object.values(dependencies as Record<string, unknown>)) {
+		if (!step || typeof step !== "object") continue;
+		const s = step as Record<string, unknown>;
+		if (s.type !== "extract") continue;
+		const source =
+			s.source && typeof s.source === "object"
+				? (s.source as Record<string, unknown>)
+				: {};
+		if (typeof source.standard_field === "string" && source.standard_field)
+			out.push(source.standard_field);
+	}
+	return out;
+}
+
+/**
  * Assemble the concept-spine DAG from already-fetched rows. Pure: no DB, no IO —
  * the whole node/edge derivation is unit-testable. Contracts:
  *  - Concepts are the union of metric `standard_field`s and grounded `business_concept`s.

--- a/packages/cockpit/src/tools/operating-model-graph.ts
+++ b/packages/cockpit/src/tools/operating-model-graph.ts
@@ -32,6 +32,17 @@ export type OMNodeKind =
 	| "column"
 	| "driver";
 
+/** Every node kind, in a stable order — the source of truth for filter UIs. */
+export const OM_NODE_KINDS: readonly OMNodeKind[] = [
+	"metric",
+	"validation",
+	"cycle",
+	"driver",
+	"concept",
+	"table",
+	"column",
+] as const;
+
 export type OMEdgeKind =
 	| "references" // metric → concept, cycle → concept
 	| "grounds" // concept → column
@@ -447,3 +458,52 @@ export function computeVisibleGraph(
 	}
 	return { nodes, edges: [...edges.values()] };
 }
+
+// --- Filtering: node-kind toggles + hide-unconnected --------------------------
+
+export interface GraphFilter {
+	/** Node kinds to keep. A node of any other kind (and its edges) is dropped. */
+	kinds: ReadonlySet<OMNodeKind>;
+	/** Drop nodes left with zero edges (the finance vertical's ~8 declared-but-not-
+	 *  detected cycles are degree-0 floaters — this clears them without special-casing
+	 *  their state). Orphans have no edges by definition, so removal never re-orphans
+	 *  another node: a single pass is correct. */
+	hideOrphans: boolean;
+}
+
+/**
+ * Filter the (already column-collapsed) graph by node kind, then optionally drop
+ * unconnected nodes. Pure → unit-tested. Runs AFTER `computeVisibleGraph` so orphan
+ * degree is measured on what's actually on screen (collapsed columns re-pointed to
+ * their table). Edges survive only when BOTH endpoints survive the kind filter.
+ */
+export function filterGraph(
+	graph: OperatingModelGraph,
+	filter: GraphFilter,
+): OperatingModelGraph {
+	const nodes = graph.nodes.filter((n) => filter.kinds.has(n.kind));
+	const present = new Set(nodes.map((n) => n.id));
+	const edges = graph.edges.filter(
+		(e) => present.has(e.source) && present.has(e.target),
+	);
+	if (!filter.hideOrphans) return { nodes, edges };
+
+	const connected = new Set<string>();
+	for (const e of edges) {
+		connected.add(e.source);
+		connected.add(e.target);
+	}
+	return { nodes: nodes.filter((n) => connected.has(n.id)), edges };
+}
+
+/** Named lenses for the filter bar — a preset sets the enabled node kinds. The
+ *  connective kinds (concept / table / column) ride along in every non-empty lens
+ *  so the spine stays intact; `column` is gated further by table expansion. */
+export type OMPreset = "full" | "metrics" | "validations" | "cycles";
+
+export const OM_PRESET_KINDS: Record<OMPreset, readonly OMNodeKind[]> = {
+	full: OM_NODE_KINDS,
+	metrics: ["metric", "driver", "concept", "table", "column"],
+	validations: ["validation", "concept", "table", "column"],
+	cycles: ["cycle", "concept", "table", "column"],
+};

--- a/packages/cockpit/src/tools/operating-model-load.ts
+++ b/packages/cockpit/src/tools/operating-model-load.ts
@@ -12,7 +12,6 @@
 import { and, eq, isNotNull, like } from "drizzle-orm";
 
 import { config } from "../config";
-import { resolveActiveWorkspaceRow } from "../db/cockpit/registry";
 import { metadataDb } from "../db/metadata/client";
 import {
 	columns as columnsView,
@@ -32,7 +31,6 @@ import {
 	type ConceptColumnInput,
 	type CycleInput,
 	type DriverInput,
-	extractConceptsFromDag,
 	type MetricConceptInput,
 	type MetricInput,
 	type OperatingModelGraph,
@@ -40,7 +38,6 @@ import {
 	type TableInput,
 	type ValidationInput,
 } from "./operating-model-graph";
-import { readShippedMetrics } from "./teach-metric";
 
 export interface LoadOperatingModelResult {
 	/** False until the operating_model stage has a promoted run (page shows "not run"). */
@@ -56,14 +53,9 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 	// anchor the model — the page shows "run the operating model first".
 	if (!metricResult.analyzed) return { analyzed: false, graph: EMPTY_GRAPH };
 
-	// The metric→concept edges come from the metrics' computation DAGs (their extract
-	// leaves), read off the workspace vertical's shipped specs (DAT-591) — reliable,
-	// unlike snippet provenance. The DAG lives in config YAML, not Postgres.
-	const workspace = await resolveActiveWorkspaceRow();
-	const [cycleResult, validationResult, shippedMetrics] = await Promise.all([
+	const [cycleResult, validationResult] = await Promise.all([
 		lookCycle(),
 		lookValidation(),
-		readShippedMetrics(workspace.vertical),
 	]);
 
 	const [
@@ -146,30 +138,17 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 		const idx = source.indexOf(":");
 		return idx === -1 ? source : source.slice(idx + 1);
 	};
-	// Per-metric SQL bodies still come from the snippets (every step's validated body);
-	// the SQL DISPLAY is refined per node-type in Phase 2. Only the metric→concept EDGES
-	// move to the DAG below.
+	const metricConcepts: MetricConceptInput[] = [];
 	const sqlByMetric = new Map<string, string[]>();
 	for (const r of conceptSnippetRows) {
-		if (!r.source || !r.sql) continue;
+		if (!r.source) continue;
 		const graphId = graphIdOf(r.source);
-		const steps = sqlByMetric.get(graphId) ?? [];
-		steps.push(r.sql);
-		sqlByMetric.set(graphId, steps);
-	}
-
-	// metric→concept edges from each metric's DAG extract leaves (DAT-591) — complete
-	// even for metrics that reused shared extract snippets (the gross_margin→revenue/cogs
-	// gap the snippet-provenance derivation missed). `dependencies` is untrusted (rule 11).
-	const dagByGraphId = new Map(
-		shippedMetrics.map((m) => [m.graph_id, m.dependencies]),
-	);
-	const metricConcepts: MetricConceptInput[] = [];
-	for (const m of metricResult.metrics) {
-		for (const concept of extractConceptsFromDag(
-			dagByGraphId.get(m.graph_id),
-		)) {
-			metricConcepts.push({ graphId: m.graph_id, concept });
+		if (r.standardField)
+			metricConcepts.push({ graphId, concept: r.standardField });
+		if (r.sql) {
+			const steps = sqlByMetric.get(graphId) ?? [];
+			steps.push(r.sql);
+			sqlByMetric.set(graphId, steps);
 		}
 	}
 

--- a/packages/cockpit/src/tools/operating-model-load.ts
+++ b/packages/cockpit/src/tools/operating-model-load.ts
@@ -8,11 +8,12 @@
 // ONE Postgres source for structure: each metric's `graph_definition` (the effective
 // DAG). Composition is the naming convention (a step name that IS a metric graph_id).
 // Execution SQL: the metric's `formula` snippet + each measure's `extract` snippet.
-// Grounding measure→table is STRUCTURED — column_mappings names the enriched view
-// (substring-matched against known view names, no SQL-expression parsing), and
-// `current_enriched_views` maps it to its base fact/dim tables.
+// Grounding is resolved by the pure `resolveGrounding`: a measure is grounded iff its
+// extract's `failure_count == 0` (the engine's accept signal — column_mappings is only
+// a hint), and its enriched view is read from the SQL's `FROM <view>` (a hard contract),
+// mapped to base fact/dim tables via `current_enriched_views`.
 
-import { and, eq, like } from "drizzle-orm";
+import { and, desc, eq, like } from "drizzle-orm";
 
 import { config } from "../config";
 import { metadataDb } from "../db/metadata/client";
@@ -26,10 +27,11 @@ import {
 import { stripSrcDigests } from "../lib/display-names";
 import {
 	buildOperatingModelGraph,
-	type GroundedTable,
-	type MeasureGroundingInput,
+	type EnrichedViewInput,
+	type ExtractSnippetInput,
 	type MetricInput,
 	type OperatingModelGraph,
+	resolveGrounding,
 } from "./operating-model-graph";
 
 export interface LoadOperatingModelResult {
@@ -63,8 +65,10 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 			})
 			.from(currentLifecycleArtifacts)
 			.where(eq(currentLifecycleArtifacts.artifactType, "metric")),
-		// Every graph snippet: the metric's flattened SQL (formula) + each measure's
-		// grounded SQL + column_mappings (extract). Workspace-durable, keyed by graph:<id>.
+		// Graph snippets: the metric's flattened SQL (formula) + each measure's grounded
+		// SQL, column_mappings, and failure_count (extract). Newest-first, so the
+		// first-write-wins dedup below takes the LATEST row when at-least-once redelivery
+		// left duplicates (the engine treats any row as fine; the cockpit displays it).
 		metadataDb
 			.select({
 				source: sqlSnippets.source,
@@ -72,6 +76,7 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 				standardField: sqlSnippets.standardField,
 				sql: sqlSnippets.sql,
 				columnMappings: sqlSnippets.columnMappings,
+				failureCount: sqlSnippets.failureCount,
 			})
 			.from(sqlSnippets)
 			.where(
@@ -79,7 +84,8 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 					eq(sqlSnippets.schemaMappingId, config.dataraumWorkspaceId),
 					like(sqlSnippets.source, "graph:%"),
 				),
-			),
+			)
+			.orderBy(desc(sqlSnippets.updatedAt)),
 		// Enriched views → the base fact + dimension tables they derive from.
 		metadataDb
 			.select({
@@ -95,8 +101,8 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 			.from(tablesView),
 	]);
 
-	// The metric's flattened runnable SQL = its `formula` snippet (one per composed
-	// metric; ungroundable metrics have none → null).
+	// The metric's flattened runnable SQL = its `formula` snippet (newest wins;
+	// ungroundable metrics have none → null).
 	const sqlByMetric = new Map<string, string>();
 	for (const r of snippetRows) {
 		if (r.snippetType !== "formula" || !r.source || !r.sql) continue;
@@ -104,66 +110,55 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 		if (!sqlByMetric.has(g)) sqlByMetric.set(g, r.sql);
 	}
 
-	const tableNameById = new Map<string, string>();
+	const tableNames = new Map<string, string>();
 	for (const t of tableRows) {
-		if (t.tableId && t.tableName) tableNameById.set(t.tableId, t.tableName);
+		if (t.tableId && t.tableName) tableNames.set(t.tableId, t.tableName);
 	}
-	const enrichedByName = new Map<
-		string,
-		{ viewTableId: string; viewName: string; baseTableIds: string[] }
-	>();
-	for (const v of enrichedRows) {
-		if (!v.viewName || !v.viewTableId) continue;
-		const dims = Array.isArray(v.dimensionTableIds)
-			? v.dimensionTableIds.filter((d): d is string => typeof d === "string")
-			: [];
-		enrichedByName.set(v.viewName, {
-			viewTableId: v.viewTableId,
+	const views: EnrichedViewInput[] = enrichedRows
+		.filter((v): v is typeof v & { viewName: string; viewTableId: string } =>
+			Boolean(v.viewName && v.viewTableId),
+		)
+		.map((v) => ({
 			viewName: v.viewName,
-			baseTableIds: [v.factTableId, ...dims].filter(
-				(id): id is string => typeof id === "string",
-			),
-		});
-	}
-	const enrichedNames = [...enrichedByName.keys()];
+			viewTableId: v.viewTableId,
+			baseTableIds: [
+				v.factTableId,
+				...(Array.isArray(v.dimensionTableIds)
+					? v.dimensionTableIds.filter(
+							(d): d is string => typeof d === "string",
+						)
+					: []),
+			].filter((id): id is string => typeof id === "string"),
+		}));
 
-	// Per measure concept (standard_field), its grounding — resolved from the extract
-	// snippet's column_mappings (which enriched view it reads) + current_enriched_views.
-	const groundingByField = new Map<string, MeasureGroundingInput>();
-	for (const r of snippetRows) {
-		if (r.snippetType !== "extract" || !r.standardField) continue;
-		if (groundingByField.has(r.standardField)) continue; // deduped concept
-
-		const mapText = r.columnMappings ? JSON.stringify(r.columnMappings) : "";
-		const viewName = enrichedNames.find((n) => mapText.includes(n)) ?? null;
-		const view = viewName ? enrichedByName.get(viewName) : undefined;
-		let enrichedView: GroundedTable | null = null;
-		let baseTables: GroundedTable[] = [];
-		if (view) {
-			enrichedView = { tableId: view.viewTableId, tableName: view.viewName };
-			baseTables = view.baseTableIds
-				.filter((id) => tableNameById.has(id))
-				.map((id) => ({ tableId: id, tableName: tableNameById.get(id) ?? id }));
-		}
-		groundingByField.set(r.standardField, {
+	// Extract snippets (newest-first) → the pure grounding resolver (failure_count
+	// decides grounded; the view name is read from the SQL, not the optional mappings).
+	const extracts: ExtractSnippetInput[] = snippetRows
+		.filter(
+			(r): r is typeof r & { standardField: string } =>
+				r.snippetType === "extract" && Boolean(r.standardField),
+		)
+		.map((r) => ({
 			standardField: r.standardField,
 			sql: r.sql ?? null,
-			enrichedView,
-			baseTables,
-		});
-	}
+			columnMappingsText: r.columnMappings
+				? JSON.stringify(r.columnMappings)
+				: "",
+			failureCount: r.failureCount ?? 0,
+		}));
+	const grounding = resolveGrounding(extracts, views, tableNames);
 
-	const metrics: MetricInput[] = metricRows.map((r) => ({
-		graphId: r.graphId ?? "",
-		state: r.state ?? "",
-		stateReason: r.stateReason === null ? null : stripSrcDigests(r.stateReason),
-		dag: r.dag ?? null,
-		sql: sqlByMetric.get(r.graphId ?? "") ?? null,
-	}));
+	const metrics: MetricInput[] = metricRows
+		.filter((r): r is typeof r & { graphId: string } => Boolean(r.graphId))
+		.map((r) => ({
+			graphId: r.graphId,
+			state: r.state ?? "",
+			stateReason:
+				r.stateReason === null ? null : stripSrcDigests(r.stateReason),
+			dag: r.dag ?? null,
+			sql: sqlByMetric.get(r.graphId) ?? null,
+		}));
 
-	const graph = buildOperatingModelGraph({
-		metrics,
-		grounding: [...groundingByField.values()],
-	});
+	const graph = buildOperatingModelGraph({ metrics, grounding });
 	return { analyzed: true, graph };
 }

--- a/packages/cockpit/src/tools/operating-model-load.ts
+++ b/packages/cockpit/src/tools/operating-model-load.ts
@@ -7,7 +7,10 @@
 //
 // Reuses the look_* read contracts for metric/cycle/validation lifecycle state;
 // reads the views directly for the columns those projections drop (measure_column_id,
-// sql_used) and for the concept/grounding/relationship/column substrate.
+// sql_used, graph_definition) and for the concept/grounding/relationship/column
+// substrate. A metric's step structure comes from the ONE Postgres source — the
+// effective DAG the engine persists onto its lifecycle row (graph_definition,
+// DAT-591) — not from re-reading config or re-merging the overlay in the cockpit.
 
 import { and, eq, isNotNull, like } from "drizzle-orm";
 
@@ -17,6 +20,7 @@ import {
 	columns as columnsView,
 	currentColumnConcepts,
 	currentDriverRankings,
+	currentLifecycleArtifacts,
 	currentRelationships,
 	currentValidationResults,
 	sqlSnippets,
@@ -31,7 +35,6 @@ import {
 	type ConceptColumnInput,
 	type CycleInput,
 	type DriverInput,
-	type MetricConceptInput,
 	type MetricInput,
 	type OperatingModelGraph,
 	type RelationshipInput,
@@ -59,7 +62,8 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 	]);
 
 	const [
-		conceptSnippetRows,
+		metricSnippetRows,
+		metricDagRows,
 		conceptColumnRows,
 		driverRows,
 		relationshipRows,
@@ -67,13 +71,12 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 		tableRows,
 		validationSqlRows,
 	] = await Promise.all([
-		// All graph snippets (NOT filtered on standard_field) — the rows feed BOTH the
-		// concept edges (steps that carry a standard_field) and the per-metric SQL
-		// (every step's validated body, incl. compute steps with no standard_field).
+		// Every graph snippet's validated SQL body (keyed by metric via the graph:<id>
+		// source) — the per-metric assembled SQL shown in the metric detail panel. The
+		// metric's STRUCTURE (steps/kinds) comes from graph_definition below, not here.
 		metadataDb
 			.select({
 				source: sqlSnippets.source,
-				standardField: sqlSnippets.standardField,
 				sql: sqlSnippets.sql,
 			})
 			.from(sqlSnippets)
@@ -83,6 +86,16 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 					like(sqlSnippets.source, "graph:%"),
 				),
 			),
+		// The effective (shipped ⊕ overlay) DAG the metrics phase assembled from,
+		// persisted onto each metric's lifecycle row (DAT-591). The ONE Postgres
+		// source for the step nodes — overlay-inclusive, zero divergence.
+		metadataDb
+			.select({
+				graphId: currentLifecycleArtifacts.artifactKey,
+				graphDefinition: currentLifecycleArtifacts.graphDefinition,
+			})
+			.from(currentLifecycleArtifacts)
+			.where(eq(currentLifecycleArtifacts.artifactType, "metric")),
 		metadataDb
 			.select({
 				concept: currentColumnConcepts.businessConcept,
@@ -138,18 +151,20 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 		const idx = source.indexOf(":");
 		return idx === -1 ? source : source.slice(idx + 1);
 	};
-	const metricConcepts: MetricConceptInput[] = [];
 	const sqlByMetric = new Map<string, string[]>();
-	for (const r of conceptSnippetRows) {
-		if (!r.source) continue;
+	for (const r of metricSnippetRows) {
+		if (!r.source || !r.sql) continue;
 		const graphId = graphIdOf(r.source);
-		if (r.standardField)
-			metricConcepts.push({ graphId, concept: r.standardField });
-		if (r.sql) {
-			const steps = sqlByMetric.get(graphId) ?? [];
-			steps.push(r.sql);
-			sqlByMetric.set(graphId, steps);
-		}
+		const steps = sqlByMetric.get(graphId) ?? [];
+		steps.push(r.sql);
+		sqlByMetric.set(graphId, steps);
+	}
+
+	// The effective DAG per metric (graph_definition), keyed by graph_id. Left as
+	// `unknown` — parseMetricDag narrows it at the pure builder's boundary.
+	const dagByMetric = new Map<string, unknown>();
+	for (const r of metricDagRows) {
+		if (r.graphId) dagByMetric.set(r.graphId, r.graphDefinition ?? null);
 	}
 
 	const conceptColumns: ConceptColumnInput[] = conceptColumnRows
@@ -219,6 +234,7 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 			stateReason: m.state_reason,
 			snippetCount: m.snippet_count,
 			sql: steps?.length ? steps.join("\n\n-- ── next step ──\n\n") : null,
+			dag: dagByMetric.get(m.graph_id) ?? null,
 		};
 	});
 
@@ -245,7 +261,6 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 
 	const graph = buildOperatingModelGraph({
 		metrics,
-		metricConcepts,
 		cycles,
 		validations,
 		drivers,

--- a/packages/cockpit/src/tools/operating-model-load.ts
+++ b/packages/cockpit/src/tools/operating-model-load.ts
@@ -117,9 +117,15 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 				columnName: columnsView.columnName,
 			})
 			.from(columnsView),
+		// Scope to the TYPED layer — the analysis grain. Each logical table exists as
+		// several physical layers (quarantine/raw/typed/…) sharing a table_name, and
+		// `tables`/`columns` are NOT layer-scoped (no current_* variant exists, unlike
+		// relationships/drivers/concepts). Every current_* artifact grounds to `typed`
+		// columns, so without this filter each table triplicates on the canvas.
 		metadataDb
 			.select({ tableId: tablesView.tableId, tableName: tablesView.tableName })
-			.from(tablesView),
+			.from(tablesView)
+			.where(eq(tablesView.layer, "typed")),
 		metadataDb
 			.select({
 				validationId: currentValidationResults.validationId,
@@ -177,22 +183,28 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 		)
 		.map((r) => ({ fromColumnId: r.fromColumnId, toColumnId: r.toColumnId }));
 
+	const tables: TableInput[] = tableRows
+		.filter((r): r is { tableId: string; tableName: string } =>
+			Boolean(r.tableId && r.tableName),
+		)
+		.map((r) => ({ tableId: r.tableId, tableName: r.tableName }));
+
+	// Keep only columns of the typed tables — `columns` has no `layer`, so gate on
+	// the typed table ids fetched above (mirrors the tables scoping; drops the
+	// raw/quarantine column twins that would otherwise triplicate every table node).
+	const typedTableIds = new Set(tables.map((t) => t.tableId));
 	const columns: ColumnInput[] = columnRows
 		.filter(
 			(r): r is { columnId: string; tableId: string; columnName: string } =>
-				Boolean(r.columnId && r.tableId && r.columnName),
+				Boolean(r.columnId && r.columnName) &&
+				r.tableId != null &&
+				typedTableIds.has(r.tableId),
 		)
 		.map((r) => ({
 			columnId: r.columnId,
 			tableId: r.tableId,
 			columnName: r.columnName,
 		}));
-
-	const tables: TableInput[] = tableRows
-		.filter((r): r is { tableId: string; tableName: string } =>
-			Boolean(r.tableId && r.tableName),
-		)
-		.map((r) => ({ tableId: r.tableId, tableName: r.tableName }));
 
 	const sqlByValidation = new Map<string, string | null>();
 	for (const r of validationSqlRows) {

--- a/packages/cockpit/src/tools/operating-model-load.ts
+++ b/packages/cockpit/src/tools/operating-model-load.ts
@@ -12,6 +12,7 @@
 import { and, eq, isNotNull, like } from "drizzle-orm";
 
 import { config } from "../config";
+import { resolveActiveWorkspaceRow } from "../db/cockpit/registry";
 import { metadataDb } from "../db/metadata/client";
 import {
 	columns as columnsView,
@@ -31,6 +32,7 @@ import {
 	type ConceptColumnInput,
 	type CycleInput,
 	type DriverInput,
+	extractConceptsFromDag,
 	type MetricConceptInput,
 	type MetricInput,
 	type OperatingModelGraph,
@@ -38,6 +40,7 @@ import {
 	type TableInput,
 	type ValidationInput,
 } from "./operating-model-graph";
+import { readShippedMetrics } from "./teach-metric";
 
 export interface LoadOperatingModelResult {
 	/** False until the operating_model stage has a promoted run (page shows "not run"). */
@@ -53,9 +56,14 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 	// anchor the model — the page shows "run the operating model first".
 	if (!metricResult.analyzed) return { analyzed: false, graph: EMPTY_GRAPH };
 
-	const [cycleResult, validationResult] = await Promise.all([
+	// The metric→concept edges come from the metrics' computation DAGs (their extract
+	// leaves), read off the workspace vertical's shipped specs (DAT-591) — reliable,
+	// unlike snippet provenance. The DAG lives in config YAML, not Postgres.
+	const workspace = await resolveActiveWorkspaceRow();
+	const [cycleResult, validationResult, shippedMetrics] = await Promise.all([
 		lookCycle(),
 		lookValidation(),
+		readShippedMetrics(workspace.vertical),
 	]);
 
 	const [
@@ -138,17 +146,30 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 		const idx = source.indexOf(":");
 		return idx === -1 ? source : source.slice(idx + 1);
 	};
-	const metricConcepts: MetricConceptInput[] = [];
+	// Per-metric SQL bodies still come from the snippets (every step's validated body);
+	// the SQL DISPLAY is refined per node-type in Phase 2. Only the metric→concept EDGES
+	// move to the DAG below.
 	const sqlByMetric = new Map<string, string[]>();
 	for (const r of conceptSnippetRows) {
-		if (!r.source) continue;
+		if (!r.source || !r.sql) continue;
 		const graphId = graphIdOf(r.source);
-		if (r.standardField)
-			metricConcepts.push({ graphId, concept: r.standardField });
-		if (r.sql) {
-			const steps = sqlByMetric.get(graphId) ?? [];
-			steps.push(r.sql);
-			sqlByMetric.set(graphId, steps);
+		const steps = sqlByMetric.get(graphId) ?? [];
+		steps.push(r.sql);
+		sqlByMetric.set(graphId, steps);
+	}
+
+	// metric→concept edges from each metric's DAG extract leaves (DAT-591) — complete
+	// even for metrics that reused shared extract snippets (the gross_margin→revenue/cogs
+	// gap the snippet-provenance derivation missed). `dependencies` is untrusted (rule 11).
+	const dagByGraphId = new Map(
+		shippedMetrics.map((m) => [m.graph_id, m.dependencies]),
+	);
+	const metricConcepts: MetricConceptInput[] = [];
+	for (const m of metricResult.metrics) {
+		for (const concept of extractConceptsFromDag(
+			dagByGraphId.get(m.graph_id),
+		)) {
+			metricConcepts.push({ graphId: m.graph_id, concept });
 		}
 	}
 

--- a/packages/cockpit/src/tools/operating-model-load.ts
+++ b/packages/cockpit/src/tools/operating-model-load.ts
@@ -1,45 +1,35 @@
-// Operating-model canvas IO loader (DAT-591 Phase 1) — the SERVER-ONLY half.
-// Fetches every input the concept-spine graph needs and hands it to the pure
-// `buildOperatingModelGraph`. Imports the metadata DB client (bun `SQL`) +
-// config, so it must NEVER be imported by a client component — the canvas imports
-// only the pure `operating-model-graph` module; this loader is reached solely via
-// the route's `createServerFn`.
+// Operating-model METRIC graph loader (DAT-591) — the SERVER-ONLY half. Fetches the
+// inputs the metric dependency graph needs and hands them to the pure
+// `buildOperatingModelGraph`. Imports the metadata DB client + config, so it must
+// NEVER be imported by a client component — the canvas imports only the pure
+// `operating-model-graph` module; this loader is reached solely via the route's
+// `createServerFn`.
 //
-// Reuses the look_* read contracts for metric/cycle/validation lifecycle state;
-// reads the views directly for the columns those projections drop (measure_column_id,
-// sql_used, graph_definition) and for the concept/grounding/relationship/column
-// substrate. A metric's step structure comes from the ONE Postgres source — the
-// effective DAG the engine persists onto its lifecycle row (graph_definition,
-// DAT-591) — not from re-reading config or re-merging the overlay in the cockpit.
+// ONE Postgres source for structure: each metric's `graph_definition` (the effective
+// DAG). Composition is the naming convention (a step name that IS a metric graph_id).
+// Execution SQL: the metric's `formula` snippet + each measure's `extract` snippet.
+// Grounding measure→table is STRUCTURED — column_mappings names the enriched view
+// (substring-matched against known view names, no SQL-expression parsing), and
+// `current_enriched_views` maps it to its base fact/dim tables.
 
-import { and, eq, isNotNull, like } from "drizzle-orm";
+import { and, eq, like } from "drizzle-orm";
 
 import { config } from "../config";
 import { metadataDb } from "../db/metadata/client";
+import { readOperatingModelHead } from "../db/metadata/lifecycle-artifacts";
 import {
-	columns as columnsView,
-	currentColumnConcepts,
-	currentDriverRankings,
+	currentEnrichedViews,
 	currentLifecycleArtifacts,
-	currentRelationships,
-	currentValidationResults,
 	sqlSnippets,
 	tables as tablesView,
 } from "../db/metadata/schema";
-import { lookCycle } from "./look-cycle";
-import { lookMetric } from "./look-metric";
-import { lookValidation } from "./look-validation";
+import { stripSrcDigests } from "../lib/display-names";
 import {
 	buildOperatingModelGraph,
-	type ColumnInput,
-	type ConceptColumnInput,
-	type CycleInput,
-	type DriverInput,
+	type GroundedTable,
+	type MeasureGroundingInput,
 	type MetricInput,
 	type OperatingModelGraph,
-	type RelationshipInput,
-	type TableInput,
-	type ValidationInput,
 } from "./operating-model-graph";
 
 export interface LoadOperatingModelResult {
@@ -50,34 +40,38 @@ export interface LoadOperatingModelResult {
 
 const EMPTY_GRAPH: OperatingModelGraph = { nodes: [], edges: [] };
 
+/** The `graph:<id>` snippet source → the metric's graph_id. */
+const graphIdOf = (source: string): string => {
+	const idx = source.indexOf(":");
+	return idx === -1 ? source : source.slice(idx + 1);
+};
+
 export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResult> {
-	const metricResult = await lookMetric();
-	// Gate on the operating_model head: with no promoted run there are no metrics to
-	// anchor the model — the page shows "run the operating model first".
-	if (!metricResult.analyzed) return { analyzed: false, graph: EMPTY_GRAPH };
+	// Gate on the promoted operating_model head — distinguishes "promoted, zero metrics"
+	// from "never ran" (both yield empty current_* rows).
+	const head = await readOperatingModelHead();
+	if (!head) return { analyzed: false, graph: EMPTY_GRAPH };
 
-	const [cycleResult, validationResult] = await Promise.all([
-		lookCycle(),
-		lookValidation(),
-	]);
-
-	const [
-		metricSnippetRows,
-		metricDagRows,
-		conceptColumnRows,
-		driverRows,
-		relationshipRows,
-		columnRows,
-		tableRows,
-		validationSqlRows,
-	] = await Promise.all([
-		// Every graph snippet's validated SQL body (keyed by metric via the graph:<id>
-		// source) — the per-metric assembled SQL shown in the metric detail panel. The
-		// metric's STRUCTURE (steps/kinds) comes from graph_definition below, not here.
+	const [metricRows, snippetRows, enrichedRows, tableRows] = await Promise.all([
+		// The declared metric set (promoted run) + each metric's effective DAG.
+		metadataDb
+			.select({
+				graphId: currentLifecycleArtifacts.artifactKey,
+				state: currentLifecycleArtifacts.state,
+				stateReason: currentLifecycleArtifacts.stateReason,
+				dag: currentLifecycleArtifacts.graphDefinition,
+			})
+			.from(currentLifecycleArtifacts)
+			.where(eq(currentLifecycleArtifacts.artifactType, "metric")),
+		// Every graph snippet: the metric's flattened SQL (formula) + each measure's
+		// grounded SQL + column_mappings (extract). Workspace-durable, keyed by graph:<id>.
 		metadataDb
 			.select({
 				source: sqlSnippets.source,
+				snippetType: sqlSnippets.snippetType,
+				standardField: sqlSnippets.standardField,
 				sql: sqlSnippets.sql,
+				columnMappings: sqlSnippets.columnMappings,
 			})
 			.from(sqlSnippets)
 			.where(
@@ -86,189 +80,90 @@ export async function loadOperatingModelGraph(): Promise<LoadOperatingModelResul
 					like(sqlSnippets.source, "graph:%"),
 				),
 			),
-		// The effective (shipped ⊕ overlay) DAG the metrics phase assembled from,
-		// persisted onto each metric's lifecycle row (DAT-591). The ONE Postgres
-		// source for the step nodes — overlay-inclusive, zero divergence.
+		// Enriched views → the base fact + dimension tables they derive from.
 		metadataDb
 			.select({
-				graphId: currentLifecycleArtifacts.artifactKey,
-				graphDefinition: currentLifecycleArtifacts.graphDefinition,
+				viewName: currentEnrichedViews.viewName,
+				viewTableId: currentEnrichedViews.viewTableId,
+				factTableId: currentEnrichedViews.factTableId,
+				dimensionTableIds: currentEnrichedViews.dimensionTableIds,
 			})
-			.from(currentLifecycleArtifacts)
-			.where(eq(currentLifecycleArtifacts.artifactType, "metric")),
-		metadataDb
-			.select({
-				concept: currentColumnConcepts.businessConcept,
-				columnId: currentColumnConcepts.columnId,
-			})
-			.from(currentColumnConcepts)
-			.where(isNotNull(currentColumnConcepts.businessConcept)),
-		metadataDb
-			.select({
-				measureColumnId: currentDriverRankings.measureColumnId,
-				measureLabel: currentDriverRankings.measureLabel,
-				targetType: currentDriverRankings.targetType,
-				grain: currentDriverRankings.grain,
-				entity: currentDriverRankings.entity,
-				nRows: currentDriverRankings.nRows,
-				rankedDimensions: currentDriverRankings.rankedDimensions,
-				driverPaths: currentDriverRankings.driverPaths,
-				interestingSlices: currentDriverRankings.interestingSlices,
-				secondaryDimensions: currentDriverRankings.secondaryDimensions,
-			})
-			.from(currentDriverRankings),
-		metadataDb
-			.select({
-				fromColumnId: currentRelationships.fromColumnId,
-				toColumnId: currentRelationships.toColumnId,
-			})
-			.from(currentRelationships),
-		metadataDb
-			.select({
-				columnId: columnsView.columnId,
-				tableId: columnsView.tableId,
-				columnName: columnsView.columnName,
-			})
-			.from(columnsView),
-		// Scope to the TYPED layer — the analysis grain. Each logical table exists as
-		// several physical layers (quarantine/raw/typed/…) sharing a table_name, and
-		// `tables`/`columns` are NOT layer-scoped (no current_* variant exists, unlike
-		// relationships/drivers/concepts). Every current_* artifact grounds to `typed`
-		// columns, so without this filter each table triplicates on the canvas.
+			.from(currentEnrichedViews),
+		// table_id → table_name, for naming the fact/dim tables a view derives from.
 		metadataDb
 			.select({ tableId: tablesView.tableId, tableName: tablesView.tableName })
-			.from(tablesView)
-			.where(eq(tablesView.layer, "typed")),
-		metadataDb
-			.select({
-				validationId: currentValidationResults.validationId,
-				sqlUsed: currentValidationResults.sqlUsed,
-			})
-			.from(currentValidationResults),
+			.from(tablesView),
 	]);
 
-	const graphIdOf = (source: string) => {
-		const idx = source.indexOf(":");
-		return idx === -1 ? source : source.slice(idx + 1);
-	};
-	const sqlByMetric = new Map<string, string[]>();
-	for (const r of metricSnippetRows) {
-		if (!r.source || !r.sql) continue;
-		const graphId = graphIdOf(r.source);
-		const steps = sqlByMetric.get(graphId) ?? [];
-		steps.push(r.sql);
-		sqlByMetric.set(graphId, steps);
+	// The metric's flattened runnable SQL = its `formula` snippet (one per composed
+	// metric; ungroundable metrics have none → null).
+	const sqlByMetric = new Map<string, string>();
+	for (const r of snippetRows) {
+		if (r.snippetType !== "formula" || !r.source || !r.sql) continue;
+		const g = graphIdOf(r.source);
+		if (!sqlByMetric.has(g)) sqlByMetric.set(g, r.sql);
 	}
 
-	// The effective DAG per metric (graph_definition), keyed by graph_id. Left as
-	// `unknown` — parseMetricDag narrows it at the pure builder's boundary.
-	const dagByMetric = new Map<string, unknown>();
-	for (const r of metricDagRows) {
-		if (r.graphId) dagByMetric.set(r.graphId, r.graphDefinition ?? null);
+	const tableNameById = new Map<string, string>();
+	for (const t of tableRows) {
+		if (t.tableId && t.tableName) tableNameById.set(t.tableId, t.tableName);
+	}
+	const enrichedByName = new Map<
+		string,
+		{ viewTableId: string; viewName: string; baseTableIds: string[] }
+	>();
+	for (const v of enrichedRows) {
+		if (!v.viewName || !v.viewTableId) continue;
+		const dims = Array.isArray(v.dimensionTableIds)
+			? v.dimensionTableIds.filter((d): d is string => typeof d === "string")
+			: [];
+		enrichedByName.set(v.viewName, {
+			viewTableId: v.viewTableId,
+			viewName: v.viewName,
+			baseTableIds: [v.factTableId, ...dims].filter(
+				(id): id is string => typeof id === "string",
+			),
+		});
+	}
+	const enrichedNames = [...enrichedByName.keys()];
+
+	// Per measure concept (standard_field), its grounding — resolved from the extract
+	// snippet's column_mappings (which enriched view it reads) + current_enriched_views.
+	const groundingByField = new Map<string, MeasureGroundingInput>();
+	for (const r of snippetRows) {
+		if (r.snippetType !== "extract" || !r.standardField) continue;
+		if (groundingByField.has(r.standardField)) continue; // deduped concept
+
+		const mapText = r.columnMappings ? JSON.stringify(r.columnMappings) : "";
+		const viewName = enrichedNames.find((n) => mapText.includes(n)) ?? null;
+		const view = viewName ? enrichedByName.get(viewName) : undefined;
+		let enrichedView: GroundedTable | null = null;
+		let baseTables: GroundedTable[] = [];
+		if (view) {
+			enrichedView = { tableId: view.viewTableId, tableName: view.viewName };
+			baseTables = view.baseTableIds
+				.filter((id) => tableNameById.has(id))
+				.map((id) => ({ tableId: id, tableName: tableNameById.get(id) ?? id }));
+		}
+		groundingByField.set(r.standardField, {
+			standardField: r.standardField,
+			sql: r.sql ?? null,
+			enrichedView,
+			baseTables,
+		});
 	}
 
-	const conceptColumns: ConceptColumnInput[] = conceptColumnRows
-		.filter((r): r is { concept: string; columnId: string } =>
-			Boolean(r.concept && r.columnId),
-		)
-		.map((r) => ({ concept: r.concept, columnId: r.columnId }));
-
-	const drivers: DriverInput[] = driverRows
-		.filter((r): r is typeof r & { measureColumnId: string } =>
-			Boolean(r.measureColumnId),
-		)
-		.map((r) => ({
-			measureColumnId: r.measureColumnId,
-			ranking: {
-				measureLabel: r.measureLabel,
-				targetType: r.targetType,
-				grain: r.grain,
-				entity: r.entity,
-				nRows: r.nRows,
-				rankedDimensions: r.rankedDimensions,
-				driverPaths: r.driverPaths,
-				interestingSlices: r.interestingSlices,
-				secondaryDimensions: r.secondaryDimensions,
-			},
-		}));
-
-	const relationships: RelationshipInput[] = relationshipRows
-		.filter((r): r is { fromColumnId: string; toColumnId: string } =>
-			Boolean(r.fromColumnId && r.toColumnId),
-		)
-		.map((r) => ({ fromColumnId: r.fromColumnId, toColumnId: r.toColumnId }));
-
-	const tables: TableInput[] = tableRows
-		.filter((r): r is { tableId: string; tableName: string } =>
-			Boolean(r.tableId && r.tableName),
-		)
-		.map((r) => ({ tableId: r.tableId, tableName: r.tableName }));
-
-	// Keep only columns of the typed tables — `columns` has no `layer`, so gate on
-	// the typed table ids fetched above (mirrors the tables scoping; drops the
-	// raw/quarantine column twins that would otherwise triplicate every table node).
-	const typedTableIds = new Set(tables.map((t) => t.tableId));
-	const columns: ColumnInput[] = columnRows
-		.filter(
-			(r): r is { columnId: string; tableId: string; columnName: string } =>
-				Boolean(r.columnId && r.columnName) &&
-				r.tableId != null &&
-				typedTableIds.has(r.tableId),
-		)
-		.map((r) => ({
-			columnId: r.columnId,
-			tableId: r.tableId,
-			columnName: r.columnName,
-		}));
-
-	const sqlByValidation = new Map<string, string | null>();
-	for (const r of validationSqlRows) {
-		if (r.validationId) sqlByValidation.set(r.validationId, r.sqlUsed ?? null);
-	}
-
-	const metrics: MetricInput[] = metricResult.metrics.map((m) => {
-		const steps = sqlByMetric.get(m.graph_id);
-		return {
-			graphId: m.graph_id,
-			state: m.state,
-			stateReason: m.state_reason,
-			snippetCount: m.snippet_count,
-			sql: steps?.length ? steps.join("\n\n-- ── next step ──\n\n") : null,
-			dag: dagByMetric.get(m.graph_id) ?? null,
-		};
-	});
-
-	const cycles: CycleInput[] = cycleResult.cycles.map((c) => ({
-		canonicalType: c.canonical_type,
-		cycleName: c.cycle_name,
-		state: c.state,
-		completionRate: c.completion_rate,
-		completedCycles: c.completed_cycles,
-		totalRecords: c.total_records,
+	const metrics: MetricInput[] = metricRows.map((r) => ({
+		graphId: r.graphId ?? "",
+		state: r.state ?? "",
+		stateReason: r.stateReason === null ? null : stripSrcDigests(r.stateReason),
+		dag: r.dag ?? null,
+		sql: sqlByMetric.get(r.graphId ?? "") ?? null,
 	}));
-
-	const validations: ValidationInput[] = validationResult.validations.map(
-		(v) => ({
-			validationId: v.validation_id,
-			state: v.state,
-			passed: v.passed,
-			severity: v.severity,
-			status: v.status,
-			sqlUsed: sqlByValidation.get(v.validation_id) ?? null,
-			columnsUsed: v.columns_used,
-		}),
-	);
 
 	const graph = buildOperatingModelGraph({
 		metrics,
-		cycles,
-		validations,
-		drivers,
-		conceptColumns,
-		relationships,
-		columns,
-		tables,
+		grounding: [...groundingByField.values()],
 	});
-
 	return { analyzed: true, graph };
 }

--- a/packages/cockpit/src/ui/cockpit/operating-model/layout.ts
+++ b/packages/cockpit/src/ui/cockpit/operating-model/layout.ts
@@ -3,6 +3,14 @@
 // VISIBLE graph (progressive disclosure keeps the node count in dagre's comfortable
 // "hundreds" range; ELK-layered is the documented upgrade if a vertical outgrows it).
 // Pure transform: (rf nodes, rf edges) → nodes with computed positions.
+//
+// LAYOUT DIRECTION: LR (left→right), the lineage convention. The concept-spine is a
+// shallow-but-wide fan-in — many artifacts (metrics/validations/cycles) → a few
+// concept hubs → columns. TB would stack all ~40 sibling artifacts into ONE row
+// (thousands of px wide → fitView zooms to an unreadable strip); LR turns that fan
+// into a scrollable vertical column at each layer, reading like a dbt/lineage DAG.
+// `network-simplex` gives the tightest layering; the tight nodesep packs siblings so
+// the per-layer column stays compact.
 
 import dagre from "@dagrejs/dagre";
 import type { Edge, Node } from "@xyflow/react";
@@ -10,14 +18,22 @@ import type { Edge, Node } from "@xyflow/react";
 const NODE_W = 210;
 const NODE_H = 56;
 
-/** Position nodes top-to-bottom by dagre rank; returns a new node array. */
+/** Position nodes left-to-right by dagre rank; returns a new node array. */
 export function layoutGraph(
 	nodes: Node[],
 	edges: Edge[],
-	direction: "TB" | "LR" = "TB",
+	direction: "TB" | "LR" = "LR",
 ): Node[] {
 	const g = new dagre.graphlib.Graph();
-	g.setGraph({ rankdir: direction, nodesep: 36, ranksep: 90 });
+	g.setGraph({
+		rankdir: direction,
+		// LR: nodesep = vertical gap between siblings in a layer; ranksep = horizontal
+		// gap between layers. Tight sibling packing keeps the tall fan-in columns
+		// legible; wide ranksep leaves room for edge routing between layers.
+		nodesep: 18,
+		ranksep: 160,
+		ranker: "network-simplex",
+	});
 	g.setDefaultEdgeLabel(() => ({}));
 
 	for (const n of nodes) g.setNode(n.id, { width: NODE_W, height: NODE_H });

--- a/packages/cockpit/src/ui/cockpit/operating-model/nodes.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/nodes.tsx
@@ -1,31 +1,26 @@
-// Custom node renderers for the operating-model canvas (DAT-591). One component
-// switches on the node kind (concept / metric / validation / cycle / table /
-// column / driver) — a pure display of engine-persisted values (React idiom rule
-// 12: widgets color/format, never recompute). Click handling lives on the canvas
-// (onNodeClick), so these stay render-only.
+// Custom node renderers for the operating-model METRIC canvas (DAT-591). One
+// component switches on the node kind (metric / measure / constant / table) — a pure
+// display of engine-persisted values (React idiom 12: widgets color/format, never
+// recompute). Click handling lives on the canvas (onNodeClick), so these stay
+// render-only. A metric shows its output formula as a subtitle; a measure its
+// aggregation; a constant its value; an enriched-view table a collapse caret.
 
 import { Badge, Group, Paper, Stack, Text } from "@mantine/core";
 import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
 import {
-	Columns3,
 	Database,
-	FunctionSquare,
 	Gauge,
 	Hash,
-	Lightbulb,
 	type LucideIcon,
 	Network,
-	RefreshCw,
-	ShieldCheck,
 	Table2,
-	TrendingUp,
 } from "lucide-react";
 import { memo } from "react";
 
 import type { OMNode, OMNodeKind } from "#/tools/operating-model-graph";
 import { OM_NODE_WIDTH } from "./layout";
 
-/** RF node payload — the engine node plus the table-expanded flag (display only). */
+/** RF node payload — the engine node plus the expanded flag (display only). */
 export interface OMRfData extends Record<string, unknown> {
 	om: OMNode;
 	expanded: boolean;
@@ -33,18 +28,10 @@ export interface OMRfData extends Record<string, unknown> {
 export type OMRfNode = Node<OMRfData, "om">;
 
 const KIND_STYLE: Record<OMNodeKind, { color: string; Icon: LucideIcon }> = {
-	concept: { color: "grape", Icon: Lightbulb },
 	metric: { color: "blue", Icon: Gauge },
-	// The metric's DAG guts: a formula computes, an extract pulls from the data, a
-	// constant is a fixed value — each visually distinct so the structure reads.
-	formula: { color: "violet", Icon: FunctionSquare },
-	extract: { color: "cyan", Icon: Database },
+	measure: { color: "cyan", Icon: Database },
 	constant: { color: "yellow", Icon: Hash },
-	validation: { color: "teal", Icon: ShieldCheck },
-	cycle: { color: "indigo", Icon: RefreshCw },
 	table: { color: "gray", Icon: Table2 },
-	column: { color: "gray", Icon: Columns3 },
-	driver: { color: "orange", Icon: TrendingUp },
 };
 
 /** A short status chip per kind — the at-a-glance signal on the node face. */
@@ -56,37 +43,14 @@ function statusBadge(om: OMNode): React.ReactNode {
 					{om.data.state}
 				</Badge>
 			);
-		case "validation":
-			return (
+		case "measure":
+			// Aggregation (sum / avg / …); dimmed grey when the measure is ungrounded.
+			return om.data.aggregation ? (
 				<Badge
 					size="xs"
 					variant="light"
-					color={
-						om.data.passed === true
-							? "teal"
-							: om.data.passed === false
-								? "red"
-								: "gray"
-					}
+					color={om.data.grounded ? "cyan" : "gray"}
 				>
-					{om.data.passed === true
-						? "pass"
-						: om.data.passed === false
-							? "fail"
-							: (om.data.state ?? "—")}
-				</Badge>
-			);
-		case "cycle":
-			return om.data.completionRate !== null ? (
-				<Badge size="xs" variant="light" color="indigo">
-					{Math.round(om.data.completionRate * 100)}%
-				</Badge>
-			) : null;
-		// Extract shows its aggregation (sum / avg / …); constant shows its value —
-		// the at-a-glance signal that differentiates the step at a distance.
-		case "extract":
-			return om.data.aggregation ? (
-				<Badge size="xs" variant="light" color="cyan">
 					{om.data.aggregation}
 				</Badge>
 			) : null;
@@ -96,21 +60,23 @@ function statusBadge(om: OMNode): React.ReactNode {
 					{om.data.value}
 				</Badge>
 			) : null;
-		case "driver":
-			return (
-				<Badge size="xs" variant="light" color="orange">
-					{om.data.grain}
-				</Badge>
-			);
 		default:
 			return null;
 	}
 }
 
+/** The metric's output formula, shown as a subtitle under its name (its computation). */
+function subtitle(om: OMNode): string | null {
+	return om.data.kind === "metric" ? om.data.formula : null;
+}
+
 function OperatingModelNodeImpl({ data, selected }: NodeProps<OMRfNode>) {
 	const { om, expanded } = data;
-	const { color, Icon } = KIND_STYLE[om.kind] ?? KIND_STYLE.concept;
-	const isTable = om.kind === "table";
+	const { color, Icon } = KIND_STYLE[om.kind] ?? KIND_STYLE.metric;
+	// Only enriched-view tables collapse (they own base tables); base tables are leaves.
+	const isEnrichedView =
+		om.data.kind === "table" && om.data.layer === "enriched";
+	const sub = subtitle(om);
 	return (
 		<>
 			{/* Hidden handles: edges attach, but the dots don't clutter the DAG. */}
@@ -137,11 +103,16 @@ function OperatingModelNodeImpl({ data, selected }: NodeProps<OMRfNode>) {
 					<Stack gap={0} style={{ minWidth: 0, flex: 1 }}>
 						<Text size="xs" c="dimmed" tt="uppercase" fw={600}>
 							{om.kind}
-							{isTable ? (expanded ? " ▾" : " ▸") : ""}
+							{isEnrichedView ? (expanded ? " ▾" : " ▸") : ""}
 						</Text>
 						<Text size="sm" fw={500} truncate title={om.label}>
 							{om.label}
 						</Text>
+						{sub ? (
+							<Text size="xs" c="dimmed" truncate title={sub}>
+								{sub}
+							</Text>
+						) : null}
 					</Stack>
 					{statusBadge(om)}
 				</Group>

--- a/packages/cockpit/src/ui/cockpit/operating-model/nodes.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/nodes.tsx
@@ -44,16 +44,17 @@ function statusBadge(om: OMNode): React.ReactNode {
 				</Badge>
 			);
 		case "measure":
-			// Aggregation (sum / avg / …); dimmed grey when the measure is ungrounded.
-			return om.data.aggregation ? (
+			// Aggregation (sum / avg / …), cyan when grounded; ORANGE when the extract
+			// was not accepted (no support) — a clear flag, not a silent grey.
+			return (
 				<Badge
 					size="xs"
 					variant="light"
-					color={om.data.grounded ? "cyan" : "gray"}
+					color={om.data.grounded ? "cyan" : "orange"}
 				>
-					{om.data.aggregation}
+					{om.data.grounded ? (om.data.aggregation ?? "measure") : "no support"}
 				</Badge>
-			) : null;
+			);
 		case "constant":
 			return om.data.value !== null ? (
 				<Badge size="xs" variant="light" color="yellow">
@@ -122,6 +123,9 @@ function OperatingModelNodeImpl({ data, selected }: NodeProps<OMRfNode>) {
 	);
 }
 
+// memo (rule 6): React Flow re-renders the whole node set on every pan/zoom/viewport
+// change; memoizing the per-node component keeps that to nodes whose data actually
+// changed — the xyflow-recommended pattern for custom nodes.
 export const OperatingModelNode = memo(OperatingModelNodeImpl);
 
 /** Single node type — the component switches on `data.om.kind` internally. */

--- a/packages/cockpit/src/ui/cockpit/operating-model/nodes.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/nodes.tsx
@@ -8,7 +8,10 @@ import { Badge, Group, Paper, Stack, Text } from "@mantine/core";
 import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
 import {
 	Columns3,
+	Database,
+	FunctionSquare,
 	Gauge,
+	Hash,
 	Lightbulb,
 	type LucideIcon,
 	Network,
@@ -32,6 +35,11 @@ export type OMRfNode = Node<OMRfData, "om">;
 const KIND_STYLE: Record<OMNodeKind, { color: string; Icon: LucideIcon }> = {
 	concept: { color: "grape", Icon: Lightbulb },
 	metric: { color: "blue", Icon: Gauge },
+	// The metric's DAG guts: a formula computes, an extract pulls from the data, a
+	// constant is a fixed value — each visually distinct so the structure reads.
+	formula: { color: "violet", Icon: FunctionSquare },
+	extract: { color: "cyan", Icon: Database },
+	constant: { color: "yellow", Icon: Hash },
 	validation: { color: "teal", Icon: ShieldCheck },
 	cycle: { color: "indigo", Icon: RefreshCw },
 	table: { color: "gray", Icon: Table2 },
@@ -72,6 +80,20 @@ function statusBadge(om: OMNode): React.ReactNode {
 			return om.data.completionRate !== null ? (
 				<Badge size="xs" variant="light" color="indigo">
 					{Math.round(om.data.completionRate * 100)}%
+				</Badge>
+			) : null;
+		// Extract shows its aggregation (sum / avg / …); constant shows its value —
+		// the at-a-glance signal that differentiates the step at a distance.
+		case "extract":
+			return om.data.aggregation ? (
+				<Badge size="xs" variant="light" color="cyan">
+					{om.data.aggregation}
+				</Badge>
+			) : null;
+		case "constant":
+			return om.data.value !== null ? (
+				<Badge size="xs" variant="light" color="yellow">
+					{om.data.value}
 				</Badge>
 			) : null;
 		case "driver":

--- a/packages/cockpit/src/ui/cockpit/operating-model/operating-model-canvas.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/operating-model-canvas.tsx
@@ -187,6 +187,9 @@ function FitOnLayout({ layout }: { layout: Node[] }) {
 // it always rides in the effective filter set.
 const TOGGLE_KINDS: readonly OMNodeKind[] = [
 	"metric",
+	"formula",
+	"extract",
+	"constant",
 	"validation",
 	"cycle",
 	"driver",
@@ -419,10 +422,46 @@ function NodeDetailBody({ node }: { node: OMNode }) {
 					)}
 				</Stack>
 			);
+		case "extract":
+			return (
+				<Stack gap="xs">
+					{d.standardField ? (
+						<Field label="Concept" value={d.standardField} />
+					) : null}
+					{d.statement ? <Field label="Statement" value={d.statement} /> : null}
+					{d.aggregation ? (
+						<Field label="Aggregation" value={d.aggregation} />
+					) : null}
+					<Text size="sm" c="dimmed">
+						An extract pulls one concept from the data; it is grounded when the
+						concept resolves to a column below it, ungrounded when it doesn't.
+					</Text>
+				</Stack>
+			);
+		case "formula":
+			return (
+				<Stack gap="xs">
+					{d.outputStep ? <Field label="Role" value="metric result" /> : null}
+					{d.expression ? (
+						<Field label="Expression" value={d.expression} />
+					) : (
+						<Text size="sm" c="dimmed">
+							No expression.
+						</Text>
+					)}
+				</Stack>
+			);
+		case "constant":
+			return (
+				<Stack gap="xs">
+					{d.parameter ? <Field label="Parameter" value={d.parameter} /> : null}
+					<Field label="Value" value={d.value ?? "—"} />
+				</Stack>
+			);
 		case "concept":
 			return (
 				<Text size="sm" c="dimmed">
-					A vocabulary concept — the hub linking the metrics, cycles and
+					A vocabulary concept — the hub linking the metric extracts, cycles and
 					validations that reference it to the columns it grounds to.
 				</Text>
 			);

--- a/packages/cockpit/src/ui/cockpit/operating-model/operating-model-canvas.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/operating-model-canvas.tsx
@@ -65,7 +65,10 @@ export function OperatingModelCanvas({
 	graph: OperatingModelGraph;
 }) {
 	const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
-	const [selected, setSelected] = useState<OMNode | null>(null);
+	// Store the selected id, not the node — the node is DERIVED from the visible set
+	// (React idiom rule 1), so the detail panel never goes stale and auto-closes when a
+	// filter/collapse removes the node.
+	const [selectedId, setSelectedId] = useState<string | null>(null);
 	const [enabledKinds, setEnabledKinds] = useState<ReadonlySet<OMNodeKind>>(
 		() => new Set(OM_NODE_KINDS),
 	);
@@ -83,6 +86,11 @@ export function OperatingModelCanvas({
 		() => filterGraph(visible, { kinds: enabledKinds, hideOrphans }),
 		[visible, enabledKinds, hideOrphans],
 	);
+	// Derived, not mirrored: null when the selection is filtered/collapsed out of view.
+	const selected =
+		selectedId != null
+			? (filtered.nodes.find((n) => n.id === selectedId) ?? null)
+			: null;
 
 	const { nodes, edges } = useMemo(() => {
 		const rfNodes: Node<OMRfData>[] = filtered.nodes.map((om) => ({
@@ -115,7 +123,7 @@ export function OperatingModelCanvas({
 		}
 		// Base tables are leaf grounding nodes — nothing to detail; ignore the click.
 		if (om.kind === "table") return;
-		setSelected(om);
+		setSelectedId(om.id);
 	}, []);
 
 	return (
@@ -125,7 +133,7 @@ export function OperatingModelCanvas({
 				edges={edges}
 				nodeTypes={omNodeTypes}
 				onNodeClick={onNodeClick}
-				onPaneClick={() => setSelected(null)}
+				onPaneClick={() => setSelectedId(null)}
 				nodesDraggable={false}
 				nodesConnectable={false}
 				edgesFocusable={false}
@@ -158,7 +166,7 @@ export function OperatingModelCanvas({
 				</Center>
 			) : null}
 			{selected ? (
-				<NodeDetail node={selected} onClose={() => setSelected(null)} />
+				<NodeDetail node={selected} onClose={() => setSelectedId(null)} />
 			) : null}
 		</Box>
 	);
@@ -309,12 +317,17 @@ function NodeDetailBody({ node }: { node: OMNode }) {
 					{d.aggregation ? (
 						<Field label="Aggregation" value={d.aggregation} />
 					) : null}
-					<Field label="Grounded" value={d.grounded ? "yes" : "no"} />
+					{!d.grounded ? (
+						<Text size="sm" c="orange" fw={500}>
+							Not accepted — the extract composed SQL below, but it returned no
+							rows (no support), so no metric using it can execute.
+						</Text>
+					) : null}
 					{d.sql ? (
 						<SqlBlock sql={d.sql} maxHeight={320} />
 					) : (
 						<Text size="sm" c="dimmed">
-							Ungrounded — this measure resolved to no table.
+							No SQL composed.
 						</Text>
 					)}
 				</Stack>

--- a/packages/cockpit/src/ui/cockpit/operating-model/operating-model-canvas.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/operating-model-canvas.tsx
@@ -10,7 +10,19 @@
 
 import "@xyflow/react/dist/style.css";
 
-import { Badge, Box, Group, ScrollArea, Stack, Text } from "@mantine/core";
+import {
+	Badge,
+	Box,
+	Button,
+	Center,
+	Chip,
+	Group,
+	Paper,
+	ScrollArea,
+	Stack,
+	Switch,
+	Text,
+} from "@mantine/core";
 import {
 	Background,
 	Controls,
@@ -27,7 +39,12 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import {
 	computeVisibleGraph,
+	filterGraph,
+	OM_NODE_KINDS,
+	OM_PRESET_KINDS,
 	type OMNode,
+	type OMNodeKind,
+	type OMPreset,
 	type OperatingModelGraph,
 } from "#/tools/operating-model-graph";
 import { SqlBlock } from "#/ui/cockpit/widgets/sql-block";
@@ -36,6 +53,12 @@ import { type OMRfData, omNodeTypes } from "./nodes";
 
 const EDGE_COLOR = "var(--mantine-color-gray-5)";
 
+// Land at a READABLE zoom, not fit-everything-tiny. The concept-spine fans ~40
+// artifacts into a few hubs — fitting the whole width would zoom to an illegible
+// strip (≈0.13). Cap the fit zoom so nodes stay readable on entry; the minimap +
+// pan carry navigation across the rest. padding keeps the entry off the edge.
+const FIT_VIEW_OPTIONS = { maxZoom: 0.85, padding: 0.15 } as const;
+
 export function OperatingModelCanvas({
 	graph,
 }: {
@@ -43,20 +66,34 @@ export function OperatingModelCanvas({
 }) {
 	const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
 	const [selected, setSelected] = useState<OMNode | null>(null);
+	// Filter state: which kinds show + whether to drop unconnected nodes. Hiding
+	// orphans is ON by default — it clears the finance vertical's ~8 declared-but-
+	// not-detected cycles (degree-0 floaters) on first paint.
+	const [enabledKinds, setEnabledKinds] = useState<ReadonlySet<OMNodeKind>>(
+		() => new Set(OM_NODE_KINDS),
+	);
+	const [hideOrphans, setHideOrphans] = useState(true);
 
+	// Pipeline: collapse columns under tables (progressive disclosure) → filter by
+	// kind + orphan → dagre layout. Orphan degree is measured post-collapse so a
+	// table's collapsed column edges count toward keeping it.
 	const visible = useMemo(
 		() => computeVisibleGraph(graph, expanded),
 		[graph, expanded],
 	);
+	const filtered = useMemo(
+		() => filterGraph(visible, { kinds: enabledKinds, hideOrphans }),
+		[visible, enabledKinds, hideOrphans],
+	);
 
 	const { nodes, edges } = useMemo(() => {
-		const rfNodes: Node<OMRfData>[] = visible.nodes.map((om) => ({
+		const rfNodes: Node<OMRfData>[] = filtered.nodes.map((om) => ({
 			id: om.id,
 			type: "om",
 			position: { x: 0, y: 0 },
 			data: { om, expanded: expanded.has(om.id) },
 		}));
-		const rfEdges: Edge[] = visible.edges.map((e) => ({
+		const rfEdges: Edge[] = filtered.edges.map((e) => ({
 			id: e.id,
 			source: e.source,
 			target: e.target,
@@ -64,7 +101,7 @@ export function OperatingModelCanvas({
 			style: { stroke: EDGE_COLOR },
 		}));
 		return { nodes: layoutGraph(rfNodes, rfEdges), edges: rfEdges };
-	}, [visible, expanded]);
+	}, [filtered, expanded]);
 
 	const onNodeClick = useCallback<NodeMouseHandler>((_event, node) => {
 		const data = node.data as OMRfData;
@@ -96,6 +133,7 @@ export function OperatingModelCanvas({
 				nodesConnectable={false}
 				edgesFocusable={false}
 				fitView
+				fitViewOptions={FIT_VIEW_OPTIONS}
 				minZoom={0.1}
 				onlyRenderVisibleElements
 				proOptions={{ hideAttribution: false }}
@@ -108,6 +146,25 @@ export function OperatingModelCanvas({
 				    reach useReactFlow(). */}
 				<FitOnLayout layout={nodes} />
 			</ReactFlow>
+			<FilterBar
+				enabledKinds={enabledKinds}
+				onKindsChange={setEnabledKinds}
+				hideOrphans={hideOrphans}
+				onHideOrphansChange={setHideOrphans}
+			/>
+			{nodes.length === 0 ? (
+				<Center
+					style={{
+						position: "absolute",
+						inset: 0,
+						pointerEvents: "none",
+					}}
+				>
+					<Text size="sm" c="dimmed">
+						No nodes match the current filters.
+					</Text>
+				</Center>
+			) : null}
 			{selected ? (
 				<NodeDetail node={selected} onClose={() => setSelected(null)} />
 			) : null}
@@ -120,9 +177,106 @@ function FitOnLayout({ layout }: { layout: Node[] }) {
 	const { fitView } = useReactFlow();
 	useEffect(() => {
 		if (layout.length === 0) return;
-		void fitView({ duration: 200 });
+		void fitView({ duration: 200, ...FIT_VIEW_OPTIONS });
 	}, [layout, fitView]);
 	return null;
+}
+
+// The kinds exposed as individual toggles. `column` is omitted — its visibility is
+// governed by table expansion (progressive disclosure), not a top-level toggle, so
+// it always rides in the effective filter set.
+const TOGGLE_KINDS: readonly OMNodeKind[] = [
+	"metric",
+	"validation",
+	"cycle",
+	"driver",
+	"concept",
+	"table",
+];
+
+const PRESETS: readonly { key: OMPreset; label: string }[] = [
+	{ key: "full", label: "Full" },
+	{ key: "metrics", label: "Metrics" },
+	{ key: "validations", label: "Validations" },
+	{ key: "cycles", label: "Cycles" },
+];
+
+const sameKinds = (
+	a: ReadonlySet<OMNodeKind>,
+	b: readonly OMNodeKind[],
+): boolean => a.size === b.length && b.every((k) => a.has(k));
+
+/** Overlay filter control: preset lenses + per-kind toggles + hide-unconnected. */
+function FilterBar({
+	enabledKinds,
+	onKindsChange,
+	hideOrphans,
+	onHideOrphansChange,
+}: {
+	enabledKinds: ReadonlySet<OMNodeKind>;
+	onKindsChange: (kinds: ReadonlySet<OMNodeKind>) => void;
+	hideOrphans: boolean;
+	onHideOrphansChange: (value: boolean) => void;
+}) {
+	const activePreset = PRESETS.find((p) =>
+		sameKinds(enabledKinds, OM_PRESET_KINDS[p.key]),
+	)?.key;
+	return (
+		<Paper
+			shadow="sm"
+			p="xs"
+			radius="md"
+			withBorder
+			style={{
+				position: "absolute",
+				top: 8,
+				left: 8,
+				zIndex: 5,
+				maxWidth: 360,
+			}}
+		>
+			<Stack gap={8}>
+				<Group gap={6} wrap="nowrap">
+					<Text size="xs" c="dimmed" fw={600} tt="uppercase">
+						Lens
+					</Text>
+					<Button.Group>
+						{PRESETS.map((p) => (
+							<Button
+								key={p.key}
+								size="compact-xs"
+								variant={activePreset === p.key ? "filled" : "default"}
+								onClick={() => onKindsChange(new Set(OM_PRESET_KINDS[p.key]))}
+							>
+								{p.label}
+							</Button>
+						))}
+					</Button.Group>
+				</Group>
+				<Chip.Group
+					multiple
+					value={[...enabledKinds].filter((k) => k !== "column")}
+					onChange={(vals) =>
+						onKindsChange(new Set([...(vals as OMNodeKind[]), "column"]))
+					}
+				>
+					<Group gap={4}>
+						{TOGGLE_KINDS.map((k) => (
+							<Chip key={k} value={k} size="xs" variant="light">
+								{k}
+							</Chip>
+						))}
+					</Group>
+				</Chip.Group>
+				<Switch
+					size="xs"
+					label="Hide unconnected"
+					checked={hideOrphans}
+					onChange={(e) => onHideOrphansChange(e.currentTarget.checked)}
+				/>
+			</Stack>
+		</Paper>
+	);
 }
 
 /** Read-only detail for the selected node — the "expand to read the SQL" surface. */

--- a/packages/cockpit/src/ui/cockpit/operating-model/operating-model-canvas.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/operating-model-canvas.tsx
@@ -1,19 +1,18 @@
-// The operating-model canvas (DAT-591 Phase 1) — renders the workspace's
-// concept-spine DAG with React Flow + dagre. Client-only (the route wraps this in
+// The operating-model METRIC canvas (DAT-591) — renders the workspace's metric
+// dependency graph with React Flow + dagre. Client-only (the route wraps this in
 // <ClientOnly>): React Flow measures the DOM, so it must not render on the server.
 //
-// Progressive disclosure: columns are collapsed under their table by default
-// (computeVisibleGraph re-points their edges to the table); clicking a table node
-// toggles its columns. Clicking any other node opens a read-only detail panel
-// (metric/validation SQL, driver dimensions, cycle completion). Pure render of
-// engine-persisted values — no analysis happens here.
+// STRUCTURE the graph shows: metric → metric (composition) → measure → table, plus
+// metric → constant. EXECUTION detail: clicking a metric/measure opens a read-only
+// panel with its flattened SQL. Progressive disclosure: base fact/dim tables are
+// collapsed under their enriched view (computeVisibleGraph re-points their edges);
+// clicking an enriched-view node toggles them. Pure render of engine-persisted values.
 
 import "@xyflow/react/dist/style.css";
 
 import {
 	Badge,
 	Box,
-	Button,
 	Center,
 	Chip,
 	Group,
@@ -41,10 +40,8 @@ import {
 	computeVisibleGraph,
 	filterGraph,
 	OM_NODE_KINDS,
-	OM_PRESET_KINDS,
 	type OMNode,
 	type OMNodeKind,
-	type OMPreset,
 	type OperatingModelGraph,
 } from "#/tools/operating-model-graph";
 import { SqlBlock } from "#/ui/cockpit/widgets/sql-block";
@@ -53,11 +50,14 @@ import { type OMRfData, omNodeTypes } from "./nodes";
 
 const EDGE_COLOR = "var(--mantine-color-gray-5)";
 
-// Land at a READABLE zoom, not fit-everything-tiny. The concept-spine fans ~40
-// artifacts into a few hubs — fitting the whole width would zoom to an illegible
-// strip (≈0.13). Cap the fit zoom so nodes stay readable on entry; the minimap +
-// pan carry navigation across the rest. padding keeps the entry off the edge.
+// Land at a READABLE zoom, not fit-everything-tiny. Cap the fit zoom so nodes stay
+// legible on entry; the minimap + pan carry navigation across the rest.
 const FIT_VIEW_OPTIONS = { maxZoom: 0.85, padding: 0.15 } as const;
+
+/** True for an enriched-view table node (the expandable ones — base tables are leaves). */
+function isEnrichedView(om: OMNode): boolean {
+	return om.data.kind === "table" && om.data.layer === "enriched";
+}
 
 export function OperatingModelCanvas({
 	graph,
@@ -66,17 +66,15 @@ export function OperatingModelCanvas({
 }) {
 	const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
 	const [selected, setSelected] = useState<OMNode | null>(null);
-	// Filter state: which kinds show + whether to drop unconnected nodes. Hiding
-	// orphans is ON by default — it clears the finance vertical's ~8 declared-but-
-	// not-detected cycles (degree-0 floaters) on first paint.
 	const [enabledKinds, setEnabledKinds] = useState<ReadonlySet<OMNodeKind>>(
 		() => new Set(OM_NODE_KINDS),
 	);
+	// Hiding orphans is ON by default — it clears any ungrounded-measure floaters and
+	// declared-but-uncomposed metrics from first paint.
 	const [hideOrphans, setHideOrphans] = useState(true);
 
-	// Pipeline: collapse columns under tables (progressive disclosure) → filter by
-	// kind + orphan → dagre layout. Orphan degree is measured post-collapse so a
-	// table's collapsed column edges count toward keeping it.
+	// Pipeline: collapse base tables under their enriched view → filter by kind + orphan
+	// → dagre layout. Orphan degree is measured post-collapse.
 	const visible = useMemo(
 		() => computeVisibleGraph(graph, expanded),
 		[graph, expanded],
@@ -104,10 +102,9 @@ export function OperatingModelCanvas({
 	}, [filtered, expanded]);
 
 	const onNodeClick = useCallback<NodeMouseHandler>((_event, node) => {
-		const data = node.data as OMRfData;
-		const om = data.om;
-		if (om.kind === "table") {
-			// Toggle this table's columns (progressive disclosure).
+		const om = (node.data as OMRfData).om;
+		if (isEnrichedView(om)) {
+			// Toggle this enriched view's base tables (progressive disclosure).
 			setExpanded((prev) => {
 				const next = new Set(prev);
 				if (next.has(om.id)) next.delete(om.id);
@@ -116,8 +113,8 @@ export function OperatingModelCanvas({
 			});
 			return;
 		}
-		// Columns are leaf grounding nodes — nothing to detail; ignore the click.
-		if (om.kind === "column") return;
+		// Base tables are leaf grounding nodes — nothing to detail; ignore the click.
+		if (om.kind === "table") return;
 		setSelected(om);
 	}, []);
 
@@ -141,9 +138,8 @@ export function OperatingModelCanvas({
 				<Background />
 				<Controls showInteractive={false} />
 				<MiniMap pannable zoomable />
-				{/* Re-fit when a table expand/collapse re-lays-out the graph (the
-				    fitView prop only fires on mount). Must be a ReactFlow child to
-				    reach useReactFlow(). */}
+				{/* Re-fit when an expand/collapse re-lays-out the graph (fitView only fires
+				    on mount). Must be a ReactFlow child to reach useReactFlow(). */}
 				<FitOnLayout layout={nodes} />
 			</ReactFlow>
 			<FilterBar
@@ -154,11 +150,7 @@ export function OperatingModelCanvas({
 			/>
 			{nodes.length === 0 ? (
 				<Center
-					style={{
-						position: "absolute",
-						inset: 0,
-						pointerEvents: "none",
-					}}
+					style={{ position: "absolute", inset: 0, pointerEvents: "none" }}
 				>
 					<Text size="sm" c="dimmed">
 						No nodes match the current filters.
@@ -182,34 +174,7 @@ function FitOnLayout({ layout }: { layout: Node[] }) {
 	return null;
 }
 
-// The kinds exposed as individual toggles. `column` is omitted — its visibility is
-// governed by table expansion (progressive disclosure), not a top-level toggle, so
-// it always rides in the effective filter set.
-const TOGGLE_KINDS: readonly OMNodeKind[] = [
-	"metric",
-	"formula",
-	"extract",
-	"constant",
-	"validation",
-	"cycle",
-	"driver",
-	"concept",
-	"table",
-];
-
-const PRESETS: readonly { key: OMPreset; label: string }[] = [
-	{ key: "full", label: "Full" },
-	{ key: "metrics", label: "Metrics" },
-	{ key: "validations", label: "Validations" },
-	{ key: "cycles", label: "Cycles" },
-];
-
-const sameKinds = (
-	a: ReadonlySet<OMNodeKind>,
-	b: readonly OMNodeKind[],
-): boolean => a.size === b.length && b.every((k) => a.has(k));
-
-/** Overlay filter control: preset lenses + per-kind toggles + hide-unconnected. */
+/** Overlay filter control: per-kind toggles + hide-unconnected. */
 function FilterBar({
 	enabledKinds,
 	onKindsChange,
@@ -221,9 +186,6 @@ function FilterBar({
 	hideOrphans: boolean;
 	onHideOrphansChange: (value: boolean) => void;
 }) {
-	const activePreset = PRESETS.find((p) =>
-		sameKinds(enabledKinds, OM_PRESET_KINDS[p.key]),
-	)?.key;
 	return (
 		<Paper
 			shadow="sm"
@@ -235,36 +197,17 @@ function FilterBar({
 				top: 8,
 				right: 8,
 				zIndex: 5,
-				maxWidth: 360,
+				maxWidth: 320,
 			}}
 		>
 			<Stack gap={8}>
-				<Group gap={6} wrap="nowrap">
-					<Text size="xs" c="dimmed" fw={600} tt="uppercase">
-						Lens
-					</Text>
-					<Button.Group>
-						{PRESETS.map((p) => (
-							<Button
-								key={p.key}
-								size="compact-xs"
-								variant={activePreset === p.key ? "filled" : "default"}
-								onClick={() => onKindsChange(new Set(OM_PRESET_KINDS[p.key]))}
-							>
-								{p.label}
-							</Button>
-						))}
-					</Button.Group>
-				</Group>
 				<Chip.Group
 					multiple
-					value={[...enabledKinds].filter((k) => k !== "column")}
-					onChange={(vals) =>
-						onKindsChange(new Set([...(vals as OMNodeKind[]), "column"]))
-					}
+					value={[...enabledKinds]}
+					onChange={(vals) => onKindsChange(new Set(vals as OMNodeKind[]))}
 				>
 					<Group gap={4}>
-						{TOGGLE_KINDS.map((k) => (
+						{OM_NODE_KINDS.map((k) => (
 							<Chip key={k} value={k} size="xs" variant="light">
 								{k}
 							</Chip>
@@ -291,7 +234,7 @@ function NodeDetail({ node, onClose }: { node: OMNode; onClose: () => void }) {
 				top: 8,
 				right: 8,
 				bottom: 8,
-				width: 360,
+				width: 380,
 				zIndex: 5,
 			}}
 		>
@@ -345,108 +288,33 @@ function NodeDetailBody({ node }: { node: OMNode }) {
 			return (
 				<Stack gap="xs">
 					<Field label="State" value={d.state} />
+					{d.unit ? <Field label="Unit" value={d.unit} /> : null}
 					{d.stateReason ? (
 						<Field label="Reason" value={d.stateReason} />
 					) : null}
-					<Field label="SQL steps" value={String(d.snippetCount)} />
+					{d.formula ? <Field label="Formula" value={d.formula} /> : null}
 					{d.sql ? (
-						<SqlBlock sql={d.sql} maxHeight={300} />
+						<SqlBlock sql={d.sql} maxHeight={320} />
 					) : (
 						<Text size="sm" c="dimmed">
-							No grounded SQL yet.
+							No composed SQL — the metric did not ground.
 						</Text>
 					)}
 				</Stack>
 			);
-		case "validation":
+		case "measure":
 			return (
 				<Stack gap="xs">
-					<Field
-						label="Result"
-						value={
-							d.passed === true
-								? "passed"
-								: d.passed === false
-									? "failed"
-									: (d.status ?? d.state)
-						}
-					/>
-					{d.severity ? <Field label="Severity" value={d.severity} /> : null}
-					{d.sqlUsed ? (
-						<SqlBlock sql={d.sqlUsed} maxHeight={300} />
-					) : (
-						<Text size="sm" c="dimmed">
-							No executed SQL.
-						</Text>
-					)}
-				</Stack>
-			);
-		case "cycle":
-			return (
-				<Stack gap="xs">
-					<Field label="State" value={d.state} />
-					{d.completionRate !== null ? (
-						<Field
-							label="Completion"
-							value={`${Math.round(d.completionRate * 100)}%`}
-						/>
-					) : null}
-					{d.completedCycles !== null && d.totalRecords !== null ? (
-						<Field
-							label="Completed"
-							value={`${d.completedCycles} / ${d.totalRecords}`}
-						/>
-					) : null}
-				</Stack>
-			);
-		case "driver":
-			return (
-				<Stack gap="xs">
-					<Field label="Target" value={d.targetType} />
-					<Field label="Grain" value={d.grain} />
-					<Text size="xs" c="dimmed" tt="uppercase" fw={600}>
-						Top dimensions
-					</Text>
-					{d.topDimensions.length ? (
-						<Group gap="xs">
-							{d.topDimensions.map((dim) => (
-								<Badge key={dim} variant="light" color="orange">
-									{dim}
-								</Badge>
-							))}
-						</Group>
-					) : (
-						<Text size="sm" c="dimmed">
-							No significant dimensions.
-						</Text>
-					)}
-				</Stack>
-			);
-		case "extract":
-			return (
-				<Stack gap="xs">
-					{d.standardField ? (
-						<Field label="Concept" value={d.standardField} />
-					) : null}
 					{d.statement ? <Field label="Statement" value={d.statement} /> : null}
 					{d.aggregation ? (
 						<Field label="Aggregation" value={d.aggregation} />
 					) : null}
-					<Text size="sm" c="dimmed">
-						An extract pulls one concept from the data; it is grounded when the
-						concept resolves to a column below it, ungrounded when it doesn't.
-					</Text>
-				</Stack>
-			);
-		case "formula":
-			return (
-				<Stack gap="xs">
-					{d.outputStep ? <Field label="Role" value="metric result" /> : null}
-					{d.expression ? (
-						<Field label="Expression" value={d.expression} />
+					<Field label="Grounded" value={d.grounded ? "yes" : "no"} />
+					{d.sql ? (
+						<SqlBlock sql={d.sql} maxHeight={320} />
 					) : (
 						<Text size="sm" c="dimmed">
-							No expression.
+							Ungrounded — this measure resolved to no table.
 						</Text>
 					)}
 				</Stack>
@@ -454,23 +322,28 @@ function NodeDetailBody({ node }: { node: OMNode }) {
 		case "constant":
 			return (
 				<Stack gap="xs">
-					{d.parameter ? <Field label="Parameter" value={d.parameter} /> : null}
 					<Field label="Value" value={d.value ?? "—"} />
+					<Text size="sm" c="dimmed">
+						A declared parameter used by the metrics that reference it.
+					</Text>
 				</Stack>
 			);
-		case "concept":
+		case "table":
 			return (
-				<Text size="sm" c="dimmed">
-					A vocabulary concept — the hub linking the metric extracts, cycles and
-					validations that reference it to the columns it grounds to.
-				</Text>
+				<Stack gap="xs">
+					<Field
+						label="Kind"
+						value={d.layer === "enriched" ? "enriched view" : "base table"}
+					/>
+					<Text size="sm" c="dimmed">
+						{d.layer === "enriched"
+							? "The enriched view a measure reads — click the node to reveal the base fact/dim tables it derives from."
+							: "A base fact/dimension table an enriched view is built from."}
+					</Text>
+				</Stack>
 			);
 		default:
-			return (
-				<Text size="sm" c="dimmed">
-					{node.kind} node.
-				</Text>
-			);
+			return null;
 	}
 }
 

--- a/packages/cockpit/src/ui/cockpit/operating-model/operating-model-canvas.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/operating-model-canvas.tsx
@@ -230,7 +230,7 @@ function FilterBar({
 			style={{
 				position: "absolute",
 				top: 8,
-				left: 8,
+				right: 8,
 				zIndex: 5,
 				maxWidth: 360,
 			}}

--- a/packages/dataraum-config/verticals/finance/metrics/working_capital/dio.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/working_capital/dio.yaml
@@ -1,0 +1,88 @@
+graph_id: dio
+version: '1.0'
+metadata:
+  name: Days Inventory Outstanding
+  description: Average days inventory is held before being sold
+  category: working_capital
+  source: system
+  tags:
+  - inventory
+  - working-capital
+  - efficiency
+output:
+  type: scalar
+  metric_id: dio
+  unit: days
+  decimal_places: 1
+parameters:
+  days_in_period:
+    type: integer
+    default: 30
+    options:
+    - 30
+    - 90
+    - 365
+    description: Analysis period length
+dependencies:
+  inventory:
+    level: 1
+    type: extract
+    source:
+      standard_field: inventory
+      statement: balance_sheet
+    aggregation: sum  # period axis (all vs latest) is data-reconciled via target_type — never hardcode end_of_period
+    validation:
+    - condition: value >= 0
+      severity: error
+      message: Inventory cannot be negative
+  cost_of_goods_sold:
+    level: 1
+    type: extract
+    source:
+      standard_field: cost_of_goods_sold
+      statement: income_statement
+    aggregation: sum
+    validation:
+    - condition: value > 0
+      severity: error
+      message: COGS must be positive for DIO
+  days_in_period:
+    level: 1
+    type: constant
+    parameter: days_in_period
+    default: 30
+  dio:
+    level: 2
+    type: formula
+    expression: (inventory / cost_of_goods_sold) * days_in_period
+    depends_on:
+    - inventory
+    - cost_of_goods_sold
+    - days_in_period
+    output_step: true
+    validation:
+    - condition: 0 <= value <= 365
+      severity: warning
+      message: DIO outside typical range
+interpretation:
+  ranges:
+  - min: 0
+    max: 30
+    label: EXCELLENT
+    description: Fast inventory turnover - lean operations
+  - min: 31
+    max: 60
+    label: GOOD
+    description: Healthy inventory turnover
+  - min: 61
+    max: 90
+    label: MODERATE
+    description: Inventory turning at an average pace
+  - min: 91
+    max: 120
+    label: EXTENDED
+    description: Slow turnover - capital tied up in stock
+  - min: 121
+    max: 999
+    label: CRITICAL
+    description: Excess or obsolete inventory risk

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -49,6 +49,7 @@ CREATE TABLE lifecycle_artifacts (
 	strictness FLOAT, 
 	grounded_against JSON, 
 	teaches JSON, 
+	graph_definition JSON, 
 	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	state_changed_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	CONSTRAINT pk_lifecycle_artifacts PRIMARY KEY (artifact_id), 

--- a/packages/engine/src/dataraum/lifecycle/db_models.py
+++ b/packages/engine/src/dataraum/lifecycle/db_models.py
@@ -56,6 +56,12 @@ class LifecycleArtifact(Base):
         strictness: the journey's strictness parameter at build time; nullable.
         grounded_against: the pinned base-run map the bind read from (JSON).
         teaches: what declared/produced it — spec id, vertical, spec version (JSON).
+        graph_definition: METRIC artifacts only — the effective (shipped ⊕ overlay)
+            metric-graph the phase assembled from (the DAG dict from
+            ``get_metric_definitions``). Persisted so the cockpit reads the EXACT
+            structure it rendered (steps / formulas / extracts / constants) from one
+            Postgres source, overlay-inclusive, zero divergence (DAT-591). Null for
+            validation/cycle rows.
         created_at / state_changed_at: row birth / last in-run state advance.
     """
 
@@ -82,6 +88,9 @@ class LifecycleArtifact(Base):
     strictness: Mapped[float | None] = mapped_column(Float)
     grounded_against: Mapped[dict[str, Any] | None] = mapped_column(JSON)
     teaches: Mapped[dict[str, Any] | None] = mapped_column(JSON)
+    # METRIC rows only: the effective (shipped ⊕ overlay) DAG the phase assembled from
+    # (DAT-591). One Postgres source for the cockpit's step rendering; null otherwise.
+    graph_definition: Mapped[dict[str, Any] | None] = mapped_column(JSON)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=lambda: datetime.now(UTC)

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -218,6 +218,10 @@ class MetricsPhase(BasePhase):
                     "category": (defn.get("metadata") or {}).get("category"),
                 },
             )
+            # Persist the effective (shipped ⊕ overlay) DAG this row was assembled from
+            # (DAT-591) — the cockpit reads the exact rendered structure from this one
+            # Postgres source, so it never re-reads config or re-merges the overlay.
+            artifacts[graph_id].graph_definition = defn
 
         # Parse declared definitions into graphs. A definition that won't parse
         # stays declared with the parse error recorded — visibly impossible.

--- a/packages/engine/tests/integration/pipeline/test_metrics_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_metrics_phase.py
@@ -270,6 +270,9 @@ class TestMetricLifecycleFlow:
         assert artifacts["m_exec"].state == ArtifactState.EXECUTED.value
         assert artifacts["m_exec"].grounded_against is not None
         assert artifacts["m_exec"].teaches["vertical"] == "finance"
+        # DAT-591: the effective (shipped ⊕ overlay) DAG this row assembled from is
+        # persisted verbatim — the cockpit's one Postgres source for the metric's steps.
+        assert artifacts["m_exec"].graph_definition == mock_defs.return_value["m_exec"]
         # Composed but unexecutable: the agent could not materialize runnable SQL,
         # so it stays grounded with the reason — born-loud at the agent.
         assert artifacts["m_unexec"].state == ArtifactState.GROUNDED.value

--- a/packages/engine/tests/unit/graphs/test_config.py
+++ b/packages/engine/tests/unit/graphs/test_config.py
@@ -20,13 +20,15 @@ class TestGetMetricDefinitionsProduction:
     def teardown_method(self) -> None:
         reset_overlay_resolver_for_tests()
 
-    def test_returns_all_12_finance_metrics(self) -> None:
+    def test_returns_all_13_finance_metrics(self) -> None:
         defs = get_metric_definitions("finance")
-        assert len(defs) == 12
+        assert len(defs) == 13
 
     def test_keyed_by_graph_id_with_known_metrics(self) -> None:
         defs = get_metric_definitions("finance")
-        expected = {"dso", "dpo", "cash_conversion_cycle", "current_ratio", "ebitda"}
+        # dio (Days Inventory Outstanding) is a first-class metric (DAT-591) — it
+        # completes cash_conversion_cycle = dso + dio - dpo as a real composition.
+        expected = {"dso", "dio", "dpo", "cash_conversion_cycle", "current_ratio", "ebitda"}
         assert expected.issubset(defs.keys())
 
     def test_definitions_carry_their_structure(self) -> None:
@@ -65,7 +67,7 @@ class TestGetMetricsConfigOverlay:
         )
         defs = get_metric_definitions("finance")
         assert "custom_kpi" in defs
-        assert len(defs) == 13  # the 12 shipped + the taught one
+        assert len(defs) == 14  # the 13 shipped + the taught one
         assert "vertical" not in defs["custom_kpi"]
 
     def test_overlay_row_replaces_shipped_metric_by_graph_id(self) -> None:
@@ -83,7 +85,7 @@ class TestGetMetricsConfigOverlay:
             ]
         )
         defs = get_metric_definitions("finance")
-        assert len(defs) == 12  # replace, not append
+        assert len(defs) == 13  # replace, not append
         assert defs["dso"]["metadata"]["name"] == "DSO (taught)"
 
 


### PR DESCRIPTION
## What

Makes the cockpit **Model** page a readable, faithful **metric composition graph**, and gives the engine the one Postgres source it needs to drive it.

Before: the page drew ~124 undifferentiated nodes — 39 duplicate "extract" nodes for 11 concepts, formulas as nodes, a concept/column pile. You couldn't tell what was grounded. After: **26 nodes** on the same finance run, each metric reading as `name · formula · state`, measures deduped, grounding visible.

## The model (metrics-only this cut)

- **Nodes:** `metric` / `measure` / `constant` / `table`. A metric's output formula is a **data attribute**, never a node. `credit`/`debit`/`net_amount` are not nodes — they live in each node's flattened SQL.
- **Edges:** `metric → metric` (composition) · `metric → measure` · `metric → constant` · `measure → table` (enriched view → base fact/dim).
- **Composition** is resolved by the naming convention: a metric's output-step `depends_on` name that IS a metric graph_id → a `metric → metric` edge (follow that metric, ignore the self-contained inlined copy). Verified this resolves cleanly for the whole finance catalogue once `dio` became a first-class metric.
- **Grounding** uses the engine's own accept signal — `sql_snippets.failure_count == 0` — with the enriched view read from the SQL's `FROM <view>` (a hard prompt contract). A **failed** extract (e.g. `inventory`, whose account has no postings) is flagged "no support" and still shows its attempted SQL, so "why can't DIO compute" is answerable on the page.

## Changes

- **Engine:** persist the effective (shipped ⊕ overlay) metric DAG onto the metric `lifecycle_artifacts` row (`graph_definition`) — the cockpit's single, overlay-inclusive structure source. Schema + Drizzle mirror regenerated.
- **Config:** add `dio.yaml` (Days Inventory Outstanding) — the one inlined sub-formula across the finance catalogue that wasn't yet a standalone metric, so `cash_conversion_cycle = dso + dio − dpo` composes cleanly.
- **Cockpit:** rewrite `operating-model-graph.ts` (pure assembly + `resolveGrounding`), `operating-model-load.ts` (reads graph_definitions + snippets + `enriched_views`; drops concept/column/driver/validation reads), and the render (4 kinds, formula on the metric, retired lens presets).

## Testing

- Pure assembly + grounding unit-tested (name-trust composition incl. `ccc → dso/dio/dpo`, measure/constant dedup, `resolveGrounding` accept/failure paths, longest-view-name match, shared-dimension collapse). tsc clean · 1473 cockpit tests green · schema-drift clean.
- Live-verified on the finance run: 124 → 26 nodes, composition + grounding correct, `inventory` flagged "no support" with its SQL, no console errors.

## Deferred (own tickets)

- Validation / cycle / driver as their own graphs (tabs).
- `measure`/`dimension` as first-class nodes — needs the engine to emit structured grounding (measure column + dimension filter) instead of free-form `column_mappings`.
- YAML de-dup / RDF upgrade (composites reference sub-metrics rather than inlining).

🤖 Generated with [Claude Code](https://claude.com/claude-code)