### PR TITLE
chore(release): v0.3.0 prep

### DIFF
--- a/.claude/skills/release-prep/SKILL.md
+++ b/.claude/skills/release-prep/SKILL.md
@@ -12,134 +12,83 @@ allowed-tools:
 
 # Release prep: $ARGUMENTS
 
-A version bump is about to happen. The CI preflight enforces the *mechanical*
-facts — version match across `pyproject.toml` / `server.json`, `server.json`
-schema, and numeric counts of phases / MCP tools / detectors via
-`scripts/check_doc_counts.py`. CI cannot tell you whether the **prose** still
-matches reality. That's this skill's job.
+A release is about to be cut. Releasing = the user publishes a GitHub Release with tag
+`v<version>`; `release.yml` then pushes the three container images to GHCR
+(`dataraum`, `dataraum-cockpit`, `dataraum-cockpit-migrate`), each tagged `:{version}` +
+`:latest`. **The git tag is the single source of version truth** — nothing is published
+to PyPI or npm. CI's preflight runs `packages/engine/scripts/check_doc_counts.py`
+(numbered phase/detector claims across the doc files it lists). CI cannot tell whether
+the **prose** still matches reality; that's this skill's job.
 
-**Run this BEFORE creating the release commit and tag.**
-
-## Scope
-
-This skill is scoped to **`packages/engine`** — the Python engine + FastAPI shell, which is the only package with a semver release process today. The cockpit and api packages currently ship via docker image (no per-package tag); revisit this skill when that changes.
-
-All commands and paths below are **relative to `packages/engine/`**. Run them from that directory, or prefix with `(cd packages/engine && ...)`.
+**Run this BEFORE the release commit and tag.** Scope is the whole monorepo.
 
 ## Input
 
