### PR TITLE
feat(DAT-697): composite verdicts gate the silent-accept keeper machinery

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,51 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-697 — composite verdicts gate the silent-accept keeper machinery
+
+**Branch:** `feat/dat-697-keeper-adjudication`. Fixes the resurrection loop
+found live on the bookkeeping smoke: a judge-DECLINED composite (DAT-695
+measured-usage decline) was silently lifted back as a `keeper` by DAT-409's
+silent-accept, and the mint's grace window then kept its hollow `_sk__`
+columns alive run after run.
+
+### What changed
+
+- **`surrogate_key_intents` gained `status`** (`'confirmed' | 'declined'`,
+  schema.sql + drizzle mirror re-dumped): `semantic_per_table` now records a
+  verdict row for EVERY offered rescue hint — declined = offered − confirmed.
+  The mint loads only confirmed intents (unchanged behavior).
+- **`intent_digest` is direction-neutral** (`surrogate.py::composite_intent_digest`
+  — sha1 over unordered id pairs; the canonical NAME order key is likewise
+  direction-neutral now). Neither the judge's anchor nor its from/to
+  orientation is run-stable; matching recomputes digests from stored natural
+  column ids, never compares stored strings.
+- **Keeper machinery honors adjudication** (`materialize.py`): a prior llm
+  pair the current run RULED on is not lifted; a stale `keep` overlay on an
+  adjudicated pair is superseded (never deleted — audit trail) and no longer
+  materializes a keeper row. Pairs with NO verdict this run keep full DAT-409
+  flake protection. Polluted workspaces self-heal within ~2 runs (grace ages
+  out of the promoted head) instead of requiring a wipe.
+
+### Calibration to run
+
+- Composite/relationship confirmation suites: run-over-run STABILITY is the
+  new observable — a declined lookalike must STAY declined across consecutive
+  begin_session runs (pre-fix it flip-flopped back via keeper). The DAT-695
+  decline-recall expectations are unchanged.
+- Surrogate column lifecycle: after a decline, `_sk__*` columns for that
+  composite must be GONE by the second following run (grace window is one
+  promoted head, not forever).
+
+### testdata hints
+
+The lookalike-negative corpus (DAT-695 entry below) doubles as the
+resurrection fixture: run begin_session twice on it — first with the hint
+confirmed (or seeded keeper state), then with the decline — and assert the
+keeper does not resurrect the declined composite.
+
+---
+
 ## DAT-695 — join coverage as judge evidence + driver routing fixes
 
 **Branch:** `feat/dat-695-coverage-and-routing`. Root cause of "driver rankings

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -429,6 +429,7 @@ export const currentSurrogateKeyIntents = metadataSchema
 		intentId: varchar("intent_id"),
 		runId: varchar("run_id"),
 		intentDigest: varchar("intent_digest"),
+		status: varchar(),
 		fromTableId: varchar("from_table_id"),
 		toTableId: varchar("to_table_id"),
 		columnPairs: json("column_pairs"),
