### PR TITLE
fix(DAT-603): retro-review findings — parallel-tool-call guard, explicit adaptive thinking, typed guard error

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,18 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-603 — graph agent: single-extract output schema + adaptive thinking (PRs #434, merged 2026-07-03)
+
+**Re-baseline `graph_sql_generation` before trusting comparisons against the DAT-602 eval baseline.** Three changes eval must know about:
+
+1. **Output schema replaced.** `GraphSQLGenerationOutput` (summary/steps[]/final_sql) is gone; the tool now takes `ExtractGroundingOutput`: `grounding` (evidence commitment, FIRST field), `sql`, `description`, `column_mappings`, `assumptions`, `provenance` (no more `llm_reasoning`). The agent binds the SQL to the graph's own leaf id — snippet `step_id`s always equal catalogue step ids now (the DAT-664 paraphrase class is structurally gone). `validation_sql`'s schema also lost its unread `explanation` field.
+2. **Adaptive thinking ON for this label** (`thinking: true` in `llm/config.yaml`), with `tool_choice: auto` + `disable_parallel_tool_use`. Latency/token profile shifted: measured 763 → ~3,726 mean output tokens/call (thinking billed as output), ~10s → ~35s/call, absorbed by the 10-wide fan-out. Any eval latency/cost assertions on this label need new baselines.
+3. **Prompt v6.1** (floors-not-scripts rewrite) — grounding QUALITY improved on the finance fresh-wipe smoke: revenue grounds via the complete `account_type` classification and matches `ground_truth.yaml` exactly (51,766,199.72); cogs+opex+depreciation match `total_expenses` to the cent; 22/34 executed (prior fresh runs: 21 and 19). Value-level GT comparison is now part of the grounding smoke — distribution parity alone masked a 48% revenue error in pre-rework sampling.
+
+**Testdata note:** `trial_balance.csv` carries trailing periods (2026-01/02) with only partial accounts (no AR rows) — an extract grounding AR at `period = MAX(period)` honestly NULLs. Consider whether the generator should emit complete trailing periods.
+
+---
+
 ## DAT-654 — SQL canonicalization on DuckDB `json_serialize_sql` (retire sqlglot)
 
 **Branch:** `feat/dat-654-engine-json-serialize`. **No calibration action required.**

--- a/packages/cockpit/src/lib/agent-turn.ts
+++ b/packages/cockpit/src/lib/agent-turn.ts
@@ -24,6 +24,7 @@ import { llmTelemetryMiddleware } from "#/lib/llm-telemetry";
 import { toolArgsGuardMiddleware } from "#/lib/tool-args-guard";
 import { AGENT_LOOP_MAX_ITERATIONS, MAX_OUTPUT_TOKENS, MODEL } from "#/llm";
 import { getInstructions } from "#/prompts";
+import type { WorkspaceContext } from "#/prompts/workspace-context";
 import { toolsByKind } from "#/tools/registry";
 
 export type ChatMessages = Awaited<
@@ -57,14 +58,19 @@ type ChatStream = ReturnType<
  * prompt-cache hit for the chat's life (a chat's kind is immutable). It must stay
  * stateless — that's what is cached.
  *
- * `workspaceContext` (the workspace's vertical + imported tables — workspace-
- * awareness for replay / teach / look) is a SECOND system block placed AFTER the
- * orchestrator, with its OWN cache breakpoint (DAT-606): it is stable within a
- * session, so it reads from cache from turn 2 on. Because prefix caching
+ * `workspaceContext.stable` (the workspace's vertical + imported tables —
+ * workspace-awareness for replay / teach / look) is a SECOND system block placed
+ * AFTER the orchestrator, with its OWN cache breakpoint (DAT-606): it is stable
+ * within a session, so it reads from cache from turn 2 on. Because prefix caching
  * invalidates only from the changed block onward, an import that changes this
  * block leaves the orchestrator block's cache intact — the two don't thrash.
