### PR TITLE
feat(DAT-673): flow gate — time grain only on summable-flow measures

### DIFF
--- a/packages/cockpit/src/duckdb/sql-ast.integration.test.ts
+++ b/packages/cockpit/src/duckdb/sql-ast.integration.test.ts
@@ -1,0 +1,49 @@
+// Real-DuckDB integration: the AST read extracts the AGGREGATED base columns
+// off an extract's value expression, including the engine's actual COALESCE/
+// CASE-wrapped shapes (DAT-673 flow gate).
+
+import { describe, expect, it } from "vitest";
+
+import { aggregatedColumns } from "./sql-ast";
+
+describe("aggregatedColumns", () => {
+	it("pulls columns from inside aggregates, ignoring bare refs", async () => {
+		expect(
+			[...(await aggregatedColumns("SUM(credit) - SUM(debit)"))].sort(),
+		).toEqual(["credit", "debit"]);
+	});
+
+	it("handles the engine's COALESCE/CASE-wrapped extract shape", async () => {
+		const expr =
+			"CASE WHEN COUNT(*) = 0 THEN NULL ELSE COALESCE(SUM(credit), 0) - COALESCE(SUM(debit), 0) END";
+		expect([...(await aggregatedColumns(expr))].sort()).toEqual([
+			"credit",
+			"debit",
+		]);
+	});
+
+	it("reads a balance (stock) expression's column", async () => {
+		expect(
+			[
+				...(await aggregatedColumns(
+					"SUM(debit_balance) - SUM(credit_balance)",
+				)),
+			].sort(),
+		).toEqual(["credit_balance", "debit_balance"]);
+	});
+
+	it("ignores a column referenced only OUTSIDE an aggregate", async () => {
+		// `rate` scales the aggregate but is not itself aggregated — not a measure.
+		expect([...(await aggregatedColumns("SUM(amount) * rate"))]).toEqual([
+			"amount",
+		]);
+	});
+
+	it("drops table qualification to the bare column", async () => {
+		expect([...(await aggregatedColumns("SUM(t.credit)"))]).toEqual(["credit"]);
+	});
+
+	it("returns empty for an unparseable expression (fail-closed signal)", async () => {
+		expect((await aggregatedColumns("this is not sql )(")).size).toBe(0);
+	});
+});

--- a/packages/cockpit/src/duckdb/sql-ast.integration.test.ts
+++ b/packages/cockpit/src/duckdb/sql-ast.integration.test.ts
@@ -46,4 +46,13 @@ describe("aggregatedColumns", () => {
 	it("returns empty for an unparseable expression (fail-closed signal)", async () => {
 		expect((await aggregatedColumns("this is not sql )(")).size).toBe(0);
 	});
+
+	it("fails CLOSED on a window aggregate — a WINDOW node yields an empty set (DAT-673)", async () => {
+		// `SUM(x) OVER (…)` parses as a WINDOW node, not FUNCTION — the aggregate
+		// walk can't read it, so returning {} makes the gate fail closed (strip
+		// grain) rather than miss a windowed stock. Proper window parsing: DAT-715.
+		expect((await aggregatedColumns("SUM(x) OVER (PARTITION BY y)")).size).toBe(
+			0,
+		);
+	});
 });

--- a/packages/cockpit/src/duckdb/sql-ast.ts
+++ b/packages/cockpit/src/duckdb/sql-ast.ts
@@ -1,0 +1,94 @@
+// SQL-as-structure via DuckDB's own AST (DAT-713 direction): read structure
+// off the JSON parse tree — the same parser that executes, so a parse can never
+// diverge from the binder. This module is the READ side used by the flow gate
+// (DAT-673): "which base columns does an extract AGGREGATE?" The mutation side
+// (the drill's clause appends) lands with DAT-678.
+//
+// The parser is the shared memoized in-memory DuckDB in `sql-canonical.ts`
+// (`json_serialize_sql` is parse-only — no lake, no table binding), so this
+// adds a walk, not a second native binding.
+
+import { getParser, parseSqlToJson } from "#/lib/sql-canonical";
+
+let aggregateNamesPromise: Promise<ReadonlySet<string>> | null = null;
+
+/** DuckDB's authoritative aggregate-function names — the JSON AST does NOT mark
+ *  a `FUNCTION` node as aggregate vs scalar (bind-time classification), so the
+ *  catalog is the source of truth (and it can't drift from the executor). */
+function aggregateNames(): Promise<ReadonlySet<string>> {
+	if (!aggregateNamesPromise) {
+		aggregateNamesPromise = (async () => {
+			const conn = await (await getParser()).connect();
+			try {
+				const reader = await conn.runAndReadAll(
+					"SELECT DISTINCT function_name FROM duckdb_functions() WHERE function_type = 'aggregate'",
+				);
+				const names = new Set<string>();
+				for (const row of reader.getRowObjectsJson()) {
+					if (typeof row.function_name === "string") {
+						names.add(row.function_name);
+					}
+				}
+				return names;
+			} finally {
+				conn.closeSync();
+			}
+		})().catch((err) => {
+			aggregateNamesPromise = null; // let a later call retry
+			throw err;
+		});
+	}
+	return aggregateNamesPromise;
+}
+
+/** The last element of a COLUMN_REF's `column_names` — the bare column, dropping
+ *  any table/schema qualification (`["t","credit"]` → `credit`). */
+function bareColumn(columnNames: unknown): string | null {
+	if (!Array.isArray(columnNames) || columnNames.length === 0) return null;
+	const last = columnNames[columnNames.length - 1];
+	return typeof last === "string" ? last : null;
+}
+
+/**
+ * The base columns an extract's select expression AGGREGATES — the column
+ * references INSIDE an aggregate function (`SUM(credit)` → `credit`; a bare
+ * `credit` outside any aggregate is ignored, as is a scalar-only multiplier).
+ * Parse-only: the relation need not exist. Returns an empty set when the
+ * expression can't be parsed — the caller treats "couldn't determine" as
+ * fail-closed (no time grain).
+ */
+export async function aggregatedColumns(
+	selectExpr: string,
+): Promise<Set<string>> {
+	const aggregates = await aggregateNames();
+	const ast = await parseSqlToJson(`SELECT ${selectExpr} AS value`);
+	if (
+		ast === null ||
+		typeof ast !== "object" ||
+		(ast as { error?: unknown }).error
+	) {
+		return new Set();
+	}
+
+	const columns = new Set<string>();
+	const walk = (node: unknown, insideAggregate: boolean): void => {
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child, insideAggregate);
+			return;
+		}
+		if (node === null || typeof node !== "object") return;
+		const obj = node as Record<string, unknown>;
+		const entersAggregate =
+			obj.class === "FUNCTION" &&
+			typeof obj.function_name === "string" &&
+			aggregates.has(obj.function_name);
+		const nowInside = insideAggregate || entersAggregate;
+		if (nowInside && obj.class === "COLUMN_REF") {
+			const col = bareColumn(obj.column_names);
+			if (col !== null) columns.add(col);
+		}
+		for (const value of Object.values(obj)) walk(value, nowInside);
+	};
+	walk(ast, false);
+	return columns;
+}