@@ -438,7 +439,7 @@ export const currentSurrogateKeyIntents = metadataSchema
 		detectedAt: timestamp("detected_at"),
 	})
 	.as(
-		sql`SELECT intent_id, run_id, intent_digest, from_table_id, to_table_id, column_pairs, cardinality, confidence, reasoning, detected_at FROM ws_00000000_0000_0000_0000_000000000001.surrogate_key_intents r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
+		sql`SELECT intent_id, run_id, intent_digest, status, from_table_id, to_table_id, column_pairs, cardinality, confidence, reasoning, detected_at FROM ws_00000000_0000_0000_0000_000000000001.surrogate_key_intents r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
 	);
 
 export const currentTableEntities = metadataSchema

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -285,6 +285,7 @@ CREATE TABLE surrogate_key_intents (
 	intent_id VARCHAR NOT NULL, 
 	run_id VARCHAR NOT NULL, 
 	intent_digest VARCHAR NOT NULL, 
+	status VARCHAR NOT NULL, 
 	from_table_id VARCHAR NOT NULL, 
 	to_table_id VARCHAR NOT NULL, 
 	column_pairs JSON NOT NULL, 

--- a/packages/engine/src/dataraum/analysis/relationships/db_models.py
+++ b/packages/engine/src/dataraum/analysis/relationships/db_models.py
@@ -121,19 +121,25 @@ Index("idx_relationships_to_table_column", Relationship.to_table_id, Relationshi
 
 
 class SurrogateKeyIntent(Base):
-    """An LLM-confirmed composite key awaiting its surrogate mint (DAT-277).
+    """The run's composite-key VERDICT record (DAT-277, DAT-697).
 
-    ``semantic_per_table`` confirms a composite via ``RelationshipOutput.key_columns``;
-    the confirmation is persisted HERE — never as plain llm relationship rows — so
-    no single-column consumer ever joins on a half-key. The ``surrogate_mint``
-    phase reads the run's intents, mints the NULL-propagating hash column on both
-    typed tables, and persists the ONE single-column relationship on the surrogate
-    pair (method 'llm', evidence carrying this provenance).
+    ``semantic_per_table`` writes one row per composite the judge ruled on:
+    ``status='confirmed'`` (via ``RelationshipOutput.key_columns`` — persisted
+    HERE, never as plain llm relationship rows, so no single-column consumer
+    ever joins on a half-key) or ``status='declined'`` (a COMPOSITE-KEY RESCUE
+    hint was offered and the judge did not confirm it). The ``surrogate_mint``
+    phase reads only the run's confirmed intents; the keeper machinery
+    (``materialize.py``) reads both — an adjudicated composite must not be
+    silently kept (DAT-697), because silence-as-acceptance requires the system
+    to have been silent, and a verdict is not silence.
 
     Run-versioned like the relationship catalog (DAT-408): rows coexist across
     runs; the mint reads only its own run's intents. ``intent_digest`` is
-    deterministic in the ordered component column ids so a Temporal
-    at-least-once retry upserts the same row instead of duplicating it.
+    deterministic in the component column ids and DIRECTION-NEUTRAL (neither
+    the judge's anchor choice nor its from/to orientation is run-stable), so a
+    Temporal at-least-once retry upserts the same row instead of duplicating
+    it, and the offered-vs-confirmed comparison cannot split one composite
+    into two identities.
     """
 
     __tablename__ = "surrogate_key_intents"
@@ -145,10 +151,15 @@ class SurrogateKeyIntent(Base):
     run_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
     intent_digest: Mapped[str] = mapped_column(String, nullable=False)
 
+    # The judge's ruling: 'confirmed' (mint this composite) or 'declined' (the
+    # rescue hint was offered and not confirmed — no relationship in the data).
+    status: Mapped[str] = mapped_column(String, nullable=False, default="confirmed")
+
     from_table_id: Mapped[str] = mapped_column(ForeignKey("tables.table_id"), nullable=False)
     to_table_id: Mapped[str] = mapped_column(ForeignKey("tables.table_id"), nullable=False)
 
-    # Ordered component pairs, anchor FIRST: [[from_column_id, to_column_id], …].
+    # Component pairs in CANONICAL order (direction-neutral name key — the
+    # anchor holds no positional privilege): [[from_column_id, to_column_id], …].
     # Column ids, not names — the id is the cross-phase-stable identity; the mint
     # resolves physical names from the Column rows when composing the hash DDL.
     column_pairs: Mapped[list[Any]] = mapped_column(JSON, nullable=False)

--- a/packages/engine/src/dataraum/analysis/relationships/materialize.py
+++ b/packages/engine/src/dataraum/analysis/relationships/materialize.py
@@ -22,19 +22,36 @@ Rejected pairs are skipped (a reject wins over a stale add/confirm/keep).
 Re-running the same ``run_id`` (a Temporal retry) clears only this run's own
 ``manual``/``keeper`` rows first, so it is idempotent and non-destructive to
 other runs.
+
+Adjudication outranks silence (DAT-697): silent-accept exists for pairs the
+run did NOT rule on (an LLM flake must not erase catalog state the user
+relied on), but ``semantic_per_table`` records a VERDICT for every composite
+whose rescue hint it offered (``SurrogateKeyIntent.status``), and a verdict
+is not silence. A ``keep`` overlay on an adjudicated pair is neither
+materialized nor lifted — it is superseded — so a judge-declined composite
+(and its hollow surrogate columns, via the mint's keeper-grace window)
+cannot be resurrected run after run by machinery meant to guard against
+flakes. User assertions are untouched: ``manual`` overlays never yield to
+the judge, and ``keep`` has exactly one author (this module — the cockpit
+teach surface rejects it as a user action).
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
 from uuid import uuid4
 
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
-from dataraum.analysis.relationships.db_models import Relationship
+from dataraum.analysis.relationships.db_models import Relationship, SurrogateKeyIntent
+from dataraum.analysis.relationships.surrogate import composite_intent_digest
 from dataraum.analysis.relationships.utils import (
     load_suppressed_relationship_pairs,
     relationship_overlay_pairs,
+    relationship_overlay_rows,
 )
 from dataraum.core.logging import get_logger
 from dataraum.storage import Column
@@ -45,6 +62,94 @@ logger = get_logger(__name__)
 # ``confirm`` are both explicit human assertions (manual); ``add`` is listed
 # first so it wins the per-(pair, method) dedup when both overlays exist.
 _ACTION_METHOD = {"add": "manual", "confirm": "manual", "keep": "keeper"}
+
+
+@dataclass(frozen=True)
+class _Adjudication:
+    """One run's composite verdicts, in the shapes the keeper machinery matches on.
+
+    ``digests``: direction-neutral identities of EVERY composite the judge ruled
+    on this run (confirmed or declined) — matched against a surrogate
+    relationship's mint provenance, so a confirmed composite also supersedes a
+    stale differently-named/anchored surrogate twin of itself.
+    ``declined_pairs``: the unordered natural component pairs of DECLINED
+    composites — a declined verdict covers the composite's own column pairs
+    (anchor included: the judge was told to decline the relationship entirely).
+    Component pairs of CONFIRMED composites are deliberately absent: a second,
+    independent relationship between the same tables (two real FKs) must keep
+    its flake protection.
+    """
+
+    digests: frozenset[str]
+    declined_pairs: frozenset[frozenset[str]]
+
+    @property
+    def empty(self) -> bool:
+        return not self.digests and not self.declined_pairs
+
+
+def _load_adjudication(session: Session, run_id: str) -> _Adjudication:
+    """This run's composite verdicts (both statuses), from the intent rows."""
+    intents = session.execute(
+        select(SurrogateKeyIntent).where(SurrogateKeyIntent.run_id == run_id)
+    ).scalars()
+    digests: set[str] = set()
+    declined_pairs: set[frozenset[str]] = set()
+    for intent in intents:
+        digests.add(composite_intent_digest(intent.column_pairs))
+        if intent.status == "declined":
+            declined_pairs.update(frozenset(pair) for pair in intent.column_pairs)
+    return _Adjudication(frozenset(digests), frozenset(declined_pairs))
+
+
+def _natural_id_pairs(evidence: dict[str, Any] | None) -> list[Any] | None:
+    """The mint's natural component-id pairs from a relationship's evidence."""
+    surrogate = (evidence or {}).get("surrogate")
+    ids = surrogate.get("natural_column_ids") if isinstance(surrogate, dict) else None
+    return ids if isinstance(ids, list) and len(ids) >= 2 else None
+
+
+def _row_adjudicated(
+    adjudication: _Adjudication, pair: tuple[str, str], evidence: dict[str, Any] | None
+) -> bool:
+    """Whether this run RULED on the composite behind a relationship row.
+
+    Declined verdicts match the natural component pairs directly; surrogate
+    rows (whose pair is the minted ``_sk__`` columns, not the components)
+    match via the digest recomputed from their mint provenance — recomputed,
+    never string-compared, so digest-format changes cannot strand old rows.
+    """
+    if frozenset(pair) in adjudication.declined_pairs:
+        return True
+    natural = _natural_id_pairs(evidence)
+    return natural is not None and composite_intent_digest(natural) in adjudication.digests
+
+
+def _pair_adjudicated(session: Session, adjudication: _Adjudication, pair: tuple[str, str]) -> bool:
+    """`_row_adjudicated` for a bare pair (a keep overlay carries no evidence).
+
+    Surrogate provenance is recovered from the newest ``llm`` row on the same
+    pair (the original mint — mirrors the mint phase's own fallback for
+    overlay-materialized rows).
+    """
+    if frozenset(pair) in adjudication.declined_pairs:
+        return True
+    if not adjudication.digests:
+        return False
+    evidences = session.execute(
+        select(Relationship.evidence)
+        .where(
+            Relationship.from_column_id == pair[0],
+            Relationship.to_column_id == pair[1],
+            Relationship.detection_method == "llm",
+        )
+        .order_by(Relationship.detected_at.desc())
+    ).scalars()
+    for evidence in evidences:
+        natural = _natural_id_pairs(evidence)
+        if natural is not None:
+            return composite_intent_digest(natural) in adjudication.digests
+    return False
 
 
 def materialize_relationship_overlays(
@@ -68,6 +173,7 @@ def materialize_relationship_overlays(
     )
 
     suppressed = load_suppressed_relationship_pairs(session)
+    adjudication = _load_adjudication(session, run_id)
 
     # The run's DEFINED rows so far, keyed (pair, method) — candidates are
     # ephemeral and excluded. Dedup is per METHOD: an overlay row may join a
@@ -94,6 +200,12 @@ def materialize_relationship_overlays(
         for from_col, to_col in relationship_overlay_pairs(session, action):
             pair = (from_col, to_col)
             if pair in suppressed or (from_col, to_col, method) in written:
+                continue
+            if action == "keep" and _pair_adjudicated(session, adjudication, pair):
+                # This run RULED on the pair's composite (DAT-697) — a verdict
+                # is not silence, so the stale keep does not materialize. The
+                # overlay itself is superseded at the end of the run by
+                # ``write_relationship_keepers``.
                 continue
             from_table = table_by_column.get(from_col)
             to_table = table_by_column.get(to_col)
@@ -159,6 +271,13 @@ def write_relationship_keepers(
     The lifted relationship is absent from the run that detected its absence; the
     ``keep`` overlay materializes it as ``keeper`` from the NEXT run onward (the
     accepted one-run gap, by spec).
+
+    Adjudication outranks silence (DAT-697): a prior pair whose composite this
+    run's judge RULED on — declined on evidence, or confirmed under its
+    canonical surrogate identity (superseding a stale differently-named twin)
+    — is not lifted, and any existing keep overlay on such a pair is
+    superseded, so an already-polluted workspace self-heals instead of
+    resurrecting the pair every run.
     """
     from dataraum.storage import ConfigOverlay
     from dataraum.storage.snapshot_head import catalog_head_target, head_run_id
@@ -167,22 +286,37 @@ def write_relationship_keepers(
     if prior_run is None or prior_run == current_run_id:
         return 0
 
-    prior_llm = _run_pairs(session, prior_run, method="llm")
+    adjudication = _load_adjudication(session, current_run_id)
+    retracted = _retract_adjudicated_keeps(session, adjudication)
+
+    prior_llm = list(
+        session.execute(
+            select(
+                Relationship.from_column_id, Relationship.to_column_id, Relationship.evidence
+            ).where(
+                Relationship.run_id == prior_run,
+                Relationship.detection_method == "llm",
+            )
+        ).tuples()
+    )
     reproduced = _run_pairs(session, current_run_id)
     rejected = load_suppressed_relationship_pairs(session)
     already_kept = set(relationship_overlay_pairs(session, "keep"))
 
     count = 0
-    for pair in prior_llm:
+    for from_col, to_col, evidence in prior_llm:
+        pair = (from_col, to_col)
         if pair in reproduced or pair in rejected or pair in already_kept:
             continue
+        if _row_adjudicated(adjudication, pair, evidence):
+            continue  # the judge ruled this run — a verdict is not silence
         session.add(
             ConfigOverlay(
                 type="relationship",
                 payload={
                     "action": "keep",
-                    "from_column_id": pair[0],
-                    "to_column_id": pair[1],
+                    "from_column_id": from_col,
+                    "to_column_id": to_col,
                 },
             )
         )
@@ -194,8 +328,36 @@ def write_relationship_keepers(
         prior_run=prior_run,
         current_run=current_run_id,
         count=count,
+        retracted=retracted,
     )
     return count
+
+
+def _retract_adjudicated_keeps(session: Session, adjudication: _Adjudication) -> int:
+    """Supersede active ``keep`` overlays whose pair this run's judge ruled on.
+
+    Without this, a keep overlay written before the verdict re-materializes a
+    ``keeper`` row every subsequent run and the mint's grace window keeps the
+    declined composite's hollow ``_sk__`` columns alive indefinitely.
+    Supersede (the overlay system's own undo marker), never delete — the
+    record that the pair was silently kept until a verdict landed stays
+    auditable. Safe by construction: ``keep`` overlays are machine-authored
+    only (the cockpit teach validator rejects the action), so no user
+    assertion can be retracted here.
+    """
+    if adjudication.empty:
+        return 0
+    retracted = 0
+    # One provenance query per keep overlay (`_pair_adjudicated`) — fine at
+    # keeper volumes (a handful per workspace); revisit if that ever grows.
+    for overlay in relationship_overlay_rows(session, "keep"):
+        pair = (overlay.payload["from_column_id"], overlay.payload["to_column_id"])
+        if _pair_adjudicated(session, adjudication, pair):
+            overlay.superseded_at = datetime.now(UTC)
+            retracted += 1
+    if retracted:
+        session.flush()
+    return retracted
 
 
 def _run_pairs(

--- a/packages/engine/src/dataraum/analysis/relationships/surrogate.py
+++ b/packages/engine/src/dataraum/analysis/relationships/surrogate.py
@@ -25,6 +25,8 @@ from raw keeps hash values in lockstep with the data by construction.
 
 from __future__ import annotations
 
+import hashlib
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 
 SURROGATE_PREFIX = "_sk__"
@@ -55,12 +57,32 @@ def surrogate_column_name(component_names: list[str]) -> str:
     """The deterministic surrogate name for a component set, e.g. ``_sk__a__b``.
 
     Component order is the intent's CANONICAL pair order (all pairs sorted by
-    the referencing side's column name — the anchor is deliberately NOT first:
-    the LLM's anchor choice is not run-stable, and the name must be), so the
+    a direction-neutral name key — neither the anchor nor the from/to
+    orientation holds positional privilege: the LLM's anchor choice AND its
+    emission direction are not run-stable, and the name must be), so the
     ``(table_id, column_name)``-upserted ``column_id`` is stable across runs
     for the same confirmed key.
     """
     return SURROGATE_PREFIX + "__".join(component_names)
+
+
+def composite_intent_digest(id_pairs: Iterable[Sequence[str]]) -> str:
+    """The direction-neutral identity of a composite key (DAT-697).
+
+    sha1 over the UNORDERED component column-id pairs, each rendered
+    ``min:max`` and the pair set sorted — identity depends only on WHICH
+    column pairs the key joins. Neither the judge's anchor choice nor its
+    from/to orientation is run-stable (seen live on DAT-695), and the
+    declined-composite record is digested from the HINT's orientation while
+    a confirmation is digested from the LLM's — a direction-sensitive digest
+    would split one composite into two identities and break the
+    offered-vs-confirmed verdict arithmetic. Consumers matching stored rows
+    recompute this from the row's natural column ids rather than comparing
+    stored digest strings, so the digest format can evolve without stranding
+    old rows.
+    """
+    keys = sorted(":".join(sorted((a, b))) for a, b in id_pairs)
+    return hashlib.sha1("|".join(keys).encode(), usedforsecurity=False).hexdigest()
 
 
 def is_surrogate_column(column_name: str) -> bool:

--- a/packages/engine/src/dataraum/analysis/relationships/utils.py
+++ b/packages/engine/src/dataraum/analysis/relationships/utils.py
@@ -15,13 +15,18 @@ from dataraum.storage import Column, Table
 def load_surrogate_key_intents(session: Session, run_id: str) -> list[SurrogateKeyIntent]:
     """This run's LLM-confirmed composite keys awaiting their mint (DAT-277).
 
-    Written by ``semantic_per_table`` (one row per confirmed composite), consumed
-    ONLY by the ``surrogate_mint`` phase. Run-scoped by construction — an intent
-    is an instruction to this run's mint, not durable catalog state.
+    Written by ``semantic_per_table`` (one row per composite VERDICT), consumed
+    ONLY by the ``surrogate_mint`` phase — hence the ``status='confirmed'``
+    filter: declined verdicts (DAT-697) exist for the keeper machinery, never
+    for the mint. Run-scoped by construction — an intent is an instruction to
+    this run's mint, not durable catalog state.
     """
     return list(
         session.execute(
-            select(SurrogateKeyIntent).where(SurrogateKeyIntent.run_id == run_id)
+            select(SurrogateKeyIntent).where(
+                SurrogateKeyIntent.run_id == run_id,
+                SurrogateKeyIntent.status == "confirmed",
+            )
         ).scalars()
     )
 
@@ -73,6 +78,32 @@ def load_defined_relationships(
     return list(session.execute(stmt).scalars())
 
 
+def relationship_overlay_rows(session: Session, action: str) -> list[Any]:
+    """Active ``ConfigOverlay(type='relationship')`` ROWS for one ``action``.
+
+    For callers that mutate overlays (e.g. the DAT-697 keep retraction, which
+    needs ``superseded_at``); readers that only need the column pairs use
+    :func:`relationship_overlay_pairs`. Malformed payloads (missing either
+    column id) are excluded — every consumer of the rows may rely on both ids
+    being present.
+    """
+    from dataraum.storage import ConfigOverlay
+
+    rows = session.execute(
+        select(ConfigOverlay).where(
+            ConfigOverlay.type == "relationship",
+            ConfigOverlay.superseded_at.is_(None),
+        )
+    ).scalars()
+    return [
+        row
+        for row in rows
+        if (row.payload or {}).get("action") == action
+        and (row.payload or {}).get("from_column_id")
+        and (row.payload or {}).get("to_column_id")
+    ]
+
+
 def relationship_overlay_pairs(session: Session, action: str) -> list[tuple[str, str]]:
     """Active ``ConfigOverlay(type='relationship')`` column pairs for one ``action``.
 
@@ -83,26 +114,10 @@ def relationship_overlay_pairs(session: Session, action: str) -> list[tuple[str,
     these overlays goes through this one parser so they agree on the shape.
     ``superseded_at IS NULL`` filters undone teaches out.
     """
-    from dataraum.storage import ConfigOverlay
-
-    rows = list(
-        session.execute(
-            select(ConfigOverlay).where(
-                ConfigOverlay.type == "relationship",
-                ConfigOverlay.superseded_at.is_(None),
-            )
-        ).scalars()
-    )
-    out: list[tuple[str, str]] = []
-    for row in rows:
-        payload = row.payload or {}
-        if payload.get("action") != action:
-            continue
-        from_col = payload.get("from_column_id")
-        to_col = payload.get("to_column_id")
-        if from_col and to_col:
-            out.append((from_col, to_col))
-    return out
+    return [
+        (row.payload["from_column_id"], row.payload["to_column_id"])
+        for row in relationship_overlay_rows(session, action)
+    ]
 
 
 def load_suppressed_relationship_pairs(session: Session) -> set[tuple[str, str]]:

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -5,7 +5,6 @@ Orchestrates semantic analysis using the SemanticAgent and stores results.
 
 from __future__ import annotations
 
-import hashlib
 from typing import TYPE_CHECKING, Any
 
 import duckdb
@@ -27,6 +26,7 @@ from dataraum.analysis.relationships.evaluator import (
     compute_ri_metrics,
 )
 from dataraum.analysis.relationships.models import JoinCandidate, RelationshipCandidate
+from dataraum.analysis.relationships.surrogate import composite_intent_digest
 from dataraum.analysis.semantic.agent import SemanticAgent
 from dataraum.analysis.semantic.db_models import (
     ColumnConcept as ConceptModel,
@@ -421,6 +421,76 @@ def _first_wins(rows: list[dict[str, Any]], key_fields: tuple[str, ...]) -> list
     return list(folded.values())
 
 
+def _declined_intent_rows(
+    candidates: list[dict[str, Any]],
+    *,
+    confirmed_digests: set[str],
+    table_map: dict[str, str],
+    column_map: dict[tuple[str, str], str],
+    run_id: str,
+) -> list[dict[str, Any]]:
+    """Verdict rows for OFFERED composites the judge did not confirm (DAT-697).
+
+    Every COMPOSITE-KEY RESCUE hint is adjudicated: the judge either confirms
+    it (a ``status='confirmed'`` intent exists) or it was declined. A
+    confirmation the system could not build into an intent (unresolvable
+    component, non-collapsing measurement) also lands here: either way this
+    run produced no usable composite, the hint re-offers deterministically
+    next run, and the declined record is what stops the keeper machinery from
+    silently resurrecting the pair against the judge's evidence-based verdict
+    (``materialize.py``). An unresolvable HINT writes no record at all —
+    without an identity there is no verdict, and keeper protection stands.
+    """
+    rows: list[dict[str, Any]] = []
+    for cand in candidates:
+        hint = cand.get("composite_key")
+        table1, table2 = cand.get("table1"), cand.get("table2")
+        if not hint or not table1 or not table2:
+            continue
+        from_table_id, to_table_id = table_map.get(table1), table_map.get(table2)
+        id_pairs: list[tuple[str, str]] = []
+        name_pairs: list[tuple[str, str]] = []
+        for name1, name2 in hint.get("column_pairs", []):
+            id1, id2 = column_map.get((table1, name1)), column_map.get((table2, name2))
+            if not id1 or not id2:
+                id_pairs = []
+                break
+            id_pairs.append((id1, id2))
+            name_pairs.append((name1, name2))
+        if len(id_pairs) < 2 or not from_table_id or not to_table_id:
+            logger.warning(
+                "composite_decline_unrecordable",
+                table1=table1,
+                table2=table2,
+                pairs=hint.get("column_pairs"),
+            )
+            continue
+        digest = composite_intent_digest(id_pairs)
+        if digest in confirmed_digests:
+            continue
+        # Same canonical (direction-neutral) pair order as the confirmed path.
+        ordered = sorted(zip(id_pairs, name_pairs, strict=True), key=lambda t: tuple(sorted(t[1])))
+        coverage = hint.get("coverage")
+        usage = f" (measured usage {coverage:.1%})" if coverage is not None else ""
+        rows.append(
+            {
+                "run_id": run_id,
+                "intent_digest": digest,
+                "status": "declined",
+                "from_table_id": from_table_id,
+                "to_table_id": to_table_id,
+                "column_pairs": [list(pair) for pair, _n in ordered],
+                "cardinality": hint.get("cardinality"),
+                "confidence": 0.0,
+                # Neutral wording: this path also catches a confirmation the
+                # system could not build into an intent (component/measurement
+                # rejection), not only a judge omission.
+                "reasoning": f"offered rescue hint produced no confirmed composite{usage}",
+            }
+        )
+    return rows
+
+
 def _build_surrogate_intent(
     *,
     rel: SemanticRelationship,
@@ -469,15 +539,17 @@ def _build_surrogate_intent(
     if len(components) < 2:
         return None  # anchor-only after dedup — effectively single-column
 
-    # Canonical component order: ALL pairs sorted by from-side column name —
-    # including the anchor. Neither the LLM's key_columns ordering NOR its
-    # anchor choice is stable across runs (seen live 2026-07-06: the same
-    # composite arrived anchored on payment_method one run and business_id the
-    # next, minting two differently-named surrogates for one key), and the
-    # digest, the surrogate column NAME, and the hash-input order all derive
-    # from this list. The anchor's semantics live in the relationship
-    # DIRECTION, never in the column identity.
-    ordered = sorted(zip(components, name_pairs, strict=True), key=lambda t: t[1][0])
+    # Canonical component order: ALL pairs sorted by a DIRECTION-NEUTRAL name
+    # key — including the anchor. Neither the LLM's key_columns ordering, NOR
+    # its anchor choice (seen live 2026-07-06: the same composite arrived
+    # anchored on payment_method one run and business_id the next), NOR its
+    # from/to emission direction is stable across runs, and the surrogate
+    # column NAME and the hash-input order both derive from this list. A
+    # from-side-only sort key would reorder under a direction flip whenever
+    # the two sides' names sort differently (account vs account_name). The
+    # anchor's semantics live in the relationship DIRECTION, never in the
+    # column identity.
+    ordered = sorted(zip(components, name_pairs, strict=True), key=lambda t: tuple(sorted(t[1])))
     components = [c for c, _n in ordered]
     name_pairs = [n for _c, n in ordered]
 
@@ -504,12 +576,10 @@ def _build_surrogate_intent(
             )
             return None
 
-    digest = hashlib.sha1(
-        "|".join(f"{a}:{b}" for a, b in components).encode(), usedforsecurity=False
-    ).hexdigest()
     return {
         "run_id": run_id,
-        "intent_digest": digest,
+        "intent_digest": composite_intent_digest(components),
+        "status": "confirmed",
         "from_table_id": from_table_id,
         "to_table_id": to_table_id,
         "column_pairs": [list(pair) for pair in components],
@@ -713,8 +783,21 @@ def synthesize_and_store_tables(
         ],
     )
 
-    # Surrogate-key intents (DAT-277): the confirmed composites, versioned under
-    # this run for the mint phase. Same fold-then-upsert discipline as above.
+    # Surrogate-key intents (DAT-277 / DAT-697): the run's composite VERDICTS —
+    # confirmed composites for the mint phase, plus declined records for every
+    # offered-but-unconfirmed rescue hint (the keeper machinery must never
+    # silently resurrect an adjudicated pair). Confirmed rows come first so
+    # they win the fold when the same digest appears in both sets.
+    if run_id is not None:
+        intent_rows.extend(
+            _declined_intent_rows(
+                relationship_candidates or [],
+                confirmed_digests={r["intent_digest"] for r in intent_rows},
+                table_map=table_map,
+                column_map=column_map,
+                run_id=run_id,
+            )
+        )
     intent_rows = _first_wins(intent_rows, ("run_id", "intent_digest"))
     upsert(
         session,

--- a/packages/engine/tests/unit/analysis/relationships/test_relationship_durability.py
+++ b/packages/engine/tests/unit/analysis/relationships/test_relationship_durability.py
@@ -487,3 +487,177 @@ def test_keeper_noop_when_head_already_names_current_run(session: Session) -> No
 
     assert count == 0
     assert _keep_overlays(session) == []
+
+
+# --- Adjudication outranks silence (DAT-697) --------------------------------------
+#
+# The judge's per-run composite verdicts (SurrogateKeyIntent.status) gate the
+# silent-accept machinery: a declined composite's pairs are not lifted, its
+# stale keep overlays are superseded, and a keep overlay on an adjudicated
+# pair does not materialize a keeper row. Pairs the run did NOT rule on keep
+# full DAT-409 flake protection.
+
+
+def _seed_more_columns(session: Session) -> None:
+    session.add(Column(column_id="cx", table_id="t1", column_name="business_id", column_position=1))
+    session.add(Column(column_id="cy", table_id="t2", column_name="business_id", column_position=1))
+    session.add(Column(column_id="sk1", table_id="t1", column_name="_sk__x", column_position=2))
+    session.add(Column(column_id="sk2", table_id="t2", column_name="_sk__x", column_position=2))
+    session.flush()
+
+
+def _intent(session: Session, pairs: list[list[str]], status: str, run_id: str = "r1") -> None:
+    from dataraum.analysis.relationships.db_models import SurrogateKeyIntent
+    from dataraum.analysis.relationships.surrogate import composite_intent_digest
+
+    session.add(
+        SurrogateKeyIntent(
+            run_id=run_id,
+            intent_digest=composite_intent_digest(pairs),
+            status=status,
+            from_table_id="t1",
+            to_table_id="t2",
+            column_pairs=pairs,
+            confidence=0.0 if status == "declined" else 0.9,
+        )
+    )
+    session.flush()
+
+
+def _surrogate_rel(
+    session: Session, run_id: str, natural_ids: list[list[str]], frm: str = "sk1", to: str = "sk2"
+) -> None:
+    session.add(
+        Relationship(
+            run_id=run_id,
+            from_table_id="t1",
+            from_column_id=frm,
+            to_table_id="t2",
+            to_column_id=to,
+            relationship_type="foreign_key",
+            confidence=0.9,
+            detection_method="llm",
+            evidence={"surrogate": {"natural_column_ids": natural_ids}},
+        )
+    )
+    session.flush()
+
+
+def test_keeper_skips_declined_component_pair(session: Session) -> None:
+    """A prior llm pair the judge declined this run (as a composite component,
+    anchor included) is a verdict, not silence — no lift."""
+    _seed_tables_columns(session)
+    _seed_more_columns(session)
+    _seed_prior_promoted_run(session, "r0")  # prior llm on (ca, cb)
+    _intent(session, [["ca", "cb"], ["cx", "cy"]], "declined")
+
+    count = write_relationship_keepers(session, current_run_id="r1")
+    session.flush()
+
+    assert count == 0
+    assert _keep_overlays(session) == []
+
+
+def test_keeper_skips_declined_pair_whichever_direction(session: Session) -> None:
+    """Decline matching is direction-neutral — the verdict covers (b, a) too."""
+    _seed_tables_columns(session)
+    _seed_more_columns(session)
+    _seed_prior_promoted_run(session, "r0")
+    _intent(session, [["cb", "ca"], ["cy", "cx"]], "declined")  # reversed orientation
+
+    assert write_relationship_keepers(session, current_run_id="r1") == 0
+    assert _keep_overlays(session) == []
+
+
+def test_keeper_still_lifts_unadjudicated_pair(session: Session) -> None:
+    """A verdict on one composite must not erode flake protection elsewhere."""
+    _seed_tables_columns(session)
+    _seed_more_columns(session)
+    _seed_prior_promoted_run(session, "r0")  # prior llm on (ca, cb)
+    _intent(session, [["cx", "cy"], ["sk1", "sk2"]], "declined")  # unrelated pairs
+
+    assert write_relationship_keepers(session, current_run_id="r1") == 1
+    assert _keep_overlays(session) == [
+        {"action": "keep", "from_column_id": "ca", "to_column_id": "cb"}
+    ]
+
+
+def test_keeper_skips_surrogate_row_of_adjudicated_composite(session: Session) -> None:
+    """A surrogate pair matches by digest recomputed from its mint provenance —
+    a CONFIRMED verdict supersedes a stale differently-anchored twin of itself."""
+    _seed_tables_columns(session)
+    _seed_more_columns(session)
+    _surrogate_rel(session, "r0", natural_ids=[["ca", "cb"], ["cx", "cy"]])
+    session.add(MetadataSnapshotHead(target=catalog_head_target(), stage="catalog", run_id="r0"))
+    session.flush()
+    # This run confirms the same composite — provenance arrives reordered and
+    # direction-flipped; identity must hold regardless.
+    _intent(session, [["cy", "cx"], ["cb", "ca"]], "confirmed")
+
+    assert write_relationship_keepers(session, current_run_id="r1") == 0
+    assert _keep_overlays(session) == []
+
+
+def test_keeper_retracts_stale_keep_on_adjudicated_pair(session: Session) -> None:
+    """An existing keep overlay on a judged pair is superseded — without this the
+    overlay re-materializes a keeper row every run and the declined composite
+    (and its hollow surrogate columns) is resurrected indefinitely."""
+    _seed_tables_columns(session)
+    _seed_more_columns(session)
+    _seed_prior_promoted_run(session, "r0")
+    _overlay(session, "keep", "ca", "cb")
+    _intent(session, [["ca", "cb"], ["cx", "cy"]], "declined")
+    session.flush()
+
+    write_relationship_keepers(session, current_run_id="r1")
+    session.flush()
+
+    kept = [
+        o
+        for o in session.query(ConfigOverlay).filter(ConfigOverlay.type == "relationship").all()
+        if (o.payload or {}).get("action") == "keep"
+    ]
+    assert len(kept) == 1 and kept[0].superseded_at is not None
+    # …and the retracted overlay is invisible to the layered readers.
+    from dataraum.analysis.relationships.utils import relationship_overlay_pairs
+
+    assert relationship_overlay_pairs(session, "keep") == []
+
+
+def test_keeper_retraction_recovers_surrogate_provenance(session: Session) -> None:
+    """A keep overlay on a surrogate pair carries no evidence — provenance comes
+    from the newest llm row on the same pair, then digest-matches the verdict."""
+    _seed_tables_columns(session)
+    _seed_more_columns(session)
+    _surrogate_rel(session, "r0", natural_ids=[["ca", "cb"], ["cx", "cy"]])
+    session.add(MetadataSnapshotHead(target=catalog_head_target(), stage="catalog", run_id="r0"))
+    _overlay(session, "keep", "sk1", "sk2")
+    _intent(session, [["ca", "cb"], ["cx", "cy"]], "declined")
+    session.flush()
+
+    write_relationship_keepers(session, current_run_id="r1")
+    session.flush()
+
+    kept = [
+        o
+        for o in session.query(ConfigOverlay).filter(ConfigOverlay.type == "relationship").all()
+        if (o.payload or {}).get("action") == "keep"
+    ]
+    assert len(kept) == 1 and kept[0].superseded_at is not None
+
+
+def test_materialize_skips_keep_on_adjudicated_pair_but_honors_manual(session: Session) -> None:
+    """A stale keep on a judged pair must not materialize a keeper row this run —
+    but a USER assertion (add/confirm → manual) on the same pair always wins."""
+    _seed_tables_columns(session)
+    _seed_more_columns(session)
+    _overlay(session, "keep", "ca", "cb")
+    _overlay(session, "confirm", "ca", "cb")
+    _intent(session, [["ca", "cb"], ["cx", "cy"]], "declined")
+    session.flush()
+
+    materialize_relationship_overlays(session, run_id="r1", table_ids=["t1", "t2"])
+    session.flush()
+
+    methods = [r.detection_method for r in _materialized(session)]
+    assert methods == ["manual"]  # keeper suppressed by the verdict; manual untouched

--- a/packages/engine/tests/unit/analysis/semantic/test_surrogate_intent.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_surrogate_intent.py
@@ -92,11 +92,12 @@ def _agent(relationships: list[Relationship]) -> MagicMock:
     return agent
 
 
-def _store(session, agent, tables, conn=None, run_id=None):
+def _store(session, agent, tables, conn=None, run_id=None, candidates=None):
     return synthesize_and_store_tables(
         session,
         agent,
         [t.table_id for t in tables],
+        relationship_candidates=candidates,
         duckdb_conn=conn,
         run_id=run_id or baseline_run_id(),
     )
@@ -125,7 +126,7 @@ def test_confirmed_composite_persists_intent_not_llm_row(session, lake) -> None:
     assert intent.column_pairs == [
         [cols[(txn.table_id, "account")], cols[(coa.table_id, "account_name")]],
         [cols[(txn.table_id, "business_id")], cols[(coa.table_id, "business_id")]],
-    ]  # anchor FIRST, then the scoping component
+    ]  # canonical direction-neutral order ('account…' sorts before 'business_id')
     assert intent.cardinality == "many-to-one"  # the collapse proof, measured
     assert intent.from_table_id == txn.table_id
     assert intent.to_table_id == coa.table_id
@@ -273,8 +274,8 @@ def test_scope_component_order_is_canonical(session) -> None:
     assert a is not None and b is not None
     assert a["intent_digest"] == b["intent_digest"]
     assert a["column_pairs"] == b["column_pairs"]
-    # ALL pairs sorted by from-side name — the anchor holds no positional
-    # privilege in the column identity.
+    # ALL pairs sorted by a direction-neutral name key — neither the anchor nor
+    # the from/to orientation holds positional privilege in the column identity.
     assert a["column_pairs"][0][0] == cols[(txn.table_id, "account")]
     assert a["column_pairs"][1][0] == cols[(txn.table_id, "business_id")]
     assert a["column_pairs"][2][0] == cols[(txn.table_id, "region")]
@@ -343,3 +344,120 @@ def test_duplicate_llm_relationships_fold_to_one_row(session) -> None:
         .all()
     )
     assert len(llm_rows) == 1
+
+
+# --- Composite VERDICT records (DAT-697) ------------------------------------------
+#
+# Every offered rescue hint is adjudicated: confirmed → a status='confirmed'
+# intent (the mint's instruction), declined → a status='declined' record (the
+# keeper machinery's stop sign). The hint dicts below are pre-attached to the
+# candidates (augmentation only ADDs hints; with duckdb_conn=None it is a no-op).
+
+
+def _hint_candidate(
+    table1: str, table2: str, pairs: list[list[str]], coverage: float | None = 0.003
+) -> dict:
+    hint: dict = {"column_pairs": pairs, "cardinality": "many-to-one", "coverage_table": table1}
+    if coverage is not None:
+        hint["coverage"] = coverage
+    return {"table1": table1, "table2": table2, "join_columns": [], "composite_key": hint}
+
+
+def test_offered_hint_not_confirmed_records_declined_intent(session) -> None:
+    txn = _table_with_columns(session, "txn", ["account", "business_id"])
+    coa = _table_with_columns(session, "coa", ["account_name", "business_id"])
+    candidate = _hint_candidate(
+        "txn", "coa", [["account", "account_name"], ["business_id", "business_id"]]
+    )
+
+    assert _store(session, _agent([]), [txn, coa], candidates=[candidate]).success
+    session.flush()
+
+    intents = session.execute(select(SurrogateKeyIntent)).scalars().all()
+    assert len(intents) == 1
+    declined = intents[0]
+    assert declined.status == "declined"
+    assert declined.confidence == 0.0
+    assert declined.from_table_id == txn.table_id
+    assert declined.to_table_id == coa.table_id
+    assert "0.3%" in (declined.reasoning or "")
+    cols = {(c.table_id, c.column_name): c.column_id for t in (txn, coa) for c in t.columns}
+    assert sorted(map(tuple, declined.column_pairs)) == sorted(
+        [
+            (cols[(txn.table_id, "account")], cols[(coa.table_id, "account_name")]),
+            (cols[(txn.table_id, "business_id")], cols[(coa.table_id, "business_id")]),
+        ]
+    )
+
+
+def test_confirmed_hint_records_no_declined_row_even_direction_flipped(session) -> None:
+    """The hint arrives in the candidate's orientation, the confirmation in the
+    LLM's — a direction-sensitive digest would record the SAME composite as
+    both confirmed and declined. The verdict arithmetic must see one identity."""
+    txn = _table_with_columns(session, "txn", ["account", "business_id"])
+    coa = _table_with_columns(session, "coa", ["account_name", "business_id"])
+    # Hint oriented coa→txn; the LLM confirms txn→coa (_rel's orientation).
+    flipped = _hint_candidate(
+        "coa", "txn", [["account_name", "account"], ["business_id", "business_id"]]
+    )
+    agent = _agent([_rel(key_columns=[("business_id", "business_id")])])
+
+    assert _store(session, agent, [txn, coa], candidates=[flipped]).success
+    session.flush()
+
+    intents = session.execute(select(SurrogateKeyIntent)).scalars().all()
+    assert [i.status for i in intents] == ["confirmed"]
+
+
+def test_unresolvable_hint_records_no_verdict(session) -> None:
+    """No identity, no verdict — keeper protection stands for the pair."""
+    txn = _table_with_columns(session, "txn", ["account", "business_id"])
+    coa = _table_with_columns(session, "coa", ["account_name", "business_id"])
+    ghost = _hint_candidate("txn", "coa", [["account", "account_name"], ["ghost", "ghost"]])
+
+    assert _store(session, _agent([]), [txn, coa], candidates=[ghost]).success
+    session.flush()
+
+    assert session.execute(select(SurrogateKeyIntent)).scalars().all() == []
+
+
+def test_mint_loader_excludes_declined_verdicts(session) -> None:
+    """`load_surrogate_key_intents` feeds ONLY confirmed composites to the mint."""
+    from dataraum.analysis.relationships.utils import load_surrogate_key_intents
+
+    txn = _table_with_columns(session, "txn", ["account", "business_id"])
+    coa = _table_with_columns(session, "coa", ["account_name", "business_id"])
+    candidate = _hint_candidate(
+        "txn", "coa", [["account", "account_name"], ["business_id", "business_id"]]
+    )
+    assert _store(session, _agent([]), [txn, coa], candidates=[candidate]).success
+    session.flush()
+
+    assert session.execute(select(SurrogateKeyIntent)).scalars().all() != []
+    assert load_surrogate_key_intents(session, baseline_run_id()) == []
+
+
+def test_unbuildable_confirmation_still_records_the_declined_verdict(session) -> None:
+    """The LLM confirms the offered composite but names a nonexistent component —
+    the intent build fails and falls back to the single-column anchor. This run
+    still produced no usable composite, so the verdict arithmetic records the
+    OFFERED hint as declined: the hint re-offers deterministically next run,
+    and the keeper machinery must not resurrect the pair in the meantime."""
+    txn = _table_with_columns(session, "txn", ["account", "business_id"])
+    coa = _table_with_columns(session, "coa", ["account_name", "business_id"])
+    candidate = _hint_candidate(
+        "txn", "coa", [["account", "account_name"], ["business_id", "business_id"]]
+    )
+    agent = _agent([_rel(key_columns=[("ghost", "ghost")])])  # confirmation that can't build
+
+    assert _store(session, agent, [txn, coa], candidates=[candidate]).success
+    session.flush()
+
+    intents = session.execute(select(SurrogateKeyIntent)).scalars().all()
+    assert [i.status for i in intents] == ["declined"]
+    llm_rows = (
+        session.execute(select(RelationshipDB).where(RelationshipDB.detection_method == "llm"))
+        .scalars()
+        .all()
+    )
+    assert len(llm_rows) == 1  # the anchor fallback persists with honest cardinality


### PR DESCRIPTION
## What

A verdict is not silence. `semantic_per_table` now records a `SurrogateKeyIntent` row for **every** offered composite rescue hint — `status='confirmed'` (the mint's instruction, unchanged behavior) or `status='declined'` (offered − confirmed) — and the DAT-409 keeper machinery yields to those verdicts:

- **Lift skip**: `session_write_keepers` no longer lifts a prior llm pair whose composite this run's judge ruled on — declined ⇒ the verdict wins; confirmed ⇒ a stale differently-anchored/named surrogate twin is superseded.
- **Retraction**: existing `keep` overlays on adjudicated pairs are **superseded** (never deleted — audit trail survives), so already-polluted workspaces self-heal within ~2 runs instead of resurrecting hollow `_sk__` columns forever.
- **Materialize skip**: a stale keep overlay on an adjudicated pair doesn't materialize a keeper row same-run. User assertions (`add`/`confirm` → manual) never yield to the judge; `keep` has exactly one author (the machinery — the cockpit teach validator rejects it).

`intent_digest` is now **direction-neutral** (sha1 over unordered component-id pairs; the canonical name-order key follows): neither the judge's anchor choice nor its from/to orientation is run-stable, and the declined record digests the *hint's* orientation while a confirmation digests the *LLM's* — a direction-sensitive digest would split one composite into two identities. All matching **recomputes** digests from stored natural column ids; stored digest strings are never compared, so the format change cannot strand old rows.

## Why

Observed live on the bookkeeping smoke (runs `8fc10ebb` → `db130439`): the sharpened DAT-695 judge declined the hollow customer/vendor composites on measured usage (0.3%/0.5%), but the silent-accept lift wrote keep overlays for all four old pairs against the old promoted head; the next run materialized them as keepers and the mint's grace window kept the 99.7%-NULL surrogate columns alive indefinitely. DAT-409's contract couldn't distinguish "the LLM flaked" from "the judge declined with better evidence".

## Invariants preserved

- Pairs with **no** verdict this run keep full DAT-409 flake protection (pinned by test).
- No numeric gates — the predicate is purely behavioral (offered ∧ not confirmed); coverage remains judge evidence.
- Plain single-column silent-accept untouched; scope is composites only.
- Zero intents ⇒ byte-identical behavior to before (all 27 pre-existing durability tests pass unmodified).

## Verification

- Full unit suite: 1869 passed; ruff + mypy + vulture clean.
- Schema seam regenerated (`schema.sql` + drizzle mirror via `bun run db:pull:metadata`), never hand-edited.
- Senior reviewer: **APPROVED** (4 nits, all addressed in-commit). Spec reviewer: **COMPLIANT** (its one test-gap observation pinned by `test_unbuildable_confirmation_still_records_the_declined_verdict`).
- `.claude/handoff.md` carries the eval/testdata entry (run-over-run decline stability is the new observable).

Closes DAT-697.

🤖 Generated with [Claude Code](https://claude.com/claude-code)