### PR TITLE
chore(cockpit): biome 2.5.2 schema migrate + skip the generated worke…

### DIFF
--- a/packages/cockpit/biome.json
+++ b/packages/cockpit/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -13,7 +13,8 @@
 			"**/index.html",
 			"**/vite.config.ts",
 			"!**/src/routeTree.gen.ts",
-			"!**/src/styles.css"
+			"!**/src/styles.css",
+			"!**/src/worker/generated/**"
 		]
 	},
 	"formatter": {


### PR DESCRIPTION
…r bundle

The two residual diagnostics after the version bump: the schema URL lagged the bumped CLI (biome migrate), and biome was size-warning on src/worker/generated/workflow-bundle.ts — a build artifact it should not check, excluded like routeTree.gen.ts.