--- a/packages/cockpit/src/duckdb/sql-ast.ts
+++ b/packages/cockpit/src/duckdb/sql-ast.ts
@@ -41,6 +41,17 @@ function aggregateNames(): Promise<ReadonlySet<string>> {
 	return aggregateNamesPromise;
 }
 
+/** Does any node anywhere in the parse tree carry `class === cls`? (A shallow
+ *  structural probe — used to fail closed on shapes the aggregate walk can't
+ *  yet read, e.g. `WINDOW`.) */
+function hasClass(node: unknown, cls: string): boolean {
+	if (Array.isArray(node)) return node.some((child) => hasClass(child, cls));
+	if (node === null || typeof node !== "object") return false;
+	const obj = node as Record<string, unknown>;
+	if (obj.class === cls) return true;
+	return Object.values(obj).some((value) => hasClass(value, cls));
+}
+
 /** The last element of a COLUMN_REF's `column_names` — the bare column, dropping
  *  any table/schema qualification (`["t","credit"]` → `credit`). */
 function bareColumn(columnNames: unknown): string | null {
@@ -69,6 +80,15 @@ export async function aggregatedColumns(
 	) {
 		return new Set();
 	}
+
+	// Fail CLOSED on window aggregates (DAT-673). A windowed `SUM(x) OVER (…)`
+	// parses as a `WINDOW` node, NOT a `FUNCTION`, so the aggregate walk below
+	// would miss its columns — a windowed STOCK would read as "nothing
+	// aggregated" → the gate wrongly says safe and offers grain (the one
+	// direction a safety gate must never get wrong). Stopgap: any WINDOW node →
+	// empty set → the caller fails closed (strips grain). Parsing window bodies
+	// properly (and FILTER-clause / case-sensitivity handling) is DAT-715.
+	if (hasClass(ast, "WINDOW")) return new Set();
 
 	const columns = new Set<string>();
 	const walk = (node: unknown, insideAggregate: boolean): void => {

--- a/packages/cockpit/src/lib/sql-canonical.ts
+++ b/packages/cockpit/src/lib/sql-canonical.ts
@@ -217,7 +217,9 @@ export function canonicalKey(tree: unknown, sql: string): string {
 // reachability. `@duckdb/node-api` is a native binding, imported lazily so the pure
 // `canonicalKey` path (and its unit test) never load it or `#/config`.
 let parserInstance: Promise<DuckDBInstance> | null = null;
-function getParser(): Promise<DuckDBInstance> {
+/** The shared memoized in-memory parser instance (no lake). Exported so the
+ *  AST-read module (`sql-ast.ts`) reuses one native binding, not a second. */
+export function getParser(): Promise<DuckDBInstance> {
 	if (!parserInstance) {
 		parserInstance = import("@duckdb/node-api")
 			.then(({ DuckDBInstance }) => DuckDBInstance.create(":memory:"))
@@ -263,6 +265,21 @@ async function serialize(
 		return JSON.parse(raw);
 	} catch {
 		return null;
+	}
+}
+
+/**
+ * Parse a SQL string to DuckDB's JSON AST via the shared memoized parser — the
+ * one home for "SQL as structure" (canonicalization here, the DAT-673 flow-gate
+ * column read + the DAT-678 drill mutation in `sql-ast.ts`). Returns null when
+ * the parse is unusable (fail-soft; the JSON's own `error` survives otherwise).
+ */
+export async function parseSqlToJson(sql: string): Promise<unknown> {
+	const conn = await (await getParser()).connect();
+	try {
+		return await serialize(conn, sql);
+	} finally {
+		conn.closeSync();
 	}
 }
 

--- a/packages/cockpit/src/tools/drill-axes.test.ts
+++ b/packages/cockpit/src/tools/drill-axes.test.ts
@@ -43,6 +43,9 @@ vi.mock("#/db/metadata/client", () => ({
 // tested in this pure-metadata unit.
 vi.mock("#/duckdb/sql-ast", () => ({
 	aggregatedColumns: async (expr: string) => {
+		// Mirror the real fail-closed-on-WINDOW: the aggregate walk can't read a
+		// WINDOW node, so a windowed aggregate yields NO columns (sql-ast.ts).
+		if (/\bOVER\s*\(/i.test(expr)) return new Set<string>();
 		const cols = new Set<string>();
 		for (const m of expr.matchAll(
 			/\b(?:SUM|COUNT|AVG|MIN|MAX)\s*\(\s*(\w+)/gi,
@@ -714,6 +717,57 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 		// The safe measure keeps its grain: the stale snippet contributed nothing.
 		expect(dateAxis?.temporal).toBe("date");
 		expect(res.temporalGateReason).toBeUndefined();
+	});
+
+	it("FLOW GATE: a windowed measure among flows fails the WHOLE gate closed (F3 multi-expr, DAT-673)", async () => {
+		seed();
+		// Two GROUNDED measures on the same node: `revenue` is a normal additive
+		// FLOW; `cogs` is a WINDOW aggregate the AST read can't parse → empty
+		// aggregated set. The windowed measure's stock/flow status can't be
+		// confirmed, so the whole gate must fail closed — even though the flow
+		// sibling makes the aggregated-column total non-empty (the fail-OPEN the
+		// single-expr window guard alone missed).
+		rowsByTable.set(sqlSnippets, [
+			{
+				standardField: "revenue",
+				parts: {
+					select: [{ expr: "SUM(credit)", alias: "value" }],
+					from: ["enriched_invoices"],
+					where: [],
+				},
+				failureCount: 0,
+			},
+			{
+				standardField: "cogs",
+				parts: {
+					select: [
+						{
+							expr: "SUM(running_balance) OVER (PARTITION BY period)",
+							alias: "value",
+						},
+					],
+					from: ["enriched_invoices"],
+					where: [],
+				},
+				failureCount: 0,
+			},
+		]);
+		rowsByTable.set(columns, [
+			{ tableId: "vt1", columnName: "customer__segment", resolvedType: "DATE" },
+			{
+				tableId: "fact1",
+				columnName: "credit",
+				resolvedType: "DOUBLE",
+				temporalBehavior: "additive",
+				temporalBehaviorContested: false,
+			},
+		]);
+		const res = await resolveDrillAxes({ metricKey: "gross_margin" });
+		const dateAxis = res.axes.find((a) => a.column === "customer__segment");
+		// Grain stripped despite the additive-flow sibling — couldn't confirm.
+		expect(dateAxis).toBeDefined();
+		expect(dateAxis?.temporal).toBeNull();
+		expect(res.temporalGateReason).toContain("couldn't confirm");
 	});
 });
 

--- a/packages/cockpit/src/tools/drill-axes.test.ts
+++ b/packages/cockpit/src/tools/drill-axes.test.ts
@@ -21,6 +21,7 @@ function fluent(rows: unknown[]) {
 		where: () => q,
 		orderBy: () => q,
 		limit: () => q,
+		leftJoin: () => q,
 		// biome-ignore lint/suspicious/noThenProperty: drizzle query builders ARE thenables — the double must be awaitable mid-chain
 		then: (
 			resolve: (v: unknown[]) => unknown,
@@ -34,6 +35,21 @@ vi.mock("#/db/metadata/client", () => ({
 		select: () => ({
 			from: (table: unknown) => fluent(rowsByTable.get(table) ?? []),
 		}),
+	},
+}));
+
+// The AST read (real DuckDB) is integration-tested in sql-ast.integration.test;
+// here a thin regex stub extracts the aggregated column so the GATE logic is
+// tested in this pure-metadata unit.
+vi.mock("#/duckdb/sql-ast", () => ({
+	aggregatedColumns: async (expr: string) => {
+		const cols = new Set<string>();
+		for (const m of expr.matchAll(
+			/\b(?:SUM|COUNT|AVG|MIN|MAX)\s*\(\s*(\w+)/gi,
+		)) {
+			if (m[1]) cols.add(m[1]);
+		}
+		return cols;
 	},
 }));
 
@@ -345,10 +361,18 @@ const seed = () => {
 		},
 	]);
 	// The catalog types behind temporal detection: the VIEW table (vt1) carries
-	// the FK-projected dims; customer__segment is a DATE there.
+	// the FK-projected dims; customer__segment is a DATE there. The FACT (fact1)
+	// carries the aggregated measure `amount` — additive (a flow), so the flow
+	// gate leaves the temporal grain on.
 	rowsByTable.set(columns, [
 		{ tableId: "vt1", columnName: "customer__region", resolvedType: "VARCHAR" },
 		{ tableId: "vt1", columnName: "customer__segment", resolvedType: "DATE" },
+		{
+			tableId: "fact1",
+			columnName: "amount",
+			resolvedType: "DOUBLE",
+			temporalBehavior: "additive",
+		},
 	]);
 };
 
@@ -428,6 +452,69 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 		expect((await resolveDrillAxes({ standardField: "cogs" })).axes).toEqual(
 			[],
 		);
+	});
+
+	it("FLOW GATE: a stock measure keeps the date axis but loses its grain (DAT-673)", async () => {
+		seed();
+		// The extract sums a BALANCE column (point-in-time), not a flow.
+		rowsByTable.set(sqlSnippets, [
+			{
+				standardField: "revenue",
+				parts: {
+					select: [{ expr: "SUM(debit_balance)", alias: "value" }],
+					from: ["enriched_invoices"],
+					where: [],
+				},
+				failureCount: 0,
+			},
+		]);
+		rowsByTable.set(columns, [
+			{ tableId: "vt1", columnName: "customer__segment", resolvedType: "DATE" },
+			{
+				tableId: "fact1",
+				columnName: "debit_balance",
+				resolvedType: "DOUBLE",
+				temporalBehavior: "point_in_time",
+			},
+		]);
+		const res = await resolveDrillAxes({ standardField: "revenue" });
+		const dateAxis = res.axes.find((a) => a.column === "customer__segment");
+		// Still offered as a raw slice…
+		expect(dateAxis).toBeDefined();
+		// …but the grain is gated off, with a surfaced reason.
+		expect(dateAxis?.temporal).toBeNull();
+		expect(res.temporalGateReason).toContain("debit_balance");
+		expect(res.temporalGateReason).toContain("balance");
+	});
+
+	it("FLOW GATE: an unclassified measure fails closed (no grain)", async () => {
+		seed();
+		rowsByTable.set(sqlSnippets, [
+			{
+				standardField: "revenue",
+				parts: {
+					select: [{ expr: "SUM(mystery)", alias: "value" }],
+					from: ["enriched_invoices"],
+					where: [],
+				},
+				failureCount: 0,
+			},
+		]);
+		// `mystery` has no column_concept → temporalBehavior null → fail closed.
+		rowsByTable.set(columns, [
+			{ tableId: "vt1", columnName: "customer__segment", resolvedType: "DATE" },
+			{
+				tableId: "fact1",
+				columnName: "mystery",
+				resolvedType: "DOUBLE",
+				temporalBehavior: null,
+			},
+		]);
+		const res = await resolveDrillAxes({ standardField: "revenue" });
+		expect(
+			res.axes.find((a) => a.column === "customer__segment")?.temporal,
+		).toBeNull();
+		expect(res.temporalGateReason).toContain("mystery");
 	});
 });
 

--- a/packages/cockpit/src/tools/drill-axes.test.ts
+++ b/packages/cockpit/src/tools/drill-axes.test.ts
@@ -65,6 +65,7 @@ import type { DrillAxis } from "#/duckdb/drill";
 import {
 	applyTemporalKinds,
 	axesFromSliceRows,
+	describeTemporalGate,
 	driverGains,
 	measureFieldsFromDag,
 	orderAxesByDrivers,
@@ -276,21 +277,42 @@ describe("temporalGate (DAT-673)", () => {
 		expect(gate).toEqual({ safe: true, offending: [] });
 	});
 
-	it("flags a contested additive column as stock — grain stripped", () => {
+	it("flags a contested additive column with the 'contested' cause", () => {
 		const gate = temporalGate(
 			new Set(["credit"]),
 			behavior([["credit", "additive", true]]),
 		);
-		expect(gate).toEqual({ safe: false, offending: ["credit"] });
+		expect(gate).toEqual({
+			safe: false,
+			offending: [{ column: "credit", cause: "contested" }],
+		});
 	});
 
-	it("flags a point_in_time balance and an unclassified (missing) column", () => {
+	it("distinguishes stock (point_in_time) from unclassified (missing)", () => {
 		const gate = temporalGate(
 			new Set(["balance", "mystery"]),
 			behavior([["balance", "point_in_time", false]]),
 		);
 		expect(gate.safe).toBe(false);
-		expect(gate.offending).toEqual(["balance", "mystery"]);
+		expect(gate.offending).toEqual([
+			{ column: "balance", cause: "stock" },
+			{ column: "mystery", cause: "unclassified" },
+		]);
+	});
+
+	it("reports a present-but-null behavior as unclassified", () => {
+		const gate = temporalGate(new Set(["x"]), behavior([["x", null, false]]));
+		expect(gate.offending).toEqual([{ column: "x", cause: "unclassified" }]);
+	});
+
+	it("contested outranks the behavior value in the reported cause", () => {
+		// A point_in_time that is ALSO contested reports as contested — the
+		// higher-order fact (the detectors disagreed).
+		const gate = temporalGate(
+			new Set(["x"]),
+			behavior([["x", "point_in_time", true]]),
+		);
+		expect(gate.offending).toEqual([{ column: "x", cause: "contested" }]);
 	});
 
 	it("is safe only when EVERY aggregated column is a clean flow", () => {
@@ -311,7 +333,10 @@ describe("temporalGate (DAT-673)", () => {
 					["debit", "additive", true],
 				]),
 			),
-		).toEqual({ safe: false, offending: ["debit"] });
+		).toEqual({
+			safe: false,
+			offending: [{ column: "debit", cause: "contested" }],
+		});
 	});
 
 	it("fails closed when the aggregated set is empty (unparseable expr)", () => {
@@ -321,6 +346,39 @@ describe("temporalGate (DAT-673)", () => {
 			safe: false,
 			offending: [],
 		});
+	});
+});
+
+describe("describeTemporalGate (DAT-673)", () => {
+	it("phrases each cause honestly — a balance, a dispute, a gap", () => {
+		expect(
+			describeTemporalGate([{ column: "debit_balance", cause: "stock" }]),
+		).toMatch(/debit_balance.*balance.*not a flow/);
+		expect(
+			describeTemporalGate([{ column: "net_position", cause: "contested" }]),
+		).toMatch(/net_position.*contested.*detectors disagreed/);
+		expect(
+			describeTemporalGate([{ column: "mystery", cause: "unclassified" }]),
+		).toMatch(/mystery.*no stock\/flow classification/);
+	});
+
+	it("does NOT call a contested or unclassified column a balance", () => {
+		expect(
+			describeTemporalGate([{ column: "net_position", cause: "contested" }]),
+		).not.toContain("balance");
+		expect(
+			describeTemporalGate([{ column: "mystery", cause: "unclassified" }]),
+		).not.toContain("balance");
+	});
+
+	it("joins multiple offenders and covers the empty (couldn't-confirm) case", () => {
+		const msg = describeTemporalGate([
+			{ column: "a", cause: "stock" },
+			{ column: "b", cause: "unclassified" },
+		]);
+		expect(msg).toContain("a");
+		expect(msg).toContain("b");
+		expect(describeTemporalGate([])).toContain("couldn't confirm");
 	});
 });
 
@@ -582,6 +640,9 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 			res.axes.find((a) => a.column === "customer__segment")?.temporal,
 		).toBeNull();
 		expect(res.temporalGateReason).toContain("mystery");
+		// Accurate cause: an unclassified column is NOT called a balance.
+		expect(res.temporalGateReason).toContain("no stock/flow classification");
+		expect(res.temporalGateReason).not.toContain("balance");
 	});
 
 	it("FLOW GATE: a CONTESTED additive measure counts as stock — grain stripped (DAT-673)", async () => {
@@ -615,6 +676,44 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 		expect(dateAxis).toBeDefined();
 		expect(dateAxis?.temporal).toBeNull();
 		expect(res.temporalGateReason).toContain("net_position");
+		// Accurate cause: a contested verdict is reported as such, NOT as a balance.
+		expect(res.temporalGateReason).toContain("contested");
+		expect(res.temporalGateReason).not.toContain("balance");
+	});
+
+	it("FLOW GATE: a stale multi-measure snippet does NOT strip a safe measure's grain (scope leak, DAT-673)", async () => {
+		seed();
+		// The metric `gross_margin` names two extracts: `revenue` grounds to a
+		// promoted view and aggregates an additive FLOW; `cogs` is ACCEPTED but
+		// reads an UNPROMOTED relation (not in currentEnrichedViews) and sums a
+		// stock. The stale snippet's `debit_balance` must never reach the gate —
+		// otherwise it would strip grain from the whole node, including the
+		// genuinely-safe `revenue` measure.
+		rowsByTable.set(sqlSnippets, [
+			{
+				standardField: "revenue",
+				parts: {
+					select: [{ expr: "SUM(amount)", alias: "value" }],
+					from: ["enriched_invoices"],
+					where: [],
+				},
+				failureCount: 0,
+			},
+			{
+				standardField: "cogs",
+				parts: {
+					select: [{ expr: "SUM(debit_balance)", alias: "value" }],
+					from: ["enriched_stale_ledger"], // not a promoted view → ungrounded
+					where: [],
+				},
+				failureCount: 0,
+			},
+		]);
+		const res = await resolveDrillAxes({ metricKey: "gross_margin" });
+		const dateAxis = res.axes.find((a) => a.column === "customer__segment");
+		// The safe measure keeps its grain: the stale snippet contributed nothing.
+		expect(dateAxis?.temporal).toBe("date");
+		expect(res.temporalGateReason).toBeUndefined();
 	});
 });
 

--- a/packages/cockpit/src/tools/drill-axes.test.ts
+++ b/packages/cockpit/src/tools/drill-axes.test.ts
@@ -69,6 +69,8 @@ import {
 	measureFieldsFromDag,
 	orderAxesByDrivers,
 	resolveDrillAxes,
+	type TemporalBehavior,
+	temporalGate,
 	temporalKindsFromColumns,
 	unionSubstrateAxes,
 } from "./drill-axes";
@@ -258,6 +260,70 @@ describe("applyTemporalKinds", () => {
 	});
 });
 
