### PR TITLE
docs(DAT-699): contested stock/flow is deliberately not rendered to SQL agents

### DIFF
--- a/packages/engine/src/dataraum/entropy/resolve.py
+++ b/packages/engine/src/dataraum/entropy/resolve.py
@@ -73,9 +73,14 @@ def resolve_temporal_behavior(session: Session, run_id: str | None) -> int:
     DAT-445) and, for each column whose adjudication resolved to a behaviour, UPDATEs
     the matching ``(column_id, run_id)`` annotation: ``temporal_behavior`` becomes the
     pooled-resolved value (the ontology prior reconciled with the LLM stock/flow
-    claim) and ``temporal_behavior_contested`` records whether the witnesses disagreed
-    — so the query agent's don't-SUM-a-stock read incorporates the LLM witness and can
-    caveat a contested stock. Columns that resolved to total ignorance (no witness)
+    claim) and ``temporal_behavior_contested`` records whether the witnesses disagreed.
+    The contested flag is DELIBERATELY NOT rendered to the SQL-authoring agents
+    (decision 2026-07-07): the adjudication outperforms an LLM reading stock/flow
+    from metadata alone, so the agents get the resolved verdict as settled fact —
+    a "(contested)" tag would invite second-guessing by the weaker judge. The
+    flag's consumers are the teach/readiness lane (the entropy object already
+    carries the ranked teach suggestion). Columns that resolved to total
+    ignorance (no witness)
     are left untouched, preserving the ontology backfill. Idempotent on retry (same
     run_id → same UPDATE). Returns the number of annotations updated.
     """

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -1011,6 +1011,10 @@ def build_execution_context(
                     semantic_role=sem_ann.semantic_role if sem_ann else None,
                     entity_type=sem_ann.entity_type if sem_ann else None,
                     business_concept=concept.business_concept if concept else None,
+                    # The RESOLVED stock/flow verdict (entropy/resolve.py re-bases
+                    # the ColumnConcept row at session_detect). Served as settled
+                    # fact — temporal_behavior_contested is deliberately NOT
+                    # rendered here (see resolve_temporal_behavior's docstring).
                     temporal_behavior=concept.temporal_behavior if concept else None,
                     business_name=sem_ann.business_name if sem_ann else None,
                     business_description=sem_ann.business_description if sem_ann else None,


### PR DESCRIPTION
Records the decision (2026-07-07) at the two sites a future session would "helpfully fix": the resolve docstring promised *caveat a contested stock*, and the context assembler serves `temporal_behavior` with no contested marker.

The adjudication (ontology prior × LLM claim × structural lineage witness) outperforms an LLM reading stock/flow from metadata alone, so the SQL-authoring agents get the **resolved verdict as settled fact** — a `(contested)` tag would invite second-guessing by the weaker judge and add insecurity to values that have been correct per the decision tree. The flag's consumers are the teach/readiness lane, where it already drives the ranked teach suggestion.

Docs/comments only — no behavior change. Verified live on the finance corpus: balances resolve stock, movements flow, and the AR grounding followed stock semantics (point-in-time at MAX(period)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)