### PR TITLE
docs(DAT-277): composite-key architecture — ADR-0018 + concept pages

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -55,7 +55,7 @@ now only ever sees single-column FKs.
 ### Calibration to run
 
 - **Relationship detection / FK confirmation** on composite-key datasets: the
-  fan-trap edge (e.g. BookSQL `master_txn.account ↔ chart_of_accounts`) should
+  fan-trap edge (a transactions↔chart-of-accounts pair scoped by tenant) should
   now surface as ONE stable many-to-one surrogate relationship instead of a
   flaky/degenerate many-to-many + 20 tenant-key candidates. Watch single-key
   datasets for regressions — with no composite hint the pipeline is
@@ -64,9 +64,9 @@ now only ever sees single-column FKs.
   previously fan-trapped dimension becomes joinable; metrics should ground on
   the real discriminator (`account_type`), not single-table proxies
   (`transaction_type` at 0.35). DAT-652's acceptance case (non-empty driver
-  rankings on BookSQL) is the headline check.
-- **BookSQL becomes a legitimate grounding oracle once this lands** — the
-  standing "don't use BookSQL as the acceptance oracle" caveat retires.
+  rankings on the bookkeeping smoke corpus) is the headline check.
+- **The bookkeeping smoke corpus becomes a legitimate grounding oracle once this lands** — the
+  standing "don't use it as the acceptance oracle" caveat retires.
 
 ### testdata hints
 
@@ -78,7 +78,7 @@ fan-trap). New assertable surface: the `_sk__*` columns themselves (both
 tables), the `surrogate_key_intents` row, and the surrogate relationship's
 `evidence.surrogate.natural_pairs`.
 
-### Validated live on BookSQL (2026-07-03, full 7-table set, real LLM)
+### Validated live on the bookkeeping smoke corpus (2026-07-03, full 7-table set, real LLM)
 
 Four composites minted (`(name, business_id)` for customer/vendor/
 payment_method/product_service), all persisted fact→dim many-to-one,
@@ -87,7 +87,7 @@ the 810k-row fact with 11 dim columns joined via the surrogates; the flaky
 20-candidate `business_id` degeneracy is gone. `gl_invoice_match` validation
 went declared→executed (the surrogates gave it a join path); revenue grounds
 on `account_type='Income'` (the real classification, not transaction_type).
-Two BookSQL DATA truths the platform now states instead of absorbing:
+Two smoke-corpus DATA truths the platform now states instead of absorbing:
 `chart_of_account_OB`'s `(account, business)` collisions are 82 exact duplicate
 rows PLUS 135 dual-role accounts (same name+full name, DIFFERENT account type —
 Installation as both Income and Expenses in one business), so no name-based
