### PR TITLE
feat(DAT-712): analyse surface re-cut — live equation, time grain, total row, ledger ink

### DIFF
--- a/packages/cockpit/bun.lock
+++ b/packages/cockpit/bun.lock
@@ -42,6 +42,7 @@
         "nitro": "^3.0.260522-beta",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "sql-formatter": "^15.8.2",
         "tailwindcss": "^4.3.2",
         "vega": "^6.2.0",
         "vega-lite": "^6.4.3",
@@ -862,6 +863,8 @@
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
+    "discontinuous-range": ["discontinuous-range@1.0.0", "", {}, "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="],
+
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
@@ -1036,9 +1039,13 @@
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
+    "moo": ["moo@0.5.3", "", {}, "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA=="],
+
     "ms": ["ms@3.0.0-canary.1", "", {}, "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g=="],
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "nearley": ["nearley@2.20.1", "", { "dependencies": { "commander": "^2.19.0", "moo": "^0.5.0", "railroad-diagrams": "^1.0.0", "randexp": "0.4.6" }, "bin": { "nearleyc": "bin/nearleyc.js", "nearley-test": "bin/nearley-test.js", "nearley-unparse": "bin/nearley-unparse.js", "nearley-railroad": "bin/nearley-railroad.js" } }, "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ=="],
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
@@ -1096,6 +1103,10 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "railroad-diagrams": ["railroad-diagrams@1.0.0", "", {}, "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="],
+
+    "randexp": ["randexp@0.4.6", "", { "dependencies": { "discontinuous-range": "1.0.0", "ret": "~0.1.10" } }, "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ=="],
+
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
@@ -1117,6 +1128,8 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "ret": ["ret@0.1.15", "", {}, "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="],
 
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
 
