### PR TITLE
fix(DAT-664) + feat(DAT-601): snippet step-id rebind; warm-first stagger for LLM fan-outs

### DIFF
--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -1197,6 +1197,34 @@ class GraphAgent(LLMFeature):
             if step_id:
                 generated_steps[step_id] = step_dict
 
+        # Sonnet 5 paraphrases step ids instead of echoing them (`revenue` comes
+        # back as `revenue_extract`, `accounts_receivable` as `ar_extract` —
+        # 2026-07-02), so a name-keyed lookup misses and the snippet silently
+        # never persists: the leaf grounds, assembly then finds an empty cache,
+        # and every metric composed from it dies "absent from the snippet
+        # cache". The authoring path grounds exactly ONE extract leaf per call
+        # (DAT-646), so when the shapes are unambiguous — one EXTRACT step in
+        # the graph, one generated step — bind them positionally regardless of
+        # the model's self-chosen id.
+        extract_steps = [
+            (sid, st)
+            for sid, st in graph.steps.items()
+            if st.step_type == StepType.EXTRACT and st.source
+        ]
+        if (
+            len(extract_steps) == 1
+            and len(generated_code.steps) == 1
+            and extract_steps[0][0] not in generated_steps
+        ):
+            model_id = generated_code.steps[0].get("step_id", "")
+            logger.info(
+                "snippet_step_id_rebound",
+                graph_id=graph.graph_id,
+                step_id=extract_steps[0][0],
+                model_step_id=model_id,
+            )
+            generated_steps = {extract_steps[0][0]: generated_code.steps[0]}
+
         repair_by_step: dict[str, StepResult] = {}
         if step_results:
             for sr in step_results:
@@ -1207,11 +1235,21 @@ class GraphAgent(LLMFeature):
             generated_code, repaired=bool(repair_by_step)
         )
 
+        saved_count = 0
         for step_id, graph_step in graph.steps.items():
             if graph_step.step_type != StepType.EXTRACT or not graph_step.source:
                 continue
             gen_step = generated_steps.get(step_id)
             if not gen_step:
+                # Ambiguous drift (multi-step output or multi-leaf graph) — a
+                # grounded leaf whose snippet fails to save starves every metric
+                # composed from it, so this must be LOUD, never silent.
+                logger.warning(
+                    "snippet_save_skipped",
+                    graph_id=graph.graph_id,
+                    step_id=step_id,
+                    generated_step_ids=sorted(generated_steps),
+                )
                 continue
 
             repaired = repair_by_step.get(step_id)
@@ -1240,8 +1278,9 @@ class GraphAgent(LLMFeature):
                 llm_model=generated_code.llm_model,
                 provenance=provenance_dict,
             )
+            saved_count += 1
 
-        logger.debug("saved_snippets", graph_id=graph.graph_id)
+        logger.info("saved_snippets", graph_id=graph.graph_id, count=saved_count)
 
     def _save_failed_snippet(
         self,
@@ -1284,11 +1323,21 @@ class GraphAgent(LLMFeature):
             s.get("step_id", ""): s for s in generated_code.steps if s.get("step_id")
         }
         provenance = {"failure_mode": mode, "failure_reason": reason}
+        saved_count = 0
         for step_id, graph_step in graph.steps.items():
             if graph_step.step_type != StepType.EXTRACT or not graph_step.source:
                 continue
             gen_step = generated_steps.get(step_id)
             if not gen_step:
+                # Ambiguous drift (multi-step output or multi-leaf graph) — a
+                # grounded leaf whose snippet fails to save starves every metric
+                # composed from it, so this must be LOUD, never silent.
+                logger.warning(
+                    "snippet_save_skipped",
+                    graph_id=graph.graph_id,
+                    step_id=step_id,
+                    generated_step_ids=sorted(generated_steps),
+                )
                 continue
             library.save_snippet(
                 snippet_type="extract",
@@ -1434,6 +1483,7 @@ class GraphAgent(LLMFeature):
 
         cached_steps: dict[str, dict[str, Any]] = {}
 
+        saved_count = 0
         for step_id, graph_step in graph.steps.items():
             if graph_step.step_type != StepType.EXTRACT or not graph_step.source:
                 continue

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -1323,7 +1323,6 @@ class GraphAgent(LLMFeature):
             s.get("step_id", ""): s for s in generated_code.steps if s.get("step_id")
         }
         provenance = {"failure_mode": mode, "failure_reason": reason}
-        saved_count = 0
         for step_id, graph_step in graph.steps.items():
             if graph_step.step_type != StepType.EXTRACT or not graph_step.source:
                 continue
@@ -1483,7 +1482,6 @@ class GraphAgent(LLMFeature):
 
         cached_steps: dict[str, dict[str, Any]] = {}
 