-`$ARGUMENTS` is the target version, e.g. `0.2.2`. If empty, read the version
-from `pyproject.toml` and ask the user whether that's the target.
-
-## Why this exists
-
-Past releases shipped with stale facts (e.g. README claiming "17-phase
-pipeline" after we added phase 18, missing tool rows in the tool table). The
-CI count-check now catches numeric drift, but tool rows, descriptions, examples,
-and links rot quietly. A 5-minute editorial pass before tagging is cheaper than
-a docs-only patch release.
+`$ARGUMENTS` is the target version, e.g. `0.3.0`. If empty, read
+`packages/engine/pyproject.toml` and ask the user for the target.
 
 ## Procedure
 
-### 1. Establish the baseline
-
-Find the previous release tag and the diff since:
+### 1. Baseline
 
 ```bash
 PREV=$(git tag --sort=-creatordate | head -1)
-echo "Previous release: $PREV"
-git log --oneline "$PREV"..HEAD
-git diff --stat "$PREV"..HEAD
+git log --oneline "$PREV"..HEAD | wc -l
+git diff --stat "$PREV"..HEAD | tail -5
 ```
 
-If `$ARGUMENTS` was empty, also confirm the target version with the user before
-proceeding.
-
-### 2. Run the mechanical check first
+### 2. Mechanical check
 
 ```bash
-uv run python scripts/check_doc_counts.py
+(cd packages/engine && uv run python scripts/check_doc_counts.py)
 ```
 
-If it reports drift, fix the doc files it points to before going further. This
-check covers:
-
-- numbered claims like "18 phases", "10 MCP tools", "16 detectors" across the
-  user-facing docs in `DOC_FILES`
-- README tool table completeness vs. tools registered in
-  `src/dataraum/mcp/server.py`
+If it reports drift, fix the docs it names. Note: the script **silently skips missing
+files** — if the docs tree moved, fix its `DOC_FILES` first or it checks nothing.
 
 ### 3. Editorial sweep
 
-For each file below, skim the **diff since `$PREV`** for behavior changes that
-affect prose, then read the file and update anything that's now wrong.
+Skim the diff since `$PREV` for behavior changes, then review these against today's
+behavior — the question per file is "what would surprise a new user?":
 
-Files to review (in order):
+1. `README.md` (root) — status claims, quick start, release-overlay instructions
+2. `packages/engine/README.md` + `packages/cockpit/README.md` — package maps, dev loops
+3. `docs/` (workspace root, the published site) — `index.md`, `getting-started/`,
+   `concepts/` (pipeline table, relationships), `platform/architecture.md`,
+   `operations/deployment.md`
+4. `CHANGELOG.md` (root) — add the `$ARGUMENTS` section. **Keep it brief**: the net
+   user-facing change since `$PREV`, grouped Added / Changed / Removed, thematic bullets
+   with ADR links — never a per-commit or per-PR list. Intermediate states that shipped
+   and were retired within the cycle get no entry (Keep-a-Changelog documents releases,
+   not the path between them).
 
-1. `README.md` — quick start commands, tool table descriptions, workflow
-   example, doc links, badges, install instructions
-2. `CHANGELOG.md` — must have a section for `$ARGUMENTS` summarizing user-facing
-   changes (added / changed / removed / fixed). Don't list internal refactors.
-3. `docs/index.md` — landing page claims and entry points
-4. `docs/pipeline.md` — phase list and per-phase descriptions if phases were
-   added/removed/renamed
-5. `docs/entropy.md` — detector list, scores, thresholds
-6. `docs/architecture.md` — module diagram, tool count, data flow
-8. `docs/configuration.md` — env vars, paths, contracts
-9. `docs/data-model.md` — tables, schema fields
-10. `docs/contributing.md` — module tree, dev commands
+### 4. Verify documented commands
 
-For each: ask "what would surprise a new user who reads this against today's
-behavior?" — that's what to fix.
-
-### 4. Verify documented commands actually work
-
-If the docs claim a CLI command exists, run `--help` on it. If they show a
-shell example, sanity-check that it parses (`bash -n` on snippets, or just
-read carefully). Tool descriptions in the README table should match the
-descriptions registered in `src/dataraum/mcp/server.py` at the spirit level
-(don't mechanically copy the multi-paragraph server description into the
-table — keep the README terse).
+Run the quick-start and dev-loop commands the docs claim (or at minimum parse-check
+them). The compose quick start + the release overlay
+(`docker-compose.release.yml` + `DATARAUM_VERSION`) are the two a new user hits first.
 
 ### 5. Version metadata
 
-Confirm the version bump touches all three places (CI will enforce this on
-tag, but catching it now is cheaper than a failed release):
-
 ```bash
-grep '^version = ' pyproject.toml
-python -c 'import json; print(json.load(open("server.json"))["version"])'
-python -c 'import json; print(json.load(open("server.json"))["packages"][0]["version"])'
+grep '^version = ' packages/engine/pyproject.toml   # must equal $ARGUMENTS
+(cd packages/engine && uv lock --offline)            # keep uv.lock's own version in sync
 ```
 
-All three must equal `$ARGUMENTS`.
+The cockpit's `package.json` carries no version — the image tag is its version. If that
+changes, add it here.
 
-### 6. Final mechanical check + summary
+### 6. Wrap up
 
-```bash
-uv run python scripts/check_doc_counts.py
-uv run pytest --testmon tests -q
-```
-
-Report to the user:
-
-- the previous tag and number of commits since
-- which doc files you edited and a one-line summary per file
-- the CHANGELOG entry you wrote (paste it)
-- anything you noticed but didn't change (because it wasn't clearly stale or
-  needed product judgment)
-
-Then stop. **Do NOT create the release commit, tag, or PR yourself** — the user
-does that. The skill ends with "ready for tagging".
+Re-run the mechanical check, then report: previous tag + commit count, files edited
+(one line each), the CHANGELOG entry (paste it), and anything noticed but deliberately
+not changed. Then stop — **the user creates the release commit, tag, and GitHub
+Release**. Docs deploy independently of the release (`docs.yml`, on any main push
+touching `docs/**`).
 
 ## Rules
 
-- This is editorial, not architectural. Don't refactor. Don't rename anything.
-- Don't invent new docs pages. If something is undocumented, say so in the
-  summary so the user can decide whether to defer.
-- Don't update `plans/` (gitignored), Confluence, or Jira from here.
-- Don't push, don't tag, don't run the release workflow.
-- If the diff reveals a behavior change that has no doc anywhere, flag it
-  loudly in the summary — that's the most important thing this skill catches.
-- If `scripts/check_doc_counts.py` exits non-zero after your edits, you are
-  not done.
+- Editorial, not architectural — don't refactor or rename.
+- Don't invent docs pages; flag gaps in the summary instead.
+- A behavior change with no doc anywhere is the loudest thing to flag.
+- Don't push, don't tag, don't publish the release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2026-07-06
 
