### PR TITLE
feat(DAT-673): drill axes = curated ∪ substrate, alias-collapsed, driver-ordered

### DIFF
--- a/packages/cockpit/src/duckdb/drill.ts
+++ b/packages/cockpit/src/duckdb/drill.ts
@@ -35,8 +35,10 @@ export type DrillAxesRequest =
 
 /** One sliceable dimension of a metric's fact catalog (`/api/drill/axes`). */
 export interface DrillAxis {
-	/** The `slice_definitions.column_name` — addressable verbatim in the
-	 *  metric's SQL scope (the enriched view exposes FK-prefixed dim columns). */
+	/** The catalog column name — a curated `slice_definitions.column_name` or
+	 *  a grain-verified `enriched_views.dimension_columns` entry (DAT-673);
+	 *  either way addressable verbatim in the metric's SQL scope (the enriched
+	 *  view exposes exactly these FK-prefixed dim columns). */
 	column: string;
 	/** The relations this axis column LIVES on (the fact table and its
 	 *  enriched view). When the measure's SQL joins other relations sharing

--- a/packages/cockpit/src/tools/drill-axes.test.ts
+++ b/packages/cockpit/src/tools/drill-axes.test.ts
@@ -37,16 +37,23 @@ vi.mock("#/db/metadata/client", () => ({
 }));
 
 import {
+	currentDimensionHierarchies,
+	currentDriverRankings,
 	currentEnrichedViews,
 	currentLifecycleArtifacts,
 	currentSliceDefinitions,
 	currentTables,
 	sqlSnippets,
 } from "#/db/metadata/schema";
+import type { DrillAxis } from "#/duckdb/drill";
 import {
 	axesFromSliceRows,
+	collapseAliasAxes,
+	driverGains,
 	measureFieldsFromDag,
+	orderAxesByDrivers,
 	resolveDrillAxes,
+	unionSubstrateAxes,
 } from "./drill-axes";
 
 describe("measureFieldsFromDag", () => {
@@ -144,6 +151,111 @@ describe("axesFromSliceRows", () => {
 	});
 });
 
+/** A minimal curated axis for the pure-function tests. */
+const axis = (column: string, priority = 1): DrillAxis => ({
+	column,
+	sourceRelations: ["orders", "enriched_orders"],
+	priority,
+	sliceType: "categorical",
+	values: [],
+	valueCount: null,
+	businessContext: null,
+});
+
+describe("unionSubstrateAxes", () => {
+	it("appends uncataloged substrate dims below curated axes, skipping covered columns", () => {
+		const sources = new Map([["fact1", ["orders", "enriched_orders"]]]);
+		const substrate = new Map([
+			["fact1", ["customer__region", "customer__segment"]],
+		]);
+		const out = unionSubstrateAxes(
+			[axis("customer__region", 1)],
+			substrate,
+			sources,
+		);
+		expect(out.map((a) => a.column)).toEqual([
+			"customer__region",
+			"customer__segment",
+		]);
+		// The curated row is untouched; the substrate row carries no curation.
+		expect(out[0]?.priority).toBe(1);
+		expect(out[1]).toEqual({
+			column: "customer__segment",
+			sourceRelations: ["orders", "enriched_orders"],
+			priority: Number.MAX_SAFE_INTEGER,
+			sliceType: "categorical",
+			values: [],
+			valueCount: null,
+			businessContext: null,
+		});
+	});
+});
+
+describe("collapseAliasAxes", () => {
+	it("drops non-canonical alias members while the canonical survives", () => {
+		const out = collapseAliasAxes(
+			[axis("account__name"), axis("account__code")],
+			[
+				{
+					canonicalLabel: "account__name",
+					members: [
+						{ column_name: "account__name" },
+						{ column_name: "account__code" },
+					],
+				},
+			],
+		);
+		expect(out.map((a) => a.column)).toEqual(["account__name"]);
+	});
+
+	it("keeps a member when its canonical is not an offered axis, and tolerates malformed members", () => {
+		const out = collapseAliasAxes(
+			[axis("account__code")],
+			[
+				{
+					canonicalLabel: "account__name",
+					members: [{ column_name: "account__code" }],
+				},
+				{ canonicalLabel: "account__code", members: "not-an-array" },
+				{ canonicalLabel: null, members: [{ column_name: "account__code" }] },
+			],
+		);
+		expect(out.map((a) => a.column)).toEqual(["account__code"]);
+	});
+});
+
+describe("driver ordering", () => {
+	it("takes the max gain per dimension across rankings, ignoring malformed entries", () => {
+		const gains = driverGains([
+			{
+				rankedDimensions: [
+					{ dimension: "region", gain: 0.2 },
+					{ dimension: "channel", gain: 0.5 },
+					{ dimension: 7, gain: 0.9 },
+					"junk",
+				],
+			},
+			{ rankedDimensions: [{ dimension: "region", gain: 0.4 }] },
+			{ rankedDimensions: null },
+		]);
+		expect([...gains.entries()]).toEqual([
+			["region", 0.4],
+			["channel", 0.5],
+		]);
+	});
+
+	it("puts measured drivers first by gain and keeps the rest in incoming order", () => {
+		const out = orderAxesByDrivers(
+			[axis("a", 1), axis("b", 2), axis("c", 3), axis("d", 4)],
+			new Map([
+				["c", 0.1],
+				["b", 0.6],
+			]),
+		);
+		expect(out.map((a) => a.column)).toEqual(["b", "c", "a", "d"]);
+	});
+});
+
 const seed = () => {
 	rowsByTable.clear();
 	rowsByTable.set(currentLifecycleArtifacts, [
@@ -182,11 +294,17 @@ const seed = () => {
 			viewName: "enriched_invoices",
 			viewTableId: "vt1",
 			factTableId: "fact1",
+			// The grain-verified substrate: one column the catalog also curates
+			// (stays curated) and one it doesn't (offered bare, after curated).
+			dimensionColumns: ["customer__region", "customer__segment"],
+			isGrainVerified: true,
 		},
 		{
 			viewName: "enriched_purchases",
 			viewTableId: "vt2",
 			factTableId: "fact2",
+			dimensionColumns: ["supplier__country"],
+			isGrainVerified: true,
 		},
 		{ viewName: "enriched_bank", viewTableId: "vt3", factTableId: "fact3" },
 	]);
@@ -205,7 +323,7 @@ const seed = () => {
 };
 
 describe("resolveDrillAxes (mocked metadata client)", () => {
-	it("joins dag → grounded extracts → fact table → slice definitions", async () => {
+	it("joins dag → grounded extracts → fact table → curated ∪ substrate axes", async () => {
 		seed();
 		const { axes } = await resolveDrillAxes({ metricKey: "gross_margin" });
 		expect(axes).toEqual([
@@ -218,6 +336,61 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 				valueCount: 2,
 				businessContext: null,
 			},
+			// Substrate-only: the view exposes it, the catalog never curated it.
+			// supplier__country stays absent — its fact (cogs) never grounded.
+			{
+				column: "customer__segment",
+				sourceRelations: ["invoices", "enriched_invoices"],
+				priority: Number.MAX_SAFE_INTEGER,
+				sliceType: "categorical",
+				values: [],
+				valueCount: null,
+				businessContext: null,
+			},
+		]);
+	});
+
+	it("offers no substrate from a view that is not grain-verified", async () => {
+		seed();
+		rowsByTable.set(currentEnrichedViews, [
+			{
+				viewName: "enriched_invoices",
+				viewTableId: "vt1",
+				factTableId: "fact1",
+				dimensionColumns: ["customer__region", "customer__segment"],
+				isGrainVerified: false,
+			},
+		]);
+		const { axes } = await resolveDrillAxes({ standardField: "revenue" });
+		expect(axes.map((a) => a.column)).toEqual(["customer__region"]);
+	});
+
+	it("collapses a persisted alias group to its canonical axis", async () => {
+		seed();
+		rowsByTable.set(currentDimensionHierarchies, [
+			{
+				canonicalLabel: "customer__region",
+				members: [
+					{ column_name: "customer__region" },
+					{ column_name: "customer__segment" },
+				],
+			},
+		]);
+		const { axes } = await resolveDrillAxes({ standardField: "revenue" });
+		expect(axes.map((a) => a.column)).toEqual(["customer__region"]);
+	});
+
+	it("puts a measured driver ahead of curated priority", async () => {
+		seed();
+		rowsByTable.set(currentDriverRankings, [
+			{
+				rankedDimensions: [{ dimension: "customer__segment", gain: 0.31 }],
+			},
+		]);
+		const { axes } = await resolveDrillAxes({ standardField: "revenue" });
+		expect(axes.map((a) => a.column)).toEqual([
+			"customer__segment",
+			"customer__region",
 		]);
 	});
 
@@ -225,7 +398,10 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 		seed();
 		rowsByTable.delete(currentLifecycleArtifacts);
 		const { axes } = await resolveDrillAxes({ standardField: "revenue" });
-		expect(axes.map((a) => a.column)).toEqual(["customer__region"]);
+		expect(axes.map((a) => a.column)).toEqual([
+			"customer__region",
+			"customer__segment",
+		]);
 	});
 
 	it("yields no axes for an unknown metric or a fully ungrounded one", async () => {
@@ -269,11 +445,30 @@ describe("resolveDrillAxes empty-result reasons", () => {
 });
 
 describe("resolveDrillAxes bare-catalog reason", () => {
-	it("names the bare catalog when the fact resolves but has no slice definitions", async () => {
+	it("names the bare catalogs when the fact resolves but neither source offers a dimension", async () => {
 		seed();
 		rowsByTable.set(currentSliceDefinitions, []);
+		rowsByTable.set(currentEnrichedViews, [
+			{
+				viewName: "enriched_invoices",
+				viewTableId: "vt1",
+				factTableId: "fact1",
+				dimensionColumns: [],
+				isGrainVerified: true,
+			},
+		]);
 		const result = await resolveDrillAxes({ standardField: "revenue" });
 		expect(result.axes).toEqual([]);
-		expect(result.reason).toContain("No dimensions cataloged");
+		expect(result.reason).toContain("No dimensions available");
+	});
+
+	it("still resolves axes from the substrate alone when the slice catalog is empty", async () => {
+		seed();
+		rowsByTable.set(currentSliceDefinitions, []);
+		const { axes } = await resolveDrillAxes({ standardField: "revenue" });
+		expect(axes.map((a) => a.column)).toEqual([
+			"customer__region",
+			"customer__segment",
+		]);
 	});
 });

--- a/packages/cockpit/src/tools/drill-axes.ts
+++ b/packages/cockpit/src/tools/drill-axes.ts
@@ -8,12 +8,21 @@
 //   metric → dag extract steps (standard fields) → newest extract snippet per
 //   field → the extract SQL's parsed relations (`sqlRelations`, DuckDB's own
 //   parser) → the promoted enriched view among them (`resolveGrounding`, the
-//   same matcher the Model loader uses) → that view's FACT table →
-//   `current_slice_definitions` rows on the fact, priority-ordered.
+//   same matcher the Model loader uses) → that view's FACT table → the axes.
 //
-// `slice_definitions.column_name` is addressable VERBATIM in the metric's SQL
-// scope: metric SQL reads the enriched view (the GraphAgent's prefer-enriched
-// contract) and the enriched view exposes exactly those FK-prefixed dimension
+// Axes come from TWO catalogs on the fact (DAT-673): the slicing agent's
+// curated `current_slice_definitions` (priority, values, context) UNIONED with
+// the enriched view's grain-verified `dimension_columns` substrate — the
+// curation is an annotation layer, never a filter (the slicing agent picks a
+// handful; the substrate routinely exposes more grain-safe joined dims). DAT-537
+// 1:1 alias groups collapse to their canonical member (mirroring the drivers
+// processor's `_candidate_dims`), and `driver_rankings.ranked_dimensions`
+// orders what survives: measured drivers first by gain, then curated priority,
+// then bare substrate.
+//
+// Every offered column is addressable VERBATIM in the metric's SQL scope:
+// metric SQL reads the enriched view (the GraphAgent's prefer-enriched
+// contract) and the enriched view exposes exactly these FK-prefixed dimension
 // columns. Whether an axis actually binds in a given statement stays the
 // composer's call (`/api/drill/compose`, binder-gated).
 
@@ -22,6 +31,8 @@ import { and, asc, desc, eq, inArray, like } from "drizzle-orm";
 import { config } from "#/config";
 import { metadataDb } from "#/db/metadata/client";
 import {
+	currentDimensionHierarchies,
+	currentDriverRankings,
 	currentEnrichedViews,
 	currentLifecycleArtifacts,
 	currentSliceDefinitions,
@@ -90,6 +101,114 @@ export function axesFromSliceRows(
 	return [...byColumn.values()];
 }
 
+/**
+ * Union the enriched views' grain-verified `dimension_columns` substrate into
+ * the curated axes (pure): every join-projected dim the view exposes is
+ * drillable, whether or not the slicing agent picked it. Substrate-only axes
+ * carry no curation metadata and sink below curated ones (max priority);
+ * columns the catalog already covers keep their curated row untouched.
+ */
+export function unionSubstrateAxes(
+	axes: DrillAxis[],
+	substrateByFact: ReadonlyMap<string, string[]>,
+	sourcesByFact: ReadonlyMap<string, string[]>,
+): DrillAxis[] {
+	const seen = new Set(axes.map((a) => a.column));
+	const out = [...axes];
+	for (const [factId, columns] of substrateByFact) {
+		for (const column of columns) {
+			if (seen.has(column)) continue;
+			seen.add(column);
+			out.push({
+				column,
+				sourceRelations: sourcesByFact.get(factId) ?? [],
+				priority: Number.MAX_SAFE_INTEGER,
+				sliceType: "categorical",
+				values: [],
+				valueCount: null,
+				businessContext: null,
+			});
+		}
+	}
+	return out;
+}
+
+/** One `current_dimension_hierarchies` alias-group row as the resolver reads
+ *  it (`members` is engine JSON: `[{column_name: ...}, ...]`). */
+export interface AliasGroupInput {
+	canonicalLabel: string | null;
+	members: unknown;
+}
+
+/**
+ * Collapse DAT-537 1:1 alias groups to their canonical axis (pure) — two
+ * columns that identify each other are ONE dimension, not two menu entries.
+ * Mirrors the drivers processor's `_candidate_dims`, with one deliberate
+ * difference: a non-canonical member is dropped only while its canonical
+ * survives as an axis — drill offers dimensions to a user, and losing a
+ * group's only drillable representative would hide the dimension entirely.
+ */
+export function collapseAliasAxes(
+	axes: DrillAxis[],
+	groups: AliasGroupInput[],
+): DrillAxis[] {
+	const present = new Set(axes.map((a) => a.column));
+	const dropped = new Set<string>();
+	for (const g of groups) {
+		if (!g.canonicalLabel || !present.has(g.canonicalLabel)) continue;
+		if (!Array.isArray(g.members)) continue;
+		for (const member of g.members) {
+			const name =
+				typeof member === "object" && member !== null
+					? (member as Record<string, unknown>).column_name
+					: undefined;
+			if (typeof name === "string" && name !== g.canonicalLabel) {
+				dropped.add(name);
+			}
+		}
+	}
+	return axes.filter((a) => !dropped.has(a.column));
+}
+
+/** One `current_driver_rankings` row as the resolver reads it
+ *  (`ranked_dimensions` is engine JSON: `[{dimension, gain}, ...]`). */
+export interface DriverRankingInput {
+	rankedDimensions: unknown;
+}
+
+/** Measured driver gain per dimension (pure): the max across a fact's measure
+ *  rankings — a dim that drives ANY of the metric's measures leads the menu. */
+export function driverGains(rows: DriverRankingInput[]): Map<string, number> {
+	const gains = new Map<string, number>();
+	for (const row of rows) {
+		if (!Array.isArray(row.rankedDimensions)) continue;
+		for (const entry of row.rankedDimensions) {
+			if (typeof entry !== "object" || entry === null) continue;
+			const { dimension, gain } = entry as Record<string, unknown>;
+			if (typeof dimension !== "string" || typeof gain !== "number") continue;
+			const prev = gains.get(dimension);
+			if (prev === undefined || gain > prev) gains.set(dimension, gain);
+		}
+	}
+	return gains;
+}
+
+/**
+ * Order axes for the menu (pure): measured drivers first by gain (the engine
+ * already gated what earns a ranking entry — any listed gain outranks curated
+ * intuition), then everything else in its incoming order (curated priority,
+ * then substrate). Stable within each group.
+ */
+export function orderAxesByDrivers(
+	axes: DrillAxis[],
+	gains: ReadonlyMap<string, number>,
+): DrillAxis[] {
+	const ranked = axes
+		.filter((a) => gains.has(a.column))
+		.sort((a, b) => (gains.get(b.column) ?? 0) - (gains.get(a.column) ?? 0));
+	return [...ranked, ...axes.filter((a) => !gains.has(a.column))];
+}
+
 /** The measure standard fields the request targets: a measure names itself, a
  *  metric contributes every extract step of its promoted DAG. */
 async function targetFields(req: DrillAxesRequest): Promise<string[]> {
@@ -149,6 +268,8 @@ export async function resolveDrillAxes(
 				viewName: currentEnrichedViews.viewName,
 				viewTableId: currentEnrichedViews.viewTableId,
 				factTableId: currentEnrichedViews.factTableId,
+				dimensionColumns: currentEnrichedViews.dimensionColumns,
+				isGrainVerified: currentEnrichedViews.isGrainVerified,
 			})
 			.from(currentEnrichedViews),
 	]);
@@ -236,26 +357,73 @@ export async function resolveDrillAxes(
 			]),
 	);
 
-	const sliceRows = await metadataDb
-		.select({
-			tableId: currentSliceDefinitions.tableId,
-			columnName: currentSliceDefinitions.columnName,
-			slicePriority: currentSliceDefinitions.slicePriority,
-			sliceType: currentSliceDefinitions.sliceType,
-			distinctValues: currentSliceDefinitions.distinctValues,
-			valueCount: currentSliceDefinitions.valueCount,
-			businessContext: currentSliceDefinitions.businessContext,
-		})
-		.from(currentSliceDefinitions)
-		.where(inArray(currentSliceDefinitions.tableId, factIds))
-		.orderBy(asc(currentSliceDefinitions.slicePriority));
+	// The grain-verified substrate: the enriched view's join-projected
+	// dimension columns, keyed by fact. Only a row-count-verified view's dims
+	// are safe to group by (the same gate the drivers phase applies).
+	const substrateByFact = new Map<string, string[]>(
+		viewRows
+			.filter(
+				(v): v is typeof v & { factTableId: string } =>
+					Boolean(v.factTableId) &&
+					factIds.includes(v.factTableId as string) &&
+					v.isGrainVerified === true,
+			)
+			.map((v) => [
+				v.factTableId,
+				Array.isArray(v.dimensionColumns)
+					? v.dimensionColumns.filter((c): c is string => typeof c === "string")
+					: [],
+			]),
+	);
 
-	const axes = axesFromSliceRows(sliceRows, sourcesByFact);
+	const [sliceRows, aliasRows, rankingRows] = await Promise.all([
+		metadataDb
+			.select({
+				tableId: currentSliceDefinitions.tableId,
+				columnName: currentSliceDefinitions.columnName,
+				slicePriority: currentSliceDefinitions.slicePriority,
+				sliceType: currentSliceDefinitions.sliceType,
+				distinctValues: currentSliceDefinitions.distinctValues,
+				valueCount: currentSliceDefinitions.valueCount,
+				businessContext: currentSliceDefinitions.businessContext,
+			})
+			.from(currentSliceDefinitions)
+			.where(inArray(currentSliceDefinitions.tableId, factIds))
+			.orderBy(asc(currentSliceDefinitions.slicePriority)),
+		metadataDb
+			.select({
+				canonicalLabel: currentDimensionHierarchies.canonicalLabel,
+				members: currentDimensionHierarchies.members,
+			})
+			.from(currentDimensionHierarchies)
+			.where(
+				and(
+					inArray(currentDimensionHierarchies.tableId, factIds),
+					eq(currentDimensionHierarchies.kind, "alias"),
+				),
+			),
+		metadataDb
+			.select({ rankedDimensions: currentDriverRankings.rankedDimensions })
+			.from(currentDriverRankings)
+			.where(inArray(currentDriverRankings.measureTableId, factIds)),
+	]);
+
+	const axes = orderAxesByDrivers(
+		collapseAliasAxes(
+			unionSubstrateAxes(
+				axesFromSliceRows(sliceRows, sourcesByFact),
+				substrateByFact,
+				sourcesByFact,
+			),
+			aliasRows,
+		),
+		driverGains(rankingRows),
+	);
 	if (axes.length === 0) {
 		return {
 			axes,
 			reason:
-				"No dimensions cataloged for this computation's fact table — the slicing phase found nothing grain-safe to offer.",
+				"No dimensions available for this computation's facts — neither the slicing catalog nor a grain-verified enriched view exposes anything to slice by.",
 		};
 	}
 	return { axes };

--- a/packages/cockpit/src/tools/drill-axes.ts
+++ b/packages/cockpit/src/tools/drill-axes.ts
@@ -271,7 +271,11 @@ export async function resolveDrillAxes(
 				dimensionColumns: currentEnrichedViews.dimensionColumns,
 				isGrainVerified: currentEnrichedViews.isGrainVerified,
 			})
-			.from(currentEnrichedViews),
+			.from(currentEnrichedViews)
+			// Deterministic pick: the per-fact maps below (substrate, view name)
+			// fold on first occurrence — without an ORDER BY, which row wins
+			// would be Postgres row-order roulette.
+			.orderBy(asc(currentEnrichedViews.viewTableId)),
 	]);
 
 	const wanted = new Set(fields);


### PR DESCRIPTION
## What

First cut of DAT-673 (drill guidance): the axis resolver behind `/api/drill/axes` now offers every dimension the metric's enriched view actually exposes, not just what the slicing agent curated.

- **Axes-union**: `current_slice_definitions` (curated — priority, values, context) ∪ the enriched view's grain-verified `dimension_columns` substrate. Curation becomes an annotation layer, never a filter. Substrate-only axes are offered bare and sink below curated ones.
- **Alias collapse**: DAT-537 `kind='alias'` hierarchy groups collapse to their canonical member — the drivers processor's `_candidate_dims` rule, with one deliberate deviation: a non-canonical member is dropped only while its canonical survives as an axis (a drill menu must not silently hide a dimension's only representative).
- **Driver-ranked ordering**: `driver_rankings.ranked_dimensions` gains (max per dimension across the fact's measures) order the menu ahead of curated priority; degrades to curated order when rankings are empty.
- Review findings folded in: deterministic `ORDER BY` on the view read (first-occurrence maps), `DrillAxis.column` doc covers the substrate origin.

## Why

Evaluated on both datasets, the curated catalog is a fraction of the drillable surface: finance `journal_lines` exposes 5 grain-safe joined dims, the catalog offered 1. The substrate is grain-verified by construction and addressable verbatim in metric SQL scope, so the composer's binder gate stays the only arbiter.

## Verified

- 1550 cockpit unit tests green (17 in drill-axes: pure helpers incl. malformed-input paths + orchestration through the mocked metadata client).
- Live on the running finance stack: `net_income` axes 1 → 5; substrate-only axis `entry_id__status` composes tier B with a qualified reference and executes — revenue by status totals **51,766,199.72**, exactly the known ground truth.
- Reviewers: senior APPROVE, spec-compliance APPROVE (both findings addressed in the second commit).

Remaining DAT-673 scope (not in this PR): `interesting_slices` badges, hierarchy descent (`kind='drilldown'`), flow-gated time bucketing, binder-failure LLM fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)