-        saved_count = 0
         for step_id, graph_step in graph.steps.items():
             if graph_step.step_type != StepType.EXTRACT or not graph_step.source:
                 continue

--- a/packages/engine/src/dataraum/pipeline/phases/_warm_first.py
+++ b/packages/engine/src/dataraum/pipeline/phases/_warm_first.py
@@ -1,0 +1,57 @@
+"""Warm-first submission for concurrent identical-prefix LLM fan-outs (DAT-601).
+
+Concurrent LLM calls that share a byte-identical prompt prefix (same tools +
+system per phase template) cannot read a prompt-cache entry that is still being
+written — an unstaggered burst pays the cache write N times over. Measured on
+the finance smoke workspace: metrics warming fired 11 calls in one generation
+at cap 10 and wrote the same ~6.9k-token prefix 10 times (only call 11 read);
+validation's first wave of 4 did the same at its cap.
+
+Letting the FIRST call run to completion commits the shared prefix; every call
+released after it reads the entry instead. Wall-clock cost is ~zero whenever
+the item count exceeds the pool cap (the wave count is unchanged) and one
+call-time otherwise.
+
+This is deliberately the ONLY place the stagger lives: metrics warming and
+validation are the engine's only two concurrent LLM fan-outs (every other
+ThreadPoolExecutor is pure statistics; all other LLM phases are single batched
+calls).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from concurrent.futures import Future, wait
+
+
+def submit_warm_first[K, R](
+    submit: Callable[[K], Future[R]],
+    keys: Sequence[K],
+) -> dict[Future[R], K]:
+    """Submit ``keys[0]``, wait for it to finish, then submit the rest.
+
+    The first future is awaited with :func:`concurrent.futures.wait`, which
+    does NOT consume its exception — the caller's ``as_completed`` collect
+    loop sees exactly the same per-future success/failure semantics as an
+    unstaggered submit.
+
+    Args:
+        submit: Submits one key's work to the caller's pool, returning its
+            future (a closure over ``pool.submit(fn, …)``).
+        keys: Work items in submission order; ``keys[0]`` is the cache warmer.
+
+    Returns:
+        ``{future: key}`` for the caller's collect loop (the first key's
+        completed future included).
+    """
+    ordered = list(keys)
+    futures: dict[Future[R], K] = {}
+    if not ordered:
+        return futures
+    first = submit(ordered[0])
+    futures[first] = ordered[0]
+    if len(ordered) > 1:
+        wait([first])
+        for key in ordered[1:]:
+            futures[submit(key)] = key
+    return futures

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -62,6 +62,7 @@ from dataraum.graphs.loader import GraphLoadError
 from dataraum.lifecycle import BaseRunMap, declare_artifact, transition
 from dataraum.llm import PromptRenderer, create_provider, load_llm_config
 from dataraum.pipeline.base import PhaseContext, PhaseResult
+from dataraum.pipeline.phases._warm_first import submit_warm_first
 from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.registry import analysis_phase
 
@@ -504,21 +505,25 @@ def _warm_generations_parallel(
         for generation in generations:
             # Only leaf EXTRACTs warm now (DAT-646) — they have no dependencies, so
             # there is no dep-gate: each is authored once, concept-keyed.
-            futures: dict[Future[NodeDecision], NodeKey] = {}
-            for key in generation:
-                futures[
-                    pool.submit(
-                        _warm_isolated,
-                        nodes[key],
-                        manager,
-                        agent,
-                        schema_mapping_id,
-                        table_ids,
-                        vertical,
-                        om_run_id,
-                        catalogue_run_id,
-                    )
-                ] = key
+            # Warm-first (DAT-601): the generation's first node runs alone so its
+            # completed call commits the shared prompt-cache prefix; the rest then
+            # read it instead of re-writing it cap-wide.
+            def _submit(key: NodeKey) -> Future[NodeDecision]:
+                return pool.submit(
+                    _warm_isolated,
+                    nodes[key],
+                    manager,
+                    agent,
+                    schema_mapping_id,
+                    table_ids,
+                    vertical,
+                    om_run_id,
+                    catalogue_run_id,
+                )
+
+            futures: dict[Future[NodeDecision], NodeKey] = submit_warm_first(
+                _submit, list(generation)
+            )
             for future in as_completed(futures):
                 key = futures[future]
                 try:

--- a/packages/engine/src/dataraum/pipeline/phases/validation_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/validation_phase.py
@@ -25,7 +25,7 @@ with an explicit ``no_declared_validations`` outcome.
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 from types import ModuleType
 from typing import TYPE_CHECKING, Any
@@ -46,6 +46,7 @@ from dataraum.core.logging import get_logger
 from dataraum.lifecycle import BaseRunMap, declare_artifact, transition
 from dataraum.llm import PromptRenderer, create_provider, load_llm_config
 from dataraum.pipeline.base import PhaseContext, PhaseResult
+from dataraum.pipeline.phases._warm_first import submit_warm_first
 from dataraum.pipeline.phases.base import BasePhase
 from dataraum.pipeline.registry import analysis_phase
 from dataraum.storage.upsert import upsert
@@ -247,10 +248,12 @@ class ValidationPhase(BasePhase):
             with ThreadPoolExecutor(
                 max_workers=_MAX_CONCURRENT_VALIDATIONS, thread_name_prefix="validation"
             ) as pool:
-                futures = {
-                    pool.submit(_isolated, validation_id, spec): validation_id
-                    for validation_id, spec in specs.items()
-                }
+                # Warm-first (DAT-601): the first spec runs alone to commit the
+                # shared prompt-cache prefix; the remaining specs then read it.
+                def _submit(validation_id: str) -> Future[_WorkOutcome]:
+                    return pool.submit(_isolated, validation_id, specs[validation_id])
+
+                futures = submit_warm_first(_submit, list(specs))
                 for future in as_completed(futures):
                     collected[futures[future]] = future.result()
         else:

--- a/packages/engine/tests/unit/graphs/test_assemble.py
+++ b/packages/engine/tests/unit/graphs/test_assemble.py
@@ -9,7 +9,7 @@ longer ground three different ways across dependent metrics.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from dataraum.graphs.agent import ExecutionContext, GraphAgent
 from dataraum.graphs.models import (
@@ -109,3 +109,62 @@ def test_assemble_fails_when_grounded_but_absent_from_cache() -> None:
     assert result.success is False
     assert "absent from the snippet cache" in (result.error or "")
     provider.converse.assert_not_called()
+
+
+class TestSaveSnippetsStepIdRebind:
+    """_save_snippets must tolerate the model renaming its single step
+    (Sonnet 5 echoes `revenue` back as `revenue_extract` — 2026-07-02): the
+    authoring path grounds exactly ONE extract leaf (DAT-646), so an
+    unambiguous one-leaf/one-step pair binds positionally. Without the rebind
+    the snippet silently never persists, assembly finds an empty cache, and
+    every metric composed from the leaf dies 'absent from the snippet cache'."""
+
+    def _generated(self, step_id: str) -> MagicMock:
+        code = MagicMock()
+        code.steps = [{"step_id": step_id, "sql": "SELECT 1", "description": "d"}]
+        code.summary = "s"
+        code.column_mappings = {}
+        code.llm_model = "claude-test"
+        code.provenance = None
+        code.assumptions = []
+        return code
+
+    def _save(self, graph, code) -> MagicMock:
+        agent = GraphAgent.__new__(GraphAgent)
+        with patch("dataraum.query.snippet_library.SnippetLibrary") as lib_cls:
+            GraphAgent._save_snippets(
+                agent,
+                session=MagicMock(),
+                graph=graph,
+                generated_code=code,
+                schema_mapping_id="ws",
+                step_results=None,
+                workspace_id="ws",
+            )
+            return lib_cls.return_value
+
+    def test_renamed_single_step_is_rebound_and_saved(self) -> None:
+        rev = _extract("revenue", "revenue")
+        graph = _graph("revenue_only", {"revenue": rev})
+        library = self._save(graph, self._generated("revenue_extract"))
+        library.save_snippet.assert_called_once()
+        assert library.save_snippet.call_args.kwargs["standard_field"] == "revenue"
+
+    def test_exact_echo_still_saves(self) -> None:
+        rev = _extract("revenue", "revenue")
+        graph = _graph("revenue_only", {"revenue": rev})
+        library = self._save(graph, self._generated("revenue"))
+        library.save_snippet.assert_called_once()
+
+    def test_ambiguous_multi_step_drift_skips_loud(self) -> None:
+        # Two generated steps for one leaf: no unambiguous positional bind —
+        # nothing saved (the loud warning path), never a wrong-SQL snippet.
+        rev = _extract("revenue", "revenue")
+        graph = _graph("revenue_only", {"revenue": rev})
+        code = self._generated("revenue_extract")
+        code.steps = [
+            {"step_id": "a", "sql": "SELECT 1", "description": ""},
+            {"step_id": "b", "sql": "SELECT 2", "description": ""},
+        ]
+        library = self._save(graph, code)
+        library.save_snippet.assert_not_called()

--- a/packages/engine/tests/unit/pipeline/test_warm_first.py
+++ b/packages/engine/tests/unit/pipeline/test_warm_first.py
@@ -1,0 +1,77 @@
+"""Tests for the warm-first fan-out stagger (DAT-601).
+
+The load-bearing property: the FIRST item's call completes before any other
+item is submitted, so its finished request has committed the shared
+prompt-cache prefix that the rest then read.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+
+from dataraum.pipeline.phases._warm_first import submit_warm_first
+
+
+def test_first_completes_before_rest_start() -> None:
+    first_finished_at: list[float] = []
+    later_started_at: list[float] = []
+    lock = threading.Lock()
+
+    def work(key: int) -> int:
+        if key == 0:
+            time.sleep(0.05)
+            with lock:
+                first_finished_at.append(time.monotonic())
+        else:
+            with lock:
+                later_started_at.append(time.monotonic())
+        return key
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+
+        def submit(key: int) -> Future[int]:
+            return pool.submit(work, key)
+
+        futures = submit_warm_first(submit, list(range(6)))
+        results = sorted(futures[f] for f in as_completed(futures) if f.result() is not None)
+
+    assert results == [0, 1, 2, 3, 4, 5]
+    assert len(first_finished_at) == 1 and len(later_started_at) == 5
+    assert min(later_started_at) >= first_finished_at[0]
+
+
+def test_single_item_and_empty() -> None:
+    with ThreadPoolExecutor(max_workers=2) as pool:
+
+        def submit(key: str) -> Future[str]:
+            return pool.submit(lambda: key)
+
+        assert submit_warm_first(submit, []) == {}
+        futures = submit_warm_first(submit, ["only"])
+        assert [f.result() for f in futures] == ["only"]
+
+
+def test_first_failure_surfaces_in_collect_not_at_submit() -> None:
+    # wait() must not consume the first future's exception — the caller's
+    # collect loop owns per-future failure handling, exactly as unstaggered.
+    def work(key: int) -> int:
+        if key == 0:
+            raise ValueError("boom")
+        return key
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+
+        def submit(key: int) -> Future[int]:
+            return pool.submit(work, key)
+
+        futures = submit_warm_first(submit, [0, 1])  # must NOT raise here
+        outcomes: dict[int, str] = {}
+        for f in as_completed(futures):
+            try:
+                outcomes[futures[f]] = str(f.result())
+            except ValueError as exc:
+                outcomes[futures[f]] = f"error: {exc}"
+
+    assert outcomes == {0: "error: boom", 1: "1"}