-### Removed (BREAKING)
-- **HTTP MCP transport gone, bearer auth gone (PR 3a of v1 plan, 2026-05-19 pivot)**. The earlier DAT-325 cutover landed `/mcp/` as a Starlette sub-app mounted onto the FastAPI control plane, gated by `BearerAuthMiddleware` + `DATARAUM_MCP_TOKEN`. The [Cockpit + Engine REST v1 plan](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/22872066) drops MCP at the transport level entirely — the cockpit (TanStack Start) is the only client; v1 has no auth (single user). Removed: the `app.mount("/mcp", ...)` line, `_StreamableHTTPASGIApp`, `_build_mcp_subapp`, `BearerAuthMiddleware`, `_TOKEN_ENV_VAR`, the lifespan's `DATARAUM_MCP_TOKEN` refusal, the bearer-enforcement step in `compose-smoke.yml`, the `DATARAUM_MCP_TOKEN` env in `docker-compose.yml` and `.env.example`, `docs/mcp-setup.md`, `tests/platform/smoke_dat325.py`, and all bearer/MCP test classes in `tests/unit/server/test_app.py`. `src/dataraum/mcp/server.py` is **untouched** — its engine logic gets extracted into `src/dataraum/api/` route handlers in step 3b. The lifespan still refuses to start without `DUCKLAKE_CATALOG_URL` + `DUCKLAKE_DATA_PATH` (real substrate prereqs).
-- **stdio MCP transport gone (DAT-325)**. The `dataraum-mcp` script entry, the `--transport stdio` mode, the `run_server()` runner, and the standalone Starlette HTTP runner (`_build_http_app`, `run_http_server`) are all deleted. The control plane is now a single FastAPI app (`dataraum.server.app:app`); since PR 3a above, it no longer mounts an MCP transport at all. Run via `uvicorn dataraum.server.app:app` or `docker compose up`.
-- **`dataraum` CLI gone (DAT-325)**. The `dataraum run` and `dataraum dev` commands have been non-functional since DAT-321 made `setup_pipeline` require a `session_id` the CLI never provided. Removed: `src/dataraum/cli/` tree, `tests/unit/cli/` tree, `docs/cli.md`, `dataraum` script entry, `typer` dep. The MCP `measure` tool is the supported way to run the pipeline.
-- **`rich` rendering path in `core/logging.py` (DAT-325)**. The Rich console renderer was only ever activated by the deleted CLI's interactive run progress display. With the CLI gone, the path was dead-but-reachable: removed `_RichConsole`/`_RichText` imports, `LogBuffer`, `activate_console`/`deactivate_console`, `_build_text`, and the `rich>=13.0.0` dep. `_ProxyLogger.msg` now always routes through stderr (and optionally a file). Library consumers and JSON-renderer mode are unchanged.
+The platform release. DataRaum is now a multi-container platform — a web cockpit over a
+durable analysis engine — rather than a Python library with an MCP surface. Nearly every
+subsystem changed; this entry records the net result, the architecture lives in
+[`docs/adr/`](docs/adr/README.md) and the [platform docs](docs/index.md).
 
 ### Changed
-- **`/health` is now the substrate probe** (DuckLake catalog + workspace Postgres). The DAT-291 version-only `/health` shape is gone — the unified app's `/health` already returned the richer substrate result. Container orchestrators using `/health` for readiness see `{"status":"ok"|"degraded","ducklake":...,"postgres":...}`.
-- **`mcp/__init__.py` public surface**: drops `run_server` re-export. Only `create_server` remains for in-process callers that build their own transport.
+- **The engine is a Temporal activity worker with no HTTP surface** (ADR-0001/0002). The
+  three analysis stages — `add_source`, `begin_session`, `operating_model` — run as
+  durable, run-versioned workflows; a promote step makes a run visible only once it fully
+  succeeded (ADR-0008/0010), isolated per workspace (ADR-0012).
+- **The engine↔cockpit seam is Postgres + Temporal, nothing else**: the cockpit reads
+  workspace metadata through a generated Drizzle mirror (ADR-0003); data lives in a
+  DuckLake lake on S3.
+- **Releases ship as three container images on GHCR** (engine, cockpit, cockpit-migrate);
+  the git tag is the single version truth.
 
 ### Added
