### PR TITLE
feat(DAT-699): flag-and-surface over fabricated determinism — metric grounding robustness + judge-sees-all

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -40,6 +40,18 @@ plus the determinism audit. Response shapes eval reads have changed:
   (`CASE WHEN COUNT(*) = 0 THEN NULL ELSE COALESCE(SUM(a),0) - COALESCE(SUM(b),0) END`)
   — absence still surfaces as NULL, never masked as 0.
 
+- **Declared metric validations flag, never gate** (approved follow-up on this
+  branch): a violated catalogue `validation:` condition no longer blocks
+  execution ("composed but not executed: declared validation failed …" is
+  gone) — the metric EXECUTES and the violation rides `state_reason` as
+  "declared expectation not met for 'X': … (value=…, severity=…)", combined
+  with the DAT-631 low-confidence flag. Config-side, all extract-level sign
+  bounds (revenue > 0, COGS >= 0, …) were removed from the finance metric
+  YAMLs — the sign rule's homes are the `sign_natural_balance` convention
+  (authoring) and the `sign_conventions` validation (dataset-level); only
+  formula-level plausibility ranges remain (dso/dpo/dio 0–365 at warning,
+  current_ratio sign) and they flag.
+
 ### Calibration to run
 
 - Metric grounding recall on ledger-shaped corpora: dso-class metrics

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -7,7 +7,7 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ## DAT-699 — flag-and-surface over fabricated determinism (metric grounding + enrichment)
 
-**Branch:** `feat/dat-699-flag-and-surface`. Seven changes from the BookSQL
+**Branch:** `feat/dat-699-flag-and-surface`. Seven changes from the the bookkeeping smoke corpus
 clean-stack root-cause pass (0/13 metrics executed vs. a measured ceiling of 2)
 plus the determinism audit. Response shapes eval reads have changed:
 
@@ -28,7 +28,7 @@ plus the determinism audit. Response shapes eval reads have changed:
   (> 200 distinct) are served as size+sample+`search_values` hint instead of
   nothing, and the agent may spend up to 4 bounded catalog searches before
   emitting `generate_sql`. Expect grounding recall UP on datasets whose
