### PR TITLE
fix(DAT-672): tier C output-reachability gate — close the silent-miss slice (post-merge review)

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -52,11 +52,21 @@ DAT-679 fixture work (greedy-search miss-rate corpus).
 
 ---
 
+## DAT-672 — drill keystone; `column_mappings` removed end-to-end (PR #438, merged 2026-07-06)
+
+**For dataraum-eval:**
+- **`sql_snippets.column_mappings` no longer exists** (column dropped; LLM output field, `GeneratedCode`, reuse-merge and persist paths all removed). Any eval strategy reading it gets `UndefinedColumn` — switch to `provenance.column_mappings_basis` (`{concept: {column, filter, resolution}}`), which is the prompted, populated per-concept grounding record. The flat field had been silently empty since DAT-636 dropped its prompt teaching (`default_factory=dict` masked it).
+- No other engine response/pipeline shape changed; the rest of the PR is cockpit-side (drill tiers A/B/C over the promoted surface — read-only).
+
+**Testdata note:** BookSQL's COA has **zero COGS-type and zero inventory accounts**, so gross-profit-family metrics can never execute there (honest NULL extracts) — don't read that as a grounding regression; realistic executed ceiling on BookSQL ≈ dso + current_ratio.
+
+---
+
 ## DAT-603 — graph agent: single-extract output schema + adaptive thinking (PRs #434, merged 2026-07-03)
 
 **Re-baseline `graph_sql_generation` before trusting comparisons against the DAT-602 eval baseline.** Three changes eval must know about:
 
-1. **Output schema replaced.** `GraphSQLGenerationOutput` (summary/steps[]/final_sql) is gone; the tool now takes `ExtractGroundingOutput`: `grounding` (evidence commitment, FIRST field), `sql`, `description`, `column_mappings`, `assumptions`, `provenance` (no more `llm_reasoning`). The agent binds the SQL to the graph's own leaf id — snippet `step_id`s always equal catalogue step ids now (the DAT-664 paraphrase class is structurally gone). `validation_sql`'s schema also lost its unread `explanation` field.
+1. **Output schema replaced.** `GraphSQLGenerationOutput` (summary/steps[]/final_sql) is gone; the tool now takes `ExtractGroundingOutput`: `grounding` (evidence commitment, FIRST field), `sql`, `description`, `assumptions`, `provenance` (no more `llm_reasoning`; `column_mappings` was removed by DAT-672 — see its entry). The agent binds the SQL to the graph's own leaf id — snippet `step_id`s always equal catalogue step ids now (the DAT-664 paraphrase class is structurally gone). `validation_sql`'s schema also lost its unread `explanation` field.
 2. **Adaptive thinking ON for this label** (`thinking: true` in `llm/config.yaml`), with `tool_choice: auto` + `disable_parallel_tool_use`. Latency/token profile shifted: measured 763 → ~3,726 mean output tokens/call (thinking billed as output), ~10s → ~35s/call, absorbed by the 10-wide fan-out. Any eval latency/cost assertions on this label need new baselines.
 3. **Prompt v6.1** (floors-not-scripts rewrite) — grounding QUALITY improved on the finance fresh-wipe smoke: revenue grounds via the complete `account_type` classification and matches `ground_truth.yaml` exactly (51,766,199.72); cogs+opex+depreciation match `total_expenses` to the cent; 22/34 executed (prior fresh runs: 21 and 19). Value-level GT comparison is now part of the grounding smoke — distribution parity alone masked a 48% revenue error in pre-rework sampling.
 