@@ -95,9 +95,9 @@ composite is a key there and **dedup cannot fix it** (the true key would need
 `account_type`, which the fact doesn't carry) — the confirmed composite was
 REFUSED (non-collapsing gate), the anchor persists m2m + fan-trap-flagged, and
 the semi-join grounding pattern (`account IN (SELECT … WHERE account_type=…)`)
-is the correct end-state consumption. And BookSQL has NO COGS account type, so
+is the correct end-state consumption. And the corpus has NO COGS account type, so
 `cost_of_goods_sold` is honestly inconclusive ("filter matched no rows"), never
-a transaction_type proxy. Eval should treat both as expected BookSQL baseline,
+a transaction_type proxy. Eval should treat both as expected corpus baseline,
 not regressions.
 
 ---
@@ -488,7 +488,7 @@ under a second name is the natural regression for the original duplication bug.
 - The `derived_value` / `temporal_behavior` detector inputs (`entropy/detectors/loaders.load_semantic`) now grain-split: object-grain fields from `SemanticAnnotation`, catalogue-grain from `ColumnConcept` at the run — so catalogue fields are present at `session_detect`, ABSENT at add_source `detect` (the intended grain boundary). `entropy/resolve.resolve_temporal_behavior` now writes `ColumnConcept`.
 
 ### Calibration to run
-- **BookSQL cold re-seed grounding** — the headline acceptance check: `revenue`/`accounts_payable`/`accounts_receivable` must NO LONGER trap-bind to near-constant flags (`sale`/`ap_paid`/`ar_paid`) — they bind to a genuine discriminator or stay null (value-set grounded). The 11 already-grounding metrics must NOT regress.
+- **Bookkeeping-corpus cold re-seed grounding** — the headline acceptance check: `revenue`/`accounts_payable`/`accounts_receivable` must NO LONGER trap-bind to near-constant flags (`sale`/`ap_paid`/`ar_paid`) — they bind to a genuine discriminator or stay null (value-set grounded). The 11 already-grounding metrics must NOT regress.
 - Driver-discovery `target_type` (reads `ColumnConcept.temporal_behavior` now) — confirm stock/flow target selection is unchanged on the calibration corpora.
 
 ### Thresholds / new fields

--- a/docs/adr/0018-composite-keys-surrogate-mint.md
+++ b/docs/adr/0018-composite-keys-surrogate-mint.md
@@ -9,15 +9,16 @@
 
 The relationship model is a single column pair (`from_column_id → to_column_id`). Real
 datasets carry **composite** foreign keys — a referencing column plus one or more scoping
-columns present on both sides, canonically a tenant key: BookSQL's
-`master_txn.account → chart_of_accounts.account_name` is only meaningful together with
-`business_id`. A single-column model cannot express this, with three measured consequences:
+columns present on both sides, canonically a tenant key: a transaction's
+`account → chart_of_accounts.account_name` reference is only meaningful together with the
+tenant id. A single-column model cannot express this, with three measured consequences:
 
 - The best single-column join is **many-to-many** — aggregates over it silently
   over-count (the fan-trap).
 - The scoping column links every table to every table on its own, so its standalone
   candidates are degenerate and the LLM elevates them **inconsistently** across runs
-  (BookSQL: 20 `business_id ↔ business_id` pairs, a different survivor each run).
+  (measured on the validation dataset: 20 tenant-key pairs, a different survivor each
+  run).
 - The SQL agents learn to **avoid the join** and ground on weaker single-table
   discriminators.
 
@@ -81,12 +82,13 @@ No consumer ever sees a multi-column key.**
   defined relationship is a single column pair — now also holds for composite-keyed data.
 - `views/builder.py`, the enrichment agent, cycles, lineage, validation, and both SQL
   agents are unchanged: they consume the surrogate as an ordinary many-to-one FK.
-- Validated on BookSQL (7 tables, 810k-row fact): four `(name, business_id)` composites
-  mint stably every run, the enriched view joins them grain-verified, and
-  `gl_invoice_match` gained a join path. The chart-of-accounts composite is **refused**
-  — BookSQL's dual-role accounts (same name, both Income and Expenses within one
-  business) make a row-grain FK impossible by construction; the honest outcome is the
-  flagged fan-trap plus set-grain semi-joins at answer time.
+- Validated end-to-end on a seven-table multi-tenant bookkeeping dataset (810k-row
+  fact): four `(name, tenant)` composites mint stably every run, the enriched view joins
+  them grain-verified, and an invoice-matching validation gained a join path. The
+  chart-of-accounts composite is **refused** — that dataset's dual-role accounts (the
+  same account name carrying both an income and an expense account within one tenant)
+  make a row-grain FK impossible by construction; the honest outcome is the flagged
+  fan-trap plus set-grain semi-joins at answer time.
 - Deploying a workflow-chain change: an in-flight begin_session run fails Temporal replay
   determinism on the new code and needs a re-run (true of every phase addition).
 - Search-quality follow-up (the greedy finds local optima; misses are safe but real) is