+describe("temporalGate (DAT-673)", () => {
+	const behavior = (
+		entries: [string, string | null, boolean][],
+	): Map<string, TemporalBehavior> =>
+		new Map(
+			entries.map(([col, b, contested]) => [col, { behavior: b, contested }]),
+		);
+
+	it("passes a plain additive (uncontested) flow — grain stays", () => {
+		const gate = temporalGate(
+			new Set(["credit"]),
+			behavior([["credit", "additive", false]]),
+		);
+		expect(gate).toEqual({ safe: true, offending: [] });
+	});
+
+	it("flags a contested additive column as stock — grain stripped", () => {
+		const gate = temporalGate(
+			new Set(["credit"]),
+			behavior([["credit", "additive", true]]),
+		);
+		expect(gate).toEqual({ safe: false, offending: ["credit"] });
+	});
+
+	it("flags a point_in_time balance and an unclassified (missing) column", () => {
+		const gate = temporalGate(
+			new Set(["balance", "mystery"]),
+			behavior([["balance", "point_in_time", false]]),
+		);
+		expect(gate.safe).toBe(false);
+		expect(gate.offending).toEqual(["balance", "mystery"]);
+	});
+
+	it("is safe only when EVERY aggregated column is a clean flow", () => {
+		expect(
+			temporalGate(
+				new Set(["credit", "debit"]),
+				behavior([
+					["credit", "additive", false],
+					["debit", "additive", false],
+				]),
+			),
+		).toEqual({ safe: true, offending: [] });
+		expect(
+			temporalGate(
+				new Set(["credit", "debit"]),
+				behavior([
+					["credit", "additive", false],
+					["debit", "additive", true],
+				]),
+			),
+		).toEqual({ safe: false, offending: ["debit"] });
+	});
+
+	it("fails closed when the aggregated set is empty (unparseable expr)", () => {
+		expect(
+			temporalGate(new Set(), behavior([["credit", "additive", false]])),
+		).toEqual({
+			safe: false,
+			offending: [],
+		});
+	});
+});
+
 describe("driver ordering", () => {
 	it("takes the max gain per dimension across rankings, ignoring malformed entries", () => {
 		const gains = driverGains([
@@ -362,8 +428,8 @@ const seed = () => {
 	]);
 	// The catalog types behind temporal detection: the VIEW table (vt1) carries
 	// the FK-projected dims; customer__segment is a DATE there. The FACT (fact1)
-	// carries the aggregated measure `amount` — additive (a flow), so the flow
-	// gate leaves the temporal grain on.
+	// carries the aggregated measure `amount` — additive AND uncontested (a clean
+	// flow), so the flow gate leaves the temporal grain on.
 	rowsByTable.set(columns, [
 		{ tableId: "vt1", columnName: "customer__region", resolvedType: "VARCHAR" },
 		{ tableId: "vt1", columnName: "customer__segment", resolvedType: "DATE" },
@@ -372,6 +438,7 @@ const seed = () => {
 			columnName: "amount",
 			resolvedType: "DOUBLE",
 			temporalBehavior: "additive",
+			temporalBehaviorContested: false,
 		},
 	]);
 };
@@ -515,6 +582,39 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 			res.axes.find((a) => a.column === "customer__segment")?.temporal,
 		).toBeNull();
 		expect(res.temporalGateReason).toContain("mystery");
+	});
+
+	it("FLOW GATE: a CONTESTED additive measure counts as stock — grain stripped (DAT-673)", async () => {
+		seed();
+		rowsByTable.set(sqlSnippets, [
+			{
+				standardField: "revenue",
+				parts: {
+					select: [{ expr: "SUM(net_position)", alias: "value" }],
+					from: ["enriched_invoices"],
+					where: [],
+				},
+				failureCount: 0,
+			},
+		]);
+		// `net_position` is additive, but the detectors CONTESTED it — we can't
+		// stand behind "summable flow", so the grain must fail closed.
+		rowsByTable.set(columns, [
+			{ tableId: "vt1", columnName: "customer__segment", resolvedType: "DATE" },
+			{
+				tableId: "fact1",
+				columnName: "net_position",
+				resolvedType: "DOUBLE",
+				temporalBehavior: "additive",
+				temporalBehaviorContested: true,
+			},
+		]);
+		const res = await resolveDrillAxes({ standardField: "revenue" });
+		const dateAxis = res.axes.find((a) => a.column === "customer__segment");
+		// Still offered as a raw slice, but the grain is gated off.
+		expect(dateAxis).toBeDefined();
+		expect(dateAxis?.temporal).toBeNull();
+		expect(res.temporalGateReason).toContain("net_position");
 	});
 });
 