- * The caller computes the block (a DB read) and passes it; `buildChatOptions`
- * stays pure for the unit wiring test.
+ * `workspaceContext.digest` (the live readiness digest, DAT-634) is per-turn
+ * VOLATILE — its counts change exactly when the agent acts (replay/teach) — so it
+ * rides as a THIRD, UNCACHED block after the cached prefix: both breakpoints stay
+ * hot and only this tail is re-read fresh each turn (retro-review of PR #432; it
+ * previously lived INSIDE the cached block and defeated it). The caller computes
+ * the blocks (a DB read) and passes them; `buildChatOptions` stays pure for the
+ * unit wiring test.
  *
  * `abortController` (when given) is threaded into the agentic loop so a cancelled
  * stream — the client calling useChat's `stop()`, or simply disconnecting —
@@ -75,7 +81,7 @@ export function buildChatOptions(
 	kind: ConversationKind,
 	messages: ChatMessages,
 	abortController?: AbortController,
-	workspaceContext?: string | null,
+	workspaceContext?: WorkspaceContext | null,
 ): ChatOptions {
 	const systemPrompts: Array<{
 		content: string;
@@ -86,16 +92,21 @@ export function buildChatOptions(
 			metadata: { cache_control: { type: "ephemeral" } },
 		},
 	];
-	// A second CACHED block (DAT-606): the workspace context (vertical + imported
-	// tables) is stable within a session, so its own breakpoint makes it a cache
+	// A second CACHED block (DAT-606): the stable workspace context (vertical +
+	// imported tables) is session-stable, so its own breakpoint makes it a cache
 	// read from turn 2 on — while leaving the orchestrator block's cache untouched
 	// when an import DOES change it (prefix caching invalidates only from the
 	// changed block onward).
 	if (workspaceContext != null) {
 		systemPrompts.push({
-			content: workspaceContext,
+			content: workspaceContext.stable,
 			metadata: { cache_control: { type: "ephemeral" } },
 		});
+		// The readiness digest is live per-turn state — NO cache_control, placed
+		// LAST so the two cached breakpoints above stay hot every turn.
+		if (workspaceContext.digest != null) {
+			systemPrompts.push({ content: workspaceContext.digest });
+		}
 	}
 	return {
 		adapter: createAnthropicChat(MODEL, config.anthropicApiKey),
@@ -168,7 +179,7 @@ export async function streamAgentTurnToBus(
 		// The chat's kind (DAT-532) — selects the toolstack + prompt for this turn.
 		// Required: both producers resolve it from the conversation row.
 		kind: ConversationKind;
-		workspaceContext?: string | null;
+		workspaceContext?: WorkspaceContext | null;
 		abortController?: AbortController;
 		persist?: boolean;
 	},

--- a/packages/cockpit/src/prompts/workspace-context.integration.test.ts
+++ b/packages/cockpit/src/prompts/workspace-context.integration.test.ts
@@ -143,7 +143,8 @@ describe.skipIf(!STACK_AVAILABLE)(
 		});
 
 		it("buildWorkspaceContext surfaces the imported tables by filename + the workspace vertical", async () => {
-			const block: string = await buildWorkspaceContext();
+			const ctx: { stable: string } = await buildWorkspaceContext();
+			const block = ctx.stable;
 			expect(block).toContain("Imported tables");
 			expect(block).toContain("widgets"); // de-prefixed table name, not the raw __ name
 			expect(block).toContain("vertical finance"); // the WORKSPACE vertical

--- a/packages/cockpit/src/prompts/workspace-context.ts
+++ b/packages/cockpit/src/prompts/workspace-context.ts
@@ -74,22 +74,34 @@ export function formatWorkspaceContext(
  * WORKSPACE's (DAT-506: a workspace property); the table set is the workspace-current
  * set (the generation heads).
  */
+export interface WorkspaceContext {
+	/** Session-stable block (vertical + imported tables) — cached (DAT-606). */
+	stable: string;
+	/** Live per-turn readiness digest (DAT-634) — VOLATILE; must ride uncached. */
+	digest: string | null;
+}
+
 export async function buildWorkspaceContext(
 	kind: ConversationKind,
-): Promise<string | null> {
+): Promise<WorkspaceContext | null> {
 	const workspace = await resolveActiveWorkspaceRow();
 	const tableNames = await workspaceTableNames();
 	if (tableNames.length === 0) return null;
 	const block = formatWorkspaceContext(workspace.vertical, tableNames);
+	if (block == null) return null;
 
-	// Append a compact, PROJECTED readiness digest (DAT-634) so the agent can speak
-	// to "what's blocked / what to do next" for this chat's kind without a tool
+	// A compact, PROJECTED readiness digest (DAT-634) so the agent can speak to
+	// "what's blocked / what to do next" for this chat's kind without a tool
 	// round-trip. Soft: a briefing read blip just drops the digest, keeping the base
-	// block. TODO(DAT-634): cache candidate — buildWorkspaceBriefing runs ~9 queries
+	// block. Returned SEPARATELY from the stable block (retro-review of PR #432):
+	// the digest's counts change exactly when the agent acts (replay/teach), so
+	// embedding it in the cached block made the DAT-606 breakpoint miss on the
+	// turns that matter — it must ride as its own uncached tail block.
+	// TODO(DAT-634): cache candidate — buildWorkspaceBriefing runs ~9 queries
 	// per turn here; a short-TTL / invalidate-on-promote cache would cut it.
 	// Intentionally UNCACHED for now (correctness first; DB cost is negligible beside
 	// the LLM call). Do NOT add a cache without measuring.
 	const briefing = await buildWorkspaceBriefing().catch(() => null);
 	const digest = briefing ? formatBriefingDigest(briefing, kind) : null;
-	return digest && block ? `${block}\n\n${digest}` : block;
+	return { stable: block, digest };
 }

--- a/packages/cockpit/src/routes/api/chat.test.ts
+++ b/packages/cockpit/src/routes/api/chat.test.ts
@@ -79,19 +79,39 @@ describe("chat route wiring (DAT-353, DAT-532)", () => {
 		expect((sys?.content ?? "").length).toBeGreaterThan(0);
 	});
 
-	it("appends the workspace context as a SECOND, cached system block (DAT-606)", () => {
-		const ctx = "WORKSPACE CONTEXT — session abc";
+	it("appends the STABLE workspace context cached and the digest UNCACHED last (DAT-606)", () => {
+		const ctx = {
+			stable: "WORKSPACE CONTEXT — session abc",
+			digest: "READINESS — 3 columns blocked",
+		};
 		const opts = buildChatOptions("connect", MSG, undefined, ctx);
 		const prompts = systemPromptObjects(opts);
-		expect(prompts).toHaveLength(2);
+		expect(prompts).toHaveLength(3);
 		// The instructions stay the cached FIRST block…
 		expect(prompts[0]?.metadata?.cache_control).toEqual({
 			type: "ephemeral",
 		});
-		// …and the session-stable workspace context carries its OWN breakpoint,
-		// so it reads from cache from turn 2 on; an import that changes it
-		// invalidates only this block, never the orchestrator prefix.
-		expect(prompts[1]?.content).toBe(ctx);
+		// …the session-stable workspace context carries its OWN breakpoint, so it
+		// reads from cache from turn 2 on…
+		expect(prompts[1]?.content).toBe(ctx.stable);
+		expect(prompts[1]?.metadata?.cache_control).toEqual({
+			type: "ephemeral",
+		});
+		// …and the live readiness digest rides LAST with NO breakpoint — its
+		// counts change exactly when the agent acts (replay/teach), and a cached
+		// volatile block would defeat the breakpoint it sits in (PR #432 retro
+		// review finding).
+		expect(prompts[2]?.content).toBe(ctx.digest);
+		expect(prompts[2]?.metadata).toBeUndefined();
+	});
+
+	it("omits the digest block when the briefing read degraded to null", () => {
+		const opts = buildChatOptions("connect", MSG, undefined, {
+			stable: "WORKSPACE CONTEXT",
+			digest: null,
+		});
+		const prompts = systemPromptObjects(opts);
+		expect(prompts).toHaveLength(2);
 		expect(prompts[1]?.metadata?.cache_control).toEqual({
 			type: "ephemeral",
 		});

--- a/packages/dataraum-config/llm/config.yaml
+++ b/packages/dataraum-config/llm/config.yaml
@@ -77,9 +77,11 @@ features:
 limits:
   # Bumped 16000 -> 24000 with the Sonnet 5 swap: its tokenizer emits ~30% more
   # tokens for the same text, so a response that fit under 16000 on Sonnet 4.6
-  # can now clip. 24000 restores the old margin. (Thinking is disabled on the
-  # engine's forced-tool calls, so this budget is response-only, not shared with
-  # a thinking trace.)
+  # can now clip. 24000 restores the old margin. For the thinking-off extractors
+  # this budget is response-only; for graph_sql_generation (thinking: true,
+  # DAT-603) it is SHARED with the thinking trace — max_tokens caps both.
+  # Measured 2026-07-03: ~3.7k mean output tokens/call incl. thinking, ample
+  # headroom under 24000.
   max_output_tokens_per_request: 24000
 
 # Privacy settings for data sent to LLM

--- a/packages/engine/src/dataraum/graphs/__init__.py
+++ b/packages/engine/src/dataraum/graphs/__init__.py
@@ -1,24 +1,16 @@
 """Transformation graphs for metric computation.
 
 Graphs are SPECIFICATIONS, not executable code. They define WHAT to calculate
-with rich accounting context. The GraphAgent uses LLM to interpret graphs +
-data schemas and generate executable SQL.
+with rich accounting context. The GraphAgent grounds each EXTRACT leaf to SQL
+via the LLM and composes metrics deterministically from those groundings.
 
-Usage:
-    from dataraum.graphs import GraphLoader, GraphAgent, ExecutionContext
-    from dataraum.graphs.config import get_metric_definitions
-
-    loader = GraphLoader()
-    loader.graphs.update(loader.graphs_from_definitions(get_metric_definitions("finance")))
-    graph = loader.graphs["dso"]
-
-    agent = GraphAgent(config, provider, renderer)
-    context = ExecutionContext.with_rich_context(
-        session=session,
-        duckdb_conn=conn,
-        table_ids=table_ids,
-    )
-    result = agent.execute(session, graph, context, workspace_id=workspace_id)
+How a metric actually runs (DAT-646/DAT-603 — there is no whole-graph LLM
+authoring): the metrics phase warms each unique EXTRACT leaf once via
+``agent.execute`` on a single-extract mini-graph (``node_warming.build_mini_
+graph``), then assembles every metric from the recorded bindings with NO LLM
+(``agent.assemble``). ``execute`` fails loud on anything but a single-extract
+mini-graph. See ``pipeline/phases/metrics_phase.py`` for the driving loop —
+that is the usage example.
 """
 
 from .agent import ExecutionContext, GeneratedCode, GraphAgent

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -672,16 +672,24 @@ class GraphAgent(LLMFeature):
 
         # Thinking (DAT-603): grounding is the pipeline's hardest reasoning task
         # and Sonnet 5-class models expose no sampling knobs — the model's own
-        # reflection is the quality lever. The API rejects thinking with a
-        # FORCED tool_choice, so a thinking run offers the tool on auto and the
-        # prompt mandates the call; no tool call remains a loud bind error
-        # (checked below), never a silent prose answer.
+        # reflection is the quality lever. A FORCED tool_choice silently
+        # suppresses thinking on the live API (probed 2026-07-03: forced -> no
+        # thinking block, auto -> thinking block), so a thinking run offers the
+        # tool on auto and the prompt mandates the call; no tool call remains a
+        # loud bind error (checked below), never a silent prose answer.
         thinking = bool(feature_config and feature_config.thinking)
         request = ConversationRequest(
             messages=[Message(role="user", content=user_prompt)],
             system=system_prompt,
             tools=[tool],
-            tool_choice={"type": "auto"} if thinking else {"type": "tool", "name": "generate_sql"},
+            # auto (not forced): a forced choice silently suppresses thinking on
+            # the live API (probed 2026-07-03). disable_parallel_tool_use restores
+            # the <=1-tool-call guarantee that forcing used to provide — under
+            # plain auto the model may emit MULTIPLE generate_sql calls in one
+            # turn and binding [0] could ground a superseded SQL.
+            tool_choice={"type": "auto", "disable_parallel_tool_use": True}
+            if thinking
+            else {"type": "tool", "name": "generate_sql"},
             thinking=thinking,
             label=prompt_name,
             effort=feature_config.effort if feature_config else None,
@@ -700,6 +708,13 @@ class GraphAgent(LLMFeature):
         # be composed stays grounded with the reason, it does not get a guessed SQL.
         if not response.tool_calls:
             return Result.fail("LLM did not call the generate_sql tool")
+        if len(response.tool_calls) > 1:
+            # disable_parallel_tool_use makes this unreachable; guard stays LOUD
+            # because binding [0] of several calls could ground a superseded SQL.
+            return Result.fail(
+                f"LLM emitted {len(response.tool_calls)} tool calls for a single "
+                "extract grounding — ambiguous, refusing to pick one"
+            )
 
         tool_call = response.tool_calls[0]
         if tool_call.name != "generate_sql":

--- a/packages/engine/src/dataraum/llm/providers/anthropic.py
+++ b/packages/engine/src/dataraum/llm/providers/anthropic.py
@@ -47,11 +47,13 @@ logger = get_logger(__name__)
 #     on these models we OMIT ``temperature`` and rely on the forced tool +
 #     prompt for stable output (temperature 0 never guaranteed identical output
 #     anyway).
-#   * Adaptive thinking is ON by default when ``thinking`` is omitted. A
-#     forced-tool extractor never wants it: it burns output budget the
-#     small-cap calls (validation caps at 2000) can't spare, and it diverges
-#     from the prior Sonnet 4.6 behaviour where thinking was off. So we DISABLE
-#     it explicitly.
+#   * Thinking defaults DIFFER across the family: Sonnet 5 runs adaptive
+#     thinking ON when ``thinking`` is omitted; Opus 4.7/4.8 default it OFF.
+#     A forced-tool extractor never wants it (it burns output budget the
+#     small-cap calls can't spare, and it diverges from the prior Sonnet 4.6
+#     behaviour), so the default path DISABLES it explicitly where a default-on
+#     model would otherwise think. A thinking feature (request.thinking) sends
+#     an EXPLICIT ``{"type": "adaptive"}`` instead of trusting any default.
 #
 # Older models (Haiku 4.5, Sonnet 4.6) accept temperature and default thinking
 # off, so their request shape is unchanged. Prefix match covers the undated
@@ -63,10 +65,11 @@ _TEMPERATURE_REJECTING_PREFIXES = (
     "claude-fable-5",
     "claude-mythos-5",
 )
-# Subset that additionally defaults adaptive thinking ON *and* accepts an
-# explicit disable. Fable 5 / Mythos 5 are always-on (they reject an explicit
-# ``thinking: disabled``), so they are intentionally excluded — the engine's
-# forced-tool tier does not target them.
+# Subset that accepts an explicit ``thinking: disabled`` — sent on the
+# non-thinking path so a default-on model (Sonnet 5) doesn't think; harmless
+# on Opus 4.7/4.8 (already default-off). Fable 5 / Mythos 5 are always-on and
+# REJECT an explicit disable, so they are intentionally excluded — the
+# engine's forced-tool tier does not target them.
 _THINKING_DEFAULT_ON_PREFIXES = (
     "claude-sonnet-5",
     "claude-opus-4-7",
@@ -80,7 +83,7 @@ def _rejects_temperature(model: str) -> bool:
 
 
 def _thinking_defaults_on(model: str) -> bool:
-    """True when the model runs adaptive thinking unless explicitly disabled."""
+    """True when the model accepts an explicit thinking disable (see above)."""
     return model.startswith(_THINKING_DEFAULT_ON_PREFIXES)
 
 
@@ -298,14 +301,20 @@ class AnthropicProvider(LLMProvider):
         Returns:
             Result containing ConversationResponse or error message
         """
-        # Request-shape validation BEFORE the API error domain: thinking with a
-        # forced tool_choice is a call-site programming error (the API rejects
-        # the combination), not a provider failure to classify for retry.
+        # Request-shape validation: thinking with a forced tool_choice is a
+        # call-site programming error. Probed live (2026-07-03): the first-party
+        # API does NOT 400 on the combination — it silently SUPPRESSES thinking
+        # (forced choice returned no thinking block; auto did) — worse than an
+        # error, the feature quietly stops working. Raise the TYPED permanent
+        # error (DAT-503) so the Temporal boundary fails loud on attempt 1: a
+        # bare ValueError would not be classified and the _LLM_RETRY policy
+        # would retry a deterministic misconfiguration 8x.
         if request.thinking and (request.tool_choice or {}).get("type") in ("tool", "any"):
-            raise ValueError(
-                "thinking=True is incompatible with a forced tool_choice "
-                f"({request.tool_choice}); use auto/none and mandate the "
-                "tool call in the prompt"
+            raise PermanentProviderError(
+                "thinking=True with a forced tool_choice "
+                f"({request.tool_choice}) silently suppresses thinking; use "
+                '{"type": "auto", "disable_parallel_tool_use": True} and '
+                "mandate the tool call in the prompt"
             )
         try:
             model = request.model or self.config.default_model
@@ -339,15 +348,21 @@ class AnthropicProvider(LLMProvider):
             }
 
             # Sonnet 5 / Opus 4.7-4.8 / Fable 5 reject a non-default temperature
-            # (400) and default adaptive thinking ON. Omit temperature on those;
-            # pass it through on the older models that still honour it. Thinking
-            # is per-REQUEST (DAT-603): the mechanical extractors run with it
-            # explicitly disabled (output budget + Sonnet 4.6 parity), while a
-            # reasoning-heavy feature (metric grounding) opts in by LEAVING the
-            # adaptive default on. (thinking + forced tool_choice is rejected at
-            # the top of converse — request-shape error, not an API failure.)
+            # (400). Omit temperature on those; pass it through on the older
+            # models that still honour it. Thinking is per-REQUEST (DAT-603):
+            # the mechanical extractors run with it explicitly disabled (output
+            # budget + Sonnet 4.6 parity); a reasoning-heavy feature (metric
+            # grounding) opts in with an EXPLICIT {"type": "adaptive"} — never
+            # by relying on the model default, because the defaults DIFFER
+            # across the family (Sonnet 5 defaults thinking ON, Opus 4.7/4.8
+            # default OFF): an omitted key would silently run a thinking
+            # feature without thinking the moment a tier repoints to Opus.
+            # Explicit adaptive is accepted by the whole family, including the
+            # always-on Fable/Mythos.
             if _rejects_temperature(model):
-                if _thinking_defaults_on(model) and not request.thinking:
+                if request.thinking:
+                    kwargs["thinking"] = {"type": "adaptive"}
+                elif _thinking_defaults_on(model):
                     kwargs["thinking"] = {"type": "disabled"}
             else:
                 kwargs["temperature"] = request.temperature

--- a/packages/engine/src/dataraum/llm/providers/base.py
+++ b/packages/engine/src/dataraum/llm/providers/base.py
@@ -109,7 +109,9 @@ class ConversationRequest(BaseModel):
     messages: list[Message]
     system: str | None = None
     tools: list[ToolDefinition] = Field(default_factory=list)
-    tool_choice: dict[str, str] | None = None  # e.g. {"type": "tool", "name": "..."}
+    # e.g. {"type": "tool", "name": "..."} or
+    # {"type": "auto", "disable_parallel_tool_use": True} (bool values occur).
+    tool_choice: dict[str, Any] | None = None
     max_tokens: int = 4096
     temperature: float = 0.0
     model: str | None = None  # Override default model
@@ -120,8 +122,9 @@ class ConversationRequest(BaseModel):
     # Let the model THINK (DAT-603): on thinking-default-on models (Sonnet 5 …)
     # the provider normally disables adaptive thinking for the forced-tool
     # extraction tier; a reasoning-heavy feature (metric grounding) opts back
-    # in. Thinking is API-incompatible with a FORCED tool_choice ("tool"/"any")
-    # — a thinking request must use auto/none and mandate the call via prompt.
+    # in. A FORCED tool_choice ("tool"/"any") silently SUPPRESSES thinking on
+    # the first-party API (probed 2026-07-03) — a thinking request must use
+    # auto (+ disable_parallel_tool_use) and mandate the call via prompt.
     thinking: bool = False
     # Greppable agent/phase tag for per-call telemetry (DAT-600). The provider
     # has no phase context of its own, so each call site stamps the prompt

--- a/packages/engine/src/dataraum/pipeline/phases/_warm_first.py
+++ b/packages/engine/src/dataraum/pipeline/phases/_warm_first.py
@@ -10,7 +10,15 @@ validation's first wave of 4 did the same at its cap.
 Letting the FIRST call run to completion commits the shared prefix; every call
 released after it reads the entry instead. Wall-clock cost is ~zero whenever
 the item count exceeds the pool cap (the wave count is unchanged) and one
-call-time otherwise.
+call-time otherwise. Waiting for FULL completion is deliberately conservative
+— the cache entry is committed once the prompt is processed (≈ first streamed
+token), so the theoretical optimum releases the rest on first-token. That
+would need a cross-layer signal out of the provider; not worth it while the
+tax is one call-time per phase. Know the price though: with adaptive thinking
+on graph_sql_generation (DAT-603) the first metrics call runs ~35s, and
+post-DAT-646 the warm DAG is a single generation of leaf extracts — when the
+unique-extract count fits inside the pool cap, that ~35s is a real one-time
+serial add to the metrics phase (retro-review of PR #433, 2026-07-03).
 
 This is deliberately the ONLY place the stagger lives: metrics warming and
 validation are the engine's only two concurrent LLM fan-outs (every other

--- a/packages/engine/tests/unit/graphs/test_prompt_selection.py
+++ b/packages/engine/tests/unit/graphs/test_prompt_selection.py
@@ -165,7 +165,43 @@ def test_thinking_feature_uses_auto_tool_choice(monkeypatch) -> None:
 
     request = provider.converse.call_args.args[0]
     assert request.thinking is True
-    assert request.tool_choice == {"type": "auto"}
+    # disable_parallel_tool_use restores the <=1-call guarantee forcing gave.
+    assert request.tool_choice == {"type": "auto", "disable_parallel_tool_use": True}
+
+
+def test_multiple_tool_calls_fail_loud(monkeypatch) -> None:
+    """Review fix: under auto tool_choice the model COULD emit several
+    generate_sql calls; binding [0] silently could ground a superseded SQL —
+    refuse instead (disable_parallel_tool_use makes this unreachable; the
+    guard is the tripwire)."""
+    monkeypatch.setattr("dataraum.graphs.context.format_metadata_document", lambda c: "META")
+    monkeypatch.setattr(
+        "dataraum.graphs.field_mapping.format_mappings_for_prompt", lambda f: "MAPS"
+    )
+    ext = GraphStep(
+        step_id="revenue",
+        step_type=StepType.EXTRACT,
+        source=StepSource(standard_field="revenue", statement="income_statement"),
+        aggregation="sum",
+        output_step=True,
+    )
+    graph = _graph("revenue", {"revenue": ext})
+    renderer, provider = _mocks()
+    call_a, call_b = MagicMock(), MagicMock()
+    call_a.name = call_b.name = "generate_sql"
+    provider.converse.return_value.unwrap.return_value = MagicMock(tool_calls=[call_a, call_b])
+    agent = _agent_with(renderer, provider)
+    agent._build_schema_info = MagicMock(return_value={})  # type: ignore[method-assign]
+    agent._build_prior_context = MagicMock(return_value="")  # type: ignore[method-assign]
+    rich = MagicMock()
+    rich.field_mappings.mappings = {"revenue": object()}
+    rich.conventions = ""
+    ctx = ExecutionContext(duckdb_conn=MagicMock(), schema_mapping_id="ws", rich_context=rich)
+
+    result = agent._generate_sql(MagicMock(), graph, ctx, {})
+
+    assert result.success is False
+    assert "2 tool calls" in (result.error or "")
 
 
 def test_multi_step_graph_fails_loud_before_any_llm_call() -> None:

--- a/packages/engine/tests/unit/llm/test_anthropic_provider.py
+++ b/packages/engine/tests/unit/llm/test_anthropic_provider.py
@@ -256,24 +256,34 @@ class TestConverseRequestShape:
         assert kwargs["temperature"] == 0.0
         assert "thinking" not in kwargs
 
-    def test_thinking_request_leaves_adaptive_default_on(
+    def test_thinking_request_sends_explicit_adaptive(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # DAT-603: a thinking feature (metric grounding) opts back into the
-        # model's adaptive default — no explicit thinking key at all.
+        # DAT-603 review fix: EXPLICIT adaptive, never the model default —
+        # defaults differ across the family (Sonnet 5 ON, Opus 4.7/4.8 OFF),
+        # so an omitted key would silently lose thinking on an Opus tier.
         kwargs = self._capture(monkeypatch, "claude-sonnet-5", thinking=True)
         assert "temperature" not in kwargs
-        assert "thinking" not in kwargs
+        assert kwargs["thinking"] == {"type": "adaptive"}
+
+    def test_thinking_request_explicit_adaptive_on_opus(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Opus 4.7/4.8 default thinking OFF — relying on the default here would
+        # run a "thinking" feature without thinking, silently.
+        kwargs = self._capture(monkeypatch, "claude-opus-4-8", thinking=True)
+        assert kwargs["thinking"] == {"type": "adaptive"}
 
     def test_thinking_with_forced_tool_choice_fails_loud(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # The API rejects thinking + forced tool_choice; that shape is a
-        # call-site programming error, surfaced as ValueError, never a 400
-        # dressed up as a transient provider failure.
+        # A forced tool_choice silently SUPPRESSES thinking on the live API
+        # (probed 2026-07-03) — a call-site programming error, surfaced as the
+        # TYPED permanent error so the Temporal retry policy fails it on
+        # attempt 1 (a bare ValueError would be retried 8x, DAT-503).
         provider = _provider()
         _patch_stream(monkeypatch, provider, lambda **kwargs: _ok_response())
-        with pytest.raises(ValueError, match="forced tool_choice"):
+        with pytest.raises(PermanentProviderError, match="suppresses thinking"):
             provider.converse(
                 ConversationRequest(
                     messages=[Message(role="user", content="hi")],


### PR DESCRIPTION
## Summary

The reviewer stage skipped on PRs #432–#435 was run retroactively (senior-code-reviewer + spec-compliance-reviewer on the merged #434/#435 diffs). **#435 (cockpit) came back clean** — every SDK claim verified against the installed @tanstack/ai source. #434 (engine) had four findings, all fixed here, plus two spec-review items.

### Senior-review findings → fixes

1. **[Critical, live] Multiple tool calls under `auto` choice.** The thinking path switched to `tool_choice: auto`, which permits parallel tool use — the code bound `tool_calls[0]` silently, risking grounding a superseded SQL. Fixed: `{"type": "auto", "disable_parallel_tool_use": true}` (restores the ≤1-call guarantee; **probed live**: 200, thinking block present, single call) plus a loud `>1 calls` refusal in `_generate_sql` as the tripwire. Test added.
2. **[Latent] Opus 4.7/4.8 default thinking OFF, not ON.** The code relied on "leave the adaptive default on", which only holds for Sonnet 5 — a tier repoint to Opus would silently run the thinking feature without thinking. Fixed: thinking requests send an explicit `{"type": "adaptive"}` (accepted family-wide, incl. always-on Fable/Mythos). Tests for Sonnet 5 + Opus 4.8.
3. **[Latent] Bare `ValueError` in `converse()`'s guard** sat outside the DAT-503 typed-error contract — Temporal's `_LLM_RETRY` would have retried a deterministic misconfiguration 8×. Fixed: `PermanentProviderError`, fails attempt 1.
4. **Doc-conflict resolved by live probe** (the reviewer flagged the "API rejects thinking+forced tool" claim as possibly Bedrock-only): the first-party API does **not** 400 — forced choice **silently suppresses thinking** (forced → no thinking block; auto → thinking block). Worse than an error; the guard stays, and every comment now states the probed truth. `ConversationRequest.tool_choice` widened to `dict[str, Any]` for the bool.

### Spec-review items

- **`.claude/handoff.md` entry for DAT-603** (was missing — the eval bridge): output-schema swap, thinking latency profile (763→~3.7k tokens/call, ~10s→~35s), prompt v6.1, and the trial-balance trailing-period testdata note, so `dataraum-eval` re-baselines `graph_sql_generation` before trusting DAT-602 comparisons.
- **`graphs/__init__.py`** stale full-graph usage example replaced with the warm/assemble reality (it demonstrated a call shape that now fails loud).

## Verification

Unit 257 + integration 38 (graphs + metrics phase) green; ruff/mypy/vulture clean. The `disable_parallel_tool_use` shape verified against the live API in the probe (three-way: forced 200/no-thinking, any 200/no-thinking, auto+disable 200/thinking+single-call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)