--- a/docs/adr/0018-composite-keys-surrogate-mint.md
+++ b/docs/adr/0018-composite-keys-surrogate-mint.md
@@ -1,0 +1,109 @@
+# ADR-0018 — Composite keys are cured at the source by a surrogate-key mint
+
+- **Status:** Accepted
+- **Date:** 2026-07-03
+- **Ticket:** DAT-277 (epic DAT-652)
+- **Reference:** dbt's surrogate-key pattern (hash of the key columns); plan + validation record on the DAT-277 ticket
+
+## Context
+
+The relationship model is a single column pair (`from_column_id → to_column_id`). Real
+datasets carry **composite** foreign keys — a referencing column plus one or more scoping
+columns present on both sides, canonically a tenant key: BookSQL's
+`master_txn.account → chart_of_accounts.account_name` is only meaningful together with
+`business_id`. A single-column model cannot express this, with three measured consequences:
+
+- The best single-column join is **many-to-many** — aggregates over it silently
+  over-count (the fan-trap).
+- The scoping column links every table to every table on its own, so its standalone
+  candidates are degenerate and the LLM elevates them **inconsistently** across runs
+  (BookSQL: 20 `business_id ↔ business_id` pairs, a different survivor each run).
+- The SQL agents learn to **avoid the join** and ground on weaker single-table
+  discriminators.
+
+A first cut (`refactor/dat-277-composite-key-rescue`, PR #394, parked) expressed the
+composite downstream: relationship groups (`relationship_group_id`/`key_position`) and a
+multi-column `ON` clause in the view builder. It worked, but every single-column consumer
+needed gating or threading (anchor recovery, column-name collisions, suppression gaps),
+and the complexity grew with each consumer. The parked branch's own conclusion: the
+composite is a symptom to cure at the source, not to rescue at every reader.
+
+## Decision
+
+**A confirmed composite key is fused into ONE deterministic hash column on both typed
+tables, and the catalog persists ONE ordinary single-column relationship on that pair.
+No consumer ever sees a multi-column key.**
+
+1. **Detection is evidence, the LLM is the judge.** A greedy pre-pass
+   (`analysis/relationships/composite.py`) probes each fan-out candidate: anchor on the
+   strongest pair, fuse the co-present pair that most reduces join multiplicity, accept
+   only when the composite's measured cardinality collapses out of many-to-many — else
+   abstain (a genuine bridge can never satisfy the criterion). A hit is attached to the
+   `semantic_per_table` candidate feed as a `composite_key` hint; the LLM confirms via
+   `RelationshipOutput.key_columns`. Nothing is auto-created from statistics.
+
+2. **A confirmed composite never enters the catalog as a half-key.** It persists as a
+   `surrogate_key_intents` row (run-versioned, digest-keyed for retry idempotency). The
+   plain single-column persist path is byte-identical when no composite is confirmed.
+
+3. **The `surrogate_mint` phase** (begin_session, after the teach overlays, before
+   `enriched_views`) cures each intent at the source:
+   - Both typed tables are re-materialized with the hash column by **wrapping the typing
+     recipe's DDL** on the ADR-0010/DAT-414 substrate (emit → store → execute; steady
+     state executes nothing). The expression is **NULL-propagating**
+     (`md5(a::VARCHAR || '|' || b …)`): any NULL component yields a NULL surrogate, so a
+     LEFT JOIN misses — FK semantics, deliberately not dbt's NULL placeholder, which
+     would false-join NULL↔NULL.
+   - The column name is deterministic in the component set (`_sk__<components>`, anchor
+     first, scope sorted), and the `Column` row is upserted by `(table_id, column_name)`
+     — so `column_id` is stable across runs and teach/keeper overlays keyed on it hold.
+   - ONE relationship persists on the surrogate pair, **FK-side-first by measured
+     cardinality** (a dim→fact confirmation flips to fact→dim many-to-one), with the
+     natural→surrogate provenance in `evidence.surrogate`.
+   - Reconcile owns the `_sk__*` namespace: a surrogate neither re-confirmed nor still
+     referenced by the promoted/kept catalog (the keeper grace window) is dropped,
+     physical and metadata.
+
+4. **Guardrails make the worst case "no column minted", never a wrong join.** The mint
+   abstains on: divergent component types (native `=` coerces, `'007' = 7`; the hash
+   compares VARCHAR renderings, `'7' ≠ '007'` — a same-type pair is provably
+   equivalent, a divergent pair is not), float components (equal DOUBLEs can render
+   differently: `-0.0`/`0.0`), a composite whose measured cardinality does **not**
+   collapse (the LLM confirmed against the data — the flagged single-column anchor
+   persists instead), a vanished component (the pair aborts as a unit), and a missing
+   typing recipe. A DuckLake commit race propagates as a retryable failure (DAT-641
+   pattern) rather than a silent miss.
+
+## Consequences
+
+- The begin_session chain is 14 phases; typed tables can carry engine-minted `_sk__*`
+  columns (VARCHAR, profiled, reconciled by the mint). The catalog invariant — every
+  defined relationship is a single column pair — now also holds for composite-keyed data.
+- `views/builder.py`, the enrichment agent, cycles, lineage, validation, and both SQL
+  agents are unchanged: they consume the surrogate as an ordinary many-to-one FK.
+- Validated on BookSQL (7 tables, 810k-row fact): four `(name, business_id)` composites
+  mint stably every run, the enriched view joins them grain-verified, and
+  `gl_invoice_match` gained a join path. The chart-of-accounts composite is **refused**
+  — BookSQL's dual-role accounts (same name, both Income and Expenses within one
+  business) make a row-grain FK impossible by construction; the honest outcome is the
+  flagged fan-trap plus set-grain semi-joins at answer time.
+- Deploying a workflow-chain change: an in-flight begin_session run fails Temporal replay
+  determinism on the new code and needs a re-run (true of every phase addition).
+- Search-quality follow-up (the greedy finds local optima; misses are safe but real) is
+  DAT-679, evaluation-first.
+
+## Alternatives rejected
+
+- **Multi-column ON at the consumers** (the parked branch): every single-column consumer
+  pays — group storage, anchor recovery, collision suffixing, suppression gating. The
+  complexity compounds per consumer instead of being paid once at the source.
+- **Hash expression inside the view SQL only:** the catalog still cannot express the key,
+  so the answer agent still sees a many-to-many natural edge and the flaky elevation
+  persists — the multi-column rescue in disguise.
+- **Fixing direction handling in the enrichment agent** instead of orienting at the mint:
+  changes behavior for every natural relationship (a consumer-side blast radius) to fix a
+  producer-side convention.
+- **Deriving a missing key component semantically** (e.g. inferring an account's side
+  from credit/debit): an unreliable per-row heuristic pre-pass; where the fact does not
+  carry the discriminator, the honest verdict is the fan-trap flag, and interpretation
+  belongs to the agent at answer time.

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -48,6 +48,7 @@ columns and a terminal step measures.
 | `session_materialize_overlays` | deterministic | Fold durable relationship teaches into the run |
 | `relationships` | deterministic | Value-overlap, cardinality, and join detection |
 | `semantic_per_table` | **LLM** | Classify tables (fact/dimension, grain), confirm relationships, author catalogue-grain column semantics |
