### PR TITLE
feat(DAT-603): Half B — single-extract output model, effort knob, consumer-audited schema trim

### DIFF
--- a/packages/dataraum-config/llm/config.yaml
+++ b/packages/dataraum-config/llm/config.yaml
@@ -63,6 +63,14 @@ features:
     model_tier: fast
     max_repair_attempts: 2
 
+  # DAT-603: metric grounding (graph_sql_generation) — the pipeline's most
+  # central agent. `effort` is deliberately UNSET (= API default, high) until
+  # the A/B against the DAT-602 eval baseline settles a lower value; flip it
+  # here (bind-mounted data, no rebuild) once the eval says coverage holds.
+  graph_sql_generation:
+    enabled: true
+    model_tier: balanced
+
 # Cost controls
 limits:
   # Bumped 16000 -> 24000 with the Sonnet 5 swap: its tokenizer emits ~30% more

--- a/packages/dataraum-config/llm/config.yaml
+++ b/packages/dataraum-config/llm/config.yaml
@@ -64,12 +64,14 @@ features:
     max_repair_attempts: 2
 
   # DAT-603: metric grounding (graph_sql_generation) — the pipeline's most
-  # central agent. `effort` is deliberately UNSET (= API default, high) until
-  # the A/B against the DAT-602 eval baseline settles a lower value; flip it
-  # here (bind-mounted data, no rebuild) once the eval says coverage holds.
+  # central agent and its hardest reasoning task. `thinking: true` keeps the
+  # model's adaptive reflection ON (Sonnet 5-class models expose no sampling
+  # knobs; reflection is the quality lever — 2026-07-03 review). `effort` stays
+  # UNSET (API default): low is wrong here, this agent needs the thinking.
   graph_sql_generation:
     enabled: true
     model_tier: balanced
+    thinking: true
 
 # Cost controls
 limits:

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -1,6 +1,6 @@
 name: "graph_sql_generation"
-version: "6.0"
-description: "Ground ONE business concept to an executable DuckDB extract. The LLM grounds; it is fed deterministic evidence (ADR-0016). Formula composition is a separate prompt. v6.0 (DAT-603): single-extract output — one sql + description; no steps[]/step_id/final_sql/summary."
+version: "6.1"
+description: "Ground ONE business concept to an executable DuckDB extract. The LLM grounds; it is fed deterministic evidence (ADR-0016). Formula composition is a separate prompt. v6.0 (DAT-603): single-extract output — no steps[]/step_id/final_sql. v6.1: adaptive thinking on; grounding commitment emitted before sql; floors compacted, reasoning invited."
 temperature: 0.0
 
 # System prompt — defines the single job: ground ONE concept to one extract.
@@ -18,6 +18,13 @@ system_prompt: |
   concept, e.g.
     `SELECT SUM("amount") AS value FROM <enriched_view> WHERE "<discriminator>" IN ('<v1>','<v2>')`
   plus a one-line `description` of what it computes and how it is filtered.
+
+  Reason before you commit. Use your thinking to weigh the candidate groundings against each
+  other — which column really expresses the concept, which served values mean it, whether a
+  complete low-cardinality classification (e.g. an account-type column) expresses the concept
+  more reliably than a partial high-cardinality name enumeration — and to CHECK your chosen
+  predicate against the served evidence before emitting it. The evidence sections below tell
+  you what each signal is and how much to trust it; the reasoning is yours.
 
   Alias the computed column `AS value` (the snippet-library convention — the same computation
   is then recognised as the same reusable snippet). The SQL is saved and reused across the
@@ -42,49 +49,30 @@ system_prompt: |
     `indicators` and `exclude` patterns). Map the concept to the SPECIFIC discriminator values
     that mean it, then filter with an explicit `IN (...)` list of those values.
 
