### PR TITLE
feat(DAT-695): join coverage as judge evidence + driver routing fixes

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -131,8 +131,7 @@ Four composites minted (`(name, business_id)` for customer/vendor/
 payment_method/product_service), all persisted fact→dim many-to-one,
 `introduces_duplicates=false`; `enriched_master_txn_table` grain-verified over
 the 810k-row fact with 11 dim columns joined via the surrogates; the flaky
-20-candidate `business_id` degeneracy is gone. `gl_invoice_match` validation
-went declared→executed (the surrogates gave it a join path); revenue grounds
+20-candidate `business_id` degeneracy is gone. revenue grounds
 on `account_type='Income'` (the real classification, not transaction_type).
 Two smoke-corpus DATA truths the platform now states instead of absorbing:
 `chart_of_account_OB`'s `(account, business)` collisions are 82 exact duplicate

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -47,7 +47,8 @@ referential coverage: a fact whose composite `(name, tenant)` FK actually
 resolves against its dimensions (coverage ≥ ~0.9), dim attributes that drive the
 measure, plus a LOOKALIKE negative (name pools overlap, coverage ≪ 1) that the
 judge must now decline. The bookkeeping smoke corpus structurally cannot serve
-this: only its payment_method dim is genuinely referenced.
+this: only its payment_method dim is genuinely referenced. Pairs with the
+DAT-679 fixture work (greedy-search miss-rate corpus).
 
 ---
 

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,52 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-695 — join coverage as judge evidence + driver routing fixes
+
+**Branch:** `feat/dat-695-coverage-and-routing`. Root cause of "driver rankings
+empty over surrogate-joined dims" on the bookkeeping smoke corpus.
+
+### What changed
+
+- **New measured signal `coverage`** (`relationships/evaluator.py::compute_join_coverage`
+  — share of fact rows with a non-NULL key that find a dim match). Multiplicity
+  proves a key's SHAPE; coverage proves it is USED — the corpus's customer/vendor
+  dims verified many-to-one at **0.27% / ~0% coverage** (independently generated
+  lookalike tables). Coverage now rides: the composite-rescue hint + the
+  `semantic_per_table` prompt (decline lookalikes), the minted relationship's
+  evidence (`evidence.coverage`, low-coverage warning log), and the enrichment
+  feed (`[matches 0.3% of fact rows]` next to the grain marker). **Evidence for
+  the LLM judges — no numeric gate**; the slicing null-filter stays the floor.
+- **Driver routing** (`drivers/processor.py`): (1) a dim SATURATED against its
+  home entity (distinct == entity count, constant within) is a 1:1 alias of the
+  key and is dropped — it fabricated a guaranteed-empty headline family
+  (`business_id ↔ created_user`); (2) the headline family must carry content —
+  first non-empty family in precedence order wins, but never past the row
+  family (the DAT-561 low-ICC demotion is preserved, pinned by the existing
+  `test_entity_constant_dim_never_enters_row_wise_primary`).
+
+### Calibration to run
+
+- Driver-discovery recall/precision on the calibration corpora — the routing
+  changes alter WHICH family headlines (alias dims no longer home; empty
+  high-ICC families no longer block the row family). The DAT-561/563 grain
+  contracts are pinned by the existing suites, but ranked-dimension sets can
+  legitimately shift on corpora with tenant-alias structures.
+- Relationship confirmation on composite corpora — the LLM now sees coverage in
+  the hint; expect DECLINES of lookalike composites (a recall drop there is the
+  intended behavior, not a regression).
+
+### testdata hints
+
+The driver-over-surrogate acceptance (epic DAT-652) needs a corpus with REAL
+referential coverage: a fact whose composite `(name, tenant)` FK actually
+resolves against its dimensions (coverage ≥ ~0.9), dim attributes that drive the
+measure, plus a LOOKALIKE negative (name pools overlap, coverage ≪ 1) that the
+judge must now decline. The bookkeeping smoke corpus structurally cannot serve
+this: only its payment_method dim is genuinely referenced.
+
+---
+
 ## DAT-603 — graph agent: single-extract output schema + adaptive thinking (PRs #434, merged 2026-07-03)
 
 **Re-baseline `graph_sql_generation` before trusting comparisons against the DAT-602 eval baseline.** Three changes eval must know about:

--- a/packages/dataraum-config/llm/prompts/semantic_per_table.yaml
+++ b/packages/dataraum-config/llm/prompts/semantic_per_table.yaml
@@ -115,10 +115,15 @@ system_prompt: |
   to_column) and list the REMAINING component pair(s) in its key_columns. Leave
   key_columns empty for an ordinary single-column relationship. Only confirm a
   composite when the data shows it RESOLVES the fan-out — never staple together
-  unrelated columns. Weigh the measured COVERAGE: a key can join cleanly yet
-  match almost no rows — that is a lookalike table whose values happen to
-  overlap (shared name pools, shared code formats), not a reference the data
-  actually uses. Confirming it enriches nothing; decline instead.
+  unrelated columns. Treat the MEASURED USAGE on the hint as decisive evidence,
+  not color: it is the fraction of the referencing table's rows that actually
+  resolve against the key. When only a few percent resolve, the two tables
+  merely share a value format or name pool — there is NO relationship in the
+  data to confirm, however plausible the column names look. A key that "joins
+  cleanly" at near-zero usage enriches nothing and misleads every downstream
+  consumer; declining it — anchor pair included — is the correct answer, not a
+  missed detection. Confirm a low-usage reference only when the table context
+  gives strong, explicit evidence that the reference is real but sparse.
 
   Note: Do NOT determine cardinality (one-to-one, many-to-one, etc.) — this is
   computed automatically from actual data after your analysis. Focus on whether

--- a/packages/dataraum-config/llm/prompts/semantic_per_table.yaml
+++ b/packages/dataraum-config/llm/prompts/semantic_per_table.yaml
@@ -115,7 +115,10 @@ system_prompt: |
   to_column) and list the REMAINING component pair(s) in its key_columns. Leave
   key_columns empty for an ordinary single-column relationship. Only confirm a
   composite when the data shows it RESOLVES the fan-out — never staple together
