### PR TITLE
fix(DAT-663) + feat(DAT-661): telemetry riders — real usage on drain-aborted runs; tool-args coercion counters

### DIFF
--- a/packages/cockpit/src/charts/author-chart.ts
+++ b/packages/cockpit/src/charts/author-chart.ts
@@ -23,6 +23,7 @@ import { createAnthropicChat } from "@tanstack/ai-anthropic";
 import { config } from "#/config";
 import { linkedAbortController } from "#/lib/abort";
 import { llmTelemetryMiddleware } from "#/lib/llm-telemetry";
+import { toolArgsGuardMiddleware } from "#/lib/tool-args-guard";
 import { MAX_OUTPUT_TOKENS, MODEL } from "#/llm";
 import {
 	type ChartConfig,
@@ -105,7 +106,10 @@ const emitOnce: EmitFn = async (systemPrompts, messages, signal) => {
 	const abortController = linkedAbortController(signal);
 	const stream = await chat({
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
-		middleware: [llmTelemetryMiddleware("chart_author")],
+		middleware: [
+			llmTelemetryMiddleware("chart_author"),
+			toolArgsGuardMiddleware("chart_author"),
+		],
 		abortController,
 		modelOptions: {
 			max_tokens: MAX_OUTPUT_TOKENS,

--- a/packages/cockpit/src/lib/agent-turn.ts
+++ b/packages/cockpit/src/lib/agent-turn.ts
@@ -21,6 +21,7 @@ import {
 } from "#/db/cockpit/conversations";
 import { publish } from "#/lib/chat-bus";
 import { llmTelemetryMiddleware } from "#/lib/llm-telemetry";
+import { toolArgsGuardMiddleware } from "#/lib/tool-args-guard";
 import { AGENT_LOOP_MAX_ITERATIONS, MAX_OUTPUT_TOKENS, MODEL } from "#/llm";
 import { getInstructions } from "#/prompts";
 import { toolsByKind } from "#/tools/registry";
@@ -111,9 +112,14 @@ export function buildChatOptions(
 		messages,
 		tools: [...toolsByKind[kind]],
 		abortController,
-		// Per-turn LLM telemetry (DAT-600). Observe-only; tags this orchestrator
-		// turn distinctly from the nested `answer` sub-agent (tools/query.ts).
-		middleware: [llmTelemetryMiddleware("orchestrator")],
+		// Per-turn LLM telemetry (DAT-600) + the tool-args guard (DAT-661
+		// coercion/rejection counters). Same label so the lines correlate; tags
+		// this orchestrator turn distinctly from the nested `answer` sub-agent
+		// (tools/query.ts).
+		middleware: [
+			llmTelemetryMiddleware("orchestrator"),
+			toolArgsGuardMiddleware("orchestrator"),
+		],
 	};
 }
 

--- a/packages/cockpit/src/lib/llm-telemetry.test.ts
+++ b/packages/cockpit/src/lib/llm-telemetry.test.ts
@@ -1,7 +1,7 @@
 // Unit test for the DAT-600 LLM telemetry middleware. Drives the hooks with
 // synthetic SDK fixtures (no chat() / no network) and asserts the emitted
-// `llm_call` line — snake_case keys, terminal status, iteration count — mirrors
-// the engine half.
+// `llm_call` line — snake_case keys, terminal status, iteration count, and the
+// per-iteration usage ACCUMULATION (DAT-663) — mirrors the engine half.
 
 import type {
 	AbortInfo,
@@ -38,24 +38,42 @@ const usage = (over: Partial<UsageInfo>): UsageInfo =>
 afterEach(() => vi.restoreAllMocks());
 
 describe("llmTelemetryMiddleware", () => {
-	it("emits one finished llm_call with label, model, elapsed, mapped tokens, iterations", () => {
+	it("emits one finished llm_call with label, model, elapsed, iterations, and usage SUMMED over iterations", () => {
 		const info = vi.spyOn(console, "info").mockImplementation(() => {});
 		const mw = llmTelemetryMiddleware("answer_subagent");
 
-		// Three agent-loop iterations before the run finishes.
+		// Three agent-loop iterations, each reporting ITS OWN (incremental) usage —
+		// the SDK fires onUsage once per usage-bearing RUN_FINISHED.
 		mw.onIteration?.(ctx("claude-x"), iter(0));
+		mw.onUsage?.(
+			ctx("claude-x"),
+			usage({
+				promptTokens: 500,
+				completionTokens: 50,
+				promptTokensDetails: { cachedTokens: 400, cacheWriteTokens: 100 },
+			}),
+		);
 		mw.onIteration?.(ctx("claude-x"), iter(1));
+		mw.onUsage?.(
+			ctx("claude-x"),
+			usage({
+				promptTokens: 700,
+				completionTokens: 30,
+				promptTokensDetails: { cachedTokens: 600 },
+			}),
+		);
 		mw.onIteration?.(ctx("claude-x"), iter(2));
+		const lastIterationUsage = usage({
+			promptTokens: 800,
+			completionTokens: 20,
+			promptTokensDetails: { cachedTokens: 700, cacheWriteTokens: 10 },
+		});
+		mw.onUsage?.(ctx("claude-x"), lastIterationUsage);
+		// FinishInfo.usage is the LAST iteration's RUN_FINISHED usage (the SDK never
+		// sums) — the middleware must IGNORE it, or the final iteration double-counts.
 		mw.onFinish?.(
 			ctx("claude-x"),
-			finish({
-				duration: 4200.7,
-				usage: usage({
-					promptTokens: 512,
-					completionTokens: 64,
-					promptTokensDetails: { cachedTokens: 480, cacheWriteTokens: 32 },
-				}),
-			}),
+			finish({ duration: 4200.7, usage: lastIterationUsage }),
 		);
 
 		expect(info).toHaveBeenCalledTimes(1);
@@ -64,10 +82,10 @@ describe("llmTelemetryMiddleware", () => {
 			model: "claude-x",
 			status: "finished",
 			elapsed_ms: 4201, // rounded
-			input_tokens: 512,
-			output_tokens: 64,
-			cache_read_input_tokens: 480,
-			cache_creation_input_tokens: 32,
+			input_tokens: 2000,
+			output_tokens: 100,
+			cache_read_input_tokens: 1700,
+			cache_creation_input_tokens: 110,
 			iterations: 3,
 		});
 	});
@@ -76,7 +94,7 @@ describe("llmTelemetryMiddleware", () => {
 		const info = vi.spyOn(console, "info").mockImplementation(() => {});
 		const mw = llmTelemetryMiddleware("orchestrator");
 
-		// usage field absent on the finish info, and no iterations recorded.
+		// No onUsage ever fired, and no iterations recorded.
 		mw.onFinish?.(ctx("claude-y"), finish({ duration: 10, usage: undefined }));
 
 		expect(info).toHaveBeenCalledWith("llm_call", {
@@ -92,11 +110,26 @@ describe("llmTelemetryMiddleware", () => {
 		});
 	});
 
-	it("logs aborted runs with status + elapsed and zero tokens (frame induction aborts deliberately)", () => {
+	it("logs aborted runs with the usage accumulated up to the abort (DAT-663 drain-abort)", () => {
 		const info = vi.spyOn(console, "info").mockImplementation(() => {});
 		const mw = llmTelemetryMiddleware("frame_family");
 
+		// Two iterations report usage, then the caller drain-aborts (the forced
+		// tool fired) — the aborted row must carry the real accumulated spend.
 		mw.onIteration?.(ctx("claude-x"), iter(0));
+		mw.onUsage?.(
+			ctx("claude-x"),
+			usage({
+				promptTokens: 1200,
+				completionTokens: 40,
+				promptTokensDetails: { cachedTokens: 1000, cacheWriteTokens: 200 },
+			}),
+		);
+		mw.onIteration?.(ctx("claude-x"), iter(1));
+		mw.onUsage?.(
+			ctx("claude-x"),
+			usage({ promptTokens: 1300, completionTokens: 60 }),
+		);
 		mw.onAbort?.(ctx("claude-x"), {
 			reason: "captured",
 			duration: 87.4,
@@ -107,19 +140,23 @@ describe("llmTelemetryMiddleware", () => {
 			model: "claude-x",
 			status: "aborted",
 			elapsed_ms: 87,
-			input_tokens: 0,
-			output_tokens: 0,
-			cache_read_input_tokens: 0,
-			cache_creation_input_tokens: 0,
-			iterations: 1,
+			input_tokens: 2500,
+			output_tokens: 100,
+			cache_read_input_tokens: 1000,
+			cache_creation_input_tokens: 200,
+			iterations: 2,
 		});
 	});
 
-	it("logs errored runs with status + elapsed", () => {
+	it("logs errored runs with the usage accumulated before the failure", () => {
 		const info = vi.spyOn(console, "info").mockImplementation(() => {});
 		const mw = llmTelemetryMiddleware("grounding");
 
 		mw.onIteration?.(ctx("claude-x"), iter(0));
+		mw.onUsage?.(
+			ctx("claude-x"),
+			usage({ promptTokens: 300, completionTokens: 25 }),
+		);
 		mw.onError?.(ctx("claude-x"), {
 			error: new Error("boom"),
 			duration: 200,
@@ -130,22 +167,24 @@ describe("llmTelemetryMiddleware", () => {
 			model: "claude-x",
 			status: "error",
 			elapsed_ms: 200,
-			input_tokens: 0,
-			output_tokens: 0,
+			input_tokens: 300,
+			output_tokens: 25,
 			cache_read_input_tokens: 0,
 			cache_creation_input_tokens: 0,
 			iterations: 1,
 		});
 	});
 
-	it("keeps the iteration counter private per middleware instance", () => {
+	it("keeps the iteration counter and usage accumulator private per middleware instance", () => {
 		const info = vi.spyOn(console, "info").mockImplementation(() => {});
 		const a = llmTelemetryMiddleware("a");
 		const b = llmTelemetryMiddleware("b");
 
 		a.onIteration?.(ctx("m"), iter(0));
+		a.onUsage?.(ctx("m"), usage({ promptTokens: 10, completionTokens: 1 }));
 		a.onIteration?.(ctx("m"), iter(1));
 		b.onIteration?.(ctx("m"), iter(0));
+		b.onUsage?.(ctx("m"), usage({ promptTokens: 7, completionTokens: 2 }));
 
 		a.onFinish?.(ctx("m"), finish({}));
 		b.onFinish?.(ctx("m"), finish({}));
@@ -153,12 +192,12 @@ describe("llmTelemetryMiddleware", () => {
 		expect(info).toHaveBeenNthCalledWith(
 			1,
 			"llm_call",
-			expect.objectContaining({ label: "a", iterations: 2 }),
+			expect.objectContaining({ label: "a", iterations: 2, input_tokens: 10 }),
 		);
 		expect(info).toHaveBeenNthCalledWith(
 			2,
 			"llm_call",
-			expect.objectContaining({ label: "b", iterations: 1 }),
+			expect.objectContaining({ label: "b", iterations: 1, input_tokens: 7 }),
 		);
 	});
 });

--- a/packages/cockpit/src/lib/llm-telemetry.ts
+++ b/packages/cockpit/src/lib/llm-telemetry.ts
@@ -21,23 +21,46 @@
 //   promptTokensDetails.cacheWriteTokens  -> cache_creation_input_tokens
 // `elapsed_ms` is the run duration the SDK already measures.
 //
+// Token accounting (DAT-663): each token field is the SUM over the run's model
+// iterations, accumulated live via `onUsage` — the SDK fires it once per model
+// iteration whose RUN_FINISHED chunk carries usage, and that usage is the single
+// API call's own spend (INCREMENTAL per iteration, never cumulative: the adapter
+// builds it from one response's final message_delta, and the chat engine never
+// sums across iterations). Summing here is therefore double-count-free and gives
+// the true loop total. We deliberately do NOT read `FinishInfo.usage`: it is only
+// the LAST iteration's RUN_FINISHED usage (the engine overwrites per iteration),
+// so it under-reports any multi-iteration run — and every usage-bearing
+// RUN_FINISHED that could feed it also fires `onUsage` first, so the accumulator
+// is always a superset.
+//
 // The SDK guarantees exactly one terminal hook per run (onFinish/onAbort/onError),
-// so we log on all three with a `status` — unlike the engine (success-only), the
-// cockpit has deliberate early-abort paths (frame induction aborts after the
-// forced tool fires, ×4/frame), and an aborted/errored turn is still latency data.
-// Tokens are only known on a clean finish; abort/error lines carry zeros. So
-// any per-label token aggregation must FILTER `status == "finished"` first —
-// frame induction alone emits up to 4 aborted rows per frame() (it aborts after
-// the forced tool fires), and those intentional zeros would skew a naive average.
+// so we log on all three with a `status`, and ALL THREE carry the accumulated
+// totals — a finished, aborted, and errored row mean the same thing per field.
+// The cockpit's deliberate drain-abort call sites (the `answer` sub-agent, frame
+// induction ×4 per frame(), the chart author) abort only AFTER the forced tool's
+// iteration reported usage, so their aborted rows carry the real spend up to the
+// abort — no longer zeros (DAT-663). Error rows likewise carry everything
+// accumulated before the failure. The one systematic loss: an iteration aborted
+// or errored MID-GENERATION contributes nothing (its usage would only arrive with
+// that response's final message_delta), so such rows under-count by at most the
+// one in-flight call. Aggregations can sum over every status without filtering.
 //
 // Granularity note: the engine logs one line per model call; here one line is a
-// whole chat() run — the RUN_FINISHED usage is the loop total across iterations
+// whole chat() run — the accumulated totals span the loop's iterations
 // (orchestrator ≤20, sub-agent ≤10). That is the right grain for "which agent
 // dominates wall-clock"; `iterations` exposes the per-run round-trip depth.
 
-import type { ChatMiddleware, TokenUsage } from "@tanstack/ai";
+import type { ChatMiddleware } from "@tanstack/ai";
 
 type CallStatus = "finished" | "aborted" | "error";
+
+/** The run's additive token totals, already in the engine's snake_case shape. */
+interface UsageTotals {
+	input_tokens: number;
+	output_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+}
 
 function emitLlmCall(
 	label: string,
@@ -45,18 +68,14 @@ function emitLlmCall(
 	status: CallStatus,
 	durationMs: number,
 	iterations: number,
-	usage?: TokenUsage,
+	totals: UsageTotals,
 ): void {
-	const promptDetails = usage?.promptTokensDetails;
 	console.info("llm_call", {
 		label,
 		model,
 		status,
 		elapsed_ms: Math.round(durationMs),
-		input_tokens: usage?.promptTokens ?? 0,
-		output_tokens: usage?.completionTokens ?? 0,
-		cache_read_input_tokens: promptDetails?.cachedTokens ?? 0,
-		cache_creation_input_tokens: promptDetails?.cacheWriteTokens ?? 0,
+		...totals,
 		iterations,
 	});
 }
@@ -67,15 +86,32 @@ function emitLlmCall(
  * "orchestrator" / "answer_subagent"). Observe-only — it never transforms config.
  *
  * A fresh instance is constructed per chat() invocation (every call site builds it
- * inline), so the `iterations` counter is private to that one run — no cross-run
- * or concurrent-call races.
+ * inline), so the `iterations` counter and the usage accumulator are private to
+ * that one run — no cross-run or concurrent-call races.
  */
 export function llmTelemetryMiddleware(label: string): ChatMiddleware {
 	let iterations = 0;
+	const totals: UsageTotals = {
+		input_tokens: 0,
+		output_tokens: 0,
+		cache_read_input_tokens: 0,
+		cache_creation_input_tokens: 0,
+	};
 	return {
 		name: "llm-telemetry",
 		onIteration() {
 			iterations += 1;
+		},
+		// Fires once per model iteration that reports usage, with that iteration's
+		// OWN spend (incremental — see the header). Accumulate; the terminal hook
+		// emits the totals.
+		onUsage(_ctx, usage) {
+			totals.input_tokens += usage.promptTokens;
+			totals.output_tokens += usage.completionTokens;
+			totals.cache_read_input_tokens +=
+				usage.promptTokensDetails?.cachedTokens ?? 0;
+			totals.cache_creation_input_tokens +=
+				usage.promptTokensDetails?.cacheWriteTokens ?? 0;
 		},
 		onFinish(ctx, info) {
 			emitLlmCall(
@@ -84,14 +120,21 @@ export function llmTelemetryMiddleware(label: string): ChatMiddleware {
 				"finished",
 				info.duration,
 				iterations,
-				info.usage,
+				totals,
 			);
 		},
 		onAbort(ctx, info) {
-			emitLlmCall(label, ctx.model, "aborted", info.duration, iterations);
+			emitLlmCall(
+				label,
+				ctx.model,
+				"aborted",
+				info.duration,
+				iterations,
+				totals,
+			);
 		},
 		onError(ctx, info) {
-			emitLlmCall(label, ctx.model, "error", info.duration, iterations);
+			emitLlmCall(label, ctx.model, "error", info.duration, iterations, totals);
 		},
 	};
 }

--- a/packages/cockpit/src/lib/tool-args-guard.test.ts
+++ b/packages/cockpit/src/lib/tool-args-guard.test.ts
@@ -1,0 +1,272 @@
+// Unit tests for the DAT-661 tool-args guard. Drives the pure coercion + the
+// middleware hooks with synthetic SDK fixtures (no chat() / no network): the
+// onConfig schema wrap (rescue + idempotency), the onToolPhaseComplete rejection
+// counter, and the onError parse-failure counter.
+
+import type {
+	ChatMiddleware,
+	ChatMiddlewareConfig,
+	ChatMiddlewareContext,
+	ErrorInfo,
+	Tool,
+	ToolPhaseCompleteInfo,
+} from "@tanstack/ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import {
+	coerceStringifiedToolArgs,
+	readTopLevelProperties,
+	type TopLevelProperties,
+	toolArgsGuardMiddleware,
+} from "./tool-args-guard";
+
+const ctx = () => ({ model: "claude-x" }) as unknown as ChatMiddlewareContext;
+
+const cfg = (tools: Tool[]): ChatMiddlewareConfig => ({
+	messages: [],
+	systemPrompts: [],
+	tools,
+});
+
+const phase = (
+	results: ToolPhaseCompleteInfo["results"],
+): ToolPhaseCompleteInfo => ({
+	toolCalls: [],
+	results,
+	needsApproval: [],
+	needsClientExecution: [],
+});
+
+/** Resolve onConfig's transformed tools (the hooks are sync in practice). */
+async function runOnConfig(mw: ChatMiddleware, config: ChatMiddlewareConfig) {
+	return await mw.onConfig?.(ctx(), config);
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("readTopLevelProperties", () => {
+	it("collects every top-level key and the exactly-typed container fields", () => {
+		const props = readTopLevelProperties(
+			z.object({
+				steps: z.array(z.object({ name: z.string() })),
+				deps: z.record(z.string(), z.array(z.string())),
+				final_sql: z.string(),
+				// Nullable containers surface as anyOf (no top-level type) and are
+				// deliberately NOT rescue candidates — engine parity.
+				cfg: z.object({ a: z.string() }).nullable(),
+			}),
+		);
+		expect(props).not.toBeNull();
+		expect([...(props?.allKeys ?? [])].sort()).toEqual([
+			"cfg",
+			"deps",
+			"final_sql",
+			"steps",
+		]);
+		expect(Object.fromEntries(props?.containers ?? [])).toEqual({
+			steps: "array",
+			deps: "object",
+		});
+	});
+
+	it("returns null for schemas without an object shape", () => {
+		expect(readTopLevelProperties(z.string())).toBeNull();
+	});
+});
+
+describe("coerceStringifiedToolArgs", () => {
+	const props: TopLevelProperties = {
+		allKeys: new Set(["steps", "final_sql"]),
+		containers: new Map([["steps", "array"]]),
+	};
+
+	it("parse-rescues a stringified container field and reports the argument", () => {
+		const coerced: string[] = [];
+		const out = coerceStringifiedToolArgs(
+			{ steps: '[{"name":"n","sql":"s"}]', final_sql: "select 1" },
+			props,
+			(a) => coerced.push(a),
+		);
+		expect(out).toEqual({
+			steps: [{ name: "n", sql: "s" }],
+			final_sql: "select 1",
+		});
+		expect(coerced).toEqual(["steps"]);
+	});
+
+	it("adopts a whole-payload string wholesale when its keys are the tool's own", () => {
+		const coerced: string[] = [];
+		const out = coerceStringifiedToolArgs(
+			{ steps: '{"steps": [{"name":"n","sql":"s"}], "final_sql": "select 1"}' },
+			props,
+			(a) => coerced.push(a),
+		);
+		expect(out).toEqual({
+			steps: [{ name: "n", sql: "s" }],
+			final_sql: "select 1",
+		});
+		expect(coerced).toEqual(["steps"]);
+	});
+
+	it("leaves unparseable strings for zod to reject, without reporting", () => {
+		const coerced: string[] = [];
+		const input = { steps: "not json", final_sql: "x" };
+		const out = coerceStringifiedToolArgs(input, props, (a) => coerced.push(a));
+		expect(out).toBe(input); // untouched — same reference
+		expect(coerced).toEqual([]);
+	});
+
+	it("touches neither string scalars on non-container fields nor well-formed input", () => {
+		const coerced: string[] = [];
+		const wellFormed = { steps: [{ name: "n" }], final_sql: "select 1" };
+		expect(
+			coerceStringifiedToolArgs(wellFormed, props, (a) => coerced.push(a)),
+		).toBe(wellFormed);
+		// A parsed scalar (JSON.parse("42") → number) is not a container — skip.
+		const scalar = { steps: "42", final_sql: "x" };
+		expect(
+			coerceStringifiedToolArgs(scalar, props, (a) => coerced.push(a)),
+		).toBe(scalar);
+		expect(coerced).toEqual([]);
+	});
+
+	it("passes non-object raw values through (the SDK flattens those to {} anyway)", () => {
+		const coerced: string[] = [];
+		expect(
+			coerceStringifiedToolArgs("raw", props, (a) => coerced.push(a)),
+		).toBe("raw");
+		expect(coerced).toEqual([]);
+	});
+});
+
+describe("toolArgsGuardMiddleware", () => {
+	const makeTool = (): Tool => ({
+		name: "run_steps",
+		description: "d",
+		inputSchema: z.object({
+			steps: z.array(z.object({ name: z.string(), sql: z.string() })),
+			final_sql: z.string(),
+		}),
+		execute: async () => ({ ok: true }),
+	});
+
+	it("wraps zod tool schemas so a stringified container field validates after rescue, logging tool_args_coerced", async () => {
+		const info = vi.spyOn(console, "info").mockImplementation(() => {});
+		const mw = toolArgsGuardMiddleware("answer_subagent");
+		const tool = makeTool();
+
+		const out = await runOnConfig(mw, cfg([tool]));
+		expect(out?.tools).toHaveLength(1);
+		const guarded = out?.tools?.[0];
+		expect(guarded?.inputSchema).not.toBe(tool.inputSchema);
+		// The handler-facing contract is preserved.
+		expect(guarded?.name).toBe("run_steps");
+		expect(guarded?.execute).toBe(tool.execute);
+
+		// The SDK validates through the (wrapped) inputSchema — a stringified
+		// `steps` now parses and validates instead of rejecting.
+		const parsed = (guarded?.inputSchema as z.ZodType).safeParse({
+			steps: '[{"name":"n","sql":"select 1"}]',
+			final_sql: "select * from n",
+		});
+		expect(parsed.success).toBe(true);
+		expect(parsed.data).toEqual({
+			steps: [{ name: "n", sql: "select 1" }],
+			final_sql: "select * from n",
+		});
+		expect(info).toHaveBeenCalledWith("tool_args_coerced", {
+			label: "answer_subagent",
+			tool: "run_steps",
+			argument: "steps",
+		});
+	});
+
+	it("still rejects genuinely invalid args after the wrap (the rescue admits nothing)", async () => {
+		vi.spyOn(console, "info").mockImplementation(() => {});
+		const mw = toolArgsGuardMiddleware("answer_subagent");
+		const out = await runOnConfig(mw, cfg([makeTool()]));
+		const parsed = (out?.tools?.[0]?.inputSchema as z.ZodType).safeParse({
+			steps: '["not-a-step"]',
+			final_sql: "x",
+		});
+		expect(parsed.success).toBe(false);
+	});
+
+	it("is idempotent across onConfig re-fires (tools persist between iterations)", async () => {
+		vi.spyOn(console, "info").mockImplementation(() => {});
+		const mw = toolArgsGuardMiddleware("answer_subagent");
+		const first = await runOnConfig(mw, cfg([makeTool()]));
+		expect(first?.tools).toBeDefined();
+		// The engine feeds the TRANSFORMED tools back on the next iteration.
+		const second = await runOnConfig(mw, cfg(first?.tools as Tool[]));
+		expect(second).toBeUndefined(); // no re-wrap, no change
+	});
+
+	it("leaves tools without rescuable container fields untouched", async () => {
+		const mw = toolArgsGuardMiddleware("nav");
+		const scalarTool: Tool = {
+			name: "pick",
+			description: "d",
+			inputSchema: z.object({ kind: z.string() }),
+			execute: async () => ({ ok: true }),
+		};
+		expect(await runOnConfig(mw, cfg([scalarTool]))).toBeUndefined();
+	});
+
+	it("logs tool_args_rejected for the SDK's input-validation failures only", () => {
+		const info = vi.spyOn(console, "info").mockImplementation(() => {});
+		const mw = toolArgsGuardMiddleware("answer_subagent");
+
+		mw.onToolPhaseComplete?.(
+			ctx(),
+			phase([
+				{
+					toolCallId: "t1",
+					toolName: "emit_result",
+					result: {
+						error:
+							"Input validation failed for tool emit_result: Validation failed: expected array, received string",
+					},
+				},
+				// A handler-authored agent-error envelope — NOT a validation failure.
+				{
+					toolCallId: "t2",
+					toolName: "run_steps",
+					result: { error: "no such table: lake.raw.orders" },
+				},
+				// A plain success.
+				{ toolCallId: "t3", toolName: "run_steps", result: { ok: true } },
+			]),
+		);
+
+		expect(info).toHaveBeenCalledTimes(1);
+		expect(info).toHaveBeenCalledWith("tool_args_rejected", {
+			label: "answer_subagent",
+			tool: "emit_result",
+			error:
+				"Input validation failed for tool emit_result: Validation failed: expected array, received string",
+		});
+	});
+
+	it("counts the run-fatal unparseable-args path via onError, and ignores other errors", () => {
+		const info = vi.spyOn(console, "info").mockImplementation(() => {});
+		const mw = toolArgsGuardMiddleware("frame_family");
+
+		mw.onError?.(ctx(), {
+			error: new Error('Failed to parse tool arguments as JSON: "{oops'),
+			duration: 12,
+		} as ErrorInfo);
+		mw.onError?.(ctx(), {
+			error: new Error("overloaded_error"),
+			duration: 12,
+		} as ErrorInfo);
+
+		expect(info).toHaveBeenCalledTimes(1);
+		expect(info).toHaveBeenCalledWith("tool_args_rejected", {
+			label: "frame_family",
+			tool: null,
+			error: 'Failed to parse tool arguments as JSON: "{oops',
+		});
+	});
+});

--- a/packages/cockpit/src/lib/tool-args-guard.ts
+++ b/packages/cockpit/src/lib/tool-args-guard.ts
@@ -1,0 +1,220 @@
+// Tool-boundary args guard — coercion + rejection counters for DAT-661.
+//
+// The cockpit mirror of the engine's provider-boundary coercion telemetry
+// (`stringified_tool_payload_coerced` in llm/providers/anthropic.py): when a model
+// emits malformed tool arguments, make it COUNTABLE from logs — and rescue the one
+// shape that is mechanically recoverable — so the DAT-661 strict-tools decision
+// can measure the baseline malformation rate. Two structured console.info lines:
+//   tool_args_coerced  { label, tool, argument } — a JSON-STRING payload where the
+//     schema expects an array/object was parse-rescued; the call then proceeded.
+//   tool_args_rejected { label, tool, error }    — args failed schema validation
+//     with no rescue; the SDK fed the failure back to the model as a tool error.
+//
+// WHERE the SDK lets us intercept (verified against the installed @tanstack/ai
+// dist, activities/chat/tools/tool-calls.js `executeToolCalls`): the SDK
+// hard-validates a zod `inputSchema` (via Standard Schema) BEFORE the `.server()`
+// handler runs — handlers can never see malformed input. The order per tool call:
+//   1. JSON.parse the accumulated args string; a top-level NON-OBJECT parse result
+//      (e.g. a double-encoded whole payload) is silently flattened to `{}` — the
+//      raw string is discarded before any extension point sees it. An UNPARSEABLE
+//      args string throws and kills the whole run (surfaces via onError).
+//   2. `inputSchema` validation; a failure becomes an output-error tool result
+//      (`{ error: "Input validation failed for tool <name>: …" }`) fed back to the
+//      model — the handler never runs, and onBeforeToolCall does NOT fire for it.
+//   3. onBeforeToolCall → handler.
+// Consequences for this module:
+//   - The ONLY rescue point is the schema itself: `onConfig` (a documented
+//     transform hook) wraps each tool's zod inputSchema in a `z.preprocess` that
+//     parse-rescues string-where-container fields before validation. The wrapper
+//     is invisible to the provider — zod pipes report the INNER schema as their
+//     input-side JSON Schema, which is exactly what the SDK advertises
+//     (verified: identical bytes with and without the wrapper).
+//   - Rejections are only visible to middleware in `onToolPhaseComplete.results`,
+//     as the SDK's distinctive "Input validation failed for tool " error results.
+//   - A top-level stringified payload (case 1) cannot be rescued at all: it
+//     reaches the schema as `{}` and is counted as a rejection, not a coercion.
+//
+// The coercion logic mirrors the engine's `_coerce_stringified_args` exactly
+// (observed malformation: Sonnet 5 serializing a whole array/object argument into
+// a JSON string — `{"steps": "[{…}]"}` — plus the whole-payload-in-one-field
+// variant). Only top-level fields whose declared JSON type is exactly
+// `array`/`object` are candidates; everything else passes through untouched, and
+// zod still validates the parsed value, so the rescue cannot admit bad data.
+//
+// Observe-only beyond that one rescue. Attach next to llmTelemetryMiddleware with
+// the same label at every chat() that passes `tools`. chat({ outputSchema }) has
+// no tool boundary (native structured output) — nothing to guard there.
+
+import type { ChatMiddleware, Tool } from "@tanstack/ai";
+import { z } from "zod";
+
+type ContainerKind = "array" | "object";
+
+/** The top-level view of a tool's input schema the coercion needs: every
+ * property name, plus which properties are declared as containers. */
+export interface TopLevelProperties {
+	allKeys: ReadonlySet<string>;
+	containers: ReadonlyMap<string, ContainerKind>;
+}
+
+/**
+ * Read a zod input schema's top-level properties off its input-side JSON Schema —
+ * the same view the SDK advertises to the provider. Returns null when the schema
+ * can't be converted or has no object shape (leave such tools unwrapped).
+ */
+export function readTopLevelProperties(
+	schema: z.ZodType,
+): TopLevelProperties | null {
+	let json: unknown;
+	try {
+		json = z.toJSONSchema(schema, { io: "input", target: "draft-7" });
+	} catch {
+		return null;
+	}
+	if (json === null || typeof json !== "object") return null;
+	const properties = (json as Record<string, unknown>).properties;
+	if (properties === null || typeof properties !== "object") return null;
+	const allKeys = new Set<string>();
+	const containers = new Map<string, ContainerKind>();
+	for (const [key, prop] of Object.entries(properties)) {
+		allKeys.add(key);
+		if (prop === null || typeof prop !== "object") continue;
+		const type = (prop as Record<string, unknown>).type;
+		// Exact-`type` match, mirroring the engine: nullable/union containers
+		// surface as `anyOf` (no top-level type) and are deliberately skipped.
+		if (type === "array" || type === "object") containers.set(key, type);
+	}
+	return { allKeys, containers };
+}
+
+/**
+ * Parse tool arguments the model JSON-stringified against the schema's declared
+ * containers (the engine's `_coerce_stringified_args`, ported): a string value
+ * where the schema expects an array/object is JSON.parsed; everything else passes
+ * through untouched. Handles the whole-payload variant too — the model serializing
+ * the ENTIRE input object into one array-typed field (`{"steps": '{"steps": […]}'}`);
+ * when the parsed object's keys are the tool's own top-level properties, it IS the
+ * input and is adopted wholesale. Each rescue reports the argument name via
+ * `onCoerced`. Never throws; unparseable strings are left for zod to reject.
+ */
+export function coerceStringifiedToolArgs(
+	raw: unknown,
+	props: TopLevelProperties,
+	onCoerced: (argument: string) => void,
+): unknown {
+	if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return raw;
+	const input = raw as Record<string, unknown>;
+	const out = { ...input };
+	let changed = false;
+	for (const [key, kind] of props.containers) {
+		const value = input[key];
+		if (typeof value !== "string") continue;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(value);
+		} catch {
+			continue;
+		}
+		if (
+			kind !== "object" &&
+			parsed !== null &&
+			typeof parsed === "object" &&
+			!Array.isArray(parsed) &&
+			Object.keys(parsed).every((k) => props.allKeys.has(k))
+		) {
+			// Whole-payload variant: adopt the parsed object as the input.
+			onCoerced(key);
+			return parsed;
+		}
+		if (parsed !== null && typeof parsed === "object") {
+			out[key] = parsed;
+			changed = true;
+			onCoerced(key);
+		}
+	}
+	return changed ? out : raw;
+}
+
+/** The SDK's input-validation failure results carry this exact prefix (the only
+ * producer is `executeToolCalls`); handler-authored `{ error }` envelopes (the
+ * agent-error contract) never match it. */
+const VALIDATION_ERROR_PREFIX = "Input validation failed for tool ";
+
+/** Narrow an `onToolPhaseComplete` result to the SDK's input-validation failure
+ * message, or null for everything else (successes, handler errors, envelopes). */
+function readValidationError(result: unknown): string | null {
+	if (result === null || typeof result !== "object") return null;
+	const error = (result as Record<string, unknown>).error;
+	if (typeof error !== "string" || !error.startsWith(VALIDATION_ERROR_PREFIX))
+		return null;
+	return error;
+}
+
+/** Wrap one tool's zod inputSchema in the coercion preprocess. Non-zod schemas,
+ * schemas without top-level container fields, and unconvertible schemas are left
+ * untouched (rejection counting still covers them). */
+function guardTool(label: string, tool: Tool): Tool {
+	const schema = tool.inputSchema;
+	if (!(schema instanceof z.ZodType)) return tool;
+	const props = readTopLevelProperties(schema);
+	if (props === null || props.containers.size === 0) return tool;
+	const guarded = z.preprocess(
+		(raw) =>
+			coerceStringifiedToolArgs(raw, props, (argument) => {
+				console.info("tool_args_coerced", { label, tool: tool.name, argument });
+			}),
+		schema,
+	);
+	return { ...tool, inputSchema: guarded };
+}
+
+/**
+ * Build the tool-args guard middleware for one chat() run. `label` tags the call
+ * site, matching the site's llmTelemetryMiddleware label. A fresh instance per
+ * chat() invocation, like the telemetry middleware.
+ */
+export function toolArgsGuardMiddleware(label: string): ChatMiddleware {
+	// onConfig re-fires per agent iteration and the transformed tools PERSIST
+	// across iterations (applyMiddlewareConfig keeps the returned array), so the
+	// wrap must be idempotent: tools this instance already processed are skipped.
+	const seen = new WeakSet<object>();
+	return {
+		name: "tool-args-guard",
+		onConfig(_ctx, config) {
+			let changed = false;
+			const tools = config.tools.map((tool) => {
+				if (seen.has(tool)) return tool;
+				const guarded = guardTool(label, tool);
+				seen.add(guarded);
+				if (guarded !== tool) changed = true;
+				return guarded;
+			});
+			return changed ? { tools } : undefined;
+		},
+		onToolPhaseComplete(_ctx, info) {
+			for (const r of info.results) {
+				const error = readValidationError(r.result);
+				if (error !== null) {
+					console.info("tool_args_rejected", {
+						label,
+						tool: r.toolName,
+						error,
+					});
+				}
+			}
+		},
+		onError(_ctx, info) {
+			// An unparseable args string aborts the whole run before validation (the
+			// SDK throws out of executeToolCalls) — count it here so it isn't lost.
+			const message =
+				info.error instanceof Error ? info.error.message : undefined;
+			if (message?.startsWith("Failed to parse tool arguments as JSON")) {
+				console.info("tool_args_rejected", {
+					label,
+					tool: null,
+					error: message,
+				});
+			}
+		},
+	};
+}

--- a/packages/cockpit/src/tools/frame-family.ts
+++ b/packages/cockpit/src/tools/frame-family.ts
@@ -27,6 +27,7 @@ import type { z } from "zod";
 import { config } from "../config";
 import { linkedAbortController } from "../lib/abort";
 import { llmTelemetryMiddleware } from "../lib/llm-telemetry";
+import { toolArgsGuardMiddleware } from "../lib/tool-args-guard";
 import { MAX_OUTPUT_TOKENS, MODEL } from "../llm";
 import { teach } from "./teach";
 import type { TeachType } from "./teach.validation";
@@ -72,7 +73,10 @@ export async function induceStructured<R>(opts: {
 	const abortController = linkedAbortController(opts.signal);
 	const stream = await chat({
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
-		middleware: [llmTelemetryMiddleware("frame_family")],
+		middleware: [
+			llmTelemetryMiddleware("frame_family"),
+			toolArgsGuardMiddleware("frame_family"),
+		],
 		abortController,
 		modelOptions: {
 			max_tokens: MAX_OUTPUT_TOKENS,

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -44,6 +44,7 @@ import {
 import { linkedAbortController } from "../lib/abort";
 import { llmTelemetryMiddleware } from "../lib/llm-telemetry";
 import { sqlEquivalent } from "../lib/sql-canonical";
+import { toolArgsGuardMiddleware } from "../lib/tool-args-guard";
 import {
 	MAX_OUTPUT_TOKENS,
 	MODEL,
@@ -660,9 +661,13 @@ export async function querySubAgent(
 			makeRunStepsTool(captured, nearUniqueColumns),
 			emitResult,
 		],
-		// Per-turn LLM telemetry (DAT-600). Logs this nested sub-agent loop SEPARATELY
-		// from the orchestrator; `iterations` exposes its round-trip depth.
-		middleware: [llmTelemetryMiddleware("answer_subagent")],
+		// Per-turn LLM telemetry (DAT-600) + the tool-args guard (DAT-661 coercion/
+		// rejection counters). Logs this nested sub-agent loop SEPARATELY from the
+		// orchestrator; `iterations` exposes its round-trip depth.
+		middleware: [
+			llmTelemetryMiddleware("answer_subagent"),
+			toolArgsGuardMiddleware("answer_subagent"),
+		],
 	});
 
 	// Drain the agent-loop stream so the tools actually execute. Stop as soon as the

--- a/packages/cockpit/src/worker/grounding-agent.ts
+++ b/packages/cockpit/src/worker/grounding-agent.ts
@@ -26,6 +26,7 @@ import {
 	readGroundingReadiness,
 } from "#/db/metadata/grounding-readiness";
 import { llmTelemetryMiddleware } from "#/lib/llm-telemetry";
+import { toolArgsGuardMiddleware } from "#/lib/tool-args-guard";
 import { MAX_OUTPUT_TOKENS, MODEL } from "#/llm";
 import { teach } from "#/tools/teach";
 import {
@@ -159,7 +160,10 @@ export async function assessAndGround(
 	const captured = { count: 0 };
 	const verdict = await chat({
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
-		middleware: [llmTelemetryMiddleware("grounding")],
+		middleware: [
+			llmTelemetryMiddleware("grounding"),
+			toolArgsGuardMiddleware("grounding"),
+		],
 		modelOptions: { max_tokens: MAX_OUTPUT_TOKENS },
 		agentLoopStrategy: maxIterations(GROUNDING_LOOP_MAX_ITERATIONS),
 		systemPrompts: [GROUNDING_INSTRUCTIONS],


### PR DESCRIPTION
## Summary

The two telemetry riders from the DAT-599 prioritization.

### DAT-663: `llm_call` telemetry accumulates token usage per iteration

The answer sub-agent (and frame induction ×4, chart author) complete via deliberate drain-abort, so their `llm_call` rows carried zeros — the cockpit's biggest per-question consumer was unmeasurable. `llm-telemetry.ts` now accumulates usage in the SDK's `onUsage` hook (fires once per model iteration with that iteration's own incremental spend — verified in the installed `@tanstack/ai` 0.39.0 dist + the anthropic adapter, no double-count) and all three terminal hooks emit the accumulated totals.

**Bonus finding:** in this SDK version `FinishInfo.usage` is the *last iteration's* usage only (the engine overwrites per iteration) — so **finished** rows were under-reporting multi-iteration runs too. The accumulator fixes both; finished/aborted/error rows now mean the same thing per field, and aggregations no longer need status filtering. One documented residual: an iteration aborted mid-generation contributes nothing (usage only arrives with the final `message_delta`), so a row can under-count by at most the one in-flight call.

### DAT-661 rider: tool-boundary coercion + rejection counters

The cockpit mirror of the engine's `stringified_tool_payload_coerced` telemetry, so the DAT-661 strict-tools decision can measure the baseline malformation rate. New `src/lib/tool-args-guard.ts` middleware, attached next to `llmTelemetryMiddleware` (same label) at the five tool-bearing chat() sites:

- `tool_args_coerced { label, tool, argument }` — a JSON-string payload where the schema expects an array/object is parse-rescued via an `onConfig` schema wrap (`z.preprocess`; the SDK hard-validates before handlers, so the schema is the only rescue point — verified against the installed dist). The wrapper is invisible to the provider (zod reports the inner schema's JSON Schema — verified byte-identical). Ports the engine's `_coerce_stringified_args` semantics incl. the whole-payload variant.
- `tool_args_rejected { label, tool, error }` — the SDK's `"Input validation failed for tool …"` results counted in `onToolPhaseComplete`; the run-fatal unparseable-args throw counted in `onError`.

Reading the baseline: `rejected` = failure rate, `coerced` = rescue rate (a coerced-then-still-invalid call logs both, same as the engine).

## Verification

- `bun run check` (biome), `bun run typecheck` (tsc), `bun run test`: **1490 tests passed** (163 files).
- New tests: multi-iteration abort carries summed usage; finished ignores `FinishInfo.usage` (pins no-double-count); 13 tool-args-guard tests (coercion incl. whole-payload/unparseable/passthrough, wrap+rescue through `safeParse`, still-rejects-invalid, idempotent re-wrap across `onConfig` re-fires, rejection-counter selectivity vs handler `{error}` envelopes).
- Live acceptance (needs a running stack + an Analyse question): an `answer_subagent` row with `status:"aborted"` and non-zero tokens, `cache_read_input_tokens > 0` from iteration 2 (DAT-660's breakpoints) — proposed as the follow-up smoke on DAT-663.

Closes DAT-663; feeds DAT-661 (decision stays open until a baseline rate is read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)