--- a/packages/cockpit/src/tools/drill-axes.ts
+++ b/packages/cockpit/src/tools/drill-axes.ts
@@ -561,12 +561,28 @@ export async function resolveDrillAxes(
 		// the relations→factIds filter above — a stale/unpromoted snippet
 		// contributes NO aggregated column to the gate.
 		const aggCols = new Set<string>();
+		// If ANY grounded expr yields no columns, we couldn't read what it
+		// aggregates (a window aggregate / COUNT(*) / unparseable) — fail the WHOLE
+		// gate closed rather than skip that expr, or a windowed STOCK would slip
+		// through when a non-windowed sibling makes aggCols non-empty (fail-open,
+		// DAT-673). Per-shape handling (COUNT(*)→flow, window bodies) is DAT-715.
+		let couldNotDetermine = false;
 		for (const { relation, selectExpr } of acceptedExprs) {
 			const factId = viewByName.get(relation)?.factTableId;
 			if (!factId || !factIdSet.has(factId)) continue;
-			for (const c of await aggregatedColumns(selectExpr)) aggCols.add(c);
+			const cols = await aggregatedColumns(selectExpr);
+			if (cols.size === 0) {
+				couldNotDetermine = true;
+				break;
+			}
+			for (const c of cols) aggCols.add(c);
 		}
-		const gate = temporalGate(aggCols, behaviorByColumn);
+		// An empty set makes temporalGate fail closed with no column to name — the
+		// "could not confirm a summable flow" verdict couldNotDetermine warrants.
+		const gate = temporalGate(
+			couldNotDetermine ? new Set<string>() : aggCols,
+			behaviorByColumn,
+		);
 		if (!gate.safe) {
 			const gated = axes.map((a) =>
 				a.temporal !== null ? { ...a, temporal: null } : a,

--- a/packages/cockpit/src/tools/drill-axes.ts
+++ b/packages/cockpit/src/tools/drill-axes.ts
@@ -233,26 +233,36 @@ async function targetFields(req: DrillAxesRequest): Promise<string[]> {
 	return measureFieldsFromDag(row?.dag ?? null);
 }
 
+/** A column's stock/flow adjudication as the flow gate reads it: the
+ *  `temporal_behavior` verdict plus whether that verdict is CONTESTED (the
+ *  detectors disagreed). A contested or point_in_time input counts as stock. */
+export interface TemporalBehavior {
+	behavior: string | null;
+	contested: boolean;
+}
+
 /**
  * The FLOW GATE (DAT-673): a node's measures may be summed into time buckets
- * only when every base column they aggregate is a FLOW (`temporal_behavior =
- * additive`). A stock (point-in-time balance) summed per period double-counts —
- * arithmetically consistent, semantically fabricated. Unclassified (null) fails
- * CLOSED: we can't assert "summable flow", so we don't offer the grain.
- * Pure → unit-tested; the aggregated-column extraction is the AST read
- * (`sql-ast.ts`).
+ * only when every base column they aggregate is a summable FLOW —
+ * `temporal_behavior = additive` AND NOT `temporal_behavior_contested`. A stock
+ * (point-in-time balance) summed per period double-counts — arithmetically
+ * consistent, semantically fabricated; a CONTESTED verdict counts as stock too
+ * (we can't stand behind "summable flow" when the detectors disagreed).
+ * Unclassified (null) fails CLOSED for the same reason. Pure → unit-tested; the
+ * aggregated-column extraction is the AST read (`sql-ast.ts`).
  */
 export function temporalGate(
 	aggregatedCols: ReadonlySet<string>,
-	behaviorByColumn: ReadonlyMap<string, string | null>,
+	behaviorByColumn: ReadonlyMap<string, TemporalBehavior>,
 ): { safe: boolean; offending: string[] } {
 	if (aggregatedCols.size === 0) {
 		// Couldn't determine what's aggregated (unparseable expr) → fail closed.
 		return { safe: false, offending: [] };
 	}
-	const offending = [...aggregatedCols].filter(
-		(c) => behaviorByColumn.get(c) !== "additive",
-	);
+	const offending = [...aggregatedCols].filter((c) => {
+		const b = behaviorByColumn.get(c);
+		return b === undefined || b.behavior !== "additive" || b.contested;
+	});
 	return { safe: offending.length === 0, offending };
 }
 
@@ -414,6 +424,10 @@ export async function resolveDrillAxes(
 				// The adjudicated stock/flow verdict for the flow gate (DAT-673) —
 				// null when the column has no concept (unclassified → fail closed).
 				temporalBehavior: currentColumnConcepts.temporalBehavior,
+				// …and whether that verdict is CONTESTED: a contested `additive` is
+				// treated as stock (fail closed — the detectors disagreed).
+				temporalBehaviorContested:
+					currentColumnConcepts.temporalBehaviorContested,
 			})
 			.from(columns)
 			.leftJoin(
@@ -457,16 +471,23 @@ export async function resolveDrillAxes(
 	// gate the grain on their stock/flow verdict.
 	if (axes.some((a) => a.temporal !== null)) {
 		const factIdSet = new Set(factIds);
-		const behaviorByColumn = new Map<string, string | null>();
+		const behaviorByColumn = new Map<string, TemporalBehavior>();
 		for (const r of columnRows) {
 			if (!r.columnName || !r.tableId || !factIdSet.has(r.tableId)) continue;
-			// First-wins per name (rows are ordered); a stock verdict is never
-			// overwritten by a later additive one for the same name.
-			if (
-				!behaviorByColumn.has(r.columnName) ||
-				behaviorByColumn.get(r.columnName) === "additive"
-			) {
-				behaviorByColumn.set(r.columnName, r.temporalBehavior ?? null);
+			// First-wins per name (rows are ordered); an OFFENDING verdict (stock,
+			// unclassified, or contested) is sticky — never overwritten by a later
+			// flow-safe (additive & uncontested) row for the same name, so a shared
+			// column can only lose grain, never regain it across facts.
+			const current = behaviorByColumn.get(r.columnName);
+			const currentFlowSafe =
+				current !== undefined &&
+				current.behavior === "additive" &&
+				!current.contested;
+			if (current === undefined || currentFlowSafe) {
+				behaviorByColumn.set(r.columnName, {
+					behavior: r.temporalBehavior ?? null,
+					contested: r.temporalBehaviorContested ?? false,
+				});
 			}
 		}
 		const aggCols = new Set<string>();

--- a/packages/cockpit/src/tools/drill-axes.ts
+++ b/packages/cockpit/src/tools/drill-axes.ts
@@ -27,6 +27,7 @@ import { config } from "#/config";
 import { metadataDb } from "#/db/metadata/client";
 import {
 	columns,
+	currentColumnConcepts,
 	currentDriverRankings,
 	currentEnrichedViews,
 	currentLifecycleArtifacts,
@@ -36,6 +37,7 @@ import {
 import type { DrillAxesRequest, DrillAxis } from "#/duckdb/drill";
 import { type TemporalKind, temporalKindOfType } from "#/duckdb/grain";
 import { narrowSnippetParts } from "#/duckdb/parts";
+import { aggregatedColumns } from "#/duckdb/sql-ast";
 
 import { parseMetricDag } from "./operating-model-graph";
 
@@ -231,12 +233,40 @@ async function targetFields(req: DrillAxesRequest): Promise<string[]> {
 	return measureFieldsFromDag(row?.dag ?? null);
 }
 
+/**
+ * The FLOW GATE (DAT-673): a node's measures may be summed into time buckets
+ * only when every base column they aggregate is a FLOW (`temporal_behavior =
+ * additive`). A stock (point-in-time balance) summed per period double-counts —
+ * arithmetically consistent, semantically fabricated. Unclassified (null) fails
+ * CLOSED: we can't assert "summable flow", so we don't offer the grain.
+ * Pure → unit-tested; the aggregated-column extraction is the AST read
+ * (`sql-ast.ts`).
+ */
+export function temporalGate(
+	aggregatedCols: ReadonlySet<string>,
+	behaviorByColumn: ReadonlyMap<string, string | null>,
+): { safe: boolean; offending: string[] } {
+	if (aggregatedCols.size === 0) {
+		// Couldn't determine what's aggregated (unparseable expr) → fail closed.
+		return { safe: false, offending: [] };
+	}
+	const offending = [...aggregatedCols].filter(
+		(c) => behaviorByColumn.get(c) !== "additive",
+	);
+	return { safe: offending.length === 0, offending };
+}
+
 /** Axes plus — when empty — the WHY, so the UI never shows a dead-end badge:
  *  each empty case names the stage of the resolution chain that yielded
  *  nothing (no extracts / stale relations / bare catalog). */
 export interface DrillAxesResult {
 	axes: DrillAxis[];
 	reason?: string;
+	/** Set when the flow gate stripped time grain from the temporal axes — the
+	 *  node aggregates a stock/unclassified measure that can't be summed into
+	 *  periods (DAT-673). The date axis stays as a raw slice; the UI surfaces
+	 *  this so the missing grain chip reads as a decision, not a gap. */
+	temporalGateReason?: string;
 }
 
 export async function resolveDrillAxes(
@@ -290,6 +320,9 @@ export async function resolveDrillAxes(
 	// SQL `inArray` (belt over braces — the field set defines the node).
 	const wanted = new Set(fields);
 	const relations: string[] = [];
+	// The accepted extracts' value expressions — the flow gate reads the base
+	// columns they AGGREGATE off these (DAT-673).
+	const selectExprs: string[] = [];
 	const decided = new Set<string>();
 	for (const r of snippetRows) {
 		if (!r.standardField || !wanted.has(r.standardField)) continue;
@@ -298,6 +331,7 @@ export async function resolveDrillAxes(
 		if ((r.failureCount ?? 0) !== 0) continue;
 		const parts = narrowSnippetParts(r.parts);
 		if (parts?.relation) relations.push(parts.relation);
+		if (parts?.selectExpr) selectExprs.push(parts.selectExpr);
 	}
 	const viewByName = new Map(
 		viewRows
@@ -377,8 +411,15 @@ export async function resolveDrillAxes(
 				tableId: columns.tableId,
 				columnName: columns.columnName,
 				resolvedType: columns.resolvedType,
+				// The adjudicated stock/flow verdict for the flow gate (DAT-673) —
+				// null when the column has no concept (unclassified → fail closed).
+				temporalBehavior: currentColumnConcepts.temporalBehavior,
 			})
 			.from(columns)
+			.leftJoin(
+				currentColumnConcepts,
+				eq(columns.columnId, currentColumnConcepts.columnId),
+			)
 			.where(inArray(columns.tableId, typeTableIds))
 			// Deterministic row order — temporalKindsFromColumns is first-wins
 			// per name, so an unordered read would be Postgres row-order
@@ -409,6 +450,42 @@ export async function resolveDrillAxes(
 			reason:
 				"No dimensions available for this computation's facts — neither the slicing catalog nor a grain-verified enriched view exposes anything to slice by.",
 		};
+	}
+
+	// FLOW GATE (DAT-673): only run when a temporal axis is actually offered.
+	// Extract the base columns the node's measures aggregate (AST read), then
+	// gate the grain on their stock/flow verdict.
+	if (axes.some((a) => a.temporal !== null)) {
+		const factIdSet = new Set(factIds);
+		const behaviorByColumn = new Map<string, string | null>();
+		for (const r of columnRows) {
+			if (!r.columnName || !r.tableId || !factIdSet.has(r.tableId)) continue;
+			// First-wins per name (rows are ordered); a stock verdict is never
+			// overwritten by a later additive one for the same name.
+			if (
+				!behaviorByColumn.has(r.columnName) ||
+				behaviorByColumn.get(r.columnName) === "additive"
+			) {
+				behaviorByColumn.set(r.columnName, r.temporalBehavior ?? null);
+			}
+		}
+		const aggCols = new Set<string>();
+		for (const expr of selectExprs) {
+			for (const c of await aggregatedColumns(expr)) aggCols.add(c);
+		}
+		const gate = temporalGate(aggCols, behaviorByColumn);
+		if (!gate.safe) {
+			const gated = axes.map((a) =>
+				a.temporal !== null ? { ...a, temporal: null } : a,
+			);
+			return {
+				axes: gated,
+				temporalGateReason:
+					gate.offending.length > 0
+						? `Time grain is off: this measure aggregates ${gate.offending.join(", ")}, which the catalog reads as a balance (point-in-time), not a flow. Summing a balance into time periods double-counts.`
+						: "Time grain is off: could not confirm this measure is a summable flow.",
+			};
+		}
 	}
 	return { axes };
 }

--- a/packages/cockpit/src/tools/drill-axes.ts
+++ b/packages/cockpit/src/tools/drill-axes.ts
@@ -241,6 +241,28 @@ export interface TemporalBehavior {
 	contested: boolean;
 }
 
+/** Why an aggregated column disqualifies the node's grain: a point-in-time
+ *  `stock`, a `contested` verdict (detectors disagreed), or `unclassified`
+ *  (no — or a non-flow — stock/flow classification). */
+export type OffendingCause = "stock" | "contested" | "unclassified";
+
+/** An aggregated column that fails the flow gate, with the reason it fails —
+ *  so the caller can phrase an accurate refusal per cause (DAT-673). */
+export interface OffendingColumn {
+	column: string;
+	cause: OffendingCause;
+}
+
+/** Why a non-flow column offends (pure). Contested outranks the behavior value:
+ *  a disputed verdict is reported as such even if the last-written behavior was
+ *  a balance; a plain `point_in_time` is a stock; anything else — null, missing,
+ *  or an unrecognized value — is unclassified. */
+function offendingCause(b: TemporalBehavior | undefined): OffendingCause {
+	if (b?.contested) return "contested";
+	if (b?.behavior === "point_in_time") return "stock";
+	return "unclassified";
+}
+
 /**
  * The FLOW GATE (DAT-673): a node's measures may be summed into time buckets
  * only when every base column they aggregate is a summable FLOW —
@@ -248,22 +270,55 @@ export interface TemporalBehavior {
  * (point-in-time balance) summed per period double-counts — arithmetically
  * consistent, semantically fabricated; a CONTESTED verdict counts as stock too
  * (we can't stand behind "summable flow" when the detectors disagreed).
- * Unclassified (null) fails CLOSED for the same reason. Pure → unit-tested; the
- * aggregated-column extraction is the AST read (`sql-ast.ts`).
+ * Unclassified (null) fails CLOSED for the same reason. Returns the offending
+ * columns WITH their cause so the caller phrases an accurate refusal. Pure →
+ * unit-tested; the aggregated-column extraction is the AST read (`sql-ast.ts`).
  */
 export function temporalGate(
 	aggregatedCols: ReadonlySet<string>,
 	behaviorByColumn: ReadonlyMap<string, TemporalBehavior>,
-): { safe: boolean; offending: string[] } {
+): { safe: boolean; offending: OffendingColumn[] } {
 	if (aggregatedCols.size === 0) {
 		// Couldn't determine what's aggregated (unparseable expr) → fail closed.
 		return { safe: false, offending: [] };
 	}
-	const offending = [...aggregatedCols].filter((c) => {
-		const b = behaviorByColumn.get(c);
-		return b === undefined || b.behavior !== "additive" || b.contested;
-	});
+	const offending: OffendingColumn[] = [];
+	for (const column of aggregatedCols) {
+		const b = behaviorByColumn.get(column);
+		// A clean flow — additive AND uncontested — is the ONLY safe shape.
+		if (b !== undefined && b.behavior === "additive" && !b.contested) continue;
+		offending.push({ column, cause: offendingCause(b) });
+	}
 	return { safe: offending.length === 0, offending };
+}
+
+/** One offending column's honest phrasing — a contested verdict is NOT a
+ *  "balance", and an unclassified column has no classification at all. */
+function phraseOffender({ column, cause }: OffendingColumn): string {
+	switch (cause) {
+		case "stock":
+			return `${column} is a balance (point-in-time stock), not a flow`;
+		case "contested":
+			return `${column} has a contested stock/flow verdict (the detectors disagreed)`;
+		case "unclassified":
+			return `${column} has no stock/flow classification`;
+	}
+}
+
+/** Phrase the flow-gate refusal from the per-column causes (pure). The empty
+ *  case (nothing aggregated — unparseable or windowed expr, DAT-673) can only
+ *  say it couldn't confirm a flow. */
+export function describeTemporalGate(
+	offending: readonly OffendingColumn[],
+): string {
+	if (offending.length === 0) {
+		return "Time grain is off: couldn't confirm this measure is a summable flow.";
+	}
+	return `Time grain is off: this measure aggregates ${offending
+		.map(phraseOffender)
+		.join(
+			"; ",
+		)}. Only a summable flow can be bucketed by period without double-counting.`;
 }
 
 /** Axes plus — when empty — the WHY, so the UI never shows a dead-end badge:
@@ -273,9 +328,11 @@ export interface DrillAxesResult {
 	axes: DrillAxis[];
 	reason?: string;
 	/** Set when the flow gate stripped time grain from the temporal axes — the
-	 *  node aggregates a stock/unclassified measure that can't be summed into
-	 *  periods (DAT-673). The date axis stays as a raw slice; the UI surfaces
-	 *  this so the missing grain chip reads as a decision, not a gap. */
+	 *  node aggregates a stock / contested / unclassified measure that can't be
+	 *  summed into periods (DAT-673). The date axis stays as a raw slice. This is
+	 *  a SERVER-SIDE signal only — no client reads it yet; surfacing it in the
+	 *  drill UI (so the missing grain chip reads as a decision, not a gap) is
+	 *  deferred to DAT-715. */
 	temporalGateReason?: string;
 }
 
@@ -330,9 +387,14 @@ export async function resolveDrillAxes(
 	// SQL `inArray` (belt over braces — the field set defines the node).
 	const wanted = new Set(fields);
 	const relations: string[] = [];
-	// The accepted extracts' value expressions — the flow gate reads the base
-	// columns they AGGREGATE off these (DAT-673).
-	const selectExprs: string[] = [];
+	// The accepted extracts' (relation, value-expression) pairs. The flow gate
+	// reads the base columns each expr AGGREGATES, but ONLY off snippets that
+	// ground to a promoted view's fact (filtered below against `factIds`).
+	// Pairing keeps every expr tied to its relation so a stale/unpromoted
+	// snippet's columns can never reach the gate — otherwise, on a multi-measure
+	// node, one stale measure's column would strip grain from the whole node,
+	// including its genuinely-safe measures (scope leak, DAT-673).
+	const acceptedExprs: { relation: string; selectExpr: string }[] = [];
 	const decided = new Set<string>();
 	for (const r of snippetRows) {
 		if (!r.standardField || !wanted.has(r.standardField)) continue;
@@ -341,7 +403,11 @@ export async function resolveDrillAxes(
 		if ((r.failureCount ?? 0) !== 0) continue;
 		const parts = narrowSnippetParts(r.parts);
 		if (parts?.relation) relations.push(parts.relation);
-		if (parts?.selectExpr) selectExprs.push(parts.selectExpr);
+		if (parts?.relation && parts.selectExpr)
+			acceptedExprs.push({
+				relation: parts.relation,
+				selectExpr: parts.selectExpr,
+			});
 	}
 	const viewByName = new Map(
 		viewRows
@@ -490,9 +556,15 @@ export async function resolveDrillAxes(
 				});
 			}
 		}
+		// Scope the exprs to the SAME grounded facts as behaviorByColumn: only
+		// snippets whose relation resolves to a fact we kept (factIds). Mirrors
+		// the relations→factIds filter above — a stale/unpromoted snippet
+		// contributes NO aggregated column to the gate.
 		const aggCols = new Set<string>();
-		for (const expr of selectExprs) {
-			for (const c of await aggregatedColumns(expr)) aggCols.add(c);
+		for (const { relation, selectExpr } of acceptedExprs) {
+			const factId = viewByName.get(relation)?.factTableId;
+			if (!factId || !factIdSet.has(factId)) continue;
+			for (const c of await aggregatedColumns(selectExpr)) aggCols.add(c);
 		}
 		const gate = temporalGate(aggCols, behaviorByColumn);
 		if (!gate.safe) {
@@ -501,10 +573,7 @@ export async function resolveDrillAxes(
 			);
 			return {
 				axes: gated,
-				temporalGateReason:
-					gate.offending.length > 0
-						? `Time grain is off: this measure aggregates ${gate.offending.join(", ")}, which the catalog reads as a balance (point-in-time), not a flow. Summing a balance into time periods double-counts.`
-						: "Time grain is off: could not confirm this measure is a summable flow.",
+				temporalGateReason: describeTemporalGate(gate.offending),
 			};
 		}
 	}


### PR DESCRIPTION
Part of DAT-671. First use of the DAT-713 SQL-as-structure (DuckDB-JSON AST) direction.

## What

Time grain (and any temporal slice) is offered on a node's date axis **iff every base column its extracts aggregate is a summable flow** — `column_concepts.temporal_behavior = additive` AND NOT `temporal_behavior_contested`. A stock (point-in-time balance) summed into time buckets double-counts: arithmetically consistent, semantically fabricated. The gate **fails closed** — it does not offer grain — for every shape it can't stand behind: a `point_in_time` stock, a **contested** verdict (the detectors disagreed), an **unclassified** column, or an expression it can't read (unparseable, or a **windowed** aggregate — see below).

The aggregated columns are read from the extract's value expression via **DuckDB's own AST** (`json_serialize_sql`, parse-only, no lake) — walk the `COLUMN_REF`s inside aggregate `FUNCTION` nodes (aggregate names from `duckdb_functions()`, authoritative — the JSON AST doesn't mark aggregates). This reuses the shared memoized parser from `sql-canonical.ts` (DAT-654), which gains `parseSqlToJson` + an exported `getParser`, so this adds a walk, not a second native binding.

## Files

- `src/duckdb/sql-ast.ts` (new) — `aggregatedColumns(selectExpr)`. Integration-tested on the engine's real `CASE/COALESCE`-wrapped extract shapes. A windowed `SUM(x) OVER (…)` parses as a `WINDOW` node (not `FUNCTION`), which the aggregate walk can't read — so any `WINDOW` node returns an empty set, and the caller fails closed. Proper window-body parsing is DAT-715.
- `src/tools/drill-axes.ts` — `temporalGate` (pure) + wiring: strips the temporal kind from the axes when unsafe (keeps the date axis as a raw slice) and records a per-cause `temporalGateReason`. The exprs fed to the gate are scoped to the SAME grounded facts as the stock/flow verdicts, so a stale/unpromoted snippet on a multi-measure node can't strip grain from its genuinely-safe measures.
- `src/lib/sql-canonical.ts` — `parseSqlToJson` + exported `getParser` (shared parser).

`temporalGateReason` is a **server-side signal only** — no client reads it yet. Surfacing it in the drill UI (so the missing grain chip reads as a decision, not a gap) is deferred to **DAT-715**, along with COUNT(*)-as-flow handling and proper window/FILTER parsing.

## Verification

- 1684 unit tests + 7 sql-ast integration tests green; tsc + biome clean. Covers: the contested fail-closed, the window fail-closed, the multi-measure scope-leak regression (a stale measure does NOT strip a safe measure's grain), and per-cause reason phrasing (a contested/unclassified column is never called a "balance").
- Live regression smoke: `gross_margin` (aggregates additive `credit`/`debit`) keeps its `Month` grain chip — the gate doesn't over-fire on flows.
- `current_assets` aggregates `debit_balance`/`credit_balance` (`point_in_time`) → the gate correctly classifies it non-additive. No visible change here — **not** because the fact has no date: `trial_balance.period` is a real `DATE` column, it exists. It simply isn't surfaced as an axis because the enriched view projects only FK-joined dims, not a fact's own columns, so `period` never reaches the resolver as a temporal axis to gate in the first place. The flow gate is about stock-vs-flow **summability**, not about whether a date column exists — it's the correct guard for when a stock measure does meet a dated axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
