### PR TITLE
fix(DAT-714): NULL-safe carrier join for non-additive metric drills

### DIFF
--- a/packages/cockpit/src/duckdb/parts.test.ts
+++ b/packages/cockpit/src/duckdb/parts.test.ts
@@ -478,7 +478,7 @@ describe("composeNodeQuery — grouped", () => {
 		for (const r of result) expect(r.value).toBeNull();
 	});
 
-	it("slices by several dims at once (GROUP BY + USING both)", async () => {
+	it("slices by several dims at once (GROUP BY over every dim, deduped)", async () => {
 		const q = composed(GROSS_PROFIT, undefined, {
 			slices: [
 				{ column: "account" },
@@ -610,6 +610,76 @@ describe("composeNodeQuery — NULL-dim non-additive slice (DAT-714)", () => {
 				9,
 			);
 		}
+	});
+
+	it("3 carriers × 2 dims: the chained spine COALESCEs the left key across ALL prior carriers — no split, no dup keys", async () => {
+		// revenue / cogs * depreciation is non-additive with THREE carriers,
+		// sliced by region AND cost_center at once. depr lives only on
+		// (west, NULL) — a group present ONLY in the 3rd (last-joined) carrier,
+		// absent in the first two; revenue and cogs share (west, cc1) and
+		// (east, NULL). A FULL JOIN can leave EITHER side's key NULL, so the left
+		// key of the third join must be COALESCE over BOTH prior carriers, not
+		// just the immediate-left neighbour — the accumulation the reviewers
+		// verified with throwaway probes, pinned here as a real regression.
+		const steps: NodeStep[] = [
+			REVENUE,
+			COGS,
+			DEPR,
+			formula(
+				"tri",
+				"revenue / cost_of_goods_sold * depreciation_amortization",
+				["revenue", "cost_of_goods_sold", "depreciation_amortization"],
+				true,
+			),
+		];
+		const q = composed(steps, undefined, {
+			slices: [{ column: "region" }, { column: "cost_center" }],
+			pins: [],
+		});
+		// The 3rd carrier's ON accumulates COALESCE over BOTH prior carriers per
+		// dim (the immediate-left-neighbour bug would reference only cogs).
+		expect(q.sql).toContain(
+			'COALESCE("revenue"."region", "cost_of_goods_sold"."region") ' +
+				'IS NOT DISTINCT FROM "depreciation_amortization"."region"',
+		);
+		expect(q.sql).toContain(
+			'COALESCE("revenue"."cost_center", "cost_of_goods_sold"."cost_center") ' +
+				'IS NOT DISTINCT FROM "depreciation_amortization"."cost_center"',
+		);
+		// …and each output dim is COALESCE across all THREE carriers.
+		expect(q.sql).toContain(
+			'COALESCE("revenue"."region", "cost_of_goods_sold"."region", ' +
+				'"depreciation_amortization"."region") AS "region"',
+		);
+		expect(q.sql).toContain(
+			'COALESCE("revenue"."cost_center", "cost_of_goods_sold"."cost_center", ' +
+				'"depreciation_amortization"."cost_center") AS "cost_center"',
+		);
+
+		const result = await rows(q.sql);
+		// Three groups, each ONCE: (west,cc1) rev+cogs, (east,NULL) rev+cogs — the
+		// NULL cost_center never splits — and (west,NULL) depr-only. USING would
+		// split every NULL-cost_center group → four rows, (east,NULL) twice.
+		expect(result).toHaveLength(3);
+		const key = (r: Record<string, unknown>) =>
+			`${String(r.region)}|${String(r.cost_center)}`;
+		const keys = result.map(key);
+		expect(new Set(keys).size).toBe(keys.length); // no duplicate group keys
+		const byKey = new Map(result.map((r) => [key(r), r]));
+		// (west,cc1): the NULL-safe first join matched rev+cogs on non-null dims.
+		expect(num(byKey.get("west|cc1")?.revenue)).toBe(500);
+		expect(num(byKey.get("west|cc1")?.cost_of_goods_sold)).toBe(120);
+		// (east,NULL): first join matched despite a NULL cost_center.
+		expect(num(byKey.get("east|null")?.revenue)).toBe(300);
+		expect(num(byKey.get("east|null")?.cost_of_goods_sold)).toBe(80);
+		// The 3rd-carrier-only group lands as ONE correct row: depr observed, the
+		// other carriers absent → the honest dash (doctrine v2), never a split.
+		const depOnly = byKey.get("west|null");
+		expect(depOnly).toBeDefined();
+		expect(num(depOnly?.depreciation_amortization)).toBe(40);
+		expect(depOnly?.revenue).toBeNull();
+		expect(depOnly?.cost_of_goods_sold).toBeNull();
+		expect(depOnly?.value).toBeNull();
 	});
 });
 

--- a/packages/cockpit/src/duckdb/parts.test.ts
+++ b/packages/cockpit/src/duckdb/parts.test.ts
@@ -32,20 +32,23 @@ beforeAll(async () => {
 	instance = await DuckDBInstance.create(":memory:");
 	conn = await instance.connect();
 	await conn.run(
-		"CREATE TABLE enriched_txn (account VARCHAR, region VARCHAR, kind VARCHAR, credit DOUBLE, debit DOUBLE, open_balance DOUBLE, booked_on DATE)",
+		"CREATE TABLE enriched_txn (account VARCHAR, region VARCHAR, kind VARCHAR, credit DOUBLE, debit DOUBLE, open_balance DOUBLE, booked_on DATE, cost_center VARCHAR)",
 	);
 	// revenue lives on 'sales' accounts, cogs on 'materials', depreciation on
 	// 'depr', AR balances on 'sales' west only — the disjoint shapes the
 	// grouped composition must keep honest. Dates: revenue books only in
 	// January (two days), cogs in BOTH months — the time-grain tests bucket
 	// these (raw days ≠ month groups; February has cogs but no revenue).
+	// cost_center is a PARTIALLY-NULL slice dim (the 'east' rows are NULL): both
+	// revenue and cogs are observed in the NULL group AND in 'cc1', the shape
+	// the DAT-714 NULL-safe FULL-JOIN tests pin.
 	await conn.run(`INSERT INTO enriched_txn VALUES
-		('sales', 'west', 'rev', 500, 0, 0, DATE '2025-01-05'),
-		('sales', 'east', 'rev', 400, 100, 0, DATE '2025-01-20'),
-		('materials', 'west', 'cogs', 0, 120, 0, DATE '2025-01-12'),
-		('materials', 'east', 'cogs', 0, 80, 0, DATE '2025-02-08'),
-		('depr', 'west', 'depr', 0, 40, 0, DATE '2025-02-15'),
-		('sales', 'west', 'ar', 0, 0, 180, DATE '2025-02-15')`);
+		('sales', 'west', 'rev', 500, 0, 0, DATE '2025-01-05', 'cc1'),
+		('sales', 'east', 'rev', 400, 100, 0, DATE '2025-01-20', NULL),
+		('materials', 'west', 'cogs', 0, 120, 0, DATE '2025-01-12', 'cc1'),
+		('materials', 'east', 'cogs', 0, 80, 0, DATE '2025-02-08', NULL),
+		('depr', 'west', 'depr', 0, 40, 0, DATE '2025-02-15', NULL),
+		('sales', 'west', 'ar', 0, 0, 180, DATE '2025-02-15', 'cc1')`);
 });
 afterAll(() => {
 	conn?.closeSync();
@@ -315,7 +318,12 @@ describe("composeNodeQuery — grouped", () => {
 			pins: [],
 		});
 		expect(q.sql).toContain("FULL JOIN");
-		expect(q.sql).not.toContain("COALESCE");
+		// NULL-safe carrier join (DAT-714): the spine matches on `IS NOT DISTINCT
+		// FROM`, not `USING`. The COALESCE here is the NULL-safe DIM KEY, never a
+		// value-fabricating COALESCE-0 — the value guard is the `— for the absent
+		// side` assertions below (east's value/avg_balance stay NULL).
+		expect(q.sql).toContain("IS NOT DISTINCT FROM");
+		expect(q.sql).not.toContain("USING (");
 		const byRegion = new Map((await rows(q.sql)).map((r) => [r.region, r]));
 		// AR balances exist only in the west: east has revenue but not the
 		// other carrier — NULL absorbs, the group is honestly undefined, and
@@ -522,6 +530,86 @@ describe("composeNodeQuery — grouped", () => {
 		);
 		expect(byRegion.get("west")).toBe(500);
 		expect(byRegion.get("east")).toBe(300);
+	});
+});
+
+// --- NULL-dim non-additive slice (DAT-714) ----------------------------------------
+//
+// `FULL JOIN … USING (dim)` treats NULL as UNEQUAL (NULL != NULL), so a slice
+// group whose dim is NULL never matches across carriers — it SPLITS into two
+// one-sided rows that each render `—` and DISCARD the real value. On the live
+// workspace `operating_margin` by `cost_center` (NULL for 52% of journal rows)
+// returned 7 rows for 6 groups, the NULL group twice and both dashed, its true
+// 46.46% lost. The fix joins ON `dim IS NOT DISTINCT FROM dim` (NULL ≡ NULL)
+// with a COALESCE'd key. cost_center is NULL for the 'east' rows here, and BOTH
+// carriers (revenue, cogs) are observed in the NULL group, so it must be ONE
+// row with a REAL value — the exact shape the buggy USING join loses.
+describe("composeNodeQuery — NULL-dim non-additive slice (DAT-714)", () => {
+	const RATIO: NodeStep[] = [
+		REVENUE,
+		COGS,
+		formula(
+			"rev_over_cogs",
+			"revenue / cost_of_goods_sold",
+			["revenue", "cost_of_goods_sold"],
+			true,
+		),
+	];
+	const sliced = (): ComposedNodeQuery =>
+		composed(RATIO, undefined, {
+			slices: [{ column: "cost_center" }],
+			pins: [],
+		});
+
+	it("joins NULL-safe (IS NOT DISTINCT FROM) — never FULL JOIN … USING", () => {
+		const q = sliced();
+		expect(q.sql).toContain("FULL JOIN");
+		expect(q.sql).toContain("IS NOT DISTINCT FROM");
+		expect(q.sql).not.toContain("USING (");
+	});
+
+	it("the NULL group is ONE row with the real value, never two dashes", async () => {
+		const result = await rows(sliced().sql);
+		// cc1 (both carriers) + NULL (both carriers) = exactly two groups. Under
+		// the USING bug the NULL group split into two dashed rows → three rows.
+		expect(result).toHaveLength(2);
+		// No duplicate group keys — the split's signature is two rows sharing a
+		// key (here, the NULL key appearing twice).
+		const keys = result.map((r) => JSON.stringify(r.cost_center));
+		expect(new Set(keys).size).toBe(keys.length);
+		const byCc = new Map(result.map((r) => [r.cost_center, r]));
+		expect(num(byCc.get("cc1")?.value)).toBeCloseTo(500 / 120, 9);
+		// The NULL group: revenue 300 (east 400−100), cogs 80 (east) — both
+		// observed, so a REAL value (3.75), never a dash.
+		const nullRow = byCc.get(null);
+		expect(nullRow).toBeDefined();
+		expect(num(nullRow?.value)).toBeCloseTo(300 / 80, 9);
+		expect(num(nullRow?.revenue)).toBe(300);
+		expect(num(nullRow?.cost_of_goods_sold)).toBe(80);
+	});
+
+	it("pin ≡ group for EVERY group INCLUDING the NULL group (IS NULL pin)", async () => {
+		const groups = await rows(sliced().sql);
+		// The NULL group must actually be present — the old test only sampled a
+		// non-null group, which is exactly why the split went uncaught.
+		expect(groups.some((r) => r.cost_center === null)).toBe(true);
+		for (const row of groups) {
+			const pinValue: DrillPinValue =
+				row.cost_center === null ? null : String(row.cost_center);
+			const pinned = composed(RATIO, undefined, {
+				slices: [],
+				pins: [{ column: "cost_center", value: pinValue }],
+			});
+			if (pinValue === null) {
+				expect(pinned.sql).toContain('"cost_center" IS NULL');
+				expect(pinned.params).toEqual([]);
+			}
+			const [pinnedRow] = await rows(pinned.sql, pinned.params);
+			expect(num(pinnedRow?.value)).toBeCloseTo(
+				num(row.value) ?? Number.NaN,
+				9,
+			);
+		}
 	});
 });
 

--- a/packages/cockpit/src/duckdb/parts.ts
+++ b/packages/cockpit/src/duckdb/parts.ts
@@ -28,10 +28,12 @@
 //   holds by algebra.
 //
 //   NON-ADDITIVE (any ratio, product, literal, constant ref, or fall-loud
-//   leaf) — carriers join `FULL JOIN … USING (dims)` and every ref renders
-//   BARE. SQL NULL absorbs through the arithmetic, so a group shows a value
-//   iff EVERY carrier the formula touches is observed in that group; anything
-//   partial is the honest `—` (filterable), never a fabricated number.
+//   leaf) — carriers join `FULL JOIN … ON (dim IS NOT DISTINCT FROM dim)`
+//   (NULL-safe: a slice group whose dim is NULL stays ONE group, not a split
+//   of dashes — DAT-714) and every ref renders BARE. SQL NULL absorbs through
+//   the arithmetic, so a group shows a value iff EVERY carrier the formula
+//   touches is observed in that group; anything partial is the honest `—`
+//   (filterable), never a fabricated number.
 //
 // Pins follow the node's mode (additive → contributions under the filter,
 // non-additive → bare), so a pinned re-evaluation reproduces exactly the
@@ -381,6 +383,23 @@ const invalidGrain = (token: string): { refusal: string } => ({
 		`1d, 1w, 1M, 1q, 1y (m is minutes, M is months)`,
 });
 
+/** A carrier CTE's dim column, fully qualified: `"revenue"."cost_center"`. The
+ *  carrier alias is its CTE name (a step id, IDENT_RE-gated) and the dim is a
+ *  slice column (user/agent-influenced) — both are quoted. */
+const qualifiedDim = (carrierId: string, dim: string): string =>
+	`${quoteIdentifier(carrierId)}.${quoteIdentifier(dim)}`;
+
+/** The NULL-safe dim key across the carriers already in the FULL-JOIN spine
+ *  (DAT-714). A FULL JOIN can leave ANY joined carrier's key NULL, so a dim's
+ *  live value is the COALESCE across every carrier so far — a single carrier
+ *  needs none. Drives BOTH the `IS NOT DISTINCT FROM` join key (left side) and
+ *  the `COALESCE(…) AS dim` output projection (with ON, not USING, every
+ *  carrier alias carries the dim, so a bare `dim` would be ambiguous). */
+const coalesceDim = (carrierIds: readonly string[], dim: string): string => {
+	const refs = carrierIds.map((c) => qualifiedDim(c, dim));
+	return refs.length === 1 ? refs[0] : `COALESCE(${refs.join(", ")})`;
+};
+
 function composeNode(
 	steps: NodeStep[],
 	requestedStepId: string | undefined,
@@ -687,14 +706,34 @@ function composeNode(
 				),
 			}));
 			if (dims.length > 0 && first !== undefined) {
-				// FULL JOIN … USING (dims) spine over the dim-carrying deps; scalar
-				// deps (constants, fall-loud extracts) stay subqueries in the value.
+				// NULL-SAFE FULL-JOIN spine over the dim-carrying deps (DAT-714);
+				// scalar deps (constants, fall-loud extracts) stay subqueries in the
+				// value. `FULL JOIN … USING (dim)` treats NULL as UNEQUAL (NULL !=
+				// NULL), so a slice group whose dim is NULL never matches across
+				// carriers — it SPLITS into two one-sided rows that each dash out and
+				// DISCARD the real value. Join ON `dim IS NOT DISTINCT FROM dim`
+				// instead (NULL ≡ NULL, one honest group); because a FULL JOIN can
+				// leave EITHER side's key NULL, the left key of each successive join
+				// is the COALESCE over every carrier already in the spine. The output
+				// dim is likewise COALESCE(all carriers) AS dim — with ON (not USING)
+				// every carrier alias carries the dim column, so a bare `dim` is
+				// ambiguous. (The additive path stays GROUP BY, which already folds
+				// NULL into one group — this is the non-additive spine only.)
+				const joined: string[] = [first];
 				let spine: Parameters<typeof join>[0] = first;
 				for (const dep of rest) {
-					spine = join(spine, dep, { type: "FULL", using: dimColumns });
+					const on = dimColumns
+						.map(
+							(d) =>
+								`(${coalesceDim(joined, d)} IS NOT DISTINCT FROM ` +
+								`${qualifiedDim(dep, d)})`,
+						)
+						.join(" AND ");
+					spine = join(spine, dep, { type: "FULL", on: verbatim(on) });
+					joined.push(dep);
 				}
 				ctes[step.stepId] = Query.from(spine).select(
-					...dimColumns.map((d) => column(d)),
+					...dimColumns.map((d) => ({ [d]: verbatim(coalesceDim(joined, d)) })),
 					...operandCols,
 					{
 						value: verbatim(rendered.sql),


### PR DESCRIPTION
## The bug (verified on live data)

`packages/cockpit/src/duckdb/parts.ts` composes a non-additive metric drill (a ratio like `operating_margin`) by joining the dim-carrying carrier CTEs with `FULL JOIN … USING(dim)`. `USING` treats NULL as **unequal** (`NULL != NULL`), so when the slice dimension has NULL values (e.g. `cost_center` is NULL for 52% of journal rows) the NULL group never matches across carriers: it **SPLITS into two one-sided rows** that each render a dash (`—`) and **discard the real value**.

On the live workspace, `operating_margin` by `cost_center` returned **7 rows for 6 groups** — the NULL group appeared twice, both dashed, true value **46.46% lost**. The additive path was already correct because it uses `GROUP BY`, which folds NULL into one group.

## The fix

Make the carrier join NULL-safe and type-preserving (semantics verified against the real lake in a Python spike):

1. Replace `USING(dim)` with an explicit `ON dim IS NOT DISTINCT FROM dim` per dim (NULL matches NULL). For the chained spine (`carrier1 FULL JOIN carrier2 FULL JOIN carrier3 …`), the **left key of each successive join is `COALESCE(<all prior carriers>.dim)`** — a FULL JOIN can leave either side's key NULL.
2. The output dim projection becomes `COALESCE(c1.dim, c2.dim, …) AS dim` — with `ON` (not `USING`) every carrier alias now carries the dim column, so a bare `dim` would be ambiguous.

The value expression is **unchanged** (bare refs, `NULLIF`-guarded division). The **additive path and every other composition tier are untouched.**

Generated SQL (`rev_over_cogs` sliced by `cost_center`), matching the spike's reference shape:

```sql
... "rev_over_cogs" AS (
  SELECT COALESCE("revenue"."cost_center", "cost_of_goods_sold"."cost_center") AS "cost_center",
         "revenue"."value" AS "revenue",
         "cost_of_goods_sold"."value" AS "cost_of_goods_sold",
         ("revenue"."value" / NULLIF("cost_of_goods_sold"."value", 0)) AS "value"
  FROM "revenue"
  FULL JOIN "cost_of_goods_sold"
    ON ("revenue"."cost_center" IS NOT DISTINCT FROM "cost_of_goods_sold"."cost_center")
) ...
```

3-carrier chained spine correctly COALESCEs over all prior carriers:

```
FROM "a" FULL JOIN "b" ON ("a"."d1" IS NOT DISTINCT FROM "b"."d1") ...
       FULL JOIN "c" ON (COALESCE("a"."d1", "b"."d1") IS NOT DISTINCT FROM "c"."d1") ...
```

## Test hardening

`parts.test.ts` gains a partially-NULL slice dim (`cost_center`, NULL for the `east` rows — both carriers observed in the NULL group and in `cc1`) and a new `NULL-dim non-additive slice (DAT-714)` block:
- NULL group is **ONE row with the real value** (`300/80 = 3.75`), never two dashes; **no duplicate group keys**.
- **pin ≡ group for EVERY group INCLUDING the NULL group** (a NULL-group pin renders `IS NULL`, consumes no param).
- joins NULL-safe (`IS NOT DISTINCT FROM`), never `FULL JOIN … USING`.

The existing one-sided-ratio test's stale `not.toContain("COALESCE")` string-proxy is replaced by `toContain("IS NOT DISTINCT FROM")` + `not.toContain("USING (")`; its value-fabrication guard (the absent side stays NULL) is unchanged.

**These 4 tests fail against the old `USING` join and pass with the fix** (verified by reverting only the source change).

## Verification

- `bun run test` — **177 files, 1669 tests, all green** (parts.test.ts: 47).
- `bun run check` (biome) — clean.
- `tsc --noEmit` — clean.

```
 Test Files  177 passed (177)
      Tests  1669 passed (1669)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)