--- a/packages/cockpit/src/duckdb/drill-sql.test.ts
+++ b/packages/cockpit/src/duckdb/drill-sql.test.ts
@@ -566,3 +566,57 @@ SELECT * FROM m`;
 		});
 	});
 });
+
+describe("composeDrill tier C output-reachability gate (post-merge review)", () => {
+	it("refuses when the dim-carrying CTE is off the output's reference chain", async () => {
+		// The empirically-reproduced silent-miss shape: `orphan` is a real
+		// extract (dim-carrying after injection) but the output formula only
+		// references the constant — without the gate this composed
+		// "successfully" with the slice silently absent from the result.
+		const ORPHAN = `WITH orphan AS (
+SELECT SUM(credit) AS value FROM enriched_txn
+),
+y AS (
+SELECT 30 AS value
+),
+final AS (
+SELECT ((SELECT value FROM y) * 2.0) AS value
+)
+SELECT * FROM final`;
+		const result = await composeDrill(conn, {
+			sql: ORPHAN,
+			params: [],
+			steps: [
+				{
+					kind: "slice",
+					column: "transaction_type",
+					source: ["txn", "enriched_txn"],
+				},
+			],
+		});
+		expect(result).toEqual({
+			ok: false,
+			reason: "the metric's output step cannot carry the dimension",
+		});
+	});
+
+	it("refuses a composed-metric shape whose outer select is not a bare star", async () => {
+		// The engine always emits `SELECT * FROM <output>`; a narrowed outer
+		// select would hide injected dims — assert loudly instead.
+		const result = await composeDrill(conn, {
+			sql: "WITH a AS (SELECT SUM(credit) AS value FROM enriched_txn) SELECT value FROM a",
+			params: [],
+			steps: [
+				{
+					kind: "slice",
+					column: "transaction_type",
+					source: ["txn", "enriched_txn"],
+				},
+			],
+		});
+		expect(result).toEqual({
+			ok: false,
+			reason: "metric output shape not recognized",
+		});
+	});
+});

--- a/packages/cockpit/src/duckdb/drill-sql.ts
+++ b/packages/cockpit/src/duckdb/drill-sql.ts
@@ -417,6 +417,21 @@ function composeTierC(
 	node: AstNode,
 	req: DrillComposeRequest,
 ): { pinParams: DrillPinValue[] } | { refusal: string } {
+	// The engine's composed-metric outer statement is literally
+	// `SELECT * FROM <output_step>` (agent.py hardcodes it at both call
+	// sites). Assert the STAR so a future engine change that narrows the
+	// outer select refuses loudly instead of silently hiding injected dims
+	// (post-merge review, 2026-07-06).
+	const topSelect = node.select_list;
+	if (
+		!Array.isArray(topSelect) ||
+		topSelect.length !== 1 ||
+		!isRecord(topSelect[0]) ||
+		topSelect[0].class !== "STAR"
+	) {
+		return { refusal: "metric output shape not recognized" };
+	}
+
 	const entries = cteEntries(node);
 	const cteNames = new Set(entries.map((e) => e.key));
 	const dims = req.steps.filter((s) => s.kind === "slice");
@@ -463,6 +478,17 @@ function composeTierC(
 
 	if (dimCarrying.size === 0) {
 		return { refusal: "no step of this metric can carry the dimension" };
+	}
+	// The gate must prove the dims reach the CTE the OUTER statement actually
+	// selects from — "some CTE carries them" is not enough: an extract CTE off
+	// the output's reference chain (over-declared `depends_on` in the metric
+	// YAML) would compose "successfully" with the slice silently missing from
+	// the result. Wrong numbers are worse than refusals (post-merge review,
+	// 2026-07-06 — empirically reproduced).
+	const outputRels: { table: string; alias: string }[] = [];
+	collectScopeRelations(node.from_table, outputRels);
+	if (!outputRels.some((r) => dimCarrying.has(r.table))) {
+		return { refusal: "the metric's output step cannot carry the dimension" };
 	}
 	return { pinParams };
 }

--- a/packages/cockpit/src/tools/drill-axes.test.ts
+++ b/packages/cockpit/src/tools/drill-axes.test.ts
@@ -267,3 +267,13 @@ describe("resolveDrillAxes empty-result reasons", () => {
 		expect(stale.reason).toContain("enriched_master_txn_table");
 	});
 });
+
+describe("resolveDrillAxes bare-catalog reason", () => {
+	it("names the bare catalog when the fact resolves but has no slice definitions", async () => {
+		seed();
+		rowsByTable.set(currentSliceDefinitions, []);
+		const result = await resolveDrillAxes({ standardField: "revenue" });
+		expect(result.axes).toEqual([]);
+		expect(result.reason).toContain("No dimensions cataloged");
+	});
+});


### PR DESCRIPTION
Follow-up to #438, from the post-merge reviewer pass over the unreviewed tail (the review gate was skipped for the commits after the 7/3 approval — this PR carries its findings).

**Critical (senior review, empirically reproduced):** `composeTierC` gated on *"some CTE is dim-carrying"*, not *"the dims reach the CTE the outer statement selects from."* An extract CTE off the output's reference chain — possible via an over-declared `depends_on` in a metric YAML — composed "successfully" with the slice **silently missing from the result**: DuckDB doesn't bind an unreferenced CTE, so even the bound-DESCRIBE gate never saw it. Dormant in today's catalogs (hand-authored `depends_on` happens to match expressions) but unenforced.

Fixes:
- Output-reachability gate: the outer `from_table` must name a dim-carrying CTE, else the clean refusal ("the metric's output step cannot carry the dimension").
- STAR assertion: the outer select must be the engine's literal `SELECT *` — a future engine change narrowing it would hide injected dims the same way; now it refuses loudly.
- Tests for both, including the reviewer's exact repro shape.

**Spec-review findings:** `.claude/handoff.md` gains the DAT-672 eval entry (`sql_snippets.column_mappings` no longer exists — read `provenance.column_mappings_basis`; plus the BookSQL COGS/inventory testdata note) and the stale DAT-603 entry's field list is corrected. The bare-catalog no-axes reason gets its missing test.

1540 cockpit tests, tsc, biome green. Reviewer verdicts on the tail: senior NEEDS FIX → this PR; spec COMPLIANT with the two doc/test findings → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)