### PR DESCRIPTION
Two changes in the same code region, verified together on the smoke workspace via the DB-dump A/B protocol (operating-model re-runs, ~4 min each).

## DAT-664 — Sonnet 5 regression: snippet save silently skipped, income-statement metrics dead

Sonnet 5 paraphrases step ids instead of echoing them (`revenue` → `revenue_extract`, `accounts_receivable` → `ar_extract`), so `_save_snippets`' name-keyed lookup missed and skipped **silently**: 10 of 11 grounded leaves never persisted, assembly found an empty snippet cache, and current_ratio/ebitda/ebitda_margin/gross_margin/gross_profit/net_margin/operating_income/operating_margin all honest-failed "absent from the snippet cache". Both merge smokes masked it — aggregate artifact counts looked similar while the distribution regressed.

Fix (same boundary-tolerance family as the stringify coercion in #422): the authoring path grounds exactly ONE extract leaf per call (DAT-646's contract), so an unambiguous one-leaf/one-step pair binds positionally regardless of the model's self-chosen id (`snippet_step_id_rebound`). Ambiguous shapes skip LOUD (`snippet_save_skipped` — was silent), and `saved_snippets` logs a real count (it previously fired even when nothing saved).

**Verified:** post-fix OM re-run → 9/11 extracts persist (the two misses are honest no-support leaves: tax, inventory) and every data-supported metric executes again, matching the Model-canvas oracle. Residual non-executions are declared sign-convention validations firing born-loud (current_assets/AP negative) — the DAT-652/eval quality thread, not persistence.

## DAT-601 — warm-first stagger (Piece 1)

Concurrent identical-prefix LLM calls can't read a cache entry still being written: metrics warming fired 11 calls in one generation at cap 10 and wrote the same ~6.9k-token prefix 10 times (per-call reads `[0×10, 7620]`); validation's first wave of 4 showed the same signature. The generation's first item now runs alone — its completed call commits the shared prefix — then the rest release. One helper (`_warm_first.py`), two consumers: the engine's only concurrent LLM fan-outs. `wait()` on the first future preserves the callers' per-future failure semantics exactly; wall-clock cost ~zero when items exceed the pool cap.

**Verified:** two post-stagger OM runs show the collision signature eliminated — `graph_sql_generation` reads `[7620×11]`, `validation_sql` `[2162×9]`, zero writes; timing proves the gate (all ten later calls started 1.1–1.3 s after the first ended). Artifact-state diffs across runs stayed within LLM variance.

**Piece 2 (run-stable user-prefix as a cached context block) is deliberately NOT in this PR** — with the corrected diagnosis the static prefix already caches cleanly; the remaining gain is ~8k tokens/call (~$0.25/run) against an M-sized change with a byte-determinism precondition. Measured economics and design are on DAT-601 for a later call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)