-  discriminators exceed the enumeration bound (BookSQL depreciation/tax
+  discriminators exceed the enumeration bound (the bookkeeping smoke's depreciation/tax
   class) and 1–5 extra small LLM turns per affected extract. A tool-output
   schema validation failure gets ONE model repair turn before failing.
 - **Enrichment**: the 0.7 confidence floor is gone (the judge sees all
@@ -156,7 +156,7 @@ DAT-679 fixture work (greedy-search miss-rate corpus).
 - **`sql_snippets.column_mappings` no longer exists** (column dropped; LLM output field, `GeneratedCode`, reuse-merge and persist paths all removed). Any eval strategy reading it gets `UndefinedColumn` — switch to `provenance.column_mappings_basis` (`{concept: {column, filter, resolution}}`), which is the prompted, populated per-concept grounding record. The flat field had been silently empty since DAT-636 dropped its prompt teaching (`default_factory=dict` masked it).
 - No other engine response/pipeline shape changed; the rest of the PR is cockpit-side (drill tiers A/B/C over the promoted surface — read-only).
 
-**Testdata note:** BookSQL's COA has **zero COGS-type and zero inventory accounts**, so gross-profit-family metrics can never execute there (honest NULL extracts) — don't read that as a grounding regression; realistic executed ceiling on BookSQL ≈ dso + current_ratio.
+**Testdata note:** the bookkeeping smoke corpus's COA has **zero COGS-type and zero inventory accounts**, so gross-profit-family metrics can never execute there (honest NULL extracts) — don't read that as a grounding regression; realistic executed ceiling on the bookkeeping smoke corpus ≈ dso + current_ratio.
 
 ---
 

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,59 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-699 — flag-and-surface over fabricated determinism (metric grounding + enrichment)
+
+**Branch:** `feat/dat-699-flag-and-surface`. Seven changes from the BookSQL
+clean-stack root-cause pass (0/13 metrics executed vs. a measured ceiling of 2)
+plus the determinism audit. Response shapes eval reads have changed:
+
+### What changed
+
+- **Metric artifact `state_reason` format** (biggest eval-facing change): a
+  metric with ungroundable dependencies now reads
+  `dependency 'cogs' is ungroundable — revenue = 5,925,920,163.00 ✓ · cogs ✗ <reason> · gross_profit blocked (needs cogs)`
+  — ALL holes named (not just the first), per-step measured values for the
+  groundable subgraph, which EXECUTES. Assertions matching the old
+  `dependency 'X' is ungroundable: <reason>` prefix need updating.
+- **Verifier no-support reason**: `has no support: it aggregated to NULL —
+  either its filter matched no rows, or an aggregated operand is entirely
+  NULL over the rows it did match` — the old `its filter matched no rows`
+  ASSERTED an unmeasured cause (misclassified a one-sided A/R ledger whose
+  join matched 167k rows).
+- **Grounding agent is no longer one-shot**: high-cardinality columns
+  (> 200 distinct) are served as size+sample+`search_values` hint instead of
+  nothing, and the agent may spend up to 4 bounded catalog searches before
+  emitting `generate_sql`. Expect grounding recall UP on datasets whose
+  discriminators exceed the enumeration bound (BookSQL depreciation/tax
+  class) and 1–5 extra small LLM turns per affected extract. A tool-output
+  schema validation failure gets ONE model repair turn before failing.
+- **Enrichment**: the 0.7 confidence floor is gone (the judge sees all
+  defined relationships); keeper rows carry their last-measured
+  confidence/cardinality/evidence stamped `not_remeasured` (never
+  `confidence=1.0, cardinality=NULL`); the sticky shape re-offers a pair
+  when its evidence fingerprint changed.
+- **Prompt** (`graph_sql_generation.yaml`): one-sided-ledger netting shape
+  (`CASE WHEN COUNT(*) = 0 THEN NULL ELSE COALESCE(SUM(a),0) - COALESCE(SUM(b),0) END`)
+  — absence still surfaces as NULL, never masked as 0.
+
+### Calibration to run
+
+- Metric grounding recall on ledger-shaped corpora: dso-class metrics
+  (one-sided debit/credit ledgers) and depreciation/tax-class extracts
+  (values beyond the enumeration bound) should now ground; COGS-class
+  honest-NULLs must STAY declined (a confident number for an absent concept
+  is the regression to watch).
+- Any eval parser reading metric `state_reason` needs the new format.
+
+### testdata hints
+
+A one-sided-ledger fixture (AR-style: 100%-NULL credit leg over matched
+rows) + a lookalike-negative distinguishes the netting fix from COALESCE
+masking: correct = dso executes with the real balance; regression = a
+metric executes as 0 when the filter matches nothing.
+
+---
+
 ## DAT-697 — composite verdicts gate the silent-accept keeper machinery
 
 **Branch:** `feat/dat-697-keeper-adjudication`. Fixes the resurrection loop

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -179,12 +179,14 @@ system_prompt: |
      zero matching rows MUST surface as NULL, never a fabricated 0 — a masked 0 reads as a real
      value and silently corrupts the metric. Only COALESCE a genuinely-nullable NON-aggregate
      input where 0 is the semantically correct value.
-     One-sided ledgers are the exception that proves the rule: when NETTING two aggregate legs
-     (`SUM(debit) - SUM(credit)`), a leg that is entirely NULL over MATCHED rows is real
-     information (e.g. an A/R account only ever debited) and must not NULL-destroy the other
-     leg. Net with row-guarded NULL-safety so no-support still surfaces honestly:
-     `CASE WHEN COUNT(*) = 0 THEN NULL ELSE COALESCE(SUM(debit), 0) - COALESCE(SUM(credit), 0) END AS value`
-     — NULL when nothing matched, the populated leg's balance when the ledger is one-sided.
+     One-sided data is the exception that proves the rule: when an extract COMBINES two or
+     more aggregates arithmetically (`SUM(a) - SUM(b)`), an operand that is entirely NULL over
+     MATCHED rows is real information (activity recorded on one side only), and must not
+     NULL-destroy the other operand. Combine with row-guarded NULL-safety so no-support still
+     surfaces honestly:
+     `CASE WHEN COUNT(*) = 0 THEN NULL ELSE COALESCE(SUM(a), 0) - COALESCE(SUM(b), 0) END AS value`
+     — NULL when nothing matched, the populated operand's total when the data is one-sided.
+     Domain conventions (when served below) say WHICH operands combine and in what order.
   3. GROUP BY strictness: every non-aggregated column in SELECT/ORDER BY/HAVING must appear in
      GROUP BY (or use ANY_VALUE). An extract returns one scalar row, so it rarely needs GROUP BY.
   4. Types: DuckDB is strict — use explicit CAST() when comparing/joining columns of different

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -59,16 +59,20 @@ system_prompt: |
 
   FLOORS — few, and non-negotiable, because each one is a silent-wrong-number we have actually
   shipped (reason freely above them; never through them):
-  - Every predicate literal must appear VERBATIM in a served Value-set marked **complete**
-    (on the fact column, or on a joined dimension's column). Choosing a subset of listed values
-    by meaning is your judgment; adding one unlisted "expected" name — even mixed in with valid
-    ones — is invention, and invented literals silently undercount.
+  - Every predicate literal must appear VERBATIM in a served Value-set marked **complete**,
+    or in a `search_values` result you obtained this conversation (on the fact column, or on
+    a joined dimension's column). Choosing a subset of listed values by meaning is your
+    judgment; adding one unlisted "expected" name — even mixed in with valid ones — is
+    invention, and invented literals silently undercount.
   - No substring/`ILIKE` membership guessing (ILIKE only for case-insensitivity on a known
-    served value). No filters on `near-constant` columns or on columns with NO served
-    Value-set (high-cardinality, deliberately unenumerated — join to a dimension that has a
-    complete set instead, or abstain). Never use a concept name as a table name.
+    served value). No filters on `near-constant` columns. A column marked "NOT enumerated"
+    (high-cardinality) is EXPLORABLE, not forbidden: call the `search_values` tool with the
+    concept's likely names/synonyms (e.g. 'deprec', 'tax') to resolve its EXACT values, then
+    draw your IN-list from the results. You have a small search budget — search for what the
+    concept needs, then call generate_sql. Never use a concept name as a table name.
   - If the concept cannot be grounded within these floors — opaque codes with no semantic
-    signal, needed values absent, only PARTIAL sets available — fall loud: emit
+    signal, needed values absent (including after searching an explorable column), only
+    PARTIAL sets available — fall loud: emit
     `SELECT NULL AS value` plus a LOW-confidence "inferred" assumption naming the concept and
     why. NEVER a fabricated `SELECT 0` — a 0 reads downstream as a real amount and corrupts
     every metric built on it. A flagged inconclusive result is correct; a confident wrong

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -175,6 +175,12 @@ system_prompt: |
      zero matching rows MUST surface as NULL, never a fabricated 0 — a masked 0 reads as a real
      value and silently corrupts the metric. Only COALESCE a genuinely-nullable NON-aggregate
      input where 0 is the semantically correct value.
+     One-sided ledgers are the exception that proves the rule: when NETTING two aggregate legs
+     (`SUM(debit) - SUM(credit)`), a leg that is entirely NULL over MATCHED rows is real
+     information (e.g. an A/R account only ever debited) and must not NULL-destroy the other
+     leg. Net with row-guarded NULL-safety so no-support still surfaces honestly:
+     `CASE WHEN COUNT(*) = 0 THEN NULL ELSE COALESCE(SUM(debit), 0) - COALESCE(SUM(credit), 0) END AS value`
+     — NULL when nothing matched, the populated leg's balance when the ledger is one-sided.
   3. GROUP BY strictness: every non-aggregated column in SELECT/ORDER BY/HAVING must appear in
      GROUP BY (or use ANY_VALUE). An extract returns one scalar row, so it rarely needs GROUP BY.
   4. Types: DuckDB is strict — use explicit CAST() when comparing/joining columns of different

--- a/packages/dataraum-config/verticals/finance/metrics/liquidity/current_ratio.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/liquidity/current_ratio.yaml
@@ -22,10 +22,6 @@ dependencies:
       standard_field: current_assets
       statement: balance_sheet
     aggregation: sum  # period axis (all vs latest) is data-reconciled via target_type — never hardcode end_of_period
-    validation:
-    - condition: value >= 0
-      severity: error
-      message: Current assets cannot be negative
   current_liabilities:
     level: 1
     type: extract
@@ -33,10 +29,6 @@ dependencies:
       standard_field: current_liabilities
       statement: balance_sheet
     aggregation: sum  # period axis (all vs latest) is data-reconciled via target_type — never hardcode end_of_period
-    validation:
-    - condition: value > 0
-      severity: error
-      message: Current liabilities must be positive
   current_ratio:
     level: 2
     type: formula
@@ -48,7 +40,7 @@ dependencies:
     validation:
     - condition: value >= 0
       severity: error
-      message: Current ratio cannot be negative
+      message: Current ratio should not be negative (assets and liabilities disagree in sign)
 interpretation:
   ranges:
   - min: 0

--- a/packages/dataraum-config/verticals/finance/metrics/profitability/ebitda.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/profitability/ebitda.yaml
@@ -23,10 +23,6 @@ dependencies:
       standard_field: revenue
       statement: income_statement
     aggregation: sum
-    validation:
-    - condition: value > 0
-      severity: error
-      message: Revenue must be positive
   cost_of_goods_sold:
     level: 1
     type: extract

--- a/packages/dataraum-config/verticals/finance/metrics/profitability/ebitda_margin.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/profitability/ebitda_margin.yaml
@@ -23,10 +23,6 @@ dependencies:
       standard_field: revenue
       statement: income_statement
     aggregation: sum
-    validation:
-    - condition: value > 0
-      severity: error
-      message: Revenue must be positive for margin calculation
   cost_of_goods_sold:
     level: 1
     type: extract

--- a/packages/dataraum-config/verticals/finance/metrics/profitability/gross_margin.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/profitability/gross_margin.yaml
@@ -22,10 +22,6 @@ dependencies:
       standard_field: revenue
       statement: income_statement
     aggregation: sum
-    validation:
-    - condition: value > 0
-      severity: error
-      message: Revenue must be positive for margin calculation
   cost_of_goods_sold:
     level: 1
     type: extract

--- a/packages/dataraum-config/verticals/finance/metrics/profitability/gross_profit.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/profitability/gross_profit.yaml
@@ -22,10 +22,6 @@ dependencies:
       standard_field: revenue
       statement: income_statement
     aggregation: sum
-    validation:
-    - condition: value > 0
-      severity: error
-      message: Revenue must be positive
   cost_of_goods_sold:
     level: 1
     type: extract
@@ -33,10 +29,6 @@ dependencies:
       standard_field: cost_of_goods_sold
       statement: income_statement
     aggregation: sum
-    validation:
-    - condition: value >= 0
-      severity: error
-      message: COGS cannot be negative
   gross_profit:
     level: 2
     type: formula

--- a/packages/dataraum-config/verticals/finance/metrics/profitability/net_income.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/profitability/net_income.yaml
@@ -23,10 +23,6 @@ dependencies:
       standard_field: revenue
       statement: income_statement
     aggregation: sum
-    validation:
-    - condition: value > 0
-      severity: error
-      message: Revenue must be positive
   cost_of_goods_sold:
     level: 1
     type: extract

--- a/packages/dataraum-config/verticals/finance/metrics/profitability/net_margin.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/profitability/net_margin.yaml
@@ -23,10 +23,6 @@ dependencies:
       standard_field: revenue
       statement: income_statement
     aggregation: sum
-    validation:
-    - condition: value > 0
-      severity: error
-      message: Revenue must be positive for margin calculation
   cost_of_goods_sold:
     level: 1
     type: extract

--- a/packages/dataraum-config/verticals/finance/metrics/profitability/operating_income.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/profitability/operating_income.yaml
@@ -22,10 +22,6 @@ dependencies:
       standard_field: revenue
       statement: income_statement
     aggregation: sum
-    validation:
-    - condition: value > 0
-      severity: error
-      message: Revenue must be positive
   cost_of_goods_sold:
     level: 1
     type: extract

--- a/packages/dataraum-config/verticals/finance/metrics/profitability/operating_margin.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/profitability/operating_margin.yaml
@@ -22,10 +22,6 @@ dependencies:
       standard_field: revenue
       statement: income_statement
     aggregation: sum
-    validation:
-    - condition: value > 0
-      severity: error
-      message: Revenue must be positive for margin calculation
   cost_of_goods_sold:
     level: 1
     type: extract

--- a/packages/dataraum-config/verticals/finance/metrics/working_capital/dio.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/working_capital/dio.yaml
@@ -31,10 +31,6 @@ dependencies:
       standard_field: inventory
       statement: balance_sheet
     aggregation: sum  # period axis (all vs latest) is data-reconciled via target_type — never hardcode end_of_period
-    validation:
-    - condition: value >= 0
-      severity: error
-      message: Inventory cannot be negative
   cost_of_goods_sold:
     level: 1
     type: extract
@@ -42,10 +38,6 @@ dependencies:
       standard_field: cost_of_goods_sold
       statement: income_statement
     aggregation: sum
-    validation:
-    - condition: value > 0
-      severity: error
-      message: COGS must be positive for DIO
   days_in_period:
     level: 1
     type: constant

--- a/packages/dataraum-config/verticals/finance/metrics/working_capital/dpo.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/working_capital/dpo.yaml
@@ -31,10 +31,6 @@ dependencies:
       standard_field: accounts_payable
       statement: balance_sheet
     aggregation: sum  # period axis (all vs latest) is data-reconciled via target_type — never hardcode end_of_period
-    validation:
-    - condition: value >= 0
-      severity: error
-      message: AP cannot be negative
   cost_of_goods_sold:
     level: 1
     type: extract
@@ -42,10 +38,6 @@ dependencies:
       standard_field: cost_of_goods_sold
       statement: income_statement
     aggregation: sum
-    validation:
-    - condition: value > 0
-      severity: error
-      message: COGS must be positive for DPO
   days_in_period:
     level: 1
     type: constant

--- a/packages/dataraum-config/verticals/finance/metrics/working_capital/dso.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/working_capital/dso.yaml
@@ -31,10 +31,6 @@ dependencies:
       standard_field: accounts_receivable
       statement: balance_sheet
     aggregation: sum  # period axis (all vs latest) is data-reconciled via target_type — never hardcode end_of_period
-    validation:
-    - condition: value >= 0
-      severity: error
-      message: AR cannot be negative
   revenue:
     level: 1
     type: extract
@@ -42,10 +38,6 @@ dependencies:
       standard_field: revenue
       statement: income_statement
     aggregation: sum
-    validation:
-    - condition: value > 0
-      severity: error
-      message: Revenue must be positive for DSO
   days_in_period:
     level: 1
     type: constant

--- a/packages/dataraum-config/verticals/finance/ontology.yaml
+++ b/packages/dataraum-config/verticals/finance/ontology.yaml
@@ -318,6 +318,20 @@ conventions:
         - current_assets
         - cash
 
+    # Ledger legs net one-sidedly all the time (an A/R account only ever debited,
+    # an A/P account only ever credited) — the generic empty-aggregation rule
+    # owns the row-guarded netting SHAPE; which legs net, and that a one-sided
+    # account is normal ledger reality, is finance knowledge and lives here.
+  - id: ledger_leg_netting
+    targets: [extraction, qa]
+    statement: >
+      Ledger measures net two legs (debit and credit). A one-sided account — e.g.
+      a receivables account only ever debited, a payables account only ever
+      credited — has an entirely NULL opposite leg over its matched rows; that is
+      normal ledger reality, not missing data. Net the legs with the row-guarded
+      NULL-safe shape from the empty-aggregation rule, ordering the legs by the
+      account family's natural balance (see sign_natural_balance).
+
     # Balance-sheet concepts are NOT single columns — they are account FAMILIES
     # drawn from the chart of accounts. account_type (asset/liability/…) is too
     # coarse (it mixes current and non-current), and the abstract concept

--- a/packages/engine/src/dataraum/analysis/relationships/materialize.py
+++ b/packages/engine/src/dataraum/analysis/relationships/materialize.py
@@ -161,6 +161,17 @@ def materialize_relationship_overlays(
     """Write this run's durable (`manual`/`keeper`) relationships from overlays.
 
     Returns the number of rows materialized. Idempotent per ``run_id``.
+
+    Materialized rows carry their LAST MEASURED evidence (DAT-699): the newest
+    llm row on the same pair supplies cardinality, evidence and — for keepers —
+    confidence, stamped ``not_remeasured`` so no consumer mistakes a copied
+    measurement for a fresh one. A keeper is silence over a prior measurement;
+    materializing it at a fabricated ``confidence=1.0`` with no cardinality
+    laundered "not re-measured this run" into full certainty (it also sailed
+    over the late confidence gate this fix's sibling removed). A keeper whose
+    measurement is unrecoverable has no basis and is skipped LOUD. ``manual``
+    rows keep ``confidence=1.0`` — that one is the user's own assertion, not a
+    fabrication — but copy the measured evidence too when it exists.
     """
     # Retry-safe clear: drop only THIS run's prior durable rows (run_id-scoped, like
     # the candidate clear), never another run's. candidate/llm are owned by their
@@ -213,6 +224,31 @@ def materialize_relationship_overlays(
                 # Endpoint outside the session's tables (or unknown) — nothing to
                 # anchor the row to; skip rather than write a dangling relationship.
                 continue
+            measured = _last_measured_row(session, pair)
+            if method == "keeper" and measured is None:
+                # A keeper is lifted FROM an llm row; with no measurement
+                # recoverable it has no basis, and any confidence we stamped
+                # would be fabricated. Loud skip — the overlay stays for a
+                # future run where the measurement may reappear.
+                logger.warning(
+                    "keeper_without_measurement_skipped",
+                    from_column=from_col,
+                    to_column=to_col,
+                )
+                continue
+            evidence: dict[str, Any] = {"source": "config_overlay", "action": action}
+            cardinality = None
+            confidence = 1.0
+            if measured is not None:
+                evidence = {
+                    **(measured.evidence or {}),
+                    **evidence,
+                    "measured_run_id": measured.run_id,
+                    "not_remeasured": True,
+                }
+                cardinality = measured.cardinality
+                if method == "keeper":
+                    confidence = measured.confidence
             session.add(
                 Relationship(
                     relationship_id=str(uuid4()),
@@ -222,10 +258,10 @@ def materialize_relationship_overlays(
                     to_table_id=to_table,
                     to_column_id=to_col,
                     relationship_type="foreign_key",
-                    cardinality=None,
-                    confidence=1.0,
+                    cardinality=cardinality,
+                    confidence=confidence,
                     detection_method=method,
-                    evidence={"source": "config_overlay", "action": action},
+                    evidence=evidence,
                     is_confirmed=True,
                 )
             )
@@ -238,6 +274,28 @@ def materialize_relationship_overlays(
         count=count,
     )
     return count
+
+
+def _last_measured_row(session: Session, pair: tuple[str, str]) -> Relationship | None:
+    """The newest ``llm`` row on a pair — the last time this edge was MEASURED.
+
+    Overlay materialization copies its cardinality/evidence (and, for keepers,
+    confidence) so a durable row never asserts more than was ever measured.
+    """
+    return (
+        session.execute(
+            select(Relationship)
+            .where(
+                Relationship.from_column_id == pair[0],
+                Relationship.to_column_id == pair[1],
+                Relationship.detection_method == "llm",
+            )
+            .order_by(Relationship.detected_at.desc())
+            .limit(1)
+        )
+        .scalars()
+        .first()
+    )
 
 
 def _column_table_map(session: Session, table_ids: list[str]) -> dict[str, str]:

--- a/packages/engine/src/dataraum/analysis/relationships/utils.py
+++ b/packages/engine/src/dataraum/analysis/relationships/utils.py
@@ -38,7 +38,6 @@ def load_defined_relationships(
     run_id: str | None = None,
     both_tables: bool = True,
     eager_columns: bool = False,
-    min_confidence: float | None = None,
 ) -> list[Relationship]:
     """The session's **defined** relationships for ``table_ids`` (DAT-408).
 
@@ -54,7 +53,10 @@ def load_defined_relationships(
     - ``both_tables``: require BOTH endpoints in ``table_ids`` (intra-selection
       joins) vs either endpoint.
     - ``eager_columns``: eager-load from/to columns + their tables.
-    - ``min_confidence``: optional confidence floor.
+
+    Deliberately NO confidence filter (DAT-699): defined rows are already
+    judge-verified or user-asserted; a numeric floor here pre-empts downstream
+    judges with an uncalibrated number. Confidence is evidence, not a gate.
     """
     stmt = select(Relationship).where(Relationship.detection_method != "candidate")
     if eager_columns:
@@ -73,8 +75,6 @@ def load_defined_relationships(
         )
     if run_id is not None:
         stmt = stmt.where(Relationship.run_id == run_id)
-    if min_confidence is not None:
-        stmt = stmt.where(Relationship.confidence >= min_confidence)
     return list(session.execute(stmt).scalars())
 
 

--- a/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
+++ b/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
@@ -7,6 +7,7 @@ Uses tool-based output for structured responses.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -33,6 +34,25 @@ if TYPE_CHECKING:
     from dataraum.llm.providers.base import LLMProvider
 
 logger = get_logger(__name__)
+
+
+def dossier_fingerprint(
+    cardinality: str | None, confidence: float | None, coverage: float | None
+) -> str:
+    """Fingerprint of the evidence the judge sees for one relationship (DAT-699).
+
+    Mirrors exactly the measured fields ``_format_relationships`` renders per
+    pair — cardinality, confidence, coverage — so the two cannot disagree
+    about what "the dossier" is. The sticky shape (DAT-516) stores this beside
+    each considered pair; a pair whose CURRENT dossier no longer matches
+    counts as undecided and is re-offered. Not a threshold: ANY change to the
+    measured evidence re-opens the question ("the dossier changed, re-ask the
+    judge"). Pairs judged before an evidence field existed (e.g. pre-DAT-695
+    coverage) re-open exactly once, then stick under the new fingerprint.
+    """
+    return hashlib.sha1(
+        f"{cardinality}|{confidence}|{coverage}".encode(), usedforsecurity=False
+    ).hexdigest()[:16]
 
 
 class EnrichmentAgent(LLMFeature):

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -398,21 +398,32 @@ class GraphAgent(LLMFeature):
         resolved_params = self._resolve_parameters(graph, parameters or {})
         schema_mapping_id = context.schema_mapping_id or "default"
 
-        # Honest-fail on the first ungroundable dependency — born-loud, no LLM. A
+        # Collect EVERY ungroundable dependency — born-loud, no re-authoring. A
         # keyable step absent from the map is a contract violation (the authoring
-        # pass authors every keyable node), so fail loud here, not silently later.
+        # pass authors every keyable node), so it fails loud here too. The metric
+        # still honest-fails, but the groundable subgraph EXECUTES first
+        # (DAT-699): revenue — groundable, 5.93B — ran zero times all day on the
+        # BookSQL smoke because gross_profit aborted whole on cost_of_goods_sold,
+        # and the artifact reason said nothing about what WAS measurable.
+        ungroundable: dict[str, str] = {}
         for step_id, step in graph.steps.items():
             key = node_key(step, graph)
             if key is None:
                 continue  # non-keyable step (rare) — caught by the cache check below
             decision = bindings.get(key)
             if decision is None or not decision.grounded:
-                reason = (
-                    decision.reason
+                ungroundable[step_id] = (
+                    (decision.reason or "ungroundable")
                     if decision is not None
                     else "not authored (absent from binding map)"
                 )
-                return Result.fail(f"dependency '{step_id}' is ungroundable: {reason}")
+        if ungroundable:
+            cached = self._lookup_snippets(session, graph, schema_mapping_id)
+            return Result.fail(
+                self._partial_execution_report(
+                    graph, cached, resolved_params, ungroundable, context
+                )
+            )
 
         # Every extract dep grounded → compose the metric PER-METRIC from the DAG
         # (DAT-646): extract leaves come from the warm cache, formulas/constants are
@@ -485,8 +496,6 @@ class GraphAgent(LLMFeature):
         CTE. Returns ``None`` when an extract leaf is absent (its dep ungroundable — the
         caller honest-fails) or a step is malformed.
         """
-        from dataraum.graphs.formula_composer import compose_constant_sql, compose_formula_sql
-
         output_step = graph.get_output_step()
         if output_step is None:
             return None
@@ -502,39 +511,25 @@ class GraphAgent(LLMFeature):
             step = graph.steps.get(step_id)
             if step is None:
                 return None
-            description = step_id
-            try:
-                if step.step_type == StepType.EXTRACT:
-                    snippet = cached_snippets.get(step_id)
-                    if not snippet:
-                        return None  # an extract leaf is missing → dep ungroundable
-                    sql = snippet["sql"]
-                    description = snippet.get("description") or step_id
-                    for a in snippet.get("assumptions") or []:
-                        assumptions.append(
-                            GraphAssumptionOutput(
-                                dimension=a.get("dimension", "grounding.cached"),
-                                target=a.get("target", f"step:{step_id}"),
-                                assumption=a.get("assumption", ""),
-                                basis=a.get("basis", "inferred"),
-                                confidence=a.get("confidence", 0.5),
-                            )
-                        )
-                elif step.step_type == StepType.CONSTANT:
-                    value = resolved_params.get(step.parameter) if step.parameter else None
-                    if value is None:
-                        return None
-                    sql = compose_constant_sql(value)
-                elif step.step_type == StepType.FORMULA:
-                    if not step.expression:
-                        return None
-                    sql = compose_formula_sql(step.expression, set(step.depends_on))
-                else:
-                    return None
-            except ValueError:
-                # Malformed expression / non-numeric constant — composer raises; the
-                # metric honest-fails (the caller surfaces None as ungroundable).
+            sql = self._compose_step_sql(step, cached_snippets, resolved_params)
+            if sql is None:
+                # Missing extract snippet / unresolvable constant / malformed
+                # formula — the metric honest-fails (caller surfaces the reason).
                 return None
+            description = step_id
+            if step.step_type == StepType.EXTRACT:
+                snippet = cached_snippets.get(step_id) or {}
+                description = snippet.get("description") or step_id
+                for a in snippet.get("assumptions") or []:
+                    assumptions.append(
+                        GraphAssumptionOutput(
+                            dimension=a.get("dimension", "grounding.cached"),
+                            target=a.get("target", f"step:{step_id}"),
+                            assumption=a.get("assumption", ""),
+                            basis=a.get("basis", "inferred"),
+                            confidence=a.get("confidence", 0.5),
+                        )
+                    )
             steps.append({"step_id": step_id, "sql": sql, "description": description})
 
         return GeneratedCode(
@@ -548,6 +543,125 @@ class GraphAgent(LLMFeature):
             generated_at=datetime.now(UTC),
             assumptions=assumptions,
         )
+
+    @staticmethod
+    def _compose_step_sql(
+        step: GraphStep,
+        cached_snippets: dict[str, dict[str, Any]],
+        resolved_params: dict[str, Any],
+    ) -> str | None:
+        """One step's CTE SQL: extract = cached snippet, constant/formula = composed.
+
+        ``None`` = not composable (missing snippet, unresolvable constant,
+        malformed formula) — both the full compose and the DAT-699 partial
+        execution treat that as this step's honest hole.
+        """
+        from dataraum.graphs.formula_composer import compose_constant_sql, compose_formula_sql
+
+        try:
+            if step.step_type == StepType.EXTRACT:
+                snippet = cached_snippets.get(step.step_id)
+                return snippet["sql"] if snippet else None
+            if step.step_type == StepType.CONSTANT:
+                value = resolved_params.get(step.parameter) if step.parameter else None
+                return compose_constant_sql(value) if value is not None else None
+            if step.step_type == StepType.FORMULA:
+                if not step.expression:
+                    return None
+                return compose_formula_sql(step.expression, set(step.depends_on))
+        except ValueError:
+            # Malformed expression / non-numeric constant — the composer raises;
+            # the step is not composable.
+            return None
+        return None
+
+    def _partial_execution_report(
+        self,
+        graph: TransformationGraph,
+        cached_snippets: dict[str, dict[str, Any]],
+        resolved_params: dict[str, Any],
+        ungroundable: dict[str, str],
+        context: ExecutionContext,
+    ) -> str:
+        """Execute the groundable subgraph and report EVERY step's outcome (DAT-699).
+
+        A metric with an ungroundable extract used to abort whole — on the
+        BookSQL smoke, revenue (groundable, 5.93B) executed zero times all day
+        because every profitability metric died on cost_of_goods_sold first,
+        and the artifact reason said nothing about what WAS measurable. The
+        metric still honest-fails (its composed value cannot exist), but every
+        step whose transitive dependencies ground executes, and the reason
+        names each step's measured value, its hole, or what blocks it — the
+        exact per-step story the drill-down (DAT-671) renders.
+        """
+        output_step = graph.get_output_step()
+        ordered = (
+            _ordered_dep_steps(graph, output_step) + [output_step.step_id]
+            if output_step is not None
+            else []
+        )
+        # Steps outside the output's dependency cone still get reported —
+        # nothing in the graph is silently absent from the per-step story.
+        ordered += sorted(step_id for step_id in graph.steps if step_id not in set(ordered))
+
+        # The maximal executable subgraph: a step runs iff it is not a hole,
+        # composes, and every dependency it names is itself executable.
+        executable: list[dict[str, str]] = []
+        executable_ids: set[str] = set()
+        blocked: dict[str, str] = {}
+        for step_id in ordered:
+            step = graph.steps.get(step_id)
+            if step is None or step_id in ungroundable:
+                continue
+            missing = [d for d in step.depends_on if d not in executable_ids]
+            if missing:
+                blocked[step_id] = ", ".join(missing)
+                continue
+            sql = self._compose_step_sql(step, cached_snippets, resolved_params)
+            if sql is None:
+                blocked[step_id] = "not composable"
+                continue
+            executable.append({"step_id": step_id, "sql": sql, "description": step_id})
+            executable_ids.add(step_id)
+
+        values: dict[str, Any] = {}
+        exec_note = ""
+        if executable:
+            code = GeneratedCode(
+                code_id=str(uuid4()),
+                graph_id=graph.graph_id,
+                summary=f"Partial execution of {graph.graph_id} ({len(executable)} steps)",
+                steps=executable,
+                final_sql=f"SELECT * FROM {executable[-1]['step_id']}",
+                llm_model="composed",
+                prompt_hash="composed",
+                generated_at=datetime.now(UTC),
+            )
+            exec_result = self._execute_sql(code, context, graph)
+            if exec_result.success and exec_result.value:
+                values = {sr.step_id: sr.value for sr in exec_result.value.step_results}
+            else:
+                exec_note = f" (partial execution failed: {exec_result.error})"
+
+        parts: list[str] = []
+        for step_id in ordered:
+            if step_id in ungroundable:
+                parts.append(f"{step_id} ✗ {ungroundable[step_id]}")
+            elif step_id in blocked:
+                parts.append(f"{step_id} blocked (needs {blocked[step_id]})")
+            elif step_id in values:
+                value = values[step_id]
+                if value is None:
+                    parts.append(f"{step_id} = NULL (aggregated with no measured support)")
+                elif isinstance(value, (int, float, Decimal)):
+                    parts.append(f"{step_id} = {float(value):,.2f} ✓")
+                else:
+                    parts.append(f"{step_id} = {value} ✓")
+            elif step_id in executable_ids:
+                parts.append(f"{step_id} composed but not executed")
+        names = ", ".join(f"'{s}'" for s in sorted(ungroundable))
+        verb = "is" if len(ungroundable) == 1 else "are"
+        return f"dependency {names} {verb} ungroundable — " + " · ".join(parts) + exec_note
 
     def _generate_sql(
         self,

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -661,12 +661,20 @@ class GraphAgent(LLMFeature):
                 value = values[step_id]
                 if value is None:
                     parts.append(f"{step_id} = NULL (aggregated with no measured support)")
+                elif isinstance(value, bool):
+                    # bool BEFORE the numeric check (bool is an int subclass) —
+                    # a boolean step must read True/False, never 1.00.
+                    parts.append(f"{step_id} = {value} ✓")
                 elif isinstance(value, (int, float, Decimal)):
                     parts.append(f"{step_id} = {float(value):,.2f} ✓")
                 else:
                     parts.append(f"{step_id} = {value} ✓")
             elif step_id in executable_ids:
                 parts.append(f"{step_id} composed but not executed")
+            else:
+                # A dep referenced by the graph but absent from graph.steps
+                # (cache-only leaf) — nothing is silently absent from the story.
+                parts.append(f"{step_id} not defined in the graph")
         names = ", ".join(f"'{s}'" for s in sorted(ungroundable))
         verb = "is" if len(ungroundable) == 1 else "are"
         return f"dependency {names} {verb} ungroundable — " + " · ".join(parts) + exec_note

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -23,6 +23,7 @@ from uuid import uuid4
 
 import duckdb
 import yaml
+from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from dataraum.core.logging import get_logger
@@ -48,6 +49,7 @@ from .verifier import verify_execution
 
 if TYPE_CHECKING:
     from dataraum.graphs.node_warming import NodeDecision, NodeKey
+    from dataraum.llm.providers.base import ToolDefinition
 
 logger = get_logger(__name__)
 
@@ -716,8 +718,15 @@ class GraphAgent(LLMFeature):
 
         try:
             output = ExtractGroundingOutput.model_validate(tool_call.input)
-        except Exception as e:
-            return Result.fail(f"Failed to validate tool response: {e}")
+        except ValidationError as e:
+            # Enforced schema, never coercion (DAT-699): the model fixes its own
+            # output in one cheap repair turn. A finished, correct grounding was
+            # previously discarded whole on a single stringified `provenance`
+            # field — losing the metric to a serialization slip, silently.
+            repaired = self._repair_tool_output(tool, tool_call.input, e, model, prompt_name)
+            if not repaired.success:
+                return Result.fail(repaired.error or "schema repair failed")
+            output = repaired.unwrap()
 
         # Bind the one generated SQL to the graph's own leaf id (the model never
         # names a step — DAT-664's id-paraphrase class is gone by construction)
@@ -772,6 +781,62 @@ class GraphAgent(LLMFeature):
         )
 
         return Result.ok(generated_code)
+
+    def _repair_tool_output(
+        self,
+        tool: ToolDefinition,
+        invalid_input: dict[str, Any],
+        error: ValidationError,
+        model: str,
+        label: str,
+    ) -> Result[ExtractGroundingOutput]:
+        """One schema-repair turn: the model fixes its own tool output (DAT-699).
+
+        The output schema is ENFORCED, never coerced: a validation failure
+        re-prompts the model with its own serialized output plus the exact
+        validation error, under a forced tool choice — a stringified nested
+        object or a mistyped field is the model's to fix, not ours to
+        ``json.loads`` behind its back. The repair request is a fresh
+        single-turn conversation (no dataset context, so it is cheap, and no
+        assistant-turn continuation, so it cannot trip the thinking-block
+        continuation constraint). One repair attempt: a model that cannot
+        satisfy the schema twice fails loud with both errors.
+        """
+        from dataraum.llm.providers.base import ConversationRequest, Message
+
+        repair_prompt = (
+            "Your previous call to the tool below failed schema validation.\n\n"
+            f"Validation error:\n{error}\n\n"
+            f"Your tool input was:\n{json.dumps(invalid_input, indent=2)}\n\n"
+            f"Call {tool.name} again with the SAME content, corrected to satisfy "
+            "the schema exactly — e.g. a field you emitted as a JSON-encoded "
+            "string must be a structured object. Fix only the schema "
+            "violations; do not change the substance of any field."
+        )
+        request = ConversationRequest(
+            messages=[Message(role="user", content=repair_prompt)],
+            system="You repair tool-call arguments to satisfy their JSON schema exactly.",
+            tools=[tool],
+            tool_choice={"type": "tool", "name": tool.name},
+            label=f"{label}_repair",
+            max_tokens=self.config.limits.max_output_tokens_per_request,
+            temperature=0.0,
+            model=model,
+        )
+        logger.warning("tool_output_schema_repair", tool=tool.name, error=str(error)[:200])
+        response = self.provider.converse(request).unwrap()
+        if not response.tool_calls:
+            return Result.fail(
+                f"Failed to validate tool response ({error}); the schema-repair "
+                "turn produced no tool call"
+            )
+        try:
+            return Result.ok(ExtractGroundingOutput.model_validate(response.tool_calls[0].input))
+        except ValidationError as second:
+            return Result.fail(
+                f"Failed to validate tool response after a repair turn: {second} "
+                f"(original error: {error})"
+            )
 
     def _execute_sql(
         self,

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -410,9 +410,9 @@ class GraphAgent(LLMFeature):
         # keyable step absent from the map is a contract violation (the authoring
         # pass authors every keyable node), so it fails loud here too. The metric
         # still honest-fails, but the groundable subgraph EXECUTES first
-        # (DAT-699): revenue — groundable, 5.93B — ran zero times all day on the
-        # BookSQL smoke because gross_profit aborted whole on cost_of_goods_sold,
-        # and the artifact reason said nothing about what WAS measurable.
+        # (DAT-699): a groundable revenue leaf can otherwise run zero times all
+        # day because gross_profit aborts whole on cost_of_goods_sold, and the
+        # artifact reason says nothing about what WAS measurable.
         ungroundable: dict[str, str] = {}
         for step_id, step in graph.steps.items():
             key = node_key(step, graph)
@@ -519,7 +519,7 @@ class GraphAgent(LLMFeature):
             step = graph.steps.get(step_id)
             if step is None:
                 return None
-            sql = self._compose_step_sql(step, cached_snippets, resolved_params)
+            sql = self._compose_step_sql(step, step_id, cached_snippets, resolved_params)
             if sql is None:
                 # Missing extract snippet / unresolvable constant / malformed
                 # formula — the metric honest-fails (caller surfaces the reason).
@@ -555,20 +555,25 @@ class GraphAgent(LLMFeature):
     @staticmethod
     def _compose_step_sql(
         step: GraphStep,
+        step_key: str,
         cached_snippets: dict[str, dict[str, Any]],
         resolved_params: dict[str, Any],
     ) -> str | None:
         """One step's CTE SQL: extract = cached snippet, constant/formula = composed.
 
-        ``None`` = not composable (missing snippet, unresolvable constant,
-        malformed formula) — both the full compose and the DAT-699 partial
-        execution treat that as this step's honest hole.
+        ``step_key`` is the step's key in ``graph.steps`` — the dependency
+        namespace that CTE names and the snippet cache are keyed on. It usually
+        equals ``step.step_id`` but is passed explicitly because nothing
+        enforces that, and a lookup on ``step.step_id`` silently misses when
+        they diverge. ``None`` = not composable (missing snippet, unresolvable
+        constant, malformed formula) — both the full compose and the DAT-699
+        partial execution treat that as this step's honest hole.
         """
         from dataraum.graphs.formula_composer import compose_constant_sql, compose_formula_sql
 
         try:
             if step.step_type == StepType.EXTRACT:
-                snippet = cached_snippets.get(step.step_id)
+                snippet = cached_snippets.get(step_key)
                 return snippet["sql"] if snippet else None
             if step.step_type == StepType.CONSTANT:
                 value = resolved_params.get(step.parameter) if step.parameter else None
@@ -593,10 +598,10 @@ class GraphAgent(LLMFeature):
     ) -> str:
         """Execute the groundable subgraph and report EVERY step's outcome (DAT-699).
 
-        A metric with an ungroundable extract used to abort whole — on the
-        BookSQL smoke, revenue (groundable, 5.93B) executed zero times all day
-        because every profitability metric died on cost_of_goods_sold first,
-        and the artifact reason said nothing about what WAS measurable. The
+        A metric with an ungroundable extract used to abort whole — a
+        groundable sibling (revenue) could execute zero times all day because
+        every profitability metric died on cost_of_goods_sold first, and the
+        artifact reason said nothing about what WAS measurable. The
         metric still honest-fails (its composed value cannot exist), but every
         step whose transitive dependencies ground executes, and the reason
         names each step's measured value, its hole, or what blocks it — the
@@ -625,7 +630,7 @@ class GraphAgent(LLMFeature):
             if missing:
                 blocked[step_id] = ", ".join(missing)
                 continue
-            sql = self._compose_step_sql(step, cached_snippets, resolved_params)
+            sql = self._compose_step_sql(step, step_id, cached_snippets, resolved_params)
             if sql is None:
                 blocked[step_id] = "not composable"
                 continue
@@ -1926,9 +1931,10 @@ class GraphAgent(LLMFeature):
                         "Revise to address the reason, or abstain (low-confidence). If the "
                         "prior SQL aggregated to NULL, decide from the schema evidence which "
                         "case applies: the concept has no supporting rows (abstain — never "
-                        "mask absence as 0), or the filter matches rows and one aggregate "
-                        "leg is legitimately empty (a one-sided ledger — net the legs with "
-                        "row-guarded NULL-safety per the empty-aggregation rule)."
+                        "mask absence as 0), or the filter matches rows and one aggregated "
+                        "operand is legitimately empty (one-sided data — combine the "
+                        "operands with row-guarded NULL-safety per the empty-aggregation "
+                        "rule)."
                     )
         except Exception as e:
             # Feedback is best-effort — a lookup hiccup must not fail metric authoring

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -366,6 +366,7 @@ class GraphAgent(LLMFeature):
                 reason=reason,
             )
             return Result.fail(reason)
+        execution.verification_flags = verdict.unwrap() or []
 
         # Save snippets AFTER successful execution AND verification — includes
         # repair info and only saves SQL that actually works AND is trustworthy.
@@ -466,6 +467,7 @@ class GraphAgent(LLMFeature):
         verdict = verify_execution(graph, execution)
         if not verdict.success:
             return Result.fail(verdict.error or "metric verification failed")
+        execution.verification_flags = verdict.unwrap() or []
 
         # Persist THIS metric's composed FORMULA/CONSTANT snippets (DAT-646) AFTER it
         # executed AND verified — only trustworthy SQL enters the cockpit reuse KB. The

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -1612,7 +1612,12 @@ class GraphAgent(LLMFeature):
                     parts.append(
                         f"Your prior attempt to ground this extract was {mode}: {why}\n"
                         f"Prior SQL (do NOT re-emit unchanged):\n{rec.sql}\n"
-                        "Revise to address the reason, or abstain (low-confidence)."
+                        "Revise to address the reason, or abstain (low-confidence). If the "
+                        "prior SQL aggregated to NULL, decide from the schema evidence which "
+                        "case applies: the concept has no supporting rows (abstain — never "
+                        "mask absence as 0), or the filter matches rows and one aggregate "
+                        "leg is legitimately empty (a one-sided ledger — net the legs with "
+                        "row-guarded NULL-safety per the empty-aggregation rule)."
                     )
         except Exception as e:
             # Feedback is best-effort — a lookup hiccup must not fail metric authoring

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -44,6 +44,7 @@ from .models import (
     StepResult,
     StepType,
     TransformationGraph,
+    ValueSearchInput,
 )
 from .verifier import verify_execution
 
@@ -52,6 +53,13 @@ if TYPE_CHECKING:
     from dataraum.llm.providers.base import ToolDefinition
 
 logger = get_logger(__name__)
+
+# The grounding agent's catalog-search budget (DAT-699): enough turns to
+# resolve a couple of concepts' exact values on a high-cardinality
+# discriminator, small enough that a lost agent fails loud instead of
+# spelunking. Each search is one bounded DuckDB DISTINCT query.
+_MAX_VALUE_SEARCHES = 4
+_VALUE_SEARCH_LIMIT = 25
 
 
 def _ordered_dep_steps(graph: TransformationGraph, output_step: GraphStep) -> list[str]:
@@ -690,6 +698,7 @@ class GraphAgent(LLMFeature):
             ConversationRequest,
             Message,
             ToolDefinition,
+            ToolResult,
         )
 
         extract_leaves = [
@@ -773,11 +782,24 @@ class GraphAgent(LLMFeature):
             model=model,
         )
 
-        # Define tool for structured output
+        # Define tools: the structured output plus the bounded catalog search
+        # (DAT-699) — high-cardinality discriminators are served size+sample
+        # only, and their exact values live behind search_values.
         tool = ToolDefinition(
             name="generate_sql",
             description="Provide the SQL grounding the one concept in the graph specification",
             input_schema=ExtractGroundingOutput.model_json_schema(),
+        )
+        search_tool = ToolDefinition(
+            name="search_values",
+            description=(
+                "Search a column's distinct values by case-insensitive substring. "
+                "Use it to resolve the EXACT values of a high-cardinality "
+                "discriminator (marked 'NOT enumerated' in the Value sets) before "
+                "writing an IN-list — never guess a predicate. Always finish by "
+                "calling generate_sql."
+            ),
+            input_schema=ValueSearchInput.model_json_schema(),
         )
 
         # Thinking (DAT-603): grounding is the pipeline's hardest reasoning task
@@ -785,33 +807,78 @@ class GraphAgent(LLMFeature):
         # reflection is the quality lever. A FORCED tool_choice silently
         # suppresses thinking on the live API (probed 2026-07-03: forced -> no
         # thinking block, auto -> thinking block), so a thinking run offers the
-        # tool on auto and the prompt mandates the call; no tool call remains a
-        # loud bind error (checked below), never a silent prose answer.
+        # tools on auto and the prompt mandates the final call; no tool call
+        # remains a loud bind error (checked below), never a silent prose
+        # answer. Non-thinking runs use "any" (some tool must be called —
+        # search_values or generate_sql; the old forced generate_sql would
+        # make searching impossible). disable_parallel_tool_use keeps every
+        # turn to ONE call, so the search loop stays sequential and binding
+        # [0] can never ground a superseded SQL.
         thinking = bool(feature_config and feature_config.thinking)
-        request = ConversationRequest(
-            messages=[Message(role="user", content=user_prompt)],
-            system=system_prompt,
-            tools=[tool],
-            # auto (not forced): a forced choice silently suppresses thinking on
-            # the live API (probed 2026-07-03). disable_parallel_tool_use restores
-            # the <=1-tool-call guarantee that forcing used to provide — under
-            # plain auto the model may emit MULTIPLE generate_sql calls in one
-            # turn and binding [0] could ground a superseded SQL.
-            tool_choice={"type": "auto", "disable_parallel_tool_use": True}
+        tool_choice: dict[str, Any] = (
+            {"type": "auto", "disable_parallel_tool_use": True}
             if thinking
-            else {"type": "tool", "name": "generate_sql"},
-            thinking=thinking,
-            label=prompt_name,
-            effort=feature_config.effort if feature_config else None,
-            max_tokens=self.config.limits.max_output_tokens_per_request,
-            temperature=temperature,
-            model=model,
+            else {"type": "any", "disable_parallel_tool_use": True}
         )
+        messages = [Message(role="user", content=user_prompt)]
 
-        # converse raises a typed ProviderError on an API failure (DAT-503) —
-        # retryability rides the exception to the worker's durable boundary, so
-        # we don't re-wrap it. A returned Result is always a success.
-        response = self.provider.converse(request).unwrap()
+        def _converse() -> Any:
+            # converse raises a typed ProviderError on an API failure (DAT-503) —
+            # retryability rides the exception to the worker's durable boundary,
+            # so we don't re-wrap it. A returned Result is always a success.
+            return self.provider.converse(
+                ConversationRequest(
+                    messages=messages,
+                    system=system_prompt,
+                    tools=[tool, search_tool],
+                    tool_choice=tool_choice,
+                    thinking=thinking,
+                    label=prompt_name,
+                    effort=feature_config.effort if feature_config else None,
+                    max_tokens=self.config.limits.max_output_tokens_per_request,
+                    temperature=temperature,
+                    model=model,
+                )
+            ).unwrap()
+
+        response = _converse()
+
+        # Bounded exploration loop (DAT-699): answer each search_values call and
+        # continue the conversation (raw_content round-trips the signed thinking
+        # blocks). The budget is small — a lost agent fails loud below, never
+        # spelunks. The last allowed search's result carries the budget notice.
+        searches = 0
+        while (
+            searches < _MAX_VALUE_SEARCHES
+            and len(response.tool_calls) == 1
+            and response.tool_calls[0].name == "search_values"
+        ):
+            searches += 1
+            search_call = response.tool_calls[0]
+            outcome = self._run_value_search(context, search_call.input)
+            if searches == _MAX_VALUE_SEARCHES:
+                outcome += "\n(search budget exhausted — call generate_sql now)"
+            logger.info(
+                "grounding_value_search",
+                graph_id=graph.graph_id,
+                pattern=search_call.input.get("pattern"),
+                turn=searches,
+            )
+            messages.append(
+                Message(
+                    role="assistant",
+                    content=response.content,
+                    tool_calls=response.tool_calls,
+                    raw_content=response.raw_content,
+                )
+            )
+            messages.append(
+                Message(
+                    role="user",
+                    content=[ToolResult(tool_use_id=search_call.id, content=outcome)],
+                )
+            )
+            response = _converse()
 
         # Extract tool call result. No tool call is a bind ERROR — never guess by
         # parsing free text as JSON (DAT-439's born-loud cut): a metric that can't
@@ -828,7 +895,10 @@ class GraphAgent(LLMFeature):
 
         tool_call = response.tool_calls[0]
         if tool_call.name != "generate_sql":
-            return Result.fail(f"Unexpected tool call: {tool_call.name}")
+            return Result.fail(
+                f"Unexpected tool call: {tool_call.name}"
+                + (" (search budget exhausted)" if searches >= _MAX_VALUE_SEARCHES else "")
+            )
 
         try:
             output = ExtractGroundingOutput.model_validate(tool_call.input)
@@ -895,6 +965,60 @@ class GraphAgent(LLMFeature):
         )
 
         return Result.ok(generated_code)
+
+    def _run_value_search(self, context: ExecutionContext, raw_input: dict[str, Any]) -> str:
+        """Execute one bounded catalog value search (DAT-699).
+
+        Returns compact text for the tool_result. Errors come back as TEXT (an
+        unknown table/column or a bad pattern is the agent's to correct within
+        its search budget), never as an exception — a broken search must not
+        kill the grounding turn. Table and column names are validated against
+        our own catalog before touching SQL; only the pattern is user…model
+        text, escaped for the one ILIKE literal it lands in.
+        """
+        try:
+            params = ValueSearchInput.model_validate(raw_input)
+        except ValidationError as e:
+            return f"invalid search_values input: {e}"
+        rich = context.rich_context
+        tables = {t.table_name: t for t in getattr(rich, "tables", None) or []}
+        table = tables.get(params.table)
+        if table is None or not table.duckdb_name:
+            known = ", ".join(sorted(tables)) or "(none)"
+            return f"unknown table '{params.table}' — known tables: {known}"
+        if params.column not in {c.column_name for c in table.columns}:
+            known = ", ".join(sorted(c.column_name for c in table.columns))
+            return f"unknown column '{params.column}' on '{params.table}' — columns: {known}"
+        if context.duckdb_conn is None:
+            return "no data connection available for value search"
+        needle = (
+            params.pattern.replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+            .replace("'", "''")
+        )
+        try:
+            rows = context.duckdb_conn.execute(
+                f'SELECT CAST("{params.column}" AS VARCHAR) AS value, COUNT(*) AS n '
+                f'FROM "{table.duckdb_name}" '
+                f'WHERE "{params.column}" IS NOT NULL '
+                f"AND CAST(\"{params.column}\" AS VARCHAR) ILIKE '%{needle}%' ESCAPE '\\' "
+                f"GROUP BY 1 ORDER BY n DESC, value LIMIT {_VALUE_SEARCH_LIMIT}"
+            ).fetchall()
+        except Exception as e:
+            return f"search failed: {e}"
+        if not rows:
+            return f"no values matching '{params.pattern}' in {params.table}.{params.column}"
+        listed = "\n".join(f"- {v} ({n} rows)" for v, n in rows)
+        truncated = (
+            f"\n(first {_VALUE_SEARCH_LIMIT} matches by frequency — narrow the pattern for more)"
+            if len(rows) == _VALUE_SEARCH_LIMIT
+            else ""
+        )
+        return (
+            f"values matching '{params.pattern}' in "
+            f"{params.table}.{params.column}:\n{listed}{truncated}"
+        )
 
     def _repair_tool_output(
         self,

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -1600,8 +1600,8 @@ def _build_value_sets(table: TableContext) -> list[str]:
       hint (DAT-699). The GraphAgent can now drill: it resolves the exact values by
       bounded substring search and grounds the IN-list on the results. The old
       render-nothing rule made a present-but-unenumerated concept structurally
-      ungroundable — on the BookSQL smoke, Depreciation and Taxes & Licenses sat
-      unseen in a 340-name account column and the agent emitted SELECT NULL;
+      ungroundable — concepts present by name in a several-hundred-value column
+      were unreachable and the agent emitted SELECT NULL for them;
     - degenerate (one value dominates) → flagged "near-constant", NO value-set — grounding
       on a ~constant flag (e.g. a 99%-true boolean) is silently wrong.
     Only key/measure/time roles are skipped (never partitions).

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -1593,14 +1593,15 @@ def _build_value_sets(table: TableContext) -> list[str]:
     """Render the value enumeration for a table's categorical columns (DAT-621).
 
     The agent grounds a concept in the discriminator VALUES from here, never a guessed
-    ILIKE. The GraphAgent is ONE-SHOT with NO tools (it cannot drill), so it gets the
-    LOW-CARD BASELINE only — nothing it would be tempted to guess at:
+    ILIKE:
     - low-card (≤ reasonable-top) + non-degenerate → the COMPLETE value-set inline (the
       assembler fetched it live);
-    - high-card (> reasonable-top) → NOT rendered at all. High-card discriminators are the
-      cockpit answer sub-agent's + user's lane (they have look_values to drill on demand);
-      dangling a high-card column here only invites the ILIKE-guess that is the root bug. A
-      metric that genuinely needs one falls loud (no value-set → no IN-list → abstain);
+    - high-card (> reasonable-top) → size + a frequency sample + the ``search_values``
+      hint (DAT-699). The GraphAgent can now drill: it resolves the exact values by
+      bounded substring search and grounds the IN-list on the results. The old
+      render-nothing rule made a present-but-unenumerated concept structurally
+      ungroundable — on the BookSQL smoke, Depreciation and Taxes & Licenses sat
+      unseen in a 340-name account column and the agent emitted SELECT NULL;
     - degenerate (one value dominates) → flagged "near-constant", NO value-set — grounding
       on a ~constant flag (e.g. a 99%-true boolean) is silently wrong.
     Only key/measure/time roles are skipped (never partitions).
@@ -1613,10 +1614,18 @@ def _build_value_sets(table: TableContext) -> list[str]:
             continue
         served = len(col.top_values)
         dc = col.distinct_count
-        # High-card / incomplete-fetch → NOT served to the one-shot GraphAgent at all (it
-        # can't drill; high-card is the cockpit/user lane). The served set must be the
-        # COMPLETE enumeration to render — a partial never becomes a value list here.
+        # High-card / incomplete-fetch → size + sample + the drill hint; the
+        # values NEVER render as an (incomplete) enumeration the agent might
+        # mistake for the complete set.
         if dc is not None and dc > served:
+            sample = ", ".join(
+                str(tv.get("value")) for tv in col.top_values[:8] if tv.get("value") is not None
+            )
+            out.append(
+                f"- **{col.column_name}**: {dc} distinct values — NOT enumerated; "
+                f"resolve exact values with the search_values tool before filtering. "
+                f"Most frequent: {sample}"
+            )
             continue
         # Degenerate / near-constant → not a discriminator; flag, don't serve as groundable
         # (grounding a concept on a ~constant flag is silently wrong).

--- a/packages/engine/src/dataraum/graphs/models.py
+++ b/packages/engine/src/dataraum/graphs/models.py
@@ -338,15 +338,16 @@ class ValueSearchInput(BaseModel):
     served as size + sample, never enumerated — the exact values live behind
     THIS tool. The agent resolves them by substring search and grounds its
     IN-list on the results instead of guessing an ILIKE predicate or falling
-    loud on a concept whose values it was never shown (the BookSQL smoke's
-    Depreciation / Taxes & Licenses accounts sat unseen in a 340-name column).
+    loud on a concept whose values it was never shown (observed live: concepts
+    present by name in a several-hundred-value column were unreachable).
     """
 
     table: str = Field(description="Table name exactly as shown in <data_schema>.")
     column: str = Field(description="Column name exactly as shown in <data_schema>.")
     pattern: str = Field(
         description="Case-insensitive substring to search the column's distinct "
-        "values for (e.g. 'deprec', 'tax'). Plain text, not a SQL pattern."
+        "values for — a fragment of the concept's likely name or a synonym. "
+        "Plain text, not a SQL pattern."
     )
 
 

--- a/packages/engine/src/dataraum/graphs/models.py
+++ b/packages/engine/src/dataraum/graphs/models.py
@@ -331,6 +331,25 @@ class GraphProvenanceOutput(BaseModel):
     # tokens are serial-decode latency, so an unread sentence per call is pure cost.
 
 
+class ValueSearchInput(BaseModel):
+    """Input for the grounding agent's bounded catalog search (DAT-699).
+
+    High-cardinality discriminators (above the complete-enumeration bound) are
+    served as size + sample, never enumerated — the exact values live behind
+    THIS tool. The agent resolves them by substring search and grounds its
+    IN-list on the results instead of guessing an ILIKE predicate or falling
+    loud on a concept whose values it was never shown (the BookSQL smoke's
+    Depreciation / Taxes & Licenses accounts sat unseen in a 340-name column).
+    """
+
+    table: str = Field(description="Table name exactly as shown in <data_schema>.")
+    column: str = Field(description="Column name exactly as shown in <data_schema>.")
+    pattern: str = Field(
+        description="Case-insensitive substring to search the column's distinct "
+        "values for (e.g. 'deprec', 'tax'). Plain text, not a SQL pattern."
+    )
+
+
 class ExtractGroundingOutput(BaseModel):
     """LLM tool output for grounding ONE extract leaf to SQL (DAT-603).
 

--- a/packages/engine/src/dataraum/graphs/models.py
+++ b/packages/engine/src/dataraum/graphs/models.py
@@ -286,6 +286,11 @@ class GraphExecution:
     # Assumptions made during execution (populated from LLM output)
     assumptions: list[QueryAssumption] = field(default_factory=list)
 
+    # Declared-expectation violations from the verifier (DAT-699): the metric
+    # EXECUTED; these surface on the artifact as visible state_reason flags
+    # (execute-and-flag) — never a reason the number was refused.
+    verification_flags: list[str] = field(default_factory=list)
+
     @classmethod
     def create(cls, graph: TransformationGraph) -> GraphExecution:
         """Create a new execution for a graph."""

--- a/packages/engine/src/dataraum/graphs/verifier.py
+++ b/packages/engine/src/dataraum/graphs/verifier.py
@@ -4,10 +4,9 @@ This is a *cheap value-space sanity check*, NOT the grounding fix. It keeps a
 metric ``grounded``/inconclusive (never silently ``executed``/green) when:
 - an extract aggregated to NULL ("no support") — reported as the MEASUREMENT,
   never a cause: a NULL aggregate can mean the filter matched no rows OR that
-  an aggregated operand was entirely NULL over matched rows (seen live: an A/R
-  ledger whose credit leg is all-NULL turned ``SUM(debit) - SUM(credit)`` into
-  NULL over 167,743 matched rows; the old fabricated "filter matched no rows"
-  text sent the whole triage down a wrong path — DAT-699);
+  an aggregated operand was entirely NULL over the matched rows (a one-sided
+  two-operand extract). The old text asserted the zero-row cause as fact and
+  misdirected diagnosis of exactly the second case — DAT-699;
 - the composed value is NULL (a contributing extract had no support);
 - a catalogue-declared per-extract ``validation:`` bound is violated (e.g. revenue
   ``value > 0``) — a one-number comparison on the step's executed scalar.

--- a/packages/engine/src/dataraum/graphs/verifier.py
+++ b/packages/engine/src/dataraum/graphs/verifier.py
@@ -1,15 +1,22 @@
 """Post-execution SANITY floor for metric graphs (DAT-616).
 
 This is a *cheap value-space sanity check*, NOT the grounding fix. It keeps a
-metric ``grounded``/inconclusive (never silently ``executed``/green) when:
+metric ``grounded``/inconclusive (never silently ``executed``/green) when there
+is NO VALUE to stand behind:
 - an extract aggregated to NULL ("no support") — reported as the MEASUREMENT,
   never a cause: a NULL aggregate can mean the filter matched no rows OR that
   an aggregated operand was entirely NULL over the matched rows (a one-sided
   two-operand extract). The old text asserted the zero-row cause as fact and
   misdirected diagnosis of exactly the second case — DAT-699;
-- the composed value is NULL (a contributing extract had no support);
-- a catalogue-declared per-extract ``validation:`` bound is violated (e.g. revenue
-  ``value > 0``) — a one-number comparison on the step's executed scalar.
+- the composed value is NULL (a contributing extract had no support).
+
+A catalogue-declared ``validation:`` bound (e.g. ``0 <= value <= 365``) is an
+EXPECTATION, not a gate (DAT-699): a violation FLAGS the executed metric
+(execute-and-flag, the DAT-631 amber pattern) — it never refuses the number.
+A declared "shouldn't" stated as "can't" kept blocking real values (negative
+COGS is unusual, not impossible), and refusing the number hides exactly the
+signal the user needs; the measured value disagreeing with the declared
+expectation IS the signal (ADR-0009).
 
 **It is structurally blind to the real bug** (DAT-616): a *wrong-but-non-empty*
 filter (the agent improvises ``WHERE account_type ILIKE '%cost%'`` and matches the
@@ -46,18 +53,20 @@ _COMPARATORS: dict[type[ast.cmpop], Callable[[Any, Any], bool]] = {
 }
 
 
-def verify_execution(graph: TransformationGraph, execution: GraphExecution) -> Result[None]:
-    """Judge a clean execution for support, non-degeneracy, and declared conditions.
+def verify_execution(graph: TransformationGraph, execution: GraphExecution) -> Result[list[str]]:
+    """Judge a clean execution for support and non-degeneracy; flag declared expectations.
 
     Args:
         graph: The metric graph (carries each step's declared ``validations``).
         execution: The completed execution (per-step values + composed value).
 
     Returns:
-        ``Result.ok(None)`` if the metric is trustworthy; ``Result.fail(reason)``
-        with a human-readable reason if it is inconclusive or violates a declared
-        condition — the caller keeps the artifact ``grounded`` with that reason
-        and does not cache the SQL.
+        ``Result.ok(flags)`` — the metric EXECUTES; ``flags`` is the (possibly
+        empty) list of declared-expectation violations to surface on the
+        artifact as visible state_reason flags. ``Result.fail(reason)`` is
+        reserved for NO-VALUE outcomes (no support / degenerate NULL) — there
+        is nothing to execute-and-flag, the caller keeps the artifact
+        ``grounded`` with the reason and does not cache the SQL.
     """
     by_step = {sr.step_id: sr for sr in execution.step_results}
 
@@ -92,10 +101,15 @@ def verify_execution(graph: TransformationGraph, execution: GraphExecution) -> R
             "composed metric value is NULL — a contributing extract had no support; inconclusive"
         )
 
-    # 3. Enforce the catalogue's declared per-extract conditions (e.g. revenue
-    #    `value > 0`, cogs `value >= 0`), bound to the executed step by step_id
-    #    (the dependency key). An unbindable condition is skipped — the support
-    #    gate above already guards the real risk; DAT-619 hardens the binding.
+    # 3. The catalogue's declared conditions (e.g. `0 <= value <= 365`), bound
+    #    to the executed step by step_id (the dependency key). Violations FLAG,
+    #    never gate (DAT-699) — the number executed; the flag says the declared
+    #    expectation disagrees with it, and severity rides along as the flag's
+    #    weight. An unbindable condition is skipped — the support gate above
+    #    already guards the real risk; DAT-619 hardens the binding. A malformed
+    #    condition is a config bug: flagged on the artifact (visible where the
+    #    cockpit shows it) and never a reason to refuse a good number.
+    flags: list[str] = []
     for step_id, step in graph.steps.items():
         bound = by_step.get(step_id)
         if bound is None or bound.value is None:
@@ -104,22 +118,22 @@ def verify_execution(graph: TransformationGraph, execution: GraphExecution) -> R
             try:
                 holds = _condition_holds(check.condition, bound.value)
             except (ValueError, SyntaxError) as exc:
-                # A malformed catalogue condition fails loud HERE as a clean
-                # Result.fail (routed through the caller's snippet-failure path),
-                # not escaping to the blanket worker handler. ValueError = parseable
-                # but unsupported (e.g. a bad operator); SyntaxError = unparseable
-                # (e.g. SQL `AND` where Python wants `and` or a chained comparison).
-                return Result.fail(
-                    f"catalogue validation condition for '{step_id}' is malformed "
+                # ValueError = parseable but unsupported (e.g. a bad operator);
+                # SyntaxError = unparseable (e.g. SQL `AND` where Python wants
+                # `and`). Neither escapes to the blanket worker handler.
+                flags.append(
+                    f"declared expectation for '{step_id}' is malformed "
                     f"({check.condition!r}): {exc}"
                 )
+                continue
             if not holds:
                 reason = check.message or check.condition
-                return Result.fail(
-                    f"declared validation failed for '{step_id}': {reason} (value={bound.value})"
+                flags.append(
+                    f"declared expectation not met for '{step_id}': {reason} "
+                    f"(value={bound.value}, severity={check.severity})"
                 )
 
-    return Result.ok(None)
+    return Result.ok(flags)
 
 
 def _condition_holds(condition: str, value: Any) -> bool:

--- a/packages/engine/src/dataraum/graphs/verifier.py
+++ b/packages/engine/src/dataraum/graphs/verifier.py
@@ -2,7 +2,12 @@
 
 This is a *cheap value-space sanity check*, NOT the grounding fix. It keeps a
 metric ``grounded``/inconclusive (never silently ``executed``/green) when:
-- an extract aggregated to NULL — its filter matched no rows ("no support");
+- an extract aggregated to NULL ("no support") — reported as the MEASUREMENT,
+  never a cause: a NULL aggregate can mean the filter matched no rows OR that
+  an aggregated operand was entirely NULL over matched rows (seen live: an A/R
+  ledger whose credit leg is all-NULL turned ``SUM(debit) - SUM(credit)`` into
+  NULL over 167,743 matched rows; the old fabricated "filter matched no rows"
+  text sent the whole triage down a wrong path — DAT-699);
 - the composed value is NULL (a contributing extract had no support);
 - a catalogue-declared per-extract ``validation:`` bound is violated (e.g. revenue
   ``value > 0``) — a one-number comparison on the step's executed scalar.
@@ -57,18 +62,25 @@ def verify_execution(graph: TransformationGraph, execution: GraphExecution) -> R
     """
     by_step = {sr.step_id: sr for sr in execution.step_results}
 
-    # 1. Support: an extract whose aggregate is NULL matched no rows. With the
-    #    COALESCE mask removed from the prompt, an empty filter surfaces as NULL
-    #    here — no support, so the metric is inconclusive (not a real value). A
-    #    non-extract step (formula/constant) that is NULL is degenerate, not
-    #    "unfiltered" — word the reason for what the step actually is.
+    # 1. Support: an extract whose aggregate is NULL has no measured support.
+    #    With the COALESCE mask removed from the prompt, that surfaces as NULL
+    #    here — inconclusive (not a real value). Report ONLY the measurement:
+    #    this check cannot see whether the filter matched zero rows or whether
+    #    an aggregated operand was all-NULL over matched rows, and asserting
+    #    either would fabricate a cause (DAT-699). The reason enumerates the
+    #    possibility space so the re-author loop (retained failed snippet →
+    #    prior context) can resolve it instead of trusting a wrong diagnosis.
+    #    A non-extract step (formula/constant) that is NULL is degenerate —
+    #    word the reason for what the step actually is.
     for sr in execution.step_results:
         if sr.value is None:
             step = graph.steps.get(sr.step_id)
             if step is None or step.step_type == StepType.EXTRACT:
                 return Result.fail(
-                    f"extract '{sr.step_id}' has no support: its filter matched no rows "
-                    f"(aggregated to NULL) — metric inconclusive, not a real value"
+                    f"extract '{sr.step_id}' has no support: it aggregated to NULL — "
+                    "either its filter matched no rows, or an aggregated operand is "
+                    "entirely NULL over the rows it did match; metric inconclusive, "
+                    "not a real value"
                 )
             return Result.fail(
                 f"step '{sr.step_id}' computed to NULL (degenerate) — metric inconclusive"

--- a/packages/engine/src/dataraum/llm/providers/anthropic.py
+++ b/packages/engine/src/dataraum/llm/providers/anthropic.py
@@ -408,28 +408,55 @@ class AnthropicProvider(LLMProvider):
                 response = stream.get_final_message()
             elapsed_ms = round((time.perf_counter() - start) * 1000)
 
-            # Extract content and tool calls from response
+            # Extract content and tool calls from response. raw_content keeps
+            # the turn's blocks VERBATIM (incl. signed thinking blocks) so a
+            # continued conversation can echo the assistant turn back — the
+            # thinking-model API rejects a continuation whose assistant turn
+            # lost its thinking blocks (DAT-699).
             text_content = ""
             tool_calls: list[ToolCall] = []
+            raw_content: list[dict[str, Any]] = []
 
             schemas_by_name = {t.name: t.input_schema for t in request.tools}
             for block in response.content:
                 if block.type == "text":
                     text_content += block.text
+                    raw_content.append({"type": "text", "text": block.text})
                 elif block.type == "tool_use":
-                    raw_input = dict(block.input) if block.input else {}
+                    original_input = dict(block.input) if block.input else {}
+                    # Echo the ORIGINAL input in raw_content (exact round-trip);
+                    # the coerced form is for OUR consumers only.
+                    raw_content.append(
+                        {
+                            "type": "tool_use",
+                            "id": block.id,
+                            "name": block.name,
+                            "input": original_input,
+                        }
+                    )
+                    coerced = original_input
                     tool_schema = schemas_by_name.get(block.name)
                     if tool_schema is not None:
-                        raw_input = _coerce_stringified_args(
-                            raw_input, tool_schema, label=request.label
+                        coerced = _coerce_stringified_args(
+                            original_input, tool_schema, label=request.label
                         )
                     tool_calls.append(
                         ToolCall(
                             id=block.id,
                             name=block.name,
-                            input=raw_input,
+                            input=coerced,
                         )
                     )
+                elif block.type == "thinking":
+                    raw_content.append(
+                        {
+                            "type": "thinking",
+                            "thinking": block.thinking,
+                            "signature": block.signature,
+                        }
+                    )
+                elif block.type == "redacted_thinking":
+                    raw_content.append({"type": "redacted_thinking", "data": block.data})
 
             # Cache-usage fields are optional on the SDK Usage object (None when
             # no cache_control is in play — the engine today, until DAT-601);
@@ -464,6 +491,7 @@ class AnthropicProvider(LLMProvider):
                 ConversationResponse(
                     content=text_content,
                     tool_calls=tool_calls,
+                    raw_content=raw_content or None,
                     stop_reason=response.stop_reason or "end_turn",
                     model=response.model,
                     input_tokens=usage.input_tokens,
@@ -526,6 +554,15 @@ class AnthropicProvider(LLMProvider):
                     result.append(cast(MessageParam, {"role": "user", "content": msg.content}))
 
             elif msg.role == "assistant":
+                # Verbatim continuation (DAT-699): an echoed assistant turn uses
+                # its captured blocks unchanged — signed thinking blocks must
+                # round-trip exactly or the API rejects the continuation.
+                if msg.raw_content:
+                    result.append(
+                        cast(MessageParam, {"role": "assistant", "content": msg.raw_content})
+                    )
+                    continue
+
                 # Assistant message - could have text and/or tool calls
                 content_blocks: list[Any] = []
 

--- a/packages/engine/src/dataraum/llm/providers/base.py
+++ b/packages/engine/src/dataraum/llm/providers/base.py
@@ -101,6 +101,13 @@ class Message(BaseModel):
     role: str  # "user", "assistant", "tool_result"
     content: str | list[ToolResult] = ""
     tool_calls: list[ToolCall] | None = None  # For assistant messages with tool use
+    # Verbatim provider content blocks for an ASSISTANT turn being echoed back
+    # in a continued conversation (DAT-699). A thinking model's assistant turn
+    # must round-trip its (signed) thinking blocks when the conversation
+    # continues past a tool call — rebuilding from text + tool_calls drops
+    # them and the API rejects the continuation. Set from
+    # ConversationResponse.raw_content; None = rebuild from text/tool_calls.
+    raw_content: list[dict[str, Any]] | None = None
 
 
 class ConversationRequest(BaseModel):
@@ -137,6 +144,9 @@ class ConversationResponse(BaseModel):
 
     content: str  # Text content (may be empty if only tool calls)
     tool_calls: list[ToolCall] = Field(default_factory=list)
+    # The turn's verbatim content blocks (text / tool_use / thinking /
+    # redacted_thinking) for continuation — see Message.raw_content (DAT-699).
+    raw_content: list[dict[str, Any]] | None = None
     stop_reason: str  # "end_turn", "tool_use", "max_tokens"
     model: str
     input_tokens: int

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -56,6 +56,41 @@ from dataraum.storage import Column, Table
 logger = get_logger(__name__)
 
 
+def _dossier(rel: Relationship) -> str:
+    """The enrichment judge's dossier fingerprint for one relationship row."""
+    from dataraum.analysis.views.enrichment_agent import dossier_fingerprint
+
+    return dossier_fingerprint(
+        rel.cardinality, rel.confidence, (rel.evidence or {}).get("coverage")
+    )
+
+
+def _unchanged_considered_pairs(
+    entries: list[Any] | None,
+    current: dict[tuple[str, str], Relationship],
+) -> set[tuple[str, str]]:
+    """The prior considered pairs whose dossier is UNCHANGED (DAT-699).
+
+    Entries are ``[from_col, to_col, dossier_fingerprint]``. The DAT-516 sticky
+    shape froze the VERDICT but the dossier isn't frozen — pairs judged before
+    DAT-695 existed never saw the coverage note, and inheritance meant they
+    never would. A pair re-opens (counts as undecided, re-offered to the
+    judge) when its current dossier no longer matches the one its verdict was
+    made on, and when the stored entry carries no fingerprint at all (the
+    dossier the judge saw is unknown — conservatively re-ask). A pair absent
+    from the current catalog stays considered: there is nothing to re-judge,
+    and the existing Layer-A prune handles real drop+re-adds.
+    """
+    out: set[tuple[str, str]] = set()
+    for entry in entries or []:
+        pair = (entry[0], entry[1])
+        fingerprint = entry[2] if len(entry) > 2 else None
+        rel = current.get(pair)
+        if rel is None or (fingerprint is not None and fingerprint == _dossier(rel)):
+            out.add(pair)
+    return out
+
+
 def _lake_fqn(layer: str, bare: str) -> str:
     """Fully-qualified DuckDB name ``catalog.schema."bare"`` for a lake-layer artifact.
 
@@ -197,7 +232,11 @@ class EnrichedViewsPhase(BasePhase):
 
         def considered_pairs(fact_id: str) -> set[tuple[str, str]]:
             pv = prior_views.get(fact_id)
-            return {(a, b) for a, b in (pv.considered_relationship_pairs or [])} if pv else set()
+            if pv is None:
+                return set()
+            return _unchanged_considered_pairs(
+                pv.considered_relationship_pairs, rels_touching.get(fact_id, {})
+            )
 
         # Feed the enrichment LLM ONLY the undecided relationships (candidates not yet
         # judged for their fact), and skip the call entirely when none are undecided — the
@@ -451,11 +490,14 @@ class EnrichedViewsPhase(BasePhase):
             # later returns is thus re-judged, not stuck invisible — and since Layer A's
             # silent-accept keeps the confirmed SET stable across runs, this prune only fires
             # on a real drop+re-add, never on LLM re-judgment (the determinism the ticket wants).
+            # Each entry carries the DOSSIER FINGERPRINT its verdict was made on
+            # (DAT-699): the verdict sticks only while the measured evidence the
+            # judge saw is unchanged — a changed dossier re-opens the pair.
             considered_now = considered_pairs(fact_id) & set(cand_by_pair)
             if judged:
                 considered_now |= set(cand_by_pair)
             view_record.considered_relationship_pairs = [
-                [a, b] for (a, b) in sorted(considered_now)
+                [a, b, _dossier(cand_by_pair[(a, b)])] for (a, b) in sorted(considered_now)
             ]
             view_record.exposed_dimension_joins = [
                 {

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -4,13 +4,17 @@ Creates grain-preserving DuckDB views that LEFT JOIN fact tables with their
 confirmed dimension tables. Uses LLM to identify which relationships add
 valuable analytical dimensions (geographic, category, reference data).
 
-Only uses relationships that are:
-- Confirmed by LLM (detection_method = "llm")
-- Cardinality many_to_one or one_to_one (grain-preserving)
-- Confidence >= 0.7
-- Not flagged as introducing duplicates
+The enrichment judge sees EVERY defined relationship (llm / manual / keeper —
+raw candidates never reach this phase; they die at the semantic judge). The
+old ``confidence >= 0.7`` floor was an uncalibrated numeric gate deciding on
+the judge's behalf which already-verified relationships it was allowed to see
+— and keeper rows carried a fabricated ``confidence=1.0`` that sailed through
+it anyway (DAT-699). Confidence and cardinality are served as evidence; the
+judge decides.
 
-Post-creation: verifies row count matches fact table. Drops view if grain violated.
+Post-creation: verifies row count matches fact table. Drops view if grain
+violated — grain is the view's CONTRACT (a fan-out view silently corrupts
+every downstream number), so this stays deterministic.
 """
 
 from __future__ import annotations
@@ -50,8 +54,6 @@ from dataraum.server.storage import LAKE_CATALOG_ALIAS
 from dataraum.storage import Column, Table
 
 logger = get_logger(__name__)
-
-_MIN_CONFIDENCE = 0.7
 
 
 def _lake_fqn(layer: str, bare: str) -> str:
@@ -160,7 +162,6 @@ class EnrichedViewsPhase(BasePhase):
             table_ids,
             run_id=ctx.run_id,
             both_tables=False,
-            min_confidence=_MIN_CONFIDENCE,
         )
 
         # Build column lookups

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -317,15 +317,20 @@ class MetricsPhase(BasePhase):
         for graph_id, result, inspiration_id in results:
             artifact = artifacts[graph_id]
             if result.success:
-                # DAT-631: consume the grounding confidence. A clean+verified run
-                # reaches executed, but if its weakest input grounded below the
-                # floor we record WHY on the (still-executed) artifact, so it is
-                # no longer silently green.
-                reason = _low_confidence_reason(result.value)
+                # Execute-and-flag (DAT-631 + DAT-699): a clean run reaches
+                # executed, and everything the run has to say about the number
+                # rides the (still-executed) artifact's state_reason — the
+                # weakest input's low grounding confidence AND any declared
+                # expectations the executed value violates. Never silently
+                # green, never a refused number.
+                confidence_reason = _low_confidence_reason(result.value)
+                flags = result.value.verification_flags if result.value else []
+                parts = [p for p in [confidence_reason, *flags] if p]
+                reason = "; ".join(parts) or None
                 transition(artifact, operation="execute", stage=_STAGE, state_reason=reason)
                 if reason:
                     low_confidence += 1
-                    _log.warning("metric_executed_low_confidence", graph_id=graph_id, reason=reason)
+                    _log.warning("metric_executed_flagged", graph_id=graph_id, reason=reason)
                 else:
                     _log.info("metric_executed", graph_id=graph_id)
                 # Snippet promotion: drop the ad-hoc snippet once the metric it
@@ -350,10 +355,11 @@ class MetricsPhase(BasePhase):
         previews: list[str] = []
         for graph_id, a in artifacts.items():
             if a.state == "executed":
-                # An executed artifact carries a reason ONLY when flagged
-                # low-confidence (DAT-631) — surface it so the flag is visible.
+                # An executed artifact carries a reason ONLY when flagged —
+                # low grounding confidence (DAT-631) and/or a declared
+                # expectation the value violates (DAT-699). Surface it.
                 if a.state_reason:
-                    previews.append(f"{graph_id}: executed (low-confidence) — {a.state_reason}")
+                    previews.append(f"{graph_id}: executed (flagged) — {a.state_reason}")
                 else:
                     previews.append(f"{graph_id}: executed")
             else:

--- a/packages/engine/tests/integration/graphs/test_agent.py
+++ b/packages/engine/tests/integration/graphs/test_agent.py
@@ -1105,6 +1105,11 @@ class TestPriorContextFeedback:
         assert "SENTINEL_NO_SUPPORT" in out
         assert "SELECT SUM(x)" in out
         assert "do NOT re-emit unchanged" in out
+        # DAT-699: the NULL-ambiguity steer — the agent must be told how to
+        # resolve BOTH cases (absent concept -> abstain; one-sided ledger ->
+        # row-guarded netting), because the verifier no longer asserts a cause.
+        assert "concept has no supporting rows (abstain" in out
+        assert "one-sided ledger" in out
 
     def test_retained_failure_reuse_excluded_but_fed_back(
         self, session: Session, sample_graph

--- a/packages/engine/tests/integration/graphs/test_agent.py
+++ b/packages/engine/tests/integration/graphs/test_agent.py
@@ -1106,10 +1106,10 @@ class TestPriorContextFeedback:
         assert "SELECT SUM(x)" in out
         assert "do NOT re-emit unchanged" in out
         # DAT-699: the NULL-ambiguity steer — the agent must be told how to
-        # resolve BOTH cases (absent concept -> abstain; one-sided ledger ->
-        # row-guarded netting), because the verifier no longer asserts a cause.
+        # resolve BOTH cases (absent concept -> abstain; one-sided data ->
+        # row-guarded combination), because the verifier no longer asserts a cause.
         assert "concept has no supporting rows (abstain" in out
-        assert "one-sided ledger" in out
+        assert "one-sided data" in out
 
     def test_retained_failure_reuse_excluded_but_fed_back(
         self, session: Session, sample_graph

--- a/packages/engine/tests/unit/analysis/relationships/test_composite.py
+++ b/packages/engine/tests/unit/analysis/relationships/test_composite.py
@@ -231,13 +231,9 @@ def test_coverage_none_on_empty_or_missing(con) -> None:
 def test_rescued_key_carries_coverage(con) -> None:
     """The canonical rescue fixture matches every fact row → coverage 1.0."""
     con.execute("CREATE TABLE txn2 (account VARCHAR, business_id VARCHAR)")
-    con.execute(
-        "INSERT INTO txn2 VALUES ('Sales','B1'),('Sales','B2'),('COGS','B1'),('COGS','B2')"
-    )
+    con.execute("INSERT INTO txn2 VALUES ('Sales','B1'),('Sales','B2'),('COGS','B1'),('COGS','B2')")
     con.execute("CREATE TABLE coa2 (account_name VARCHAR, business_id VARCHAR)")
-    con.execute(
-        "INSERT INTO coa2 VALUES ('Sales','B1'),('COGS','B1'),('Sales','B2'),('COGS','B2')"
-    )
+    con.execute("INSERT INTO coa2 VALUES ('Sales','B1'),('COGS','B1'),('Sales','B2'),('COGS','B2')")
     key = rescue_fanout_to_composite(
         _candidate(
             "txn2", "coa2", [("account", "account_name", 0.9), ("business_id", "business_id", 0.5)]
@@ -255,9 +251,7 @@ def test_coverage_is_oriented_to_the_referencing_side(con) -> None:
     the MANY (referencing) side either way, or a lookalike dim as table1 reads
     near-100% while the fact-side truth is tiny (DAT-695 review)."""
     con.execute("CREATE TABLE dim3 (account_name VARCHAR, business_id VARCHAR)")
-    con.execute(
-        "INSERT INTO dim3 VALUES ('Sales','B1'),('Sales','B2'),('COGS','B1'),('COGS','B2')"
-    )
+    con.execute("INSERT INTO dim3 VALUES ('Sales','B1'),('Sales','B2'),('COGS','B1'),('COGS','B2')")
     con.execute("CREATE TABLE fact3 (account VARCHAR, business_id VARCHAR)")
     # 10 fact rows; only the two ('Sales','B1') rows resolve against dim3.
     con.execute(

--- a/packages/engine/tests/unit/analysis/relationships/test_relationship_durability.py
+++ b/packages/engine/tests/unit/analysis/relationships/test_relationship_durability.py
@@ -136,6 +136,29 @@ def test_load_defined_relationships_excludes_candidates_and_scopes_run(session: 
     assert all(r.run_id == "run-A" for r in defined)
 
 
+def test_load_defined_relationships_has_no_confidence_gate(session: Session) -> None:
+    """A defined row is judge-verified or user-asserted — a numeric floor here
+    would pre-empt downstream judges with an uncalibrated number (DAT-699).
+    Low-confidence rows are served as evidence, never filtered."""
+    _seed_tables_columns(session)
+    session.add(
+        Relationship(
+            run_id="run-A",
+            from_table_id="t1",
+            from_column_id="ca",
+            to_table_id="t2",
+            to_column_id="cb",
+            relationship_type="foreign_key",
+            confidence=0.3,
+            detection_method="llm",
+        )
+    )
+    session.flush()
+
+    defined = load_defined_relationships(session, ["t1", "t2"], run_id="run-A")
+    assert [r.confidence for r in defined] == [0.3]
+
+
 def test_suppressed_pairs_read_from_reject_overlay(session: Session) -> None:
     """``load_suppressed_relationship_pairs`` returns only active reject pairs."""
     session.add(

--- a/packages/engine/tests/unit/analysis/relationships/test_relationship_durability.py
+++ b/packages/engine/tests/unit/analysis/relationships/test_relationship_durability.py
@@ -295,9 +295,27 @@ def test_materialize_add_overlay_creates_manual(session: Session) -> None:
     assert row.is_confirmed is True
 
 
-def test_materialize_keep_overlay_creates_keeper(session: Session) -> None:
-    """A `keep` overlay (silent-accept) materializes as `keeper`, not `manual`."""
+def test_materialize_keep_overlay_creates_keeper_with_last_measured_evidence(
+    session: Session,
+) -> None:
+    """A `keep` overlay materializes as `keeper` CARRYING its last measurement
+    (DAT-699): the newest llm row's confidence/cardinality/evidence, stamped
+    not_remeasured — never a fabricated confidence=1.0 with no cardinality."""
     _seed_tables_columns(session)
+    session.add(
+        Relationship(
+            run_id="r0",
+            from_table_id="t1",
+            from_column_id="ca",
+            to_table_id="t2",
+            to_column_id="cb",
+            relationship_type="foreign_key",
+            cardinality="many-to-one",
+            confidence=0.85,
+            detection_method="llm",
+            evidence={"coverage": 0.92},
+        )
+    )
     _overlay(session, "keep", "ca", "cb")
     session.flush()
 
@@ -306,6 +324,30 @@ def test_materialize_keep_overlay_creates_keeper(session: Session) -> None:
 
     rows = _materialized(session)
     assert [r.detection_method for r in rows] == ["keeper"]
+    keeper = rows[0]
+    assert keeper.confidence == 0.85
+    assert keeper.cardinality == "many-to-one"
+    assert keeper.evidence == {
+        "coverage": 0.92,
+        "source": "config_overlay",
+        "action": "keep",
+        "measured_run_id": "r0",
+        "not_remeasured": True,
+    }
+
+
+def test_keep_overlay_without_measurement_is_skipped_loud(session: Session) -> None:
+    """A keeper is lifted FROM an llm row; with no measurement recoverable it
+    has no basis — any stamped confidence would be fabricated. Loud skip."""
+    _seed_tables_columns(session)
+    _overlay(session, "keep", "ca", "cb")
+    session.flush()
+
+    count = materialize_relationship_overlays(session, run_id="r1", table_ids=["t1", "t2"])
+    session.flush()
+
+    assert count == 0
+    assert _materialized(session) == []
 
 
 def test_materialize_joins_a_pair_already_llm_this_run(session: Session) -> None:
@@ -347,7 +389,14 @@ def test_confirm_overlay_materializes_a_manual_row_beside_llm(session: Session) 
     pairs = session.query(Relationship).filter(Relationship.run_id == "r1").all()
     by_method = {p.detection_method: p for p in pairs}
     assert set(by_method) == {"llm", "manual"}
-    assert by_method["manual"].evidence == {"source": "config_overlay", "action": "confirm"}
+    manual = by_method["manual"]
+    # The user's assertion keeps confidence 1.0 (their voice, not a fabrication)
+    # and copies the pair's last measurement alongside the overlay stamp.
+    assert manual.confidence == 1.0
+    assert manual.evidence["source"] == "config_overlay"
+    assert manual.evidence["action"] == "confirm"
+    assert manual.evidence["not_remeasured"] is True
+    assert manual.evidence["measured_run_id"] == "r1"
 
 
 def test_add_and_confirm_overlays_never_duplicate_the_manual_row(session: Session) -> None:

--- a/packages/engine/tests/unit/graphs/test_assemble.py
+++ b/packages/engine/tests/unit/graphs/test_assemble.py
@@ -240,3 +240,46 @@ def test_assemble_partial_report_names_every_hole_not_just_the_first() -> None:
     assert "'cost_of_goods_sold', 'revenue' are ungroundable" in error
     assert "reason-a" in error and "reason-b" in error
     provider.converse.assert_not_called()
+
+
+def test_assemble_executes_and_flags_a_violated_declared_expectation() -> None:
+    """DAT-699: a declared expectation is a 'should', not a gate — the metric
+    EXECUTES and the violation rides execution.verification_flags to the
+    artifact's state_reason (the amber pattern). The old gate refused the
+    number ('composed but not executed: declared validation failed')."""
+    import duckdb
+
+    from dataraum.graphs.models import StepValidation
+
+    cogs = GraphStep(
+        step_id="cost_of_goods_sold",
+        step_type=StepType.EXTRACT,
+        source=StepSource(standard_field="cost_of_goods_sold", statement="income_statement"),
+        aggregation="sum",
+        output_step=True,
+        validations=[StepValidation(condition="value >= 0", message="COGS should not be negative")],
+    )
+    graph = _graph("cogs_only", {"cost_of_goods_sold": cogs})
+    bindings = {node_key(cogs, graph): NodeDecision(grounded=True)}
+    provider = MagicMock()
+    agent = _bare_agent(provider)
+    config = MagicMock()
+    config.features.sql_repair = None
+    agent.config = config  # type: ignore[attr-defined]
+    agent._lookup_snippets = MagicMock(  # type: ignore[method-assign]
+        return_value={"cost_of_goods_sold": {"sql": "SELECT -4200000.0 AS value"}}
+    )
+    agent._resolve_parameters = MagicMock(return_value={})  # type: ignore[method-assign]
+    agent._track_snippet_usage = MagicMock()  # type: ignore[method-assign]
+    agent._save_composed_snippets = MagicMock()  # type: ignore[method-assign]
+    ctx = ExecutionContext(duckdb_conn=duckdb.connect(), schema_mapping_id="ws")
+
+    result = agent.assemble(MagicMock(), graph, ctx, bindings, workspace_id="ws")
+
+    assert result.success  # the number is never refused
+    execution = result.unwrap()
+    assert execution.output_value == -4200000.0
+    assert len(execution.verification_flags) == 1
+    assert "declared expectation not met" in execution.verification_flags[0]
+    assert "COGS should not be negative" in execution.verification_flags[0]
+    provider.converse.assert_not_called()

--- a/packages/engine/tests/unit/graphs/test_assemble.py
+++ b/packages/engine/tests/unit/graphs/test_assemble.py
@@ -154,3 +154,89 @@ class TestSaveSnippetsCallerAssignedIds:
         graph = _graph("revenue_only", {"revenue": rev})
         library = self._save(graph, self._generated("someone_elses_id"))
         library.save_snippet.assert_not_called()
+
+
+def _leaf(step_id: str) -> GraphStep:
+    """A NON-output extract leaf — real metric graphs have exactly one output."""
+    return GraphStep(
+        step_id=step_id,
+        step_type=StepType.EXTRACT,
+        source=StepSource(standard_field=step_id, statement="income_statement"),
+        aggregation="sum",
+    )
+
+
+def test_assemble_executes_the_groundable_subgraph_and_reports_per_step() -> None:
+    """DAT-699: an ungroundable dep no longer aborts the whole graph silently.
+    The groundable extracts EXECUTE (real values in the reason), the holes are
+    named with their reasons, and downstream formulas read as blocked — the
+    per-step story the drill-down renders. The metric itself still fails."""
+    import duckdb
+
+    revenue = _leaf("revenue")
+    cogs = _leaf("cost_of_goods_sold")
+    gross = GraphStep(
+        step_id="gross_profit",
+        step_type=StepType.FORMULA,
+        expression="revenue - cost_of_goods_sold",
+        depends_on=["revenue", "cost_of_goods_sold"],
+        output_step=True,
+    )
+    graph = _graph(
+        "gross_profit",
+        {"revenue": revenue, "cost_of_goods_sold": cogs, "gross_profit": gross},
+    )
+    bindings = {
+        node_key(revenue, graph): NodeDecision(grounded=True),
+        node_key(cogs, graph): NodeDecision(
+            grounded=False, reason="no support: it aggregated to NULL"
+        ),
+    }
+    provider = MagicMock()
+    agent = _bare_agent(provider)
+    config = MagicMock()
+    config.features.sql_repair = None  # default repair attempts (int), never a mock
+    agent.config = config  # type: ignore[attr-defined]
+    agent._lookup_snippets = MagicMock(  # type: ignore[method-assign]
+        return_value={"revenue": {"sql": "SELECT 5925920163.0 AS value"}}
+    )
+    agent._resolve_parameters = MagicMock(return_value={})  # type: ignore[method-assign]
+    ctx = ExecutionContext(duckdb_conn=duckdb.connect(), schema_mapping_id="ws")
+
+    result = agent.assemble(MagicMock(), graph, ctx, bindings, workspace_id="ws")
+
+    assert result.success is False
+    error = result.error or ""
+    # The hole, named with its honest reason:
+    assert "dependency 'cost_of_goods_sold' is ungroundable" in error
+    assert "no support" in error
+    # The groundable extract EXECUTED — its measured value is in the reason:
+    assert "revenue = 5,925,920,163.00 ✓" in error
+    # The formula downstream of the hole is blocked, not silently absent:
+    assert "gross_profit blocked (needs cost_of_goods_sold)" in error
+    # Still no LLM anywhere in assembly.
+    provider.converse.assert_not_called()
+
+
+def test_assemble_partial_report_names_every_hole_not_just_the_first() -> None:
+    """Two ungroundable deps → both named (the old path aborted on the first)."""
+    revenue = _leaf("revenue")
+    cogs = _leaf("cost_of_goods_sold")
+    graph = _graph("both_dead", {"revenue": revenue, "cost_of_goods_sold": cogs})
+    bindings = {
+        node_key(revenue, graph): NodeDecision(grounded=False, reason="reason-a"),
+        node_key(cogs, graph): NodeDecision(grounded=False, reason="reason-b"),
+    }
+    provider = MagicMock()
+    agent = _bare_agent(provider)
+    agent._lookup_snippets = MagicMock(return_value={})  # type: ignore[method-assign]
+    agent._resolve_parameters = MagicMock(return_value={})  # type: ignore[method-assign]
+    ctx = ExecutionContext(duckdb_conn=MagicMock(), schema_mapping_id="ws")
+
+    result = agent.assemble(MagicMock(), graph, ctx, bindings, workspace_id="ws")
+
+    assert result.success is False
+    error = result.error or ""
+    assert "'cost_of_goods_sold', 'revenue' are ungroundable" in error
+    assert "reason-a" in error and "reason-b" in error
+    provider.converse.assert_not_called()

--- a/packages/engine/tests/unit/graphs/test_context.py
+++ b/packages/engine/tests/unit/graphs/test_context.py
@@ -671,8 +671,9 @@ class TestValueSetGrounding:
         """DAT-699: a high-card / incompletely-fetched column (distinct > served) renders
         size + a frequency sample + the search_values hint — the agent can now DRILL for
         exact values instead of the old render-nothing rule, which made a
-        present-but-unenumerated concept structurally ungroundable (BookSQL's
-        Depreciation/Taxes accounts sat unseen in a 340-name column). The values still
+        present-but-unenumerated concept structurally ungroundable (concepts
+        present by name in a several-hundred-value column were unreachable). The
+        values still
         never render as an enumeration the agent might mistake for the complete set."""
         table = TableContext(
             table_id="t1",

--- a/packages/engine/tests/unit/graphs/test_context.py
+++ b/packages/engine/tests/unit/graphs/test_context.py
@@ -667,11 +667,13 @@ class TestValueSetGrounding:
         assert "Sales Revenue (120)" in result
         assert "COGS (100)" in result
 
-    def test_high_card_column_not_served_to_graph_agent(self) -> None:
-        """DAT-621: the one-shot GraphAgent gets the LOW-CARD BASELINE only. A high-card /
-        incompletely-fetched column (distinct > served) is NOT rendered at all — no size
-        line, no partial sample. High-card is the cockpit sub-agent's + user's drill lane;
-        dangling it here only invites the ILIKE-guess that is the root bug."""
+    def test_high_card_column_served_as_explorable_never_enumerated(self) -> None:
+        """DAT-699: a high-card / incompletely-fetched column (distinct > served) renders
+        size + a frequency sample + the search_values hint — the agent can now DRILL for
+        exact values instead of the old render-nothing rule, which made a
+        present-but-unenumerated concept structurally ungroundable (BookSQL's
+        Depreciation/Taxes accounts sat unseen in a 340-name column). The values still
+        never render as an enumeration the agent might mistake for the complete set."""
         table = TableContext(
             table_id="t1",
             table_name="ledger",
@@ -679,11 +681,11 @@ class TestValueSetGrounding:
         )
         result = format_metadata_document(GraphExecutionContext(tables=[table], total_tables=1))
 
-        # The column is still MENTIONED in the catalog, but carries NO value-set entry and
-        # no size-only/abstain line — high-card is simply not a groundable surface here.
-        assert "**cost_center**" not in result  # no value-set entry
-        assert "not inlined" not in result  # the old size-only branch is gone
-        assert "North (9)" not in result  # no partial value sample leaked
+        assert "**cost_center**: 30 distinct values — NOT enumerated" in result
+        assert "search_values" in result
+        assert "Most frequent: North, South" in result
+        assert "North (9)" not in result  # a sample, never a count-enumerated value set
+        assert "(complete" not in result  # and never marked complete
 
     def test_near_constant_column_flagged_not_served(self) -> None:
         """A near-constant column (one value ≥90%) is flagged, never served as groundable —

--- a/packages/engine/tests/unit/graphs/test_loader.py
+++ b/packages/engine/tests/unit/graphs/test_loader.py
@@ -52,26 +52,30 @@ class TestLoadMetricGraphs:
 class TestParseStepValidation:
     """The catalogue's per-extract `validation:` block is parsed, not dropped (DAT-616)."""
 
-    def test_finance_gross_margin_revenue_condition_parsed(self) -> None:
-        """gross_margin's revenue extract carries its declared `value > 0` check."""
+    def test_finance_dso_formula_expectation_parsed(self) -> None:
+        """dso's formula step carries its declared plausibility range — a chained
+        comparison at severity=warning, parsed from the shipped config."""
         loader = _finance_loader()
-        gm = loader.graphs["gross_margin"]
-        revenue = gm.steps["revenue"]
-        assert len(revenue.validations) == 1
-        assert revenue.validations[0].condition == "value > 0"
-        assert revenue.validations[0].severity == "error"
-        assert "positive" in revenue.validations[0].message.lower()
-        # The cogs extract declares no condition; the formula step none either.
-        assert gm.steps["cost_of_goods_sold"].validations == []
-        assert gm.steps["gross_margin"].validations == []
+        dso = loader.graphs["dso"]
+        formula = dso.steps["dso"]
+        assert [v.condition for v in formula.validations] == ["0 <= value <= 365"]
+        assert formula.validations[0].severity == "warning"
 
-    def test_finance_gross_profit_cogs_condition_parsed(self) -> None:
-        """gross_profit's cogs extract carries its declared `value >= 0` check."""
+    def test_finance_extract_steps_declare_no_sign_bounds(self) -> None:
+        """DAT-699: extract-level sign expectations were removed from the metric
+        catalogue — the sign rule's home is the vertical's sign_natural_balance
+        convention (authoring) + the sign_conventions validation (dataset-level).
+        A per-metric `value > 0` on a shared extract was a duplicated hard gate
+        that blocked real numbers and drifted between hand-copied blocks."""
         loader = _finance_loader()
-        gp = loader.graphs["gross_profit"]
-        cogs = gp.steps["cost_of_goods_sold"]
-        assert [v.condition for v in cogs.validations] == ["value >= 0"]
-        assert [v.condition for v in gp.steps["revenue"].validations] == ["value > 0"]
+        from dataraum.graphs.models import StepType
+
+        for graph in loader.graphs.values():
+            for step in graph.steps.values():
+                if step.step_type == StepType.EXTRACT:
+                    assert step.validations == [], (
+                        f"{graph.graph_id}.{step.step_id} declares an extract-level bound"
+                    )
 
     def test_missing_validation_block_yields_empty_list(self) -> None:
         """A step with no `validation:` key parses to an empty list, not None."""

--- a/packages/engine/tests/unit/graphs/test_prompt_selection.py
+++ b/packages/engine/tests/unit/graphs/test_prompt_selection.py
@@ -130,9 +130,12 @@ def test_feature_config_sets_tier_and_effort(monkeypatch) -> None:
     provider.get_model_for_tier.assert_called_with("fast")
     request = provider.converse.call_args.args[0]
     assert request.effort == "low"
-    # thinking not set on the feature → forced tool_choice, thinking off.
+    # thinking not set on the feature → thinking off; tool_choice is "any"
+    # (some tool must be called — search_values or generate_sql; forcing
+    # generate_sql would make the DAT-699 catalog search impossible), one
+    # call per turn.
     assert request.thinking is False
-    assert request.tool_choice == {"type": "tool", "name": "generate_sql"}
+    assert request.tool_choice == {"type": "any", "disable_parallel_tool_use": True}
 
 
 def test_thinking_feature_uses_auto_tool_choice(monkeypatch) -> None:

--- a/packages/engine/tests/unit/graphs/test_tool_repair.py
+++ b/packages/engine/tests/unit/graphs/test_tool_repair.py
@@ -1,0 +1,167 @@
+"""Tool-boundary schema enforcement with a repair turn (DAT-699).
+
+The grounding output schema is ENFORCED, never coerced: when the model's
+generate_sql arguments fail validation (live kill: `provenance` emitted as a
+JSON-encoded string), the agent re-prompts the model with its own output plus
+the exact validation error under a forced tool choice, and validates again.
+One finished, correct grounding must never be discarded whole on a
+serialization slip — and the repair is the model's, not a silent
+``json.loads`` behind its back.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from dataraum.graphs.agent import ExecutionContext, GraphAgent
+from dataraum.graphs.models import (
+    GraphMetadata,
+    GraphSource,
+    GraphStep,
+    OutputDef,
+    OutputType,
+    StepSource,
+    StepType,
+    TransformationGraph,
+)
+
+_VALID_INPUT = {
+    "grounding": "revenue via account_type = 'Income' (complete value set)",
+    "sql": "SELECT SUM(amount) AS value FROM t WHERE account_type IN ('Income')",
+    "description": "Total revenue",
+    "provenance": {
+        "field_resolution": "direct",
+        "column_mappings_basis": {"revenue": {"column": "amount", "filter": "Income"}},
+    },
+}
+
+# The live failure shape: the nested provenance object emitted as a JSON string.
+_STRINGIFIED_INPUT = {**_VALID_INPUT, "provenance": json.dumps(_VALID_INPUT["provenance"])}
+
+
+def _graph() -> TransformationGraph:
+    ext = GraphStep(
+        step_id="revenue",
+        step_type=StepType.EXTRACT,
+        source=StepSource(standard_field="revenue", statement="income_statement"),
+        aggregation="sum",
+        output_step=True,
+    )
+    return TransformationGraph(
+        graph_id="revenue",
+        version="1.0",
+        metadata=GraphMetadata(
+            name="revenue", description="", category="profitability", source=GraphSource.SYSTEM
+        ),
+        output=OutputDef(output_type=OutputType.SCALAR),
+        steps={"revenue": ext},
+    )
+
+
+def _agent_with(provider: MagicMock) -> GraphAgent:
+    agent = GraphAgent.__new__(GraphAgent)
+    renderer = MagicMock()
+    renderer.render_split.return_value = ("system", "user", 0.0)
+    agent.renderer = renderer  # type: ignore[attr-defined]
+    agent.provider = provider  # type: ignore[attr-defined]
+    config = MagicMock()
+    config.limits.max_output_tokens_per_request = 4000
+    config.features.graph_sql_generation = None
+    agent.config = config  # type: ignore[attr-defined]
+    agent._build_schema_info = MagicMock(return_value={})  # type: ignore[method-assign]
+    agent._build_prior_context = MagicMock(return_value="")  # type: ignore[method-assign]
+    return agent
+
+
+def _tool_response(tool_input: dict | None) -> MagicMock:
+    response = MagicMock()
+    if tool_input is None:
+        response.tool_calls = []
+    else:
+        call = MagicMock()
+        call.name = "generate_sql"
+        call.input = tool_input
+        response.tool_calls = [call]
+    return response
+
+
+def _provider(*responses: MagicMock) -> MagicMock:
+    provider = MagicMock()
+    provider.get_model_for_tier.side_effect = lambda tier: f"model-{tier}"
+    results = [MagicMock(unwrap=MagicMock(return_value=r)) for r in responses]
+    provider.converse.side_effect = results
+    return provider
+
+
+def _ctx() -> ExecutionContext:
+    rich = MagicMock()
+    rich.field_mappings.mappings = {"revenue": object()}
+    rich.conventions = ""
+    return ExecutionContext(duckdb_conn=MagicMock(), schema_mapping_id="ws", rich_context=rich)
+
+
+def _generate(agent: GraphAgent) -> object:
+    return agent._generate_sql(MagicMock(), _graph(), _ctx(), {})
+
+
+def test_valid_output_needs_no_repair(monkeypatch) -> None:
+    monkeypatch.setattr("dataraum.graphs.context.format_metadata_document", lambda c: "META")
+    monkeypatch.setattr("dataraum.graphs.field_mapping.format_mappings_for_prompt", lambda f: "M")
+    provider = _provider(_tool_response(_VALID_INPUT))
+    agent = _agent_with(provider)
+
+    result = _generate(agent)
+
+    assert result.success
+    assert provider.converse.call_count == 1
+
+
+def test_stringified_field_is_repaired_by_the_model(monkeypatch) -> None:
+    """The live kill: provenance as a JSON string. The repair turn carries the
+    invalid input + the validation error, forces the tool, and the repaired
+    output grounds the extract — the finished SQL is never discarded."""
+    monkeypatch.setattr("dataraum.graphs.context.format_metadata_document", lambda c: "META")
+    monkeypatch.setattr("dataraum.graphs.field_mapping.format_mappings_for_prompt", lambda f: "M")
+    provider = _provider(_tool_response(_STRINGIFIED_INPUT), _tool_response(_VALID_INPUT))
+    agent = _agent_with(provider)
+
+    result = _generate(agent)
+
+    assert result.success
+    generated = result.unwrap()
+    assert generated.steps[0]["sql"] == _VALID_INPUT["sql"]
+    assert provider.converse.call_count == 2
+
+    repair_request = provider.converse.call_args_list[1].args[0]
+    assert repair_request.tool_choice == {"type": "tool", "name": "generate_sql"}
+    assert repair_request.label == "graph_sql_generation_repair"
+    content = repair_request.messages[0].content
+    assert "Validation error" in content
+    assert "field_resolution" in content  # the model's own output rides along
+
+
+def test_second_validation_failure_fails_loud_with_both_errors(monkeypatch) -> None:
+    monkeypatch.setattr("dataraum.graphs.context.format_metadata_document", lambda c: "META")
+    monkeypatch.setattr("dataraum.graphs.field_mapping.format_mappings_for_prompt", lambda f: "M")
+    provider = _provider(_tool_response(_STRINGIFIED_INPUT), _tool_response(_STRINGIFIED_INPUT))
+    agent = _agent_with(provider)
+
+    result = _generate(agent)
+
+    assert not result.success
+    assert "after a repair turn" in result.error
+    assert "original error" in result.error
+    assert provider.converse.call_count == 2
+
+
+def test_repair_turn_without_tool_call_fails_loud(monkeypatch) -> None:
+    monkeypatch.setattr("dataraum.graphs.context.format_metadata_document", lambda c: "META")
+    monkeypatch.setattr("dataraum.graphs.field_mapping.format_mappings_for_prompt", lambda f: "M")
+    provider = _provider(_tool_response(_STRINGIFIED_INPUT), _tool_response(None))
+    agent = _agent_with(provider)
+
+    result = _generate(agent)
+
+    assert not result.success
+    assert "no tool call" in result.error

--- a/packages/engine/tests/unit/graphs/test_value_search.py
+++ b/packages/engine/tests/unit/graphs/test_value_search.py
@@ -3,8 +3,8 @@
 High-cardinality discriminators are served size+sample only; their exact
 values live behind the search_values tool. The agent resolves them by
 substring search inside a small budget, then grounds its IN-list on the
-results — the BookSQL smoke's Depreciation / Taxes & Licenses accounts sat
-unseen in a 340-name column and the agent emitted SELECT NULL.
+results — before this, concepts present by name in a several-hundred-value
+column were unreachable and the agent emitted SELECT NULL for them.
 """
 
 from __future__ import annotations

--- a/packages/engine/tests/unit/graphs/test_value_search.py
+++ b/packages/engine/tests/unit/graphs/test_value_search.py
@@ -1,0 +1,239 @@
+"""The grounding agent's bounded catalog search (DAT-699).
+
+High-cardinality discriminators are served size+sample only; their exact
+values live behind the search_values tool. The agent resolves them by
+substring search inside a small budget, then grounds its IN-list on the
+results — the BookSQL smoke's Depreciation / Taxes & Licenses accounts sat
+unseen in a 340-name column and the agent emitted SELECT NULL.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import duckdb
+
+from dataraum.graphs.agent import ExecutionContext, GraphAgent
+from dataraum.graphs.context import ColumnContext, GraphExecutionContext, TableContext
+
+
+def _context(conn: duckdb.DuckDBPyConnection | None = None) -> ExecutionContext:
+    coa = TableContext(
+        table_id="t1",
+        table_name="chart_of_account_ob",
+        duckdb_name="coa",
+        columns=[
+            ColumnContext(
+                column_id="c1", column_name="account_name", table_name="chart_of_account_ob"
+            ),
+        ],
+    )
+    rich = GraphExecutionContext(tables=[coa], total_tables=1)
+    return ExecutionContext(
+        duckdb_conn=conn if conn is not None else MagicMock(),
+        schema_mapping_id="ws",
+        rich_context=rich,
+    )
+
+
+def _agent() -> GraphAgent:
+    return GraphAgent.__new__(GraphAgent)
+
+
+def _search(agent: GraphAgent, ctx: ExecutionContext, **kwargs: str) -> str:
+    return agent._run_value_search(ctx, dict(kwargs))
+
+
+class TestRunValueSearch:
+    def _conn(self) -> duckdb.DuckDBPyConnection:
+        conn = duckdb.connect()
+        conn.execute(
+            "CREATE TABLE coa AS SELECT * FROM (VALUES "
+            "('Depreciation'), ('Depreciation'), ('Taxes & Licenses'), "
+            "('Cost of Labor'), (NULL)) v(account_name)"
+        )
+        return conn
+
+    def test_matches_are_frequency_ordered_with_counts(self) -> None:
+        out = _search(
+            _agent(),
+            _context(self._conn()),
+            table="chart_of_account_ob",
+            column="account_name",
+            pattern="deprec",
+        )
+        assert "Depreciation (2 rows)" in out
+
+    def test_no_match_reports_honestly(self) -> None:
+        out = _search(
+            _agent(),
+            _context(self._conn()),
+            table="chart_of_account_ob",
+            column="account_name",
+            pattern="inventory",
+        )
+        assert "no values matching 'inventory'" in out
+
+    def test_pattern_wildcards_are_literal(self) -> None:
+        """% and _ in the pattern are text, not SQL wildcards — '%' must not
+        match everything."""
+        out = _search(
+            _agent(),
+            _context(self._conn()),
+            table="chart_of_account_ob",
+            column="account_name",
+            pattern="%",
+        )
+        assert "no values matching" in out
+
+    def test_unknown_table_returns_correctable_text(self) -> None:
+        out = _search(_agent(), _context(), table="nope", column="account_name", pattern="tax")
+        assert "unknown table 'nope'" in out
+        assert "chart_of_account_ob" in out  # the agent can correct itself
+
+    def test_unknown_column_returns_correctable_text(self) -> None:
+        out = _search(
+            _agent(),
+            _context(),
+            table="chart_of_account_ob",
+            column="nope",
+            pattern="tax",
+        )
+        assert "unknown column 'nope'" in out
+        assert "account_name" in out
+
+    def test_invalid_input_returns_text_never_raises(self) -> None:
+        out = _agent()._run_value_search(_context(), {"table": "coa"})
+        assert "invalid search_values input" in out
+
+
+# --- The bounded search loop inside _generate_sql ---------------------------------
+
+from dataraum.graphs.models import (  # noqa: E402
+    GraphMetadata,
+    GraphSource,
+    GraphStep,
+    OutputDef,
+    OutputType,
+    StepSource,
+    StepType,
+    TransformationGraph,
+)
+
+_VALID_OUTPUT = {
+    "grounding": "depreciation via account_name IN ('Depreciation') (searched)",
+    "sql": "SELECT SUM(amount) AS value FROM t WHERE account_name IN ('Depreciation')",
+    "description": "Depreciation expense",
+}
+
+
+def _graph() -> TransformationGraph:
+    ext = GraphStep(
+        step_id="depreciation",
+        step_type=StepType.EXTRACT,
+        source=StepSource(standard_field="depreciation", statement="income_statement"),
+        aggregation="sum",
+        output_step=True,
+    )
+    return TransformationGraph(
+        graph_id="depreciation",
+        version="1.0",
+        metadata=GraphMetadata(
+            name="depreciation", description="", category="profitability", source=GraphSource.SYSTEM
+        ),
+        output=OutputDef(output_type=OutputType.SCALAR),
+        steps={"depreciation": ext},
+    )
+
+
+def _response(tool_name: str | None, tool_input: dict | None = None) -> MagicMock:
+    from dataraum.llm.providers.base import ToolCall
+
+    response = MagicMock()
+    response.content = ""
+    response.raw_content = None
+    if tool_name is None:
+        response.tool_calls = []
+    else:
+        # Real ToolCall models — the loop echoes them back into a Message,
+        # which validates its fields (a MagicMock would be rejected).
+        response.tool_calls = [ToolCall(id="tc-1", name=tool_name, input=tool_input or {})]
+    return response
+
+
+def _loop_agent(provider: MagicMock) -> GraphAgent:
+    agent = GraphAgent.__new__(GraphAgent)
+    renderer = MagicMock()
+    renderer.render_split.return_value = ("system", "user", 0.0)
+    agent.renderer = renderer  # type: ignore[attr-defined]
+    agent.provider = provider  # type: ignore[attr-defined]
+    config = MagicMock()
+    config.limits.max_output_tokens_per_request = 4000
+    config.features.graph_sql_generation = None
+    agent.config = config  # type: ignore[attr-defined]
+    agent._build_schema_info = MagicMock(return_value={})  # type: ignore[method-assign]
+    agent._build_prior_context = MagicMock(return_value="")  # type: ignore[method-assign]
+    return agent
+
+
+def _rich_exec_ctx(conn: duckdb.DuckDBPyConnection) -> ExecutionContext:
+    ctx = _context(conn)
+    ctx.rich_context.field_mappings = MagicMock()
+    ctx.rich_context.field_mappings.mappings = {"depreciation": object()}
+    ctx.rich_context.conventions = ""
+    return ctx
+
+
+def _provider(*responses: MagicMock) -> MagicMock:
+    provider = MagicMock()
+    provider.get_model_for_tier.side_effect = lambda tier: f"model-{tier}"
+    provider.converse.side_effect = [MagicMock(unwrap=MagicMock(return_value=r)) for r in responses]
+    return provider
+
+
+def test_search_then_generate_grounds_with_the_searched_values(monkeypatch) -> None:
+    monkeypatch.setattr("dataraum.graphs.context.format_metadata_document", lambda c: "META")
+    monkeypatch.setattr("dataraum.graphs.field_mapping.format_mappings_for_prompt", lambda f: "M")
+    conn = duckdb.connect()
+    conn.execute("CREATE TABLE coa AS SELECT * FROM (VALUES ('Depreciation')) v(account_name)")
+    provider = _provider(
+        _response(
+            "search_values",
+            {"table": "chart_of_account_ob", "column": "account_name", "pattern": "deprec"},
+        ),
+        _response("generate_sql", _VALID_OUTPUT),
+    )
+    agent = _loop_agent(provider)
+
+    result = agent._generate_sql(MagicMock(), _graph(), _rich_exec_ctx(conn), {})
+
+    assert result.success
+    assert provider.converse.call_count == 2
+    # The second request's conversation carries the assistant turn + the
+    # search result the model grounds on.
+    second = provider.converse.call_args_list[1].args[0]
+    assert len(second.messages) == 3
+    tool_result = second.messages[2].content[0]
+    assert "Depreciation (1 rows)" in tool_result.content
+    assert tool_result.tool_use_id == "tc-1"
+
+
+def test_search_budget_exhaustion_fails_loud(monkeypatch) -> None:
+    """A model that never stops searching hits the budget and fails loud —
+    the last allowed search's result carries the budget notice."""
+    monkeypatch.setattr("dataraum.graphs.context.format_metadata_document", lambda c: "META")
+    monkeypatch.setattr("dataraum.graphs.field_mapping.format_mappings_for_prompt", lambda f: "M")
+    conn = duckdb.connect()
+    conn.execute("CREATE TABLE coa AS SELECT * FROM (VALUES ('Depreciation')) v(account_name)")
+    search = {"table": "chart_of_account_ob", "column": "account_name", "pattern": "x"}
+    provider = _provider(*[_response("search_values", search) for _ in range(5)])
+    agent = _loop_agent(provider)
+
+    result = agent._generate_sql(MagicMock(), _graph(), _rich_exec_ctx(conn), {})
+
+    assert not result.success
+    assert "search budget exhausted" in (result.error or "")
+    assert provider.converse.call_count == 5  # 1 initial + 4 budgeted continuations
+    # The final tool_result told the model to emit generate_sql now.
+    last = provider.converse.call_args_list[4].args[0]
+    assert "call generate_sql now" in last.messages[-1].content[0].content

--- a/packages/engine/tests/unit/graphs/test_verifier.py
+++ b/packages/engine/tests/unit/graphs/test_verifier.py
@@ -139,8 +139,14 @@ class TestSupportGate:
 
 
 class TestDeclaredConditions:
-    def test_violated_condition_fails_with_message(self) -> None:
-        """A declared `value > 0` on a 0-valued extract fails with the message."""
+    """Declared conditions are EXPECTATIONS, not gates (DAT-699): violations flag
+    the executed metric — the number is never refused. Result.fail is reserved
+    for no-value outcomes (the support gate)."""
+
+    def test_violated_condition_flags_with_message_never_gates(self) -> None:
+        """A declared `value > 0` on a 0-valued extract executes WITH the flag —
+        a "shouldn't" stated as "can't" used to block real numbers (negative
+        COGS is unusual, not impossible)."""
         graph = _graph(
             {
                 "revenue": _extract(
@@ -154,10 +160,15 @@ class TestDeclaredConditions:
         execution = _execution({"revenue": 0.0}, output_value=0.0)
 
         result = verify_execution(graph, execution)
-        assert not result.success
-        assert "Revenue must be positive" in result.error
+        assert result.success
+        flags = result.unwrap()
+        assert len(flags) == 1
+        assert "declared expectation not met" in flags[0]
+        assert "Revenue must be positive" in flags[0]
+        assert "value=0.0" in flags[0]
+        assert "severity=error" in flags[0]  # severity rides as the flag's weight
 
-    def test_satisfied_condition_passes(self) -> None:
+    def test_satisfied_condition_passes_with_no_flags(self) -> None:
         graph = _graph(
             {
                 "revenue": _extract("revenue", validations=[StepValidation(condition="value > 0")]),
@@ -166,10 +177,12 @@ class TestDeclaredConditions:
         )
         execution = _execution({"revenue": 1000.0, "cogs": 0.0}, output_value=100.0)
 
-        assert verify_execution(graph, execution).success
+        result = verify_execution(graph, execution)
+        assert result.success
+        assert result.unwrap() == []
 
     def test_unbindable_condition_is_skipped(self) -> None:
-        """A condition whose step_id has no executed step is skipped, not failed —
+        """A condition whose step_id has no executed step is skipped, not flagged —
         the support gate already guards the real risk; DAT-619 hardens binding."""
         graph = _graph(
             {"revenue": _extract("revenue", validations=[StepValidation(condition="value > 0")])}
@@ -177,10 +190,13 @@ class TestDeclaredConditions:
         # The executed step is named differently (LLM renamed it) — no binding.
         execution = _execution({"total_revenue": 1000.0}, output_value=1000.0)
 
-        assert verify_execution(graph, execution).success
+        result = verify_execution(graph, execution)
+        assert result.success
+        assert result.unwrap() == []
 
-    def test_malformed_condition_fails_loud_not_raises(self) -> None:
-        """A malformed catalogue condition becomes a clean Result.fail, not a raise."""
+    def test_malformed_condition_flags_never_raises_or_gates(self) -> None:
+        """A malformed catalogue condition is a config bug: flagged visibly on the
+        executed artifact, never a raise and never a reason to refuse a good number."""
         graph = _graph(
             {
                 "revenue": _extract(
@@ -191,13 +207,13 @@ class TestDeclaredConditions:
         execution = _execution({"revenue": 1000.0}, output_value=1000.0)
 
         result = verify_execution(graph, execution)
-        assert not result.success
-        assert "malformed" in result.error
+        assert result.success
+        assert any("malformed" in f for f in result.unwrap())
 
-    def test_unparseable_condition_fails_loud_not_crashes_worker(self) -> None:
+    def test_unparseable_condition_flags_not_crashes_worker(self) -> None:
         """A condition that isn't valid Python (e.g. SQL `AND` instead of a chained
-        comparison) raises SyntaxError in ast.parse — it must be caught HERE as a
-        clean Result.fail, not escape to the blanket worker handler as an opaque
+        comparison) raises SyntaxError in ast.parse — caught HERE as a flag, not
+        escaping to the blanket worker handler as an opaque
         "Unexpected error ... invalid syntax" (the dso/dpo regression)."""
         graph = _graph(
             {
@@ -209,8 +225,26 @@ class TestDeclaredConditions:
         execution = _execution({"revenue": 30.0}, output_value=30.0)
 
         result = verify_execution(graph, execution)
-        assert not result.success
-        assert "malformed" in result.error
+        assert result.success
+        assert any("malformed" in f for f in result.unwrap())
+
+    def test_all_violations_flag_not_just_the_first(self) -> None:
+        """Every violated expectation surfaces — the old gate stopped at one."""
+        graph = _graph(
+            {
+                "revenue": _extract(
+                    "revenue", validations=[StepValidation(condition="value > 0", message="R")]
+                ),
+                "cogs": _extract(
+                    "cogs", validations=[StepValidation(condition="value >= 0", message="C")]
+                ),
+            }
+        )
+        execution = _execution({"revenue": 0.0, "cogs": -5.0}, output_value=5.0)
+
+        result = verify_execution(graph, execution)
+        assert result.success
+        assert len(result.unwrap()) == 2
 
     def test_decimal_value_is_comparable(self) -> None:
         """Currency sums arrive as Decimal in production — conditions still hold."""
@@ -223,7 +257,9 @@ class TestDeclaredConditions:
         ex.step_results = [sr]
         ex.output_value = Decimal("1234.56")
 
-        assert verify_execution(graph, ex).success
+        result = verify_execution(graph, ex)
+        assert result.success
+        assert result.unwrap() == []
 
 
 class TestConditionEvaluator:

--- a/packages/engine/tests/unit/graphs/test_verifier.py
+++ b/packages/engine/tests/unit/graphs/test_verifier.py
@@ -65,7 +65,7 @@ def _execution(step_values: dict[str, float | None], output_value: object) -> Gr
 
 class TestSupportGate:
     def test_null_extract_is_inconclusive(self) -> None:
-        """An extract that aggregated to NULL (no rows matched) fails loud."""
+        """An extract that aggregated to NULL fails loud."""
         graph = _graph({"revenue": _extract("revenue"), "cogs": _extract("cogs")})
         execution = _execution({"revenue": 1000.0, "cogs": None}, output_value=100.0)
 
@@ -74,6 +74,23 @@ class TestSupportGate:
         assert not result.success
         assert "cogs" in result.error
         assert "no support" in result.error
+
+    def test_null_extract_reason_reports_measurement_never_a_cause(self) -> None:
+        """The reason states what was MEASURED (aggregated to NULL) and the
+        possibility space — it must never assert 'filter matched no rows' as
+        fact (DAT-699: that fabricated diagnosis misclassified a one-sided
+        ledger whose join matched 167k rows, and the re-author loop feeds this
+        exact text back to the agent)."""
+        graph = _graph({"revenue": _extract("revenue"), "cogs": _extract("cogs")})
+        execution = _execution({"revenue": 1000.0, "cogs": None}, output_value=100.0)
+
+        result = verify_execution(graph, execution)
+
+        assert not result.success
+        assert "aggregated to NULL" in result.error
+        # Both possibilities enumerated, neither asserted:
+        assert "either its filter matched no rows" in result.error
+        assert "entirely NULL over the rows it did match" in result.error
 
     def test_all_supported_passes(self) -> None:
         graph = _graph({"revenue": _extract("revenue"), "cogs": _extract("cogs")})

--- a/packages/engine/tests/unit/llm/test_anthropic_provider.py
+++ b/packages/engine/tests/unit/llm/test_anthropic_provider.py
@@ -556,3 +556,67 @@ class TestEffort:
     def test_no_effort_no_output_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
         kwargs = self._capture_kwargs(monkeypatch, "claude-sonnet-5", None)
         assert "output_config" not in kwargs
+
+
+class TestRawContentRoundTrip:
+    """Thinking-block continuation plumbing (DAT-699): converse captures the
+    turn's blocks VERBATIM in raw_content, and _convert_messages echoes an
+    assistant turn's raw_content unchanged — the live API rejects a continued
+    conversation whose assistant turn lost its signed thinking blocks."""
+
+    def _fake_message(self) -> SimpleNamespace:
+        usage = SimpleNamespace(
+            input_tokens=10,
+            output_tokens=5,
+            cache_read_input_tokens=None,
+            cache_creation_input_tokens=None,
+        )
+        blocks = [
+            SimpleNamespace(type="thinking", thinking="chain", signature="sig-1"),
+            SimpleNamespace(type="text", text="here"),
+            SimpleNamespace(
+                type="tool_use", id="tu-1", name="search_values", input={"pattern": "tax"}
+            ),
+            SimpleNamespace(type="redacted_thinking", data="opaque"),
+        ]
+        return SimpleNamespace(
+            content=blocks, usage=usage, stop_reason="tool_use", model="claude-test"
+        )
+
+    def test_converse_captures_blocks_verbatim(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _provider()
+        message = self._fake_message()
+        _patch_stream(monkeypatch, provider, lambda **_: message)
+
+        response = provider.converse(_request()).unwrap()
+
+        assert response.raw_content == [
+            {"type": "thinking", "thinking": "chain", "signature": "sig-1"},
+            {"type": "text", "text": "here"},
+            {
+                "type": "tool_use",
+                "id": "tu-1",
+                "name": "search_values",
+                "input": {"pattern": "tax"},
+            },
+            {"type": "redacted_thinking", "data": "opaque"},
+        ]
+        assert [tc.name for tc in response.tool_calls] == ["search_values"]
+
+    def test_assistant_raw_content_echoes_unchanged(self) -> None:
+        provider = _provider()
+        raw = [
+            {"type": "thinking", "thinking": "chain", "signature": "sig-1"},
+            {"type": "tool_use", "id": "tu-1", "name": "search_values", "input": {"p": 1}},
+        ]
+        converted = provider._convert_messages(
+            [Message(role="assistant", content="ignored-when-raw", raw_content=raw)]
+        )
+
+        assert converted == [{"role": "assistant", "content": raw}]
+
+    def test_assistant_without_raw_content_rebuilds_from_fields(self) -> None:
+        provider = _provider()
+        converted = provider._convert_messages([Message(role="assistant", content="plain")])
+
+        assert converted == [{"role": "assistant", "content": [{"type": "text", "text": "plain"}]}]

--- a/packages/engine/tests/unit/pipeline/test_enrichment_dossier.py
+++ b/packages/engine/tests/unit/pipeline/test_enrichment_dossier.py
@@ -1,0 +1,87 @@
+"""Dossier-fingerprint re-offer for the sticky enrichment shape (DAT-699).
+
+DAT-516 froze the enrichment judge's per-pair VERDICT, but the dossier the
+verdict was made on isn't frozen: pairs judged before DAT-695 existed never
+saw the coverage note, and inheritance meant they never would. Each considered
+entry now carries the fingerprint of the evidence the judge saw; a pair whose
+current dossier differs counts as undecided and is re-offered. Not a
+threshold — any material evidence change re-opens the question.
+"""
+
+from __future__ import annotations
+
+from dataraum.analysis.relationships.db_models import Relationship
+from dataraum.analysis.views.enrichment_agent import dossier_fingerprint
+from dataraum.pipeline.phases.enriched_views_phase import (
+    _dossier,
+    _unchanged_considered_pairs,
+)
+
+
+def _rel(
+    cardinality: str = "many-to-one",
+    confidence: float = 0.9,
+    coverage: float | None = 0.85,
+) -> Relationship:
+    return Relationship(
+        run_id="r1",
+        from_table_id="t1",
+        from_column_id="ca",
+        to_table_id="t2",
+        to_column_id="cb",
+        relationship_type="foreign_key",
+        cardinality=cardinality,
+        confidence=confidence,
+        detection_method="llm",
+        evidence={"coverage": coverage} if coverage is not None else {},
+    )
+
+
+def test_unchanged_dossier_stays_considered() -> None:
+    rel = _rel()
+    entries = [["ca", "cb", _dossier(rel)]]
+
+    assert _unchanged_considered_pairs(entries, {("ca", "cb"): rel}) == {("ca", "cb")}
+
+
+def test_changed_dossier_reopens_the_pair() -> None:
+    """Judged at coverage 0.85; the measurement now reads 0.003 — the verdict
+    was made on a different dossier, so the pair is undecided again."""
+    entries = [["ca", "cb", _dossier(_rel(coverage=0.85))]]
+    current = {("ca", "cb"): _rel(coverage=0.003)}
+
+    assert _unchanged_considered_pairs(entries, current) == set()
+
+
+def test_new_evidence_field_reopens_the_pair() -> None:
+    """The live case: judged before coverage existed (dossier had coverage=None);
+    the mint now measures it — re-ask the judge exactly once."""
+    entries = [["ca", "cb", _dossier(_rel(coverage=None))]]
+    current = {("ca", "cb"): _rel(coverage=0.0027)}
+
+    assert _unchanged_considered_pairs(entries, current) == set()
+
+
+def test_entry_without_fingerprint_reopens_conservatively() -> None:
+    """A pre-DAT-699 entry carries no fingerprint — the dossier the judge saw
+    is unknown, so the pair re-opens once and sticks under the new shape."""
+    entries = [["ca", "cb"]]
+
+    assert _unchanged_considered_pairs(entries, {("ca", "cb"): _rel()}) == set()
+
+
+def test_pair_absent_from_catalog_stays_considered() -> None:
+    """Nothing to re-judge; the Layer-A prune owns real drop+re-adds."""
+    entries = [["ca", "cb", "whatever"]]
+
+    assert _unchanged_considered_pairs(entries, {}) == {("ca", "cb")}
+
+
+def test_fingerprint_mirrors_the_rendered_evidence_fields() -> None:
+    """Cardinality, confidence and coverage each move the fingerprint; the
+    identity fields (names/ids) do not participate — the pair key carries them."""
+    base = dossier_fingerprint("many-to-one", 0.9, 0.85)
+    assert dossier_fingerprint("one-to-one", 0.9, 0.85) != base
+    assert dossier_fingerprint("many-to-one", 0.8, 0.85) != base
+    assert dossier_fingerprint("many-to-one", 0.9, None) != base
+    assert dossier_fingerprint("many-to-one", 0.9, 0.85) == base


### PR DESCRIPTION
## Why

The clean-stack the bookkeeping smoke corpus verification executed **0/13 metrics against a measured ceiling of 2**. Root-caused on the raw data: the A/R extract joined 167,743 rows and NULLed on an all-NULL credit leg while the verifier *fabricated* the cause ('filter matched no rows' — sending the whole triage into a nonexistent failure class); current_assets' correct grounding was discarded whole on one stringified field; revenue (5.93B, groundable) never executed because the first hole aborted every graph; Depreciation and Taxes & Licenses sat unseen in a 340-name column the agent was served NOTHING of. Plus the determinism audit across begin_session/operating_model.

## What (7 approved items)

1. **Verifier reports measurements, never inferred causes** — the NULL-aggregate reason enumerates the possibility space; the retained-failure loop feeds it back with the abstain-vs-net-the-legs steer; the prompt gains the row-guarded one-sided-ledger netting shape (absence still surfaces NULL, never a masked 0).
2. **Tool-boundary schema repair** — a grounding output failing validation gets one model repair turn (enforced schema, never silent json.loads); a finished grounding is never discarded on a serialization slip.
3. **Enrichment confidence gate dropped** — the judge sees ALL defined relationships (candidates already never reach it); `min_confidence` died with its only caller.
4. **Keeper rows carry last-measured evidence** — cardinality/evidence/confidence copied from the newest llm row, stamped `not_remeasured`; no more fabricated `confidence=1.0, cardinality=NULL`; measurement unrecoverable → loud skip.
5. **Partial-subgraph metric execution** — all holes collected, the groundable subgraph executes, the reason tells the per-step story: `revenue = 5,925,920,163.00 ✓ · cogs ✗ no support · gross_profit blocked (needs cogs)`. The metric itself still honest-fails.
6. **Dossier-fingerprint re-offer** — a sticky enrichment verdict re-opens when the measured evidence the judge saw (cardinality/confidence/coverage) changed. Not a threshold: the dossier changed, re-ask the judge.
7. **Explorable value sets** — high-card columns render size+sample+hint instead of nothing; the grounding agent gets a bounded `search_values` tool (4 turns, 25 matches, catalog-validated identifiers, escaped pattern); provider `raw_content` round-trips signed thinking blocks across tool-call continuations.

## Constraints held

No new numeric gates or verdict machinery — measurements, enforced schemas, judge decides. NULL is information (the netting shape is row-guarded). Slicing floors deliberately untouched. Worker contracts untouched.

## Verification

- Full unit suite **1895 passed**; mypy (258 files), ruff, vulture clean.
- Senior reviewer: **APPROVED**; spec reviewer: **COMPLIANT** — all findings addressed in the final commit (raw_content provider tests, bool/unknown-step report branches, both-cases steer pinned, drive-by reflow reverted).
- `.claude/handoff.md` carries the eval entry — **the metric `state_reason` format changed** (all holes + per-step values); eval parsers of the old prefix need updating.
- Live verification (bookkeeping-smoke clean stack, expects dso + current_ratio to execute at their honest values) needs a rebuilt engine + re-run — not done in this PR's cycle since the cluster schedule is yours.

Closes DAT-699.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Post-review amendment** (commit 10): domain-neutral generic surfaces — the ledger-netting guidance moved from the generic grounding prompt to a `ledger_leg_netting` convention in the finance vertical (DAT-645 channel); search-tool examples and docstring narratives neutralized. Also fixes a step-composer regression the integration suite caught: the snippet/CTE lookup key is the `graph.steps` key, not `step.step_id`, and now travels explicitly.
