### PR TITLE
feat(DAT-707): logs over OTLP — structlog→OTel bridge, trace-correlated lines in Loki

### DIFF
--- a/packages/engine/src/dataraum/core/__init__.py
+++ b/packages/engine/src/dataraum/core/__init__.py
@@ -7,10 +7,8 @@ from dataraum.core.connections import (
     get_connection_manager,
 )
 from dataraum.core.logging import (
-    LogConfig,
     configure_logging,
     get_logger,
-    log_context,
 )
 from dataraum.core.models.base import (
     Cardinality,
@@ -32,10 +30,8 @@ __all__ = [
     "close_default_manager",
     "get_connection_manager",
     # Logging
-    "LogConfig",
     "configure_logging",
     "get_logger",
-    "log_context",
     # Models - enums
     "Cardinality",
     "DataType",

--- a/packages/engine/src/dataraum/core/logging.py
+++ b/packages/engine/src/dataraum/core/logging.py
@@ -1,44 +1,62 @@
-"""Structured logging infrastructure for cloud-ready instrumentation.
+"""Structured logging for the engine.
 
-This module provides extensible logging that works for:
-- Local development (stderr console output)
-- Cloud deployments (JSON structured logs)
-- Future OpenTelemetry integration
+structlog renders human-readable lines to stderr (the container's docker-logs
+stream). When telemetry is on (``OTEL_EXPORTER_OTLP_ENDPOINT`` set — the worker
+bootstrap calls :func:`enable_otel_logging`), every event additionally ships
+over OTLP to Loki carrying the active span's trace context, and events emitted
+inside a span carry ``trace_id``/``span_id`` on the rendered stderr line too.
+
+Logs are the narrative; analysis lives in traces and metrics (Tempo/Prometheus
+per ADR-0019). The former ``grep llm_call | jq`` aggregation path is retired
+(DAT-707) — token usage and latency are span attributes and histograms now.
 
 Usage:
     from dataraum.core.logging import get_logger, configure_logging
 
-    # Configure at startup
-    configure_logging(log_level="INFO", log_format="console")
+    # Configured at import time with defaults; call again to change the level
+    configure_logging(log_level="DEBUG")
 
-    # Get logger in any module
     logger = get_logger(__name__)
-
-    # Log with structured context
     logger.info("phase_started", phase="import", source_id="abc123")
-
-    # Use context managers for automatic context propagation
-    with logger.context(run_id="run-123", phase="typing"):
-        logger.info("processing_table", table="customers", rows=1000)
 """
 
 from __future__ import annotations
 
 import logging
 import sys
-from collections.abc import MutableMapping
-from contextvars import ContextVar
-from dataclasses import dataclass
 from typing import Any, cast
 
 import structlog
+from opentelemetry import trace
+from opentelemetry._logs import Logger, LoggerProvider, SeverityNumber
 from structlog.typing import EventDict, FilteringBoundLogger
 
-# Context variables for correlation
-_run_context: ContextVar[dict[str, Any] | None] = ContextVar("run_context", default=None)
+# The OTel logs-bridge logger; None means OTLP shipping is off and logging
+# behaves exactly as before telemetry existed (no collector needed for tests
+# or host dev). Set via enable_otel_logging() at worker bootstrap.
+_otel_logger: Logger | None = None
+
+_SEVERITY: dict[str, SeverityNumber] = {
+    "debug": SeverityNumber.DEBUG,
+    "info": SeverityNumber.INFO,
+    "warning": SeverityNumber.WARN,
+    "error": SeverityNumber.ERROR,
+    "critical": SeverityNumber.FATAL,
+}
 
 
-_active_log_file: Any | None = None  # file handle for file logging
+def enable_otel_logging(provider: LoggerProvider) -> None:
+    """Ship every structlog event over OTLP in addition to stderr (DAT-707).
+
+    Only structlog events ship — stdlib logging (library output) stays
+    stderr-only, which also keeps the OTel SDK's own error logging out of the
+    export path (no feedback loop on exporter failures).
+
+    Args:
+        provider: The logs provider whose exporter pipeline receives events.
+    """
+    global _otel_logger
+    _otel_logger = provider.get_logger("dataraum")
 
 
 def _fmt_value(v: Any) -> str:
@@ -49,26 +67,17 @@ def _fmt_value(v: Any) -> str:
 
 
 class _ProxyLogger:
-    """Logger that routes structured log events to stderr (and optionally a file).
+    """Logger that renders structured log events to stderr.
 
     structlog dispatches ``dict`` return values from the final processor as
     ``logger.msg(**event_dict)``, so ``msg`` receives keyword arguments.
     """
 
     def msg(self, **kv: Any) -> None:
-        timestamp = kv.pop("timestamp", None)
         level = kv.pop("level", "")
         event = kv.pop("event", "")
         phase = kv.pop("phase", "")
 
-        self._stderr_print(level, event, phase, kv)
-
-        # File logging: also write when enabled (alongside stderr output)
-        if _active_log_file is not None:
-            self._file_print(_active_log_file, timestamp, level, event, phase, kv)
-
-    @staticmethod
-    def _stderr_print(level: str, event: str, phase: str, kv: dict[str, Any]) -> None:
         parts: list[str] = []
         if level and level not in ("info", "debug"):
             parts.append(f"[{level}]")
@@ -79,27 +88,6 @@ class _ProxyLogger:
             pairs = ", ".join(f"{k}: {_fmt_value(v)}" for k, v in kv.items())
             parts.append(f"({pairs})")
         print("  ".join(parts), file=sys.stderr, flush=True)
-
-    @staticmethod
-    def _file_print(
-        f: Any,
-        timestamp: str | None,
-        level: str,
-        event: str,
-        phase: str,
-        kv: dict[str, Any],
-    ) -> None:
-        parts: list[str] = []
-        if timestamp:
-            parts.append(str(timestamp))
-        parts.append(f"[{level.upper()}]" if level else "[INFO]")
-        if phase:
-            parts.append(phase)
-        parts.append(str(event))
-        if kv:
-            pairs = ", ".join(f"{k}: {_fmt_value(v)}" for k, v in kv.items())
-            parts.append(f"({pairs})")
-        print("  ".join(parts), file=f, flush=True)
 
     log = debug = info = warn = warning = msg
     err = error = exception = msg
@@ -115,90 +103,73 @@ def _passthrough_renderer(logger: Any, method_name: str, event_dict: EventDict) 
     return event_dict
 
 
-def enable_file_logging(path: Any) -> None:
-    """Enable file logging alongside stderr output.
+def _add_trace_context(logger: Any, method_name: str, event_dict: EventDict) -> EventDict:
+    """Stamp the active span's ids so rendered lines correlate with Tempo.
 
-    Structlog events are written to the file in plain text format.
-    Stdlib logging (library output) also gets a file handler.
-
-    Intended for headless processes where capturing crash tracebacks to a
-    persistent file is useful for postmortem.
-
-    Args:
-        path: Path to the log file (will be opened in append mode).
+    Outside a recording span (telemetry off, or code not under a span) the
+    context is invalid and the event passes through untouched.
     """
-    global _active_log_file
-    _active_log_file = open(path, "a")  # noqa: SIM115
-
-    # Also route stdlib logging to the file (for library output like httpx)
-    file_handler = logging.FileHandler(path)
-    file_handler.setFormatter(
-        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s  %(message)s")
-    )
-    logging.getLogger().addHandler(file_handler)
-
-
-@dataclass
-class LogConfig:
-    """Logging configuration."""
-
-    level: str = "INFO"
-    format: str = "console"  # "console" or "json"
-    show_timestamps: bool = True
-    show_caller: bool = False  # Show file:line in console mode
-    color: bool = True
-
-
-def _add_run_context(
-    logger: Any, method_name: str, event_dict: MutableMapping[str, Any]
-) -> MutableMapping[str, Any]:
-    """Processor to add run context to log events."""
-    context = _run_context.get()
-    if context:
-        event_dict.update(context)
+    ctx = trace.get_current_span().get_span_context()
+    if ctx.is_valid:
+        event_dict["trace_id"] = format(ctx.trace_id, "032x")
+        event_dict["span_id"] = format(ctx.span_id, "016x")
     return event_dict
 
 
-def configure_logging(
-    log_level: str = "INFO",
-    log_format: str = "console",
-    show_timestamps: bool = True,
-) -> None:
-    """Configure structured logging for the application.
+def _resolve_exception(exc_info: Any) -> BaseException | None:
+    """Normalize structlog's ``exc_info`` forms to the exception instance."""
+    if exc_info is True:
+        return sys.exc_info()[1]
+    if isinstance(exc_info, BaseException):
+        return exc_info
+    if isinstance(exc_info, tuple) and len(exc_info) == 3:
+        return cast("BaseException | None", exc_info[1])
+    return None
+
+
+def _otel_emit(logger: Any, method_name: str, event_dict: EventDict) -> EventDict:
+    """Mirror the event to the OTel logs bridge when shipping is enabled.
+
+    Body is the event name; the remaining kv pairs ride as attributes (Loki
+    structured metadata). ``trace_id``/``span_id`` are skipped — the record's
+    own trace context carries them — and ``exc_info`` becomes a real exception
+    on the record (``exception.*`` attributes) rather than a string attribute.
+    Runs before ``format_exc_info`` so the raw exception is still available.
+    """
+    if _otel_logger is None:
+        return event_dict
+    attributes: dict[str, Any] = {}
+    for key, value in event_dict.items():
+        if key in ("event", "level", "trace_id", "span_id", "exc_info"):
+            continue
+        attributes[key] = value if isinstance(value, str | bool | int | float) else str(value)
+    level = str(event_dict.get("level", "info"))
+    _otel_logger.emit(
+        severity_number=_SEVERITY.get(level, SeverityNumber.INFO),
+        severity_text=level.upper(),
+        body=str(event_dict.get("event", "")),
+        attributes=attributes,
+        exception=_resolve_exception(event_dict.get("exc_info")),
+    )
+    return event_dict
+
+
+def configure_logging(log_level: str = "INFO") -> None:
+    """Configure structured logging for the process.
 
     Args:
-        log_level: Logging level (DEBUG, INFO, WARNING, ERROR)
-        log_format: Output format ("console" for development, "json" for production/cloud)
-        show_timestamps: Whether to show timestamps in console mode
+        log_level: Logging level (DEBUG, INFO, WARNING, ERROR).
     """
-    # Shared processors for all formats
-    shared_processors: list[structlog.types.Processor] = [
-        structlog.contextvars.merge_contextvars,
-        _add_run_context,
-        structlog.processors.add_log_level,
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.UnicodeDecoder(),
-    ]
-
-    if show_timestamps:
-        shared_processors.insert(0, structlog.processors.TimeStamper(fmt="iso", utc=True))
-
-    if log_format == "json":
-        # JSON format for cloud/production
-        processors = shared_processors + [
-            structlog.processors.format_exc_info,
-            structlog.processors.JSONRenderer(),
-        ]
-    else:
-        # Console format — pass structured dict to _ProxyLogger for rendering
-        processors = shared_processors + [
+    structlog.configure(
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.UnicodeDecoder(),
+            _add_trace_context,
+            _otel_emit,
             structlog.processors.format_exc_info,
             _passthrough_renderer,
-        ]
-
-    # Configure structlog
-    structlog.configure(
-        processors=processors,
+        ],
         wrapper_class=structlog.make_filtering_bound_logger(getattr(logging, log_level.upper())),
         context_class=dict,
         logger_factory=_ProxyLoggerFactory(),
@@ -229,37 +200,6 @@ def get_logger(name: str | None = None) -> FilteringBoundLogger:
         Bound structlog logger
     """
     return cast(FilteringBoundLogger, structlog.get_logger(name))
-
-
-class LogContext:
-    """Context manager for adding context to logs within a scope."""
-
-    def __init__(self, **context: Any):
-        """Initialize with context key-value pairs."""
-        self.context = context
-        self.token: Any = None
-
-    def __enter__(self) -> LogContext:
-        """Enter context, adding values to log context."""
-        current = _run_context.get() or {}
-        new_context = {**current, **self.context}
-        self.token = _run_context.set(new_context)
-        return self
-
-    def __exit__(self, *_args: Any) -> None:
-        """Exit context, restoring previous values."""
-        if self.token:
-            _run_context.reset(self.token)
-
-
-def log_context(**context: Any) -> LogContext:
-    """Create a context manager for scoped logging context.
-
-    Usage:
-        with log_context(run_id="abc", phase="import"):
-            logger.info("processing")  # Will include run_id and phase
-    """
-    return LogContext(**context)
 
 
 # Initialize with default configuration

--- a/packages/engine/src/dataraum/core/logging.py
+++ b/packages/engine/src/dataraum/core/logging.py
@@ -52,6 +52,12 @@ def enable_otel_logging(provider: LoggerProvider) -> None:
     stderr-only, which also keeps the OTel SDK's own error logging out of the
     export path (no feedback loop on exporter failures).
 
+    Once armed, every kv pair at every call site leaves the container. The
+    same boundary ADR-0019 sets for spans applies to log attributes: metadata
+    only (counts, ids, labels, table/column names) — never row values, prompt
+    or completion text, or other business data, while PII handling (DAT-554)
+    is open.
+
     Args:
         provider: The logs provider whose exporter pipeline receives events.
     """
@@ -90,7 +96,7 @@ class _ProxyLogger:
         print("  ".join(parts), file=sys.stderr, flush=True)
 
     log = debug = info = warn = warning = msg
-    err = error = exception = msg
+    err = error = exception = critical = fatal = msg
 
 
 class _ProxyLoggerFactory:
@@ -142,7 +148,15 @@ def _otel_emit(logger: Any, method_name: str, event_dict: EventDict) -> EventDic
     for key, value in event_dict.items():
         if key in ("event", "level", "trace_id", "span_id", "exc_info"):
             continue
-        attributes[key] = value if isinstance(value, str | bool | int | float) else str(value)
+        if isinstance(value, str | bool | int | float):
+            attributes[key] = value
+        else:
+            # Coerced objects get a defensive cap: an accidentally-logged
+            # DataFrame/dict must not become a multi-MB OTLP attribute.
+            # Explicit strings pass whole (e.g. base.py's phase_failed
+            # traceback is a deliberate, bounded payload).
+            text = str(value)
+            attributes[key] = text[:2048] + "…[truncated]" if len(text) > 2048 else text
     level = str(event_dict.get("level", "info"))
     _otel_logger.emit(
         severity_number=_SEVERITY.get(level, SeverityNumber.INFO),

--- a/packages/engine/src/dataraum/llm/providers/anthropic.py
+++ b/packages/engine/src/dataraum/llm/providers/anthropic.py
@@ -526,10 +526,10 @@ class AnthropicProvider(LLMProvider):
                 elif block.type == "redacted_thinking":
                     raw_content.append({"type": "redacted_thinking", "data": block.data})
 
-            # Per-call telemetry log (DAT-600): elapsed + token usage, tagged by
-            # the caller's agent/phase label. The gen_ai span above is the
-            # analysis path since DAT-706; this line stays until DAT-707 settles
-            # log shipping, then follows it.
+            # Narrative log line — the gen_ai span above is the analysis path
+            # (DAT-706); this ships to Loki with trace correlation like every
+            # structlog event (DAT-707), so it stays a human-readable marker,
+            # not an aggregation surface.
             logger.info(
                 "llm_call",
                 label=request.label,

--- a/packages/engine/src/dataraum/worker/main.py
+++ b/packages/engine/src/dataraum/worker/main.py
@@ -126,8 +126,8 @@ async def run_worker() -> None:
     namespace = settings.temporal_namespace
     task_queue = settings.temporal_task_queue
 
-    # OTel tracing (ADR-0019/DAT-705) — no-op unless OTEL_EXPORTER_OTLP_ENDPOINT
-    # is set. On the Client, TracingInterceptor covers BOTH directions: outbound
+    # OTel tracing + log shipping (ADR-0019/DAT-705/707) — no-op unless
+    # OTEL_EXPORTER_OTLP_ENDPOINT is set. On the Client, TracingInterceptor covers BOTH directions: outbound
     # client calls AND this worker's workflow/activity spans. Every workflow
     # start arrives from the traced cockpit client (ADR-0020 — the orchestration
     # workflows run HERE and the cockpit is the only starter), so each run is
@@ -139,7 +139,7 @@ async def run_worker() -> None:
     # `always_create_workflow_spans`: it exists for client-context-LESS starts
     # (CLI/schedules/smoke scripts), which stay untraced rather than minting
     # orphan-parented trace shards.
-    tracer_provider = init_telemetry(settings)
+    telemetry = init_telemetry(settings)
 
     # Substrate bootstrap strictly precedes worker.run() — the worker must not
     # advertise itself as polling until its DuckLake anchor + ConnectionManager
@@ -150,7 +150,7 @@ async def run_worker() -> None:
             host,
             namespace=namespace,
             data_converter=pydantic_data_converter,  # PhaseActivity{Input,Result} are Pydantic
-            interceptors=[TracingInterceptor()] if tracer_provider else [],
+            interceptors=[TracingInterceptor()] if telemetry else [],
         )
         phase_activities = PhaseActivities(manager)
         activities = worker_activities(phase_activities)
@@ -228,8 +228,8 @@ async def run_worker() -> None:
             logger.info("worker_stopping")
     finally:
         shutdown_worker_substrate(manager)
-        if tracer_provider:
-            tracer_provider.shutdown()  # flush buffered spans before exit
+        if telemetry:
+            telemetry.shutdown()  # flush buffered spans + log records before exit
 
 
 def main() -> None:

--- a/packages/engine/src/dataraum/worker/telemetry.py
+++ b/packages/engine/src/dataraum/worker/telemetry.py
@@ -1,51 +1,73 @@
-"""OpenTelemetry bootstrap for the worker process (ADR-0019 / DAT-705).
+"""OpenTelemetry bootstrap for the worker process (ADR-0019 / DAT-705/707).
 
-Tracing only — metrics and log shipping land with DAT-706/707. The single
-on/off switch is ``OTEL_EXPORTER_OTLP_ENDPOINT`` (the OTLP vendor seam per
-ADR-0019): unset or empty means the worker runs exactly as before and nothing
-here is constructed.
+Traces and logs — metrics are cockpit-side (DAT-706). The single on/off switch
+is ``OTEL_EXPORTER_OTLP_ENDPOINT`` (the OTLP vendor seam per ADR-0019): unset
+or empty means the worker runs exactly as before and nothing here is
+constructed.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from dataraum.core.logging import get_logger
+from dataraum.core.logging import enable_otel_logging, get_logger
 from dataraum.core.settings import Settings
 
 logger = get_logger(__name__)
 
 
-def init_telemetry(settings: Settings) -> TracerProvider | None:
-    """Install the global tracer provider when an OTLP endpoint is configured.
+@dataclass
+class TelemetryHandles:
+    """The providers whose buffered telemetry the caller flushes on exit."""
 
-    Returns the provider — the caller owns ``shutdown()`` so buffered spans
-    flush on worker exit — or ``None`` when telemetry is off. The exporter is
-    constructed without an explicit endpoint: it resolves
-    ``OTEL_EXPORTER_OTLP_ENDPOINT`` itself per the OTLP spec (base URL +
-    ``/v1/traces``), so the Settings field only gates construction and the
-    URL semantics stay the SDK's.
+    tracer_provider: TracerProvider
+    logger_provider: LoggerProvider
+
+    def shutdown(self) -> None:
+        """Flush and stop both exporter pipelines (worker exit path)."""
+        self.logger_provider.shutdown()
+        self.tracer_provider.shutdown()
+
+
+def init_telemetry(settings: Settings) -> TelemetryHandles | None:
+    """Install the tracer provider and arm log shipping when OTLP is configured.
+
+    Returns the provider handles — the caller owns ``shutdown()`` so buffered
+    spans and log records flush on worker exit — or ``None`` when telemetry is
+    off. The exporters are constructed without an explicit endpoint: they
+    resolve ``OTEL_EXPORTER_OTLP_ENDPOINT`` themselves per the OTLP spec (base
+    URL + ``/v1/traces`` / ``/v1/logs``), so the Settings field only gates
+    construction and the URL semantics stay the SDK's.
 
     Args:
         settings: The validated process settings.
     """
     if not settings.otel_exporter_otlp_endpoint:
         return None
-    provider = TracerProvider(
-        resource=Resource.create(
-            {
-                "service.name": "dataraum-engine-worker",
-                # One worker container per workspace (DAT-505) — the workspace
-                # id distinguishes their spans in a multi-workspace stack.
-                "service.instance.id": settings.dataraum_workspace_id,
-            }
-        )
+    resource = Resource.create(
+        {
+            "service.name": "dataraum-engine-worker",
+            # One worker container per workspace (DAT-505) — the workspace
+            # id distinguishes their telemetry in a multi-workspace stack.
+            "service.instance.id": settings.dataraum_workspace_id,
+        }
     )
-    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
-    trace.set_tracer_provider(provider)
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(tracer_provider)
+    logger_provider = LoggerProvider(resource=resource)
+    logger_provider.add_log_record_processor(BatchLogRecordProcessor(OTLPLogExporter()))
+    enable_otel_logging(logger_provider)
+    # Emitted after arming, so this line is the first record shipped to Loki —
+    # its presence there is the boot-time proof the logs pipeline works.
     logger.info("telemetry_enabled", otlp_endpoint=settings.otel_exporter_otlp_endpoint)
-    return provider
+    return TelemetryHandles(tracer_provider=tracer_provider, logger_provider=logger_provider)

--- a/packages/engine/tests/unit/core/test_logging.py
+++ b/packages/engine/tests/unit/core/test_logging.py
@@ -1,15 +1,28 @@
-"""Tests for structlog proxy logger routing."""
+"""Tests for structlog proxy logger routing and the OTel logs bridge (DAT-707)."""
 
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterator
 from io import StringIO
 
+import pytest
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import (
+    InMemoryLogRecordExporter,
+    SimpleLogRecordProcessor,
+)
+from opentelemetry.sdk.trace import TracerProvider
+
+import dataraum.core.logging as logging_module
 from dataraum.core.logging import (
+    _add_trace_context,
     _fmt_value,
     _passthrough_renderer,
     _ProxyLogger,
     _ProxyLoggerFactory,
+    enable_otel_logging,
+    get_logger,
 )
 
 
@@ -90,3 +103,78 @@ class TestPassthroughRenderer:
         event_dict = {"event": "test", "level": "info", "key": "value"}
         result = _passthrough_renderer(None, "info", event_dict)
         assert result is event_dict
+
+
+class TestAddTraceContext:
+    def test_stamps_ids_inside_span(self) -> None:
+        """Inside a recording span, trace_id/span_id land as hex strings."""
+        tracer = TracerProvider().get_tracer("test")
+        with tracer.start_as_current_span("s") as span:
+            event_dict = _add_trace_context(None, "info", {"event": "e"})
+        ctx = span.get_span_context()
+        assert event_dict["trace_id"] == format(ctx.trace_id, "032x")
+        assert event_dict["span_id"] == format(ctx.span_id, "016x")
+
+    def test_untouched_outside_span(self) -> None:
+        """No active span (telemetry off / host dev) → dict passes through."""
+        event_dict = _add_trace_context(None, "info", {"event": "e"})
+        assert "trace_id" not in event_dict
+        assert "span_id" not in event_dict
+
+
+class TestOtelEmit:
+    @pytest.fixture
+    def exporter(self) -> Iterator[InMemoryLogRecordExporter]:
+        """OTLP shipping enabled against an in-memory exporter; off after."""
+        exporter = InMemoryLogRecordExporter()
+        provider = LoggerProvider()
+        provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+        enable_otel_logging(provider)
+        try:
+            yield exporter
+        finally:
+            logging_module._otel_logger = None
+
+    def test_ships_body_severity_attributes(self, exporter: InMemoryLogRecordExporter) -> None:
+        """Event name → body, level → severity, kv → coerced attributes."""
+        get_logger("test").warning("slow_thing", elapsed=1.5, table="x", extra={"a": 1})
+        (record,) = [f.log_record for f in exporter.get_finished_logs()]
+        assert record.body == "slow_thing"
+        assert record.severity_text == "WARNING"
+        # Primitives pass through; non-primitives are str()-coerced.
+        assert dict(record.attributes or {}) == {
+            "elapsed": 1.5,
+            "table": "x",
+            "extra": "{'a': 1}",
+        }
+
+    def test_record_carries_active_span_context(self, exporter: InMemoryLogRecordExporter) -> None:
+        """Records emitted inside a span correlate with it (Loki→Tempo hop)."""
+        tracer = TracerProvider().get_tracer("test")
+        with tracer.start_as_current_span("s") as span:
+            get_logger("test").info("in_span")
+        (record,) = [f.log_record for f in exporter.get_finished_logs()]
+        assert record.trace_id == span.get_span_context().trace_id
+        assert record.span_id == span.get_span_context().span_id
+        # trace ids ride the record's own context, not the attribute bag
+        assert "trace_id" not in dict(record.attributes or {})
+
+    def test_exception_becomes_exception_attributes(
+        self, exporter: InMemoryLogRecordExporter
+    ) -> None:
+        """logger.exception() ships the real exception, not a string blob."""
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            get_logger("test").exception("it_failed", phase="typing")
+        (record,) = [f.log_record for f in exporter.get_finished_logs()]
+        attrs = dict(record.attributes or {})
+        assert attrs["exception.type"] == "ValueError"
+        assert attrs["exception.message"] == "boom"
+        assert "raise ValueError" in str(attrs["exception.stacktrace"])
+        assert record.severity_text == "ERROR"
+
+    def test_off_by_default_no_ship_no_error(self) -> None:
+        """Without enable_otel_logging, logging works and nothing ships."""
+        assert logging_module._otel_logger is None
+        get_logger("test").info("plain_line", key="value")

--- a/packages/engine/tests/unit/core/test_logging.py
+++ b/packages/engine/tests/unit/core/test_logging.py
@@ -72,6 +72,8 @@ class TestProxyLogger:
             "err",
             "error",
             "exception",
+            "critical",
+            "fatal",
         ]
         for alias in aliases:
             assert getattr(proxy, alias) == proxy.msg, f"{alias} does not match msg"
@@ -173,6 +175,22 @@ class TestOtelEmit:
         assert attrs["exception.message"] == "boom"
         assert "raise ValueError" in str(attrs["exception.stacktrace"])
         assert record.severity_text == "ERROR"
+
+    def test_coerced_attribute_capped(self, exporter: InMemoryLogRecordExporter) -> None:
+        """A huge coerced object ships truncated, not as a multi-MB attribute."""
+        get_logger("test").info("big_thing", blob=list(range(5000)))
+        (record,) = [f.log_record for f in exporter.get_finished_logs()]
+        blob = str(dict(record.attributes or {})["blob"])
+        assert blob.endswith("…[truncated]")
+        assert len(blob) < 2100
+
+    def test_critical_maps_to_fatal(self, exporter: InMemoryLogRecordExporter) -> None:
+        """logger.critical() renders AND ships as FATAL severity."""
+        get_logger("test").critical("meltdown")
+        (record,) = [f.log_record for f in exporter.get_finished_logs()]
+        assert record.severity_text == "CRITICAL"
+        assert record.severity_number is not None
+        assert record.severity_number.name == "FATAL"
 
     def test_off_by_default_no_ship_no_error(self) -> None:
         """Without enable_otel_logging, logging works and nothing ships."""

--- a/packages/engine/tests/unit/worker/test_telemetry.py
+++ b/packages/engine/tests/unit/worker/test_telemetry.py
@@ -1,16 +1,19 @@
-"""Telemetry bootstrap gating (ADR-0019 / DAT-705).
+"""Telemetry bootstrap gating (ADR-0019 / DAT-705/707).
 
 The contract under test: ``OTEL_EXPORTER_OTLP_ENDPOINT`` is the single on/off
 switch — unset/empty constructs nothing (the worker runs exactly as before);
-set yields a provider carrying the worker's service identity.
+set yields the tracer + logger providers carrying the worker's service
+identity, with the structlog→OTel bridge armed.
 """
 
 from __future__ import annotations
 
 import pytest
 from opentelemetry import trace
+from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.trace import TracerProvider
 
+import dataraum.core.logging as logging_module
 from dataraum.core.settings import Settings
 from dataraum.worker.telemetry import init_telemetry
 
@@ -18,6 +21,7 @@ from dataraum.worker.telemetry import init_telemetry
 def test_off_when_endpoint_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
     assert init_telemetry(Settings()) is None  # type: ignore[call-arg]
+    assert logging_module._otel_logger is None
 
 
 def test_off_when_endpoint_empty(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -25,9 +29,10 @@ def test_off_when_endpoint_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     # never a half-configured exporter.
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
     assert init_telemetry(Settings()) is None  # type: ignore[call-arg]
+    assert logging_module._otel_logger is None
 
 
-def test_provider_when_endpoint_set(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_providers_when_endpoint_set(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
     # Intercept the GLOBAL provider registration: opentelemetry treats
     # set_tracer_provider as once-per-process (an override only warns and is
@@ -38,12 +43,22 @@ def test_provider_when_endpoint_set(monkeypatch: pytest.MonkeyPatch) -> None:
     registered: list[trace.TracerProvider] = []
     monkeypatch.setattr(trace, "set_tracer_provider", registered.append)
 
-    provider = init_telemetry(Settings())  # type: ignore[call-arg]
-    assert isinstance(provider, TracerProvider)
-    assert registered == [provider]  # installed as the process-global provider
-    attrs = provider.resource.attributes
-    assert attrs["service.name"] == "dataraum-engine-worker"
-    # conftest pins DATARAUM_WORKSPACE_ID=test — the per-workspace identity.
-    assert attrs["service.instance.id"] == "test"
-    # No spans were created, so shutdown flushes nothing and stays offline.
-    provider.shutdown()
+    try:
+        telemetry = init_telemetry(Settings())  # type: ignore[call-arg]
+        assert telemetry is not None
+        assert isinstance(telemetry.tracer_provider, TracerProvider)
+        assert registered == [telemetry.tracer_provider]  # the process-global provider
+        assert isinstance(telemetry.logger_provider, LoggerProvider)
+        # The structlog→OTel bridge is armed against this provider's pipeline.
+        assert logging_module._otel_logger is not None
+        # Both signals carry the same service identity (Loki's service_name
+        # label must match the Tempo spans for trace↔logs click-through).
+        for provider in (telemetry.tracer_provider, telemetry.logger_provider):
+            attrs = provider.resource.attributes
+            assert attrs["service.name"] == "dataraum-engine-worker"
+            # conftest pins DATARAUM_WORKSPACE_ID=test — per-workspace identity.
+            assert attrs["service.instance.id"] == "test"
+        telemetry.shutdown()
+    finally:
+        # enable_otel_logging set module state; never leak it into other tests.
+        logging_module._otel_logger = None

--- a/packages/engine/tests/unit/worker/test_telemetry.py
+++ b/packages/engine/tests/unit/worker/test_telemetry.py
@@ -33,7 +33,13 @@ def test_off_when_endpoint_empty(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_providers_when_endpoint_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+    # Deliberately NOT the collector's real port (4318): shutdown() flushes the
+    # buffered telemetry_enabled record, and on a dev host with the compose
+    # stack up that would ship a stray unit-test record into the live Loki.
+    # The 1s timeout caps the exporter's connection-refused retry backoff so
+    # the flush fails fast instead of burning ~7s of test time.
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:9")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "1")
     # Intercept the GLOBAL provider registration: opentelemetry treats
     # set_tracer_provider as once-per-process (an override only warns and is
     # ignored), so letting the test mutate real process-global state could


### PR DESCRIPTION
Phase 3 of the observability epic (DAT-704 / ADR-0019). Engine log lines now carry the active span's trace context and ship over OTLP to Loki; \`grep llm_call | jq\` is retired as an analysis path (traces/metrics own analysis; logs are the narrative).

## What

- **\`core/logging.py\`**: two new structlog processors — \`_add_trace_context\` stamps \`trace_id\`/\`span_id\` (hex) onto every event inside a valid span; \`_otel_emit\` mirrors each event to the OTel logs bridge when \`enable_otel_logging()\` armed it (body = event name, kv → attributes with primitive passthrough + 2048-char cap on coerced objects, structlog level → SeverityNumber, real exception passed through → \`exception.*\` attributes). structlog-only by design: stdlib library logs stay stderr-only, which keeps the OTel SDK's own error logging out of the export path (no feedback loop).
- **Clean cut of dead surface**: json log format (broken on main — \`JSONRenderer\`'s string output hit \`_ProxyLogger.msg(**kv)\` → \`TypeError\` on the first call; zero users, zero tests), \`enable_file_logging\` (zero callers repo-wide), \`LogConfig\`, \`LogContext\`/\`log_context\` (re-exported, never used). Rationale: OTLP is now the structured-shipping path the json renderer was aspirationally reserved for.
- **\`worker/telemetry.py\`**: \`init_telemetry\` returns \`TelemetryHandles\` (tracer + logger provider, one \`shutdown()\` flushing both). Both providers share one \`Resource\` — the \`service.name\` match is what makes Grafana's Tempo→Loki click-through resolve. \`telemetry_enabled\` is emitted after arming, so it's the first record shipped (boot-time pipeline proof).
- \`_ProxyLogger\` gains \`critical\`/\`fatal\` aliases (pre-existing gap: \`logger.critical()\` raised \`AttributeError\`; zero call sites).

## Cockpit half: cut, per the ticket's escape hatch

The ticket allows scoping to the engine if the cockpit's ad-hoc \`console.*\` surface makes the bridge disproportionate — it does: 55 \`console.*\` sites across ~30 files, no logging framework, so the only bridge is a console monkey-patch, which the ticket itself forbids ("do not build a bespoke console shim"). If cockpit server logs in Loki matter later, the real move is introducing an actual logger there (own ticket).

## Verified live (branch container on the compose stack)

- Boot logs in Loki with only \`service_name\`/\`service_instance_id\` as index labels; per-event kv rides as structured metadata (no label-cardinality risk).
- In-span stderr lines carry \`trace_id\`/\`span_id\`; the exact \`tracesToLogsV2\` query Grafana runs (\`{service_name="dataraum-engine-worker"} | trace_id = "…"\`) returns the span's lines, and Tempo resolves the same trace — the click-through AC, proven programmatically. The lgtm image's bundled Grafana provisioning needed zero changes.
- With the endpoint unset, logging is byte-identical to before (unit-tested off-mode; no collector needed for tests/host dev).

Unit: 1930 passed (7 new logging tests against the real SDK in-memory exporter — no mocks). Reviewers: senior APPROVED, spec-compliance APPROVED (both findings landed: PII-boundary docstring per ADR-0019, coercion cap, critical alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)