+| `surrogate_mint` | deterministic | Fuse confirmed composite keys into hash key columns; record the single-column join |
 | `enriched_views` | **LLM** | Score and build grain-preserving join views |
 | `slicing` | **LLM** | Identify the categorical dimensions you can slice by |
 | `aggregation_lineage` | deterministic | Reconcile measures across facts (sum-consistency) |

--- a/docs/concepts/relationships-and-aggregation.md
+++ b/docs/concepts/relationships-and-aggregation.md
@@ -25,6 +25,29 @@ manual curation (a `relationship` teach), and keeper retention (a join you chose
 A confident LLM witness over a weak data witness raises conflict, and the relationship is
 flagged for investigation rather than silently kept or dropped.
 
+### Composite keys
+
+Some joins need more than one column: a referencing column plus a scoping column present
+on both sides, typically a tenant key — `(account, business_id)` rather than `account`
+alone. On its own, each half is wrong: the referencing column joins many-to-many across
+scopes, and the scoping column joins everything to everything.
+
+These are detected and cured in the same measured way. When a candidate's best
+single-column join is many-to-many, a pre-pass tests whether fusing co-present columns
+collapses the join out of many-to-many; the fused key is offered to the same LLM
+confirmation step as a hint. A confirmed composite is then **minted as a surrogate key**:
+both tables gain one deterministic hash column over the key's components
+(`_sk__account__business_id`), and the catalog records one ordinary single-column
+relationship on that pair — many-to-one, measured. A NULL in any component yields a NULL
+hash, so unkeyed rows simply don't match. Downstream, a composite key is
+indistinguishable from any other foreign key.
+
+The cure is only applied when the data proves the key. A confirmed composite whose fused
+join still measures many-to-many is refused — the single-column relationship stays,
+flagged as a fan trap. Some dimensions are structurally unjoinable at row grain (two
+rows sharing every attribute the referencing table carries); the flag is the honest
+verdict there, and answer-time SQL falls back to set-grain semi-joins.
+
 Confirmed relationships feed three consumers: **enriched join views** (grain-preserving
 joins of a fact table with its dimensions — a view whose row count differs from the fact's
 is dropped, because the join changed the grain), the **Model** graph's *relates* edges,

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -487,7 +487,7 @@ def _build_surrogate_intent(
         if cardinality == "many-to-many":
             # The LLM confirmed a composite the data measurably REJECTS (the
             # prompt's contract: only confirm when it resolves the fan-out).
-            # Seen live on BookSQL: chart_of_accounts carries duplicate
+            # Seen live on a multi-tenant bookkeeping smoke: the chart of accounts carries duplicate
             # (account, business) rows, so no name-based composite collapses.
             # Fall back to the plain single-column anchor — it persists with
             # its honest cardinality + fan-trap flag, exactly the pre-mint

--- a/packages/engine/src/dataraum/pipeline/phases/surrogate_mint_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/surrogate_mint_phase.py
@@ -579,7 +579,7 @@ class SurrogateMintPhase(BasePhase):
         natural_ids = [list(pair) for pair in intent.column_pairs]
         # The catalog's FK convention: `from` is the referencing (many) side.
         # The LLM may confirm the composite in dim→fact order (seen live on
-        # BookSQL: all four clean composites arrived one-to-many), and the
+        # the live smoke: all four clean composites arrived one-to-many), and the
         # enrichment grain-safe marker reads the STORED direction — so orient
         # deterministically by the measured cardinality, not by emission order.
         if cardinality == "one-to-many":

--- a/packages/engine/tests/unit/analysis/relationships/test_composite.py
+++ b/packages/engine/tests/unit/analysis/relationships/test_composite.py
@@ -66,7 +66,7 @@ def test_empty_key_is_none(con) -> None:
 
 
 def test_spurious_m2m_rescued_by_one_scoping_col(con) -> None:
-    """The BookSQL shape: account recurs across tenants; (account, business_id) is the real key."""
+    """The multi-tenant bookkeeping shape: account recurs across tenants; (account, business_id) is the real key."""
     con.execute("CREATE TABLE txn (account VARCHAR, business_id VARCHAR, amount INT)")
     con.execute(
         "INSERT INTO txn VALUES "

--- a/packages/engine/tests/unit/analysis/semantic/test_surrogate_intent.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_surrogate_intent.py
@@ -45,7 +45,7 @@ def _table_with_columns(session, name: str, columns: list[str]) -> Table:
 
 @pytest.fixture
 def lake() -> Iterator[duckdb.DuckDBPyConnection]:
-    """The BookSQL fan-out shape in a ``lake.typed`` schema (mirrors the worker attach)."""
+    """The tenant-scoped fan-out shape in a ``lake.typed`` schema (mirrors the worker attach)."""
     c = duckdb.connect()
     try:
         c.execute("ATTACH ':memory:' AS lake")
@@ -205,7 +205,7 @@ def test_missing_run_id_builds_no_intent(session) -> None:
 def test_non_collapsing_composite_falls_back_to_single(session, lake) -> None:
     """A confirmed composite the data REJECTS (still m2m — dup dim rows) must not
     become an intent: fall back to the plain anchor with its honest fan-trap
-    flag. Seen live on BookSQL (duplicate (account, business) rows in the
+    flag. Seen live on the bookkeeping smoke corpus (duplicate (account, business) rows in the
     chart of accounts)."""
     lake.execute("INSERT INTO lake.typed.\"coa\" VALUES ('Sales','B1')")  # dup dim row
     txn = _table_with_columns(session, "txn", ["account", "business_id"])

--- a/packages/engine/tests/unit/graphs/test_formula_composer.py
+++ b/packages/engine/tests/unit/graphs/test_formula_composer.py
@@ -1,6 +1,6 @@
 """Unit tests for deterministic formula composition (DAT-636).
 
-Covers every BookSQL finance formula shape, the NULLIF division guard, and the
+Covers every finance formula shape from the smoke corpus, the NULLIF division guard, and the
 born-loud failures (unknown operand, unsupported construct). The composed SQL is
 also executed against in-memory DuckDB CTEs to prove it is valid and evaluates to
 the arithmetic result — no LLM, no smoke.

--- a/packages/engine/tests/unit/pipeline/test_surrogate_mint_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_surrogate_mint_phase.py
@@ -1,6 +1,6 @@
 """The surrogate_mint phase (DAT-277) — mint, reconcile, and abstain semantics.
 
-Seeds the BookSQL fan-out shape (fact ``txn`` whose ``account`` recurs across
+Seeds the tenant-scoped fan-out shape (fact ``txn`` whose ``account`` recurs across
 ``business_id`` tenants, dim ``coa`` keyed on the composite) with real raw +
 typed DuckDB tables, generation-head recipes, and a confirmed intent — then
 drives the phase and asserts on the physical lake, the Column/profile rows,
@@ -85,7 +85,7 @@ def lake() -> Iterator[_LakeScopedConnection]:
 
 
 def _seed(session: Session) -> dict[str, Any]:
-    """Typed tables + columns + generation-head recipes for the BookSQL shape."""
+    """Typed tables + columns + generation-head recipes for the multi-tenant bookkeeping shape."""
     src = Source(name="s", source_type="csv")
     session.add(src)
     session.flush()
@@ -226,7 +226,7 @@ def test_mint_end_to_end(session, lake) -> None:
 
 def test_dim_to_fact_intent_persists_fk_side_first(session, lake) -> None:
     """The LLM may confirm the composite dim→fact (one-to-many) — seen live on
-    BookSQL, where all four clean composites arrived in that orientation and
+    the bookkeeping smoke corpus, where all four clean composites arrived in that orientation and
     the enrichment grain-safe marker (which reads the STORED direction) then
     refused every join. The mint must orient by measured cardinality: persist
     fact→dim many-to-one with flipped provenance.


### PR DESCRIPTION
## What & why

DAT-277 (surrogate-key mint) merged in #439 without its documentation. This records the architecture where it belongs:

- **ADR-0018** — the settled decision: composite keys are cured at the source (evidence → LLM judge → deterministic NULL-propagating hash column on both typed tables → one ordinary single-column FK in the catalog), the guardrail set (type equivalence, float refusal, non-collapse refusal, keeper grace, retryable commit races), the validation outcome, and the rejected alternatives — including the parked multi-column rescue (PR #394) and why it lost.
- **concepts/relationships-and-aggregation.md** — a Composite keys section in the relationship story: detection, the mint, and the honest refusal when the data rejects a key (structurally unjoinable dimensions stay flagged fan-traps; answer-time SQL falls back to set-grain semi-joins).
- **concepts/pipeline.md** — the `surrogate_mint` row in the begin_session phase table.

**Plus a dataset-name scrub across the public tree**: the validation dataset is not open source, so the ADR, code comments, test docstrings, and the eval handoff now describe it (seven-table multi-tenant bookkeeping corpus, 810k-row fact) without naming it. Comment/docstring-only — no behavior change; the touched test files pass (61/61), ruff clean, `zensical build` clean. Merging auto-deploys the docs via docs.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)