-  unrelated columns.
+  unrelated columns. Weigh the measured COVERAGE: a key can join cleanly yet
+  match almost no rows — that is a lookalike table whose values happen to
+  overlap (shared name pools, shared code formats), not a reference the data
+  actually uses. Confirming it enriches nothing; decline instead.
 
   Note: Do NOT determine cardinality (one-to-one, many-to-one, etc.) — this is
   computed automatically from actual data after your analysis. Focus on whether

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -624,7 +624,18 @@ def _home_grain_partition(
         if not homes:
             row_dims.append(d)
             continue
-        home_by_entity[max(homes, key=lambda e: (card[e], e))].append(d)
+        home = max(homes, key=lambda e: (card[e], e))
+        # A dim SATURATED against its home entity — as many distinct values as
+        # the entity has members, while constant within each — is a 1:1 alias
+        # of the key itself. Ranking an entity's own renaming across those same
+        # entities is structurally information-free, and worse: it fabricates a
+        # family whose ranking is guaranteed empty and can win headline
+        # precedence (DAT-695: business_id ↔ created_user, 27 = 27). Drop it —
+        # neither a home dim nor row-level (row-wise it is still just the key).
+        if int(frame[d].drop_nulls().n_unique()) == card[home]:
+            logger.info("driver_alias_dim_dropped", dim=d, entity=home)
+            continue
+        home_by_entity[home].append(d)
     return {e: ds for e, ds in home_by_entity.items() if ds}, row_dims
 
 
@@ -717,10 +728,26 @@ def _routed_ranking(
         return (1, 0.0, "")  # row family sits between high- and low-ICC entity families
 
     families.sort(key=precedence)
-    primary, _primary_grain, primary_entity = families[0]
+    # The headline must carry content: an empty high-ICC entity family ahead of
+    # a non-empty row family would bury every real driver in ``secondary`` and
+    # persist ``ranked: 0`` (DAT-695). Take the first family WITH ranked
+    # dimensions — but never past the row family: the low-ICC entity families
+    # behind it are DELIBERATELY demoted (DAT-561 — at low ICC the measure does
+    # not cluster by that entity, so its grain must not headline), content or
+    # not. All of buckets 0–1 empty → strict precedence, as before.
+    primary_idx = next(
+        (
+            i
+            for i, fam in enumerate(families)
+            if fam[0].ranked_dimensions and precedence(fam)[0] <= 1
+        ),
+        0,
+    )
+    primary, _primary_grain, primary_entity = families[primary_idx]
     secondary = [
         SecondaryDriver(d, g, grain, entity)
-        for ranking, grain, entity in families[1:]
+        for i, (ranking, grain, entity) in enumerate(families)
+        if i != primary_idx
         for d, g in ranking.ranked_dimensions
     ]
     return replace(primary, secondary_dimensions=secondary, entity=primary_entity)

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -611,7 +611,9 @@ def _home_grain_partition(
     to find the dims constant within it. A dim constant within ONE entity homes there; a
     dim constant within SEVERAL homes at the **finest** (highest-cardinality) one — the
     most specific grain — with a deterministic name tiebreak; a dim constant within none
-    is row-level. Returns ``({entity: [home dims]}, row_dims)`` with empty entities dropped.
+    is row-level. A dim SATURATED against its home entity (a 1:1 alias of the key) is
+    DROPPED — neither homed nor row-level (DAT-695); callers must not assume every dim
+    survives. Returns ``({entity: [home dims]}, row_dims)`` with empty entities dropped.
     """
     card = {e: int(frame[e].drop_nulls().n_unique()) for e in cluster_keys}
     constant_within = {
@@ -728,6 +730,13 @@ def _routed_ranking(
         return (1, 0.0, "")  # row family sits between high- and low-ICC entity families
 
     families.sort(key=precedence)
+    # The alias-drop above can discard EVERY candidate (a table whose only dims
+    # were renamings of its entity keys) — no family exists then; return the
+    # honest empty ranking rather than index into nothing (DAT-695 review).
+    if not families:
+        return DriverRanking(
+            measure=measure.label, target_type=measure.target_type, n_rows=frame.height
+        )
     # The headline must carry content: an empty high-ICC entity family ahead of
     # a non-empty row family would bury every real driver in ``secondary`` and
     # persist ``ranked: 0`` (DAT-695). Take the first family WITH ranked

--- a/packages/engine/src/dataraum/analysis/relationships/composite.py
+++ b/packages/engine/src/dataraum/analysis/relationships/composite.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 import duckdb
 
-from dataraum.analysis.relationships.evaluator import compute_composite_cardinality
+from dataraum.analysis.relationships.evaluator import (
+    compute_composite_cardinality,
+    compute_join_coverage,
+)
 from dataraum.analysis.relationships.models import CompositeKey, RelationshipCandidate
 from dataraum.core.logging import get_logger
 
@@ -79,14 +82,19 @@ def rescue_fanout_to_composite(
 
         card = compute_composite_cardinality(table1_path, table2_path, chosen, duckdb_conn)
         if card is not None and card != _MANY_TO_MANY:
+            # Multiplicity proves the key SHAPE; coverage says whether the key
+            # matches the data at all (DAT-695) — measured here once, carried
+            # as evidence for the LLM judge.
+            coverage = compute_join_coverage(table1_path, table2_path, chosen, duckdb_conn)
             logger.info(
                 "composite_key_rescued",
                 table1=candidate.table1,
                 table2=candidate.table2,
                 key_columns=len(chosen),
                 cardinality=card,
+                coverage=coverage,
             )
-            return CompositeKey(column_pairs=chosen, cardinality=card)
+            return CompositeKey(column_pairs=chosen, cardinality=card, coverage=coverage)
 
     return None  # genuine many-to-many — no composite of these columns collapses it
 

--- a/packages/engine/src/dataraum/analysis/relationships/composite.py
+++ b/packages/engine/src/dataraum/analysis/relationships/composite.py
@@ -83,9 +83,22 @@ def rescue_fanout_to_composite(
         card = compute_composite_cardinality(table1_path, table2_path, chosen, duckdb_conn)
         if card is not None and card != _MANY_TO_MANY:
             # Multiplicity proves the key SHAPE; coverage says whether the key
-            # matches the data at all (DAT-695) — measured here once, carried
-            # as evidence for the LLM judge.
-            coverage = compute_join_coverage(table1_path, table2_path, chosen, duckdb_conn)
+            # matches the data at all (DAT-695) — measured once, carried as
+            # evidence for the LLM judge. Coverage is DIRECTIONAL and must be
+            # measured from the MANY (referencing) side: table1/table2 come
+            # from arbitrary structural pairing order, and measured dim-side, a
+            # lookalike table's handful of values can read near-100% while the
+            # fact-side truth is ~0 (DAT-695 review). Orient by the measured
+            # cardinality, mirroring the mint's persisted direction.
+            if card == "one-to-many":
+                cov_t1, cov_t2 = table2_path, table1_path
+                cov_pairs = [(b, a) for a, b in chosen]
+                coverage_table = candidate.table2
+            else:  # many-to-one / one-to-one: table1 is the referencing side
+                cov_t1, cov_t2 = table1_path, table2_path
+                cov_pairs = chosen
+                coverage_table = candidate.table1
+            coverage = compute_join_coverage(cov_t1, cov_t2, cov_pairs, duckdb_conn)
             logger.info(
                 "composite_key_rescued",
                 table1=candidate.table1,
@@ -93,8 +106,14 @@ def rescue_fanout_to_composite(
                 key_columns=len(chosen),
                 cardinality=card,
                 coverage=coverage,
+                coverage_table=coverage_table,
             )
-            return CompositeKey(column_pairs=chosen, cardinality=card, coverage=coverage)
+            return CompositeKey(
+                column_pairs=chosen,
+                cardinality=card,
+                coverage=coverage,
+                coverage_table=coverage_table,
+            )
 
     return None  # genuine many-to-many — no composite of these columns collapses it
 

--- a/packages/engine/src/dataraum/analysis/relationships/evaluator.py
+++ b/packages/engine/src/dataraum/analysis/relationships/evaluator.py
@@ -219,6 +219,47 @@ def compute_composite_cardinality(
         return None
 
 
+def compute_join_coverage(
+    table1_path: str,
+    table2_path: str,
+    column_pairs: list[tuple[str, str]],
+    duckdb_conn: duckdb.DuckDBPyConnection,
+) -> float | None:
+    """Share of table1 rows (non-NULL on every key component) with a table2 match.
+
+    Cardinality proves match MULTIPLICITY; this proves match COVERAGE — the two
+    are independent, and a key can be perfectly many-to-one while matching
+    almost nothing (DAT-695: a lookalike dimension whose values barely overlap
+    the fact's verified many-to-one at 0.3% coverage). Serves as EVIDENCE for
+    the LLM judges (relationship confirmation, enrichment), never a gate.
+
+    Returns:
+        Matched fraction in [0, 1], or ``None`` when table1 has no non-NULL
+        key rows or the probe fails.
+    """
+    if not column_pairs:
+        return None
+    on_clause = " AND ".join(f't1."{a}" = t2."{b}"' for a, b in column_pairs)
+    t1_not_null = " AND ".join(f't1."{a}" IS NOT NULL' for a, _b in column_pairs)
+    try:
+        row = duckdb_conn.execute(
+            f"""
+            SELECT
+                COUNT(*) FILTER (WHERE EXISTS (
+                    SELECT 1 FROM {table2_path} t2 WHERE {on_clause})) AS matched,
+                COUNT(*) AS total
+            FROM {table1_path} t1
+            WHERE {t1_not_null}
+            """
+        ).fetchone()
+        if not row or not row[1]:
+            return None
+        return float(row[0]) / float(row[1])
+    except Exception as e:
+        logger.warning("join_coverage_failed", column_pairs=column_pairs, error=str(e))
+        return None
+
+
 def _verify_cardinality(
     detected_cardinality: str,
     table1_path: str,

--- a/packages/engine/src/dataraum/analysis/relationships/models.py
+++ b/packages/engine/src/dataraum/analysis/relationships/models.py
@@ -85,14 +85,18 @@ class CompositeKey(BaseModel):
             columns added to collapse the fan-out.
         cardinality: the composite join's cardinality — never ``"many-to-many"``
             (a non-m2m result IS the rescue-success condition).
-        coverage: share of table1 rows (non-NULL key) the composite actually
-            matches — the multiplicity proof says nothing about it (DAT-695).
-            Evidence for the LLM judge, never a gate.
+        coverage: share of the REFERENCING (many) side's non-NULL-key rows the
+            composite actually matches — the multiplicity proof says nothing
+            about it (DAT-695). Oriented by the measured cardinality, never by
+            the arbitrary table1/table2 pairing order. Evidence for the LLM
+            judge, never a gate.
+        coverage_table: the table whose rows ``coverage`` describes.
     """
 
     column_pairs: list[tuple[str, str]]
     cardinality: str
     coverage: float | None = None
+    coverage_table: str | None = None
 
 
 class RelationshipDetectionResult(BaseModel):

--- a/packages/engine/src/dataraum/analysis/relationships/models.py
+++ b/packages/engine/src/dataraum/analysis/relationships/models.py
@@ -85,10 +85,14 @@ class CompositeKey(BaseModel):
             columns added to collapse the fan-out.
         cardinality: the composite join's cardinality — never ``"many-to-many"``
             (a non-m2m result IS the rescue-success condition).
+        coverage: share of table1 rows (non-NULL key) the composite actually
+            matches — the multiplicity proof says nothing about it (DAT-695).
+            Evidence for the LLM judge, never a gate.
     """
 
     column_pairs: list[tuple[str, str]]
     cardinality: str
+    coverage: float | None = None
 
 
 class RelationshipDetectionResult(BaseModel):

--- a/packages/engine/src/dataraum/analysis/relationships/surrogate.py
+++ b/packages/engine/src/dataraum/analysis/relationships/surrogate.py
@@ -54,9 +54,11 @@ class SurrogateSpec:
 def surrogate_column_name(component_names: list[str]) -> str:
     """The deterministic surrogate name for a component set, e.g. ``_sk__a__b``.
 
-    Component order is the intent's pair order (anchor first), so the name — and
-    with it the ``(table_id, column_name)``-upserted ``column_id`` — is stable
-    across runs for the same confirmed key.
+    Component order is the intent's CANONICAL pair order (all pairs sorted by
+    the referencing side's column name — the anchor is deliberately NOT first:
+    the LLM's anchor choice is not run-stable, and the name must be), so the
+    ``(table_id, column_name)``-upserted ``column_id`` is stable across runs
+    for the same confirmed key.
     """
     return SURROGATE_PREFIX + "__".join(component_names)
 

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -492,8 +492,10 @@ class SemanticAgent(LLMFeature):
             if composite:
                 pair_strs = [f"{a} <-> {b}" for a, b in composite.get("column_pairs", [])]
                 coverage = composite.get("coverage")
+                coverage_table = composite.get("coverage_table") or "the referencing table"
                 coverage_note = (
-                    f" It matches {coverage:.1%} of rows with a populated key."
+                    f" It matches {coverage:.1%} of {coverage_table}'s rows "
+                    "with a populated key."
                     if coverage is not None
                     else ""
                 )

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -494,8 +494,7 @@ class SemanticAgent(LLMFeature):
                 coverage = composite.get("coverage")
                 coverage_table = composite.get("coverage_table") or "the referencing table"
                 coverage_note = (
-                    f" It matches {coverage:.1%} of {coverage_table}'s rows "
-                    "with a populated key."
+                    f" It matches {coverage:.1%} of {coverage_table}'s rows with a populated key."
                     if coverage is not None
                     else ""
                 )

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -491,10 +491,17 @@ class SemanticAgent(LLMFeature):
             composite = rel.get("composite_key")
             if composite:
                 pair_strs = [f"{a} <-> {b}" for a, b in composite.get("column_pairs", [])]
+                coverage = composite.get("coverage")
+                coverage_note = (
+                    f" It matches {coverage:.1%} of rows with a populated key."
+                    if coverage is not None
+                    else ""
+                )
                 lines.append(
                     "COMPOSITE-KEY RESCUE: the best single-column join is many-to-many "
                     "(fan-out / over-counts). Joining on the full key "
-                    f"[{', '.join(pair_strs)}] is {composite.get('cardinality', '?')}. "
+                    f"[{', '.join(pair_strs)}] is {composite.get('cardinality', '?')}."
+                    f"{coverage_note} "
                     "If this composite is the real key, confirm it: emit ONE relationship "
                     "for the anchor pair and put the remaining pair(s) in key_columns."
                 )

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -494,7 +494,8 @@ class SemanticAgent(LLMFeature):
                 coverage = composite.get("coverage")
                 coverage_table = composite.get("coverage_table") or "the referencing table"
                 coverage_note = (
-                    f" It matches {coverage:.1%} of {coverage_table}'s rows with a populated key."
+                    f" MEASURED USAGE: {coverage:.1%} of {coverage_table}'s "
+                    "populated-key rows resolve against this key."
                     if coverage is not None
                     else ""
                 )
@@ -503,8 +504,12 @@ class SemanticAgent(LLMFeature):
                     "(fan-out / over-counts). Joining on the full key "
                     f"[{', '.join(pair_strs)}] is {composite.get('cardinality', '?')}."
                     f"{coverage_note} "
-                    "If this composite is the real key, confirm it: emit ONE relationship "
-                    "for the anchor pair and put the remaining pair(s) in key_columns."
+                    "Confirm ONLY when both hold: the composite resolves the fan-out AND "
+                    "the measured usage shows the reference is actually used — a "
+                    "near-zero match rate means a lookalike table (shared name pools), "
+                    "and the correct output is to DECLINE the relationship entirely, "
+                    "anchor included. To confirm: emit ONE relationship for the anchor "
+                    "pair and put the remaining pair(s) in key_columns."
                 )
 
             lines.append("Column pairs with value overlap:")

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -409,6 +409,7 @@ def _augment_candidates_with_composite_rescue(
                 "column_pairs": [list(pair) for pair in key.column_pairs],
                 "cardinality": key.cardinality,
                 "coverage": key.coverage,
+                "coverage_table": key.coverage_table,
             }
 
 

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -469,15 +469,17 @@ def _build_surrogate_intent(
     if len(components) < 2:
         return None  # anchor-only after dedup — effectively single-column
 
-    # Canonical component order: anchor first, then scope components sorted by
-    # from-side column name. The LLM's key_columns ordering is not stable across
-    # runs, and the digest, the surrogate column NAME, and the hash-input order
-    # all derive from this list — a canonical order keeps the minted column
-    # (and its (table_id, name)-upserted column_id) identical when the same key
-    # is re-confirmed with its components shuffled.
-    scope = sorted(zip(components[1:], name_pairs[1:], strict=True), key=lambda t: t[1][0])
-    components = [components[0], *(c for c, _n in scope)]
-    name_pairs = [name_pairs[0], *(n for _c, n in scope)]
+    # Canonical component order: ALL pairs sorted by from-side column name —
+    # including the anchor. Neither the LLM's key_columns ordering NOR its
+    # anchor choice is stable across runs (seen live 2026-07-06: the same
+    # composite arrived anchored on payment_method one run and business_id the
+    # next, minting two differently-named surrogates for one key), and the
+    # digest, the surrogate column NAME, and the hash-input order all derive
+    # from this list. The anchor's semantics live in the relationship
+    # DIRECTION, never in the column identity.
+    ordered = sorted(zip(components, name_pairs, strict=True), key=lambda t: t[1][0])
+    components = [c for c, _n in ordered]
+    name_pairs = [n for _c, n in ordered]
 
     # The composite's measured cardinality (the collapse proof). Best-effort:
     # the mint recomputes on the minted surrogate column anyway.

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -408,6 +408,7 @@ def _augment_candidates_with_composite_rescue(
             cand["composite_key"] = {
                 "column_pairs": [list(pair) for pair in key.column_pairs],
                 "cardinality": key.cardinality,
+                "coverage": key.coverage,
             }
 
 

--- a/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
+++ b/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
@@ -183,9 +183,17 @@ class EnrichmentAgent(LLMFeature):
             grain_safe = cardinality in ("many-to-one", "one-to-one")
             grain_marker = " [GRAIN-SAFE]" if grain_safe else " [AVOID - may duplicate rows]"
 
+            # Measured join coverage (DAT-695): a grain-safe key can still match
+            # almost nothing (a lookalike table) — the judge sees the number and
+            # can decline a join that would enrich nothing.
+            coverage = rel.get("coverage")
+            coverage_note = (
+                f" [matches {coverage:.1%} of fact rows]" if coverage is not None else ""
+            )
+
             lines.append(
                 f"- {from_table}.{from_col} -> {to_table}.{to_col} "
-                f"({cardinality}, confidence={confidence:.2f}){grain_marker}"
+                f"({cardinality}, confidence={confidence:.2f}){grain_marker}{coverage_note}"
             )
 
         return "\n".join(lines)

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -858,6 +858,9 @@ class EnrichedViewsPhase(BasePhase):
                         "to_column": to_col_name,
                         "cardinality": rel.cardinality,
                         "confidence": rel.confidence,
+                        # Measured join coverage from the mint's evidence
+                        # (DAT-695) — how much of the fact the join enriches.
+                        "coverage": (rel.evidence or {}).get("coverage"),
                     }
                 )
 

--- a/packages/engine/src/dataraum/pipeline/phases/surrogate_mint_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/surrogate_mint_phase.py
@@ -40,6 +40,7 @@ from dataraum.analysis.relationships.db_models import Relationship, SurrogateKey
 from dataraum.analysis.relationships.evaluator import (
     compute_actual_cardinality,
     compute_introduces_duplicates,
+    compute_join_coverage,
     compute_ri_metrics,
 )
 from dataraum.analysis.relationships.surrogate import (
@@ -590,11 +591,25 @@ class SurrogateMintPhase(BasePhase):
             cardinality = "many-to-one"
             natural_pairs = [[t, f] for f, t in natural_pairs]
             natural_ids = [[t, f] for f, t in natural_ids]
+        # Coverage on the MINTED pair, in the persisted (FK-side-first)
+        # direction: the share of fact rows the join actually enriches.
+        # Multiplicity said "key"; this says "used" (DAT-695). Evidence for
+        # the enrichment judge, never a gate.
+        coverage = compute_join_coverage(
+            from_fqn, to_fqn, [(from_spec.column_name, to_spec.column_name)], ctx.duckdb_conn
+        )
+        if coverage is not None and coverage < 0.5:
+            logger.warning(
+                "surrogate_low_coverage",
+                intent=intent.intent_digest,
+                coverage=round(coverage, 4),
+            )
         evidence: dict[str, Any] = {
             "source": "surrogate_mint",
             "intent_digest": intent.intent_digest,
             "reasoning": intent.reasoning,
             "composite_cardinality": intent.cardinality,
+            "coverage": coverage,
             "surrogate": {
                 "natural_pairs": natural_pairs,
                 "natural_column_ids": natural_ids,

--- a/packages/engine/src/dataraum/pipeline/phases/surrogate_mint_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/surrogate_mint_phase.py
@@ -609,12 +609,13 @@ class SurrogateMintPhase(BasePhase):
             "intent_digest": intent.intent_digest,
             "reasoning": intent.reasoning,
             "composite_cardinality": intent.cardinality,
-            "coverage": coverage,
             "surrogate": {
                 "natural_pairs": natural_pairs,
                 "natural_column_ids": natural_ids,
             },
         }
+        if coverage is not None:
+            evidence["coverage"] = coverage
         try:
             evidence["introduces_duplicates"] = compute_introduces_duplicates(
                 from_fqn, to_fqn, from_spec.column_name, to_spec.column_name, ctx.duckdb_conn

--- a/packages/engine/tests/unit/analysis/drivers/test_grain.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain.py
@@ -249,3 +249,32 @@ class TestAliasAndEmptyHeadline:
         assert rank.ranked_dimensions, "headline family must carry content"
         assert rank.grain == "row"
         assert "row_driver" in {d for d, _ in rank.ranked_dimensions}
+
+    def test_all_dims_alias_yields_empty_ranking_not_crash(self) -> None:
+        """Every candidate an alias → no families at all; the honest empty
+        ranking comes back instead of an IndexError (DAT-695 review)."""
+        from dataraum.analysis.drivers.models import Measure
+        from dataraum.analysis.drivers.processor import (
+            DEFAULT_ICC_THRESHOLD,
+            DEFAULT_MIN_ENTITIES,
+            _routed_ranking,
+        )
+
+        df = self._frame(np.random.default_rng(3))
+        rank = _routed_ranking(
+            df,
+            ["alias"],  # the only candidate is a 1:1 renaming of the key
+            Measure(target_type="flow", column="measure"),
+            ["entity"],
+            seed=0,
+            max_depth=2,
+            alpha=0.05,
+            min_support=25,
+            missingness_gate=0.5,
+            n_perm=50,
+            icc_threshold=DEFAULT_ICC_THRESHOLD,
+            min_entities=DEFAULT_MIN_ENTITIES,
+        )
+        assert rank.ranked_dimensions == []
+        assert rank.secondary_dimensions == []
+        assert rank.n_rows == df.height

--- a/packages/engine/tests/unit/analysis/drivers/test_grain.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_grain.py
@@ -184,3 +184,68 @@ class TestWithinEntityDemean:
         assert np.isnan(residual[0]) and weight[0] == 0.0
         # the rest are unaffected (still produce finite residuals somewhere)
         assert np.isfinite(residual[1:]).any()
+
+
+class TestAliasAndEmptyHeadline:
+    """DAT-695: alias dims never home; the headline family must carry content."""
+
+    @staticmethod
+    def _frame(rng: np.random.Generator) -> pl.DataFrame:
+        # 40 entities × 20 rows; measure clusters strongly by entity (high ICC).
+        # ``alias`` is a 1:1 renaming of the entity key; ``home_null`` is a
+        # legitimate (non-saturated) entity attribute with NO relation to the
+        # measure; ``row_driver`` drives WITHIN-entity variation, so it survives
+        # the row family's de-meaning.
+        n_ent, per = 40, 20
+        entity = [f"e{i}" for i in range(n_ent) for _ in range(per)]
+        alias = [f"tenant_{e}" for e in entity]
+        home_null = [f"g{i % 3}" for i in range(n_ent) for _ in range(per)]
+        row_driver = rng.choice(["hi", "lo"], size=n_ent * per)
+        base = np.repeat(rng.normal(0, 50, n_ent), per)
+        measure = base + np.where(row_driver == "hi", 5.0, -5.0) + rng.normal(0, 0.5, n_ent * per)
+        return pl.DataFrame(
+            {
+                "entity": entity,
+                "alias": alias,
+                "home_null": home_null,
+                "row_driver": row_driver,
+                "measure": measure,
+            }
+        )
+
+    def test_alias_of_cluster_key_is_dropped_not_homed(self) -> None:
+        df = self._frame(np.random.default_rng(7))
+        home, row = _home_grain_partition(df, ["entity"], ["alias", "row_driver"])
+        assert home == {}  # the alias is neither a home dim...
+        assert row == ["row_driver"]  # ...nor row-level — it IS the key, renamed
+
+    def test_headline_skips_empty_family_for_content(self) -> None:
+        from dataraum.analysis.drivers.models import Measure
+        from dataraum.analysis.drivers.processor import (
+            DEFAULT_ICC_THRESHOLD,
+            DEFAULT_MIN_ENTITIES,
+            _routed_ranking,
+        )
+
+        df = self._frame(np.random.default_rng(7))
+        rank = _routed_ranking(
+            df,
+            ["home_null", "row_driver"],
+            Measure(target_type="flow", column="measure"),
+            ["entity"],
+            seed=0,
+            max_depth=2,
+            alpha=0.05,
+            min_support=25,
+            missingness_gate=0.5,
+            n_perm=200,
+            icc_threshold=DEFAULT_ICC_THRESHOLD,
+            min_entities=DEFAULT_MIN_ENTITIES,
+        )
+        # The entity family (home_null over 40 entities, pure noise) ranks
+        # nothing; the headline must fall through to the row family that DID
+        # find the within-entity driver — never persist ranked: 0 while a
+        # non-empty family sits in secondary.
+        assert rank.ranked_dimensions, "headline family must carry content"
+        assert rank.grain == "row"
+        assert "row_driver" in {d for d, _ in rank.ranked_dimensions}

--- a/packages/engine/tests/unit/analysis/relationships/test_composite.py
+++ b/packages/engine/tests/unit/analysis/relationships/test_composite.py
@@ -248,3 +248,47 @@ def test_rescued_key_carries_coverage(con) -> None:
     )
     assert key is not None
     assert key.coverage == 1.0
+
+
+def test_coverage_is_oriented_to_the_referencing_side(con) -> None:
+    """table1/table2 come from arbitrary pairing order — coverage must describe
+    the MANY (referencing) side either way, or a lookalike dim as table1 reads
+    near-100% while the fact-side truth is tiny (DAT-695 review)."""
+    con.execute("CREATE TABLE dim3 (account_name VARCHAR, business_id VARCHAR)")
+    con.execute(
+        "INSERT INTO dim3 VALUES ('Sales','B1'),('Sales','B2'),('COGS','B1'),('COGS','B2')"
+    )
+    con.execute("CREATE TABLE fact3 (account VARCHAR, business_id VARCHAR)")
+    # 10 fact rows; only the two ('Sales','B1') rows resolve against dim3.
+    con.execute(
+        "INSERT INTO fact3 VALUES ('Sales','B1'),('Sales','B1'),"
+        "('O1','B9'),('O2','B9'),('O3','B9'),('O4','B9'),('O5','B9'),"
+        "('O6','B9'),('O7','B9'),('O8','B9')"
+    )
+
+    # Dim as table1 (one-to-many measured): the naive direction would read
+    # 25% of the DIM's rows; the oriented number is the fact's 20%.
+    key = rescue_fanout_to_composite(
+        _candidate(
+            "dim3", "fact3", [("account_name", "account", 0.9), ("business_id", "business_id", 0.5)]
+        ),
+        "dim3",
+        "fact3",
+        con,
+    )
+    assert key is not None
+    assert key.coverage_table == "fact3"
+    assert key.coverage is not None and abs(key.coverage - 0.2) < 1e-9
+
+    # Mirrored pairing (fact as table1, many-to-one): identical answer.
+    key2 = rescue_fanout_to_composite(
+        _candidate(
+            "fact3", "dim3", [("account", "account_name", 0.9), ("business_id", "business_id", 0.5)]
+        ),
+        "fact3",
+        "dim3",
+        con,
+    )
+    assert key2 is not None
+    assert key2.coverage_table == "fact3"
+    assert key2.coverage is not None and abs(key2.coverage - 0.2) < 1e-9

--- a/packages/engine/tests/unit/analysis/relationships/test_composite.py
+++ b/packages/engine/tests/unit/analysis/relationships/test_composite.py
@@ -199,3 +199,52 @@ def test_join_multiplication_ranks_disambiguation(con) -> None:
         "txn", "coa", [("account", "account_name"), ("business_id", "business_id")], con
     )
     assert composite < single  # the scoping column reduces the fan-out
+
+
+# ---------------------------------------------------------------------------
+# compute_join_coverage — multiplicity says "key", coverage says "used" (DAT-695)
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_is_the_matched_fraction_of_nonnull_rows(con) -> None:
+    from dataraum.analysis.relationships.evaluator import compute_join_coverage
+
+    con.execute("CREATE TABLE f (a VARCHAR, b VARCHAR)")
+    # 3 non-NULL key rows (2 match), 1 NULL-component row (excluded from the base).
+    con.execute("INSERT INTO f VALUES ('x','1'),('x','1'),('y','1'),('z',NULL)")
+    con.execute("CREATE TABLE d (a VARCHAR, b VARCHAR)")
+    con.execute("INSERT INTO d VALUES ('x','1')")
+    cov = compute_join_coverage("f", "d", [("a", "a"), ("b", "b")], con)
+    assert cov is not None and abs(cov - 2 / 3) < 1e-9
+
+
+def test_coverage_none_on_empty_or_missing(con) -> None:
+    from dataraum.analysis.relationships.evaluator import compute_join_coverage
+
+    con.execute("CREATE TABLE f2 (a VARCHAR)")
+    con.execute("CREATE TABLE d2 (a VARCHAR)")
+    assert compute_join_coverage("f2", "d2", [("a", "a")], con) is None  # no rows
+    assert compute_join_coverage("f2", "d2", [], con) is None  # no key
+    assert compute_join_coverage("missing", "d2", [("a", "a")], con) is None  # probe fails
+
+
+def test_rescued_key_carries_coverage(con) -> None:
+    """The canonical rescue fixture matches every fact row → coverage 1.0."""
+    con.execute("CREATE TABLE txn2 (account VARCHAR, business_id VARCHAR)")
+    con.execute(
+        "INSERT INTO txn2 VALUES ('Sales','B1'),('Sales','B2'),('COGS','B1'),('COGS','B2')"
+    )
+    con.execute("CREATE TABLE coa2 (account_name VARCHAR, business_id VARCHAR)")
+    con.execute(
+        "INSERT INTO coa2 VALUES ('Sales','B1'),('COGS','B1'),('Sales','B2'),('COGS','B2')"
+    )
+    key = rescue_fanout_to_composite(
+        _candidate(
+            "txn2", "coa2", [("account", "account_name", 0.9), ("business_id", "business_id", 0.5)]
+        ),
+        "txn2",
+        "coa2",
+        con,
+    )
+    assert key is not None
+    assert key.coverage == 1.0

--- a/packages/engine/tests/unit/analysis/semantic/test_candidate_overlap_format.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_candidate_overlap_format.py
@@ -56,11 +56,13 @@ def test_composite_rescue_hint_is_rendered() -> None:
     cands[0]["composite_key"] = {
         "column_pairs": [["customer_id", "id"], ["region", "region"]],
         "cardinality": "many-to-one",
+        "coverage": 0.003,
     }
     out = agent._format_relationship_candidates(cands)
     assert "COMPOSITE-KEY RESCUE" in out
     assert "customer_id <-> id, region <-> region" in out
     assert "many-to-one" in out
+    assert "matches 0.3% of rows" in out  # the judge sees a hollow key's number (DAT-695)
 
 
 def test_no_hint_renders_no_rescue_block() -> None:

--- a/packages/engine/tests/unit/analysis/semantic/test_candidate_overlap_format.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_candidate_overlap_format.py
@@ -57,12 +57,14 @@ def test_composite_rescue_hint_is_rendered() -> None:
         "column_pairs": [["customer_id", "id"], ["region", "region"]],
         "cardinality": "many-to-one",
         "coverage": 0.003,
+        "coverage_table": "orders",
     }
     out = agent._format_relationship_candidates(cands)
     assert "COMPOSITE-KEY RESCUE" in out
     assert "customer_id <-> id, region <-> region" in out
     assert "many-to-one" in out
-    assert "matches 0.3% of rows" in out  # the judge sees a hollow key's number (DAT-695)
+    # The judge sees a hollow key's number AND whose rows it describes (DAT-695).
+    assert "matches 0.3% of orders's rows" in out
 
 
 def test_no_hint_renders_no_rescue_block() -> None:

--- a/packages/engine/tests/unit/analysis/semantic/test_candidate_overlap_format.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_candidate_overlap_format.py
@@ -63,8 +63,10 @@ def test_composite_rescue_hint_is_rendered() -> None:
     assert "COMPOSITE-KEY RESCUE" in out
     assert "customer_id <-> id, region <-> region" in out
     assert "many-to-one" in out
-    # The judge sees a hollow key's number AND whose rows it describes (DAT-695).
-    assert "matches 0.3% of orders's rows" in out
+    # The judge sees a hollow key's number AND whose rows it describes (DAT-695),
+    # leading the decision frame rather than trailing it.
+    assert "MEASURED USAGE: 0.3% of orders's populated-key rows" in out
+    assert "DECLINE the relationship entirely" in out
 
 
 def test_no_hint_renders_no_rescue_block() -> None:

--- a/packages/engine/tests/unit/analysis/semantic/test_composite_augment.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_composite_augment.py
@@ -70,6 +70,7 @@ def test_rescuable_fanout_gets_a_composite_hint(con) -> None:
     assert hint is not None
     assert hint["column_pairs"] == [["account", "account_name"], ["business_id", "business_id"]]
     assert hint["cardinality"] != "many-to-many"
+    assert hint["coverage"] == 1.0  # every fact row matches in this fixture (DAT-695)
 
 
 def test_clean_single_column_candidate_is_untouched(con) -> None:

--- a/packages/engine/tests/unit/analysis/semantic/test_surrogate_intent.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_surrogate_intent.py
@@ -275,10 +275,59 @@ def test_scope_component_order_is_canonical(session) -> None:
     assert a is not None and b is not None
     assert a["intent_digest"] == b["intent_digest"]
     assert a["column_pairs"] == b["column_pairs"]
-    # Anchor first, scope sorted by from-side name.
+    # ALL pairs sorted by from-side name — the anchor holds no positional
+    # privilege in the column identity.
     assert a["column_pairs"][0][0] == cols[(txn.table_id, "account")]
     assert a["column_pairs"][1][0] == cols[(txn.table_id, "business_id")]
     assert a["column_pairs"][2][0] == cols[(txn.table_id, "region")]
+
+
+def test_anchor_choice_does_not_change_the_surrogate_identity(session) -> None:
+    """Seen live: the LLM anchored the same composite on payment_method one run
+    and business_id the next, minting two differently-named surrogates for one
+    key. The digest and pair order must be identical whichever pair the LLM
+    picks as the anchor."""
+    from dataraum.analysis.semantic.processor import _build_surrogate_intent
+
+    txn = _table_with_columns(session, "txn", ["payment_method", "business_id"])
+    pm = _table_with_columns(session, "pm", ["payment_method", "business_id"])
+    cols = {(c.table_id, c.column_name): c.column_id for t in (txn, pm) for c in t.columns}
+    column_map = {
+        ("txn", "payment_method"): cols[(txn.table_id, "payment_method")],
+        ("txn", "business_id"): cols[(txn.table_id, "business_id")],
+        ("pm", "payment_method"): cols[(pm.table_id, "payment_method")],
+        ("pm", "business_id"): cols[(pm.table_id, "business_id")],
+    }
+
+    def _build(anchor: str, scope: str):
+        rel = Relationship(
+            relationship_id="rel-1",
+            from_table="txn",
+            from_column=anchor,
+            to_table="pm",
+            to_column=anchor,
+            key_columns=[(scope, scope)],
+            relationship_type=RelationshipType.FOREIGN_KEY,
+            confidence=0.9,
+            detection_method="llm_tool",
+            evidence={"source": "table_synthesis"},
+        )
+        return _build_surrogate_intent(
+            rel=rel,
+            from_table_id=txn.table_id,
+            from_col_id=cols[(txn.table_id, anchor)],
+            to_table_id=pm.table_id,
+            to_col_id=cols[(pm.table_id, anchor)],
+            column_map=column_map,
+            run_id=baseline_run_id(),
+            duckdb_conn=None,
+        )
+
+    anchored_on_pm = _build("payment_method", "business_id")
+    anchored_on_biz = _build("business_id", "payment_method")
+    assert anchored_on_pm is not None and anchored_on_biz is not None
+    assert anchored_on_pm["intent_digest"] == anchored_on_biz["intent_digest"]
+    assert anchored_on_pm["column_pairs"] == anchored_on_biz["column_pairs"]
 
 
 def test_duplicate_llm_relationships_fold_to_one_row(session) -> None:

--- a/packages/engine/tests/unit/analysis/views/test_enrichment_format.py
+++ b/packages/engine/tests/unit/analysis/views/test_enrichment_format.py
@@ -1,0 +1,37 @@
+"""The enrichment feed renders measured join coverage (DAT-695).
+
+A grain-safe key can still match almost nothing (a lookalike dimension) — the
+judge must see the number next to the grain marker so it can decline a join
+that would enrich nothing. No coverage in evidence → no note (older rows).
+"""
+
+from __future__ import annotations
+
+from dataraum.analysis.views.enrichment_agent import EnrichmentAgent
+
+
+def _rel(coverage: float | None) -> dict:
+    rel = {
+        "from_table": "txn",
+        "from_column": "_sk__customer_name__business_id",
+        "to_table": "customer_table",
+        "to_column": "_sk__customer_name__business_id",
+        "cardinality": "many-to-one",
+        "confidence": 0.85,
+    }
+    if coverage is not None:
+        rel["coverage"] = coverage
+    return rel
+
+
+def test_low_coverage_is_rendered_next_to_the_grain_marker() -> None:
+    agent = EnrichmentAgent.__new__(EnrichmentAgent)  # _format_* is self-contained
+    out = agent._format_relationships([_rel(0.003)])
+    assert "[GRAIN-SAFE]" in out
+    assert "[matches 0.3% of fact rows]" in out
+
+
+def test_missing_coverage_renders_no_note() -> None:
+    agent = EnrichmentAgent.__new__(EnrichmentAgent)
+    out = agent._format_relationships([_rel(None)])
+    assert "matches" not in out

--- a/packages/engine/tests/unit/pipeline/test_surrogate_mint_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_surrogate_mint_phase.py
@@ -209,6 +209,7 @@ def test_mint_end_to_end(session, lake) -> None:
     assert by_id[rel.to_column_id] == "_sk__account_name__business_id"
     assert rel.cardinality == "many-to-one"
     assert rel.evidence["introduces_duplicates"] is False
+    assert rel.evidence["coverage"] == 1.0  # every fact row joins in this fixture (DAT-695)
     assert rel.evidence["surrogate"]["natural_pairs"] == [
         ["account", "account_name"],
         ["business_id", "business_id"],


### PR DESCRIPTION
## What & why

Root cause of **driver rankings coming back empty over surrogate-joined dimensions** (clean-import verified, DAT-695 has the full diagnosis). The surrogate join itself was exonerated to the row (native == hash, 2,205 = 2,205); the defects sat above and below it.

### Coverage becomes judge evidence (no numeric gate)
The composite collapse proof measures match **multiplicity**, never **coverage** — lookalike dimension tables (independently generated name pools; 0.27% real coverage) verified as clean many-to-one keys and minted 74–100%-NULL enrichment. New `compute_join_coverage` (share of the **referencing side's** non-NULL-key rows with a match, oriented by measured cardinality — never by the arbitrary table1/table2 pairing order) now rides:
- the composite-rescue hint + `semantic_per_table` prompt guidance (*decline lookalikes*), naming whose rows the number describes;
- the minted relationship's evidence (+ low-coverage warning log);
- the enrichment feed (`[matches 0.3% of fact rows]` next to the grain marker).

Evidence for the LLM judges; the slicing null-filter stays the deterministic floor.

### Driver routing fixes (`drivers/processor.py`)
- A dim **saturated against its home entity** (distinct == entity count, constant within — a 1:1 alias of the key, e.g. `business_id ↔ created_user`, 27=27) is dropped: it fabricated a guaranteed-empty family that won headline precedence.
- The **headline family must carry content**: first non-empty family in precedence order — but never past the row family (the DAT-561 low-ICC demotion is deliberate and preserved; its existing contract test caught the blanket version of this change).
- All-families-empty (alias-only tables) returns the honest empty ranking instead of crashing the phase.

### Review gate
Spec-compliance: **COMPLIANT**. Senior review: **APPROVED** after one fix round — it caught a reproducible `IndexError` on the alias-only shape and the coverage-direction bug (a lookalike dim as table1 would have read ~100%), both now pinned by regression tests in both pairing orders.

Full `tests/unit` (no testmon): **1858 passed** · ruff · mypy clean. Handoff entry records calibration targets (ranked sets can legitimately shift on tenant-alias corpora; lookalike declines are intended) and the real-coverage acceptance corpus + lookalike negative testdata needs (pairs with DAT-679).

Closes DAT-695.

🤖 Generated with [Claude Code](https://claude.com/claude-code)