-  Resolution order:
-  1. If field_mappings gives a sound `concept → column` (a real discriminator, not near-constant),
-     use that column.
-  2. Otherwise ground via Value sets + Business Concepts: pick the discriminator column whose
-     values name the concept, then from THAT column's served Value-set select the SUBSET of its
-     listed values that ARE the concept (by MEANING — honor the concept's `exclude` patterns; a
-     value's surface string can contradict its concept), and filter `WHERE "<discriminator>" IN
-     ('<value1>', '<value2>', ...)` over THOSE EXACT SERVED values. You are choosing a subset of
-     the listed values — never adding one that is not listed.
-  3. If the discriminator lives on a DIMENSION table (a classification, not a value on the fact),
-     join to it — see the join-to-dimension blueprint.
-  4. Record the grounding in column_mappings_basis (which column, which values, why).
+  Weigh the surfaces rather than following a script: a sound field_mapping (a real
+  discriminator, not near-constant) is usually the direct answer for wide data; long-format
+  data usually grounds through discriminator values; a classification that lives on a dimension
+  table is reached by a join (see the join-to-dimension blueprint). When more than one surface
+  can express the concept, prefer the one whose served evidence is stronger — a COMPLETE
+  low-cardinality classification beats a partial high-cardinality name enumeration. Record what
+  you chose and why in column_mappings_basis (which column, which values, why).
 
-  HARD RULES — a predicate may be grounded ONLY two ways; anything else is forbidden:
-  - (1) an explicit `IN (...)` over values from a Value-set marked **complete**, or
-    (2) a join to a dimension table and an `IN (...)` over THAT dimension's complete Value-set.
-  - **NEVER `ILIKE '%fragment%'` (or `LIKE`/substring) to GUESS membership.** ILIKE is only for
-    case-insensitivity against a KNOWN exact value — never to fish for rows by a fragment.
-  - **NEVER filter on a column flagged `near-constant`** (one value ≥90% — e.g. a mostly-true
-    boolean flag); it is not a discriminator and grounding on it is silently wrong.
-  - A column with NO Value-set here is high-cardinality and deliberately not enumerated (you
-    are one-shot and cannot drill it): do NOT invent a filter on it — join to a dimension that
-    HAS a complete value-set, or ABSTAIN.
-  - Never invent a value; never use a concept name as a table name.
-  - **Every literal in an `IN (...)` MUST appear VERBATIM in the served Value-set for that
-    column.** Do NOT append a conventional or synonym name because you believe it means the
-    concept — a value that is not in the served list is an INVENTED value (forbidden above),
-    even as an exact string mixed in with valid ones. Picking the real served value AND padding
-    the list with plausible-but-unlisted names is still invention. If NONE of the served values
-    mean the concept, the concept is ABSENT in this dataset — fall loud (NULL, per below); do
-    not construct an `IN (...)` of names you expect to exist.
-
-  FALL LOUD — do not guess (this protects against a confidently-wrong number):
-  If you cannot ground the concept by rule (1) or (2) — the only complete value-set is opaque
-  codes (e.g. `4000`, `5000`) with no semantic signal, the needed values are absent, the
-  Value-set is marked PARTIAL and may be missing them, the discriminators are near-constant, or
-  the discriminator is high-card with no dimension join that reaches it — then do NOT force-fit:
-  no ILIKE, no guessed filter, and NEVER a fabricated constant. In particular, if the concept
-  simply does NOT exist in this dataset (no column and no discriminator values represent it), do
-  NOT emit `SELECT 0` — a 0 reads downstream as a real amount and silently corrupts every metric
-  built on it. Emit `SELECT NULL AS value` instead, and record a LOW-confidence "inferred"
-  assumption naming the concept and why it is ungrounded. A flagged inconclusive result is
-  correct; a confident wrong number (or a fabricated 0) is the failure we are preventing.
+  FLOORS — few, and non-negotiable, because each one is a silent-wrong-number we have actually
+  shipped (reason freely above them; never through them):
+  - Every predicate literal must appear VERBATIM in a served Value-set marked **complete**
+    (on the fact column, or on a joined dimension's column). Choosing a subset of listed values
+    by meaning is your judgment; adding one unlisted "expected" name — even mixed in with valid
+    ones — is invention, and invented literals silently undercount.
+  - No substring/`ILIKE` membership guessing (ILIKE only for case-insensitivity on a known
+    served value). No filters on `near-constant` columns or on columns with NO served
+    Value-set (high-cardinality, deliberately unenumerated — join to a dimension that has a
+    complete set instead, or abstain). Never use a concept name as a table name.
+  - If the concept cannot be grounded within these floors — opaque codes with no semantic
+    signal, needed values absent, only PARTIAL sets available — fall loud: emit
+    `SELECT NULL AS value` plus a LOW-confidence "inferred" assumption naming the concept and
+    why. NEVER a fabricated `SELECT 0` — a 0 reads downstream as a real amount and corrupts
+    every metric built on it. A flagged inconclusive result is correct; a confident wrong
+    number is the failure we are preventing.
   </field_resolution_strategy>
 
   <channel_precedence>
@@ -221,7 +209,10 @@ system_prompt: |
      SELECT (v - LAG(v) OVER (ORDER BY m)) / NULLIF(LAG(v) OVER (ORDER BY m), 0) AS value FROM per ORDER BY m DESC LIMIT 1`
   </blueprint_library>
 
-  Use the generate_sql tool to provide your structured response.
+  When your reasoning is done you MUST call the generate_sql tool exactly once with your
+  result — the tool call is the only accepted output (a prose answer discards your work).
+  Its `grounding` field comes first on purpose: commit to the evidence — the column and the
+  exact served values — before the SQL that uses it.
 
 # User prompt — fed evidence first, then the single concept to ground.
 user_prompt: |
@@ -254,22 +245,23 @@ user_prompt: |
   </prior_context>
 
   <instructions>
-  Ground the concept in <graph_specification>:
+  Ground the concept in <graph_specification>. Reason it through first — candidate columns,
+  which served values mean the concept, which surface is most reliable — then verify your
+  predicate literals against the served Value sets, and only then call generate_sql with:
 
-  1. Resolve the concept to a column/values per <field_resolution_strategy>: field_mappings for a
-     sound direct column; otherwise the discriminator values from **Value sets** + **Business
-     Concepts** (explicit IN-list), or a join to a dimension. NEVER a guessed/substring filter.
-     If it cannot be grounded, FALL LOUD: `SELECT NULL AS value` + a LOW-confidence assumption.
-  2. Produce the one SQL statement (aliased `AS value`) using the step's aggregation, plus its
-     one-line description.
-  3. Document provenance: field_resolution ("direct" if a field_mapping gave the column,
-     "inferred" if you grounded via Value sets / a join); column_mappings_basis = {concept: {column,
+  1. `grounding` — the evidence you committed to: the column and the EXACT served values (or
+     the complete discriminator) the filter uses.
+  2. `sql` — the one statement (aliased `AS value`) using the step's aggregation, within the
+     floors of <field_resolution_strategy>; if the concept cannot be grounded, FALL LOUD:
+     `SELECT NULL AS value` + a LOW-confidence assumption.
+  3. `description` — the one-line human summary.
+  4. `provenance` — field_resolution ("direct" if a field_mapping gave the column, "inferred"
+     if you grounded via Value sets / a join); column_mappings_basis = {concept: {column,
      filter (the exact values), resolution}}.
-  4. Document assumptions: genuine interpretation choices only; ALWAYS record one (LOW confidence)
+  5. `assumptions` — genuine interpretation choices only; ALWAYS record one (LOW confidence)
      in the FALL-LOUD case, naming the concept and why it is ungrounded.
 
-  Use the generate_sql tool to provide the sql, description, column_mappings, provenance, and
-  assumptions.
+  The generate_sql call is mandatory and final — exactly one, as your last action.
   </instructions>
 
 # Input variable definitions

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -1,6 +1,6 @@
 name: "graph_sql_generation"
-version: "5.1"
-description: "Ground ONE business concept to an executable DuckDB extract. The LLM grounds; it is fed deterministic evidence (ADR-0016). Formula composition is a separate prompt."
+version: "6.0"
+description: "Ground ONE business concept to an executable DuckDB extract. The LLM grounds; it is fed deterministic evidence (ADR-0016). Formula composition is a separate prompt. v6.0 (DAT-603): single-extract output — one sql + description; no steps[]/step_id/final_sql/summary."
 temperature: 0.0
 
 # System prompt — defines the single job: ground ONE concept to one extract.
@@ -14,16 +14,15 @@ system_prompt: |
   </role>
 
   <your_job>
-  You author exactly ONE step and a trivial final_sql that selects it:
-  - An EXTRACT computes one measure for one concept, e.g.
+  You author exactly ONE standalone SQL statement — the extract computing one measure for one
+  concept, e.g.
     `SELECT SUM("amount") AS value FROM <enriched_view> WHERE "<discriminator>" IN ('<v1>','<v2>')`
-  - A CONSTANT returns a parameter value directly, e.g. `SELECT 30 AS value`
-  - final_sql then just surfaces it: `SELECT value FROM <step_id>`
+  plus a one-line `description` of what it computes and how it is filtered.
 
   Alias the computed column `AS value` (the snippet-library convention — the same computation
-  is then recognised as the same reusable snippet). The step is saved and reused across the
+  is then recognised as the same reusable snippet). The SQL is saved and reused across the
   system (other metrics and the query agent match it by concept), so ground the CONCEPT
-  cleanly and keep the step free of graph-specific filters.
+  cleanly and keep it free of graph-specific filters.
   </your_job>
 
   <field_resolution_strategy>
@@ -147,7 +146,6 @@ system_prompt: |
     Pattern: `SELECT SUM("<measure>") AS value FROM <view> WHERE "<period>" = (SELECT MAX("<period>") FROM <view>)`.
     The rule: filter to ONE period, then aggregate within it. Apply this to EVERY end_of_period
     step — a balance summed across all periods double-counts every snapshot.
-  - "constant": return the parameter value directly (`SELECT <value> AS value`).
   </aggregation_types>
 
   <temporal_signals>
@@ -195,8 +193,8 @@ system_prompt: |
      types (VARCHAR vs INTEGER). Quote column names with spaces/special chars in double quotes.
   5. Dates: DATE_TRUNC('month', col), DATE_PART('year', col), col + INTERVAL '30 days'. Never use
      a reserved word as an alias (DATE/TIME/YEAR/MONTH/DAY) — use period_days, calculation_date, etc.
-  6. The step body is a single SELECT returning one row aliased `AS value`; final_sql is
-     `SELECT value FROM <step_id>`.
+  6. The SQL is one standalone SELECT returning one row aliased `AS value` (a CTE inside it is
+     fine; there is no multi-step scaffolding around it).
   </duckdb_dialect>
 
   <blueprint_library>
@@ -262,15 +260,16 @@ user_prompt: |
      sound direct column; otherwise the discriminator values from **Value sets** + **Business
      Concepts** (explicit IN-list), or a join to a dimension. NEVER a guessed/substring filter.
      If it cannot be grounded, FALL LOUD: `SELECT NULL AS value` + a LOW-confidence assumption.
-  2. Produce the one step (aliased `AS value`) using the step's aggregation, then
-     `final_sql: SELECT value FROM <step_id>`.
+  2. Produce the one SQL statement (aliased `AS value`) using the step's aggregation, plus its
+     one-line description.
   3. Document provenance: field_resolution ("direct" if a field_mapping gave the column,
      "inferred" if you grounded via Value sets / a join); column_mappings_basis = {concept: {column,
-     filter (the exact values), resolution}}; a brief llm_reasoning.
+     filter (the exact values), resolution}}.
   4. Document assumptions: genuine interpretation choices only; ALWAYS record one (LOW confidence)
      in the FALL-LOUD case, naming the concept and why it is ungrounded.
 
-  Use the generate_sql tool to provide the step, final_sql, provenance, and assumptions.
+  Use the generate_sql tool to provide the sql, description, column_mappings, provenance, and
+  assumptions.
   </instructions>
 
 # Input variable definitions

