### PR TITLE
feat(DAT-601/603/660/606): engine prompt caching + effort plumbing; cockpit context caching

### DIFF
--- a/packages/cockpit/src/lib/agent-turn.ts
+++ b/packages/cockpit/src/lib/agent-turn.ts
@@ -58,11 +58,12 @@ type ChatStream = ReturnType<
  *
  * `workspaceContext` (the workspace's vertical + imported tables — workspace-
  * awareness for replay / teach / look) is a SECOND system block placed AFTER the
- * orchestrator. The cache breakpoint is ON the orchestrator, so the cached prefix is
- * exactly the orchestrator; this dynamic block sits past the breakpoint and is never
- * cached — a small fresh suffix each turn. So the orchestrator keeps hitting even as
- * the imported tables change; the two don't thrash. The caller computes the block (a
- * DB read) and passes it; `buildChatOptions` stays pure for the unit wiring test.
+ * orchestrator, with its OWN cache breakpoint (DAT-606): it is stable within a
+ * session, so it reads from cache from turn 2 on. Because prefix caching
+ * invalidates only from the changed block onward, an import that changes this
+ * block leaves the orchestrator block's cache intact — the two don't thrash.
+ * The caller computes the block (a DB read) and passes it; `buildChatOptions`
+ * stays pure for the unit wiring test.
  *
  * `abortController` (when given) is threaded into the agentic loop so a cancelled
  * stream — the client calling useChat's `stop()`, or simply disconnecting —
@@ -84,9 +85,16 @@ export function buildChatOptions(
 			metadata: { cache_control: { type: "ephemeral" } },
 		},
 	];
-	// A second, UNCACHED block past the cache breakpoint (see above).
+	// A second CACHED block (DAT-606): the workspace context (vertical + imported
+	// tables) is stable within a session, so its own breakpoint makes it a cache
+	// read from turn 2 on — while leaving the orchestrator block's cache untouched
+	// when an import DOES change it (prefix caching invalidates only from the
+	// changed block onward).
 	if (workspaceContext != null) {
-		systemPrompts.push({ content: workspaceContext });
+		systemPrompts.push({
+			content: workspaceContext,
+			metadata: { cache_control: { type: "ephemeral" } },
+		});
 	}
 	return {
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),

--- a/packages/cockpit/src/routes/api/chat.test.ts
+++ b/packages/cockpit/src/routes/api/chat.test.ts
@@ -79,19 +79,22 @@ describe("chat route wiring (DAT-353, DAT-532)", () => {
 		expect((sys?.content ?? "").length).toBeGreaterThan(0);
 	});
 