@@ -1155,6 +1168,8 @@
     "source-map-loader": ["source-map-loader@5.0.0", "", { "dependencies": { "iconv-lite": "^0.6.3", "source-map-js": "^1.0.2" }, "peerDependencies": { "webpack": "^5.72.1" } }, "sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA=="],
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "sql-formatter": ["sql-formatter@15.8.2", "", { "dependencies": { "argparse": "^2.0.1", "nearley": "^2.20.1" }, "bin": { "sql-formatter": "bin/sql-formatter-cli.cjs" } }, "sha512-kTYRg5FIcvsDtYUG2Qn9pYT6xKwiLJN5TTIvc5Mur6hIg4pSfdpHu8Yyu5bqESLHnVM3mXzD446cb2+uEaKZXg=="],
 
     "srvx": ["srvx@0.11.16", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw=="],
 

--- a/packages/cockpit/package.json
+++ b/packages/cockpit/package.json
@@ -63,6 +63,7 @@
     "nitro": "^3.0.260522-beta",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "sql-formatter": "^15.8.2",
     "tailwindcss": "^4.3.2",
     "vega": "^6.2.0",
     "vega-lite": "^6.4.3",

--- a/packages/cockpit/spikes/drill-node.spike.ts
+++ b/packages/cockpit/spikes/drill-node.spike.ts
@@ -138,7 +138,7 @@ async function main(): Promise<void> {
 			let pinChecked = false;
 			for (const axis of axes) {
 				const q = composeNodeQuery(resolved.steps, undefined, {
-					slices: [axis.column],
+					slices: [{ column: axis.column }],
 					pins: [],
 				});
 				if ("refusal" in q) {

--- a/packages/cockpit/spikes/drill-node.spike.ts
+++ b/packages/cockpit/spikes/drill-node.spike.ts
@@ -6,8 +6,14 @@
 //
 // Checks per node:
 //   scalar   — composes, binds, executes; revenue == ground truth.
+//   totals   — composeNodeTotals binds + executes; its value == scalar and
+//              its columns == the node shape's non-constant operands + value
+//              (DAT-712: the footer + the equation's open binding).
 //   per axis — grouped composition binds + executes; additive metrics must
 //              have Σ(groups) == scalar (signed contributions); NULL counted.
+//   grain    — every TEMPORAL axis × every preset grain composes, binds,
+//              executes; additive Σ(buckets) == scalar; the first bucket row
+//              pins back exactly (grained pin ≡ group) — DAT-712's matrix.
 //   pin      — the first grouped row's value must be reproduced exactly by
 //              pinning that row (pin ≡ group, the coherence the browser
 //              smoke clicks).
@@ -21,8 +27,15 @@ import { metadataDb } from "#/db/metadata/client";
 import { currentLifecycleArtifacts, sqlSnippets } from "#/db/metadata/schema";
 import type { DrillPinValue } from "#/duckdb/drill";
 import { describeColumns } from "#/duckdb/drill-sql";
+import { grainPresets } from "#/duckdb/grain";
 import { applyEngineScope, closeLake, withLakeConnection } from "#/duckdb/lake";
-import { composeNodeQuery, flattenAdditive, type NodeStep } from "#/duckdb/parts";
+import {
+	composeNodeQuery,
+	composeNodeTotals,
+	flattenAdditive,
+	type NodeStep,
+	nodeShape,
+} from "#/duckdb/parts";
 import { resolveDrillAxes } from "#/tools/drill-axes";
 import { resolveNodeSteps } from "#/tools/drill-metric";
 
@@ -126,13 +139,53 @@ async function main(): Promise<void> {
 					: "";
 			if (gtNote.includes("✗")) fails++;
 
+			// 1b) totals (DAT-712): value == scalar, columns == shape operands+value
+			const shape = nodeShape(resolved.steps, undefined);
+			const tq = composeNodeTotals(resolved.steps, undefined);
+			let totalsNote = "";
+			if ("refusal" in tq) {
+				flag(`${label}: totals REFUSED — ${tq.refusal}`);
+			} else {
+				try {
+					const [trow] = await exec(tq.sql, []);
+					const tv = num(trow?.value);
+					const same =
+						(tv === null && scalar === null) ||
+						(tv !== null &&
+							scalar !== null &&
+							Math.abs(tv - scalar) < 1e-6);
+					if (!same) {
+						flag(`${label}: totals value ${String(tv)} ≠ scalar ${String(scalar)}`);
+					}
+					const expectCols = [
+						...("refusal" in shape
+							? []
+							: shape.operands
+									.filter((o) => o.kind !== "constant")
+									.map((o) => o.stepId)),
+						"value",
+					];
+					const gotCols = Object.keys(trow ?? {});
+					// Operand columns collide-skip against dims only in restricted
+					// views; totals are unrestricted, so the sets must match exactly.
+					if (JSON.stringify(gotCols) !== JSON.stringify(expectCols)) {
+						flag(
+							`${label}: totals columns [${gotCols.join(",")}] ≠ shape [${expectCols.join(",")}]`,
+						);
+					}
+					totalsNote = ` | totals✓(${gotCols.length - 1} operands)`;
+				} catch (err) {
+					flag(`${label}: totals ERR ${String(err).split("\n")[0]}`);
+				}
+			}
+
 			// 2) axes
 			const { axes, reason } = await resolveDrillAxes(ref);
 			const additive = isAdditive(resolved.steps);
 			report.push(
 				`## ${label} — scalar=${String(scalar)}${gtNote} | ${axes.length} axes${
 					axes.length === 0 ? ` (${reason ?? "?"})` : ""
-				} | ${additive ? "additive" : "non-additive"}`,
+				} | ${additive ? "additive" : "non-additive"}${totalsNote}`,
 			);
 
 			let pinChecked = false;
@@ -163,8 +216,91 @@ async function main(): Promise<void> {
 					}
 				}
 				report.push(
-					`  [${axis.priority === Number.MAX_SAFE_INTEGER ? "substrate" : "curated"}] ${axis.column}: ${rows.length} groups${nulls ? `, ${nulls} NULL` : ""}${sumNote}`,
+					`  [${axis.priority === Number.MAX_SAFE_INTEGER ? "substrate" : "curated"}] ${axis.column}: ${rows.length} groups${nulls ? `, ${nulls} NULL` : ""}${sumNote}${axis.temporal ? ` [temporal:${axis.temporal}]` : ""}`,
 				);
+
+				// 2b) the grain matrix (DAT-712): every preset grain on a temporal
+				// axis — compose, bind, execute; additive Σ = scalar; the first
+				// bucket pins back exactly under ITS grain.
+				if (axis.temporal !== null) {
+					for (const preset of grainPresets(axis.temporal)) {
+						const gq = composeNodeQuery(resolved.steps, undefined, {
+							slices: [{ column: axis.column, grain: preset.token }],
+							pins: [],
+						});
+						if ("refusal" in gq) {
+							flag(
+								`${label} by ${axis.column}@${preset.token}: REFUSED — ${gq.refusal}`,
+							);
+							continue;
+						}
+						let buckets: Record<string, unknown>[];
+						try {
+							buckets = await exec(gq.sql, []);
+						} catch (err) {
+							flag(
+								`${label} by ${axis.column}@${preset.token}: ERR ${String(err).split("\n")[0]}`,
+							);
+							continue;
+						}
+						let gSumNote = "";
+						if (additive && scalar !== null) {
+							const sum = buckets.reduce(
+								(s, r) => s + (num(r.value) ?? 0),
+								0,
+							);
+							if (Math.abs(sum - scalar) < 1e-6) gSumNote = " Σ=scalar";
+							else {
+								gSumNote = ` Σ≠scalar (Σ=${sum})`;
+								fails++;
+							}
+						}
+						// Grained pin ≡ bucket, on the first pinnable bucket.
+						const bRow = buckets.find(
+							(r) => toPin(r[axis.column]) !== undefined,
+						);
+						const bVal = bRow ? toPin(bRow[axis.column]) : undefined;
+						let pinNote = "";
+						if (bRow && bVal !== undefined) {
+							const gpq = composeNodeQuery(resolved.steps, undefined, {
+								slices: [],
+								pins: [
+									{ column: axis.column, value: bVal, grain: preset.token },
+								],
+							});
+							if ("refusal" in gpq) {
+								flag(
+									`${label} pin ${axis.column}@${preset.token}: REFUSED — ${gpq.refusal}`,
+								);
+							} else {
+								try {
+									const pv = num(
+										(await exec(gpq.sql, gpq.params))[0]?.value,
+									);
+									const gv = num(bRow.value);
+									const same =
+										(pv === null && gv === null) ||
+										(pv !== null &&
+											gv !== null &&
+											Math.abs(pv - gv) < 1e-6);
+									if (same) pinNote = " pin≡bucket✓";
+									else {
+										flag(
+											`${label} pin ${axis.column}@${preset.token}=${String(bVal)}: pin=${String(pv)} ≠ bucket=${String(gv)}`,
+										);
+									}
+								} catch (err) {
+									flag(
+										`${label} pin ${axis.column}@${preset.token}: ERR ${String(err).split("\n")[0]}`,
+									);
+								}
+							}
+						}
+						report.push(
+							`    grain ${preset.token} (${preset.label}): ${buckets.length} buckets${gSumNote}${pinNote}`,
+						);
+					}
+				}
 
 				// 3) pin ≡ group, once per node on the first pinnable row
 				if (!pinChecked) {

--- a/packages/cockpit/spikes/review-712.spike.ts
+++ b/packages/cockpit/spikes/review-712.spike.ts
@@ -1,0 +1,199 @@
+// REVIEW SPIKE (delete after): empirically ground the DAT-712 suspicions
+// against the installed @duckdb/node-api. In-memory, no lake.
+import { DuckDBInstance } from "@duckdb/node-api";
+
+const instance = await DuckDBInstance.create(":memory:");
+const conn = await instance.connect();
+
+async function q(sql: string, params?: (string | number | boolean | null)[]) {
+	const reader = params
+		? await conn.runAndReadAll(sql, params)
+		: await conn.runAndReadAll(sql);
+	return reader.getRowObjectsJson();
+}
+
+async function tryQ(
+	label: string,
+	sql: string,
+	params?: (string | number | boolean | null)[],
+) {
+	try {
+		const rows = await q(sql, params);
+		console.log(`OK   ${label}:`, JSON.stringify(rows));
+	} catch (e) {
+		console.log(`ERR  ${label}:`, String(e).split("\n")[0]);
+	}
+}
+
+// --- setup: a fact table with every temporal flavor ---
+await q(`CREATE TABLE t (
+  d DATE, ts TIMESTAMP, tstz TIMESTAMPTZ, s VARCHAR, i INTEGER,
+  amt DECIMAL(18,3), big HUGEINT
+)`);
+await q(`INSERT INTO t VALUES
+  (DATE '2025-01-15', TIMESTAMP '2025-01-15 10:30:00', TIMESTAMPTZ '2025-01-15 10:30:00+00', 'a', 1, 10.5, 12345678901234567890),
+  (DATE '2025-01-20', TIMESTAMP '2025-01-20 23:59:59', TIMESTAMPTZ '2025-01-20 23:59:59+00', 'b', 2, 20.25, 1),
+  (DATE '2025-02-03', TIMESTAMP '2025-02-03 00:00:00', TIMESTAMPTZ '2025-02-03 00:00:00+00', 'a', 3, 30.125, 2),
+  (NULL, NULL, NULL, 'c', 4, NULL, NULL)`);
+
+// 1. JSON serialization shapes (the grid/pin round-trip source)
+console.log("--- 1. JSON serialization of grouped bucket rows ---");
+console.log(
+	JSON.stringify(
+		await q(
+			`SELECT time_bucket(INTERVAL '1 months', "d") AS d, SUM(amt) AS value FROM t GROUP BY time_bucket(INTERVAL '1 months', "d") ORDER BY 1`,
+		),
+	),
+);
+console.log(
+	JSON.stringify(
+		await q(
+			`SELECT time_bucket(INTERVAL '1 months', "ts") AS ts, SUM(amt) AS value FROM t GROUP BY time_bucket(INTERVAL '1 months', "ts") ORDER BY 1`,
+		),
+	),
+);
+await tryQ(
+	"tstz bucket",
+	`SELECT time_bucket(INTERVAL '1 months', "tstz") AS tstz, SUM(amt) AS value FROM t GROUP BY time_bucket(INTERVAL '1 months', "tstz") ORDER BY 1`,
+);
+
+// 2. Pin round-trip: bind the JSON string back as $1
+console.log("--- 2. pin round-trip (DATE) ---");
+await tryQ(
+	"date pin '2025-01-01'",
+	`SELECT SUM(amt) AS value FROM t WHERE (time_bucket(INTERVAL '1 months', "d") = $1)`,
+	["2025-01-01"],
+);
+console.log("--- 2b. pin round-trip (TIMESTAMP) — exact JSON string ---");
+const tsRows = await q(
+	`SELECT time_bucket(INTERVAL '1 months', "ts") AS b FROM t WHERE ts IS NOT NULL LIMIT 1`,
+);
+const tsStr = String(tsRows[0]?.b);
+console.log("serialized ts bucket:", JSON.stringify(tsStr));
+await tryQ(
+	"ts pin (serialized string)",
+	`SELECT SUM(amt) AS value FROM t WHERE (time_bucket(INTERVAL '1 months', "ts") = $1)`,
+	[tsStr],
+);
+console.log("--- 2c. pin round-trip (TIMESTAMPTZ) ---");
+try {
+	const tzRows = await q(
+		`SELECT time_bucket(INTERVAL '1 months', "tstz") AS b FROM t WHERE tstz IS NOT NULL LIMIT 1`,
+	);
+	const tzStr = String(tzRows[0]?.b);
+	console.log("serialized tstz bucket:", JSON.stringify(tzStr));
+	await tryQ(
+		"tstz pin (serialized string)",
+		`SELECT SUM(amt) AS value FROM t WHERE (time_bucket(INTERVAL '1 months', "tstz") = $1)`,
+		[tzStr],
+	);
+} catch (e) {
+	console.log("tstz path failed:", String(e).split("\n")[0]);
+}
+
+// 3. comparison cast direction: does '2025-1-1' (non-canonical) match DATE?
+console.log("--- 3. cast direction ---");
+await tryQ("DATE = '2025-1-1' param", `SELECT DATE '2025-01-01' = $1 AS eq`, [
+	"2025-1-1",
+]);
+await tryQ("DATE = 'garbage' param", `SELECT DATE '2025-01-01' = $1 AS eq`, [
+	"garbage",
+]);
+
+// 4. interval plural + '1M' danger check
+console.log("--- 4. interval spellings ---");
+await tryQ("'1 months' plural", `SELECT INTERVAL '1 months' AS v`);
+await tryQ(
+	"time_bucket weeks Monday",
+	`SELECT time_bucket(INTERVAL '1 weeks', DATE '2026-07-08') AS wk, dayname(time_bucket(INTERVAL '1 weeks', DATE '2026-07-08')) AS dow`,
+);
+await tryQ(
+	"time_bucket 3 months quarter alignment",
+	`SELECT time_bucket(INTERVAL '3 months', DATE '2025-05-15') AS b`,
+);
+
+// 5. grain on non-temporal columns
+console.log("--- 5. non-temporal grain ---");
+await tryQ(
+	"time_bucket on VARCHAR col",
+	`SELECT time_bucket(INTERVAL '1 months', "s") AS b FROM t`,
+);
+await tryQ(
+	"time_bucket on VARCHAR col DESCRIBE",
+	`DESCRIBE SELECT time_bucket(INTERVAL '1 months', "s") AS b FROM t`,
+);
+await tryQ(
+	"time_bucket on INTEGER col",
+	`SELECT time_bucket(INTERVAL '1 months', "i") AS b FROM t`,
+);
+await tryQ(
+	"sub-day grain on DATE",
+	`SELECT time_bucket(INTERVAL '2 hours', "d") AS b FROM t WHERE d IS NOT NULL LIMIT 1`,
+);
+await tryQ(
+	"sub-day grain on DATE DESCRIBE",
+	`DESCRIBE SELECT time_bucket(INTERVAL '2 hours', "d") AS b FROM t`,
+);
+
+// 6. NULL pin: IS NULL over bucket
+console.log("--- 6. NULL pin ---");
+await tryQ(
+	"bucket IS NULL",
+	`SELECT COUNT(*) AS n, SUM(i) AS si FROM t WHERE (time_bucket(INTERVAL '1 months', "d") IS NULL)`,
+);
+
+// 7. alias shadowing: WHERE + GROUP BY reference vs alias
+console.log("--- 7. alias shadowing ---");
+await tryQ(
+	"GROUP BY name resolves raw (their claim)",
+	`SELECT time_bucket(INTERVAL '1 months', "d") AS d, COUNT(*) AS n FROM t GROUP BY "d" ORDER BY 1`,
+);
+await tryQ(
+	"WHERE name resolves raw when alias same name",
+	`SELECT time_bucket(INTERVAL '1 months', "d") AS d FROM t WHERE (time_bucket(INTERVAL '1 weeks', "d") = $1) GROUP BY time_bucket(INTERVAL '1 months', "d")`,
+	["2025-01-13"],
+);
+
+// 8. DESCRIBE binds params (the gate)
+console.log("--- 8. DESCRIBE with params ---");
+await tryQ(
+	"describe with param",
+	`DESCRIBE SELECT SUM(amt) AS value FROM t WHERE (time_bucket(INTERVAL '1 months', "d") = $1)`,
+	["2025-01-01"],
+);
+
+// 9. DECIMAL / HUGEINT JSON shape (equation formatNumber input)
+console.log("--- 9. decimal/hugeint JSON ---");
+console.log(
+	JSON.stringify(
+		await q(`SELECT SUM(amt) AS value, SUM(big) AS bigv, 1.5 AS ratio FROM t`),
+	),
+);
+
+// 10. same column sliced at 1M, pinned at frozen 1w — semantics
+console.log("--- 10. mixed-grain slice+pin ---");
+console.log(
+	JSON.stringify(
+		await q(
+			`SELECT time_bucket(INTERVAL '1 months', "d") AS d, SUM(i) AS value FROM t WHERE (time_bucket(INTERVAL '1 weeks', "d") = $1) GROUP BY time_bucket(INTERVAL '1 months', "d")`,
+			["2025-01-13"],
+		),
+	),
+);
+
+// 11. TIMESTAMPTZ serialization TZ dependence
+console.log("--- 11. tstz + session timezone ---");
+await q(`SET TimeZone='America/New_York'`);
+const tz2 = await q(
+	`SELECT time_bucket(INTERVAL '1 months', "tstz") AS b FROM t WHERE tstz IS NOT NULL GROUP BY 1 ORDER BY 1`,
+);
+console.log("NY buckets:", JSON.stringify(tz2));
+if (tz2[0]) {
+	await tryQ(
+		"NY pin round-trip",
+		`SELECT COUNT(*) AS n FROM t WHERE (time_bucket(INTERVAL '1 months', "tstz") = $1)`,
+		[String(tz2[0].b)],
+	);
+}
+
+console.log("done");

--- a/packages/cockpit/spikes/review-712b.spike.ts
+++ b/packages/cockpit/spikes/review-712b.spike.ts
@@ -1,0 +1,156 @@
+// REVIEW SPIKE B (delete after): drive composeNodeQuery output through a real
+// in-memory DuckDB for the pathological cases.
+import { DuckDBInstance } from "@duckdb/node-api";
+import type { NodeStep } from "#/duckdb/parts";
+import { composeNodeQuery, composeNodeTotals } from "#/duckdb/parts";
+
+const instance = await DuckDBInstance.create(":memory:");
+const conn = await instance.connect();
+
+async function q(sql: string, params?: (string | number | boolean | null)[]) {
+	const reader = params
+		? await conn.runAndReadAll(sql, params)
+		: await conn.runAndReadAll(sql);
+	return reader.getRowObjectsJson();
+}
+
+await q(`CREATE TABLE fact ("we""ird" DATE, region VARCHAR, amt INT)`);
+await q(`INSERT INTO fact VALUES
+  (DATE '2025-01-15','eu',10),(DATE '2025-02-03','us',20),(NULL,'eu',30)`);
+
+const steps: NodeStep[] = [
+	{
+		stepId: "rev",
+		kind: "extract",
+		parts: { selectExpr: "SUM(amt)", relation: "fact", where: [] },
+		expression: null,
+		value: null,
+		dependsOn: [],
+		outputStep: true,
+	},
+];
+
+// 1. slice on a column whose name contains a double quote, grained
+const c1 = composeNodeQuery(steps, undefined, {
+	slices: [{ column: 'we"ird', grain: "1M" }],
+	pins: [],
+});
+if ("refusal" in c1) console.log("REFUSAL c1:", c1.refusal);
+else {
+	console.log("SQL c1:\n", c1.sql);
+	try {
+		console.log("rows:", JSON.stringify(await q(c1.sql, c1.params)));
+	} catch (e) {
+		console.log("EXEC ERR c1:", String(e).split("\n")[0]);
+	}
+}
+
+// 2. pin on the measure alias name "value" — alias capture in WHERE?
+const c2 = composeNodeQuery(steps, undefined, {
+	slices: [],
+	pins: [{ column: "value", value: 60 }],
+});
+if ("refusal" in c2) console.log("REFUSAL c2:", c2.refusal);
+else {
+	console.log("SQL c2:\n", c2.sql);
+	try {
+		console.log("rows:", JSON.stringify(await q(c2.sql, c2.params)));
+	} catch (e) {
+		console.log("EXEC ERR c2:", String(e).split("\n")[0]);
+	}
+}
+
+// 3. additive metric: pin on "_observed"?
+const addSteps: NodeStep[] = [
+	{
+		stepId: "sales",
+		kind: "extract",
+		parts: { selectExpr: "SUM(amt)", relation: "fact", where: [] },
+		expression: null,
+		value: null,
+		dependsOn: [],
+		outputStep: false,
+	},
+	{
+		stepId: "gp",
+		kind: "formula",
+		parts: null,
+		expression: "sales - sales",
+		value: null,
+		dependsOn: ["sales"],
+		outputStep: true,
+	},
+];
+const c3 = composeNodeQuery(addSteps, undefined, {
+	slices: [{ column: "region" }],
+	pins: [{ column: "_observed", value: 1 }],
+});
+if ("refusal" in c3) console.log("REFUSAL c3:", c3.refusal);
+else {
+	console.log("SQL c3:\n", c3.sql);
+	try {
+		console.log("rows:", JSON.stringify(await q(c3.sql, c3.params)));
+	} catch (e) {
+		console.log("EXEC ERR c3:", String(e).split("\n")[0]);
+	}
+}
+
+// 4. a + a double-ref additive: contributes twice?
+const dblSteps: NodeStep[] = [
+	{
+		stepId: "sales",
+		kind: "extract",
+		parts: { selectExpr: "SUM(amt)", relation: "fact", where: [] },
+		expression: null,
+		value: null,
+		dependsOn: [],
+		outputStep: false,
+	},
+	{
+		stepId: "dbl",
+		kind: "formula",
+		parts: null,
+		expression: "sales + sales",
+		value: null,
+		dependsOn: ["sales"],
+		outputStep: true,
+	},
+];
+const c4 = composeNodeQuery(dblSteps, undefined, {
+	slices: [{ column: "region" }],
+	pins: [],
+});
+if ("refusal" in c4) console.log("REFUSAL c4:", c4.refusal);
+else {
+	try {
+		console.log("dbl rows:", JSON.stringify(await q(c4.sql, c4.params)));
+	} catch (e) {
+		console.log("EXEC ERR c4:", String(e).split("\n")[0]);
+	}
+}
+
+// 5. totals for the same — operand projection of a two-ref formula
+const c5 = composeNodeTotals(dblSteps, undefined);
+if ("refusal" in c5) console.log("REFUSAL c5:", c5.refusal);
+else {
+	console.log("SQL c5:\n", c5.sql);
+	try {
+		console.log("totals rows:", JSON.stringify(await q(c5.sql, c5.params)));
+	} catch (e) {
+		console.log("EXEC ERR c5:", String(e).split("\n")[0]);
+	}
+}
+
+// 6. NULL-date bucket pin end-to-end through the composer
+const c6 = composeNodeQuery(steps, undefined, {
+	slices: [{ column: 'we"ird', grain: "1M" }],
+	pins: [{ column: 'we"ird', value: null, grain: "1M" }],
+});
+if ("refusal" in c6) console.log("REFUSAL c6:", c6.refusal);
+else {
+	try {
+		console.log("null-pin rows:", JSON.stringify(await q(c6.sql, c6.params)));
+	} catch (e) {
+		console.log("EXEC ERR c6:", String(e).split("\n")[0]);
+	}
+}

--- a/packages/cockpit/src/duckdb/drill.ts
+++ b/packages/cockpit/src/duckdb/drill.ts
@@ -67,8 +67,9 @@ export const sliceColumns = (steps: DrillStep[]): string[] => {
 /** The slice steps themselves (deduped by column, first wins) — the node path
  *  needs the grain riding each slice, not just the column names. A `grain` on
  *  a temporal slice buckets it via `time_bucket` (DAT-712; grain.ts owns the
- *  token grammar). Tier A keeps `sliceColumns`: its wire schema carries no
- *  grain, so one can never be silently dropped there. */
+ *  token grammar). Tier A keeps `sliceColumns` and its route rejects grained
+ *  steps outright (strict zod → 400) — a grain can never be silently dropped
+ *  into raw grouping there. */
 export const sliceSteps = (
 	steps: DrillStep[],
 ): { column: string; grain?: string }[] => {

--- a/packages/cockpit/src/duckdb/drill.ts
+++ b/packages/cockpit/src/duckdb/drill.ts
@@ -17,6 +17,7 @@
 // This module is neo-free so widgets can import the types (grid-query.ts is
 // the precedent).
 
+import type { TemporalKind } from "./grain";
 import { quoteIdentifier } from "./grid-query";
 
 /** A pin carries the clicked cell's JSON value — bigints/dates arrive as
@@ -24,8 +25,8 @@ import { quoteIdentifier } from "./grid-query";
 export type DrillPinValue = string | number | boolean | null;
 
 export type DrillStep =
-	| { kind: "slice"; column: string }
-	| { kind: "pin"; column: string; value: DrillPinValue };
+	| { kind: "slice"; column: string; grain?: string }
+	| { kind: "pin"; column: string; value: DrillPinValue; grain?: string };
 
 /** Axis-resolution request (`/api/drill/axes`, metric path in P1): exactly one
  *  of the two keys. Shared client↔server so the wire contract can't silently
@@ -46,6 +47,10 @@ export interface DrillAxis {
 	values: string[];
 	valueCount: number | null;
 	businessContext: string | null;
+	/** The column's temporal resolution from the catalog's `resolved_type`
+	 *  (never a name heuristic) — non-null makes the slice grain-able and
+	 *  decides which grains the chip offers (DAT-712). */
+	temporal: TemporalKind | null;
 }
 
 export const sliceColumns = (steps: DrillStep[]): string[] => {
@@ -55,6 +60,22 @@ export const sliceColumns = (steps: DrillStep[]): string[] => {
 		if (s.kind !== "slice" || seen.has(s.column)) continue;
 		seen.add(s.column);
 		out.push(s.column);
+	}
+	return out;
+};
+
+/** The slice steps themselves (deduped by column, first wins) — the node path
+ *  needs the grain riding each slice, not just the column names. A `grain` on
+ *  a temporal slice buckets it via `time_bucket` (DAT-712; grain.ts owns the
+ *  token grammar). Tier A keeps `sliceColumns`: its wire schema carries no
+ *  grain, so one can never be silently dropped there. */
+export const sliceSteps = (
+	steps: DrillStep[],
+): { column: string; grain?: string }[] => {
+	const out: { column: string; grain?: string }[] = [];
+	for (const s of steps) {
+		if (s.kind !== "slice" || out.some((d) => d.column === s.column)) continue;
+		out.push(s.grain === undefined ? { column: s.column } : { column: s.column, grain: s.grain });
 	}
 	return out;
 };

--- a/packages/cockpit/src/duckdb/drill.ts
+++ b/packages/cockpit/src/duckdb/drill.ts
@@ -75,7 +75,11 @@ export const sliceSteps = (
 	const out: { column: string; grain?: string }[] = [];
 	for (const s of steps) {
 		if (s.kind !== "slice" || out.some((d) => d.column === s.column)) continue;
-		out.push(s.grain === undefined ? { column: s.column } : { column: s.column, grain: s.grain });
+		out.push(
+			s.grain === undefined
+				? { column: s.column }
+				: { column: s.column, grain: s.grain },
+		);
 	}
 	return out;
 };

--- a/packages/cockpit/src/duckdb/grain.test.ts
+++ b/packages/cockpit/src/duckdb/grain.test.ts
@@ -97,10 +97,14 @@ describe("temporalKindOfType", () => {
 		expect(temporalKindOfType(type)).toBe(kind);
 	});
 
-	it.each(["VARCHAR", "BIGINT", "TIME", "", null, undefined])(
-		"non-temporal %j → null",
-		(type) => {
-			expect(temporalKindOfType(type)).toBeNull();
-		},
-	);
+	it.each([
+		"VARCHAR",
+		"BIGINT",
+		"TIME",
+		"",
+		null,
+		undefined,
+	])("non-temporal %j → null", (type) => {
+		expect(temporalKindOfType(type)).toBeNull();
+	});
 });

--- a/packages/cockpit/src/duckdb/grain.test.ts
+++ b/packages/cockpit/src/duckdb/grain.test.ts
@@ -1,0 +1,106 @@
+// Grain token grammar (DAT-712): the closed, case-sensitive parse between the
+// chip and the composer — including the trap that motivated it (DuckDB parses
+// '1M' as 1 MINUTE, case-insensitively; a token must never reach SQL).
+
+import { describe, expect, it } from "vitest";
+
+import {
+	grainIntervalBody,
+	grainLabel,
+	grainPresets,
+	parseGrainToken,
+	temporalKindOfType,
+} from "./grain";
+
+describe("parseGrainToken", () => {
+	it("distinguishes 1m (minutes) from 1M (months) — the DuckDB trap", () => {
+		expect(parseGrainToken("1m")).toEqual({ n: 1, unit: "m" });
+		expect(parseGrainToken("1M")).toEqual({ n: 1, unit: "M" });
+	});
+
+	it("parses multipliers", () => {
+		expect(parseGrainToken("15m")).toEqual({ n: 15, unit: "m" });
+		expect(parseGrainToken("2h")).toEqual({ n: 2, unit: "h" });
+		expect(parseGrainToken("3M")).toEqual({ n: 3, unit: "M" });
+		expect(parseGrainToken("9999y")).toEqual({ n: 9999, unit: "y" });
+	});
+
+	it.each([
+		"", // empty
+		"d", // no multiplier
+		"0d", // zero-width bucket
+		"01d", // leading zero
+		"10000d", // over the 4-digit cap
+		"1mo", // not a token — the grammar is single-letter
+		"1q ", // whitespace
+		" 1q", // whitespace
+		"1Q", // case-sensitive: only lowercase q
+		"1D", // case-sensitive: only lowercase d
+		"1x", // unknown unit
+		"1.5d", // integers only
+		"-1d", // positive only
+		"1d2h", // one unit per token
+	])("refuses %j", (token) => {
+		expect(parseGrainToken(token)).toBeNull();
+	});
+});
+
+describe("grainIntervalBody", () => {
+	it("renders canonical plural phrases", () => {
+		expect(grainIntervalBody({ n: 1, unit: "M" })).toBe("1 months");
+		expect(grainIntervalBody({ n: 15, unit: "m" })).toBe("15 minutes");
+		expect(grainIntervalBody({ n: 1, unit: "d" })).toBe("1 days");
+		expect(grainIntervalBody({ n: 2, unit: "w" })).toBe("2 weeks");
+		expect(grainIntervalBody({ n: 1, unit: "y" })).toBe("1 years");
+	});
+
+	it("maps quarters to month-multiples (no DuckDB quarter unit)", () => {
+		expect(grainIntervalBody({ n: 1, unit: "q" })).toBe("3 months");
+		expect(grainIntervalBody({ n: 2, unit: "q" })).toBe("6 months");
+	});
+});
+
+describe("grainLabel", () => {
+	it("labels singles capitalized, multiples counted", () => {
+		expect(grainLabel({ n: 1, unit: "M" })).toBe("Month");
+		expect(grainLabel({ n: 1, unit: "q" })).toBe("Quarter");
+		expect(grainLabel({ n: 15, unit: "m" })).toBe("15 minutes");
+		expect(grainLabel({ n: 2, unit: "h" })).toBe("2 hours");
+	});
+});
+
+describe("grainPresets", () => {
+	it("offers no sub-day grains on a date column", () => {
+		const tokens = grainPresets("date").map((p) => p.token);
+		expect(tokens).toEqual(["1d", "1w", "1M", "1q", "1y"]);
+	});
+
+	it("adds minute/hour on a timestamp column", () => {
+		const tokens = grainPresets("timestamp").map((p) => p.token);
+		expect(tokens).toEqual(["1m", "1h", "1d", "1w", "1M", "1q", "1y"]);
+	});
+
+	it("labels every preset", () => {
+		for (const p of grainPresets("timestamp")) {
+			expect(p.label).not.toBe("");
+		}
+	});
+});
+
+describe("temporalKindOfType", () => {
+	it.each([
+		["DATE", "date"],
+		["TIMESTAMP", "timestamp"],
+		["TIMESTAMP WITH TIME ZONE", "timestamp"],
+		["timestamp", "timestamp"],
+	] as const)("%s → %s", (type, kind) => {
+		expect(temporalKindOfType(type)).toBe(kind);
+	});
+
+	it.each(["VARCHAR", "BIGINT", "TIME", "", null, undefined])(
+		"non-temporal %j → null",
+		(type) => {
+			expect(temporalKindOfType(type)).toBeNull();
+		},
+	);
+});

--- a/packages/cockpit/src/duckdb/grain.ts
+++ b/packages/cockpit/src/duckdb/grain.ts
@@ -1,0 +1,118 @@
+// Time-grain tokens (DAT-712, the DAT-673 date_trunc hook): the CLOSED,
+// CASE-SENSITIVE grammar between the grain chip and the composed SQL.
+//
+// The UI speaks compact interval tokens (`1d`, `15m`, `1M`, `2h` — the
+// Grafana convention: `m` is minutes, `M` is months). DuckDB CANNOT parse
+// these safely: its interval parser is case-insensitive, so `INTERVAL '1M'`
+// is 1 MINUTE, and `time_bucket(INTERVAL '1M', DATE …)` silently returns the
+// raw date — it looks like day grain, no error (verified empirically,
+// 2026-07-08; `1q`/`1mo` don't parse at all). So a token NEVER reaches SQL:
+// this module parses it against the closed grammar and the composer renders
+// the CANONICAL spelled-out interval (`'1 month'`, `'15 minutes'`) that we
+// author. An off-grammar token is a named refusal, not a guess.
+//
+// Composition target is `time_bucket(INTERVAL …, col)`, not `date_trunc`: it
+// subsumes it, preserves the column type (DATE in → DATE out; `date_trunc`
+// always widens to TIMESTAMP), arbitrary widths compose (`15m`, `3M`), weeks
+// bucket to Monday (= `date_trunc('week')`), and month-multiples align to
+// calendar boundaries from origin 2000-01-01 (`3M` = calendar quarters).
+//
+// Pure and client-safe: the chip validates typed tokens locally with the same
+// function the composer trusts server-side.
+
+export type GrainUnit = "s" | "m" | "h" | "d" | "w" | "M" | "q" | "y";
+
+export interface Grain {
+	/** The multiplier, ≥ 1 — bounded by the token's 4-digit cap. */
+	n: number;
+	unit: GrainUnit;
+}
+
+// Case-sensitive on purpose: `m`/`M` is exactly the ambiguity DuckDB's own
+// parser gets wrong. 4 digits bounds the multiplier (9999y is already absurd).
+const TOKEN_RE = /^([1-9]\d{0,3})(s|m|h|d|w|M|q|y)$/;
+
+/** Parse a grain token (`1d`, `15m`, `3M`) — null for anything off-grammar,
+ *  including `0`-multiples, `1mo`, `1Q`, and whitespace. */
+export function parseGrainToken(token: string): Grain | null {
+	const match = TOKEN_RE.exec(token);
+	if (!match) return null;
+	return { n: Number(match[1]), unit: match[2] as GrainUnit };
+}
+
+// Canonical DuckDB interval phrases per unit. Always plural — DuckDB accepts
+// `1 months`, and one spelling keeps the rendered SQL deterministic. Quarters
+// have no DuckDB unit: `q` maps to month-multiples (calendar-aligned, see
+// header).
+const UNIT_PHRASE: Record<GrainUnit, { word: string; monthsPerN?: number }> = {
+	s: { word: "seconds" },
+	m: { word: "minutes" },
+	h: { word: "hours" },
+	d: { word: "days" },
+	w: { word: "weeks" },
+	M: { word: "months" },
+	q: { word: "months", monthsPerN: 3 },
+	y: { word: "years" },
+};
+
+/** The canonical interval body for a parsed grain — `"15 minutes"`,
+ *  `"1 months"`, `"6 months"` (q×2). Only ever built from the parsed integer
+ *  and our own words; rendered by the composer as `INTERVAL '<this>'`. */
+export function grainIntervalBody(grain: Grain): string {
+	const { word, monthsPerN } = UNIT_PHRASE[grain.unit];
+	return `${grain.n * (monthsPerN ?? 1)} ${word}`;
+}
+
+const UNIT_LABEL: Record<GrainUnit, string> = {
+	s: "second",
+	m: "minute",
+	h: "hour",
+	d: "day",
+	w: "week",
+	M: "month",
+	q: "quarter",
+	y: "year",
+};
+
+/** Human label for a grain — `"Month"`, `"15 minutes"`, `"Quarter"`. */
+export function grainLabel(grain: Grain): string {
+	const unit = UNIT_LABEL[grain.unit];
+	if (grain.n === 1) return unit.charAt(0).toUpperCase() + unit.slice(1);
+	return `${grain.n} ${unit}s`;
+}
+
+/** A temporal axis column's resolution, from the catalog's `resolved_type` —
+ *  what decides WHICH grains the chip offers (a DATE column has no hours to
+ *  aggregate). */
+export type TemporalKind = "date" | "timestamp";
+
+/** The chip's preset menu for a column resolution: label + token pairs, coarse
+ *  last. Typed tokens extend past the presets (`15m`, `2h`, `3M`) — these are
+ *  the approachable defaults, not the grammar's bounds. */
+export function grainPresets(
+	kind: TemporalKind,
+): { token: string; label: string }[] {
+	const presets =
+		kind === "timestamp"
+			? ["1m", "1h", "1d", "1w", "1M", "1q", "1y"]
+			: ["1d", "1w", "1M", "1q", "1y"];
+	return presets.map((token) => {
+		// Presets are authored above — the parse cannot fail; the non-null
+		// assertion would hide a typo, so refuse loudly instead.
+		const grain = parseGrainToken(token);
+		if (!grain) throw new Error(`invalid built-in grain preset '${token}'`);
+		return { token, label: grainLabel(grain) };
+	});
+}
+
+/** Map a catalog `resolved_type` to a temporal kind — null for everything
+ *  non-temporal. Type-based on purpose: never a column-NAME heuristic. */
+export function temporalKindOfType(
+	resolvedType: string | null | undefined,
+): TemporalKind | null {
+	if (!resolvedType) return null;
+	const t = resolvedType.toUpperCase();
+	if (t === "DATE") return "date";
+	if (t.startsWith("TIMESTAMP")) return "timestamp";
+	return null;
+}

--- a/packages/cockpit/src/duckdb/parts.test.ts
+++ b/packages/cockpit/src/duckdb/parts.test.ts
@@ -310,7 +310,10 @@ describe("composeNodeQuery — grouped", () => {
 				true,
 			),
 		];
-		const q = composed(steps, undefined, { slices: [{ column: "region" }], pins: [] });
+		const q = composed(steps, undefined, {
+			slices: [{ column: "region" }],
+			pins: [],
+		});
 		expect(q.sql).toContain("FULL JOIN");
 		expect(q.sql).not.toContain("COALESCE");
 		const byRegion = new Map((await rows(q.sql)).map((r) => [r.region, r]));
@@ -341,7 +344,8 @@ describe("composeNodeQuery — grouped", () => {
 			),
 		];
 		const result = await rows(
-			composed(steps, undefined, { slices: [{ column: "account" }], pins: [] }).sql,
+			composed(steps, undefined, { slices: [{ column: "account" }], pins: [] })
+				.sql,
 		);
 		expect(result).toHaveLength(2); // the union domain still shows the groups…
 		for (const r of result) {
@@ -380,7 +384,8 @@ describe("composeNodeQuery — grouped", () => {
 		];
 		const scalar = num((await rows(composed(steps).sql))[0]?.value);
 		const result = await rows(
-			composed(steps, undefined, { slices: [{ column: "account" }], pins: [] }).sql,
+			composed(steps, undefined, { slices: [{ column: "account" }], pins: [] })
+				.sql,
 		);
 		const byAccount = new Map(result.map((r) => [r.account, num(r.value)]));
 		expect(byAccount.get("depr")).toBe(40);
@@ -409,7 +414,10 @@ describe("composeNodeQuery — grouped", () => {
 		const byAccount = new Map(
 			(
 				await rows(
-					composed(steps, undefined, { slices: [{ column: "account" }], pins: [] }).sql,
+					composed(steps, undefined, {
+						slices: [{ column: "account" }],
+						pins: [],
+					}).sql,
 				)
 			).map((r) => [r.account, num(r.value)]),
 		);
@@ -430,7 +438,8 @@ describe("composeNodeQuery — grouped", () => {
 			formula("out", "revenue + weird", ["revenue", "weird"], true),
 		];
 		const grouped = await rows(
-			composed(steps, undefined, { slices: [{ column: "account" }], pins: [] }).sql,
+			composed(steps, undefined, { slices: [{ column: "account" }], pins: [] })
+				.sql,
 		);
 		expect(grouped).toHaveLength(1); // both carriers observe only 'sales'
 		expect(grouped[0]?.value).toBeNull();
@@ -454,7 +463,8 @@ describe("composeNodeQuery — grouped", () => {
 			),
 		];
 		const result = await rows(
-			composed(steps, undefined, { slices: [{ column: "account" }], pins: [] }).sql,
+			composed(steps, undefined, { slices: [{ column: "account" }], pins: [] })
+				.sql,
 		);
 		expect(result.length).toBeGreaterThan(0); // revenue's groups still appear
 		for (const r of result) expect(r.value).toBeNull();
@@ -462,7 +472,11 @@ describe("composeNodeQuery — grouped", () => {
 
 	it("slices by several dims at once (GROUP BY + USING both)", async () => {
 		const q = composed(GROSS_PROFIT, undefined, {
-			slices: [{ column: "account" }, { column: "region" }, { column: "account" }],
+			slices: [
+				{ column: "account" },
+				{ column: "region" },
+				{ column: "account" },
+			],
 			pins: [],
 		});
 		const result = await rows(q.sql);
@@ -487,7 +501,10 @@ describe("composeNodeQuery — grouped", () => {
 		];
 		const scalar = num((await rows(composed(steps).sql))[0]?.value);
 		expect(scalar).toBe(560); // 800 - 200 - 40
-		const q = composed(steps, undefined, { slices: [{ column: "account" }], pins: [] });
+		const q = composed(steps, undefined, {
+			slices: [{ column: "account" }],
+			pins: [],
+		});
 		expect(q.sql.match(/UNION ALL/g)).toHaveLength(2); // three signed branches
 		const result = await rows(q.sql);
 		expect(result).toHaveLength(3); // union domain across all three sides
@@ -717,7 +734,8 @@ describe("composeNodeQuery — pins", () => {
 			),
 		];
 		const result = await rows(
-			composed(steps, undefined, { slices: [{ column: "region" }], pins: [] }).sql,
+			composed(steps, undefined, { slices: [{ column: "region" }], pins: [] })
+				.sql,
 		);
 		for (const r of result) {
 			expect(Object.keys(r)).toEqual([
@@ -965,9 +983,9 @@ describe("composeNodeTotals", () => {
 		expect(plain.sql.slice(plain.sql.lastIndexOf("SELECT"))).toContain(
 			'"value"',
 		);
-		expect(
-			plain.sql.slice(plain.sql.lastIndexOf("SELECT")),
-		).not.toContain('"revenue"');
+		expect(plain.sql.slice(plain.sql.lastIndexOf("SELECT"))).not.toContain(
+			'"revenue"',
+		);
 	});
 
 	it("a bare measure's totals are just its scalar", async () => {

--- a/packages/cockpit/src/duckdb/parts.test.ts
+++ b/packages/cockpit/src/duckdb/parts.test.ts
@@ -17,6 +17,7 @@ import type { DrillPinValue } from "./drill";
 import {
 	type ComposedNodeQuery,
 	composeNodeQuery,
+	composeNodeTotals,
 	flattenAdditive,
 	type NodeDrill,
 	type NodeStep,
@@ -31,18 +32,20 @@ beforeAll(async () => {
 	instance = await DuckDBInstance.create(":memory:");
 	conn = await instance.connect();
 	await conn.run(
-		"CREATE TABLE enriched_txn (account VARCHAR, region VARCHAR, kind VARCHAR, credit DOUBLE, debit DOUBLE, open_balance DOUBLE)",
+		"CREATE TABLE enriched_txn (account VARCHAR, region VARCHAR, kind VARCHAR, credit DOUBLE, debit DOUBLE, open_balance DOUBLE, booked_on DATE)",
 	);
 	// revenue lives on 'sales' accounts, cogs on 'materials', depreciation on
 	// 'depr', AR balances on 'sales' west only — the disjoint shapes the
-	// grouped composition must keep honest.
+	// grouped composition must keep honest. Dates: revenue books only in
+	// January (two days), cogs in BOTH months — the time-grain tests bucket
+	// these (raw days ≠ month groups; February has cogs but no revenue).
 	await conn.run(`INSERT INTO enriched_txn VALUES
-		('sales', 'west', 'rev', 500, 0, 0),
-		('sales', 'east', 'rev', 400, 100, 0),
-		('materials', 'west', 'cogs', 0, 120, 0),
-		('materials', 'east', 'cogs', 0, 80, 0),
-		('depr', 'west', 'depr', 0, 40, 0),
-		('sales', 'west', 'ar', 0, 0, 180)`);
+		('sales', 'west', 'rev', 500, 0, 0, DATE '2025-01-05'),
+		('sales', 'east', 'rev', 400, 100, 0, DATE '2025-01-20'),
+		('materials', 'west', 'cogs', 0, 120, 0, DATE '2025-01-12'),
+		('materials', 'east', 'cogs', 0, 80, 0, DATE '2025-02-08'),
+		('depr', 'west', 'depr', 0, 40, 0, DATE '2025-02-15'),
+		('sales', 'west', 'ar', 0, 0, 180, DATE '2025-02-15')`);
 });
 afterAll(() => {
 	conn?.closeSync();
@@ -277,7 +280,7 @@ describe("composeNodeQuery — grouped", () => {
 	it("ADDITIVE: disjoint decomposition via signed contributions — union domain, Σ = scalar, no COALESCE, no join", async () => {
 		const scalar = num((await rows(composed(GROSS_PROFIT).sql))[0]?.value);
 		const q = composed(GROSS_PROFIT, undefined, {
-			slices: ["account"],
+			slices: [{ column: "account" }],
 			pins: [],
 		});
 		expect(q.sql).toContain("UNION ALL");
@@ -307,7 +310,7 @@ describe("composeNodeQuery — grouped", () => {
 				true,
 			),
 		];
-		const q = composed(steps, undefined, { slices: ["region"], pins: [] });
+		const q = composed(steps, undefined, { slices: [{ column: "region" }], pins: [] });
 		expect(q.sql).toContain("FULL JOIN");
 		expect(q.sql).not.toContain("COALESCE");
 		const byRegion = new Map((await rows(q.sql)).map((r) => [r.region, r]));
@@ -338,7 +341,7 @@ describe("composeNodeQuery — grouped", () => {
 			),
 		];
 		const result = await rows(
-			composed(steps, undefined, { slices: ["account"], pins: [] }).sql,
+			composed(steps, undefined, { slices: [{ column: "account" }], pins: [] }).sql,
 		);
 		expect(result).toHaveLength(2); // the union domain still shows the groups…
 		for (const r of result) {
@@ -377,7 +380,7 @@ describe("composeNodeQuery — grouped", () => {
 		];
 		const scalar = num((await rows(composed(steps).sql))[0]?.value);
 		const result = await rows(
-			composed(steps, undefined, { slices: ["account"], pins: [] }).sql,
+			composed(steps, undefined, { slices: [{ column: "account" }], pins: [] }).sql,
 		);
 		const byAccount = new Map(result.map((r) => [r.account, num(r.value)]));
 		expect(byAccount.get("depr")).toBe(40);
@@ -406,7 +409,7 @@ describe("composeNodeQuery — grouped", () => {
 		const byAccount = new Map(
 			(
 				await rows(
-					composed(steps, undefined, { slices: ["account"], pins: [] }).sql,
+					composed(steps, undefined, { slices: [{ column: "account" }], pins: [] }).sql,
 				)
 			).map((r) => [r.account, num(r.value)]),
 		);
@@ -427,7 +430,7 @@ describe("composeNodeQuery — grouped", () => {
 			formula("out", "revenue + weird", ["revenue", "weird"], true),
 		];
 		const grouped = await rows(
-			composed(steps, undefined, { slices: ["account"], pins: [] }).sql,
+			composed(steps, undefined, { slices: [{ column: "account" }], pins: [] }).sql,
 		);
 		expect(grouped).toHaveLength(1); // both carriers observe only 'sales'
 		expect(grouped[0]?.value).toBeNull();
@@ -451,7 +454,7 @@ describe("composeNodeQuery — grouped", () => {
 			),
 		];
 		const result = await rows(
-			composed(steps, undefined, { slices: ["account"], pins: [] }).sql,
+			composed(steps, undefined, { slices: [{ column: "account" }], pins: [] }).sql,
 		);
 		expect(result.length).toBeGreaterThan(0); // revenue's groups still appear
 		for (const r of result) expect(r.value).toBeNull();
@@ -459,7 +462,7 @@ describe("composeNodeQuery — grouped", () => {
 
 	it("slices by several dims at once (GROUP BY + USING both)", async () => {
 		const q = composed(GROSS_PROFIT, undefined, {
-			slices: ["account", "region", "account"],
+			slices: [{ column: "account" }, { column: "region" }, { column: "account" }],
 			pins: [],
 		});
 		const result = await rows(q.sql);
@@ -484,7 +487,7 @@ describe("composeNodeQuery — grouped", () => {
 		];
 		const scalar = num((await rows(composed(steps).sql))[0]?.value);
 		expect(scalar).toBe(560); // 800 - 200 - 40
-		const q = composed(steps, undefined, { slices: ["account"], pins: [] });
+		const q = composed(steps, undefined, { slices: [{ column: "account" }], pins: [] });
 		expect(q.sql.match(/UNION ALL/g)).toHaveLength(2); // three signed branches
 		const result = await rows(q.sql);
 		expect(result).toHaveLength(3); // union domain across all three sides
@@ -494,7 +497,7 @@ describe("composeNodeQuery — grouped", () => {
 
 	it("a grouped bare measure carries the dims itself", async () => {
 		const q = composed([{ ...REVENUE, outputStep: true }], undefined, {
-			slices: ["region"],
+			slices: [{ column: "region" }],
 			pins: [],
 		});
 		const byRegion = new Map(
@@ -627,7 +630,7 @@ describe("composeNodeQuery — pins", () => {
 
 	it("pushes a pin into EVERY extract's WHERE, pre-aggregation, as $n", async () => {
 		const q = composed(GROSS_PROFIT, undefined, {
-			slices: ["account"],
+			slices: [{ column: "account" }],
 			pins: [{ column: "region", value: "west" }],
 		});
 		expect(q.params).toEqual(["west"]);
@@ -653,7 +656,7 @@ describe("composeNodeQuery — pins", () => {
 		// -cogs); the pinned re-evaluation composes the same contributions under
 		// the filter — never a contradicting number.
 		const grouped = composed(GROSS_PROFIT, undefined, {
-			slices: ["account"],
+			slices: [{ column: "account" }],
 			pins: [],
 		});
 		const materialsRow = (await rows(grouped.sql)).find(
@@ -680,7 +683,7 @@ describe("composeNodeQuery — pins", () => {
 			),
 		];
 		const grouped = composed(MARGIN, undefined, {
-			slices: ["account"],
+			slices: [{ column: "account" }],
 			pins: [],
 		});
 		const salesRow = (await rows(grouped.sql)).find(
@@ -714,7 +717,7 @@ describe("composeNodeQuery — pins", () => {
 			),
 		];
 		const result = await rows(
-			composed(steps, undefined, { slices: ["region"], pins: [] }).sql,
+			composed(steps, undefined, { slices: [{ column: "region" }], pins: [] }).sql,
 		);
 		for (const r of result) {
 			expect(Object.keys(r)).toEqual([
@@ -756,6 +759,223 @@ describe("composeNodeQuery — pins", () => {
 		// v2 — nothing observed, nothing fabricated), matching the grouped
 		// view where such a group simply would not appear.
 		expect(num((await rows(q.sql, q.params))[0]?.value)).toBeNull();
+	});
+});
+
+// --- time grain (DAT-712, the DAT-673 hook) ----------------------------------------
+
+describe("composeNodeQuery — time grain", () => {
+	const GROSS_PROFIT: NodeStep[] = [
+		REVENUE,
+		COGS,
+		formula(
+			"gross_profit",
+			"revenue - cost_of_goods_sold",
+			["revenue", "cost_of_goods_sold"],
+			true,
+		),
+	];
+
+	it("renders the CANONICAL interval, never the token — 1M is months, 1m is minutes", () => {
+		const months = composed(GROSS_PROFIT, undefined, {
+			slices: [{ column: "booked_on", grain: "1M" }],
+			pins: [],
+		});
+		expect(months.sql).toContain(
+			`time_bucket(INTERVAL '1 months', "booked_on")`,
+		);
+		expect(months.sql).not.toContain("'1M'");
+		const minutes = composed(GROSS_PROFIT, undefined, {
+			slices: [{ column: "booked_on", grain: "1m" }],
+			pins: [],
+		});
+		expect(minutes.sql).toContain(
+			`time_bucket(INTERVAL '1 minutes', "booked_on")`,
+		);
+		const quarters = composed(GROSS_PROFIT, undefined, {
+			slices: [{ column: "booked_on", grain: "1q" }],
+			pins: [],
+		});
+		expect(quarters.sql).toContain(
+			`time_bucket(INTERVAL '3 months', "booked_on")`,
+		);
+	});
+
+	it("ADDITIVE by month: buckets MERGE raw days (the GROUP-BY-alias trap), Σ = scalar", async () => {
+		const scalar = num((await rows(composed(GROSS_PROFIT).sql))[0]?.value);
+		// Raw slice: revenue books on two January DAYS → two revenue groups.
+		const raw = await rows(
+			composed(GROSS_PROFIT, undefined, {
+				slices: [{ column: "booked_on" }],
+				pins: [],
+			}).sql,
+		);
+		expect(raw.length).toBe(4); // 01-05, 01-20 (rev) ∪ 01-12, 02-08 (cogs)
+		// Month buckets: the two January days MUST fold into ONE group — if the
+		// composition grouped by the raw column while displaying the bucket
+		// start (`GROUP BY "booked_on"` resolving to the source column), this
+		// would still be 4+ rows showing duplicated bucket labels.
+		const monthly = await rows(
+			composed(GROSS_PROFIT, undefined, {
+				slices: [{ column: "booked_on", grain: "1M" }],
+				pins: [],
+			}).sql,
+		);
+		expect(monthly).toHaveLength(2);
+		const byMonth = new Map(
+			monthly.map((r) => [String(r.booked_on), num(r.value)]),
+		);
+		expect(byMonth.get("2025-01-01")).toBe(680); // 800 revenue − 120 cogs
+		expect(byMonth.get("2025-02-01")).toBe(-80); // cogs only — no fabricated pair
+		const sum = monthly.reduce((s, r) => s + (num(r.value) ?? 0), 0);
+		expect(sum).toBe(scalar);
+	});
+
+	it("a QUARTER spans both months into one bucket equal to the scalar", async () => {
+		const quarterly = await rows(
+			composed(GROSS_PROFIT, undefined, {
+				slices: [{ column: "booked_on", grain: "1q" }],
+				pins: [],
+			}).sql,
+		);
+		expect(quarterly).toHaveLength(1);
+		expect(String(quarterly[0]?.booked_on)).toBe("2025-01-01");
+		expect(num(quarterly[0]?.value)).toBe(600);
+	});
+
+	it("NON-ADDITIVE by month keeps doctrine v2: February (no revenue) is `—` with components", async () => {
+		const steps: NodeStep[] = [
+			REVENUE,
+			COGS,
+			formula(
+				"gross_margin",
+				"(revenue - cost_of_goods_sold) / revenue * 100",
+				["revenue", "cost_of_goods_sold"],
+				true,
+			),
+		];
+		const monthly = await rows(
+			composed(steps, undefined, {
+				slices: [{ column: "booked_on", grain: "1M" }],
+				pins: [],
+			}).sql,
+		);
+		const byMonth = new Map(monthly.map((r) => [String(r.booked_on), r]));
+		expect(num(byMonth.get("2025-01-01")?.value)).toBeCloseTo(
+			((800 - 120) / 800) * 100,
+			9,
+		);
+		const feb = byMonth.get("2025-02-01");
+		expect(feb?.value).toBeNull(); // revenue unobserved — no fabricated margin
+		expect(feb?.revenue).toBeNull();
+		expect(num(feb?.cost_of_goods_sold)).toBe(80);
+	});
+
+	it("pin ≡ group at a grain: a grained pin reproduces its bucket row exactly", async () => {
+		const monthly = await rows(
+			composed(GROSS_PROFIT, undefined, {
+				slices: [{ column: "booked_on", grain: "1M" }],
+				pins: [],
+			}).sql,
+		);
+		for (const row of monthly) {
+			const pinned = composed(GROSS_PROFIT, undefined, {
+				slices: [],
+				pins: [
+					{
+						column: "booked_on",
+						value: String(row.booked_on),
+						grain: "1M",
+					},
+				],
+			});
+			expect(pinned.sql).toContain(
+				`time_bucket(INTERVAL '1 months', "booked_on") = $1`,
+			);
+			expect(num((await rows(pinned.sql, pinned.params))[0]?.value)).toBe(
+				num(row.value),
+			);
+		}
+	});
+
+	it("a grained pin keeps ITS grain when the slice moves on — pin ≡ the row it came from", async () => {
+		// Pin January at month grain, then slice by account: the pin's bucket
+		// must keep filtering rows to January regardless of the new slice.
+		const q = composed(GROSS_PROFIT, undefined, {
+			slices: [{ column: "account" }],
+			pins: [{ column: "booked_on", value: "2025-01-01", grain: "1M" }],
+		});
+		const byAccount = new Map(
+			(await rows(q.sql, q.params)).map((r) => [r.account, num(r.value)]),
+		);
+		expect(byAccount.get("sales")).toBe(800); // both revenue days are January
+		expect(byAccount.get("materials")).toBe(-120); // February's 80 filtered out
+	});
+
+	it("refuses an off-grammar grain token by name — on slices and pins", () => {
+		for (const bad of ["1Q", "1mo", "0d", "1 month", "x"]) {
+			const sliced = composeNodeQuery(GROSS_PROFIT, undefined, {
+				slices: [{ column: "booked_on", grain: bad }],
+				pins: [],
+			});
+			if (!("refusal" in sliced)) throw new Error("expected refusal");
+			expect(sliced.refusal).toContain(`'${bad}' is not a valid grain token`);
+			const pinned = composeNodeQuery(GROSS_PROFIT, undefined, {
+				slices: [],
+				pins: [{ column: "booked_on", value: "2025-01-01", grain: bad }],
+			});
+			if (!("refusal" in pinned)) throw new Error("expected refusal");
+			expect(pinned.refusal).toContain(`'${bad}' is not a valid grain token`);
+		}
+	});
+});
+
+// --- totals (DAT-712: footer + scalar-bound equation) --------------------------------
+
+describe("composeNodeTotals", () => {
+	const GROSS_MARGIN: NodeStep[] = [
+		REVENUE,
+		COGS,
+		formula(
+			"gross_margin",
+			"(revenue - cost_of_goods_sold) / revenue * 100",
+			["revenue", "cost_of_goods_sold"],
+			true,
+		),
+	];
+
+	it("projects the target's operands alongside the unrestricted scalar", async () => {
+		const q = composeNodeTotals(GROSS_MARGIN, undefined);
+		if ("refusal" in q) throw new Error(q.refusal);
+		const [row] = await rows(q.sql);
+		expect(Object.keys(row ?? {})).toEqual([
+			"revenue",
+			"cost_of_goods_sold",
+			"value",
+		]);
+		expect(num(row?.revenue)).toBe(800);
+		expect(num(row?.cost_of_goods_sold)).toBe(200);
+		expect(num(row?.value)).toBeCloseTo(((800 - 200) / 800) * 100, 9);
+	});
+
+	it("leaves the plain scalar composition untouched (engine byte-parity)", () => {
+		const plain = composed(GROSS_MARGIN);
+		expect(plain.sql).not.toContain('"revenue"."value"');
+		// The plain scalar selects ONLY value — no operand projection.
+		expect(plain.sql.slice(plain.sql.lastIndexOf("SELECT"))).toContain(
+			'"value"',
+		);
+		expect(
+			plain.sql.slice(plain.sql.lastIndexOf("SELECT")),
+		).not.toContain('"revenue"');
+	});
+
+	it("a bare measure's totals are just its scalar", async () => {
+		const q = composeNodeTotals([{ ...REVENUE, outputStep: true }], undefined);
+		if ("refusal" in q) throw new Error(q.refusal);
+		const [row] = await rows(q.sql);
+		expect(Object.keys(row ?? {})).toEqual(["value"]);
+		expect(num(row?.value)).toBe(800);
 	});
 });
 
@@ -853,7 +1073,7 @@ describe("composeNodeQuery — refusals", () => {
 		for (const reserved of ["value", "_observed"]) {
 			expect(
 				composeNodeQuery([{ ...REVENUE, outputStep: true }], undefined, {
-					slices: [reserved],
+					slices: [{ column: reserved }],
 					pins: [],
 				}),
 			).toEqual({

--- a/packages/cockpit/src/duckdb/parts.ts
+++ b/packages/cockpit/src/duckdb/parts.ts
@@ -670,8 +670,7 @@ function composeNode(
 			// engineer. Only the opened node's own operands, never intermediate
 			// CTEs'; skipped on a name collision with a dim or the value alias.
 			const operands =
-				(restricted || projectOperandsOnScalar) &&
-				step.stepId === target.stepId
+				(restricted || projectOperandsOnScalar) && step.stepId === target.stepId
 					? formulaRefs(parsed.expr).filter((r) => {
 							const dep = byId.get(r);
 							return (

--- a/packages/cockpit/src/duckdb/parts.ts
+++ b/packages/cockpit/src/duckdb/parts.ts
@@ -39,6 +39,14 @@
 // (no dims, no pins) stays byte-parity with the engine composition, where a
 // whole-domain NULL is the fall-loud grounding flag.
 //
+// TIME GRAIN (DAT-712, the DAT-673 hook): a slice/pin may carry a grain token
+// (grain.ts's closed grammar — the token itself NEVER reaches SQL). The
+// extract CTE projects `time_bucket(INTERVAL '…', col)` under the column's
+// own name and groups by the expression; everything downstream — union
+// branches, join spine, pins, outCols — consumes the bucket start as an
+// ordinary dim column, so both doctrine modes and pin ≡ group hold at every
+// grain unchanged.
+//
 // mosaic-sql gotchas (pinned by the spikes, commit cacb0174): computed select
 // items MUST be `{alias: expr}` objects — bare expressions auto-alias with
 // their own text; no bare `*` in the final select; multiple `where()` exprs
@@ -58,6 +66,7 @@ import {
 } from "@uwdata/mosaic-sql";
 
 import type { DrillPinValue } from "./drill";
+import { type Grain, grainIntervalBody, parseGrainToken } from "./grain";
 import { quoteIdentifier } from "./grid-query";
 import {
 	type FormulaExpr,
@@ -128,13 +137,32 @@ export interface NodeStep {
 	outputStep: boolean;
 }
 
+/** One slice dimension of a drill. A `grain` token (`1M`, `15m` — grain.ts's
+ *  closed grammar) buckets a temporal column via `time_bucket` INSIDE every
+ *  extract CTE, so the dim the whole composition groups/joins/pins on IS the
+ *  bucket start, under the column's own name. */
+export interface NodeSlice {
+	column: string;
+	grain?: string;
+}
+
 /** A drill over the composed node: slice dims become GROUP BY appends on every
  *  dim-carrying extract; pins are row-level filters pushed into every
  *  extract's WHERE, pre-aggregation — pins without a slice re-evaluate the
- *  scalar under the filter, in the same mode as the grouped view. */
+ *  scalar under the filter, in the same mode as the grouped view. A pin
+ *  carries the grain it was CREATED under (pin ≡ the grouped row it came
+ *  from): its predicate buckets the raw column with the same `time_bucket`
+ *  before comparing, and a later grain change on the slice never re-scopes an
+ *  existing pin. */
+export interface NodePin {
+	column: string;
+	value: DrillPinValue;
+	grain?: string;
+}
+
 export interface NodeDrill {
-	slices: string[];
-	pins: { column: string; value: DrillPinValue }[];
+	slices: NodeSlice[];
+	pins: NodePin[];
 }
 
 export interface ComposedNodeQuery {
@@ -232,6 +260,72 @@ export function flattenAdditive(
 	return visitStep(target, 1) ? out : null;
 }
 
+/** One operand term of the composed node's OWN formula — what the equation
+ *  header renders and (non-constant, non-additive views) what the component
+ *  breakdown projects as columns. */
+export interface NodeOperand {
+	stepId: string;
+	kind: "extract" | "formula" | "constant";
+	/** A constant operand's resolved value, for inline rendering. */
+	value: string | null;
+}
+
+/** The composed node's header shape (DAT-712's equation layer): the target's
+ *  formula, its operand terms, and the doctrine classification. Pure — the
+ *  route ships it once per open; signs/pretty-printing derive client-side
+ *  from `expression` via the same closed grammar (metric-formula.ts). */
+export interface NodeShape {
+	targetStepId: string;
+	/** The target's formula expression — null for a bare extract node. */
+	expression: string | null;
+	/** Doctrine v2 classification of the target's reachable tree: additive
+	 *  nodes decompose grouped views via signed contributions (their grid rows
+	 *  carry NO operand columns); non-additive restricted views project them. */
+	additive: boolean;
+	operands: NodeOperand[];
+}
+
+/** Resolve the node's header shape — the same target resolution the composer
+ *  uses, no SQL. A refusal only when the target itself cannot resolve. */
+export function nodeShape(
+	steps: NodeStep[],
+	requestedStepId: string | undefined,
+): NodeShape | { refusal: string } {
+	const target = targetStep(steps, requestedStepId);
+	if ("refusal" in target) return target;
+	const byId = new Map(steps.map((s) => [s.stepId, s]));
+	const additive = flattenAdditive(target, byId) !== null;
+	if (target.kind !== "formula" || !target.expression) {
+		return {
+			targetStepId: target.stepId,
+			expression: null,
+			additive,
+			operands: [],
+		};
+	}
+	const parsed = parseFormulaExpression(target.expression);
+	if ("refusal" in parsed) {
+		return {
+			targetStepId: target.stepId,
+			expression: null,
+			additive,
+			operands: [],
+		};
+	}
+	const operands: NodeOperand[] = [];
+	for (const ref of formulaRefs(parsed.expr)) {
+		const dep = byId.get(ref);
+		if (!dep) continue; // compose validation refuses phantoms; tolerate here
+		operands.push({ stepId: dep.stepId, kind: dep.kind, value: dep.value });
+	}
+	return {
+		targetStepId: target.stepId,
+		expression: target.expression,
+		additive,
+		operands,
+	};
+}
+
 /**
  * Compose ONE standalone statement for a metric-DAG node from its persisted
  * parts, with the drill applied as clause appends. Deterministic,
@@ -248,6 +342,50 @@ export function composeNodeQuery(
 	steps: NodeStep[],
 	requestedStepId: string | undefined,
 	drill: NodeDrill = { slices: [], pins: [] },
+): ComposedNodeQuery | { refusal: string } {
+	return composeNode(steps, requestedStepId, drill, false);
+}
+
+/**
+ * The TOTALS composition (DAT-712's footer + scalar-bound equation): the
+ * UNRESTRICTED scalar with the target formula's operand components projected
+ * alongside `value` — the same operand set a restricted view carries, so the
+ * footer's columns line up under the grid's. A separate entry point on
+ * purpose: the plain scalar (`composeNodeQuery`, no drill) stays byte-parity
+ * with the engine's persisted render, which this projection would break.
+ */
+export function composeNodeTotals(
+	steps: NodeStep[],
+	requestedStepId: string | undefined,
+): ComposedNodeQuery | { refusal: string } {
+	return composeNode(steps, requestedStepId, { slices: [], pins: [] }, true);
+}
+
+/** One deduped slice dim, its grain parsed: `bucketExpr` is the rendered
+ *  `time_bucket(…)` over the RAW column — only valid in extract-CTE scope;
+ *  every downstream CTE sees the bucketed value as an output column named
+ *  `column`. */
+interface DimSpec {
+	column: string;
+	bucketExpr: string | null;
+}
+
+/** Render the bucket expression for a validated grain — the interval body is
+ *  authored by grain.ts from the parsed token, never user text. */
+const bucketExpr = (grain: Grain, columnName: string): string =>
+	`time_bucket(INTERVAL '${grainIntervalBody(grain)}', ${quoteIdentifier(columnName)})`;
+
+const invalidGrain = (token: string): { refusal: string } => ({
+	refusal:
+		`'${token}' is not a valid grain token — use a count + unit like ` +
+		`1d, 1w, 1M, 1q, 1y (m is minutes, M is months)`,
+});
+
+function composeNode(
+	steps: NodeStep[],
+	requestedStepId: string | undefined,
+	drill: NodeDrill,
+	projectOperandsOnScalar: boolean,
 ): ComposedNodeQuery | { refusal: string } {
 	const target = targetStep(steps, requestedStepId);
 	if ("refusal" in target) return target;
@@ -316,39 +454,65 @@ export function composeNodeQuery(
 	}
 
 	// First slice per column wins, order preserved (the menu disables
-	// re-slicing, but the wire shape is not trusted).
-	const dims: string[] = [];
-	for (const d of drill.slices) {
-		if (!dims.includes(d)) dims.push(d);
+	// re-slicing, but the wire shape is not trusted). Grain tokens parse
+	// against the closed grammar here — an off-grammar token is a refusal,
+	// never interpolated (grain.ts: DuckDB itself would read '1M' as minutes).
+	const dims: DimSpec[] = [];
+	for (const s of drill.slices) {
+		if (dims.some((d) => d.column === s.column)) continue;
+		let expr: string | null = null;
+		if (s.grain !== undefined) {
+			const grain = parseGrainToken(s.grain);
+			if (!grain) return invalidGrain(s.grain);
+			expr = bucketExpr(grain, s.column);
+		}
+		dims.push({ column: s.column, bucketExpr: expr });
 	}
+	const dimColumns = dims.map((d) => d.column);
 	// `value` is the composition's own measure alias in every CTE projection
 	// (`_observed` its additive observation counter) — a dimension with either
 	// literal name would collide (WHERE-level pins are fine: predicates bind
 	// against the relation, pre-projection).
 	for (const reserved of ["value", "_observed"]) {
-		if (dims.includes(reserved)) {
+		if (dimColumns.includes(reserved)) {
 			return {
 				refusal: `cannot slice by a dimension named '${reserved}' — it collides with a composed column`,
 			};
 		}
 	}
 
-	// Pins render once and are appended to EVERY extract CTE below.
+	// Pins render once and are appended to EVERY extract CTE below. A grained
+	// pin buckets the raw column exactly like the slice that produced its row,
+	// so the bound bucket start matches whole buckets, not one raw value.
 	const params: DrillPinValue[] = [];
 	const pinPredicates: string[] = [];
 	for (const p of drill.pins) {
+		let lhs = quoteIdentifier(p.column);
+		if (p.grain !== undefined) {
+			const grain = parseGrainToken(p.grain);
+			if (!grain) return invalidGrain(p.grain);
+			lhs = bucketExpr(grain, p.column);
+		}
 		if (p.value === null) {
-			pinPredicates.push(`${quoteIdentifier(p.column)} IS NULL`);
+			pinPredicates.push(`${lhs} IS NULL`);
 		} else {
 			params.push(p.value);
-			pinPredicates.push(`${quoteIdentifier(p.column)} = $${params.length}`);
+			pinPredicates.push(`${lhs} = $${params.length}`);
 		}
 	}
 
 	/** An extract's CTE under the current drill: dims + GROUP BY when sliced,
 	 *  the persisted predicates plus the pins in WHERE. The additive mode adds
 	 *  `_observed` (the row count) so a pinned-scalar extract can tell "nothing
-	 *  matched" (skip) from "matched but the aggregate is NULL" (poison). */
+	 *  matched" (skip) from "matched but the aggregate is NULL" (poison).
+	 *
+	 *  A grained dim projects its `time_bucket(…)` ALIASED to the column name
+	 *  and — load-bearing — GROUPS BY the expression itself: `GROUP BY "col"`
+	 *  would resolve to the RAW column (source columns shadow select aliases),
+	 *  yielding one group per raw value that merely DISPLAYS the bucket start.
+	 *  Only this CTE sees the raw relation; every downstream CTE (union
+	 *  branches, join spine, outer aggregate) consumes the bucketed value as an
+	 *  ordinary output column. */
 	const extractCte = (
 		parts: SnippetParts,
 		relation: string,
@@ -361,8 +525,21 @@ export function composeNodeQuery(
 		let q =
 			dims.length > 0
 				? Query.from(relation)
-						.select(...dims.map((d) => column(d)), ...valueCols)
-						.groupby(...dims.map((d) => column(d)))
+						.select(
+							...dims.map((d) =>
+								d.bucketExpr === null
+									? column(d.column)
+									: { [d.column]: verbatim(d.bucketExpr) },
+							),
+							...valueCols,
+						)
+						.groupby(
+							...dims.map((d) =>
+								d.bucketExpr === null
+									? column(d.column)
+									: verbatim(d.bucketExpr),
+							),
+						)
 				: Query.from(relation).select(...valueCols);
 		const preds = [...parts.where, ...pinPredicates];
 		if (preds.length > 0) {
@@ -406,7 +583,10 @@ export function composeNodeQuery(
 					: { value: verbatim('-("value")') };
 			const q =
 				dims.length > 0
-					? Query.from(stepId).select(...dims.map((d) => column(d)), value)
+					? Query.from(stepId).select(
+							...dimColumns.map((d) => column(d)),
+							value,
+						)
 					: Query.from(stepId).select(value);
 			return q.where(verbatim('("_observed" > 0)'));
 		});
@@ -421,8 +601,8 @@ export function composeNodeQuery(
 		ctes[target.stepId] =
 			dims.length > 0
 				? Query.from(unioned)
-						.select(...dims.map((d) => column(d)), { value: summed })
-						.groupby(...dims.map((d) => column(d)))
+						.select(...dimColumns.map((d) => column(d)), { value: summed })
+						.groupby(...dimColumns.map((d) => column(d)))
 				: Query.from(unioned).select({ value: summed });
 		targetGrouped = dims.length > 0;
 	} else {
@@ -490,14 +670,15 @@ export function composeNodeQuery(
 			// engineer. Only the opened node's own operands, never intermediate
 			// CTEs'; skipped on a name collision with a dim or the value alias.
 			const operands =
-				restricted && step.stepId === target.stepId
+				(restricted || projectOperandsOnScalar) &&
+				step.stepId === target.stepId
 					? formulaRefs(parsed.expr).filter((r) => {
 							const dep = byId.get(r);
 							return (
 								dep !== undefined &&
 								dep.kind !== "constant" &&
 								r !== "value" &&
-								!dims.includes(r)
+								!dimColumns.includes(r)
 							);
 						})
 					: [];
@@ -511,10 +692,10 @@ export function composeNodeQuery(
 				// deps (constants, fall-loud extracts) stay subqueries in the value.
 				let spine: Parameters<typeof join>[0] = first;
 				for (const dep of rest) {
-					spine = join(spine, dep, { type: "FULL", using: dims });
+					spine = join(spine, dep, { type: "FULL", using: dimColumns });
 				}
 				ctes[step.stepId] = Query.from(spine).select(
-					...dims.map((d) => column(d)),
+					...dimColumns.map((d) => column(d)),
 					...operandCols,
 					{
 						value: verbatim(rendered.sql),
@@ -535,7 +716,7 @@ export function composeNodeQuery(
 	// explicitly — dims when the target composed grouped, then the projected
 	// operand components (non-additive restricted views), then the value.
 	const outCols = [
-		...(targetGrouped ? dims.map((d) => column(d)) : []),
+		...(targetGrouped ? dimColumns.map((d) => column(d)) : []),
 		...projectedOperands.map((c) => column(c)),
 		column("value"),
 	];

--- a/packages/cockpit/src/routes/api/drill/compose.ts
+++ b/packages/cockpit/src/routes/api/drill/compose.ts
@@ -22,9 +22,13 @@ const PinValueSchema = z.union([
 ]);
 const ColumnSchema = z.string().min(1).max(256);
 
+// STRICT: tier A has no grain support (time_bucket is a node-path capability,
+// DAT-712) — a step carrying `grain` must 400 loudly here, because z.object
+// would otherwise STRIP the key and group raw values under a chip that
+// claims a bucket width.
 const StepSchema = z.discriminatedUnion("kind", [
-	z.object({ kind: z.literal("slice"), column: ColumnSchema }),
-	z.object({
+	z.strictObject({ kind: z.literal("slice"), column: ColumnSchema }),
+	z.strictObject({
 		kind: z.literal("pin"),
 		column: ColumnSchema,
 		value: PinValueSchema,

--- a/packages/cockpit/src/routes/api/drill/node.ts
+++ b/packages/cockpit/src/routes/api/drill/node.ts
@@ -11,14 +11,28 @@
 // `ok: false` refusal naming the missing part (a refusal is a domain result,
 // not a transport error). The composed SQL is executed by the CLIENT through
 // the ordinary `/api/run-sql` grid path.
+//
+// The OPEN call (empty `steps`) additionally ships what the analyse header
+// needs once per node (DAT-712) — both are drill-independent, so re-drills
+// stay lean:
+//   - `node`: name/unit + the target's formula shape (`nodeShape`) for the
+//     live equation;
+//   - `totals`: the unrestricted scalar WITH operand components projected
+//     (`composeNodeTotals`) for the footer row and the scalar-bound equation.
+//     Binder-gated like the main statement, but a totals failure only omits
+//     the field — it never blocks the node.
 
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 
-import { pinSteps, sliceColumns } from "#/duckdb/drill";
+import { pinSteps, sliceSteps } from "#/duckdb/drill";
 import { describeColumns, errorLine } from "#/duckdb/drill-sql";
 import { applyEngineScope, withLakeConnection } from "#/duckdb/lake";
-import { composeNodeQuery } from "#/duckdb/parts";
+import {
+	composeNodeQuery,
+	composeNodeTotals,
+	nodeShape,
+} from "#/duckdb/parts";
 import { resolveNodeSteps } from "#/tools/drill-metric";
 
 // Length bounds follow the grid-query convention (column names 256, values
@@ -31,13 +45,17 @@ const PinValueSchema = z.union([
 	z.null(),
 ]);
 const ColumnSchema = z.string().min(1).max(256);
+// Shape-only bound (count + unit letter); the composer parses it against the
+// closed grammar and refuses off-grammar tokens by name (grain.ts).
+const GrainSchema = z.string().min(2).max(8).optional();
 
 const StepSchema = z.discriminatedUnion("kind", [
-	z.object({ kind: z.literal("slice"), column: ColumnSchema }),
+	z.object({ kind: z.literal("slice"), column: ColumnSchema, grain: GrainSchema }),
 	z.object({
 		kind: z.literal("pin"),
 		column: ColumnSchema,
 		value: PinValueSchema,
+		grain: GrainSchema,
 	}),
 ]);
 
@@ -98,15 +116,28 @@ export const Route = createFileRoute("/api/drill/node")({
 						return Response.json({ ok: false, reason: resolved.missing });
 					}
 					const composed = composeNodeQuery(resolved.steps, stepId, {
-						slices: sliceColumns(steps),
+						slices: sliceSteps(steps),
 						pins: pinSteps(steps).map((p) => ({
 							column: p.column,
 							value: p.value,
+							grain: p.grain,
 						})),
 					});
 					if ("refusal" in composed) {
 						return Response.json({ ok: false, reason: composed.refusal });
 					}
+					// The open call's header block (drill-independent, so only when
+					// `steps` is empty): the equation's node shape + the totals
+					// statement. A shape refusal or totals bind failure only omits the
+					// block — the grid must open regardless.
+					const shape = steps.length === 0 ? nodeShape(resolved.steps, stepId) : null;
+					const node =
+						shape !== null && !("refusal" in shape)
+							? { name: resolved.name, unit: resolved.unit, ...shape }
+							: undefined;
+					const totalsCandidate =
+						steps.length === 0 ? composeNodeTotals(resolved.steps, stepId) : null;
+
 					const result = await withLakeConnection(async (conn) => {
 						// Engine scope, matching /api/run-sql: extract parts are
 						// engine-authored (unqualified enriched-view names).
@@ -117,11 +148,22 @@ export const Route = createFileRoute("/api/drill/node")({
 								composed.sql,
 								composed.params,
 							);
+							let totals: { sql: string } | undefined;
+							if (totalsCandidate !== null && !("refusal" in totalsCandidate)) {
+								try {
+									await describeColumns(conn, totalsCandidate.sql, []);
+									totals = { sql: totalsCandidate.sql };
+								} catch {
+									// Totals are an enhancement — omit, never block the node.
+								}
+							}
 							return {
 								ok: true as const,
 								sql: composed.sql,
 								params: composed.params,
 								columns,
+								node,
+								totals,
 							};
 						} catch (err) {
 							// The binder is the gate — its first line IS the refusal.

--- a/packages/cockpit/src/routes/api/drill/node.ts
+++ b/packages/cockpit/src/routes/api/drill/node.ts
@@ -28,11 +28,7 @@ import { z } from "zod";
 import { pinSteps, sliceSteps } from "#/duckdb/drill";
 import { describeColumns, errorLine } from "#/duckdb/drill-sql";
 import { applyEngineScope, withLakeConnection } from "#/duckdb/lake";
-import {
-	composeNodeQuery,
-	composeNodeTotals,
-	nodeShape,
-} from "#/duckdb/parts";
+import { composeNodeQuery, composeNodeTotals, nodeShape } from "#/duckdb/parts";
 import { resolveNodeSteps } from "#/tools/drill-metric";
 
 // Length bounds follow the grid-query convention (column names 256, values
@@ -50,7 +46,11 @@ const ColumnSchema = z.string().min(1).max(256);
 const GrainSchema = z.string().min(2).max(8).optional();
 
 const StepSchema = z.discriminatedUnion("kind", [
-	z.object({ kind: z.literal("slice"), column: ColumnSchema, grain: GrainSchema }),
+	z.object({
+		kind: z.literal("slice"),
+		column: ColumnSchema,
+		grain: GrainSchema,
+	}),
 	z.object({
 		kind: z.literal("pin"),
 		column: ColumnSchema,
@@ -130,13 +130,16 @@ export const Route = createFileRoute("/api/drill/node")({
 					// `steps` is empty): the equation's node shape + the totals
 					// statement. A shape refusal or totals bind failure only omits the
 					// block — the grid must open regardless.
-					const shape = steps.length === 0 ? nodeShape(resolved.steps, stepId) : null;
+					const shape =
+						steps.length === 0 ? nodeShape(resolved.steps, stepId) : null;
 					const node =
 						shape !== null && !("refusal" in shape)
 							? { name: resolved.name, unit: resolved.unit, ...shape }
 							: undefined;
 					const totalsCandidate =
-						steps.length === 0 ? composeNodeTotals(resolved.steps, stepId) : null;
+						steps.length === 0
+							? composeNodeTotals(resolved.steps, stepId)
+							: null;
 
 					const result = await withLakeConnection(async (conn) => {
 						// Engine scope, matching /api/run-sql: extract parts are

--- a/packages/cockpit/src/tools/drill-axes.test.ts
+++ b/packages/cockpit/src/tools/drill-axes.test.ts
@@ -38,6 +38,7 @@ vi.mock("#/db/metadata/client", () => ({
 }));
 
 import {
+	columns,
 	currentDriverRankings,
 	currentEnrichedViews,
 	currentLifecycleArtifacts,
@@ -46,11 +47,13 @@ import {
 } from "#/db/metadata/schema";
 import type { DrillAxis } from "#/duckdb/drill";
 import {
+	applyTemporalKinds,
 	axesFromSliceRows,
 	driverGains,
 	measureFieldsFromDag,
 	orderAxesByDrivers,
 	resolveDrillAxes,
+	temporalKindsFromColumns,
 	unionSubstrateAxes,
 } from "./drill-axes";
 
@@ -130,6 +133,7 @@ describe("axesFromSliceRows", () => {
 				values: ["EU", "US"],
 				valueCount: 2,
 				businessContext: "sales region",
+				temporal: null,
 			},
 			{
 				column: "booking_month",
@@ -138,6 +142,7 @@ describe("axesFromSliceRows", () => {
 				values: [],
 				valueCount: 12,
 				businessContext: null,
+				temporal: null,
 			},
 		]);
 	});
@@ -151,6 +156,7 @@ const axis = (column: string, priority = 1): DrillAxis => ({
 	values: [],
 	valueCount: null,
 	businessContext: null,
+	temporal: null,
 });
 
 describe("unionSubstrateAxes", () => {
@@ -172,7 +178,56 @@ describe("unionSubstrateAxes", () => {
 			values: [],
 			valueCount: null,
 			businessContext: null,
+			temporal: null,
 		});
+	});
+});
+
+describe("temporalKindsFromColumns", () => {
+	const viewIds = new Set(["vt1"]);
+
+	it("maps DATE/TIMESTAMP resolved types, ignoring everything else", () => {
+		const kinds = temporalKindsFromColumns(
+			[
+				{ tableId: "vt1", columnName: "entry__date", resolvedType: "DATE" },
+				{ tableId: "vt1", columnName: "created", resolvedType: "TIMESTAMP" },
+				{ tableId: "vt1", columnName: "name", resolvedType: "VARCHAR" },
+				{ tableId: "vt1", columnName: null, resolvedType: "DATE" },
+			],
+			viewIds,
+		);
+		expect(kinds.get("entry__date")).toBe("date");
+		expect(kinds.get("created")).toBe("timestamp");
+		expect(kinds.has("name")).toBe(false);
+	});
+
+	it("lets a view row decide over a same-named fact row — including 'not temporal'", () => {
+		const kinds = temporalKindsFromColumns(
+			[
+				// The fact stores the raw value as VARCHAR; the view projects DATE.
+				{ tableId: "fact1", columnName: "booked", resolvedType: "VARCHAR" },
+				{ tableId: "vt1", columnName: "booked", resolvedType: "DATE" },
+				// The view says VARCHAR — the fact's DATE must not leak through.
+				{ tableId: "vt1", columnName: "label", resolvedType: "VARCHAR" },
+				{ tableId: "fact1", columnName: "label", resolvedType: "DATE" },
+				// No view row → the fact type fills in (bare fact columns).
+				{ tableId: "fact1", columnName: "paid_at", resolvedType: "TIMESTAMP" },
+			],
+			viewIds,
+		);
+		expect(kinds.get("booked")).toBe("date");
+		expect(kinds.has("label")).toBe(false);
+		expect(kinds.get("paid_at")).toBe("timestamp");
+	});
+});
+
+describe("applyTemporalKinds", () => {
+	it("stamps resolved kinds onto matching axes only", () => {
+		const out = applyTemporalKinds(
+			[axis("entry__date"), axis("region")],
+			new Map([["entry__date", "date" as const]]),
+		);
+		expect(out.map((a) => a.temporal)).toEqual(["date", null]);
 	});
 });
 
@@ -278,6 +333,12 @@ const seed = () => {
 			businessContext: null,
 		},
 	]);
+	// The catalog types behind temporal detection: the VIEW table (vt1) carries
+	// the FK-projected dims; customer__segment is a DATE there.
+	rowsByTable.set(columns, [
+		{ tableId: "vt1", columnName: "customer__region", resolvedType: "VARCHAR" },
+		{ tableId: "vt1", columnName: "customer__segment", resolvedType: "DATE" },
+	]);
 };
 
 describe("resolveDrillAxes (mocked metadata client)", () => {
@@ -292,9 +353,11 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 				values: ["EU", "US"],
 				valueCount: 2,
 				businessContext: null,
+				temporal: null,
 			},
 			// Substrate-only: the view exposes it, the catalog never curated it.
 			// supplier__country stays absent — its fact (cogs) never grounded.
+			// Its DATE type on the view table makes it the temporal axis.
 			{
 				column: "customer__segment",
 				priority: Number.MAX_SAFE_INTEGER,
@@ -302,6 +365,7 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 				values: [],
 				valueCount: null,
 				businessContext: null,
+				temporal: "date",
 			},
 		]);
 	});

--- a/packages/cockpit/src/tools/drill-axes.test.ts
+++ b/packages/cockpit/src/tools/drill-axes.test.ts
@@ -201,6 +201,17 @@ describe("temporalKindsFromColumns", () => {
 		expect(kinds.has("name")).toBe(false);
 	});
 
+	it("is first-wins across view rows — a shared name can't flip between loads", () => {
+		const kinds = temporalKindsFromColumns(
+			[
+				{ tableId: "vt1", columnName: "shared", resolvedType: "DATE" },
+				{ tableId: "vt2", columnName: "shared", resolvedType: "VARCHAR" },
+			],
+			new Set(["vt1", "vt2"]),
+		);
+		expect(kinds.get("shared")).toBe("date");
+	});
+
 	it("lets a view row decide over a same-named fact row — including 'not temporal'", () => {
 		const kinds = temporalKindsFromColumns(
 			[

--- a/packages/cockpit/src/tools/drill-axes.ts
+++ b/packages/cockpit/src/tools/drill-axes.ts
@@ -342,7 +342,8 @@ export async function resolveDrillAxes(
 	const viewTableIds = new Set(
 		viewRows
 			.filter(
-				(v) => Boolean(v.factTableId) && factIds.includes(v.factTableId as string),
+				(v) =>
+					Boolean(v.factTableId) && factIds.includes(v.factTableId as string),
 			)
 			.map((v) => v.viewTableId)
 			.filter((id): id is string => Boolean(id)),

--- a/packages/cockpit/src/tools/drill-axes.ts
+++ b/packages/cockpit/src/tools/drill-axes.ts
@@ -143,9 +143,13 @@ export function temporalKindsFromColumns(
 ): Map<string, TemporalKind> {
 	const kinds = new Map<string, TemporalKind>();
 	const decidedByView = new Set<string>();
-	// View rows decide first — including deciding "not temporal"…
+	// View rows decide first — including deciding "not temporal". First view
+	// row per name WINS (the caller passes rows deterministically ordered), so
+	// two facts' views disagreeing about a shared name can't flip the chip's
+	// presets between loads — the multi-fact axes-union tradeoff, pinned.
 	for (const r of rows) {
 		if (!r.columnName || !r.tableId || !viewTableIds.has(r.tableId)) continue;
+		if (decidedByView.has(r.columnName)) continue;
 		decidedByView.add(r.columnName);
 		const kind = temporalKindOfType(r.resolvedType);
 		if (kind !== null) kinds.set(r.columnName, kind);
@@ -375,7 +379,11 @@ export async function resolveDrillAxes(
 				resolvedType: columns.resolvedType,
 			})
 			.from(columns)
-			.where(inArray(columns.tableId, typeTableIds)),
+			.where(inArray(columns.tableId, typeTableIds))
+			// Deterministic row order — temporalKindsFromColumns is first-wins
+			// per name, so an unordered read would be Postgres row-order
+			// roulette (the same trap the enriched-views read pins above).
+			.orderBy(asc(columns.tableId), asc(columns.columnName)),
 	]);
 
 	// The JS filter mirrors the SQL `inArray` (the belt-over-braces pattern

--- a/packages/cockpit/src/tools/drill-axes.ts
+++ b/packages/cockpit/src/tools/drill-axes.ts
@@ -26,6 +26,7 @@ import { and, asc, desc, eq, inArray, like } from "drizzle-orm";
 import { config } from "#/config";
 import { metadataDb } from "#/db/metadata/client";
 import {
+	columns,
 	currentDriverRankings,
 	currentEnrichedViews,
 	currentLifecycleArtifacts,
@@ -33,6 +34,7 @@ import {
 	sqlSnippets,
 } from "#/db/metadata/schema";
 import type { DrillAxesRequest, DrillAxis } from "#/duckdb/drill";
+import { type TemporalKind, temporalKindOfType } from "#/duckdb/grain";
 import { narrowSnippetParts } from "#/duckdb/parts";
 
 import { parseMetricDag } from "./operating-model-graph";
@@ -81,6 +83,10 @@ export function axesFromSliceRows(rows: SliceRowInput[]): DrillAxis[] {
 				: [],
 			valueCount: r.valueCount,
 			businessContext: r.businessContext,
+			// Resolved from the CATALOG's column types afterwards
+			// (`applyTemporalKinds`) — the slicing agent's rows don't carry a
+			// trustworthy type (their column_id FK points at the bare FK column).
+			temporal: null,
 		});
 	}
 	return [...byColumn.values()];
@@ -109,9 +115,60 @@ export function unionSubstrateAxes(
 			values: [],
 			valueCount: null,
 			businessContext: null,
+			temporal: null,
 		});
 	}
 	return out;
+}
+
+/** One catalog `columns` row as the temporal resolver reads it. */
+export interface CatalogColumnInput {
+	tableId: string | null;
+	columnName: string | null;
+	resolvedType: string | null;
+}
+
+/**
+ * Temporal resolution per column name, from the catalog's `resolved_type`
+ * (pure; DAT-712 — type-based, never a name heuristic). The axes bind in the
+ * enriched VIEW's scope, so a row cataloged under a view table (the
+ * FK-projected dims, e.g. `entry_id__date` DATE) wins over a same-named fact
+ * row; bare fact columns only exist on the fact and resolve from there.
+ * `slice_definitions.column_id` is deliberately not consulted — it points at
+ * the bare FK column (BIGINT), not the projected dim.
+ */
+export function temporalKindsFromColumns(
+	rows: CatalogColumnInput[],
+	viewTableIds: ReadonlySet<string>,
+): Map<string, TemporalKind> {
+	const kinds = new Map<string, TemporalKind>();
+	const decidedByView = new Set<string>();
+	// View rows decide first — including deciding "not temporal"…
+	for (const r of rows) {
+		if (!r.columnName || !r.tableId || !viewTableIds.has(r.tableId)) continue;
+		decidedByView.add(r.columnName);
+		const kind = temporalKindOfType(r.resolvedType);
+		if (kind !== null) kinds.set(r.columnName, kind);
+	}
+	// …fact rows only fill names no view row covered (bare fact columns).
+	for (const r of rows) {
+		if (!r.columnName || !r.tableId || viewTableIds.has(r.tableId)) continue;
+		if (decidedByView.has(r.columnName)) continue;
+		const kind = temporalKindOfType(r.resolvedType);
+		if (kind !== null) kinds.set(r.columnName, kind);
+	}
+	return kinds;
+}
+
+/** Stamp resolved temporal kinds onto axes (pure). */
+export function applyTemporalKinds(
+	axes: DrillAxis[],
+	kinds: ReadonlyMap<string, TemporalKind>,
+): DrillAxis[] {
+	return axes.map((a) => {
+		const kind = kinds.get(a.column) ?? null;
+		return kind === a.temporal ? a : { ...a, temporal: kind };
+	});
 }
 
 /** One `current_driver_rankings` row as the resolver reads it
@@ -211,6 +268,7 @@ export async function resolveDrillAxes(
 		metadataDb
 			.select({
 				viewName: currentEnrichedViews.viewName,
+				viewTableId: currentEnrichedViews.viewTableId,
 				factTableId: currentEnrichedViews.factTableId,
 				dimensionColumns: currentEnrichedViews.dimensionColumns,
 				isGrainVerified: currentEnrichedViews.isGrainVerified,
@@ -278,7 +336,20 @@ export async function resolveDrillAxes(
 				: [],
 		);
 
-	const [sliceRows, rankingRows] = await Promise.all([
+	// The catalog tables whose column types can speak for the axes: the node's
+	// facts plus their views' own table entries (the FK-projected dims live
+	// under the VIEW's table_id — see temporalKindsFromColumns).
+	const viewTableIds = new Set(
+		viewRows
+			.filter(
+				(v) => Boolean(v.factTableId) && factIds.includes(v.factTableId as string),
+			)
+			.map((v) => v.viewTableId)
+			.filter((id): id is string => Boolean(id)),
+	);
+	const typeTableIds = [...factIds, ...viewTableIds];
+
+	const [sliceRows, rankingRows, columnRows] = await Promise.all([
 		metadataDb
 			.select({
 				tableId: currentSliceDefinitions.tableId,
@@ -296,11 +367,32 @@ export async function resolveDrillAxes(
 			.select({ rankedDimensions: currentDriverRankings.rankedDimensions })
 			.from(currentDriverRankings)
 			.where(inArray(currentDriverRankings.measureTableId, factIds)),
+		metadataDb
+			.select({
+				tableId: columns.tableId,
+				columnName: columns.columnName,
+				resolvedType: columns.resolvedType,
+			})
+			.from(columns)
+			.where(inArray(columns.tableId, typeTableIds)),
 	]);
 
-	const axes = orderAxesByDrivers(
-		unionSubstrateAxes(axesFromSliceRows(sliceRows), substrateColumns),
-		driverGains(rankingRows),
+	// The JS filter mirrors the SQL `inArray` (the belt-over-braces pattern
+	// above): a row from any OTHER table must not pose as a fact column in the
+	// temporal fallback pass.
+	const typeTableIdSet = new Set(typeTableIds);
+	const axes = applyTemporalKinds(
+		orderAxesByDrivers(
+			unionSubstrateAxes(axesFromSliceRows(sliceRows), substrateColumns),
+			driverGains(rankingRows),
+		),
+		temporalKindsFromColumns(
+			columnRows.filter(
+				(r): r is typeof r & { tableId: string } =>
+					r.tableId !== null && typeTableIdSet.has(r.tableId),
+			),
+			viewTableIds,
+		),
 	);
 	if (axes.length === 0) {
 		return {

--- a/packages/cockpit/src/tools/drill-metric.ts
+++ b/packages/cockpit/src/tools/drill-metric.ts
@@ -26,7 +26,15 @@ import {
 
 import { parseMetricDag } from "./operating-model-graph";
 
-export type NodeDrillSteps = { steps: NodeStep[] } | { missing: string };
+export type NodeDrillSteps =
+	| {
+			steps: NodeStep[];
+			/** Display name (metric DAG metadata / the measure's field) and the
+			 *  metric's output unit — the analyse header's labels (DAT-712). */
+			name: string | null;
+			unit: string | null;
+	  }
+	| { missing: string };
 
 /** The newest graph extract per standard field DECIDES (resolveGrounding's
  *  contract): a failing newest row means the field has no accepted parts — a
@@ -94,6 +102,8 @@ export async function resolveNodeSteps(
 					outputStep: true,
 				},
 			],
+			name: req.standardField,
+			unit: null,
 		};
 	}
 
@@ -144,5 +154,5 @@ export async function resolveNodeSteps(
 					outputStep: s.outputStep,
 				},
 	);
-	return { steps };
+	return { steps, name: dag.name, unit: dag.unit };
 }

--- a/packages/cockpit/src/ui/cockpit/operating-model/analyse-overlay.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/analyse-overlay.tsx
@@ -1,6 +1,6 @@
-// The Model canvas's analyse surface (DAT-672, per-node re-cut DAT-702/703):
-// run a metric/measure node in the SHARED result grid, with drill + chart on
-// top.
+// The Model canvas's analyse surface (DAT-672, per-node re-cut DAT-702/703,
+// UX re-cut DAT-712): run a metric/measure node in the SHARED result grid,
+// with the live equation header, drill + chart on top.
 //
 // UX shape (decided in implementation, per the ticket's two options): the
 // affordance lives in the NodeDetail panel — an "Analyse" button opening a
@@ -18,15 +18,30 @@
 // (`hasDag` — a hole gets the composer's NAMED refusal in the modal instead
 // of a silently missing button); a measure must be accepted (`grounded` — an
 // unaccepted extract would render an empty grid as if it were data).
+//
+// LAYERING (DAT-712, the lead's constraint): DrillableGrid stays generic;
+// this file is the PARTS-CONTEXT layer. The open call ships the node's
+// formula shape + the totals statement; this layer owns the equation header,
+// the operand hue assignment (handed verbatim to the grid's columnAccents),
+// the totals footer cells, and the scope sentence — all keyed on "the
+// response carries a structured shape", so answer-agent results (DAT-678)
+// join by shipping the same block, not by being canvas nodes.
 
 import { Alert, Button, Center, Group, Loader, Modal } from "@mantine/core";
 import { useQuery } from "@tanstack/react-query";
 import { Play } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
-import type { DrillAxesRequest } from "#/duckdb/drill";
+import { useChartData } from "#/charts/use-chart-data";
+import type { DrillAxesRequest, DrillStep } from "#/duckdb/drill";
+import { grainLabel, parseGrainToken } from "#/duckdb/grain";
 import type { OMNode } from "#/tools/operating-model-graph";
 import { DrillableGrid } from "#/ui/cockpit/widgets/drillable-grid";
+import {
+	EquationHeader,
+	type NodeShapeWire,
+	operandAccents,
+} from "#/ui/cockpit/widgets/equation-header";
 
 /** The node's compose target — the same ref shape the axes route resolves —
  *  or null when there is nothing to run. */
@@ -40,16 +55,66 @@ export function analyseTarget(node: OMNode): DrillAxesRequest | null {
 	return null;
 }
 
-/** `/api/drill/node` response, narrowed at the boundary (never trusted). */
+/** `/api/drill/node` open response, narrowed at the boundary (never trusted).
+ *  `node` + `totals` are the DAT-712 header block — optional by design (the
+ *  grid must open without them). */
 type NodeComposeState =
-	| { ok: true; sql: string }
+	| {
+			ok: true;
+			sql: string;
+			node: NodeShapeWire | null;
+			totalsSql: string | null;
+	  }
 	| { ok: false; reason: string };
+
+function narrowShape(raw: unknown): NodeShapeWire | null {
+	if (typeof raw !== "object" || raw === null) return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.targetStepId !== "string") return null;
+	const operands = Array.isArray(r.operands)
+		? r.operands.flatMap((o): NodeShapeWire["operands"] => {
+				if (typeof o !== "object" || o === null) return [];
+				const op = o as Record<string, unknown>;
+				if (typeof op.stepId !== "string") return [];
+				const kind =
+					op.kind === "formula" || op.kind === "constant"
+						? op.kind
+						: ("extract" as const);
+				return [
+					{
+						stepId: op.stepId,
+						kind,
+						value: typeof op.value === "string" ? op.value : null,
+					},
+				];
+			})
+		: [];
+	return {
+		name: typeof r.name === "string" ? r.name : null,
+		unit: typeof r.unit === "string" ? r.unit : null,
+		targetStepId: r.targetStepId,
+		expression: typeof r.expression === "string" ? r.expression : null,
+		additive: r.additive === true,
+		operands,
+	};
+}
 
 function narrowNodeCompose(raw: unknown): NodeComposeState {
 	if (typeof raw === "object" && raw !== null) {
 		const r = raw as Record<string, unknown>;
 		if (r.ok === true && typeof r.sql === "string") {
-			return { ok: true, sql: r.sql };
+			const totals = r.totals as Record<string, unknown> | undefined;
+			return {
+				ok: true,
+				sql: r.sql,
+				node: narrowShape(r.node),
+				totalsSql:
+					typeof totals === "object" &&
+					totals !== null &&
+					typeof totals.sql === "string"
+						? totals.sql
+						: null,
+			};
 		}
 		if (r.ok === false && typeof r.reason === "string") {
 			return { ok: false, reason: r.reason };
@@ -58,9 +123,32 @@ function narrowNodeCompose(raw: unknown): NodeComposeState {
 	return { ok: false, reason: "unexpected compose response" };
 }
 
-/** Compose-on-open: fetch the node's ad-hoc composed SQL from its parts, then
- *  mount the shared grid on it. Loading/refusal states are part of the
- *  surface — a refusal names the missing part, never a dead end. */
+/** The drill scope in words, for the equation header's scope line and the
+ *  missing-operand sentence: "all data", "by Month of entry_id__date",
+ *  "pinned to 2025-01-01". Sober and literal — never inferred period names. */
+export function scopeSentence(steps: DrillStep[]): string {
+	const pins = steps.filter((s) => s.kind === "pin");
+	if (pins.length > 0) {
+		return `pinned to ${pins
+			.map((p) => `${String(p.value ?? "∅")}`)
+			.join(", ")}`;
+	}
+	const slices = steps.filter((s) => s.kind === "slice");
+	if (slices.length > 0) {
+		return `by ${slices
+			.map((s) => {
+				const grain = s.grain ? parseGrainToken(s.grain) : null;
+				return grain ? `${grainLabel(grain)} of ${s.column}` : s.column;
+			})
+			.join(", ")}`;
+	}
+	return "all data";
+}
+
+/** Compose-on-open: fetch the node's ad-hoc composed SQL (+ the DAT-712
+ *  header block) from its parts, then mount the equation layer over the
+ *  shared grid. Loading/refusal states are part of the surface — a refusal
+ *  names the missing part, never a dead end. */
 function NodeGrid({ nodeRef }: { nodeRef: DrillAxesRequest }) {
 	const compose = useQuery({
 		queryKey: ["drill-node", nodeRef],
@@ -74,6 +162,33 @@ function NodeGrid({ nodeRef }: { nodeRef: DrillAxesRequest }) {
 			return narrowNodeCompose(await res.json());
 		},
 	});
+
+	// The header's bindings (React rule 1: plain state set by grid callbacks,
+	// everything else derived during render).
+	const [hoverRow, setHoverRow] = useState<Record<string, unknown> | null>(
+		null,
+	);
+	const [lockedRow, setLockedRow] = useState<Record<string, unknown> | null>(
+		null,
+	);
+	const [steps, setSteps] = useState<DrillStep[]>([]);
+
+	const data = compose.data;
+	const ok: Extract<NodeComposeState, { ok: true }> | null =
+		data !== undefined && data.ok === true ? data : null;
+	// The totals row: one bounded query, shared cache (chart-data key).
+	const totalsQuery = useChartData(
+		ok?.totalsSql ?? "",
+		[],
+		ok?.totalsSql != null,
+	);
+	const totalsRow = totalsQuery.data?.rows[0] ?? null;
+
+	const shape = ok?.node ?? null;
+	const accents = useMemo(
+		() => (shape ? operandAccents(shape) : undefined),
+		[shape],
+	);
 
 	if (compose.isPending) {
 		return (
@@ -91,19 +206,36 @@ function NodeGrid({ nodeRef }: { nodeRef: DrillAxesRequest }) {
 			</Alert>
 		);
 	}
-	if (!compose.data.ok) {
+	if (!ok) {
 		return (
 			<Alert color="yellow" title="Cannot compose this node">
-				{compose.data.reason}
+				{compose.data && !compose.data.ok ? compose.data.reason : ""}
 			</Alert>
 		);
 	}
 	return (
-		<DrillableGrid
-			sql={compose.data.sql}
-			axesRequest={nodeRef}
-			nodeRef={nodeRef}
-		/>
+		<div>
+			{shape?.expression && (
+				<EquationHeader
+					shape={shape}
+					totals={totalsRow}
+					hoverRow={hoverRow}
+					lockedRow={lockedRow}
+					scope={scopeSentence(steps)}
+				/>
+			)}
+			<DrillableGrid
+				sql={ok.sql}
+				axesRequest={nodeRef}
+				nodeRef={nodeRef}
+				footerCells={totalsRow ?? undefined}
+				columnAccents={accents}
+				columnUnits={shape?.unit ? { value: shape.unit } : undefined}
+				onRowHover={setHoverRow}
+				onPinnedRow={setLockedRow}
+				onStepsChange={setSteps}
+			/>
+		</div>
 	);
 }
 

--- a/packages/cockpit/src/ui/cockpit/operating-model/analyse-overlay.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/analyse-overlay.tsx
@@ -161,35 +161,24 @@ export function scopeSentence(steps: DrillStep[]): string {
 	return "all data";
 }
 
-/** Compose-on-open: fetch the node's ad-hoc composed SQL (+ the DAT-712
- *  header block) from its parts, then mount the equation layer over the
- *  shared grid. Loading/refusal states are part of the surface — a refusal
- *  names the missing part, never a dead end. Drill steps report UP
- *  (`onStepsChange`) so the modal's title row carries the live scope. */
-function NodeGrid({
-	nodeRef,
-	scope,
-	onStepsChange,
+/** The analyse modal for a RUNNABLE metric/measure node — opened directly by
+ *  the canvas node click (iteration 2). Mount it keyed on the node id and
+ *  only while open, so drill/scope state resets per node. The TITLE row holds
+ *  everything above the grid (iteration 3): the identity line (kind chip,
+ *  name, unit, statement · aggregation, live scope) on the left and the live
+ *  equation on the right, a fair gap before the close button. The slice
+ *  controls live in the grid's own toolbar (`toolbarStart`). */
+export function AnalyseModal({
+	node,
+	onClose,
 }: {
-	nodeRef: DrillAxesRequest;
-	scope: string;
-	onStepsChange: (steps: DrillStep[]) => void;
+	node: OMNode;
+	onClose: () => void;
 }) {
-	const compose = useQuery({
-		queryKey: ["drill-node", nodeRef],
-		queryFn: async (): Promise<NodeComposeState> => {
-			const res = await fetch("/api/drill/node", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify(nodeRef),
-			});
-			if (!res.ok) throw new Error(`compose failed (${res.status})`);
-			return narrowNodeCompose(await res.json());
-		},
-	});
-
-	// The header's bindings (React rule 1: plain state set by grid callbacks,
-	// everything else derived during render).
+	const target = analyseTarget(node);
+	const [steps, setSteps] = useState<DrillStep[]>([]);
+	// The equation's bindings (React rule 1: plain state set by grid
+	// callbacks, everything else derived during render).
 	const [hoverRow, setHoverRow] = useState<Record<string, unknown> | null>(
 		null,
 	);
@@ -197,6 +186,19 @@ function NodeGrid({
 		null,
 	);
 
+	const compose = useQuery({
+		queryKey: ["drill-node", target],
+		enabled: target !== null,
+		queryFn: async (): Promise<NodeComposeState> => {
+			const res = await fetch("/api/drill/node", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(target),
+			});
+			if (!res.ok) throw new Error(`compose failed (${res.status})`);
+			return narrowNodeCompose(await res.json());
+		},
+	});
 	const data = compose.data;
 	const ok: Extract<NodeComposeState, { ok: true }> | null =
 		data !== undefined && data.ok === true ? data : null;
@@ -207,111 +209,87 @@ function NodeGrid({
 		ok?.totalsSql != null,
 	);
 	const totalsRow = totalsQuery.data?.rows[0] ?? null;
-
 	const shape = ok?.node ?? null;
 	const accents = useMemo(
 		() => (shape ? operandAccents(shape) : undefined),
 		[shape],
 	);
 
-	if (compose.isPending) {
-		return (
-			<Center h={160} data-testid="node-analyse-composing">
-				<Loader size="sm" />
-			</Center>
-		);
-	}
-	if (compose.isError) {
-		return (
-			<Alert color="red" title="Compose failed">
-				{compose.error instanceof Error
-					? compose.error.message
-					: "unknown error"}
-			</Alert>
-		);
-	}
-	if (!ok) {
-		return (
-			<Alert color="yellow" title="Cannot compose this node">
-				{compose.data && !compose.data.ok ? compose.data.reason : ""}
-			</Alert>
-		);
-	}
-	return (
-		<DrillableGrid
-			sql={ok.sql}
-			axesRequest={nodeRef}
-			nodeRef={nodeRef}
-			footerCells={totalsRow ?? undefined}
-			columnAccents={accents}
-			columnUnits={shape?.unit ? { value: unitSymbol(shape.unit) } : undefined}
-			onRowHover={setHoverRow}
-			onPinnedRow={setLockedRow}
-			onStepsChange={onStepsChange}
-			toolbarEnd={
-				shape?.expression ? (
-					<EquationHeader
-						shape={shape}
-						totals={totalsRow}
-						hoverRow={hoverRow}
-						lockedRow={lockedRow}
-						scope={scope}
-					/>
-				) : undefined
-			}
-		/>
-	);
-}
-
-/** The analyse modal for a RUNNABLE metric/measure node — opened directly by
- *  the canvas node click (iteration 2). Mount it keyed on the node id and
- *  only while open, so drill/scope state resets per node. The title row is
- *  the node's ONE identity line: kind chip, name, unit, the measure's
- *  statement + aggregation, and the live drill scope. */
-export function AnalyseModal({
-	node,
-	onClose,
-}: {
-	node: OMNode;
-	onClose: () => void;
-}) {
-	const [steps, setSteps] = useState<DrillStep[]>([]);
-	const target = analyseTarget(node);
 	if (!target) return null;
 	const d = node.data;
+	const scope = scopeSentence(steps);
+
 	return (
 		<Modal
 			opened
 			onClose={onClose}
 			size="90%"
 			data-testid="node-analyse-modal"
+			// The title stretches so identity (left) and equation (right) share
+			// the header row; pr keeps a fair gap to the close button.
+			styles={{ title: { flex: 1 } }}
 			title={
-				<Group gap="xs" wrap="wrap">
-					<Badge variant="light" tt="uppercase">
-						{node.kind}
-					</Badge>
-					<Text fw={600}>{node.label}</Text>
-					{d.kind === "metric" && d.unit && (
-						<Badge size="sm" variant="light" color="gray">
-							{unitSymbol(d.unit)}
+				<Group justify="space-between" wrap="wrap" align="center" pr="lg">
+					<Group gap="xs" wrap="wrap">
+						<Badge variant="light" tt="uppercase">
+							{node.kind}
 						</Badge>
-					)}
-					{d.kind === "measure" && (d.statement || d.aggregation) && (
-						<Text size="xs" c="dimmed">
-							{[d.statement, d.aggregation].filter(Boolean).join(" · ")}
+						<Text fw={600}>{node.label}</Text>
+						{d.kind === "metric" && d.unit && (
+							<Badge size="sm" variant="light" color="gray">
+								{unitSymbol(d.unit)}
+							</Badge>
+						)}
+						{d.kind === "measure" && (d.statement || d.aggregation) && (
+							<Text size="xs" c="dimmed">
+								{[d.statement, d.aggregation].filter(Boolean).join(" · ")}
+							</Text>
+						)}
+						<Text size="xs" c="dimmed" data-testid="analyse-scope">
+							{scope}
 						</Text>
+					</Group>
+					{shape?.expression && (
+						<EquationHeader
+							shape={shape}
+							totals={totalsRow}
+							hoverRow={hoverRow}
+							lockedRow={lockedRow}
+							scope={scope}
+						/>
 					)}
-					<Text size="xs" c="dimmed" data-testid="analyse-scope">
-						{scopeSentence(steps)}
-					</Text>
 				</Group>
 			}
 		>
-			<NodeGrid
-				nodeRef={target}
-				scope={scopeSentence(steps)}
-				onStepsChange={setSteps}
-			/>
+			{compose.isPending ? (
+				<Center h={160} data-testid="node-analyse-composing">
+					<Loader size="sm" />
+				</Center>
+			) : compose.isError ? (
+				<Alert color="red" title="Compose failed">
+					{compose.error instanceof Error
+						? compose.error.message
+						: "unknown error"}
+				</Alert>
+			) : !ok ? (
+				<Alert color="yellow" title="Cannot compose this node">
+					{data && !data.ok ? data.reason : ""}
+				</Alert>
+			) : (
+				<DrillableGrid
+					sql={ok.sql}
+					axesRequest={target}
+					nodeRef={target}
+					footerCells={totalsRow ?? undefined}
+					columnAccents={accents}
+					columnUnits={
+						shape?.unit ? { value: unitSymbol(shape.unit) } : undefined
+					}
+					onRowHover={setHoverRow}
+					onPinnedRow={setLockedRow}
+					onStepsChange={setSteps}
+				/>
+			)}
 		</Modal>
 	);
 }

--- a/packages/cockpit/src/ui/cockpit/operating-model/analyse-overlay.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/analyse-overlay.tsx
@@ -129,8 +129,14 @@ function narrowNodeCompose(raw: unknown): NodeComposeState {
 export function scopeSentence(steps: DrillStep[]): string {
 	const pins = steps.filter((s) => s.kind === "pin");
 	if (pins.length > 0) {
+		// A grained pin names its bucket width — "2025-01-01 (Month)" is a
+		// month, not a day, and the missing-operand sentence inherits this.
 		return `pinned to ${pins
-			.map((p) => `${String(p.value ?? "∅")}`)
+			.map((p) => {
+				const grain = p.grain ? parseGrainToken(p.grain) : null;
+				const label = String(p.value ?? "∅");
+				return grain ? `${label} (${grainLabel(grain)})` : label;
+			})
 			.join(", ")}`;
 	}
 	const slices = steps.filter((s) => s.kind === "slice");

--- a/packages/cockpit/src/ui/cockpit/operating-model/analyse-overlay.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/analyse-overlay.tsx
@@ -2,13 +2,15 @@
 // UX re-cut DAT-712): run a metric/measure node in the SHARED result grid,
 // with the live equation header, drill + chart on top.
 //
-// UX shape (decided in implementation, per the ticket's two options): the
-// affordance lives in the NodeDetail panel — an "Analyse" button opening a
-// large modal — rather than a second icon on the graph node. The 380px detail
-// panel cannot hold a grid, and NodeDetail is already the node's "expand"
-// surface, so the modal keeps one interaction path: click node → detail →
-// analyse. Nothing here is canvas-local: the modal mounts the same
-// DrillableGrid the answer surface inherits later (DAT-678).
+// UX shape (iteration 2, lead direction 2026-07-08): clicking a RUNNABLE
+// node (metric with a DAG, grounded measure) opens this modal DIRECTLY — the
+// side panel remains only for what can't run (constants, tables, failed/
+// ungrounded nodes, where the state reason and attempted SQL matter). The
+// modal's TITLE row is the node's one identity line: kind, name, unit,
+// statement/aggregation, and the live drill scope — the equation carries only
+// the math, right of the slice controls. Nothing here is canvas-local: the
+// modal mounts the same DrillableGrid the answer surface inherits later
+// (DAT-678).
 //
 // BOTH node kinds compose AD HOC on open from their persisted clause parts
 // (`/api/drill/node`, parts-at-source): a metric rebuilds its DAG subtree, a
@@ -27,9 +29,16 @@
 // response carries a structured shape", so answer-agent results (DAT-678)
 // join by shipping the same block, not by being canvas nodes.
 
-import { Alert, Button, Center, Group, Loader, Modal } from "@mantine/core";
+import {
+	Alert,
+	Badge,
+	Center,
+	Group,
+	Loader,
+	Modal,
+	Text,
+} from "@mantine/core";
 import { useQuery } from "@tanstack/react-query";
-import { Play } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { useChartData } from "#/charts/use-chart-data";
@@ -41,6 +50,7 @@ import {
 	EquationHeader,
 	type NodeShapeWire,
 	operandAccents,
+	unitSymbol,
 } from "#/ui/cockpit/widgets/equation-header";
 
 /** The node's compose target — the same ref shape the axes route resolves —
@@ -154,8 +164,17 @@ export function scopeSentence(steps: DrillStep[]): string {
 /** Compose-on-open: fetch the node's ad-hoc composed SQL (+ the DAT-712
  *  header block) from its parts, then mount the equation layer over the
  *  shared grid. Loading/refusal states are part of the surface — a refusal
- *  names the missing part, never a dead end. */
-function NodeGrid({ nodeRef }: { nodeRef: DrillAxesRequest }) {
+ *  names the missing part, never a dead end. Drill steps report UP
+ *  (`onStepsChange`) so the modal's title row carries the live scope. */
+function NodeGrid({
+	nodeRef,
+	scope,
+	onStepsChange,
+}: {
+	nodeRef: DrillAxesRequest;
+	scope: string;
+	onStepsChange: (steps: DrillStep[]) => void;
+}) {
 	const compose = useQuery({
 		queryKey: ["drill-node", nodeRef],
 		queryFn: async (): Promise<NodeComposeState> => {
@@ -177,7 +196,6 @@ function NodeGrid({ nodeRef }: { nodeRef: DrillAxesRequest }) {
 	const [lockedRow, setLockedRow] = useState<Record<string, unknown> | null>(
 		null,
 	);
-	const [steps, setSteps] = useState<DrillStep[]>([]);
 
 	const data = compose.data;
 	const ok: Extract<NodeComposeState, { ok: true }> | null =
@@ -220,63 +238,80 @@ function NodeGrid({ nodeRef }: { nodeRef: DrillAxesRequest }) {
 		);
 	}
 	return (
-		<div>
-			{shape?.expression && (
-				<EquationHeader
-					shape={shape}
-					totals={totalsRow}
-					hoverRow={hoverRow}
-					lockedRow={lockedRow}
-					scope={scopeSentence(steps)}
-				/>
-			)}
-			<DrillableGrid
-				sql={ok.sql}
-				axesRequest={nodeRef}
-				nodeRef={nodeRef}
-				footerCells={totalsRow ?? undefined}
-				columnAccents={accents}
-				columnUnits={shape?.unit ? { value: shape.unit } : undefined}
-				onRowHover={setHoverRow}
-				onPinnedRow={setLockedRow}
-				onStepsChange={setSteps}
-			/>
-		</div>
+		<DrillableGrid
+			sql={ok.sql}
+			axesRequest={nodeRef}
+			nodeRef={nodeRef}
+			footerCells={totalsRow ?? undefined}
+			columnAccents={accents}
+			columnUnits={shape?.unit ? { value: unitSymbol(shape.unit) } : undefined}
+			onRowHover={setHoverRow}
+			onPinnedRow={setLockedRow}
+			onStepsChange={onStepsChange}
+			toolbarEnd={
+				shape?.expression ? (
+					<EquationHeader
+						shape={shape}
+						totals={totalsRow}
+						hoverRow={hoverRow}
+						lockedRow={lockedRow}
+						scope={scope}
+					/>
+				) : undefined
+			}
+		/>
 	);
 }
 
-/** The "Analyse" button + modal for a metric/measure node; renders nothing for
- *  nodes without a runnable target (no affordance on ungrounded measures or
- *  DAG-less metrics — AC). */
-export function AnalyseAction({ node }: { node: OMNode }) {
-	const [opened, setOpened] = useState(false);
+/** The analyse modal for a RUNNABLE metric/measure node — opened directly by
+ *  the canvas node click (iteration 2). Mount it keyed on the node id and
+ *  only while open, so drill/scope state resets per node. The title row is
+ *  the node's ONE identity line: kind chip, name, unit, the measure's
+ *  statement + aggregation, and the live drill scope. */
+export function AnalyseModal({
+	node,
+	onClose,
+}: {
+	node: OMNode;
+	onClose: () => void;
+}) {
+	const [steps, setSteps] = useState<DrillStep[]>([]);
 	const target = analyseTarget(node);
 	if (!target) return null;
-	// The Group keeps the button intrinsic-width inside NodeDetail's stretching
-	// Stack; the Modal portals out, so it is the Group's only real child.
+	const d = node.data;
 	return (
-		<Group>
-			<Button
-				variant="light"
-				size="compact-sm"
-				leftSection={<Play size={13} />}
-				onClick={() => setOpened(true)}
-				data-testid="node-analyse-button"
-			>
-				Analyse
-			</Button>
-			<Modal
-				opened={opened}
-				onClose={() => setOpened(false)}
-				title={node.label}
-				size="90%"
-				data-testid="node-analyse-modal"
-			>
-				{/* Mounted only while open (Mantine default) — the compose fetch, the
-				    grid query, and the axes fetch fire on first open, not on node
-				    selection. */}
-				<NodeGrid nodeRef={target} />
-			</Modal>
-		</Group>
+		<Modal
+			opened
+			onClose={onClose}
+			size="90%"
+			data-testid="node-analyse-modal"
+			title={
+				<Group gap="xs" wrap="wrap">
+					<Badge variant="light" tt="uppercase">
+						{node.kind}
+					</Badge>
+					<Text fw={600}>{node.label}</Text>
+					{d.kind === "metric" && d.unit && (
+						<Badge size="sm" variant="light" color="gray">
+							{unitSymbol(d.unit)}
+						</Badge>
+					)}
+					{d.kind === "measure" && (d.statement || d.aggregation) && (
+						<Text size="xs" c="dimmed">
+							{[d.statement, d.aggregation].filter(Boolean).join(" · ")}
+						</Text>
+					)}
+					<Text size="xs" c="dimmed" data-testid="analyse-scope">
+						{scopeSentence(steps)}
+					</Text>
+				</Group>
+			}
+		>
+			<NodeGrid
+				nodeRef={target}
+				scope={scopeSentence(steps)}
+				onStepsChange={setSteps}
+			/>
+		</Modal>
 	);
 }

--- a/packages/cockpit/src/ui/cockpit/operating-model/analyse-overlay.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/analyse-overlay.tsx
@@ -226,10 +226,27 @@ export function AnalyseModal({
 			size="90%"
 			data-testid="node-analyse-modal"
 			// The title stretches so identity (left) and equation (right) share
-			// the header row; pr keeps a fair gap to the close button.
-			styles={{ title: { flex: 1 } }}
+			// the header row; pr keeps a fair gap to the close button. The
+			// content is a FIXED-height flex column and the grid body its only
+			// vertical scroller (`fillHeight`) — otherwise the 480px-capped grid
+			// plus header overflows the modal and a second scrollbar appears on
+			// the modal content.
+			styles={{
+				title: { flex: 1 },
+				content: {
+					display: "flex",
+					flexDirection: "column",
+					height: "calc(100dvh - 10dvh)",
+				},
+				body: {
+					flex: 1,
+					minHeight: 0,
+					display: "flex",
+					flexDirection: "column",
+				},
+			}}
 			title={
-				<Group justify="space-between" wrap="wrap" align="center" pr="lg">
+				<Group justify="space-between" wrap="wrap" align="center" pr="xl">
 					<Group gap="xs" wrap="wrap">
 						<Badge variant="light" tt="uppercase">
 							{node.kind}
@@ -288,6 +305,7 @@ export function AnalyseModal({
 					onRowHover={setHoverRow}
 					onPinnedRow={setLockedRow}
 					onStepsChange={setSteps}
+					fillHeight
 				/>
 			)}
 		</Modal>

--- a/packages/cockpit/src/ui/cockpit/operating-model/operating-model-canvas.tsx
+++ b/packages/cockpit/src/ui/cockpit/operating-model/operating-model-canvas.tsx
@@ -45,7 +45,7 @@ import {
 	type OperatingModelGraph,
 } from "#/tools/operating-model-graph";
 import { SqlBlock } from "#/ui/cockpit/widgets/sql-block";
-import { AnalyseAction } from "./analyse-overlay";
+import { AnalyseModal, analyseTarget } from "./analyse-overlay";
 import { layoutGraph } from "./layout";
 import { type OMRfData, omNodeTypes } from "./nodes";
 
@@ -70,6 +70,10 @@ export function OperatingModelCanvas({
 	// (React idiom rule 1), so the detail panel never goes stale and auto-closes when a
 	// filter/collapse removes the node.
 	const [selectedId, setSelectedId] = useState<string | null>(null);
+	// The analyse modal's node id (DAT-712 iteration 2: a runnable node click
+	// opens the analysis DIRECTLY). Derived from the FULL graph, not the
+	// filtered view — an overlay must not close because a filter changed.
+	const [analyseId, setAnalyseId] = useState<string | null>(null);
 	const [enabledKinds, setEnabledKinds] = useState<ReadonlySet<OMNodeKind>>(
 		() => new Set(OM_NODE_KINDS),
 	);
@@ -91,6 +95,10 @@ export function OperatingModelCanvas({
 	const selected =
 		selectedId != null
 			? (filtered.nodes.find((n) => n.id === selectedId) ?? null)
+			: null;
+	const analyseNode =
+		analyseId != null
+			? (graph.nodes.find((n) => n.id === analyseId) ?? null)
 			: null;
 
 	const { nodes, edges } = useMemo(() => {
@@ -124,6 +132,13 @@ export function OperatingModelCanvas({
 		}
 		// Base tables are leaf grounding nodes — nothing to detail; ignore the click.
 		if (om.kind === "table") return;
+		// A runnable node answers directly (DAT-712 iteration 2): straight to the
+		// analyse modal. The side panel stays for what can't run — constants and
+		// failed/ungrounded nodes, where the state reason and attempted SQL live.
+		if (analyseTarget(om)) {
+			setAnalyseId(om.id);
+			return;
+		}
 		setSelectedId(om.id);
 	}, []);
 
@@ -168,6 +183,15 @@ export function OperatingModelCanvas({
 			) : null}
 			{selected ? (
 				<NodeDetail node={selected} onClose={() => setSelectedId(null)} />
+			) : null}
+			{analyseNode ? (
+				// Keyed by node id + mounted only while open: drill/scope state
+				// resets per node without a reset effect (React rule 5).
+				<AnalyseModal
+					key={analyseNode.id}
+					node={analyseNode}
+					onClose={() => setAnalyseId(null)}
+				/>
 			) : null}
 		</Box>
 	);
@@ -296,7 +320,6 @@ function NodeDetailBody({ node }: { node: OMNode }) {
 		case "metric":
 			return (
 				<Stack gap="xs">
-					<AnalyseAction node={node} />
 					<Field label="State" value={d.state} />
 					{d.unit ? <Field label="Unit" value={d.unit} /> : null}
 					{d.stateReason ? (
@@ -315,7 +338,6 @@ function NodeDetailBody({ node }: { node: OMNode }) {
 		case "measure":
 			return (
 				<Stack gap="xs">
-					<AnalyseAction node={node} />
 					{d.statement ? <Field label="Statement" value={d.statement} /> : null}
 					{d.aggregation ? (
 						<Field label="Aggregation" value={d.aggregation} />

--- a/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.test.tsx
@@ -26,11 +26,16 @@ vi.mock("#/ui/cockpit/widgets/result-grid", () => ({
 	WindowedGrid: ({
 		sql,
 		onRowClick,
+		toolbarStart,
 	}: {
 		sql?: string;
 		onRowClick?: (row: Record<string, unknown>) => void;
+		toolbarStart?: React.ReactNode;
 	}) => (
 		<div>
+			{/* The drill controls render through the grid's toolbar-left slot
+			    (iteration 3) — the mock must mount them like the real grid. */}
+			{toolbarStart}
 			<div data-testid="mock-grid-sql">{sql}</div>
 			{onRowClick && (
 				<button

--- a/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.test.tsx
@@ -36,7 +36,13 @@ vi.mock("#/ui/cockpit/widgets/result-grid", () => ({
 				<button
 					type="button"
 					data-testid="mock-row"
-					onClick={() => onRowClick({ region: "EU", value: 5 })}
+					onClick={() =>
+						onRowClick({
+							region: "EU",
+							entry_id__date: "2025-08-01",
+							value: 5,
+						})
+					}
 				>
 					row
 				</button>
@@ -50,14 +56,17 @@ vi.mock("#/ui/cockpit/widgets/chart-toolbar-button", () => ({
 
 import { DrillableGrid } from "./drillable-grid";
 
-const axis = (column: string): DrillAxis => ({
+const axis = (
+	column: string,
+	temporal: DrillAxis["temporal"] = null,
+): DrillAxis => ({
 	column,
 	priority: 1,
 	sliceType: "categorical",
 	values: [],
 	valueCount: 3,
 	businessContext: null,
-	temporal: null,
+	temporal,
 });
 
 const jsonResponse = (body: unknown) =>
@@ -80,7 +89,13 @@ function stubFetch() {
 		vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
 			const u = String(url);
 			if (u.endsWith("/api/drill/axes")) {
-				return jsonResponse({ axes: [axis("region"), axis("product")] });
+				return jsonResponse({
+					axes: [
+						axis("region"),
+						axis("product"),
+						axis("entry_id__date", "date"),
+					],
+				});
 			}
 			if (u.endsWith("/api/drill/compose") || u.endsWith("/api/drill/node")) {
 				composeBodies.push({
@@ -96,7 +111,10 @@ function stubFetch() {
 
 const BASE_SQL = "SELECT SUM(x) AS value FROM t";
 
-function renderGrid(nodeRef?: { metricKey: string }) {
+function renderGrid(
+	nodeRef?: { metricKey: string },
+	onPinnedRow?: (row: Record<string, unknown> | null) => void,
+) {
 	stubFetch();
 	return render(
 		<TestQueryProvider>
@@ -105,6 +123,7 @@ function renderGrid(nodeRef?: { metricKey: string }) {
 					sql={BASE_SQL}
 					axesRequest={{ metricKey: "m1" }}
 					nodeRef={nodeRef}
+					onPinnedRow={onPinnedRow}
 				/>
 			</MantineProvider>
 		</TestQueryProvider>,
@@ -193,5 +212,124 @@ describe("DrillableGrid", () => {
 				},
 			},
 		]);
+	});
+});
+
+// --- time grain (DAT-712) -----------------------------------------------------
+
+/** The last compose body's steps, for wire-contract assertions. */
+const lastSteps = () =>
+	(composeBodies[composeBodies.length - 1] as { body: { steps: unknown } }).body
+		.steps;
+
+describe("DrillableGrid — time grain", () => {
+	it("slices a temporal axis at MONTH grain by default; the chip is the grain control", async () => {
+		renderGrid({ metricKey: "m1" });
+		await sliceBy("entry_id__date", "SQL_M");
+		expect(lastSteps()).toEqual([
+			{ kind: "slice", column: "entry_id__date", grain: "1M" },
+		]);
+		// The chip names the grain…
+		const chip = screen.getByTestId("drill-step-slice-entry_id__date");
+		expect(chip.textContent).toContain("Month");
+		// …and its menu re-grains in place (preset → Quarter).
+		fireEvent.click(chip);
+		fireEvent.click(await screen.findByTestId("drill-grain-entry_id__date-1q"));
+		await waitFor(() => expect(composeQueue.length).toBe(1));
+		composeQueue.shift()?.(
+			jsonResponse({ ok: true, sql: "SQL_Q", params: [] }),
+		);
+		await waitFor(() => expect(gridSql()).toBe("SQL_Q"));
+		expect(lastSteps()).toEqual([
+			{ kind: "slice", column: "entry_id__date", grain: "1q" },
+		]);
+	});
+
+	it("refuses an off-grammar custom token locally — no compose call fires", async () => {
+		renderGrid({ metricKey: "m1" });
+		await sliceBy("entry_id__date", "SQL_M");
+		const before = composeBodies.length;
+		fireEvent.click(screen.getByTestId("drill-step-slice-entry_id__date"));
+		const input = await screen.findByTestId(
+			"drill-grain-entry_id__date-custom",
+		);
+		fireEvent.change(input, { target: { value: "1Q" } });
+		fireEvent.keyDown(input, { key: "Enter" });
+		await screen.findByText(
+			"Not a grain — try 1d, 1w, 1M (m = minutes, M = months)",
+		);
+		expect(composeBodies.length).toBe(before);
+	});
+
+	it("a valid custom token composes (typed power path)", async () => {
+		renderGrid({ metricKey: "m1" });
+		await sliceBy("entry_id__date", "SQL_M");
+		fireEvent.click(screen.getByTestId("drill-step-slice-entry_id__date"));
+		const input = await screen.findByTestId(
+			"drill-grain-entry_id__date-custom",
+		);
+		fireEvent.change(input, { target: { value: "3M" } });
+		fireEvent.keyDown(input, { key: "Enter" });
+		await waitFor(() => expect(composeQueue.length).toBe(1));
+		composeQueue.shift()?.(
+			jsonResponse({ ok: true, sql: "SQL_3M", params: [] }),
+		);
+		await waitFor(() => expect(gridSql()).toBe("SQL_3M"));
+		expect(lastSteps()).toEqual([
+			{ kind: "slice", column: "entry_id__date", grain: "3M" },
+		]);
+	});
+
+	it("a row-pin FREEZES the slice's grain; re-graining the slice leaves the pin (and the lock) standing", async () => {
+		const onPinnedRow = vi.fn();
+		renderGrid({ metricKey: "m1" }, onPinnedRow);
+		await sliceBy("entry_id__date", "SQL_M");
+
+		// Pin the bucket row: the pin carries the slice's CURRENT grain.
+		fireEvent.click(screen.getByTestId("mock-row"));
+		await waitFor(() => expect(composeQueue.length).toBe(1));
+		composeQueue.shift()?.(
+			jsonResponse({ ok: true, sql: "SQL_PINNED", params: ["2025-08-01"] }),
+		);
+		await screen.findByTestId("drill-step-pin-entry_id__date");
+		expect(lastSteps()).toEqual([
+			{ kind: "slice", column: "entry_id__date", grain: "1M" },
+			{
+				kind: "pin",
+				column: "entry_id__date",
+				value: "2025-08-01",
+				grain: "1M",
+			},
+		]);
+		expect(onPinnedRow).toHaveBeenLastCalledWith({
+			region: "EU",
+			entry_id__date: "2025-08-01",
+			value: 5,
+		});
+
+		// Re-grain the slice to Quarter: the pin keeps ITS month grain, and the
+		// lock is NOT wiped (the pin's restriction didn't move).
+		onPinnedRow.mockClear();
+		fireEvent.click(screen.getByTestId("drill-step-slice-entry_id__date"));
+		fireEvent.click(await screen.findByTestId("drill-grain-entry_id__date-1q"));
+		await waitFor(() => expect(composeQueue.length).toBe(1));
+		composeQueue.shift()?.(
+			jsonResponse({ ok: true, sql: "SQL_Q_PINNED", params: ["2025-08-01"] }),
+		);
+		await waitFor(() => expect(gridSql()).toBe("SQL_Q_PINNED"));
+		expect(lastSteps()).toEqual([
+			{ kind: "slice", column: "entry_id__date", grain: "1q" },
+			{
+				kind: "pin",
+				column: "entry_id__date",
+				value: "2025-08-01",
+				grain: "1M",
+			},
+		]);
+		expect(onPinnedRow).not.toHaveBeenCalled();
+
+		// Clearing the drill releases the lock.
+		fireEvent.click(screen.getByTestId("drill-clear"));
+		expect(onPinnedRow).toHaveBeenLastCalledWith(null);
 	});
 });

--- a/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.test.tsx
@@ -223,6 +223,16 @@ const lastSteps = () =>
 		.steps;
 
 describe("DrillableGrid — time grain", () => {
+	it("WITHOUT a nodeRef a temporal axis slices RAW — grain is a node-path capability", async () => {
+		renderGrid(); // tier-A path: /api/drill/compose rejects grained steps
+		await sliceBy("entry_id__date", "SQL_RAW");
+		expect(lastSteps()).toEqual([{ kind: "slice", column: "entry_id__date" }]);
+		// A plain removable pill, not the grain chip.
+		expect(
+			screen.getByTestId("drill-step-slice-entry_id__date").textContent,
+		).not.toContain("Month");
+	});
+
 	it("slices a temporal axis at MONTH grain by default; the chip is the grain control", async () => {
 		renderGrid({ metricKey: "m1" });
 		await sliceBy("entry_id__date", "SQL_M");

--- a/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.test.tsx
@@ -57,6 +57,7 @@ const axis = (column: string): DrillAxis => ({
 	values: [],
 	valueCount: 3,
 	businessContext: null,
+	temporal: null,
 });
 
 const jsonResponse = (body: unknown) =>

--- a/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.tsx
@@ -150,9 +150,21 @@ function GrainMenu({
 	const commitCustom = () => {
 		const token = custom.trim();
 		if (token === "") return;
-		if (!parseGrainToken(token)) {
+		const grain = parseGrainToken(token);
+		if (!grain) {
 			// The named refusal, client-side: same grammar, same message shape.
 			setCustomError("Not a grain — try 1d, 1w, 1M (m = minutes, M = months)");
+			return;
+		}
+		// The same restriction the presets encode: a DATE column has no hours
+		// to bucket — DuckDB's (INTERVAL, DATE) time_bucket would floor
+		// non-divisor sub-day widths to the PREVIOUS day and no-op divisors,
+		// both silently mislabeled. Refuse by name instead.
+		if (
+			axis.temporal === "date" &&
+			(grain.unit === "s" || grain.unit === "m" || grain.unit === "h")
+		) {
+			setCustomError("This column has day resolution — use 1d or coarser");
 			return;
 		}
 		setCustomError(null);
@@ -335,17 +347,25 @@ export function DrillableGrid({
 		onSuccess: ({ candidate, generation, pinRow, result }) => {
 			if (generation !== generationRef.current) return; // superseded — drop
 			if (result.ok) {
+				const prevPinCount = steps.filter((s) => s.kind === "pin").length;
+				const nextPinCount = candidate.filter((s) => s.kind === "pin").length;
 				setSteps(candidate);
 				setComposed({ sql: result.sql, params: result.params });
 				setRefusal(null);
 				onStepsChange?.(candidate);
+				// The grid remounts on the new composition — a hover observed
+				// under the OLD one must not outlive it (it would shadow the
+				// lock/totals binding; mouse flows only self-heal by DOM-layout
+				// accident, and a keyboard focus row has no leave event at all).
+				onRowHover?.(null);
 				// The lock follows the PINS, not the apply: a row-click pin sets
-				// it, losing the last pin clears it, and a slice-only change
-				// (re-grain, extra slice) leaves an existing lock standing — the
-				// pin's restriction, and therefore its values, didn't move.
+				// it; a slice-only change (re-grain, extra slice) leaves it
+				// standing — the pins' restriction didn't move; but any SHRINK of
+				// the pin set releases it, because the locked row was captured
+				// under a filter the chips no longer represent.
 				if (pinRow !== undefined) {
 					onPinnedRow?.(pinRow);
-				} else if (!candidate.some((s) => s.kind === "pin")) {
+				} else if (nextPinCount < prevPinCount) {
 					onPinnedRow?.(null);
 				}
 			} else {
@@ -370,6 +390,7 @@ export function DrillableGrid({
 			setComposed(null);
 			setRefusal(null);
 			onStepsChange?.([]);
+			onRowHover?.(null);
 			onPinnedRow?.(null);
 			return;
 		}
@@ -415,11 +436,16 @@ export function DrillableGrid({
 				}
 			: undefined;
 
+	// Grain is a NODE-path capability: composeNodeQuery buckets it; the tier-A
+	// route rejects grained steps outright (strict zod). Without a nodeRef the
+	// temporal axis slices raw and no grain control renders.
+	const grainable = nodeRef !== undefined;
+
 	/** Slice a fresh axis — temporal axes start at the default grain. */
 	const slice = (axis: DrillAxis) => {
 		apply([
 			...steps,
-			axis.temporal !== null
+			grainable && axis.temporal !== null
 				? {
 						kind: "slice",
 						column: axis.column,
@@ -465,7 +491,7 @@ export function DrillableGrid({
 								disabled={slicedColumns.has(axis.column)}
 								onClick={() => slice(axis)}
 								rightSection={
-									axis.temporal !== null ? (
+									grainable && axis.temporal !== null ? (
 										<Text size="xs" c="dimmed">
 											{grainName(DEFAULT_TEMPORAL_GRAIN)}
 										</Text>
@@ -506,7 +532,12 @@ export function DrillableGrid({
 				{steps.map((step, i) => {
 					const axis =
 						step.kind === "slice" ? axisByColumn.get(step.column) : undefined;
-					if (step.kind === "slice" && axis && axis.temporal !== null) {
+					if (
+						grainable &&
+						step.kind === "slice" &&
+						axis &&
+						axis.temporal !== null
+					) {
 						// A temporal slice's chip IS the grain control.
 						return (
 							<GrainMenu

--- a/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.tsx
@@ -49,7 +49,7 @@ import {
 } from "@mantine/core";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { Check, ChevronDown, Layers, X } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { type ReactNode, useMemo, useRef, useState } from "react";
 import type { ChartConfig } from "#/charts/chart-config";
 import type {
 	DrillAxesRequest,
@@ -257,6 +257,7 @@ export function DrillableGrid({
 	onRowHover,
 	onPinnedRow,
 	onStepsChange,
+	toolbarEnd,
 }: {
 	/** The base query (the node's composed SQL on the canvas path). */
 	sql: string;
@@ -282,6 +283,9 @@ export function DrillableGrid({
 	onPinnedRow?: (row: Record<string, Json | null> | null) => void;
 	/** Fired with the committed step stack after every accepted apply. */
 	onStepsChange?: (steps: DrillStep[]) => void;
+	/** Rendered right-aligned on the drill-controls row — the layer above
+	 *  mounts its equation here (DAT-712 iteration 2: the busy corner). */
+	toolbarEnd?: ReactNode;
 }) {
 	const baseParams = useMemo<SqlParams>(() => params ?? [], [params]);
 	// The committed stack + its server-composed statement move TOGETHER: steps
@@ -470,119 +474,128 @@ export function DrillableGrid({
 
 	return (
 		<div data-testid="drillable-grid">
-			<Group gap="xs" mb="xs" wrap="wrap">
-				<Menu shadow="md" width={280} position="bottom-start">
-					<Menu.Target>
-						<Button
-							variant="light"
-							size="compact-xs"
-							leftSection={<Layers size={13} />}
-							loading={compose.isPending}
-							disabled={axesQuery.isPending || axes.length === 0}
-							data-testid="drill-slice-button"
-						>
-							Slice
-						</Button>
-					</Menu.Target>
-					<Menu.Dropdown>
-						{axes.map((axis) => (
-							<Menu.Item
-								key={axis.column}
-								disabled={slicedColumns.has(axis.column)}
-								onClick={() => slice(axis)}
-								rightSection={
-									grainable && axis.temporal !== null ? (
-										<Text size="xs" c="dimmed">
-											{grainName(DEFAULT_TEMPORAL_GRAIN)}
-										</Text>
-									) : axis.valueCount !== null ? (
-										<Text size="xs" c="dimmed">
-											{axis.valueCount}
-										</Text>
-									) : undefined
-								}
+			<Group
+				gap="xs"
+				mb="xs"
+				wrap="wrap"
+				justify={toolbarEnd ? "space-between" : undefined}
+				align="flex-start"
+			>
+				<Group gap="xs" wrap="wrap">
+					<Menu shadow="md" width={280} position="bottom-start">
+						<Menu.Target>
+							<Button
+								variant="light"
+								size="compact-xs"
+								leftSection={<Layers size={13} />}
+								loading={compose.isPending}
+								disabled={axesQuery.isPending || axes.length === 0}
+								data-testid="drill-slice-button"
 							>
-								<Text size="sm">{axis.column}</Text>
-								{axis.businessContext && (
-									<Text size="xs" c="dimmed" lineClamp={1}>
-										{axis.businessContext}
-									</Text>
-								)}
-							</Menu.Item>
-						))}
-					</Menu.Dropdown>
-				</Menu>
-				{axes.length === 0 && !axesQuery.isPending && (
-					// The resolver names WHY it came back empty (stale snippet, bare
-					// catalog, no extracts) — a dead-end badge with no reason reads
-					// as a bug (2026-07-06 review).
-					<Tooltip
-						label={
-							axesQuery.data?.reason ??
-							"No cataloged dimensions for this metric's facts"
-						}
-						maw={360}
-						multiline
-					>
-						<Badge color="gray" variant="light" size="sm">
-							no axes
-						</Badge>
-					</Tooltip>
-				)}
-				{steps.map((step, i) => {
-					const axis =
-						step.kind === "slice" ? axisByColumn.get(step.column) : undefined;
-					if (
-						grainable &&
-						step.kind === "slice" &&
-						axis &&
-						axis.temporal !== null
-					) {
-						// A temporal slice's chip IS the grain control.
-						return (
-							<GrainMenu
-								key={`slice:${step.column}`}
-								axis={axis}
-								grain={step.grain}
-								onGrain={(token) => regrain(step.column, token)}
-								onRemove={() => apply(steps.filter((_, j) => j !== i))}
-							/>
-						);
-					}
-					return (
-						<Pill
-							// Value-identity key: slices are unique per column (menu disables
-							// re-slicing) and pins per column+value (row-click dedupes).
-							key={
-								step.kind === "slice"
-									? `slice:${step.column}`
-									: `pin:${step.column}:${pinLabel(step.value)}`
+								Slice
+							</Button>
+						</Menu.Target>
+						<Menu.Dropdown>
+							{axes.map((axis) => (
+								<Menu.Item
+									key={axis.column}
+									disabled={slicedColumns.has(axis.column)}
+									onClick={() => slice(axis)}
+									rightSection={
+										grainable && axis.temporal !== null ? (
+											<Text size="xs" c="dimmed">
+												{grainName(DEFAULT_TEMPORAL_GRAIN)}
+											</Text>
+										) : axis.valueCount !== null ? (
+											<Text size="xs" c="dimmed">
+												{axis.valueCount}
+											</Text>
+										) : undefined
+									}
+								>
+									<Text size="sm">{axis.column}</Text>
+									{axis.businessContext && (
+										<Text size="xs" c="dimmed" lineClamp={1}>
+											{axis.businessContext}
+										</Text>
+									)}
+								</Menu.Item>
+							))}
+						</Menu.Dropdown>
+					</Menu>
+					{axes.length === 0 && !axesQuery.isPending && (
+						// The resolver names WHY it came back empty (stale snippet, bare
+						// catalog, no extracts) — a dead-end badge with no reason reads
+						// as a bug (2026-07-06 review).
+						<Tooltip
+							label={
+								axesQuery.data?.reason ??
+								"No cataloged dimensions for this metric's facts"
 							}
-							withRemoveButton
-							onRemove={() => apply(steps.filter((_, j) => j !== i))}
-							data-testid={`drill-step-${step.kind}-${step.column}`}
+							maw={360}
+							multiline
 						>
-							{step.kind === "slice"
-								? `by ${step.column}`
-								: `${step.column} = ${pinLabel(step.value)}${
-										step.grain !== undefined
-											? ` · ${grainName(step.grain)}`
-											: ""
-									}`}
-						</Pill>
-					);
-				})}
-				{steps.length > 0 && (
-					<Button
-						variant="subtle"
-						color="gray"
-						size="compact-xs"
-						onClick={() => apply([])}
-						data-testid="drill-clear"
-					>
-						Clear
-					</Button>
-				)}
+							<Badge color="gray" variant="light" size="sm">
+								no axes
+							</Badge>
+						</Tooltip>
+					)}
+					{steps.map((step, i) => {
+						const axis =
+							step.kind === "slice" ? axisByColumn.get(step.column) : undefined;
+						if (
+							grainable &&
+							step.kind === "slice" &&
+							axis &&
+							axis.temporal !== null
+						) {
+							// A temporal slice's chip IS the grain control.
+							return (
+								<GrainMenu
+									key={`slice:${step.column}`}
+									axis={axis}
+									grain={step.grain}
+									onGrain={(token) => regrain(step.column, token)}
+									onRemove={() => apply(steps.filter((_, j) => j !== i))}
+								/>
+							);
+						}
+						return (
+							<Pill
+								// Value-identity key: slices are unique per column (menu disables
+								// re-slicing) and pins per column+value (row-click dedupes).
+								key={
+									step.kind === "slice"
+										? `slice:${step.column}`
+										: `pin:${step.column}:${pinLabel(step.value)}`
+								}
+								withRemoveButton
+								onRemove={() => apply(steps.filter((_, j) => j !== i))}
+								data-testid={`drill-step-${step.kind}-${step.column}`}
+							>
+								{step.kind === "slice"
+									? `by ${step.column}`
+									: `${step.column} = ${pinLabel(step.value)}${
+											step.grain !== undefined
+												? ` · ${grainName(step.grain)}`
+												: ""
+										}`}
+							</Pill>
+						);
+					})}
+					{steps.length > 0 && (
+						<Button
+							variant="subtle"
+							color="gray"
+							size="compact-xs"
+							onClick={() => apply([])}
+							data-testid="drill-clear"
+						>
+							Clear
+						</Button>
+					)}
+				</Group>
+				{toolbarEnd}
 			</Group>
 
 			{refusal && (

--- a/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.tsx
@@ -1,5 +1,5 @@
-// DrillableGrid (DAT-672, per-node re-cut DAT-703): the shared result grid
-// with a drill layer on top.
+// DrillableGrid (DAT-672, per-node re-cut DAT-703, analyse re-cut DAT-712):
+// the shared result grid with a drill layer on top.
 //
 // Owns the drill-step stack and the EFFECTIVE query. Drill composes upstream
 // of the grid, server-side and binder-validated, into a new effective base
@@ -15,10 +15,27 @@
 // refusal shows the amber "can't slice this deterministically" state and
 // leaves the grid on the last good drill.
 //
+// TIME GRAIN (DAT-712, node path only): a temporal axis (axis.temporal from
+// the catalog's column types) slices at MONTH grain by default — raw day rows
+// of a year of bookings answer nothing — and its chip carries the grain
+// control: resolution-appropriate presets plus a typed token (`15m`, `2h`,
+// `3M`; grain.ts's closed grammar, validated HERE before it ever reaches the
+// server, which re-validates). Pins freeze the grain they were created under
+// (pin ≡ the row it came from), so re-graining a slice never re-scopes an
+// existing pin.
+//
+// This widget stays GENERIC (the lead's DAT-712 layering constraint): the
+// equation header is a parts-context layer ABOVE it. The widget only exposes
+// observational hooks — row hover/focus, the committed pin row, step
+// changes — plus pass-through rendering props (footer cells, column accents,
+// unit chips) whose CONTENT the layer owns.
+//
 // Axes come from the metric path (`/api/drill/axes`, catalog metadata only —
 // DAT-678 adds ad-hoc resolution). This widget fetches the drill routes
 // instead of importing server modules (bundle hygiene).
 
+// Type-only, erased at compile time — the same source result-grid.tsx uses.
+import type { Json } from "@duckdb/node-api";
 import {
 	Alert,
 	Badge,
@@ -27,12 +44,12 @@ import {
 	Menu,
 	Pill,
 	Text,
+	TextInput,
 	Tooltip,
 } from "@mantine/core";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { Layers } from "lucide-react";
+import { Check, ChevronDown, Layers, X } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
-
 import type { ChartConfig } from "#/charts/chart-config";
 import type {
 	DrillAxesRequest,
@@ -40,6 +57,8 @@ import type {
 	DrillPinValue,
 	DrillStep,
 } from "#/duckdb/drill";
+
+import { grainLabel, grainPresets, parseGrainToken } from "#/duckdb/grain";
 import { ChartToolbarButton } from "#/ui/cockpit/widgets/chart-toolbar-button";
 import { WindowedGrid } from "#/ui/cockpit/widgets/result-grid";
 
@@ -85,6 +104,14 @@ function DrillChartAction({ sql, params }: { sql: string; params: SqlParams }) {
 const pinLabel = (value: DrillPinValue): string =>
 	value === null ? "∅" : String(value);
 
+/** The human name of a slice/pin's grain token — "" for a raw (ungrained)
+ *  step or an off-grammar token (which the composer refuses anyway). */
+const grainName = (token: string | undefined): string => {
+	if (token === undefined) return "";
+	const grain = parseGrainToken(token);
+	return grain ? grainLabel(grain) : token;
+};
+
 /** A clicked grid cell narrowed to a bindable pin value — `undefined` for a
  *  non-scalar cell (nested json), which cannot be pinned and is skipped rather
  *  than silently pinned as NULL. */
@@ -96,11 +123,128 @@ const toPinValue = (v: unknown): DrillPinValue | undefined =>
 		? v
 		: undefined;
 
+/** The default grain for a fresh temporal slice: month. Raw day rows are the
+ *  DAT-703 verdict's "needs far too much domain knowledge" — the evidence
+ *  (DAT-673): COGS books 191/365 days, so day grain shows mostly dashes while
+ *  every MONTH bucket has both flows. "Exact values" stays one click away. */
+const DEFAULT_TEMPORAL_GRAIN = "1M";
+
+/** The grain chip's dropdown: resolution-appropriate presets, exact values,
+ *  a typed token (validated locally with the same closed grammar the
+ *  composer trusts), and the slice's removal. */
+function GrainMenu({
+	axis,
+	grain,
+	onGrain,
+	onRemove,
+}: {
+	axis: DrillAxis;
+	grain: string | undefined;
+	onGrain: (token: string | undefined) => void;
+	onRemove: () => void;
+}) {
+	const [custom, setCustom] = useState("");
+	const [customError, setCustomError] = useState<string | null>(null);
+	const presets = grainPresets(axis.temporal ?? "date");
+
+	const commitCustom = () => {
+		const token = custom.trim();
+		if (token === "") return;
+		if (!parseGrainToken(token)) {
+			// The named refusal, client-side: same grammar, same message shape.
+			setCustomError("Not a grain — try 1d, 1w, 1M (m = minutes, M = months)");
+			return;
+		}
+		setCustomError(null);
+		setCustom("");
+		onGrain(token);
+	};
+
+	return (
+		<Menu shadow="md" width={240} position="bottom-start">
+			<Menu.Target>
+				<Button
+					variant="light"
+					size="compact-xs"
+					rightSection={<ChevronDown size={12} />}
+					data-testid={`drill-step-slice-${axis.column}`}
+				>
+					by {axis.column}
+					{grain !== undefined ? ` · ${grainName(grain)}` : ""}
+				</Button>
+			</Menu.Target>
+			<Menu.Dropdown>
+				<Menu.Label>Time grain</Menu.Label>
+				{presets.map((p) => (
+					<Menu.Item
+						key={p.token}
+						onClick={() => onGrain(p.token)}
+						rightSection={grain === p.token ? <Check size={13} /> : undefined}
+						data-testid={`drill-grain-${axis.column}-${p.token}`}
+					>
+						<Group gap={6} wrap="nowrap">
+							<Text size="sm">{p.label}</Text>
+							<Text size="xs" c="dimmed">
+								{p.token}
+							</Text>
+						</Group>
+					</Menu.Item>
+				))}
+				<Menu.Item
+					onClick={() => onGrain(undefined)}
+					rightSection={grain === undefined ? <Check size={13} /> : undefined}
+					data-testid={`drill-grain-${axis.column}-raw`}
+				>
+					<Text size="sm">Exact values</Text>
+				</Menu.Item>
+				<Menu.Divider />
+				{/* The typed-token power path: any grammar token composes (15m, 2h,
+				    3M), not just the presets. */}
+				<div style={{ padding: "4px 12px 8px" }}>
+					<TextInput
+						size="xs"
+						placeholder="Custom: 15m, 2h, 3M…"
+						value={custom}
+						error={customError}
+						onChange={(e) => {
+							setCustom(e.currentTarget.value);
+							if (customError) setCustomError(null);
+						}}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") {
+								e.preventDefault();
+								commitCustom();
+							}
+						}}
+						data-testid={`drill-grain-${axis.column}-custom`}
+					/>
+				</div>
+				<Menu.Divider />
+				<Menu.Item
+					color="red"
+					leftSection={<X size={13} />}
+					onClick={onRemove}
+					data-testid={`drill-step-slice-${axis.column}-remove`}
+				>
+					Remove slice
+				</Menu.Item>
+			</Menu.Dropdown>
+		</Menu>
+	);
+}
+
 export function DrillableGrid({
 	sql,
 	params,
 	axesRequest,
 	nodeRef,
+	footerCells,
+	footerLabel,
+	columnAccents,
+	columnUnits,
+	onRowHover,
+	onPinnedRow,
+	onStepsChange,
 }: {
 	/** The base query (the node's composed SQL on the canvas path). */
 	sql: string;
@@ -110,6 +254,22 @@ export function DrillableGrid({
 	/** Present on the canvas path: drill steps recompose the NODE from its
 	 *  persisted parts (`/api/drill/node`) instead of wrapping the base SQL. */
 	nodeRef?: DrillAxesRequest;
+	/** Total-row cells (column name → value), shown as the grid's sticky footer
+	 *  WHILE a drill is active — the anchor a slice would otherwise lose. The
+	 *  layer above owns the values (DAT-712). */
+	footerCells?: Record<string, Json | null>;
+	footerLabel?: string;
+	/** Pass-through rendering props — see ResultGridView (DAT-712). */
+	columnAccents?: Record<string, string>;
+	columnUnits?: Record<string, string>;
+	/** Row hover/focus observation, forwarded from the grid (DAT-712). */
+	onRowHover?: (row: Record<string, Json | null> | null) => void;
+	/** Fired when an apply COMMITS: the clicked row when that apply pinned it,
+	 *  null otherwise (pins cleared / slice-only change) — the equation
+	 *  layer's lock-on-pin signal (DAT-712). */
+	onPinnedRow?: (row: Record<string, Json | null> | null) => void;
+	/** Fired with the committed step stack after every accepted apply. */
+	onStepsChange?: (steps: DrillStep[]) => void;
 }) {
 	const baseParams = useMemo<SqlParams>(() => params ?? [], [params]);
 	// The committed stack + its server-composed statement move TOGETHER: steps
@@ -131,6 +291,10 @@ export function DrillableGrid({
 		staleTime: 60_000,
 	});
 	const axes = axesQuery.data?.axes ?? [];
+	const axisByColumn = useMemo(
+		() => new Map(axes.map((a) => [a.column, a])),
+		[axes],
+	);
 
 	// Monotonic apply generation, bumped in the EVENT HANDLER so it carries
 	// click order. TanStack Query neither serializes nor cancels overlapping
@@ -147,12 +311,16 @@ export function DrillableGrid({
 		mutationFn: async ({
 			candidate,
 			generation,
+			pinRow,
 		}: {
 			candidate: DrillStep[];
 			generation: number;
+			/** The grid row this apply pinned (row-click applies only). */
+			pinRow?: Record<string, Json | null>;
 		}) => ({
 			candidate,
 			generation,
+			pinRow,
 			result: nodeRef
 				? await postJson<ComposeResponse>("/api/drill/node", {
 						...nodeRef,
@@ -164,12 +332,14 @@ export function DrillableGrid({
 						steps: candidate,
 					}),
 		}),
-		onSuccess: ({ candidate, generation, result }) => {
+		onSuccess: ({ candidate, generation, pinRow, result }) => {
 			if (generation !== generationRef.current) return; // superseded — drop
 			if (result.ok) {
 				setSteps(candidate);
 				setComposed({ sql: result.sql, params: result.params });
 				setRefusal(null);
+				onStepsChange?.(candidate);
+				onPinnedRow?.(pinRow ?? null);
 			} else {
 				setRefusal(result.reason);
 			}
@@ -180,7 +350,10 @@ export function DrillableGrid({
 		},
 	});
 
-	const apply = (candidate: DrillStep[]) => {
+	const apply = (
+		candidate: DrillStep[],
+		pinRow?: Record<string, Json | null>,
+	) => {
 		const generation = ++generationRef.current;
 		if (candidate.length === 0) {
 			// Clearing is synchronous — the bump above also invalidates any
@@ -188,9 +361,11 @@ export function DrillableGrid({
 			setSteps([]);
 			setComposed(null);
 			setRefusal(null);
+			onStepsChange?.([]);
+			onPinnedRow?.(null);
 			return;
 		}
-		compose.mutate({ candidate, generation });
+		compose.mutate({ candidate, generation, pinRow });
 	};
 
 	const effective =
@@ -204,8 +379,9 @@ export function DrillableGrid({
 	const slicedColumns = new Set(activeSlices.map((s) => s.column));
 
 	// Pin the clicked grouped row: one pin per active slice dimension, from the
-	// row's cell values. Only offered while sliced (a detail row has no group
-	// identity to pin).
+	// row's cell values — each pin FREEZES its slice's current grain (pin ≡ the
+	// bucket row that was clicked). Only offered while sliced (a detail row has
+	// no group identity to pin).
 	const onRowClick =
 		activeSlices.length > 0
 			? (row: Record<string, unknown>) => {
@@ -218,12 +394,45 @@ export function DrillableGrid({
 								p.kind === "pin" && p.column === s.column && p.value === value,
 						);
 						if (!duplicate) {
-							pins.push({ kind: "pin", column: s.column, value });
+							pins.push(
+								s.kind === "slice" && s.grain !== undefined
+									? { kind: "pin", column: s.column, value, grain: s.grain }
+									: { kind: "pin", column: s.column, value },
+							);
 						}
 					}
-					if (pins.length > 0) apply([...steps, ...pins]);
+					if (pins.length > 0) {
+						apply([...steps, ...pins], row as Record<string, Json | null>);
+					}
 				}
 			: undefined;
+
+	/** Slice a fresh axis — temporal axes start at the default grain. */
+	const slice = (axis: DrillAxis) => {
+		apply([
+			...steps,
+			axis.temporal !== null
+				? {
+						kind: "slice",
+						column: axis.column,
+						grain: DEFAULT_TEMPORAL_GRAIN,
+					}
+				: { kind: "slice", column: axis.column },
+		]);
+	};
+
+	/** Re-grain an active temporal slice in place (pins keep their own). */
+	const regrain = (column: string, grain: string | undefined) => {
+		apply(
+			steps.map((s) =>
+				s.kind === "slice" && s.column === column
+					? grain === undefined
+						? { kind: "slice" as const, column: s.column }
+						: { kind: "slice" as const, column: s.column, grain }
+					: s,
+			),
+		);
+	};
 
 	return (
 		<div data-testid="drillable-grid">
@@ -246,11 +455,13 @@ export function DrillableGrid({
 							<Menu.Item
 								key={axis.column}
 								disabled={slicedColumns.has(axis.column)}
-								onClick={() =>
-									apply([...steps, { kind: "slice", column: axis.column }])
-								}
+								onClick={() => slice(axis)}
 								rightSection={
-									axis.valueCount !== null ? (
+									axis.temporal !== null ? (
+										<Text size="xs" c="dimmed">
+											{grainName(DEFAULT_TEMPORAL_GRAIN)}
+										</Text>
+									) : axis.valueCount !== null ? (
 										<Text size="xs" c="dimmed">
 											{axis.valueCount}
 										</Text>
@@ -284,24 +495,44 @@ export function DrillableGrid({
 						</Badge>
 					</Tooltip>
 				)}
-				{steps.map((step, i) => (
-					<Pill
-						// Value-identity key: slices are unique per column (menu disables
-						// re-slicing) and pins per column+value (row-click dedupes).
-						key={
-							step.kind === "slice"
-								? `slice:${step.column}`
-								: `pin:${step.column}:${pinLabel(step.value)}`
-						}
-						withRemoveButton
-						onRemove={() => apply(steps.filter((_, j) => j !== i))}
-						data-testid={`drill-step-${step.kind}-${step.column}`}
-					>
-						{step.kind === "slice"
-							? `by ${step.column}`
-							: `${step.column} = ${pinLabel(step.value)}`}
-					</Pill>
-				))}
+				{steps.map((step, i) => {
+					const axis =
+						step.kind === "slice" ? axisByColumn.get(step.column) : undefined;
+					if (step.kind === "slice" && axis && axis.temporal !== null) {
+						// A temporal slice's chip IS the grain control.
+						return (
+							<GrainMenu
+								key={`slice:${step.column}`}
+								axis={axis}
+								grain={step.grain}
+								onGrain={(token) => regrain(step.column, token)}
+								onRemove={() => apply(steps.filter((_, j) => j !== i))}
+							/>
+						);
+					}
+					return (
+						<Pill
+							// Value-identity key: slices are unique per column (menu disables
+							// re-slicing) and pins per column+value (row-click dedupes).
+							key={
+								step.kind === "slice"
+									? `slice:${step.column}`
+									: `pin:${step.column}:${pinLabel(step.value)}`
+							}
+							withRemoveButton
+							onRemove={() => apply(steps.filter((_, j) => j !== i))}
+							data-testid={`drill-step-${step.kind}-${step.column}`}
+						>
+							{step.kind === "slice"
+								? `by ${step.column}`
+								: `${step.column} = ${pinLabel(step.value)}${
+										step.grain !== undefined
+											? ` · ${grainName(step.grain)}`
+											: ""
+									}`}
+						</Pill>
+					);
+				})}
 				{steps.length > 0 && (
 					<Button
 						variant="subtle"
@@ -335,6 +566,13 @@ export function DrillableGrid({
 				sql={effective.sql}
 				sqlParams={effective.params}
 				onRowClick={onRowClick}
+				onRowHover={onRowHover}
+				// The total row anchors a DRILLED view; the undrilled grid IS the
+				// scalar, so a footer there would duplicate the single row.
+				footerRow={steps.length > 0 ? footerCells : undefined}
+				footerLabel={footerLabel}
+				columnAccents={columnAccents}
+				columnUnits={columnUnits}
 				toolbarActions={
 					<DrillChartAction
 						key={effectiveKey}

--- a/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.tsx
@@ -49,7 +49,7 @@ import {
 } from "@mantine/core";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { Check, ChevronDown, Layers, X } from "lucide-react";
-import { type ReactNode, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type { ChartConfig } from "#/charts/chart-config";
 import type {
 	DrillAxesRequest,
@@ -257,7 +257,6 @@ export function DrillableGrid({
 	onRowHover,
 	onPinnedRow,
 	onStepsChange,
-	toolbarEnd,
 }: {
 	/** The base query (the node's composed SQL on the canvas path). */
 	sql: string;
@@ -283,9 +282,6 @@ export function DrillableGrid({
 	onPinnedRow?: (row: Record<string, Json | null> | null) => void;
 	/** Fired with the committed step stack after every accepted apply. */
 	onStepsChange?: (steps: DrillStep[]) => void;
-	/** Rendered right-aligned on the drill-controls row — the layer above
-	 *  mounts its equation here (DAT-712 iteration 2: the busy corner). */
-	toolbarEnd?: ReactNode;
 }) {
 	const baseParams = useMemo<SqlParams>(() => params ?? [], [params]);
 	// The committed stack + its server-composed statement move TOGETHER: steps
@@ -472,132 +468,125 @@ export function DrillableGrid({
 		);
 	};
 
+	// The drill controls live in the GRID's toolbar-left slot (where the row
+	// count used to sit — iteration 3), not on their own row above it.
+	const drillControls = (
+		<>
+			<Menu shadow="md" width={280} position="bottom-start">
+				<Menu.Target>
+					<Button
+						variant="light"
+						size="compact-xs"
+						leftSection={<Layers size={13} />}
+						loading={compose.isPending}
+						disabled={axesQuery.isPending || axes.length === 0}
+						data-testid="drill-slice-button"
+					>
+						Slice
+					</Button>
+				</Menu.Target>
+				<Menu.Dropdown>
+					{axes.map((axis) => (
+						<Menu.Item
+							key={axis.column}
+							disabled={slicedColumns.has(axis.column)}
+							onClick={() => slice(axis)}
+							rightSection={
+								grainable && axis.temporal !== null ? (
+									<Text size="xs" c="dimmed">
+										{grainName(DEFAULT_TEMPORAL_GRAIN)}
+									</Text>
+								) : axis.valueCount !== null ? (
+									<Text size="xs" c="dimmed">
+										{axis.valueCount}
+									</Text>
+								) : undefined
+							}
+						>
+							<Text size="sm">{axis.column}</Text>
+							{axis.businessContext && (
+								<Text size="xs" c="dimmed" lineClamp={1}>
+									{axis.businessContext}
+								</Text>
+							)}
+						</Menu.Item>
+					))}
+				</Menu.Dropdown>
+			</Menu>
+			{axes.length === 0 && !axesQuery.isPending && (
+				// The resolver names WHY it came back empty (stale snippet, bare
+				// catalog, no extracts) — a dead-end badge with no reason reads
+				// as a bug (2026-07-06 review).
+				<Tooltip
+					label={
+						axesQuery.data?.reason ??
+						"No cataloged dimensions for this metric's facts"
+					}
+					maw={360}
+					multiline
+				>
+					<Badge color="gray" variant="light" size="sm">
+						no axes
+					</Badge>
+				</Tooltip>
+			)}
+			{steps.map((step, i) => {
+				const axis =
+					step.kind === "slice" ? axisByColumn.get(step.column) : undefined;
+				if (
+					grainable &&
+					step.kind === "slice" &&
+					axis &&
+					axis.temporal !== null
+				) {
+					// A temporal slice's chip IS the grain control.
+					return (
+						<GrainMenu
+							key={`slice:${step.column}`}
+							axis={axis}
+							grain={step.grain}
+							onGrain={(token) => regrain(step.column, token)}
+							onRemove={() => apply(steps.filter((_, j) => j !== i))}
+						/>
+					);
+				}
+				return (
+					<Pill
+						// Value-identity key: slices are unique per column (menu disables
+						// re-slicing) and pins per column+value (row-click dedupes).
+						key={
+							step.kind === "slice"
+								? `slice:${step.column}`
+								: `pin:${step.column}:${pinLabel(step.value)}`
+						}
+						withRemoveButton
+						onRemove={() => apply(steps.filter((_, j) => j !== i))}
+						data-testid={`drill-step-${step.kind}-${step.column}`}
+					>
+						{step.kind === "slice"
+							? `by ${step.column}`
+							: `${step.column} = ${pinLabel(step.value)}${
+									step.grain !== undefined ? ` · ${grainName(step.grain)}` : ""
+								}`}
+					</Pill>
+				);
+			})}
+			{steps.length > 0 && (
+				<Button
+					variant="subtle"
+					color="gray"
+					size="compact-xs"
+					onClick={() => apply([])}
+					data-testid="drill-clear"
+				>
+					Clear
+				</Button>
+			)}
+		</>
+	);
+
 	return (
 		<div data-testid="drillable-grid">
-			<Group
-				gap="xs"
-				mb="xs"
-				wrap="wrap"
-				justify={toolbarEnd ? "space-between" : undefined}
-				align="flex-start"
-			>
-				<Group gap="xs" wrap="wrap">
-					<Menu shadow="md" width={280} position="bottom-start">
-						<Menu.Target>
-							<Button
-								variant="light"
-								size="compact-xs"
-								leftSection={<Layers size={13} />}
-								loading={compose.isPending}
-								disabled={axesQuery.isPending || axes.length === 0}
-								data-testid="drill-slice-button"
-							>
-								Slice
-							</Button>
-						</Menu.Target>
-						<Menu.Dropdown>
-							{axes.map((axis) => (
-								<Menu.Item
-									key={axis.column}
-									disabled={slicedColumns.has(axis.column)}
-									onClick={() => slice(axis)}
-									rightSection={
-										grainable && axis.temporal !== null ? (
-											<Text size="xs" c="dimmed">
-												{grainName(DEFAULT_TEMPORAL_GRAIN)}
-											</Text>
-										) : axis.valueCount !== null ? (
-											<Text size="xs" c="dimmed">
-												{axis.valueCount}
-											</Text>
-										) : undefined
-									}
-								>
-									<Text size="sm">{axis.column}</Text>
-									{axis.businessContext && (
-										<Text size="xs" c="dimmed" lineClamp={1}>
-											{axis.businessContext}
-										</Text>
-									)}
-								</Menu.Item>
-							))}
-						</Menu.Dropdown>
-					</Menu>
-					{axes.length === 0 && !axesQuery.isPending && (
-						// The resolver names WHY it came back empty (stale snippet, bare
-						// catalog, no extracts) — a dead-end badge with no reason reads
-						// as a bug (2026-07-06 review).
-						<Tooltip
-							label={
-								axesQuery.data?.reason ??
-								"No cataloged dimensions for this metric's facts"
-							}
-							maw={360}
-							multiline
-						>
-							<Badge color="gray" variant="light" size="sm">
-								no axes
-							</Badge>
-						</Tooltip>
-					)}
-					{steps.map((step, i) => {
-						const axis =
-							step.kind === "slice" ? axisByColumn.get(step.column) : undefined;
-						if (
-							grainable &&
-							step.kind === "slice" &&
-							axis &&
-							axis.temporal !== null
-						) {
-							// A temporal slice's chip IS the grain control.
-							return (
-								<GrainMenu
-									key={`slice:${step.column}`}
-									axis={axis}
-									grain={step.grain}
-									onGrain={(token) => regrain(step.column, token)}
-									onRemove={() => apply(steps.filter((_, j) => j !== i))}
-								/>
-							);
-						}
-						return (
-							<Pill
-								// Value-identity key: slices are unique per column (menu disables
-								// re-slicing) and pins per column+value (row-click dedupes).
-								key={
-									step.kind === "slice"
-										? `slice:${step.column}`
-										: `pin:${step.column}:${pinLabel(step.value)}`
-								}
-								withRemoveButton
-								onRemove={() => apply(steps.filter((_, j) => j !== i))}
-								data-testid={`drill-step-${step.kind}-${step.column}`}
-							>
-								{step.kind === "slice"
-									? `by ${step.column}`
-									: `${step.column} = ${pinLabel(step.value)}${
-											step.grain !== undefined
-												? ` · ${grainName(step.grain)}`
-												: ""
-										}`}
-							</Pill>
-						);
-					})}
-					{steps.length > 0 && (
-						<Button
-							variant="subtle"
-							color="gray"
-							size="compact-xs"
-							onClick={() => apply([])}
-							data-testid="drill-clear"
-						>
-							Clear
-						</Button>
-					)}
-				</Group>
-				{toolbarEnd}
-			</Group>
-
 			{refusal && (
 				<Alert
 					color="yellow"
@@ -625,6 +614,7 @@ export function DrillableGrid({
 				footerLabel={footerLabel}
 				columnAccents={columnAccents}
 				columnUnits={columnUnits}
+				toolbarStart={drillControls}
 				toolbarActions={
 					<DrillChartAction
 						key={effectiveKey}

--- a/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.tsx
@@ -339,7 +339,15 @@ export function DrillableGrid({
 				setComposed({ sql: result.sql, params: result.params });
 				setRefusal(null);
 				onStepsChange?.(candidate);
-				onPinnedRow?.(pinRow ?? null);
+				// The lock follows the PINS, not the apply: a row-click pin sets
+				// it, losing the last pin clears it, and a slice-only change
+				// (re-grain, extra slice) leaves an existing lock standing — the
+				// pin's restriction, and therefore its values, didn't move.
+				if (pinRow !== undefined) {
+					onPinnedRow?.(pinRow);
+				} else if (!candidate.some((s) => s.kind === "pin")) {
+					onPinnedRow?.(null);
+				}
 			} else {
 				setRefusal(result.reason);
 			}

--- a/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/drillable-grid.tsx
@@ -257,6 +257,7 @@ export function DrillableGrid({
 	onRowHover,
 	onPinnedRow,
 	onStepsChange,
+	fillHeight,
 }: {
 	/** The base query (the node's composed SQL on the canvas path). */
 	sql: string;
@@ -282,6 +283,9 @@ export function DrillableGrid({
 	onPinnedRow?: (row: Record<string, Json | null> | null) => void;
 	/** Fired with the committed step stack after every accepted apply. */
 	onStepsChange?: (steps: DrillStep[]) => void;
+	/** Fill the parent's height (flex column) instead of the grid's default
+	 *  480px body cap — see ResultGridView (DAT-712). */
+	fillHeight?: boolean;
 }) {
 	const baseParams = useMemo<SqlParams>(() => params ?? [], [params]);
 	// The committed stack + its server-composed statement move TOGETHER: steps
@@ -586,7 +590,19 @@ export function DrillableGrid({
 	);
 
 	return (
-		<div data-testid="drillable-grid">
+		<div
+			data-testid="drillable-grid"
+			style={
+				fillHeight
+					? {
+							display: "flex",
+							flexDirection: "column",
+							flex: 1,
+							minHeight: 0,
+						}
+					: undefined
+			}
+		>
 			{refusal && (
 				<Alert
 					color="yellow"
@@ -615,6 +631,7 @@ export function DrillableGrid({
 				columnAccents={columnAccents}
 				columnUnits={columnUnits}
 				toolbarStart={drillControls}
+				fillHeight={fillHeight}
 				toolbarActions={
 					<DrillChartAction
 						key={effectiveKey}

--- a/packages/cockpit/src/ui/cockpit/widgets/equation-header.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/equation-header.test.tsx
@@ -136,10 +136,11 @@ function renderHeader(props: Partial<Parameters<typeof EquationHeader>[0]>) {
 afterEach(cleanup);
 
 describe("EquationHeader", () => {
-	it("binds to the totals on open — terms, result, unit, scope", () => {
+	it("binds to the totals on open — terms, result, unit symbol", () => {
 		renderHeader({});
 		expect(screen.getByTestId("equation-result").textContent).toBe("75");
-		expect(screen.getByTestId("equation-scope").textContent).toBe("all data");
+		// Unit renders as its symbol next to the result ("75 %", not a word).
+		expect(screen.getByTestId("equation-body").textContent).toContain("%");
 		// revenue appears TWICE (numerator + divisor) — both bind.
 		for (const revenue of screen.getAllByTestId("equation-term-Revenue")) {
 			expect(revenue.textContent).toContain("800");
@@ -171,7 +172,6 @@ describe("EquationHeader", () => {
 			lockedRow: { revenue: 50, cost_of_goods_sold: 10, value: 80 },
 		});
 		expect(screen.getByTestId("equation-result").textContent).toBe("80");
-		expect(screen.getByText("pinned")).toBeDefined();
 	});
 
 	it("an observed-NULL operand is the honest gap: dash + the sentence", () => {

--- a/packages/cockpit/src/ui/cockpit/widgets/equation-header.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/equation-header.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+//
+// The live equation header (DAT-712): the role/sign walk that assigns the
+// ledger ink, the accent map the grid shares, and the header's binding logic
+// — totals on open, hover rebind, pin lock, the missing-operand sentence,
+// and the many-operand elision.
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseFormulaExpression } from "#/duckdb/metric-formula";
+import { theme } from "#/ui/theme";
+
+import {
+	EquationHeader,
+	type NodeShapeWire,
+	operandAccents,
+	operandRoles,
+} from "./equation-header";
+
+const rolesOf = (expression: string) => {
+	const parsed = parseFormulaExpression(expression);
+	if ("refusal" in parsed) throw new Error("unparseable test expression");
+	return operandRoles(parsed.expr);
+};
+
+describe("operandRoles", () => {
+	it("assigns added/subtracted/divisor from the tree walk", () => {
+		const roles = rolesOf("(revenue - cost_of_goods_sold) / revenue * 100");
+		// First occurrence wins: revenue enters as an added numerator term
+		// before it reappears as the divisor.
+		expect(roles.get("revenue")).toBe("added");
+		expect(roles.get("cost_of_goods_sold")).toBe("subtracted");
+	});
+
+	it("marks a pure divisor", () => {
+		const roles = rolesOf("current_assets / current_liabilities");
+		expect(roles.get("current_assets")).toBe("added");
+		expect(roles.get("current_liabilities")).toBe("divisor");
+	});
+
+	it("flips signs through negation and subtraction — a − (b − c)", () => {
+		const roles = rolesOf("a - (b - c)");
+		expect(roles.get("a")).toBe("added");
+		expect(roles.get("b")).toBe("subtracted");
+		expect(roles.get("c")).toBe("added"); // double flip
+	});
+
+	it("unary minus flips", () => {
+		expect(rolesOf("-a + b").get("a")).toBe("subtracted");
+		expect(rolesOf("-(a - b)").get("b")).toBe("added");
+	});
+
+	it("multiplication keeps the additive sign", () => {
+		const roles = rolesOf("a * b - c * d");
+		expect(roles.get("a")).toBe("added");
+		expect(roles.get("b")).toBe("added");
+		expect(roles.get("c")).toBe("subtracted");
+		expect(roles.get("d")).toBe("subtracted");
+	});
+});
+
+describe("operandAccents", () => {
+	it("maps every operand to a color, keyed by the COLUMN name the grid uses", () => {
+		const accents = operandAccents(
+			shape("(revenue - cost_of_goods_sold) / revenue * 100"),
+		);
+		expect(Object.keys(accents).sort()).toEqual([
+			"cost_of_goods_sold",
+			"revenue",
+		]);
+		expect(accents.revenue).toContain("teal");
+		expect(accents.cost_of_goods_sold).toContain("red");
+	});
+
+	it("is empty for a bare extract (no expression)", () => {
+		expect(operandAccents({ ...shape("a + b"), expression: null })).toEqual({});
+	});
+});
+
+function shape(
+	expression: string,
+	overrides: Partial<NodeShapeWire> = {},
+): NodeShapeWire {
+	const parsed = parseFormulaExpression(expression);
+	const refs =
+		"refusal" in parsed
+			? []
+			: [
+					...new Set(
+						(function walk(e): string[] {
+							switch (e.kind) {
+								case "ref":
+									return [e.name];
+								case "num":
+									return [];
+								case "neg":
+									return walk(e.operand);
+								case "bin":
+									return [...walk(e.left), ...walk(e.right)];
+							}
+						})(parsed.expr),
+					),
+				];
+	return {
+		name: "gross_margin",
+		unit: "percentage",
+		targetStepId: "gross_margin",
+		expression,
+		additive: false,
+		operands: refs.map((stepId) => ({
+			stepId,
+			kind: "extract" as const,
+			value: null,
+		})),
+		...overrides,
+	};
+}
+
+function renderHeader(props: Partial<Parameters<typeof EquationHeader>[0]>) {
+	return render(
+		<MantineProvider theme={theme} env="test">
+			<EquationHeader
+				shape={shape("(revenue - cost_of_goods_sold) / revenue * 100")}
+				totals={{ revenue: 800, cost_of_goods_sold: 200, value: 75 }}
+				hoverRow={null}
+				lockedRow={null}
+				scope="all data"
+				{...props}
+			/>
+		</MantineProvider>,
+	);
+}
+
+afterEach(cleanup);
+
+describe("EquationHeader", () => {
+	it("binds to the totals on open — terms, result, unit, scope", () => {
+		renderHeader({});
+		expect(screen.getByTestId("equation-result").textContent).toBe("75");
+		expect(screen.getByTestId("equation-scope").textContent).toBe("all data");
+		// revenue appears TWICE (numerator + divisor) — both bind.
+		for (const revenue of screen.getAllByTestId("equation-term-Revenue")) {
+			expect(revenue.textContent).toContain("800");
+		}
+		expect(
+			screen.getByTestId("equation-term-Cost Of Goods Sold").textContent,
+		).toContain("200");
+		expect(screen.queryByTestId("equation-missing")).toBeNull();
+	});
+
+	it("rebinds to the hover row; a term the row doesn't carry keeps its total", () => {
+		renderHeader({
+			hoverRow: { revenue: 100, cost_of_goods_sold: 40, value: 60 },
+		});
+		expect(screen.getByTestId("equation-result").textContent).toBe("60");
+		expect(
+			screen.getAllByTestId("equation-term-Revenue")[0]?.textContent,
+		).toContain("100");
+	});
+
+	it("hover previews OVER a lock; without hover the lock binds", () => {
+		renderHeader({
+			hoverRow: { revenue: 100, cost_of_goods_sold: 40, value: 60 },
+			lockedRow: { revenue: 50, cost_of_goods_sold: 10, value: 80 },
+		});
+		expect(screen.getByTestId("equation-result").textContent).toBe("60");
+		cleanup();
+		renderHeader({
+			lockedRow: { revenue: 50, cost_of_goods_sold: 10, value: 80 },
+		});
+		expect(screen.getByTestId("equation-result").textContent).toBe("80");
+		expect(screen.getByText("pinned")).toBeDefined();
+	});
+
+	it("an observed-NULL operand is the honest gap: dash + the sentence", () => {
+		renderHeader({
+			hoverRow: { revenue: null, cost_of_goods_sold: 40, value: null },
+		});
+		expect(screen.getByTestId("equation-result").textContent).toBe("—");
+		expect(screen.getByTestId("equation-missing").textContent).toBe(
+			"No Revenue booked in all data — Gross Margin needs every input.",
+		);
+	});
+
+	it("a constant operand renders its declared value inline", () => {
+		renderHeader({
+			shape: shape("(accounts_receivable / revenue) * days_in_period", {
+				name: "dso",
+				unit: "days",
+				targetStepId: "dso",
+				operands: [
+					{ stepId: "accounts_receivable", kind: "extract", value: null },
+					{ stepId: "revenue", kind: "extract", value: null },
+					{ stepId: "days_in_period", kind: "constant", value: "30" },
+				],
+			}),
+			totals: { accounts_receivable: 180, revenue: 800, value: 6.75 },
+		});
+		expect(
+			screen.getByTestId("equation-term-Days In Period").textContent,
+		).toContain("30");
+	});
+
+	it("elides past the threshold: chips instead of nested structure", () => {
+		renderHeader({
+			shape: shape("a + b + c + d + e", { name: "many" }),
+			totals: { a: 1, b: 2, c: 3, d: 4, e: 5, value: 15 },
+		});
+		expect(screen.getByTestId("equation-body").textContent).toContain("ƒ(");
+		// Every operand is still present as a chip.
+		for (const id of ["A", "B", "C", "D", "E"]) {
+			expect(screen.getByTestId(`equation-term-${id}`)).toBeDefined();
+		}
+	});
+
+	it("renders nothing without an expression (bare measures)", () => {
+		const { container } = renderHeader({
+			shape: shape("a + b", { expression: null }),
+		});
+		expect(container.querySelector("[data-testid=equation-header]")).toBeNull();
+	});
+});

--- a/packages/cockpit/src/ui/cockpit/widgets/equation-header.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/equation-header.test.tsx
@@ -215,6 +215,19 @@ describe("EquationHeader", () => {
 		}
 	});
 
+	it("passes exact big-integer strings through instead of rounding via double", () => {
+		renderHeader({
+			totals: {
+				revenue: "12345678901234567893",
+				cost_of_goods_sold: 200,
+				value: 75,
+			},
+		});
+		expect(
+			screen.getAllByTestId("equation-term-Revenue")[0]?.textContent,
+		).toContain("12345678901234567893");
+	});
+
 	it("renders nothing without an expression (bare measures)", () => {
 		const { container } = renderHeader({
 			shape: shape("a + b", { expression: null }),

--- a/packages/cockpit/src/ui/cockpit/widgets/equation-header.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/equation-header.test.tsx
@@ -174,14 +174,18 @@ describe("EquationHeader", () => {
 		expect(screen.getByTestId("equation-result").textContent).toBe("80");
 	});
 
-	it("an observed-NULL operand is the honest gap: dash + the sentence", () => {
+	it("an observed-NULL operand is the honest gap: dash + tooltip, NEVER a second line", () => {
 		renderHeader({
 			hoverRow: { revenue: null, cost_of_goods_sold: 40, value: null },
 		});
 		expect(screen.getByTestId("equation-result").textContent).toBe("—");
-		expect(screen.getByTestId("equation-missing").textContent).toBe(
-			"No Revenue booked in all data — Gross Margin needs every input.",
-		);
+		// The sentence rides the gapped term (and the result) as a tooltip —
+		// a second line would change the title row's height and jitter the
+		// modal while hover-rebinding (iteration 4).
+		expect(
+			screen.getAllByTestId("equation-term-Revenue")[0]?.getAttribute("title"),
+		).toBe("No Revenue booked in all data — Gross Margin needs every input.");
+		expect(screen.queryByTestId("equation-missing")).toBeNull();
 	});
 
 	it("a constant operand renders its declared value inline", () => {

--- a/packages/cockpit/src/ui/cockpit/widgets/equation-header.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/equation-header.tsx
@@ -17,7 +17,7 @@
 // project no operand columns) keeps its total, dimmed. An operand observed
 // as NULL is the honest gap — rendered as `—` plus one sentence naming it.
 
-import { Badge, Group, Text } from "@mantine/core";
+import { Group, Text } from "@mantine/core";
 import { useReducedMotion } from "@mantine/hooks";
 import type { ReactNode } from "react";
 
@@ -97,6 +97,12 @@ export function operandAccents(shape: NodeShapeWire): Record<string, string> {
 		accents[name] = ROLE_COLOR[role];
 	}
 	return accents;
+}
+
+/** Engine unit strings → display symbols. Only symbols users actually read as
+ *  symbols get one; everything else shows its own word. */
+export function unitSymbol(unit: string): string {
+	return unit === "percentage" ? "%" : unit;
 }
 
 /** `cost_of_goods_sold` → `Cost Of Goods Sold`. */
@@ -324,26 +330,11 @@ export function EquationHeader({
 
 	const elided = roles.size > ELISION_THRESHOLD;
 
+	// The equation IS the whole header now — identity (name, kind, unit,
+	// scope) lives in the modal's title row (DAT-712 iteration 2: the
+	// upper-left corner was carrying the metric name twice).
 	return (
-		<div data-testid="equation-header" style={{ marginBottom: 8 }}>
-			<Group gap="xs" mb={2}>
-				<Text size="sm" fw={700}>
-					{metricLabel}
-				</Text>
-				{shape.unit && (
-					<Badge size="xs" variant="light" color="gray">
-						{shape.unit}
-					</Badge>
-				)}
-				<Text size="xs" c="dimmed" data-testid="equation-scope">
-					{scope}
-				</Text>
-				{lockedRow !== null && (
-					<Badge size="xs" variant="light" color="blue">
-						pinned
-					</Badge>
-				)}
-			</Group>
+		<div data-testid="equation-header">
 			<Group gap={4} wrap="wrap" align="center" data-testid="equation-body">
 				{elided ? (
 					// Many-operand formulas elide to named chips — nesting stops
@@ -367,8 +358,9 @@ export function EquationHeader({
 					{resultText ?? "—"}
 				</Text>
 				{shape.unit && resultText !== null && (
-					<Text component="span" size="sm" c="dimmed">
-						{shape.unit}
+					// Same size as the number — "49.91 %", not a fine-print word.
+					<Text component="span" size="lg" c="dimmed">
+						{unitSymbol(shape.unit)}
 					</Text>
 				)}
 			</Group>

--- a/packages/cockpit/src/ui/cockpit/widgets/equation-header.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/equation-header.tsx
@@ -1,0 +1,367 @@
+// The live equation header (DAT-712): the metric's own formula as the analyse
+// surface's header — labeled operand terms with values, pretty-printed from
+// the parsed DAG expression via the SAME closed grammar the composer trusts
+// (metric-formula.ts, client-safe).
+//
+// This is the PARTS-CONTEXT layer above the generic DrillableGrid (the lead's
+// layering constraint): it keys on "the result carries a structured formula
+// shape", never on "this is a canvas metric node" — answer-agent results join
+// by shipping the same shape. The grid stays generic; this layer OWNS the
+// operand hue assignment and hands the identical map to the grid's
+// `columnAccents`, so equation terms and component columns can never disagree.
+//
+// Binding: the equation binds to the unrestricted TOTALS on open, REBINDS to
+// a row on hover/focus, and LOCKS to the pinned row on pin (hover still
+// previews other rows; releasing the pointer falls back to the lock). A term
+// whose column the bound row doesn't carry (additive nodes' grouped rows
+// project no operand columns) keeps its total, dimmed. An operand observed
+// as NULL is the honest gap — rendered as `—` plus one sentence naming it.
+
+import { Badge, Group, Text } from "@mantine/core";
+import { useReducedMotion } from "@mantine/hooks";
+import type { ReactNode } from "react";
+
+import {
+	type FormulaExpr,
+	parseFormulaExpression,
+} from "#/duckdb/metric-formula";
+
+/** The `/api/drill/node` open call's `node` block — the target's formula
+ *  shape (parts.ts `NodeShape` + display metadata), narrowed at the fetch
+ *  boundary by the caller. */
+export interface NodeShapeWire {
+	name: string | null;
+	unit: string | null;
+	targetStepId: string;
+	expression: string | null;
+	additive: boolean;
+	operands: {
+		stepId: string;
+		kind: "extract" | "formula" | "constant";
+		value: string | null;
+	}[];
+}
+
+/** An operand's role in the formula — what the ledger ink encodes: added
+ *  terms credit-green, subtracted terms debit-red, divisors (neither side of
+ *  the ledger) indigo. First occurrence wins, matching the additive
+ *  flattening's sign algebra. */
+export type OperandRole = "added" | "subtracted" | "divisor";
+
+export function operandRoles(expr: FormulaExpr): Map<string, OperandRole> {
+	const roles = new Map<string, OperandRole>();
+	const visit = (e: FormulaExpr, sign: 1 | -1, divisor: boolean): void => {
+		switch (e.kind) {
+			case "num":
+				return;
+			case "ref":
+				if (!roles.has(e.name)) {
+					roles.set(
+						e.name,
+						divisor ? "divisor" : sign === 1 ? "added" : "subtracted",
+					);
+				}
+				return;
+			case "neg":
+				visit(e.operand, sign === 1 ? -1 : 1, divisor);
+				return;
+			case "bin": {
+				visit(e.left, sign, divisor);
+				const rightSign = e.op === "-" ? (sign === 1 ? -1 : 1) : sign;
+				visit(e.right, rightSign, divisor || e.op === "/");
+			}
+		}
+	};
+	visit(expr, 1, false);
+	return roles;
+}
+
+// Ledger ink, theme-aware via CSS `light-dark()` (Mantine sets color-scheme).
+const ROLE_COLOR: Record<OperandRole, string> = {
+	added: "light-dark(var(--mantine-color-teal-8), var(--mantine-color-teal-4))",
+	subtracted:
+		"light-dark(var(--mantine-color-red-8), var(--mantine-color-red-4))",
+	divisor:
+		"light-dark(var(--mantine-color-indigo-8), var(--mantine-color-indigo-4))",
+};
+
+/** The hue per operand COLUMN — computed once here and passed verbatim to the
+ *  grid's `columnAccents`, the single assignment both surfaces render. */
+export function operandAccents(shape: NodeShapeWire): Record<string, string> {
+	if (!shape.expression) return {};
+	const parsed = parseFormulaExpression(shape.expression);
+	if ("refusal" in parsed) return {};
+	const accents: Record<string, string> = {};
+	for (const [name, role] of operandRoles(parsed.expr)) {
+		accents[name] = ROLE_COLOR[role];
+	}
+	return accents;
+}
+
+/** `cost_of_goods_sold` → `Cost Of Goods Sold`. */
+const labelOf = (stepId: string): string =>
+	stepId
+		.split("_")
+		.filter(Boolean)
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+		.join(" ");
+
+/** Deterministic number rendering (fixed locale — the modal is client-only,
+ *  but hydration-safe formatting is the house rule). */
+const formatNumber = (v: unknown): string | null => {
+	const n = typeof v === "number" ? v : Number(v);
+	if (v === null || v === undefined || v === "" || !Number.isFinite(n)) {
+		return null;
+	}
+	return n.toLocaleString("en-US", { maximumFractionDigits: 2 });
+};
+
+const OP_SYMBOL: Record<"+" | "-" | "*" | "/", string> = {
+	"+": "+",
+	"-": "−",
+	"*": "×",
+	"/": "÷",
+};
+
+/** How many operand terms the nested equation carries before it elides to
+ *  named chips (ebitda_margin-class formulas). */
+const ELISION_THRESHOLD = 4;
+
+function OperandTerm({
+	label,
+	value,
+	color,
+	dimmed,
+	missing,
+	transition,
+}: {
+	label: string;
+	value: string | null;
+	color: string | undefined;
+	/** The bound row doesn't carry this term — its total shows, quieted. */
+	dimmed: boolean;
+	/** Observed-NULL: doctrine v2's honest gap. */
+	missing: boolean;
+	transition: boolean;
+}) {
+	return (
+		<span
+			data-testid={`equation-term-${label}`}
+			style={{
+				display: "inline-flex",
+				flexDirection: "column",
+				alignItems: "center",
+				verticalAlign: "middle",
+				padding: "0 2px",
+				opacity: dimmed ? 0.55 : 1,
+			}}
+		>
+			<Text component="span" size="xs" style={{ color }} fw={600}>
+				{label}
+			</Text>
+			<Text
+				component="span"
+				size="sm"
+				fw={600}
+				style={{
+					fontVariantNumeric: "tabular-nums",
+					...(missing
+						? {
+								borderBottom: "2px dashed var(--mantine-color-default-border)",
+							}
+						: {}),
+					...(transition ? { transition: "opacity 120ms ease" } : {}),
+				}}
+			>
+				{value ?? "—"}
+			</Text>
+		</span>
+	);
+}
+
+export function EquationHeader({
+	shape,
+	totals,
+	hoverRow,
+	lockedRow,
+	scope,
+}: {
+	shape: NodeShapeWire;
+	/** The unrestricted totals row (operand columns + `value`) — the open
+	 *  binding and the fallback for terms a bound row doesn't carry. */
+	totals: Record<string, unknown> | null;
+	/** The grid row under the pointer/focus (rebind), or null. */
+	hoverRow: Record<string, unknown> | null;
+	/** The committed pin's row (lock), or null. */
+	lockedRow: Record<string, unknown> | null;
+	/** The drill scope in words — "all data", "January 2025" — for the
+	 *  missing-operand sentence and the header's scope line. */
+	scope: string;
+}) {
+	const reducedMotion = useReducedMotion();
+	if (!shape.expression) return null;
+	const parsed = parseFormulaExpression(shape.expression);
+	if ("refusal" in parsed) return null;
+
+	const roles = operandRoles(parsed.expr);
+	const metricLabel = labelOf(shape.name ?? shape.targetStepId);
+	const bound = hoverRow ?? lockedRow ?? null;
+	const constantsById = new Map(
+		shape.operands
+			.filter((o) => o.kind === "constant")
+			.map((o) => [o.stepId, o.value]),
+	);
+
+	/** Resolve one operand term's display state against the binding. */
+	const termOf = (stepId: string) => {
+		const constant = constantsById.get(stepId);
+		if (constant !== undefined) {
+			return {
+				value: constant,
+				dimmed: false,
+				missing: false,
+			};
+		}
+		const source =
+			bound && stepId in bound
+				? bound
+				: totals && stepId in totals
+					? totals
+					: null;
+		const raw = source?.[stepId];
+		return {
+			value: formatNumber(raw),
+			// Bound to a row that doesn't decompose this term (additive grids
+			// carry no operand columns) — the total shows, quieted.
+			dimmed: bound !== null && !(stepId in bound),
+			missing: source !== null && (raw === null || raw === undefined),
+		};
+	};
+
+	const resultRaw = bound !== null ? bound.value : totals?.value;
+	const resultText = formatNumber(resultRaw);
+	const missingTerms = [...roles.keys()].filter((id) => termOf(id).missing);
+
+	const term = (stepId: string): ReactNode => {
+		const t = termOf(stepId);
+		return (
+			<OperandTerm
+				key={`${stepId}-${String(t.value)}`}
+				label={labelOf(stepId)}
+				value={t.value}
+				color={
+					roles.get(stepId)
+						? ROLE_COLOR[roles.get(stepId) as OperandRole]
+						: undefined
+				}
+				dimmed={t.dimmed}
+				missing={t.missing}
+				transition={!reducedMotion}
+			/>
+		);
+	};
+
+	// Minimal-parens pretty-print: a child renders parenthesized only when its
+	// operator binds looser than its parent's position requires.
+	const PREC: Record<"+" | "-" | "*" | "/", number> = {
+		"+": 1,
+		"-": 1,
+		"*": 2,
+		"/": 2,
+	};
+	const renderExpr = (e: FormulaExpr, minPrec: number): ReactNode => {
+		switch (e.kind) {
+			case "num":
+				return <span>{String(e.value)}</span>;
+			case "ref":
+				return term(e.name);
+			case "neg":
+				return <span>−{renderExpr(e.operand, 3)}</span>;
+			case "bin": {
+				const prec = PREC[e.op];
+				const inner = (
+					<>
+						{renderExpr(e.left, prec)}
+						<span style={{ padding: "0 6px", opacity: 0.7 }}>
+							{OP_SYMBOL[e.op]}
+						</span>
+						{/* Right operand of − and ÷ must re-parenthesize equal
+						    precedence: a − (b − c) ≠ a − b − c. */}
+						{renderExpr(
+							e.right,
+							e.op === "-" || e.op === "/" ? prec + 1 : prec,
+						)}
+					</>
+				);
+				return prec < minPrec ? (
+					<span>
+						<span style={{ opacity: 0.5 }}>(</span>
+						{inner}
+						<span style={{ opacity: 0.5 }}>)</span>
+					</span>
+				) : (
+					<span>{inner}</span>
+				);
+			}
+		}
+	};
+
+	const elided = roles.size > ELISION_THRESHOLD;
+
+	return (
+		<div data-testid="equation-header" style={{ marginBottom: 8 }}>
+			<Group gap="xs" mb={2}>
+				<Text size="sm" fw={700}>
+					{metricLabel}
+				</Text>
+				{shape.unit && (
+					<Badge size="xs" variant="light" color="gray">
+						{shape.unit}
+					</Badge>
+				)}
+				<Text size="xs" c="dimmed" data-testid="equation-scope">
+					{scope}
+				</Text>
+				{lockedRow !== null && (
+					<Badge size="xs" variant="light" color="blue">
+						pinned
+					</Badge>
+				)}
+			</Group>
+			<Group gap={4} wrap="wrap" align="center" data-testid="equation-body">
+				{elided ? (
+					// Many-operand formulas elide to named chips — nesting stops
+					// reading as an equation past a handful of terms.
+					<>
+						<span style={{ opacity: 0.7 }}>ƒ(</span>
+						{[...roles.keys()].map((id) => term(id))}
+						<span style={{ opacity: 0.7 }}>)</span>
+					</>
+				) : (
+					renderExpr(parsed.expr, 0)
+				)}
+				<span style={{ padding: "0 6px", opacity: 0.7 }}>=</span>
+				<Text
+					component="span"
+					size="lg"
+					fw={700}
+					style={{ fontVariantNumeric: "tabular-nums" }}
+					data-testid="equation-result"
+				>
+					{resultText ?? "—"}
+				</Text>
+				{shape.unit && resultText !== null && (
+					<Text component="span" size="sm" c="dimmed">
+						{shape.unit}
+					</Text>
+				)}
+			</Group>
+			{missingTerms.length > 0 && (
+				<Text size="xs" c="dimmed" mt={2} data-testid="equation-missing">
+					No {labelOf(missingTerms[0] ?? "")} booked in {scope} — {metricLabel}{" "}
+					needs every input.
+				</Text>
+			)}
+		</div>
+	);
+}

--- a/packages/cockpit/src/ui/cockpit/widgets/equation-header.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/equation-header.tsx
@@ -144,6 +144,7 @@ function OperandTerm({
 	dimmed,
 	missing,
 	transition,
+	title,
 }: {
 	label: string;
 	value: string | null;
@@ -153,10 +154,14 @@ function OperandTerm({
 	/** Observed-NULL: doctrine v2's honest gap. */
 	missing: boolean;
 	transition: boolean;
+	/** The gap's explanation, as a tooltip — never a second line (the
+	 *  equation's height is load-bearing in the modal title). */
+	title?: string;
 }) {
 	return (
 		<span
 			data-testid={`equation-term-${label}`}
+			title={title}
 			style={{
 				display: "inline-flex",
 				flexDirection: "column",
@@ -267,6 +272,11 @@ export function EquationHeader({
 				dimmed={t.dimmed}
 				missing={t.missing}
 				transition={!reducedMotion}
+				title={
+					t.missing
+						? `No ${labelOf(stepId)} booked in ${scope} — ${metricLabel} needs every input.`
+						: undefined
+				}
 			/>
 		);
 	};
@@ -332,10 +342,14 @@ export function EquationHeader({
 
 	// The equation IS the whole header now — identity (name, kind, unit,
 	// scope) lives in the modal's title row (DAT-712 iteration 2: the
-	// upper-left corner was carrying the metric name twice).
+	// upper-left corner was carrying the metric name twice). CONSTANT HEIGHT
+	// is load-bearing (iteration 3): the equation sits in the modal title, so
+	// a rebind must never grow its wrapper — hover-while-scrolling would
+	// jitter the whole surface. Hence nowrap, and the missing-operand
+	// explanation rides the gapped term as a tooltip instead of a second line.
 	return (
 		<div data-testid="equation-header">
-			<Group gap={4} wrap="wrap" align="center" data-testid="equation-body">
+			<Group gap={4} wrap="nowrap" align="center" data-testid="equation-body">
 				{elided ? (
 					// Many-operand formulas elide to named chips — nesting stops
 					// reading as an equation past a handful of terms.
@@ -354,6 +368,11 @@ export function EquationHeader({
 					fw={700}
 					style={{ fontVariantNumeric: "tabular-nums" }}
 					data-testid="equation-result"
+					title={
+						missingTerms.length > 0
+							? `No ${labelOf(missingTerms[0] ?? "")} booked in ${scope} — ${metricLabel} needs every input.`
+							: undefined
+					}
 				>
 					{resultText ?? "—"}
 				</Text>
@@ -364,12 +383,6 @@ export function EquationHeader({
 					</Text>
 				)}
 			</Group>
-			{missingTerms.length > 0 && (
-				<Text size="xs" c="dimmed" mt={2} data-testid="equation-missing">
-					No {labelOf(missingTerms[0] ?? "")} booked in {scope} — {metricLabel}{" "}
-					needs every input.
-				</Text>
-			)}
 		</div>
 	);
 }

--- a/packages/cockpit/src/ui/cockpit/widgets/equation-header.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/equation-header.tsx
@@ -44,8 +44,9 @@ export interface NodeShapeWire {
 
 /** An operand's role in the formula — what the ledger ink encodes: added
  *  terms credit-green, subtracted terms debit-red, divisors (neither side of
- *  the ledger) indigo. First occurrence wins, matching the additive
- *  flattening's sign algebra. */
+ *  the ledger) indigo. First occurrence wins — ONE hue per operand is the
+ *  point (unlike `flattenAdditive`, which deliberately counts every
+ *  occurrence because it computes arithmetic, not ink). */
 export type OperandRole = "added" | "subtracted" | "divisor";
 
 export function operandRoles(expr: FormulaExpr): Map<string, OperandRole> {
@@ -107,12 +108,15 @@ const labelOf = (stepId: string): string =>
 		.join(" ");
 
 /** Deterministic number rendering (fixed locale — the modal is client-only,
- *  but hydration-safe formatting is the house rule). */
+ *  but hydration-safe formatting is the house rule). DECIMAL/HUGEINT arrive
+ *  as STRINGS on this path; an integer string past Number's exact range
+ *  passes through untouched — rounding it through a double would show wrong
+ *  digits while the grid's formatCell keeps them exact. */
 const formatNumber = (v: unknown): string | null => {
+	if (v === null || v === undefined || v === "") return null;
+	if (typeof v === "string" && /^-?\d{16,}$/.test(v)) return v;
 	const n = typeof v === "number" ? v : Number(v);
-	if (v === null || v === undefined || v === "" || !Number.isFinite(n)) {
-		return null;
-	}
+	if (!Number.isFinite(n)) return null;
 	return n.toLocaleString("en-US", { maximumFractionDigits: 2 });
 };
 
@@ -275,8 +279,20 @@ export function EquationHeader({
 				return <span>{String(e.value)}</span>;
 			case "ref":
 				return term(e.name);
-			case "neg":
-				return <span>−{renderExpr(e.operand, 3)}</span>;
+			case "neg": {
+				const inner = <span>−{renderExpr(e.operand, 3)}</span>;
+				// Inside anything tighter than a leftmost `+` chain, a bare unary
+				// minus is ambiguous (`a − −b`) — parenthesize it.
+				return minPrec > 1 ? (
+					<span>
+						<span style={{ opacity: 0.5 }}>(</span>
+						{inner}
+						<span style={{ opacity: 0.5 }}>)</span>
+					</span>
+				) : (
+					inner
+				);
+			}
 			case "bin": {
 				const prec = PREC[e.op];
 				const inner = (

--- a/packages/cockpit/src/ui/cockpit/widgets/result-grid.test.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/result-grid.test.tsx
@@ -88,8 +88,10 @@ describe("ResultGridView (DAT-385 P2)", () => {
 		expect(screen.getByTestId("canvas-result-grid-scroll")).toBeTruthy();
 		expect(screen.getByText("id")).toBeTruthy();
 		expect(screen.getByText("name")).toBeTruthy();
+		// The row count IS the done-status pill (DAT-712 iteration 3) — no
+		// separate "done" text, no separate count text.
 		expect(screen.getByText("3 rows")).toBeTruthy();
-		expect(screen.getByText("done")).toBeTruthy();
+		expect(screen.queryByText("done")).toBeNull();
 	});
 
 	it("shows the truncation banner when the store hit the cap", () => {

--- a/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
@@ -137,6 +137,11 @@ export function ResultGridView({
 	sqlParams,
 	toolbarActions,
 	onRowClick,
+	onRowHover,
+	footerRow,
+	footerLabel = "Total",
+	columnAccents,
+	columnUnits,
 }: {
 	store: GridView;
 	fatal?: string | null;
@@ -145,8 +150,24 @@ export function ResultGridView({
 	onReachEnd?: () => void;
 	onFilterCommit?: (column: string, raw: string) => void;
 	/** Row-click action (DAT-672: the drill's row-pin). When set, body rows read
-	 * as clickable and deliver the row as a column→cell object. */
+	 * as clickable and deliver the row as a column→cell object. Rows are also
+	 * keyboard-focusable then — Enter/Space fires the same action (DAT-712 a11y). */
 	onRowClick?: (row: Record<string, Json | null>) => void;
+	/** Row hover/focus tracking (DAT-712: the equation header's rebind). Fired
+	 * with the row object on mouseenter/focus, with null when the pointer leaves
+	 * the body. Purely observational — never changes grid behavior. */
+	onRowHover?: (row: Record<string, Json | null> | null) => void;
+	/** A pinned summary row rendered as a sticky footer under the body (DAT-712's
+	 * total row): cells matched to columns BY NAME and formatted like body cells;
+	 * the first column without a value carries `footerLabel`. */
+	footerRow?: Record<string, Json | null>;
+	footerLabel?: string;
+	/** CSS color per column name, applied to the column's header text and cell
+	 * values (DAT-712's ledger ink — the equation layer owns the assignment; the
+	 * grid only renders it, so equation and columns can never disagree). */
+	columnAccents?: Record<string, string>;
+	/** Unit chip per column name, shown next to the header text (e.g. value → %). */
+	columnUnits?: Record<string, string>;
 	/** How many push-down filters are currently active (drives the funnel toggle's
 	 * active state + count). Owner-tracked; the view only renders the row. */
 	activeFilterCount?: number;
@@ -226,6 +247,13 @@ export function ResultGridView({
 			? totalSize - virtualRows[virtualRows.length - 1].end
 			: 0;
 	const colCount = store.columns.length;
+
+	/** The row at a store index as a column→cell object — what row-level
+	 *  callbacks (click-to-pin, hover-rebind) deliver. */
+	const rowObject = (index: number): Record<string, Json | null> =>
+		Object.fromEntries(
+			store.columns.map((name, c) => [name, store.cell(c, index)]),
+		);
 
 	// Load-on-scroll (DAT-613): when the virtualized body reaches within an
 	// overscan of the last loaded row, ask the owner for the next page. This is a
@@ -372,9 +400,27 @@ export function ResultGridView({
 												wrap="nowrap"
 												justify={alignRight ? "flex-end" : "flex-start"}
 											>
-												{flexRender(
-													header.column.columnDef.header,
-													header.getContext(),
+												<span
+													style={
+														columnAccents?.[name]
+															? { color: columnAccents[name] }
+															: undefined
+													}
+												>
+													{flexRender(
+														header.column.columnDef.header,
+														header.getContext(),
+													)}
+												</span>
+												{columnUnits?.[name] && (
+													<Badge
+														size="xs"
+														variant="light"
+														color="gray"
+														data-testid={`canvas-result-grid-unit-${name}`}
+													>
+														{columnUnits[name]}
+													</Badge>
 												)}
 												{active ? (
 													sort.dir === "asc" ? (
@@ -460,7 +506,9 @@ export function ResultGridView({
 								</Table.Tr>
 							)}
 						</Table.Thead>
-						<Table.Tbody>
+						<Table.Tbody
+							onMouseLeave={onRowHover ? () => onRowHover(null) : undefined}
+						>
 							{/* Spacer rows reserve the off-screen scroll height so only the
 							    visible window carries real <tr> cells. */}
 							{padTop > 0 && (
@@ -483,15 +531,31 @@ export function ResultGridView({
 														// row action — a click that ends a selection is
 														// a copy gesture, not a pin.
 														if (window.getSelection()?.toString()) return;
-														onRowClick(
-															Object.fromEntries(
-																store.columns.map((name, c) => [
-																	name,
-																	store.cell(c, vr.index),
-																]),
-															),
-														);
+														onRowClick(rowObject(vr.index));
 													}
+												: undefined
+										}
+										// Clickable rows are keyboard rows: focus rebinds (same
+										// signal as hover), Enter/Space pins (DAT-712 a11y).
+										tabIndex={onRowClick ? 0 : undefined}
+										onKeyDown={
+											onRowClick
+												? (e) => {
+														if (e.key !== "Enter" && e.key !== " ") return;
+														if (e.target !== e.currentTarget) return;
+														e.preventDefault();
+														onRowClick(rowObject(vr.index));
+													}
+												: undefined
+										}
+										onMouseEnter={
+											onRowHover
+												? () => onRowHover(rowObject(vr.index))
+												: undefined
+										}
+										onFocus={
+											onRowHover
+												? () => onRowHover(rowObject(vr.index))
 												: undefined
 										}
 										style={onRowClick ? { cursor: "pointer" } : undefined}
@@ -499,17 +563,22 @@ export function ResultGridView({
 									>
 										{row.getVisibleCells().map((cell) => {
 											const type = cell.column.columnDef.meta?.duckdbType;
+											const accent =
+												columnAccents?.[
+													String(cell.column.columnDef.header ?? "")
+												];
 											return (
 												<Table.Td
 													key={cell.id}
-													style={
-														cellAlign(type) === "right"
+													style={{
+														...(cellAlign(type) === "right"
 															? {
 																	textAlign: "right",
 																	fontVariantNumeric: "tabular-nums",
 																}
-															: undefined
-													}
+															: {}),
+														...(accent ? { color: accent } : {}),
+													}}
 												>
 													{formatCell(cell.getValue(), type)}
 												</Table.Td>
@@ -527,6 +596,57 @@ export function ResultGridView({
 								</Table.Tr>
 							)}
 						</Table.Tbody>
+						{footerRow && (
+							<Table.Tfoot
+								style={{
+									position: "sticky",
+									bottom: 0,
+									zIndex: 1,
+									backgroundColor: "var(--mantine-color-body)",
+								}}
+								data-testid="canvas-result-grid-footer"
+							>
+								<Table.Tr style={{ fontWeight: 600 }}>
+									{store.columns.map((name, c) => {
+										const typeList = Array.isArray(store.types)
+											? (store.types as Json[])
+											: [];
+										const type = typeList[c];
+										const value = footerRow[name];
+										// The first column without a total carries the label —
+										// under a slice that's the dimension column.
+										const label =
+											value === undefined &&
+											store.columns.findIndex(
+												(n) => footerRow[n] === undefined,
+											) === c;
+										const accent = columnAccents?.[name];
+										return (
+											<Table.Td
+												key={name}
+												style={{
+													borderTop:
+														"2px solid var(--mantine-color-default-border)",
+													...(cellAlign(type) === "right"
+														? {
+																textAlign: "right",
+																fontVariantNumeric: "tabular-nums",
+															}
+														: {}),
+													...(accent ? { color: accent } : {}),
+												}}
+											>
+												{label
+													? footerLabel
+													: value === undefined
+														? ""
+														: formatCell(value, type)}
+											</Table.Td>
+										);
+									})}
+								</Table.Tr>
+							</Table.Tfoot>
+						)}
 					</Table>
 				</div>
 			)}
@@ -608,6 +728,11 @@ export function WindowedGrid({
 	sqlParams,
 	toolbarActions,
 	onRowClick,
+	onRowHover,
+	footerRow,
+	footerLabel,
+	columnAccents,
+	columnUnits,
 }: {
 	endpoint: string;
 	/** The base request body (WITHOUT sort/filters/limit/offset — the grid appends those). */
@@ -619,6 +744,14 @@ export function WindowedGrid({
 	toolbarActions?: ReactNode;
 	/** Forwarded row-click action — see ResultGridView. */
 	onRowClick?: (row: Record<string, Json | null>) => void;
+	/** Forwarded row hover/focus tracking — see ResultGridView (DAT-712). */
+	onRowHover?: (row: Record<string, Json | null> | null) => void;
+	/** Forwarded sticky total row — see ResultGridView (DAT-712). */
+	footerRow?: Record<string, Json | null>;
+	footerLabel?: string;
+	/** Forwarded per-column accents / unit chips — see ResultGridView (DAT-712). */
+	columnAccents?: Record<string, string>;
+	columnUnits?: Record<string, string>;
 }) {
 	const [sort, setSort] = useState<GridSort | null>(null);
 	const [filters, setFilters] = useState<GridFilter[]>([]);
@@ -743,6 +876,11 @@ export function WindowedGrid({
 			sqlParams={sqlParams}
 			toolbarActions={toolbarActions}
 			onRowClick={onRowClick}
+			onRowHover={onRowHover}
+			footerRow={footerRow}
+			footerLabel={footerLabel}
+			columnAccents={columnAccents}
+			columnUnits={columnUnits}
 		/>
 	);
 }

--- a/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
@@ -255,6 +255,12 @@ export function ResultGridView({
 			store.columns.map((name, c) => [name, store.cell(c, index)]),
 		);
 
+	// The footer's label column: the first column the footer row has no value
+	// for (computed once, not per cell).
+	const footerLabelIndex = footerRow
+		? store.columns.findIndex((n) => footerRow[n] === undefined)
+		: -1;
+
 	// Load-on-scroll (DAT-613): when the virtualized body reaches within an
 	// overscan of the last loaded row, ask the owner for the next page. This is a
 	// scroll-driven side effect (a DOM/measurement signal), so it lives in an
@@ -508,6 +514,21 @@ export function ResultGridView({
 						</Table.Thead>
 						<Table.Tbody
 							onMouseLeave={onRowHover ? () => onRowHover(null) : undefined}
+							// The keyboard counterpart of mouseleave: focus moving OUT of
+							// the body releases the binding (a focused row has no leave
+							// event, and virtualization can unmount it silently).
+							onBlur={
+								onRowHover
+									? (e) => {
+											if (
+												!(e.relatedTarget instanceof Node) ||
+												!e.currentTarget.contains(e.relatedTarget)
+											) {
+												onRowHover(null);
+											}
+										}
+									: undefined
+							}
 						>
 							{/* Spacer rows reserve the off-screen scroll height so only the
 							    visible window carries real <tr> cells. */}
@@ -615,11 +636,7 @@ export function ResultGridView({
 										const value = footerRow[name];
 										// The first column without a total carries the label —
 										// under a slice that's the dimension column.
-										const label =
-											value === undefined &&
-											store.columns.findIndex(
-												(n) => footerRow[n] === undefined,
-											) === c;
+										const label = c === footerLabelIndex;
 										const accent = columnAccents?.[name];
 										return (
 											<Table.Td

--- a/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
@@ -35,7 +35,6 @@ import {
 	Indicator,
 	Modal,
 	Table,
-	Text,
 	TextInput,
 } from "@mantine/core";
 import { useInfiniteQuery } from "@tanstack/react-query";
@@ -136,6 +135,7 @@ export function ResultGridView({
 	sql,
 	sqlParams,
 	toolbarActions,
+	toolbarStart,
 	onRowClick,
 	onRowHover,
 	footerRow,
@@ -183,6 +183,10 @@ export function ResultGridView({
 	 * mounts its mint-to-Report button here so it sits with the grid's own actions
 	 * instead of floating above the grid. Omitted for plain run_sql / probe grids. */
 	toolbarActions?: ReactNode;
+	/** Rendered in the toolbar's LEFT slot (where the row count used to sit —
+	 * it lives in the status pill now): the drill surface mounts its slice
+	 * controls here (DAT-712 iteration 3). */
+	toolbarStart?: ReactNode;
 }) {
 	// The filter row is hidden by default (a clean grid) and toggled by the funnel
 	// in the toolbar. An applied-but-hidden filter isn't stranded: the funnel stays
@@ -290,10 +294,13 @@ export function ResultGridView({
 
 	return (
 		<div data-testid="canvas-result-grid">
-			<Group justify="space-between" mb="xs">
-				<Text size="sm" fw={500}>
-					{store.rowCount} row{store.rowCount === 1 ? "" : "s"}
-				</Text>
+			<Group justify="space-between" mb="xs" align="flex-start">
+				{/* The row count lives in the status pill (a finished grid IS its
+				    row count) — the left slot hosts the owner's controls (the
+				    drill's slice chips, DAT-712 iteration 3). */}
+				<Group gap="xs" wrap="wrap" style={{ flex: 1, minWidth: 0 }}>
+					{toolbarStart}
+				</Group>
 				<Group gap="xs">
 					{toolbarActions}
 					{sql && (
@@ -338,7 +345,9 @@ export function ResultGridView({
 						</Indicator>
 					)}
 					<Badge color={STATUS_COLOR[status]} variant="light" size="sm">
-						{status}
+						{status === "done"
+							? `${store.rowCount} row${store.rowCount === 1 ? "" : "s"}`
+							: status}
 					</Badge>
 				</Group>
 			</Group>
@@ -744,6 +753,7 @@ export function WindowedGrid({
 	sql,
 	sqlParams,
 	toolbarActions,
+	toolbarStart,
 	onRowClick,
 	onRowHover,
 	footerRow,
@@ -759,6 +769,8 @@ export function WindowedGrid({
 	sqlParams?: (string | number | boolean | null)[];
 	/** Forwarded to the grid toolbar (left of "View SQL") — see ResultGridView. */
 	toolbarActions?: ReactNode;
+	/** Forwarded toolbar LEFT slot — see ResultGridView (DAT-712). */
+	toolbarStart?: ReactNode;
 	/** Forwarded row-click action — see ResultGridView. */
 	onRowClick?: (row: Record<string, Json | null>) => void;
 	/** Forwarded row hover/focus tracking — see ResultGridView (DAT-712). */
@@ -892,6 +904,7 @@ export function WindowedGrid({
 			sql={sql}
 			sqlParams={sqlParams}
 			toolbarActions={toolbarActions}
+			toolbarStart={toolbarStart}
 			onRowClick={onRowClick}
 			onRowHover={onRowHover}
 			footerRow={footerRow}

--- a/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/result-grid.tsx
@@ -136,6 +136,7 @@ export function ResultGridView({
 	sqlParams,
 	toolbarActions,
 	toolbarStart,
+	fillHeight = false,
 	onRowClick,
 	onRowHover,
 	footerRow,
@@ -187,6 +188,11 @@ export function ResultGridView({
 	 * it lives in the status pill now): the drill surface mounts its slice
 	 * controls here (DAT-712 iteration 3). */
 	toolbarStart?: ReactNode;
+	/** Fill the parent's height instead of capping the body at 480px — the
+	 * analyse modal sizes ITSELF and the grid body must be the modal's ONLY
+	 * vertical scroller (double scrollbars otherwise). The parent chain must
+	 * be a flex column with minHeight 0. */
+	fillHeight?: boolean;
 }) {
 	// The filter row is hidden by default (a clean grid) and toggled by the funnel
 	// in the toolbar. An applied-but-hidden filter isn't stranded: the funnel stays
@@ -293,7 +299,19 @@ export function ResultGridView({
 	const status = fatal ? "error" : store.status;
 
 	return (
-		<div data-testid="canvas-result-grid">
+		<div
+			data-testid="canvas-result-grid"
+			style={
+				fillHeight
+					? {
+							display: "flex",
+							flexDirection: "column",
+							flex: 1,
+							minHeight: 0,
+						}
+					: undefined
+			}
+		>
 			<Group justify="space-between" mb="xs" align="flex-start">
 				{/* The row count lives in the status pill (a finished grid IS its
 				    row count) — the left slot hosts the owner's controls (the
@@ -383,7 +401,11 @@ export function ResultGridView({
 			{colCount > 0 && (
 				<div
 					ref={scrollRef}
-					style={{ maxHeight: 480, overflow: "auto" }}
+					style={
+						fillHeight
+							? { flex: 1, minHeight: 0, overflow: "auto" }
+							: { maxHeight: 480, overflow: "auto" }
+					}
 					data-testid="canvas-result-grid-scroll"
 				>
 					<Table striped highlightOnHover stickyHeader>
@@ -754,6 +776,7 @@ export function WindowedGrid({
 	sqlParams,
 	toolbarActions,
 	toolbarStart,
+	fillHeight,
 	onRowClick,
 	onRowHover,
 	footerRow,
@@ -771,6 +794,8 @@ export function WindowedGrid({
 	toolbarActions?: ReactNode;
 	/** Forwarded toolbar LEFT slot — see ResultGridView (DAT-712). */
 	toolbarStart?: ReactNode;
+	/** Forwarded fill-the-parent sizing — see ResultGridView (DAT-712). */
+	fillHeight?: boolean;
 	/** Forwarded row-click action — see ResultGridView. */
 	onRowClick?: (row: Record<string, Json | null>) => void;
 	/** Forwarded row hover/focus tracking — see ResultGridView (DAT-712). */
@@ -905,6 +930,7 @@ export function WindowedGrid({
 			sqlParams={sqlParams}
 			toolbarActions={toolbarActions}
 			toolbarStart={toolbarStart}
+			fillHeight={fillHeight}
 			onRowClick={onRowClick}
 			onRowHover={onRowHover}
 			footerRow={footerRow}

--- a/packages/cockpit/src/ui/cockpit/widgets/sql-block.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/sql-block.tsx
@@ -6,9 +6,23 @@
 // This is the READ-ONLY viewer. The editable probe surface is a different
 // interaction (CodeMirror `SqlEditor`); only the literal-SQL DISPLAY is shared.
 // Plain monospace, no syntax highlighting (deferred — the precedents are plain
-// `<Code>` too); the value is the engine's persisted/agent SQL, shown verbatim.
+// `<Code>` too). The value is pretty-printed for READING (sql-formatter's
+// duckdb dialect — composed statements arrive as one line); a fragment the
+// formatter can't parse falls back verbatim, never a crash (DAT-712).
 
 import { Code, Group, ScrollArea, Stack, Text } from "@mantine/core";
+import { format } from "sql-formatter";
+
+/** Pretty-print for display only — the string shown is NEVER re-executed, so
+ *  formatting can't perturb semantics. `$1`-style binds are DuckDB's numbered
+ *  params. */
+function formatSql(sql: string): string {
+	try {
+		return format(sql, { language: "duckdb", paramTypes: { numbered: ["$"] } });
+	} catch {
+		return sql; // off-dialect fragment — show verbatim
+	}
+}
 
 /** A bound scalar bind-parameter value, as carried on the result-grid state. */
 type BindParam = string | number | boolean | null;
@@ -38,7 +52,7 @@ export function SqlBlock({
 }) {
 	const body = (
 		<ScrollArea.Autosize mah={maxHeight}>
-			<Code block>{sql}</Code>
+			<Code block>{formatSql(sql)}</Code>
 		</ScrollArea.Autosize>
 	);
 


### PR DESCRIPTION
The DAT-671 UX cut, from the DAT-703 smoke verdict. Design: DAT-712 (agreed 2026-07-07/08).

## What

- **Time grain on temporal axes** (the DAT-673 hook): temporal slices default to Month; the chip carries resolution-filtered presets (catalog `resolved_type`, no name heuristics — DATE offers no hours) plus a typed-token power path (`3M`, `15m`). Tokens go through a **closed, case-sensitive grammar** on client and composer — DuckDB itself parses `'1M'` as 1 *minute* and `time_bucket(INTERVAL '1M', DATE …)` silently returns the raw date, so a token never reaches SQL. Composition is `time_bucket` (preserves DATE, calendar-quarter alignment), grouped **by the expression** (the alias would resolve to the raw column — silently wrong groups). Pins freeze the grain they were created under (pin ≡ the row you clicked).
- **Live equation header**: the metric's formula pretty-printed from the parsed DAG, totals-bound on open, rebinding on hover/focus, locking on pin; observed-NULL renders the honest gap + sentence; >4 operands elide to chips. One hue map (added/subtracted/divisor) feeds both equation terms and grid columns — they cannot disagree.
- **Total row + unit chip**: sticky footer anchors the unrestricted scalar + operand totals under any drill (`composeNodeTotals` — a separate entry point; the plain scalar stays engine byte-parity); unit chip on the value column.
- **Strict layering**: DrillableGrid/ResultGridView stay generic (observational hooks + pass-through rendering props); the equation is a parts-context layer keyed on the response's structured shape — answer-agent results (DAT-678) join by shipping the same block.

## Verification

- 46 new tests (grain grammar, real-DuckDB grain composition in both doctrine modes incl. NULL-poison paths, pin≡group at grain, `nodeShape`/totals, equation roles/binding/elision, grid grain wire contract) — 1662 unit tests, tsc, biome all green.
- Live enumeration spike: **every node × every axis × every preset grain** on the workspace — additive Σ(buckets)=scalar at all grains, grained pin ≡ bucket, totals ≡ scalar with exact operand columns. ALL CHECKS PASS.
- Reviewed by spec-compliance + senior + strict; all findings fixed (hover/lock lifecycle, tier-A grain-strip landmine → strict zod 400, sub-day-on-DATE mislabeling → named refusal, deterministic temporal-kind resolution, big-integer passthrough).
- Pre-smoked in a real browser on the live workspace (gross_margin: 365 day-rows with 174 dashes → 12 monthly buckets, margins 93.41–98.24).

Gate: lead browser smoke (dev server on :3002 runs this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)