--- a/packages/engine/src/dataraum/analysis/validation/agent.py
+++ b/packages/engine/src/dataraum/analysis/validation/agent.py
@@ -405,7 +405,6 @@ class ValidationAgent(LLMFeature):
         generated = GeneratedSQL(
             validation_id=spec.validation_id,
             sql_query=output.sql or "",
-            explanation=output.explanation,
             columns_used=output.columns_used,
             generated_at=datetime.now(UTC),
             model_used=model,

--- a/packages/engine/src/dataraum/analysis/validation/models.py
+++ b/packages/engine/src/dataraum/analysis/validation/models.py
@@ -74,10 +74,10 @@ class ValidationSQLOutput(BaseModel):
     sql: str | None = Field(
         description="The DuckDB SQL query to execute. Null if validation cannot be performed."
     )
-    explanation: str | None = Field(
-        default=None,
-        description="Brief explanation of what this query validates and which tables/columns are used.",
-    )
+    # No free-text `explanation` field: it flowed into GeneratedSQL and was read by
+    # nothing (DAT-603 consumer audit) — an unread sentence per call is pure
+    # serial-decode latency. The judgeable context lives in columns_used +
+    # skip_reason; the spec itself already says what is being validated.
     columns_used: list[str] = Field(
         default_factory=list,
         description="List of columns used in the query, in 'table.column' format.",
@@ -96,7 +96,6 @@ class GeneratedSQL(BaseModel):
 
     validation_id: str
     sql_query: str
-    explanation: str | None = None
     columns_used: list[str] = Field(default_factory=list)  # Columns identified by LLM
 
     # Generation metadata

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -34,10 +34,10 @@ from dataraum.llm.providers.base import LLMProvider
 
 from .models import (
     AssumptionBasis,
+    ExtractGroundingOutput,
     GraphAssumptionOutput,
     GraphExecution,
     GraphProvenanceOutput,
-    GraphSQLGenerationOutput,
     GraphStep,
     QueryAssumption,
     StepResult,
@@ -569,6 +569,12 @@ class GraphAgent(LLMFeature):
         context + field mappings. ``cached_snippets`` feeds the DAT-616 prior context
         (a cached extract is ASSEMBLED upstream, never re-authored), so an extract is a
         leaf with no dependency steps to carry into the prompt.
+
+        The output schema is single-extract (``ExtractGroundingOutput``, DAT-603): the
+        model returns one SQL statement and THIS code binds it to the graph's own leaf
+        id — the model never names a step, so the DAT-664 id-paraphrase class cannot
+        occur. The graph must therefore BE a single-extract mini-graph
+        (``node_warming.build_mini_graph``); anything else fails loud here.
         """
         from dataraum.llm.providers.base import (
             ConversationRequest,
@@ -576,13 +582,31 @@ class GraphAgent(LLMFeature):
             ToolDefinition,
         )
 
+        extract_leaves = [
+            step
+            for step in graph.steps.values()
+            if step.step_type == StepType.EXTRACT and step.source
+        ]
+        if len(extract_leaves) != 1 or len(graph.steps) != 1:
+            return Result.fail(
+                f"graph '{graph.graph_id}' is not a single-extract mini-graph "
+                f"({len(graph.steps)} steps, {len(extract_leaves)} extract leaves) — "
+                "authoring grounds exactly one leaf (DAT-646); metrics are assembled "
+                "from the binding map, never authored whole"
+            )
+        leaf = extract_leaves[0]
+
         # Serialize graph to YAML for LLM context.
         graph_yaml = self._graph_to_yaml(graph)
 
         prompt_name = "graph_sql_generation"
-        # Tier = balanced/Sonnet. Extract grounding needs the dataset context + field
-        # mappings — fail loud if the semantic phase did not produce them.
-        tier = "balanced"
+        # Tier/effort from feature config (DAT-603) — absent entry keeps the
+        # defaults: balanced tier, API-default effort. `enabled` is deliberately
+        # not consulted: grounding IS the pipeline, not an optional feature.
+        feature_config = self.config.features.graph_sql_generation
+        tier = feature_config.model_tier if feature_config else "balanced"
+        # Extract grounding needs the dataset context + field mappings — fail loud
+        # if the semantic phase did not produce them.
         if context.rich_context is None:
             return Result.fail(
                 "Cannot generate SQL without dataset context. "
@@ -642,8 +666,8 @@ class GraphAgent(LLMFeature):
         # Define tool for structured output
         tool = ToolDefinition(
             name="generate_sql",
-            description="Provide generated SQL for the graph specification",
-            input_schema=GraphSQLGenerationOutput.model_json_schema(),
+            description="Provide the SQL grounding the one concept in the graph specification",
+            input_schema=ExtractGroundingOutput.model_json_schema(),
         )
 
         # Call LLM with tool use
@@ -653,6 +677,7 @@ class GraphAgent(LLMFeature):
             tools=[tool],
             tool_choice={"type": "tool", "name": "generate_sql"},
             label=prompt_name,
+            effort=feature_config.effort if feature_config else None,
             max_tokens=self.config.limits.max_output_tokens_per_request,
             temperature=temperature,
             model=model,
@@ -674,24 +699,25 @@ class GraphAgent(LLMFeature):
             return Result.fail(f"Unexpected tool call: {tool_call.name}")
 
         try:
-            output = GraphSQLGenerationOutput.model_validate(tool_call.input)
+            output = ExtractGroundingOutput.model_validate(tool_call.input)
         except Exception as e:
             return Result.fail(f"Failed to validate tool response: {e}")
 
-        # Create GeneratedCode from Pydantic output
+        # Bind the one generated SQL to the graph's own leaf id (the model never
+        # names a step — DAT-664's id-paraphrase class is gone by construction)
+        # and surface it through the same composed shape the cache path produces.
         generated_code = GeneratedCode(
             code_id=str(uuid4()),
             graph_id=graph.graph_id,
-            summary=output.summary,
+            summary=output.description,
             steps=[
                 {
-                    "step_id": step.step_id,
-                    "sql": step.sql,
-                    "description": step.description,
+                    "step_id": leaf.step_id,
+                    "sql": output.sql,
+                    "description": output.description,
                 }
-                for step in output.steps
             ],
-            final_sql=output.final_sql,
+            final_sql=f"SELECT * FROM {leaf.step_id}",
             column_mappings=output.column_mappings,
             provenance=output.provenance,
             assumptions=output.assumptions or [],
@@ -709,8 +735,8 @@ class GraphAgent(LLMFeature):
         basis = output.provenance.column_mappings_basis if output.provenance else {}
         response_body = json.dumps(
             {
-                "final_sql": output.final_sql,
-                "steps": [{"step_id": s.step_id, "sql": s.sql} for s in output.steps],
+                "step_id": leaf.step_id,
+                "sql": output.sql,
                 "field_resolution": output.provenance.field_resolution
                 if output.provenance
                 else None,
@@ -770,8 +796,9 @@ class GraphAgent(LLMFeature):
             )
         execution.assumptions = assumptions
 
-        # Get max repair attempts from config (default 2)
-        feature_config = getattr(self.config.features, "sql_repair", None)
+        # Get max repair attempts from config (default 2). max_repair_attempts is
+        # a YAML extra on FeatureConfig (extra="allow"), so getattr with default.
+        feature_config = self.config.features.sql_repair
         max_repair_attempts = (
             getattr(feature_config, "max_repair_attempts", 2) if feature_config else 2
         )
@@ -986,13 +1013,14 @@ class GraphAgent(LLMFeature):
         """
         from dataraum.llm.providers.base import ConversationRequest, Message
 
-        # Check if sql_repair feature is enabled
-        feature_config = getattr(self.config.features, "sql_repair", None)
-        if not feature_config or not getattr(feature_config, "enabled", True):
+        # Check if sql_repair feature is enabled. The field is DECLARED on
+        # LLMFeatures (DAT-603) — before that, the YAML entry was silently dropped
+        # by pydantic and this guard disabled repair on every call.
+        feature_config = self.config.features.sql_repair
+        if not feature_config or not feature_config.enabled:
             return Result.fail("SQL repair feature is disabled")
 
-        # Get model tier from config (default to fast)
-        model_tier = getattr(feature_config, "model_tier", "fast")
+        model_tier = feature_config.model_tier
 
         # Build multi-table schema for context
         schema_info = self._build_schema_info(context)
@@ -1022,7 +1050,7 @@ class GraphAgent(LLMFeature):
             temperature=temperature,
             model=self.provider.get_model_for_tier(model_tier),
             label="sql_repair",
-            effort=getattr(feature_config, "effort", None),
+            effort=feature_config.effort,
         )
 
         # converse raises a typed ProviderError on an API failure (DAT-503) —
@@ -1149,7 +1177,6 @@ class GraphAgent(LLMFeature):
                 "field_resolution": prov.field_resolution,
                 "was_repaired": repaired,
                 "column_mappings_basis": prov.column_mappings_basis,
-                "llm_reasoning": prov.llm_reasoning,
             }
         elif repaired:
             provenance = {"was_repaired": True}
@@ -1197,34 +1224,6 @@ class GraphAgent(LLMFeature):
             if step_id:
                 generated_steps[step_id] = step_dict
 
-        # Sonnet 5 paraphrases step ids instead of echoing them (`revenue` comes
-        # back as `revenue_extract`, `accounts_receivable` as `ar_extract` —
-        # 2026-07-02), so a name-keyed lookup misses and the snippet silently
-        # never persists: the leaf grounds, assembly then finds an empty cache,
-        # and every metric composed from it dies "absent from the snippet
-        # cache". The authoring path grounds exactly ONE extract leaf per call
-        # (DAT-646), so when the shapes are unambiguous — one EXTRACT step in
-        # the graph, one generated step — bind them positionally regardless of
-        # the model's self-chosen id.
-        extract_steps = [
-            (sid, st)
-            for sid, st in graph.steps.items()
-            if st.step_type == StepType.EXTRACT and st.source
-        ]
-        if (
-            len(extract_steps) == 1
-            and len(generated_code.steps) == 1
-            and extract_steps[0][0] not in generated_steps
-        ):
-            model_id = generated_code.steps[0].get("step_id", "")
-            logger.info(
-                "snippet_step_id_rebound",
-                graph_id=graph.graph_id,
-                step_id=extract_steps[0][0],
-                model_step_id=model_id,
-            )
-            generated_steps = {extract_steps[0][0]: generated_code.steps[0]}
-
         repair_by_step: dict[str, StepResult] = {}
         if step_results:
             for sr in step_results:
@@ -1241,9 +1240,11 @@ class GraphAgent(LLMFeature):
                 continue
             gen_step = generated_steps.get(step_id)
             if not gen_step:
-                # Ambiguous drift (multi-step output or multi-leaf graph) — a
-                # grounded leaf whose snippet fails to save starves every metric
-                # composed from it, so this must be LOUD, never silent.
+                # Structurally unreachable since DAT-603: step ids are assigned by
+                # THIS code (authoring binds the leaf id; compose copies graph ids) —
+                # the model can no longer drift them (DAT-664). Kept LOUD as a
+                # regression guard: a grounded leaf whose snippet fails to save
+                # starves every metric composed from it.
                 logger.warning(
                     "snippet_save_skipped",
                     graph_id=graph.graph_id,

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -670,12 +670,19 @@ class GraphAgent(LLMFeature):
             input_schema=ExtractGroundingOutput.model_json_schema(),
         )
 
-        # Call LLM with tool use
+        # Thinking (DAT-603): grounding is the pipeline's hardest reasoning task
+        # and Sonnet 5-class models expose no sampling knobs — the model's own
+        # reflection is the quality lever. The API rejects thinking with a
+        # FORCED tool_choice, so a thinking run offers the tool on auto and the
+        # prompt mandates the call; no tool call remains a loud bind error
+        # (checked below), never a silent prose answer.
+        thinking = bool(feature_config and feature_config.thinking)
         request = ConversationRequest(
             messages=[Message(role="user", content=user_prompt)],
             system=system_prompt,
             tools=[tool],
-            tool_choice={"type": "tool", "name": "generate_sql"},
+            tool_choice={"type": "auto"} if thinking else {"type": "tool", "name": "generate_sql"},
+            thinking=thinking,
             label=prompt_name,
             effort=feature_config.effort if feature_config else None,
             max_tokens=self.config.limits.max_output_tokens_per_request,
@@ -736,6 +743,7 @@ class GraphAgent(LLMFeature):
         response_body = json.dumps(
             {
                 "step_id": leaf.step_id,
+                "grounding": output.grounding,
                 "sql": output.sql,
                 "field_resolution": output.provenance.field_resolution
                 if output.provenance

--- a/packages/engine/src/dataraum/graphs/models.py
+++ b/packages/engine/src/dataraum/graphs/models.py
@@ -341,14 +341,26 @@ class ExtractGroundingOutput(BaseModel):
     (DAT-664: Sonnet 5 echoing `revenue` back as `revenue_extract` silently
     skipped snippet persistence).
 
-    Every field here has a named consumer (DAT-603 schema audit): `sql` executes
-    and persists as the snippet; `description` is the snippet's human line
-    (cockpit reuse KB, compose-path descriptions); `column_mappings` is the
-    graph-level hint the cockpit query agent reads; `assumptions` feed the
-    DAT-631 confidence gate + the answer UI; `provenance` feeds prior_context
-    (DAT-616) and the confidence gate. Add nothing without a consumer.
+    Every field here has a named consumer (DAT-603 schema audit), and the
+    consumer can be the MODEL ITSELF at generation time: `grounding` is emitted
+    FIRST, deliberately — it forces the model to commit to the served evidence
+    before writing SQL (field order is generation order). The original audit
+    cut the old `summary` field as "decorative" by counting only downstream
+    readers and missed this consumer class; don't repeat that. Downstream:
+    `sql` executes and persists as the snippet; `description` is the snippet's
+    human line (cockpit reuse KB, compose-path descriptions); `column_mappings`
+    is the graph-level hint the cockpit query agent reads; `assumptions` feed
+    the DAT-631 confidence gate + the answer UI; `provenance` feeds
+    prior_context (DAT-616) and the confidence gate.
     """
 
+    grounding: str = Field(
+        description="FIRST, commit to the evidence: which column grounds the concept, and "
+        "the EXACT served values you selected from its Value set (or the complete "
+        "discriminator you filter on) — e.g. \"revenue via account_type = 'revenue' "
+        '(complete 5-value set)". Name the value-set entries verbatim; if you cannot, '
+        "the concept is not grounded — fall loud instead of writing SQL around it."
+    )
     sql: str = Field(
         description="The single standalone DuckDB SQL statement computing the concept, "
         "returning one row aliased AS value."

--- a/packages/engine/src/dataraum/graphs/models.py
+++ b/packages/engine/src/dataraum/graphs/models.py
@@ -301,18 +301,6 @@ class GraphExecution:
 # =============================================================================
 
 
-class SQLStepOutput(BaseModel):
-    """Pydantic model for a SQL step in LLM tool output."""
-
-    step_id: str = Field(description="Identifier for this step")
-    sql: str = Field(
-        description="Standalone DuckDB SQL query for this step. "
-        "Executed as: CREATE TEMP VIEW {step_id} AS {this_sql}. "
-        "Should return a single scalar value or simple row."
-    )
-    description: str = Field(description="What this step does")
-
-
 class GraphAssumptionOutput(BaseModel):
     """An assumption made during graph SQL generation."""
 
@@ -338,31 +326,36 @@ class GraphProvenanceOutput(BaseModel):
         default_factory=dict,
         description="Per-concept grounding: {concept: {column, filter, resolution}}",
     )
-    llm_reasoning: str = Field(
-        default="",
-        description="Brief explanation of how business concepts were mapped to columns",
-    )
+    # No free-text reasoning field: the former `llm_reasoning` was written into the
+    # snippet provenance blob and read by nothing (DAT-603 consumer audit) — output
+    # tokens are serial-decode latency, so an unread sentence per call is pure cost.
 
 
-class GraphSQLGenerationOutput(BaseModel):
-    """Pydantic model for LLM tool output - graph SQL generation.
+class ExtractGroundingOutput(BaseModel):
+    """LLM tool output for grounding ONE extract leaf to SQL (DAT-603).
 
-    Used as a tool definition for structured LLM output via tool use API.
+    The authoring path grounds exactly one EXTRACT per call (DAT-646), so the
+    output is one SQL statement — not the retired full-graph shape (steps[] with
+    model-chosen step_ids + final_sql). The caller binds the SQL to the graph's
+    own leaf id, which structurally removes the step-id-paraphrase failure class
+    (DAT-664: Sonnet 5 echoing `revenue` back as `revenue_extract` silently
+    skipped snippet persistence).
+
+    Every field here has a named consumer (DAT-603 schema audit): `sql` executes
+    and persists as the snippet; `description` is the snippet's human line
+    (cockpit reuse KB, compose-path descriptions); `column_mappings` is the
+    graph-level hint the cockpit query agent reads; `assumptions` feed the
+    DAT-631 confidence gate + the answer UI; `provenance` feeds prior_context
+    (DAT-616) and the confidence gate. Add nothing without a consumer.
     """
 
-    summary: str = Field(
-        description="One sentence describing what this query calculates in plain English, "
-        "e.g., 'Calculates Days Sales Outstanding (DSO) by dividing accounts receivable "
-        "by average daily sales over the period.'"
+    sql: str = Field(
+        description="The single standalone DuckDB SQL statement computing the concept, "
+        "returning one row aliased AS value."
     )
-    steps: list[SQLStepOutput] = Field(
-        default_factory=list,
-        description="List of SQL steps, each with step_id, sql, and description",
-    )
-    final_sql: str = Field(
-        description="SQL that combines step results to produce the final output. "
-        "Steps are available as temp views — reference via: "
-        "SELECT (SELECT value FROM step_1) / (SELECT value FROM step_2)."
+    description: str = Field(
+        description="One short line: what this extract computes and how it is filtered, "
+        "e.g. 'Total revenue: SUM(amount) where account_type IN (Revenue)'."
     )
     column_mappings: dict[str, str] = Field(
         default_factory=dict,
@@ -374,5 +367,5 @@ class GraphSQLGenerationOutput(BaseModel):
     )
     provenance: GraphProvenanceOutput | None = Field(
         default=None,
-        description="How business concepts were grounded to concrete columns",
+        description="How the concept was grounded to concrete columns",
     )

--- a/packages/engine/src/dataraum/llm/config.py
+++ b/packages/engine/src/dataraum/llm/config.py
@@ -38,7 +38,16 @@ class FeatureConfig(BaseModel):
 
 
 class LLMFeatures(BaseModel):
-    """All LLM features configuration."""
+    """All LLM features configuration.
+
+    Every feature key in ``llm/config.yaml`` MUST be declared here. Extras are
+    FORBIDDEN because the silent alternative already bit us (DAT-603): pydantic's
+    default drops unknown keys, so a YAML-only feature (``sql_repair`` for months)
+    parses cleanly, ``config.features.<name>`` comes back None, and the feature is
+    disabled without a trace. A typo'd or unregistered key now fails loud at boot.
+    """
+
+    model_config = ConfigDict(extra="forbid")
 
     # Active features with implementations
     semantic_analysis: FeatureConfig
@@ -49,6 +58,12 @@ class LLMFeatures(BaseModel):
     entropy_query_interpretation: FeatureConfig | None = None
     enrichment_analysis: FeatureConfig | None = None
     why_analysis: FeatureConfig | None = None
+    # Metric grounding (GraphAgent._generate_sql) — tier + effort for the
+    # pipeline's most central agent (DAT-603). None keeps the built-in defaults
+    # (balanced tier, API-default effort).
+    graph_sql_generation: FeatureConfig | None = None
+    # LLM repair of failed step SQL (GraphAgent._repair_sql).
+    sql_repair: FeatureConfig | None = None
 
 
 class LLMLimits(BaseModel):

--- a/packages/engine/src/dataraum/llm/config.py
+++ b/packages/engine/src/dataraum/llm/config.py
@@ -33,8 +33,15 @@ class FeatureConfig(BaseModel):
     enabled: bool = True
     model_tier: str = "balanced"
     # Output effort for this feature's calls (DAT-603). "low" suits mechanical
-    # extraction (shorter output, lower latency); None = API default (high).
+    # extraction (shorter output, lower latency); None = API default. On a
+    # thinking-enabled feature, effort also governs thinking depth.
     effort: str | None = None
+    # Adaptive thinking for this feature's calls (DAT-603). Default False: the
+    # mechanical extractors run thinking-off. A reasoning-heavy feature (metric
+    # grounding) sets true — the model reflects before committing, which is the
+    # quality lever now that Sonnet 5-class models expose no sampling knobs.
+    # Requires the call site to use a non-forced tool_choice (API constraint).
+    thinking: bool = False
 
 
 class LLMFeatures(BaseModel):

--- a/packages/engine/src/dataraum/llm/providers/anthropic.py
+++ b/packages/engine/src/dataraum/llm/providers/anthropic.py
@@ -298,6 +298,15 @@ class AnthropicProvider(LLMProvider):
         Returns:
             Result containing ConversationResponse or error message
         """
+        # Request-shape validation BEFORE the API error domain: thinking with a
+        # forced tool_choice is a call-site programming error (the API rejects
+        # the combination), not a provider failure to classify for retry.
+        if request.thinking and (request.tool_choice or {}).get("type") in ("tool", "any"):
+            raise ValueError(
+                "thinking=True is incompatible with a forced tool_choice "
+                f"({request.tool_choice}); use auto/none and mandate the "
+                "tool call in the prompt"
+            )
         try:
             model = request.model or self.config.default_model
 
@@ -330,13 +339,15 @@ class AnthropicProvider(LLMProvider):
             }
 
             # Sonnet 5 / Opus 4.7-4.8 / Fable 5 reject a non-default temperature
-            # (400) and default adaptive thinking ON; a forced-tool extractor
-            # wants neither. Omit temperature on those; pass it through on the
-            # older models that still honour it. Explicitly disable thinking
-            # where the model defaults it on (parity with Sonnet 4.6). See the
-            # capability notes above.
+            # (400) and default adaptive thinking ON. Omit temperature on those;
+            # pass it through on the older models that still honour it. Thinking
+            # is per-REQUEST (DAT-603): the mechanical extractors run with it
+            # explicitly disabled (output budget + Sonnet 4.6 parity), while a
+            # reasoning-heavy feature (metric grounding) opts in by LEAVING the
+            # adaptive default on. (thinking + forced tool_choice is rejected at
+            # the top of converse — request-shape error, not an API failure.)
             if _rejects_temperature(model):
-                if _thinking_defaults_on(model):
+                if _thinking_defaults_on(model) and not request.thinking:
                     kwargs["thinking"] = {"type": "disabled"}
             else:
                 kwargs["temperature"] = request.temperature

--- a/packages/engine/src/dataraum/llm/providers/base.py
+++ b/packages/engine/src/dataraum/llm/providers/base.py
@@ -117,6 +117,12 @@ class ConversationRequest(BaseModel):
     # | "max". None = the API default. The provider only sends it to models
     # that support the parameter.
     effort: str | None = None
+    # Let the model THINK (DAT-603): on thinking-default-on models (Sonnet 5 …)
+    # the provider normally disables adaptive thinking for the forced-tool
+    # extraction tier; a reasoning-heavy feature (metric grounding) opts back
+    # in. Thinking is API-incompatible with a FORCED tool_choice ("tool"/"any")
+    # — a thinking request must use auto/none and mandate the call via prompt.
+    thinking: bool = False
     # Greppable agent/phase tag for per-call telemetry (DAT-600). The provider
     # has no phase context of its own, so each call site stamps the prompt
     # template / feature name it is invoking (e.g. "graph_sql_generation").

--- a/packages/engine/tests/integration/analysis/validation/test_agent.py
+++ b/packages/engine/tests/integration/analysis/validation/test_agent.py
@@ -182,7 +182,6 @@ class TestValidationAgentGenerateSQL:
         # Mock LLM response with tool call
         tool_input = {
             "sql": "SELECT SUM(debit) as total_debits, SUM(credit) as total_credits FROM typed_transactions",
-            "explanation": "Sums debit and credit columns",
             "columns_used": ["debit", "credit"],
             "tables_used": ["typed_transactions"],
             "can_validate": True,
@@ -217,7 +216,6 @@ class TestValidationAgentGenerateSQL:
             _make_tool_response(
                 {
                     "sql": "SELECT 1 AS x",
-                    "explanation": "e",
                     "columns_used": [],
                     "tables_used": [],
                     "can_validate": True,
@@ -253,7 +251,6 @@ class TestValidationAgentGenerateSQL:
         # Mock LLM response indicating cannot validate
         tool_input = {
             "sql": None,
-            "explanation": "No debit/credit columns found",
             "columns_used": [],
             "tables_used": [],
             "can_validate": False,
@@ -343,7 +340,6 @@ class TestValidationAgentGenerateSQL:
 
         tool_input = {
             "sql": None,
-            "explanation": "confused response",
             "columns_used": [],
             "can_validate": True,
             "skip_reason": None,
@@ -391,7 +387,6 @@ class TestValidationAgentBindExecute:
         # balanced (debits == credits) so deviation = 0 → PASSED.
         tool_input = {
             "sql": "SELECT ABS(SUM(debit) - SUM(credit)) AS deviation, GREATEST(ABS(SUM(debit)), ABS(SUM(credit))) AS magnitude FROM typed_journal_entries",
-            "explanation": "Net debit/credit deviation and its scale",
             "columns_used": ["journal_entries.debit", "journal_entries.credit"],
             "tables_used": ["journal_entries"],
             "can_validate": True,
@@ -438,7 +433,6 @@ class TestValidationAgentBindExecute:
         # Mock LLM to indicate cannot validate
         tool_input = {
             "sql": None,
-            "explanation": "Required columns not found",
             "columns_used": [],
             "tables_used": [],
             "can_validate": False,
@@ -483,7 +477,6 @@ class TestValidationAgentBindExecute:
 
         tool_input = {
             "sql": "SELECT SUM(debit) AS total_debits FROM typed_table_not_in_lake",
-            "explanation": "Sums debits from a table that does not exist",
             "columns_used": ["debit"],
             "can_validate": True,
             "skip_reason": None,
@@ -523,7 +516,6 @@ class TestValidationAgentBindExecute:
 
         tool_input = {
             "sql": "SELECT 5 AS po_count, 3 AS invoice_count FROM typed_journal_entries LIMIT 1",
-            "explanation": "Counts without a judgeable comparison column",
             "columns_used": [],
             "can_validate": True,
             "skip_reason": None,

--- a/packages/engine/tests/integration/graphs/test_agent.py
+++ b/packages/engine/tests/integration/graphs/test_agent.py
@@ -264,6 +264,7 @@ class TestGraphAgentIntegration:
         mock_tool_call = MagicMock()
         mock_tool_call.name = "generate_sql"  # Set as attribute, not constructor kwarg
         mock_tool_call.input = {
+            "grounding": "test grounding: served values verified",
             "sql": "SELECT SUM(amount) AS value FROM test_data",
             "description": "Sum amounts",
             "column_mappings": {"amount": "amount"},
@@ -301,6 +302,7 @@ def _agent_with_sql(sql: str, description: str = "test") -> GraphAgent:
     tool_call = MagicMock()
     tool_call.name = "generate_sql"
     tool_call.input = {
+        "grounding": "test grounding: served values verified",
         "sql": sql,
         "description": description,
         "column_mappings": {"amount": "amount"},
@@ -829,6 +831,7 @@ class TestGraphAgentSnippets:
         mock_tool_call = MagicMock()
         mock_tool_call.name = "generate_sql"
         mock_tool_call.input = {
+            "grounding": "test grounding: served values verified",
             "sql": "SELECT SUM(amount) AS value FROM test_data",
             "description": "Sum amounts from test data",
             "column_mappings": {"amount": "amount"},
@@ -1037,6 +1040,7 @@ class TestGraphAgentSnippets:
         mock_tool_call = MagicMock()
         mock_tool_call.name = "generate_sql"
         mock_tool_call.input = {
+            "grounding": "test grounding: served values verified",
             "sql": "SELECT SUM(amount) AS value FROM test_data",
             "description": "Sum amounts from test data",
             "column_mappings": {"amount": "amount"},

--- a/packages/engine/tests/integration/graphs/test_agent.py
+++ b/packages/engine/tests/integration/graphs/test_agent.py
@@ -246,6 +246,9 @@ class TestGraphAgentIntegration:
         mock_config = MagicMock()
         mock_config.limits.max_output_tokens_per_request = 4000
         mock_config.limits.cache_ttl_seconds = 3600
+        # Real value, never a bare MagicMock — a mock would leak a mock `effort`
+        # into ConversationRequest (pydantic rejects it loudly).
+        mock_config.features.graph_sql_generation = None
 
         mock_renderer = MagicMock()
         mock_renderer.render_split.return_value = ("System prompt", "Test prompt", 0.0)
@@ -256,19 +259,13 @@ class TestGraphAgentIntegration:
             prompt_renderer=mock_renderer,
         )
 
-        # Mock the LLM converse call with tool response
+        # Mock the LLM converse call with tool response (single-extract shape,
+        # DAT-603 — the step id is bound by the agent, not named by the model).
         mock_tool_call = MagicMock()
         mock_tool_call.name = "generate_sql"  # Set as attribute, not constructor kwarg
         mock_tool_call.input = {
-            "summary": "Calculates the sum of all amounts in the test data.",
-            "steps": [
-                {
-                    "step_id": "sum",
-                    "sql": "SELECT SUM(amount) FROM test_data",
-                    "description": "Sum amounts",
-                }
-            ],
-            "final_sql": "SELECT SUM(amount) AS total FROM test_data",
+            "sql": "SELECT SUM(amount) AS value FROM test_data",
+            "description": "Sum amounts",
             "column_mappings": {"amount": "amount"},
         }
 
@@ -289,11 +286,12 @@ class TestGraphAgentIntegration:
         assert execution.output_value == 600.0  # Sum of 100 + 200 + 300
 
 
-def _agent_with_sql(steps: list[dict[str, str]], final_sql: str) -> GraphAgent:
-    """A GraphAgent whose mocked LLM emits the given steps + final SQL."""
+def _agent_with_sql(sql: str, description: str = "test") -> GraphAgent:
+    """A GraphAgent whose mocked LLM emits the given extract SQL (DAT-603 shape)."""
     mock_config = MagicMock()
     mock_config.limits.max_output_tokens_per_request = 4000
     mock_config.limits.cache_ttl_seconds = 3600
+    mock_config.features.graph_sql_generation = None
     mock_renderer = MagicMock()
     mock_renderer.render_split.return_value = ("System prompt", "Test prompt", 0.0)
 
@@ -303,9 +301,8 @@ def _agent_with_sql(steps: list[dict[str, str]], final_sql: str) -> GraphAgent:
     tool_call = MagicMock()
     tool_call.name = "generate_sql"
     tool_call.input = {
-        "summary": "test",
-        "steps": steps,
-        "final_sql": final_sql,
+        "sql": sql,
+        "description": description,
         "column_mappings": {"amount": "amount"},
     }
     response = MagicMock()
@@ -335,14 +332,8 @@ class TestGraphAgentVerifier:
         from dataraum.query.snippet_models import SQLSnippetRecord
 
         agent = _agent_with_sql(
-            steps=[
-                {
-                    "step_id": "value",
-                    "sql": "SELECT SUM(amount) AS value FROM test_data WHERE id = 999",
-                    "description": "empty filter",
-                }
-            ],
-            final_sql="SELECT * FROM value",
+            "SELECT SUM(amount) AS value FROM test_data WHERE id = 999",
+            description="empty filter",
         )
         context = _make_execution_context(duckdb_with_data)
 
@@ -363,14 +354,8 @@ class TestGraphAgentVerifier:
         `id = 1` matches a row; `amount * 0` sums to a real 0 — support exists, so
         the metric is executed with value 0, not rejected as degenerate."""
         agent = _agent_with_sql(
-            steps=[
-                {
-                    "step_id": "value",
-                    "sql": "SELECT SUM(amount * 0) AS value FROM test_data WHERE id = 1",
-                    "description": "genuine zero with support",
-                }
-            ],
-            final_sql="SELECT * FROM value",
+            "SELECT SUM(amount * 0) AS value FROM test_data WHERE id = 1",
+            description="genuine zero with support",
         )
         context = _make_execution_context(duckdb_with_data)
 
@@ -828,6 +813,7 @@ class TestGraphAgentSnippets:
         mock_config = MagicMock()
         mock_config.limits.max_output_tokens_per_request = 4000
         mock_config.limits.cache_ttl_seconds = 3600
+        mock_config.features.graph_sql_generation = None
 
         mock_renderer = MagicMock()
         mock_renderer.render_split.return_value = ("System prompt", "Test prompt", 0.0)
@@ -838,19 +824,13 @@ class TestGraphAgentSnippets:
             prompt_renderer=mock_renderer,
         )
 
-        # Mock LLM response with step matching the graph's "value" extract step
+        # Mock LLM response (single-extract shape — the agent binds the SQL to
+        # the graph's "value" leaf itself, DAT-603).
         mock_tool_call = MagicMock()
         mock_tool_call.name = "generate_sql"
         mock_tool_call.input = {
-            "summary": "Extracts sum of amounts.",
-            "steps": [
-                {
-                    "step_id": "value",
-                    "sql": "SELECT SUM(amount) AS value FROM test_data",
-                    "description": "Sum amounts from test data",
-                }
-            ],
-            "final_sql": "SELECT * FROM value",
+            "sql": "SELECT SUM(amount) AS value FROM test_data",
+            "description": "Sum amounts from test data",
             "column_mappings": {"amount": "amount"},
         }
 
@@ -1042,6 +1022,7 @@ class TestGraphAgentSnippets:
         mock_config = MagicMock()
         mock_config.limits.max_output_tokens_per_request = 4000
         mock_config.limits.cache_ttl_seconds = 3600
+        mock_config.features.graph_sql_generation = None
 
         mock_renderer = MagicMock()
         mock_renderer.render_split.return_value = ("System prompt", "Test prompt", 0.0)
@@ -1052,19 +1033,12 @@ class TestGraphAgentSnippets:
             prompt_renderer=mock_renderer,
         )
 
-        # Mock LLM response
+        # Mock LLM response (single-extract shape, DAT-603)
         mock_tool_call = MagicMock()
         mock_tool_call.name = "generate_sql"
         mock_tool_call.input = {
-            "summary": "Extracts sum of amounts.",
-            "steps": [
-                {
-                    "step_id": "value",
-                    "sql": "SELECT SUM(amount) AS value FROM test_data",
-                    "description": "Sum amounts from test data",
-                }
-            ],
-            "final_sql": "SELECT * FROM value",
+            "sql": "SELECT SUM(amount) AS value FROM test_data",
+            "description": "Sum amounts from test data",
             "column_mappings": {"amount": "amount"},
         }
 

--- a/packages/engine/tests/unit/graphs/test_assemble.py
+++ b/packages/engine/tests/unit/graphs/test_assemble.py
@@ -111,13 +111,13 @@ def test_assemble_fails_when_grounded_but_absent_from_cache() -> None:
     provider.converse.assert_not_called()
 
 
-class TestSaveSnippetsStepIdRebind:
-    """_save_snippets must tolerate the model renaming its single step
-    (Sonnet 5 echoes `revenue` back as `revenue_extract` — 2026-07-02): the
-    authoring path grounds exactly ONE extract leaf (DAT-646), so an
-    unambiguous one-leaf/one-step pair binds positionally. Without the rebind
-    the snippet silently never persists, assembly finds an empty cache, and
-    every metric composed from the leaf dies 'absent from the snippet cache'."""
+class TestSaveSnippetsCallerAssignedIds:
+    """Step ids in GeneratedCode are assigned by OUR code since DAT-603 —
+    authoring binds the graph's leaf id, compose copies graph ids — so
+    _save_snippets' name-keyed lookup always hits. (The DAT-664 positional
+    rebind for model-paraphrased ids was deleted with the single-extract output
+    model; the model no longer names steps at all.) A mismatch can now only
+    mean an internal regression, which must skip LOUD, never silently."""
 
     def _generated(self, step_id: str) -> MagicMock:
         code = MagicMock()
@@ -143,28 +143,15 @@ class TestSaveSnippetsStepIdRebind:
             )
             return lib_cls.return_value
 
-    def test_renamed_single_step_is_rebound_and_saved(self) -> None:
-        rev = _extract("revenue", "revenue")
-        graph = _graph("revenue_only", {"revenue": rev})
-        library = self._save(graph, self._generated("revenue_extract"))
-        library.save_snippet.assert_called_once()
-        assert library.save_snippet.call_args.kwargs["standard_field"] == "revenue"
-
-    def test_exact_echo_still_saves(self) -> None:
+    def test_leaf_id_saves(self) -> None:
         rev = _extract("revenue", "revenue")
         graph = _graph("revenue_only", {"revenue": rev})
         library = self._save(graph, self._generated("revenue"))
         library.save_snippet.assert_called_once()
+        assert library.save_snippet.call_args.kwargs["standard_field"] == "revenue"
 
-    def test_ambiguous_multi_step_drift_skips_loud(self) -> None:
-        # Two generated steps for one leaf: no unambiguous positional bind —
-        # nothing saved (the loud warning path), never a wrong-SQL snippet.
+    def test_mismatched_id_skips_loud_never_saves_wrong_sql(self) -> None:
         rev = _extract("revenue", "revenue")
         graph = _graph("revenue_only", {"revenue": rev})
-        code = self._generated("revenue_extract")
-        code.steps = [
-            {"step_id": "a", "sql": "SELECT 1", "description": ""},
-            {"step_id": "b", "sql": "SELECT 2", "description": ""},
-        ]
-        library = self._save(graph, code)
+        library = self._save(graph, self._generated("someone_elses_id"))
         library.save_snippet.assert_not_called()

--- a/packages/engine/tests/unit/graphs/test_prompt_selection.py
+++ b/packages/engine/tests/unit/graphs/test_prompt_selection.py
@@ -35,12 +35,19 @@ def _graph(graph_id: str, steps: dict[str, GraphStep]) -> TransformationGraph:
     )
 
 
-def _agent_with(renderer: MagicMock, provider: MagicMock) -> GraphAgent:
+def _agent_with(
+    renderer: MagicMock,
+    provider: MagicMock,
+    feature_config: object | None = None,
+) -> GraphAgent:
     agent = GraphAgent.__new__(GraphAgent)
     agent.renderer = renderer  # type: ignore[attr-defined]
     agent.provider = provider  # type: ignore[attr-defined]
     config = MagicMock()
     config.limits.max_output_tokens_per_request = 4000
+    # A real value (or None), never a bare MagicMock — a mock here would leak a
+    # mock `effort`/`model_tier` into ConversationRequest (the PR #432 lesson).
+    config.features.graph_sql_generation = feature_config
     agent.config = config  # type: ignore[attr-defined]
     return agent
 
@@ -86,3 +93,118 @@ def test_extract_node_uses_the_grounding_prompt_on_balanced_tier(monkeypatch) ->
     assert prompt_ctx["rich_context"] == "META" and prompt_ctx["field_mappings"] == "MAPS"
     # DAT-645: the vertical's conventions are piped verbatim into the prompt context.
     assert prompt_ctx["vertical_conventions"] == "CREDIT-NORMAL → credit - debit"
+    # No feature-config entry → API-default effort (None), never a leaked mock.
+    request = provider.converse.call_args.args[0]
+    assert request.effort is None
+
+
+def test_feature_config_sets_tier_and_effort(monkeypatch) -> None:
+    """DAT-603: the graph_sql_generation feature entry reaches the request."""
+    from dataraum.llm.config import FeatureConfig
+
+    monkeypatch.setattr("dataraum.graphs.context.format_metadata_document", lambda c: "META")
+    monkeypatch.setattr(
+        "dataraum.graphs.field_mapping.format_mappings_for_prompt", lambda f: "MAPS"
+    )
+    ext = GraphStep(
+        step_id="revenue",
+        step_type=StepType.EXTRACT,
+        source=StepSource(standard_field="revenue", statement="income_statement"),
+        aggregation="sum",
+        output_step=True,
+    )
+    graph = _graph("revenue", {"revenue": ext})
+    renderer, provider = _mocks()
+    agent = _agent_with(
+        renderer, provider, feature_config=FeatureConfig(model_tier="fast", effort="low")
+    )
+    agent._build_schema_info = MagicMock(return_value={})  # type: ignore[method-assign]
+    agent._build_prior_context = MagicMock(return_value="")  # type: ignore[method-assign]
+    rich = MagicMock()
+    rich.field_mappings.mappings = {"revenue": object()}
+    rich.conventions = ""
+    ctx = ExecutionContext(duckdb_conn=MagicMock(), schema_mapping_id="ws", rich_context=rich)
+
+    agent._generate_sql(MagicMock(), graph, ctx, {})
+
+    provider.get_model_for_tier.assert_called_with("fast")
+    request = provider.converse.call_args.args[0]
+    assert request.effort == "low"
+
+
+def test_multi_step_graph_fails_loud_before_any_llm_call() -> None:
+    """DAT-603: authoring takes a single-extract mini-graph ONLY — the full-graph
+    authoring path is retired (metrics are assembled from the binding map)."""
+    ext_a = GraphStep(
+        step_id="revenue",
+        step_type=StepType.EXTRACT,
+        source=StepSource(standard_field="revenue", statement="income_statement"),
+        aggregation="sum",
+    )
+    ext_b = GraphStep(
+        step_id="cogs",
+        step_type=StepType.EXTRACT,
+        source=StepSource(standard_field="cost_of_goods_sold", statement="income_statement"),
+        aggregation="sum",
+        output_step=True,
+    )
+    graph = _graph("gross_profit", {"revenue": ext_a, "cogs": ext_b})
+    renderer, provider = _mocks()
+    agent = _agent_with(renderer, provider)
+    ctx = ExecutionContext(duckdb_conn=MagicMock(), schema_mapping_id="ws")
+
+    result = agent._generate_sql(MagicMock(), graph, ctx, {})
+
+    assert result.success is False
+    assert "single-extract mini-graph" in (result.error or "")
+    provider.converse.assert_not_called()
+
+
+def test_generated_sql_binds_to_the_graphs_own_leaf_id(monkeypatch) -> None:
+    """DAT-603: the model returns bare sql + description; THIS code binds it to
+    the leaf's step_id — the DAT-664 id-paraphrase class is gone by construction."""
+    monkeypatch.setattr("dataraum.graphs.context.format_metadata_document", lambda c: "META")
+    monkeypatch.setattr(
+        "dataraum.graphs.field_mapping.format_mappings_for_prompt", lambda f: "MAPS"
+    )
+    ext = GraphStep(
+        step_id="accounts_receivable",
+        step_type=StepType.EXTRACT,
+        source=StepSource(standard_field="accounts_receivable", statement="balance_sheet"),
+        aggregation="end_of_period",
+        output_step=True,
+    )
+    graph = _graph("accounts_receivable", {"accounts_receivable": ext})
+    renderer, provider = _mocks()
+    tool_call = MagicMock()
+    tool_call.name = "generate_sql"
+    tool_call.input = {
+        "sql": "SELECT SUM(amount) AS value FROM enriched_gl",
+        "description": "AR at latest period",
+        "column_mappings": {"accounts_receivable": "enriched_gl.amount"},
+        "assumptions": [],
+        "provenance": None,
+    }
+    provider.converse.return_value.unwrap.return_value = MagicMock(tool_calls=[tool_call])
+    agent = _agent_with(renderer, provider)
+    agent._build_schema_info = MagicMock(return_value={})  # type: ignore[method-assign]
+    agent._build_prior_context = MagicMock(return_value="")  # type: ignore[method-assign]
+    rich = MagicMock()
+    rich.field_mappings.mappings = {"accounts_receivable": object()}
+    rich.conventions = ""
+    ctx = ExecutionContext(duckdb_conn=MagicMock(), schema_mapping_id="ws", rich_context=rich)
+
+    result = agent._generate_sql(MagicMock(), graph, ctx, {})
+
+    assert result.success is True
+    code = result.value
+    assert code is not None
+    assert code.steps == [
+        {
+            "step_id": "accounts_receivable",
+            "sql": "SELECT SUM(amount) AS value FROM enriched_gl",
+            "description": "AR at latest period",
+        }
+    ]
+    assert code.final_sql == "SELECT * FROM accounts_receivable"
+    assert code.summary == "AR at latest period"

--- a/packages/engine/tests/unit/graphs/test_prompt_selection.py
+++ b/packages/engine/tests/unit/graphs/test_prompt_selection.py
@@ -130,6 +130,42 @@ def test_feature_config_sets_tier_and_effort(monkeypatch) -> None:
     provider.get_model_for_tier.assert_called_with("fast")
     request = provider.converse.call_args.args[0]
     assert request.effort == "low"
+    # thinking not set on the feature → forced tool_choice, thinking off.
+    assert request.thinking is False
+    assert request.tool_choice == {"type": "tool", "name": "generate_sql"}
+
+
+def test_thinking_feature_uses_auto_tool_choice(monkeypatch) -> None:
+    """DAT-603: thinking is API-incompatible with a forced tool_choice — a
+    thinking feature offers the tool on auto and the prompt mandates the call."""
+    from dataraum.llm.config import FeatureConfig
+
+    monkeypatch.setattr("dataraum.graphs.context.format_metadata_document", lambda c: "META")
+    monkeypatch.setattr(
+        "dataraum.graphs.field_mapping.format_mappings_for_prompt", lambda f: "MAPS"
+    )
+    ext = GraphStep(
+        step_id="revenue",
+        step_type=StepType.EXTRACT,
+        source=StepSource(standard_field="revenue", statement="income_statement"),
+        aggregation="sum",
+        output_step=True,
+    )
+    graph = _graph("revenue", {"revenue": ext})
+    renderer, provider = _mocks()
+    agent = _agent_with(renderer, provider, feature_config=FeatureConfig(thinking=True))
+    agent._build_schema_info = MagicMock(return_value={})  # type: ignore[method-assign]
+    agent._build_prior_context = MagicMock(return_value="")  # type: ignore[method-assign]
+    rich = MagicMock()
+    rich.field_mappings.mappings = {"revenue": object()}
+    rich.conventions = ""
+    ctx = ExecutionContext(duckdb_conn=MagicMock(), schema_mapping_id="ws", rich_context=rich)
+
+    agent._generate_sql(MagicMock(), graph, ctx, {})
+
+    request = provider.converse.call_args.args[0]
+    assert request.thinking is True
+    assert request.tool_choice == {"type": "auto"}
 
 
 def test_multi_step_graph_fails_loud_before_any_llm_call() -> None:
@@ -179,6 +215,7 @@ def test_generated_sql_binds_to_the_graphs_own_leaf_id(monkeypatch) -> None:
     tool_call = MagicMock()
     tool_call.name = "generate_sql"
     tool_call.input = {
+        "grounding": "accounts_receivable via account_id__name IN ('Accounts Receivable')",
         "sql": "SELECT SUM(amount) AS value FROM enriched_gl",
         "description": "AR at latest period",
         "column_mappings": {"accounts_receivable": "enriched_gl.amount"},

--- a/packages/engine/tests/unit/llm/test_anthropic_provider.py
+++ b/packages/engine/tests/unit/llm/test_anthropic_provider.py
@@ -204,7 +204,9 @@ class TestConverseRequestShape:
     that let the Sonnet 5 swap ship a request that 400s against the live API.
     """
 
-    def _capture(self, monkeypatch: pytest.MonkeyPatch, model: str) -> dict[str, object]:
+    def _capture(
+        self, monkeypatch: pytest.MonkeyPatch, model: str, *, thinking: bool = False
+    ) -> dict[str, object]:
         provider = _provider()
         captured: dict[str, object] = {}
 
@@ -215,7 +217,10 @@ class TestConverseRequestShape:
         _patch_stream(monkeypatch, provider, capture)
         provider.converse(
             ConversationRequest(
-                messages=[Message(role="user", content="hi")], temperature=0.0, model=model
+                messages=[Message(role="user", content="hi")],
+                temperature=0.0,
+                model=model,
+                thinking=thinking,
             )
         ).unwrap()
         return captured
@@ -250,6 +255,33 @@ class TestConverseRequestShape:
         kwargs = self._capture(monkeypatch, "claude-haiku-4-5")
         assert kwargs["temperature"] == 0.0
         assert "thinking" not in kwargs
+
+    def test_thinking_request_leaves_adaptive_default_on(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # DAT-603: a thinking feature (metric grounding) opts back into the
+        # model's adaptive default — no explicit thinking key at all.
+        kwargs = self._capture(monkeypatch, "claude-sonnet-5", thinking=True)
+        assert "temperature" not in kwargs
+        assert "thinking" not in kwargs
+
+    def test_thinking_with_forced_tool_choice_fails_loud(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The API rejects thinking + forced tool_choice; that shape is a
+        # call-site programming error, surfaced as ValueError, never a 400
+        # dressed up as a transient provider failure.
+        provider = _provider()
+        _patch_stream(monkeypatch, provider, lambda **kwargs: _ok_response())
+        with pytest.raises(ValueError, match="forced tool_choice"):
+            provider.converse(
+                ConversationRequest(
+                    messages=[Message(role="user", content="hi")],
+                    model="claude-sonnet-5",
+                    thinking=True,
+                    tool_choice={"type": "tool", "name": "generate_sql"},
+                )
+            )
 
 
 class TestConverseTelemetry:

--- a/packages/engine/tests/unit/llm/test_config.py
+++ b/packages/engine/tests/unit/llm/test_config.py
@@ -1,6 +1,9 @@
 """Tests for LLM config model, especially extra fields."""
 
-from dataraum.llm.config import FeatureConfig
+import pytest
+from pydantic import ValidationError
+
+from dataraum.llm.config import FeatureConfig, LLMFeatures
 
 
 class TestFeatureConfigExtra:
@@ -27,3 +30,30 @@ class TestFeatureConfigExtra:
         cfg = FeatureConfig()
         assert cfg.enabled is True
         assert cfg.model_tier == "balanced"
+
+
+class TestLLMFeaturesRegistration:
+    """Every YAML feature key must be a DECLARED LLMFeatures field (DAT-603).
+
+    Pydantic's default silently drops unknown keys — that made ``sql_repair``
+    (present in llm/config.yaml, never declared here) parse to None and disabled
+    the repair path without a trace. Unknown keys must fail loud instead.
+    """
+
+    def test_yaml_only_feature_fails_loud(self) -> None:
+        with pytest.raises(ValidationError, match="not_a_registered_feature"):
+            LLMFeatures(
+                semantic_analysis=FeatureConfig(),
+                not_a_registered_feature=FeatureConfig(),  # type: ignore[call-arg]
+            )
+
+    def test_sql_repair_and_graph_sql_generation_are_declared(self) -> None:
+        features = LLMFeatures(
+            semantic_analysis=FeatureConfig(),
+            sql_repair=FeatureConfig(model_tier="fast", max_repair_attempts=2),
+            graph_sql_generation=FeatureConfig(model_tier="balanced", effort="low"),
+        )
+        assert features.sql_repair is not None
+        assert features.sql_repair.enabled is True
+        assert features.graph_sql_generation is not None
+        assert features.graph_sql_generation.effort == "low"

--- a/packages/engine/tests/unit/query/test_snippet_library.py
+++ b/packages/engine/tests/unit/query/test_snippet_library.py
@@ -536,13 +536,13 @@ class TestSnippetLibraryFailedRetention:
     def test_success_heals_a_prior_failure(self, session):
         """A clean success on a previously-failed key clears the flag → reusable again."""
         library = SnippetLibrary(session, workspace_id=WORKSPACE_ID)
-        common = dict(
-            snippet_type="extract",
-            schema_mapping_id="s3",
-            standard_field="accounts_payable",
-            statement="balance_sheet",
-            aggregation="end_of_period",
-        )
+        common = {
+            "snippet_type": "extract",
+            "schema_mapping_id": "s3",
+            "standard_field": "accounts_payable",
+            "statement": "balance_sheet",
+            "aggregation": "end_of_period",
+        }
         library.save_snippet(
             sql="BAD",
             description="x",

--- a/packages/engine/tests/unit/query/test_snippet_provenance.py
+++ b/packages/engine/tests/unit/query/test_snippet_provenance.py
@@ -55,7 +55,6 @@ class TestSnippetProvenance:
             "column_mappings_basis": {
                 "revenue": {"column": "t.amount", "resolution": "inferred_from_enriched_view"}
             },
-            "llm_reasoning": "Mapped via account type filtering",
         }
 
         record = library.save_snippet(


### PR DESCRIPTION
## Summary

DAT-603 Half B — the output-token levers on the engine's extraction agents. Output tokens are serial decode (74–124 tok/s measured), so every unread field is wall-clock latency.

### 1. Single-extract output model (structural)

`GraphAgent._generate_sql` now accepts only a single-extract mini-graph (fails loud otherwise — the full-graph authoring path had zero callers; metrics are assembled from the binding map, DAT-646). The tool schema is the new `ExtractGroundingOutput`: **one `sql` + `description`** — no `steps[]`, no model-chosen `step_id`, no `final_sql`, no `summary`. The agent binds the SQL to the graph's own leaf id.

**This deletes the DAT-664 class by construction**: the model never names a step, so it can't paraphrase one. The positional rebind (`snippet_step_id_rebound`, PR #433) is removed as dead code; the loud `snippet_save_skipped` warning stays as a regression tripwire. Prompt `graph_sql_generation.yaml` → v6.0 to match.

### 2. Effort knob for the most central agent

`graph_sql_generation` gets a feature-config entry; tier + `effort` thread into the request (the Half A pattern, eighth site). `effort` is **deliberately unset** in config.yaml pending the A/B against the DAT-602 eval baseline — the knob is live, the value is data-gated, and config is bind-mounted so flipping it needs no rebuild.

### 3. Feature-registration fix (found during 2)

`LLMFeatures` silently **dropped** undeclared YAML features (pydantic default `extra='ignore'`): `sql_repair` has been in config.yaml but parsing to `None`, so `_repair_sql` returned "disabled" on every call — LLM SQL repair has been dead without a trace. `sql_repair` + `graph_sql_generation` are now declared fields and **extras are forbidden**, so an unregistered feature key fails loud at boot. Regression-tested.

### 4. Consumer-audited output-schema trim

Per-field consumer grep across the four big extraction labels (the AC's audit):

| Label | Field | Verdict | Consumer / evidence |
|---|---|---|---|
| graph_sql_generation | `summary`, `steps[].step_id`, `final_sql` | **cut** | structural (see 1) |
| graph_sql_generation | `provenance.llm_reasoning` | **cut** | written to snippet provenance blob, read by nothing (engine + cockpit grep) |
| graph_sql_generation | `description`, `column_mappings`, `assumptions`, `provenance.{field_resolution, column_mappings_basis}` | keep | snippet KB line / cockpit query-agent hint / DAT-631 gate + UI / DAT-616 prior_context |
| validation_sql | `explanation` | **cut** | dead end-to-end: `GeneratedSQL.explanation` never persisted, never read |
| validation_sql | `sql`, `columns_used`, `can_validate`, `skip_reason` | keep | execution / persisted + cross_table_consistency detector + cockpit verdict surfaces / skip mechanism |
| column_annotation | all fields | keep | context docs (graphs/cycles/slicing/validation resolver), stock/flow reconciliation, business_meaning detector |
| semantic_per_table | all fields | keep | metadata document + cockpit look-table (descriptions, time/identity notes), relationship evidence (reasoning), DAT-637 column_concepts |

The honest audit outcome: column_annotation's and semantic_per_table's cost is intrinsic (every field consumed) — their lever is effort (Half A, shipped). The dead fields were on the two SQL authors.

## Verification

- Unit: 1796 passed. Integration: 227 passed, 8 skipped (full tree). ruff + mypy + vulture green.
- New tests: single-extract gate fails loud before any LLM call; generated SQL binds to the graph's own leaf id; effort/tier from feature config reach the request (and a bare-mock config can't leak a mock effort — the PR #432 lesson); LLMFeatures forbids unregistered keys; caller-assigned-id save + loud-skip guard.
- Not yet measured (needs authorized LLM spend): per-label output-token deltas via DAT-600 telemetry, and the effort A/B for graph_sql_generation against the DAT-602 eval baseline. Proposed as the follow-up smoke on the ticket.

Also rides along: `tests/unit/query/test_snippet_library.py` C408 fix — ruff floated to 0.15.20 (deps unpinned by convention) and now flags a pre-existing `dict()` literal; CI will resolve the same version.

Closes the engine half of DAT-603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)