-- **Cockpit container service in `docker-compose.yml` (PR 5 of v1 plan, 2026-05-19)**. New `cockpit` service builds from `../dataraum-cockpit` (sibling clone required) with `VITE_ENGINE_API_URL=http://localhost:8000` baked into the bundle, then serves the TanStack Start production output on `127.0.0.1:3000`. Depends on `control-plane` being healthy. The cockpit-side Dockerfile (multi-stage deps/build/runner) lives in `dataraum-cockpit`. Cross-origin browser fetches to the engine are allowed by the engine's existing CORS middleware. For UI hot reload, skip the container and run `pnpm dev` in the cockpit repo directly.
-- **Engine REST surface at `/api/*` (PR 3b of v1 plan, 2026-05-19)**. New `src/dataraum/api/` package — `routes.py` (APIRouter), `services.py` (engine logic extracted from MCP handlers), `schemas.py` (Pydantic response models), `deps.py` (workspace session dependency, lazy-cached ConnectionManager). First route: `GET /api/sources` extracted from the MCP `_list_sources` handler — same data, Pydantic-shaped response (`list[Source]`), no MCP envelope. Mounted into the FastAPI control plane at `/api`. CORS middleware allows `http://localhost:3000` and `http://localhost:5173` (cockpit dev origins; tighten when the cockpit ships behind a real domain). OpenAPI 3.1 spec auto-generated at `/openapi.json`; `scripts/export_openapi.py` dumps it as YAML for publication to `dataraum-api` (CI publish-on-diff lands in PR 3c).
-- **`DATARAUM_MCP_TOKEN` is mandatory at startup**. The FastAPI lifespan raises if unset, so misconfigured deploys fail fast with a clear error instead of accepting unauthenticated requests. `docker-compose.yml` and `.env.example` now reference it.
+- **The cockpit** — the web product surface: chat-driven journeys over import →
+  relationships → operating model, the model canvas, reports with Vega-Lite charts
+  (ADR-0015), a streaming SQL grid, run monitoring, and the teach → replay loop.
+- **The operating model stage** — declared validations, business cycles, and metrics,
+  grounded in the data and executed as calculation graphs: deterministic composition with
+  LLM-authored leaf extracts (ADR-0016), verdicts computed on demand (ADR-0017), every
+  artifact tracked declared → grounded → executed.
+- **Relationship intelligence** — value-overlap detection with LLM confirmation, enriched
+  join views, slice and hierarchy catalogs, driver discovery, and composite keys fused
+  into surrogate join columns (ADR-0018).
+- **Entropy as disagreement** (ADR-0009) — independent witnesses pool per claim; conflict
+  surfaces as *investigate/blocked* readiness instead of silent guesses, teachable via
+  durable overlays.
+- **The documentation site** — `docs/` (Zensical), including the ADR series.
+
+### Removed (BREAKING)
+- **The entire MCP surface** (stdio + HTTP transports, the tool registry, the
+  `dataraum-mcp` entrypoint, PyPI packaging), **the FastAPI control plane** and its brief
+  post-0.2.2 REST/OpenAPI interim (never in a release), and **the `dataraum` CLI**. The
+  cockpit is the product surface; there is no API-first integration path in this release.
 
 ## [0.2.2] - 2026-05-14
 

--- a/packages/engine/pyproject.toml
+++ b/packages/engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dataraum"
-version = "0.2.2"
+version = "0.3.0"
 description = "Rich metadata context engine for AI-driven data analytics"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/engine/scripts/check_doc_counts.py
+++ b/packages/engine/scripts/check_doc_counts.py
@@ -10,6 +10,10 @@ We scan a fixed set of doc files for numbered claims like
 fail if the number disagrees with the truth.
 (The MCP tool count check died with the MCP surface — DAT-487.)
 
+Missing files are skipped silently, so keep DOC_FILES pointing at files that
+exist — a stale path checks nothing. The user-facing docs live at the
+WORKSPACE root (`docs/`, published via Zensical), not in this package.
+
 Run locally:  uv run python scripts/check_doc_counts.py
 Used in CI by .github/workflows/release.yml (preflight job).
 """
@@ -25,13 +29,13 @@ ROOT = Path(__file__).resolve().parent.parent
 
 DOC_FILES = [
     "README.md",
-    "docs/index.md",
-    "docs/architecture.md",
-    "docs/pipeline.md",
-    "docs/entropy.md",
-    "docs/contributing.md",
-    "docs/configuration.md",
-    "docs/data-model.md",
+    "../../README.md",
+    "../cockpit/README.md",
+    "../../docs/index.md",
+    "../../docs/getting-started/overview.md",
+    "../../docs/concepts/pipeline.md",
+    "../../docs/concepts/measurement.md",
+    "../../docs/platform/architecture.md",
 ]
 
 # Each kind matches noun forms used in prose. Order matters for regex

--- a/packages/engine/uv.lock
+++ b/packages/engine/uv.lock
@@ -207,7 +207,7 @@ wheels = [
 
 [[package]]
 name = "dataraum"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## What & why

Pre-tag editorial sweep for **v0.3.0** (previous release: v0.2.2, 2026-05-14 — ~1,700 commits ago).

- **CHANGELOG**: a brief 0.3.0 entry — the platform pivot as the net change since 0.2.2 (Changed/Added/Removed, thematic bullets with ADR links, no per-PR listing). The fossil `[Unreleased]` section (the May REST interim, since retired) is superseded.
- **Version**: engine `pyproject.toml` + `uv.lock` → 0.3.0. The tag remains the single version truth; the cockpit has no package version.
- **Preflight fix**: `check_doc_counts.py` silently scanned 1 of its 8 listed files (the engine-local docs tree it references no longer exists). Repointed at the real docs (workspace `docs/` + the three READMEs) — 8/8 scanned, passing (19 phases / 17 detectors).
- **release-prep skill rewritten** for the current world (GitHub Release → three GHCR images; no FastAPI/MCP/server.json).
- Editorial sweep of the READMEs and docs found them current — no prose edits needed.

**After merge**: create GitHub Release `v0.3.0` (publish triggers `release.yml` → the three images). Docs deploy independently on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)