-	it("appends the workspace context as a SECOND, uncached system block (session-awareness)", () => {
+	it("appends the workspace context as a SECOND, cached system block (DAT-606)", () => {
 		const ctx = "WORKSPACE CONTEXT — session abc";
 		const opts = buildChatOptions("connect", MSG, undefined, ctx);
 		const prompts = systemPromptObjects(opts);
 		expect(prompts).toHaveLength(2);
-		// The instructions stay the cached FIRST block (the cache breakpoint)…
+		// The instructions stay the cached FIRST block…
 		expect(prompts[0]?.metadata?.cache_control).toEqual({
 			type: "ephemeral",
 		});
-		// …the session context is the SECOND block, past the breakpoint → no
-		// cache_control, so it's never cached (a fresh suffix each turn).
+		// …and the session-stable workspace context carries its OWN breakpoint,
+		// so it reads from cache from turn 2 on; an import that changes it
+		// invalidates only this block, never the orchestrator prefix.
 		expect(prompts[1]?.content).toBe(ctx);
-		expect(prompts[1]?.metadata).toBeUndefined();
+		expect(prompts[1]?.metadata?.cache_control).toEqual({
+			type: "ephemeral",
+		});
 	});
 
 	it("omits the second block when there is no current session", () => {

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -597,9 +597,18 @@ export async function querySubAgent(
 	// from that batch (cheap local file read, not worth threading into the parallel set).
 	const conventionsBlock = await buildConventionsBlock(workspace.vertical);
 
-	const userMessage = `<question>\n${question}\n</question>\n\n${schemaBlock}\n\n${entitiesBlock}\n\n${catalogBlock}\n\n${relationshipsBlock}\n\n${driversBlock}\n\n${vocabularyBlock}${
+	// DAT-660: the workspace context is session-stable (all blocks read from the
+	// promoted surface; conventions from the vertical's on-disk YAML), so it rides
+	// as a CACHED second system block below — identical bytes across every answer
+	// in a session AND across this loop's own iterations. Only the question is
+	// volatile, and it rides alone in the user message, past the cache breakpoint.
+	// (The previous shape — question first, context after, all uncached in the
+	// user message — inverted the shared-prefix pattern: nothing ever cached.)
+	const stableContext = `${schemaBlock}\n\n${entitiesBlock}\n\n${catalogBlock}\n\n${relationshipsBlock}\n\n${driversBlock}\n\n${vocabularyBlock}${
 		conventionsBlock ? `\n\n${conventionsBlock}` : ""
 	}`;
+
+	const userMessage = `<question>\n${question}\n</question>`;
 
 	// Per-invocation capture cell — run_steps writes the last validation (+ last failure)
 	// and emit_result writes the model's final draft. Isolated across concurrent calls.
@@ -634,7 +643,16 @@ export async function querySubAgent(
 		abortController,
 		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
 		agentLoopStrategy: maxIterations(QUERY_SUBAGENT_MAX_ITERATIONS),
-		systemPrompts: [getQueryInstructions()],
+		systemPrompts: [
+			{
+				content: getQueryInstructions(),
+				metadata: { cache_control: { type: "ephemeral" } },
+			},
+			{
+				content: stableContext,
+				metadata: { cache_control: { type: "ephemeral" } },
+			},
+		],
 		messages: [{ role: "user", content: userMessage }],
 		tools: [
 			snippetSearchTool,

--- a/packages/dataraum-config/llm/config.yaml
+++ b/packages/dataraum-config/llm/config.yaml
@@ -23,6 +23,7 @@ features:
   column_annotation:
     enabled: true
     model_tier: balanced
+    effort: low
 
   semantic_analysis:
     enabled: true
@@ -31,10 +32,12 @@ features:
   slicing_analysis:
     enabled: true
     model_tier: balanced
+    effort: low
 
   validation:
     enabled: true
     model_tier: balanced
+    effort: low
 
   # DAT-491: events→measure aggregation-lineage proposals (one batched call per
   # begin_session run; the deterministic reconciliation disposes the candidates).

--- a/packages/engine/src/dataraum/analysis/cycles/agent.py
+++ b/packages/engine/src/dataraum/analysis/cycles/agent.py
@@ -134,6 +134,7 @@ class BusinessCycleAgent(LLMFeature):
             tools=[tool],
             tool_choice={"type": "tool", "name": "submit_analysis"},
             label="business_cycles",
+            effort=feature_config.effort,
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
             model=model,

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -191,6 +191,7 @@ class SemanticAgent(LLMFeature):
             tools=[tool],
             tool_choice={"type": "tool", "name": "analyze_tables"},
             label="semantic_per_table",
+            effort=feature_config.effort,
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
             model=model,

--- a/packages/engine/src/dataraum/analysis/semantic/column_agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/column_agent.py
@@ -146,6 +146,7 @@ class ColumnAnnotationAgent(LLMFeature):
             tools=[tool],
             tool_choice={"type": "tool", "name": "annotate_columns"},
             label="column_annotation",
+            effort=feature_config.effort,
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
             model=model,

--- a/packages/engine/src/dataraum/analysis/slicing/agent.py
+++ b/packages/engine/src/dataraum/analysis/slicing/agent.py
@@ -122,6 +122,7 @@ class SlicingAgent(LLMFeature):
             tools=[tool],
             tool_choice={"type": "tool", "name": "analyze_slicing"},
             label="slicing_analysis",
+            effort=feature_config.effort,
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
         )

--- a/packages/engine/src/dataraum/analysis/validation/agent.py
+++ b/packages/engine/src/dataraum/analysis/validation/agent.py
@@ -358,6 +358,7 @@ class ValidationAgent(LLMFeature):
             tools=[tool],
             tool_choice={"type": "tool", "name": "generate_validation_sql"},
             label="validation_sql",
+            effort=feature_config.effort,
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
             model=model,

--- a/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
+++ b/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
@@ -122,6 +122,7 @@ class EnrichmentAgent(LLMFeature):
             tools=[tool],
             tool_choice={"type": "tool", "name": "analyze_enrichment"},
             label="enrichment_analysis",
+            effort=feature_config.effort,
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
             model=model,

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -1022,6 +1022,7 @@ class GraphAgent(LLMFeature):
             temperature=temperature,
             model=self.provider.get_model_for_tier(model_tier),
             label="sql_repair",
+            effort=getattr(feature_config, "effort", None),
         )
 
         # converse raises a typed ProviderError on an API failure (DAT-503) —

--- a/packages/engine/src/dataraum/llm/config.py
+++ b/packages/engine/src/dataraum/llm/config.py
@@ -32,6 +32,9 @@ class FeatureConfig(BaseModel):
 
     enabled: bool = True
     model_tier: str = "balanced"
+    # Output effort for this feature's calls (DAT-603). "low" suits mechanical
+    # extraction (shorter output, lower latency); None = API default (high).
+    effort: str | None = None
 
 
 class LLMFeatures(BaseModel):

--- a/packages/engine/src/dataraum/llm/providers/anthropic.py
+++ b/packages/engine/src/dataraum/llm/providers/anthropic.py
@@ -122,6 +122,25 @@ def _strict_tool_schema(node: Any) -> Any:
     return node
 
 
+# Models that accept ``output_config.effort``. Haiku 4.5 (the ``fast`` tier)
+# rejects the parameter, so it is deliberately absent.
+_EFFORT_SUPPORTING_PREFIXES = (
+    "claude-sonnet-5",
+    "claude-sonnet-4-6",
+    "claude-opus-4-5",
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-fable-5",
+    "claude-mythos-5",
+)
+
+
+def _supports_effort(model: str) -> bool:
+    """True when the model accepts ``output_config.effort``."""
+    return model.startswith(_EFFORT_SUPPORTING_PREFIXES)
+
+
 def _coerce_stringified_args(
     tool_input: dict[str, Any], schema: dict[str, Any], *, label: str | None
 ) -> dict[str, Any]:
@@ -323,13 +342,34 @@ class AnthropicProvider(LLMProvider):
                 kwargs["temperature"] = request.temperature
 
             if request.system:
-                kwargs["system"] = request.system
+                # DAT-601: cache the stable prefix. Tools render before system,
+                # so this one breakpoint caches tools + system together across
+                # the run's repeated calls (identical template per phase; the
+                # metrics/validation fan-outs repeat it 10-wide). Prefixes under
+                # the model's minimum cacheable size silently don't cache — no
+                # error, just cache_creation_input_tokens=0 in the telemetry.
+                # Volatile per-call data rides in the user message (the
+                # render_split contract), never ahead of this breakpoint.
+                kwargs["system"] = [
+                    {
+                        "type": "text",
+                        "text": request.system,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ]
 
             if tools:
                 kwargs["tools"] = tools
 
             if request.tool_choice:
                 kwargs["tool_choice"] = request.tool_choice
+
+            # DAT-603: per-feature effort. Extraction agents run thinking-off +
+            # effort:low (shorter output = lower serial-decode latency). Only
+            # sent where the model supports the parameter — Haiku 4.5 rejects
+            # it, so the fast tier drops it silently.
+            if request.effort and _supports_effort(model):
+                kwargs["output_config"] = {"effort": request.effort}
 
             # Stream + accumulate instead of a one-shot create: the SDK refuses
             # a non-streaming request whose max_tokens it estimates could exceed

--- a/packages/engine/src/dataraum/llm/providers/base.py
+++ b/packages/engine/src/dataraum/llm/providers/base.py
@@ -113,6 +113,10 @@ class ConversationRequest(BaseModel):
     max_tokens: int = 4096
     temperature: float = 0.0
     model: str | None = None  # Override default model
+    # Per-feature output effort (DAT-603): "low" | "medium" | "high" | "xhigh"
+    # | "max". None = the API default. The provider only sends it to models
+    # that support the parameter.
+    effort: str | None = None
     # Greppable agent/phase tag for per-call telemetry (DAT-600). The provider
     # has no phase context of its own, so each call site stamps the prompt
     # template / feature name it is invoking (e.g. "graph_sql_generation").

--- a/packages/engine/tests/integration/analysis/validation/test_agent.py
+++ b/packages/engine/tests/integration/analysis/validation/test_agent.py
@@ -22,6 +22,9 @@ def mock_llm_config():
     config.features.validation = MagicMock()
     config.features.validation.enabled = True
     config.features.validation.model_tier = "fast"
+    # A real value, not a Mock attribute: the agent forwards effort into
+    # ConversationRequest, which validates it as str | None.
+    config.features.validation.effort = "low"
     return config
 
 

--- a/packages/engine/tests/unit/llm/test_anthropic_provider.py
+++ b/packages/engine/tests/unit/llm/test_anthropic_provider.py
@@ -394,9 +394,7 @@ class TestStringifiedArgCoercion:
     ) -> dict[str, object]:
         provider = _provider()
         response = SimpleNamespace(
-            content=[
-                SimpleNamespace(type="tool_use", id="t1", name="emit", input=tool_input)
-            ],
+            content=[SimpleNamespace(type="tool_use", id="t1", name="emit", input=tool_input)],
             stop_reason="tool_use",
             model="claude-x",
             usage=SimpleNamespace(
@@ -444,9 +442,7 @@ class TestStringifiedArgCoercion:
         coerced = self._converse_with_tool_use(monkeypatch, {"tables": "not json"})
         assert coerced["tables"] == "not json"
 
-    def test_whole_payload_stringified_into_field(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_whole_payload_stringified_into_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Smoke #6: the model serialized the ENTIRE input object into the
         # container field — the parsed dict's keys match the tool's own
         # properties, so it is adopted as the whole input.
@@ -455,3 +451,66 @@ class TestStringifiedArgCoercion:
             {"tables": '{"tables": [{"table_name": "t"}], "note": "n"}'},
         )
         assert coerced == {"tables": [{"table_name": "t"}], "note": "n"}
+
+
+class TestPromptCaching:
+    """The system prompt ships as a cached block (DAT-601): tools render before
+    system, so the one breakpoint caches tools + system across a run's repeated
+    calls. Volatile content rides in the user message, past the breakpoint."""
+
+    def test_system_becomes_cached_block(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _provider()
+        captured: dict[str, object] = {}
+
+        def capture(**kwargs: object) -> object:
+            captured.update(kwargs)
+            return _ok_response()
+
+        _patch_stream(monkeypatch, provider, capture)
+        provider.converse(
+            ConversationRequest(messages=[Message(role="user", content="hi")], system="be terse")
+        ).unwrap()
+        assert captured["system"] == [
+            {
+                "type": "text",
+                "text": "be terse",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+
+
+class TestEffort:
+    """Per-feature effort (DAT-603) reaches the API as output_config.effort —
+    only on models that accept the parameter (Haiku 4.5 rejects it)."""
+
+    def _capture_kwargs(
+        self, monkeypatch: pytest.MonkeyPatch, model: str, effort: str | None
+    ) -> dict[str, object]:
+        provider = _provider()
+        captured: dict[str, object] = {}
+
+        def capture(**kwargs: object) -> object:
+            captured.update(kwargs)
+            return _ok_response()
+
+        _patch_stream(monkeypatch, provider, capture)
+        provider.converse(
+            ConversationRequest(
+                messages=[Message(role="user", content="hi")],
+                model=model,
+                effort=effort,
+            )
+        ).unwrap()
+        return captured
+
+    def test_effort_sent_on_supporting_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = self._capture_kwargs(monkeypatch, "claude-sonnet-5", "low")
+        assert kwargs["output_config"] == {"effort": "low"}
+
+    def test_effort_dropped_on_haiku(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = self._capture_kwargs(monkeypatch, "claude-haiku-4-5", "low")
+        assert "output_config" not in kwargs
+
+    def test_no_effort_no_output_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = self._capture_kwargs(monkeypatch, "claude-sonnet-5", None)
+        assert "output_config" not in kwargs


### PR DESCRIPTION
**Stacked on #422** — the first four commits are the Sonnet 5 swap; this PR's delta is the last commit. Rebase/merge after #422 lands.

## Engine (provider chokepoint)

- **DAT-601 — prompt caching:** the system prompt ships as a cached block; tools render before system, so one breakpoint caches tools+system across a run's repeated calls. Verified in a full run: `cache_read_input_tokens` 18,430 (validation fan-out reads cleanly: 10.8k read vs 8.6k written). Known follow-up on the ticket: `graph_sql_generation`'s system prompt embeds per-metric variables → 11 unique prefixes written, net negative for that label (~19k token-equivalents/run, bounded).
- **DAT-603 Half A — effort:** `FeatureConfig.effort` → `ConversationRequest.effort` → `output_config.effort`, sent only to models that accept it (Haiku 4.5 drops it). `effort: low` on the mechanical extractors (column_annotation, slicing_analysis, validation). Verified: annotation coverage stayed full (51 annotations / 8 tables) at ~30% lower latency than the 4.6 baseline.

## Cockpit

- **DAT-660 — answer sub-agent:** the session-stable workspace context (schema/entities/catalog/relationships/drivers/vocabulary/conventions) moves out of the user message into its own cached system block; instructions get a breakpoint too; the user message carries only the question. Previously the volatile question came first and nothing ever cached.
- **DAT-606 Half A — orchestrator:** the workspace-context block gets its own breakpoint. Verified live: an orchestrator turn read 6,592 cache tokens with only 866 uncached input.

End-to-end verification: full pipeline run green (12 executed / 12 grounded, 8/9 validations, 0 failed), then an Analyse question through the cockpit — the answer grounded `account_type` via the chart_of_accounts join and its revenue total (−51,766,199.72) matches the testdata's ground truth (51.7M).

🤖 Generated with [Claude Code](https://claude.com/claude-code)