### PR TITLE
chore(cockpit): biome 2.5.2 schema migrate + skip the generated worker bundle

### DIFF
--- a/packages/cockpit/biome.json
+++ b/packages/cockpit/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -13,7 +13,8 @@
 			"**/index.html",
 			"**/vite.config.ts",
 			"!**/src/routeTree.gen.ts",
-			"!**/src/styles.css"
+			"!**/src/styles.css",
+			"!**/src/worker/generated"
 		]
 	},
 	"formatter": {


### PR DESCRIPTION
The two residual biome diagnostics after the dependency bump:

- **info:** `biome.json` schema URL lagged the bumped CLI (2.5.1 vs 2.5.2) — `biome migrate` applied.
- **warning:** biome was size-warning on `src/worker/generated/workflow-bundle.ts` (1.4 MiB generated build artifact) — excluded from `files.includes` like `routeTree.gen.ts`, using the post-2.2 folder pattern (no trailing `/**`).

`bun run check` is now diagnostic-free (470 files, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)