### PR TITLE
feat(DAT-716): engine-authored metric-drill additivity verdict

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -27,6 +27,14 @@ calibration change** — the metric grounding numbers are untouched.
   (measure, dimension)) so the full additivity matrix is exercised on real
   metrics. That is where testdata + a new calibration/eval check land.
 
+### Confirmed for DAT-717 (drill axes)
+
+A fact's own bare date/period column DOES reach the drill axis set today: the
+enriched view selects `f.*` for fact columns (`analysis/views/builder.py`),
+unfiltered by role/type — so `trial_balance.period` survives into the view as a
+usable categorical axis. No engine fix was needed for the DAT-716 AC7 check;
+surfacing it as a *time grain* (vs a categorical slice) is DAT-717's call.
+
 ### For testdata (directional, lands in DAT-718)
 
 The current finance corpus exercises only `SUM(flow)` (→ additive) and

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -13,19 +13,21 @@ calibration change** — the metric grounding numbers are untouched.
 ### What changed
 
 - **New artifact `metric_additivity`** (read-view `current_metric_additivity`,
-  operating_model stage): one row per executed metric —
-  `{categorical_additive, time_additive, categorical_reason, time_reason}`. The
-  operating_model `metrics` phase now computes it (deterministically, no LLM)
-  after each metric executes, classifying whether the value reconciles under
-  aggregation across categorical vs time axes (function symmetry × stock/flow ×
-  periodic-snapshot grain, rolled up through the metric DAG). A metric with an
-  unresolved extract gets no row.
-- **No response-shape change to existing artifacts.** The drill (cockpit) will
-  consume this in DAT-717; the eval-relevant work is **DAT-718** — extending the
-  finance vertical + `dataraum-testdata` with `AVG` / `COUNT(*)` /
-  `COUNT(DISTINCT)` metrics and a ground-truth oracle (expected verdict per
-  (measure, dimension)) so the full additivity matrix is exercised on real
-  metrics. That is where testdata + a new calibration/eval check land.
+  operating_model stage): one row per **drill target**, keyed
+  `(target_kind, target_key, run_id)` — `'metric'` (graph_id) for a formula node,
+  `'measure'` (standard_field) for a grounded-extract node (both are drillable).
+  Payload `{categorical_additive, time_additive, categorical_reason, time_reason}`.
+  The operating_model `metrics` phase computes it (deterministically, no LLM)
+  after metrics execute: each extract is classified (function symmetry × stock/flow
+  × periodic-snapshot grain), rolled up through the DAG for the metric verdict and
+  mapped by standard_field for the measure verdicts. An unresolved target gets no
+  row.
+- **No response-shape change to existing artifacts.** The drill (cockpit) consumes
+  this in DAT-717 (reading by `target_kind`); the eval-relevant work is **DAT-718**
+  — extending the finance vertical + `dataraum-testdata` with `AVG` / `COUNT(*)` /
+  `COUNT(DISTINCT)` metrics and a ground-truth oracle so the full additivity matrix
+  is exercised on real metrics. That is where testdata + a new calibration/eval
+  check land.
 
 ### Confirmed for DAT-717 (drill axes)
 
@@ -37,11 +39,11 @@ surfacing it as a *time grain* (vs a categorical slice) is DAT-717's call.
 
 ### For testdata (directional, lands in DAT-718)
 
-The current finance corpus exercises only `SUM(flow)` (→ additive) and
-`SUM(stock)` (→ semi-additive) and ratios (→ non-additive). To cover the matrix,
-DAT-718 needs induced metrics using `COUNT(*)` (event fact → time-additive),
-`COUNT(DISTINCT)` (→ non-additive), and `AVG` (→ non-additive), plus a standalone
-stock metric with a surfaced date axis.
+The current finance corpus already exercises `SUM(flow)` (→ additive), `SUM(stock)`
+(→ semi-additive — fires live now via the **measure** verdicts, e.g. `current_assets`),
+and ratios (→ non-additive). To cover the rest of the matrix, DAT-718 needs induced
+metrics using `COUNT(*)` (event fact → time-additive), `COUNT(DISTINCT)`
+(→ non-additive), and `AVG` (→ non-additive), plus the ground-truth oracle.
 
 ---
 

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,38 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-716 — metric additivity verdict (new `metric_additivity` read-view)
+
+**Branch:** `feat/dat-716-additivity-verdict`. Engine-internal, **no detector or
+calibration change** — the metric grounding numbers are untouched.
+
+### What changed
+
+- **New artifact `metric_additivity`** (read-view `current_metric_additivity`,
+  operating_model stage): one row per executed metric —
+  `{categorical_additive, time_additive, categorical_reason, time_reason}`. The
+  operating_model `metrics` phase now computes it (deterministically, no LLM)
+  after each metric executes, classifying whether the value reconciles under
+  aggregation across categorical vs time axes (function symmetry × stock/flow ×
+  periodic-snapshot grain, rolled up through the metric DAG). A metric with an
+  unresolved extract gets no row.
+- **No response-shape change to existing artifacts.** The drill (cockpit) will
+  consume this in DAT-717; the eval-relevant work is **DAT-718** — extending the
+  finance vertical + `dataraum-testdata` with `AVG` / `COUNT(*)` /
+  `COUNT(DISTINCT)` metrics and a ground-truth oracle (expected verdict per
+  (measure, dimension)) so the full additivity matrix is exercised on real
+  metrics. That is where testdata + a new calibration/eval check land.
+
+### For testdata (directional, lands in DAT-718)
+
+The current finance corpus exercises only `SUM(flow)` (→ additive) and
+`SUM(stock)` (→ semi-additive) and ratios (→ non-additive). To cover the matrix,
+DAT-718 needs induced metrics using `COUNT(*)` (event fact → time-additive),
+`COUNT(DISTINCT)` (→ non-additive), and `AVG` (→ non-additive), plus a standalone
+stock metric with a surfaced date axis.
+
+---
+
 ## DAT-699 — flag-and-surface over fabricated determinism (metric grounding + enrichment)
 
 **Branch:** `feat/dat-699-flag-and-surface`. Seven changes from the the bookkeeping smoke corpus

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -322,6 +322,21 @@ export const currentMeasureAggregationLineage = metadataSchema
 		sql`SELECT lineage_id, run_id, measure_table_id, measure_column_id, event_table_id, slice_dimension, convention_sql, period_grain, pattern, match_rate, r_flow_median, r_stock_median, n_entities, n_entities_fired, created_at FROM ws_00000000_0000_0000_0000_000000000001.measure_aggregation_lineage r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
 	);
 
+export const currentMetricAdditivity = metadataSchema
+	.view("current_metric_additivity", {
+		additivityId: varchar("additivity_id"),
+		runId: varchar("run_id"),
+		metricKey: varchar("metric_key"),
+		categoricalAdditive: boolean("categorical_additive"),
+		timeAdditive: boolean("time_additive"),
+		categoricalReason: varchar("categorical_reason"),
+		timeReason: varchar("time_reason"),
+		createdAt: timestamp("created_at", { withTimezone: true }),
+	})
+	.as(
+		sql`SELECT additivity_id, run_id, metric_key, categorical_additive, time_additive, categorical_reason, time_reason, created_at FROM ws_00000000_0000_0000_0000_000000000001.metric_additivity r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'operating_model'::text AND h.run_id::text = r.run_id::text))`,
+	);
+
 export const currentRelationships = metadataSchema
 	.view("current_relationships", {
 		relationshipId: varchar("relationship_id"),

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -326,7 +326,8 @@ export const currentMetricAdditivity = metadataSchema
 	.view("current_metric_additivity", {
 		additivityId: varchar("additivity_id"),
 		runId: varchar("run_id"),
-		metricKey: varchar("metric_key"),
+		targetKind: varchar("target_kind"),
+		targetKey: varchar("target_key"),
 		categoricalAdditive: boolean("categorical_additive"),
 		timeAdditive: boolean("time_additive"),
 		categoricalReason: varchar("categorical_reason"),
@@ -334,7 +335,7 @@ export const currentMetricAdditivity = metadataSchema
 		createdAt: timestamp("created_at", { withTimezone: true }),
 	})
 	.as(
-		sql`SELECT additivity_id, run_id, metric_key, categorical_additive, time_additive, categorical_reason, time_reason, created_at FROM ws_00000000_0000_0000_0000_000000000001.metric_additivity r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'operating_model'::text AND h.run_id::text = r.run_id::text))`,
+		sql`SELECT additivity_id, run_id, target_kind, target_key, categorical_additive, time_additive, categorical_reason, time_reason, created_at FROM ws_00000000_0000_0000_0000_000000000001.metric_additivity r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'operating_model'::text AND h.run_id::text = r.run_id::text))`,
 	);
 
 export const currentRelationships = metadataSchema

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -69,19 +69,20 @@ CREATE TABLE metadata_snapshot_head (
 CREATE TABLE metric_additivity (
 	additivity_id VARCHAR NOT NULL, 
 	run_id VARCHAR NOT NULL, 
-	metric_key VARCHAR NOT NULL, 
+	target_kind VARCHAR NOT NULL, 
+	target_key VARCHAR NOT NULL, 
 	categorical_additive BOOLEAN NOT NULL, 
 	time_additive BOOLEAN NOT NULL, 
 	categorical_reason VARCHAR, 
 	time_reason VARCHAR, 
 	created_at TIMESTAMP WITH TIME ZONE NOT NULL, 
 	CONSTRAINT pk_metric_additivity PRIMARY KEY (additivity_id), 
-	CONSTRAINT uq_metric_additivity_metric_run UNIQUE (metric_key, run_id)
+	CONSTRAINT uq_metric_additivity_target UNIQUE (target_kind, target_key, run_id)
 );
 
-CREATE INDEX ix_metric_additivity_metric_key ON metric_additivity (metric_key);
-
 CREATE INDEX ix_metric_additivity_run_id ON metric_additivity (run_id);
+
+CREATE INDEX ix_metric_additivity_target_key ON metric_additivity (target_key);
 
 CREATE TABLE sources (
 	source_id VARCHAR NOT NULL, 

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -66,6 +66,23 @@ CREATE TABLE metadata_snapshot_head (
 	CONSTRAINT uq_snapshot_head_target_stage UNIQUE (target, stage)
 );
 
+CREATE TABLE metric_additivity (
+	additivity_id VARCHAR NOT NULL, 
+	run_id VARCHAR NOT NULL, 
+	metric_key VARCHAR NOT NULL, 
+	categorical_additive BOOLEAN NOT NULL, 
+	time_additive BOOLEAN NOT NULL, 
+	categorical_reason VARCHAR, 
+	time_reason VARCHAR, 
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL, 
+	CONSTRAINT pk_metric_additivity PRIMARY KEY (additivity_id), 
+	CONSTRAINT uq_metric_additivity_metric_run UNIQUE (metric_key, run_id)
+);
+
+CREATE INDEX ix_metric_additivity_metric_key ON metric_additivity (metric_key);
+
+CREATE INDEX ix_metric_additivity_run_id ON metric_additivity (run_id);
+
 CREATE TABLE sources (
 	source_id VARCHAR NOT NULL, 
 	name VARCHAR NOT NULL, 

--- a/packages/engine/schema_read.sql
+++ b/packages/engine/schema_read.sql
@@ -229,6 +229,16 @@ DROP VIEW IF EXISTS __READ__.metadata_snapshot_head;
 CREATE VIEW __READ__.metadata_snapshot_head AS
 SELECT * FROM __WS__.metadata_snapshot_head;
 
+DROP VIEW IF EXISTS __READ__.current_metric_additivity;
+CREATE VIEW __READ__.current_metric_additivity AS
+SELECT r.* FROM __WS__.metric_additivity r
+WHERE EXISTS (
+  SELECT 1 FROM __WS__.metadata_snapshot_head h
+  WHERE h.target = 'catalog'
+    AND h.stage = 'operating_model'
+    AND h.run_id = r.run_id
+);
+
 DROP VIEW IF EXISTS __READ__.current_relationships;
 CREATE VIEW __READ__.current_relationships AS
 SELECT r.* FROM __WS__.relationships r

--- a/packages/engine/src/dataraum/graphs/additivity.py
+++ b/packages/engine/src/dataraum/graphs/additivity.py
@@ -1,0 +1,358 @@
+"""Additivity verdict for a grounded metric (DAT-716).
+
+Deterministic classification of whether a metric's value *reconciles* under
+aggregation across an axis class — the drill's grounding for two decisions:
+offer a time grain, and sum vs dash a categorical breakdown. No measurement,
+no LLM: a pure function over signals the pipeline already computes.
+
+Two independent rules (Kimball / Malloy aggregate locality):
+
+* **function symmetry** — a property of the aggregate alone, on *every* axis:
+  ``SUM``/``COUNT(*)``/``COUNT(col)`` reconcile under ``SUM``; ``AVG`` and
+  ``COUNT(DISTINCT)`` never do; ``MIN``/``MAX`` are non-summable this cut
+  (symmetric under their own function — a later refinement).
+* **time semi-additivity** — even ``SUM`` is non-additive *across time* when its
+  column is a stock (``temporal_behavior='point_in_time'``); a ``COUNT`` is
+  non-additive across time on a **periodic-snapshot** fact (a time column sits in
+  the fact's grain, e.g. a trial balance keyed by ``(account, period)``).
+
+The per-extract atoms compose through the metric DAG: a division (ratio) is
+non-additive on every axis whatever its operands; a sum/difference of additive
+extracts stays additive; any non-additive operand poisons the whole metric.
+
+The ``select_expr`` parse is the verified seam (DAT-713 ``json_serialize_sql`` on
+one small single-relation expression — never the composed metric SQL): it holds
+only the measure aggregates, so every ``COLUMN_REF`` under an aggregate node is a
+base column of that measure, with no filter-column contamination.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import duckdb
+
+# --- reasons a breakdown does not reconcile (surfaced to the drill) -----------
+STOCK = "stock"  # SUM of a point-in-time balance — not additive across time
+AVERAGE = "average"  # AVG — an average of averages is meaningless
+DISTINCT_COUNT = "distinct_count"  # COUNT(DISTINCT) — slices overlap
+MIN_MAX = "min_max"  # MIN/MAX — non-summable this cut
+SNAPSHOT_COUNT = "snapshot_count"  # COUNT over a periodic-snapshot fact, across time
+RATIO = "ratio"  # a formula division/product of measures
+UNKNOWN_AGGREGATE = "unknown_aggregate"  # an aggregate outside the doctrine — conservative
+
+POINT_IN_TIME = "point_in_time"  # temporal_behavior value marking a stock column
+
+
+@dataclass(frozen=True)
+class AggregateCall:
+    """One aggregate application inside an extract's ``select_expr``.
+
+    ``function`` is normalized to the doctrine's vocabulary
+    (``sum``/``count``/``count_star``/``count_distinct``/``avg``/``min``/``max``
+    or the raw lowercase name for anything else). ``columns`` are the base
+    columns aggregated (empty for ``COUNT(*)``).
+    """
+
+    function: str
+    columns: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AxisClass:
+    """Whether a value reconciles under SUM across the two axis classes.
+
+    ``categorical_additive`` — a breakdown by a (grain-safe) categorical
+    dimension sums to the unsliced total. ``time_additive`` — a breakdown by a
+    time grain sums to the total (the semi-additive question). A reason names
+    *why* an axis does not reconcile, for the drill to phrase plainly.
+    """
+
+    categorical_additive: bool
+    time_additive: bool
+    categorical_reason: str | None = None
+    time_reason: str | None = None
+    #: True only for a pure constant/scalar operand — it scales a measure under
+    #: multiplication without changing the measure's additivity (never emitted
+    #: as a metric verdict; an internal roll-up marker).
+    is_constant: bool = False
+
+
+ADDITIVE = AxisClass(categorical_additive=True, time_additive=True)
+CONSTANT = AxisClass(categorical_additive=True, time_additive=True, is_constant=True)
+
+
+# =============================================================================
+# 1. Parse: select_expr -> aggregate calls
+# =============================================================================
+
+
+def parse_aggregate_calls(select_expr: str, con: duckdb.DuckDBPyConnection) -> list[AggregateCall]:
+    """Recover every aggregate call in an extract's ``select_expr``.
+
+    Parses ``SELECT <select_expr>`` with DuckDB's own serializer (a catalog-free
+    parse — the columns/relation need not exist) and walks the AST for
+    ``FUNCTION`` nodes whose name is a DuckDB aggregate, collecting the
+    ``COLUMN_REF`` base columns beneath each. Arithmetic operators and
+    ``COALESCE`` are non-aggregate nodes and are recursed *through*, not counted.
+
+    Raises:
+        ValueError: the expression does not parse (a malformed catalogue extract
+            — surfaced loud rather than silently classified).
+    """
+    try:
+        raw = con.execute("SELECT json_serialize_sql(?)", [f"SELECT {select_expr}"]).fetchone()
+    except duckdb.Error as exc:  # pragma: no cover - defensive
+        raise ValueError(f"unparseable select_expr {select_expr!r}: {exc}") from exc
+    if raw is None:  # pragma: no cover - json_serialize_sql always returns a row
+        raise ValueError(f"select_expr {select_expr!r} did not serialize")
+    doc = json.loads(raw[0])
+    if doc.get("error"):
+        raise ValueError(f"unparseable select_expr {select_expr!r}: {doc.get('error_message')}")
+    agg_names = _aggregate_function_names(con)
+    calls: list[AggregateCall] = []
+    _collect_aggregates(doc["statements"][0]["node"]["select_list"], agg_names, calls)
+    return calls
+
+
+_AGG_NAMES: frozenset[str] | None = None
+
+
+def _aggregate_function_names(con: duckdb.DuckDBPyConnection) -> frozenset[str]:
+    """DuckDB's aggregate-function names (memoized; connection-independent).
+
+    The authority for "is this FUNCTION node an aggregate?" — it separates
+    ``sum``/``count`` from the arithmetic operators (``-``/``*``) that serialize
+    as ``FUNCTION`` nodes too. The set is the same for every connection, so one
+    global memo is safe.
+    """
+    global _AGG_NAMES
+    if _AGG_NAMES is None:
+        rows = con.execute(
+            "SELECT DISTINCT function_name FROM duckdb_functions() WHERE function_type='aggregate'"
+        ).fetchall()
+        _AGG_NAMES = frozenset(r[0] for r in rows)
+    return _AGG_NAMES
+
+
+def _collect_aggregates(node: Any, agg_names: frozenset[str], out: list[AggregateCall]) -> None:
+    """Recurse the AST, appending an ``AggregateCall`` per aggregate FUNCTION.
+
+    An aggregate's own arguments are scanned for columns but not for further
+    aggregates (aggregates do not nest); every other node is recursed through.
+    """
+    if isinstance(node, dict):
+        if node.get("class") == "FUNCTION" and node.get("function_name") in agg_names:
+            out.append(
+                AggregateCall(
+                    function=_normalize_function(node),
+                    columns=tuple(_column_refs(node.get("children", []))),
+                )
+            )
+            return
+        for value in node.values():
+            _collect_aggregates(value, agg_names, out)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_aggregates(item, agg_names, out)
+
+
+def _normalize_function(node: dict[str, Any]) -> str:
+    """Map a FUNCTION node to the doctrine vocabulary.
+
+    ``count`` + ``distinct`` → ``count_distinct``; everything else its lowercase name.
+    """
+    name = str(node.get("function_name", "")).lower()
+    if name == "count" and node.get("distinct"):
+        return "count_distinct"
+    return name
+
+
+def _column_refs(node: Any) -> list[str]:
+    """Every ``COLUMN_REF`` base column beneath a node.
+
+    The last name in a ``COLUMN_REF`` is the column, stripping any ``table.`` qualifier.
+    """
+    cols: list[str] = []
+
+    def rec(n: Any) -> None:
+        if isinstance(n, dict):
+            if n.get("class") == "COLUMN_REF":
+                names = n.get("column_names") or []
+                if names:
+                    cols.append(names[-1])
+            else:
+                for value in n.values():
+                    rec(value)
+        elif isinstance(n, list):
+            for item in n:
+                rec(item)
+
+    rec(node)
+    return cols
+
+
+# =============================================================================
+# 2. Classify: an extract's aggregate calls -> AxisClass
+# =============================================================================
+
+
+def classify_extract(
+    calls: list[AggregateCall],
+    temporal_by_column: dict[str, str | None],
+    fact_is_snapshot: bool,
+) -> AxisClass:
+    """The additivity of one extract — the most-restrictive of its aggregate calls.
+
+    ``temporal_by_column`` maps each base column to its ``temporal_behavior``
+    (``'additive'`` / ``'point_in_time'`` / ``None``); ``fact_is_snapshot`` is
+    True when a time column sits in the extract's fact grain (a periodic
+    snapshot), the ``COUNT``-across-time signal. An extract with no aggregate
+    (a bare passthrough) is treated as additive.
+    """
+    result = ADDITIVE
+    for call in calls:
+        result = _most_restrictive(
+            result, _classify_call(call, temporal_by_column, fact_is_snapshot)
+        )
+    return result
+
+
+def _classify_call(
+    call: AggregateCall, temporal_by_column: dict[str, str | None], fact_is_snapshot: bool
+) -> AxisClass:
+    fn = call.function
+    if fn == "sum":
+        stock = any(temporal_by_column.get(c) == POINT_IN_TIME for c in call.columns)
+        # SUM reconciles across categorical dims always; across time only for flows.
+        return AxisClass(True, not stock, None, STOCK if stock else None)
+    if fn in ("count_star", "count"):
+        # Counting rows/values: additive across categorical; across time only when
+        # the fact is not a periodic snapshot (else each period recounts the same population).
+        return AxisClass(
+            True, not fact_is_snapshot, None, SNAPSHOT_COUNT if fact_is_snapshot else None
+        )
+    if fn == "count_distinct":
+        return AxisClass(False, False, DISTINCT_COUNT, DISTINCT_COUNT)
+    if fn == "avg":
+        return AxisClass(False, False, AVERAGE, AVERAGE)
+    if fn in ("min", "max"):
+        return AxisClass(False, False, MIN_MAX, MIN_MAX)
+    # An aggregate outside the doctrine — do not guess it reconciles.
+    return AxisClass(False, False, UNKNOWN_AGGREGATE, UNKNOWN_AGGREGATE)
+
+
+def _most_restrictive(a: AxisClass, b: AxisClass) -> AxisClass:
+    """Combine two classes conservatively.
+
+    An axis is additive only if both are; a reason is carried from whichever side
+    made the axis non-additive.
+    """
+    return AxisClass(
+        categorical_additive=a.categorical_additive and b.categorical_additive,
+        time_additive=a.time_additive and b.time_additive,
+        categorical_reason=a.categorical_reason
+        or (b.categorical_reason if not b.categorical_additive else None),
+        time_reason=a.time_reason or (b.time_reason if not b.time_additive else None),
+    )
+
+
+# =============================================================================
+# 3. Roll up: the metric DAG -> one verdict
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class MetricVerdict:
+    """A metric's additivity, as the drill reads it."""
+
+    categorical_additive: bool
+    time_additive: bool
+    categorical_reason: str | None = None
+    time_reason: str | None = None
+
+
+def roll_up_metric(graph: Any, extract_class_by_step: dict[str, AxisClass]) -> MetricVerdict:
+    """Compose the per-extract classes through the metric DAG to one verdict.
+
+    ``graph`` is a ``TransformationGraph``; ``extract_class_by_step`` gives the
+    ``AxisClass`` of each EXTRACT leaf (from :func:`classify_extract`). Walks the
+    output step: a FORMULA combines its dependencies by operator (a division or a
+    product of two measures ⇒ ratio, non-additive on every axis; add/subtract or
+    scale-by-constant ⇒ combine the operands); a CONSTANT is a scalar identity.
+    """
+    output = graph.get_output_step()
+    if output is None:
+        # No output marker — fall to the most-restrictive over whatever we classified.
+        result = ADDITIVE
+        for cls in extract_class_by_step.values():
+            result = _most_restrictive(result, cls)
+        return _to_verdict(result)
+    return _to_verdict(_step_class(output.step_id, graph, extract_class_by_step))
+
+
+def _step_class(step_id: str, graph: Any, extract_class_by_step: dict[str, AxisClass]) -> AxisClass:
+    from dataraum.graphs.models import StepType
+
+    step = graph.steps.get(step_id)
+    if step is None:
+        # A referenced-but-absent dependency — conservative.
+        return AxisClass(False, False, UNKNOWN_AGGREGATE, UNKNOWN_AGGREGATE)
+    if step.step_type == StepType.EXTRACT:
+        return extract_class_by_step.get(step_id, ADDITIVE)
+    if step.step_type == StepType.CONSTANT:
+        return CONSTANT
+    # FORMULA: classify its expression over the dependency step ids.
+    try:
+        tree = ast.parse(step.expression or "", mode="eval")
+    except SyntaxError:
+        return AxisClass(False, False, RATIO, RATIO)
+    return _expr_class(tree.body, graph, extract_class_by_step)
+
+
+def _expr_class(
+    node: ast.expr, graph: Any, extract_class_by_step: dict[str, AxisClass]
+) -> AxisClass:
+    if isinstance(node, ast.Name):
+        return _step_class(node.id, graph, extract_class_by_step)
+    if isinstance(node, ast.Constant):
+        return CONSTANT
+    if isinstance(node, ast.UnaryOp):
+        return _expr_class(node.operand, graph, extract_class_by_step)
+    if isinstance(node, ast.BinOp):
+        left = _expr_class(node.left, graph, extract_class_by_step)
+        right = _expr_class(node.right, graph, extract_class_by_step)
+        if isinstance(node.op, ast.Div):
+            # A ratio never reconciles under SUM, whatever its operands.
+            return AxisClass(False, False, RATIO, RATIO)
+        if isinstance(node.op, ast.Mult):
+            # Scaling a measure by a constant preserves its additivity; a product
+            # of two measures does not.
+            if left.is_constant:
+                return right
+            if right.is_constant:
+                return left
+            return AxisClass(False, False, RATIO, RATIO)
+        # Add / Sub: additive combination — reconciles only where both operands do.
+        combined = _most_restrictive(left, right)
+        return AxisClass(
+            combined.categorical_additive,
+            combined.time_additive,
+            combined.categorical_reason,
+            combined.time_reason,
+            is_constant=left.is_constant and right.is_constant,
+        )
+    # Any other node shape — conservative.
+    return AxisClass(False, False, RATIO, RATIO)
+
+
+def _to_verdict(cls: AxisClass) -> MetricVerdict:
+    return MetricVerdict(
+        categorical_additive=cls.categorical_additive,
+        time_additive=cls.time_additive,
+        categorical_reason=cls.categorical_reason,
+        time_reason=cls.time_reason,
+    )

--- a/packages/engine/src/dataraum/graphs/additivity.py
+++ b/packages/engine/src/dataraum/graphs/additivity.py
@@ -283,7 +283,9 @@ def classify_extract(
     # (``CASE WHEN COUNT(*)=0 THEN NULL ELSE <measure> END``), not the measure — the
     # value is the other aggregate. Drop it so the guard can't strip time or taint
     # the reason (a stock balance reads ``stock``, not ``snapshot_count``). A
-    # COUNT(*) ALONE is a genuine count measure and is kept.
+    # COUNT(*) ALONE is a genuine count measure and is kept. This targets the one
+    # guard idiom the grounding prompt emits (COUNT(*)); a COUNT(1)/COUNT(col) guard
+    # would not be recognized, but the prompt never produces those.
     measures = [c for c in calls if not (c.function == "count_star" and not c.columns)]
     result = ADDITIVE
     for call in measures or calls:

--- a/packages/engine/src/dataraum/graphs/additivity.py
+++ b/packages/engine/src/dataraum/graphs/additivity.py
@@ -41,10 +41,12 @@ AVERAGE = "average"  # AVG — an average of averages is meaningless
 DISTINCT_COUNT = "distinct_count"  # COUNT(DISTINCT) — slices overlap
 MIN_MAX = "min_max"  # MIN/MAX — non-summable this cut
 SNAPSHOT_COUNT = "snapshot_count"  # COUNT over a periodic-snapshot fact, across time
-RATIO = "ratio"  # a formula division/product of measures
+RATIO = "ratio"  # a formula/extract division or product of measures
 UNKNOWN_AGGREGATE = "unknown_aggregate"  # an aggregate outside the doctrine — conservative
+UNKNOWN_TEMPORAL = "unknown_temporal"  # an aggregated column with no resolved stock/flow verdict
 
 POINT_IN_TIME = "point_in_time"  # temporal_behavior value marking a stock column
+FLOW = "additive"  # temporal_behavior value marking a flow column
 
 
 @dataclass(frozen=True)
@@ -103,19 +105,73 @@ def parse_aggregate_calls(select_expr: str, con: duckdb.DuckDBPyConnection) -> l
         ValueError: the expression does not parse (a malformed catalogue extract
             — surfaced loud rather than silently classified).
     """
+    doc = _serialize(select_expr, con)
+    agg_names = _aggregate_function_names(con)
+    calls: list[AggregateCall] = []
+    _collect_aggregates(doc["statements"][0]["node"]["select_list"], agg_names, calls)
+    return calls
+
+
+def select_expr_is_ratio(select_expr: str, con: duckdb.DuckDBPyConnection) -> bool:
+    """Whether the extract combines its measures by division or a product of measures.
+
+    A ratio computed inline in ONE ``select_expr`` (``SUM(num) / SUM(den)``) does
+    not reconcile under SUM, exactly like a formula-level division — but the flat
+    aggregate-call list can't see it. Detected structurally on the AST: a ``/``
+    whose denominator subtree contains an aggregate (dividing by a measure —
+    scaling by a constant stays additive), or a ``*`` whose BOTH sides contain an
+    aggregate (a product of measures). Sums/differences, constant scaling, and
+    ``COALESCE`` guards are not ratios.
+    """
+    doc = _serialize(select_expr, con)
+    agg_names = _aggregate_function_names(con)
+    return _has_ratio(doc["statements"][0]["node"]["select_list"], agg_names)
+
+
+def _serialize(select_expr: str, con: duckdb.DuckDBPyConnection) -> dict[str, Any]:
+    """Parse ``SELECT <select_expr>`` to DuckDB's JSON AST (a catalog-free parse)."""
     try:
         raw = con.execute("SELECT json_serialize_sql(?)", [f"SELECT {select_expr}"]).fetchone()
     except duckdb.Error as exc:  # pragma: no cover - defensive
         raise ValueError(f"unparseable select_expr {select_expr!r}: {exc}") from exc
     if raw is None:  # pragma: no cover - json_serialize_sql always returns a row
         raise ValueError(f"select_expr {select_expr!r} did not serialize")
-    doc = json.loads(raw[0])
+    doc: dict[str, Any] = json.loads(raw[0])
     if doc.get("error"):
         raise ValueError(f"unparseable select_expr {select_expr!r}: {doc.get('error_message')}")
-    agg_names = _aggregate_function_names(con)
-    calls: list[AggregateCall] = []
-    _collect_aggregates(doc["statements"][0]["node"]["select_list"], agg_names, calls)
-    return calls
+    return doc
+
+
+def _has_ratio(node: Any, agg_names: frozenset[str]) -> bool:
+    """A division-by-measure or product-of-measures anywhere in the AST."""
+    if isinstance(node, dict):
+        if node.get("class") == "FUNCTION":
+            fn = node.get("function_name")
+            kids = node.get("children") or []
+            if fn == "/" and len(kids) == 2 and _has_aggregate(kids[1], agg_names):
+                return True
+            if (
+                fn == "*"
+                and len(kids) == 2
+                and _has_aggregate(kids[0], agg_names)
+                and _has_aggregate(kids[1], agg_names)
+            ):
+                return True
+        return any(_has_ratio(v, agg_names) for v in node.values())
+    if isinstance(node, list):
+        return any(_has_ratio(item, agg_names) for item in node)
+    return False
+
+
+def _has_aggregate(node: Any, agg_names: frozenset[str]) -> bool:
+    """Whether an aggregate FUNCTION appears anywhere in a subtree."""
+    if isinstance(node, dict):
+        if node.get("class") == "FUNCTION" and node.get("function_name") in agg_names:
+            return True
+        return any(_has_aggregate(v, agg_names) for v in node.values())
+    if isinstance(node, list):
+        return any(_has_aggregate(item, agg_names) for item in node)
+    return False
 
 
 _AGG_NAMES: frozenset[str] | None = None
@@ -127,7 +183,9 @@ def _aggregate_function_names(con: duckdb.DuckDBPyConnection) -> frozenset[str]:
     The authority for "is this FUNCTION node an aggregate?" — it separates
     ``sum``/``count`` from the arithmetic operators (``-``/``*``) that serialize
     as ``FUNCTION`` nodes too. The set is the same for every connection, so one
-    global memo is safe.
+    global memo is safe; the unlocked check-then-set is benign (the value is
+    idempotent and the GIL makes the assignment atomic — and the metrics phase
+    only reaches this after its ThreadPoolExecutor stages have joined).
     """
     global _AGG_NAMES
     if _AGG_NAMES is None:
@@ -203,16 +261,24 @@ def _column_refs(node: Any) -> list[str]:
 def classify_extract(
     calls: list[AggregateCall],
     temporal_by_column: dict[str, str | None],
-    fact_is_snapshot: bool,
+    fact_is_snapshot: bool | None,
+    *,
+    is_ratio: bool = False,
 ) -> AxisClass:
     """The additivity of one extract — the most-restrictive of its aggregate calls.
 
     ``temporal_by_column`` maps each base column to its ``temporal_behavior``
-    (``'additive'`` / ``'point_in_time'`` / ``None``); ``fact_is_snapshot`` is
-    True when a time column sits in the extract's fact grain (a periodic
-    snapshot), the ``COUNT``-across-time signal. An extract with no aggregate
-    (a bare passthrough) is treated as additive.
+    (``'additive'`` / ``'point_in_time'``); a column ABSENT from the map (or
+    mapping to ``None``) has no resolved verdict and is treated conservatively.
+    ``fact_is_snapshot`` is True for a periodic-snapshot fact (a time column in
+    the grain), False for a confirmed event fact, ``None`` when the grain is
+    unknown — both snapshot and unknown deny ``COUNT`` the time axis.
+    ``is_ratio`` marks an extract whose measures are combined by division/product
+    inline in one ``select_expr`` (a ratio) — non-additive on every axis. An
+    extract with no aggregate (a bare passthrough) is treated as additive.
     """
+    if is_ratio:
+        return AxisClass(False, False, RATIO, RATIO)
     result = ADDITIVE
     for call in calls:
         result = _most_restrictive(
@@ -222,18 +288,26 @@ def classify_extract(
 
 
 def _classify_call(
-    call: AggregateCall, temporal_by_column: dict[str, str | None], fact_is_snapshot: bool
+    call: AggregateCall, temporal_by_column: dict[str, str | None], fact_is_snapshot: bool | None
 ) -> AxisClass:
     fn = call.function
     if fn == "sum":
-        stock = any(temporal_by_column.get(c) == POINT_IN_TIME for c in call.columns)
-        # SUM reconciles across categorical dims always; across time only for flows.
-        return AxisClass(True, not stock, None, STOCK if stock else None)
+        behaviors = [temporal_by_column.get(c) for c in call.columns]
+        if any(b == POINT_IN_TIME for b in behaviors):
+            # A summed balance reconciles across categories but not across time.
+            return AxisClass(True, False, None, STOCK)
+        if call.columns and all(b == FLOW for b in behaviors):
+            return AxisClass(True, True)
+        # A column with no resolved flow/stock verdict (no concept row / NULL) —
+        # can't confirm it sums across time; refuse it, never assume flow.
+        return AxisClass(True, False, None, UNKNOWN_TEMPORAL)
     if fn in ("count_star", "count"):
-        # Counting rows/values: additive across categorical; across time only when
-        # the fact is not a periodic snapshot (else each period recounts the same population).
+        # Counting is additive across categorical; across time only on a CONFIRMED
+        # event fact — a snapshot (or an unknown grain) recounts the same population.
+        if fact_is_snapshot is False:
+            return AxisClass(True, True)
         return AxisClass(
-            True, not fact_is_snapshot, None, SNAPSHOT_COUNT if fact_is_snapshot else None
+            True, False, None, SNAPSHOT_COUNT if fact_is_snapshot else UNKNOWN_TEMPORAL
         )
     if fn == "count_distinct":
         return AxisClass(False, False, DISTINCT_COUNT, DISTINCT_COUNT)
@@ -291,18 +365,32 @@ def roll_up_metric(graph: Any, extract_class_by_step: dict[str, AxisClass]) -> M
         for cls in extract_class_by_step.values():
             result = _most_restrictive(result, cls)
         return _to_verdict(result)
-    return _to_verdict(_step_class(output.step_id, graph, extract_class_by_step))
+    return _to_verdict(_step_class(output.step_id, graph, extract_class_by_step, frozenset()))
 
 
-def _step_class(step_id: str, graph: Any, extract_class_by_step: dict[str, AxisClass]) -> AxisClass:
+def _step_class(
+    step_id: str,
+    graph: Any,
+    extract_class_by_step: dict[str, AxisClass],
+    seen: frozenset[str],
+) -> AxisClass:
     from dataraum.graphs.models import StepType
 
+    if step_id in seen:
+        # A FORMULA→FORMULA cycle. Guarded upstream by agent.assemble's dependency
+        # ordering before a metric reaches `executed`, but never recurse unbounded
+        # on that assumption — refuse.
+        return AxisClass(False, False, UNKNOWN_AGGREGATE, UNKNOWN_AGGREGATE)
     step = graph.steps.get(step_id)
     if step is None:
         # A referenced-but-absent dependency — conservative.
         return AxisClass(False, False, UNKNOWN_AGGREGATE, UNKNOWN_AGGREGATE)
     if step.step_type == StepType.EXTRACT:
-        return extract_class_by_step.get(step_id, ADDITIVE)
+        # An extract absent from the map never grounded (the resolver skips a
+        # source-less/ungrounded leaf) — refuse conservatively, never assume additive.
+        return extract_class_by_step.get(
+            step_id, AxisClass(False, False, UNKNOWN_AGGREGATE, UNKNOWN_AGGREGATE)
+        )
     if step.step_type == StepType.CONSTANT:
         return CONSTANT
     # FORMULA: classify its expression over the dependency step ids.
@@ -310,21 +398,21 @@ def _step_class(step_id: str, graph: Any, extract_class_by_step: dict[str, AxisC
         tree = ast.parse(step.expression or "", mode="eval")
     except SyntaxError:
         return AxisClass(False, False, RATIO, RATIO)
-    return _expr_class(tree.body, graph, extract_class_by_step)
+    return _expr_class(tree.body, graph, extract_class_by_step, seen | {step_id})
 
 
 def _expr_class(
-    node: ast.expr, graph: Any, extract_class_by_step: dict[str, AxisClass]
+    node: ast.expr, graph: Any, extract_class_by_step: dict[str, AxisClass], seen: frozenset[str]
 ) -> AxisClass:
     if isinstance(node, ast.Name):
-        return _step_class(node.id, graph, extract_class_by_step)
+        return _step_class(node.id, graph, extract_class_by_step, seen)
     if isinstance(node, ast.Constant):
         return CONSTANT
     if isinstance(node, ast.UnaryOp):
-        return _expr_class(node.operand, graph, extract_class_by_step)
+        return _expr_class(node.operand, graph, extract_class_by_step, seen)
     if isinstance(node, ast.BinOp):
-        left = _expr_class(node.left, graph, extract_class_by_step)
-        right = _expr_class(node.right, graph, extract_class_by_step)
+        left = _expr_class(node.left, graph, extract_class_by_step, seen)
+        right = _expr_class(node.right, graph, extract_class_by_step, seen)
         if isinstance(node.op, ast.Div):
             # A ratio never reconciles under SUM, whatever its operands.
             return AxisClass(False, False, RATIO, RATIO)

--- a/packages/engine/src/dataraum/graphs/additivity.py
+++ b/packages/engine/src/dataraum/graphs/additivity.py
@@ -53,14 +53,16 @@ FLOW = "additive"  # temporal_behavior value marking a flow column
 class AggregateCall:
     """One aggregate application inside an extract's ``select_expr``.
 
-    ``function`` is normalized to the doctrine's vocabulary
-    (``sum``/``count``/``count_star``/``count_distinct``/``avg``/``min``/``max``
-    or the raw lowercase name for anything else). ``columns`` are the base
-    columns aggregated (empty for ``COUNT(*)``).
+    ``function`` is the lowercase DuckDB name (``sum`` / ``count`` / ``count_star``
+    / ``avg`` / ``min`` / ``max`` / …). ``columns`` are the base columns aggregated
+    (empty for ``COUNT(*)``). ``distinct`` is the DISTINCT qualifier — it breaks
+    additivity for ANY aggregate (the distinct set overlaps across slices), so
+    ``SUM(DISTINCT x)`` is as non-additive as ``COUNT(DISTINCT x)``.
     """
 
     function: str
     columns: tuple[str, ...]
+    distinct: bool = False
 
 
 @dataclass(frozen=True)
@@ -206,8 +208,9 @@ def _collect_aggregates(node: Any, agg_names: frozenset[str], out: list[Aggregat
         if node.get("class") == "FUNCTION" and node.get("function_name") in agg_names:
             out.append(
                 AggregateCall(
-                    function=_normalize_function(node),
+                    function=str(node.get("function_name", "")).lower(),
                     columns=tuple(_column_refs(node.get("children", []))),
+                    distinct=bool(node.get("distinct")),
                 )
             )
             return
@@ -216,17 +219,6 @@ def _collect_aggregates(node: Any, agg_names: frozenset[str], out: list[Aggregat
     elif isinstance(node, list):
         for item in node:
             _collect_aggregates(item, agg_names, out)
-
-
-def _normalize_function(node: dict[str, Any]) -> str:
-    """Map a FUNCTION node to the doctrine vocabulary.
-
-    ``count`` + ``distinct`` → ``count_distinct``; everything else its lowercase name.
-    """
-    name = str(node.get("function_name", "")).lower()
-    if name == "count" and node.get("distinct"):
-        return "count_distinct"
-    return name
 
 
 def _column_refs(node: Any) -> list[str]:
@@ -275,18 +267,23 @@ def classify_extract(
     unknown — both snapshot and unknown deny ``COUNT`` the time axis.
     ``is_ratio`` marks an extract whose measures are combined by division/product
     inline in one ``select_expr`` (a ratio) — non-additive on every axis. An
-    extract with no aggregate (a bare passthrough) is treated as additive.
+    extract that yielded NO aggregate calls (a bare passthrough, or an unparsed
+    window function) is refused conservatively — we can't confirm it reconciles.
     """
     if is_ratio:
         return AxisClass(False, False, RATIO, RATIO)
-    # A bare COUNT(*) alongside a column-bearing aggregate is a NULL-presence guard
+    if not calls:
+        # No aggregate to classify (a bare column, or a window function that didn't
+        # parse to an aggregate FUNCTION) — never assume it sums.
+        return AxisClass(False, False, UNKNOWN_AGGREGATE, UNKNOWN_AGGREGATE)
+    # A column-less COUNT alongside a real measure aggregate is a NULL-presence guard
     # (``CASE WHEN COUNT(*)=0 THEN NULL ELSE <measure> END``), not the measure — the
     # value is the other aggregate. Drop it so the guard can't strip time or taint
-    # the reason (a stock balance reads ``stock``, not ``snapshot_count``). A
-    # COUNT(*) ALONE is a genuine count measure and is kept. This targets the one
-    # guard idiom the grounding prompt emits (COUNT(*)); a COUNT(1)/COUNT(col) guard
-    # would not be recognized, but the prompt never produces those.
-    measures = [c for c in calls if not (c.function == "count_star" and not c.columns)]
+    # the reason (a stock balance reads ``stock``, not ``snapshot_count``). Covers
+    # ``COUNT(*)`` (``count_star``) and ``COUNT(1)`` (``count`` with no columns), both
+    # of which are row counts; a DISTINCT count or ``COUNT(col)`` is a real measure.
+    # A row-count ALONE (no co-occurring measure) is a genuine count and is kept.
+    measures = [c for c in calls if not _is_row_count(c)]
     result = ADDITIVE
     for call in measures or calls:
         result = most_restrictive(
@@ -295,9 +292,18 @@ def classify_extract(
     return result
 
 
+def _is_row_count(call: AggregateCall) -> bool:
+    """A plain count of rows — ``COUNT(*)`` / ``COUNT(1)`` (no columns, not DISTINCT)."""
+    return call.function in ("count_star", "count") and not call.columns and not call.distinct
+
+
 def _classify_call(
     call: AggregateCall, temporal_by_column: dict[str, str | None], fact_is_snapshot: bool | None
 ) -> AxisClass:
+    if call.distinct:
+        # DISTINCT breaks additivity for EVERY aggregate (SUM/AVG/MIN/MAX/COUNT) —
+        # the distinct set overlaps across slices, so a breakdown never reconciles.
+        return AxisClass(False, False, DISTINCT_COUNT, DISTINCT_COUNT)
     fn = call.function
     if fn == "sum":
         behaviors = [temporal_by_column.get(c) for c in call.columns]
@@ -317,8 +323,6 @@ def _classify_call(
         return AxisClass(
             True, False, None, SNAPSHOT_COUNT if fact_is_snapshot else UNKNOWN_TEMPORAL
         )
-    if fn == "count_distinct":
-        return AxisClass(False, False, DISTINCT_COUNT, DISTINCT_COUNT)
     if fn == "avg":
         return AxisClass(False, False, AVERAGE, AVERAGE)
     if fn in ("min", "max"):
@@ -368,11 +372,10 @@ def roll_up_metric(graph: Any, extract_class_by_step: dict[str, AxisClass]) -> M
     """
     output = graph.get_output_step()
     if output is None:
-        # No output marker — fall to the most-restrictive over whatever we classified.
-        result = ADDITIVE
-        for cls in extract_class_by_step.values():
-            result = most_restrictive(result, cls)
-        return _to_verdict(result)
+        # No output marker — the formula structure (ratio vs sum) is unknown, so a
+        # ratio can't be told from an additive combination; refuse conservatively
+        # rather than fold the leaves as if they were additive.
+        return MetricVerdict(False, False, UNKNOWN_AGGREGATE, UNKNOWN_AGGREGATE)
     return _to_verdict(_step_class(output.step_id, graph, extract_class_by_step, frozenset()))
 
 

--- a/packages/engine/src/dataraum/graphs/additivity.py
+++ b/packages/engine/src/dataraum/graphs/additivity.py
@@ -279,9 +279,15 @@ def classify_extract(
     """
     if is_ratio:
         return AxisClass(False, False, RATIO, RATIO)
+    # A bare COUNT(*) alongside a column-bearing aggregate is a NULL-presence guard
+    # (``CASE WHEN COUNT(*)=0 THEN NULL ELSE <measure> END``), not the measure — the
+    # value is the other aggregate. Drop it so the guard can't strip time or taint
+    # the reason (a stock balance reads ``stock``, not ``snapshot_count``). A
+    # COUNT(*) ALONE is a genuine count measure and is kept.
+    measures = [c for c in calls if not (c.function == "count_star" and not c.columns)]
     result = ADDITIVE
-    for call in calls:
-        result = _most_restrictive(
+    for call in measures or calls:
+        result = most_restrictive(
             result, _classify_call(call, temporal_by_column, fact_is_snapshot)
         )
     return result
@@ -319,7 +325,7 @@ def _classify_call(
     return AxisClass(False, False, UNKNOWN_AGGREGATE, UNKNOWN_AGGREGATE)
 
 
-def _most_restrictive(a: AxisClass, b: AxisClass) -> AxisClass:
+def most_restrictive(a: AxisClass, b: AxisClass) -> AxisClass:
     """Combine two classes conservatively.
 
     An axis is additive only if both are; a reason is carried from whichever side
@@ -363,7 +369,7 @@ def roll_up_metric(graph: Any, extract_class_by_step: dict[str, AxisClass]) -> M
         # No output marker — fall to the most-restrictive over whatever we classified.
         result = ADDITIVE
         for cls in extract_class_by_step.values():
-            result = _most_restrictive(result, cls)
+            result = most_restrictive(result, cls)
         return _to_verdict(result)
     return _to_verdict(_step_class(output.step_id, graph, extract_class_by_step, frozenset()))
 
@@ -425,7 +431,7 @@ def _expr_class(
                 return left
             return AxisClass(False, False, RATIO, RATIO)
         # Add / Sub: additive combination — reconciles only where both operands do.
-        combined = _most_restrictive(left, right)
+        combined = most_restrictive(left, right)
         return AxisClass(
             combined.categorical_additive,
             combined.time_additive,

--- a/packages/engine/src/dataraum/graphs/additivity_db_models.py
+++ b/packages/engine/src/dataraum/graphs/additivity_db_models.py
@@ -34,8 +34,8 @@ class MetricAdditivity(Base):
     resolves a canvas node to. ``*_additive`` say whether a breakdown by that
     axis class reconciles to the unsliced total; ``*_reason`` names the cause
     when it does not (``stock`` / ``average`` / ``distinct_count`` /
-    ``snapshot_count`` / ``min_max`` / ``ratio`` / ``unknown_aggregate``), NULL
-    when it reconciles.
+    ``snapshot_count`` / ``min_max`` / ``ratio`` / ``unknown_aggregate`` /
+    ``unknown_temporal``), NULL when it reconciles.
     """
 
     __tablename__ = "metric_additivity"

--- a/packages/engine/src/dataraum/graphs/additivity_db_models.py
+++ b/packages/engine/src/dataraum/graphs/additivity_db_models.py
@@ -1,0 +1,58 @@
+"""SQLAlchemy model for the per-metric additivity verdict (DAT-716).
+
+The durable form of the metric-drill additivity verdict computed at the
+operating_model ``metrics`` phase (logic in :mod:`dataraum.graphs.additivity`).
+One run-versioned row per ``(metric_key, run_id)`` — the drill reads
+``current_metric_additivity`` to decide, for a metric node, whether to offer a
+time grain and whether a categorical breakdown *reconciles* (sums to the total)
+or shows the honest dash.
+
+Run-versioned like the metric ``lifecycle_artifacts`` it derives from: the
+version axis is the operating_model ``run_id``, current once that run is promoted
+under the ``(catalog, "operating_model")`` head (``current_metric_additivity``,
+DAT-506 read-view machinery). Recomputed every session cascade from the run's
+live ``temporal_behavior`` — never frozen. The ``(metric_key, run_id)`` UNIQUE is
+the run-grain contract's form-(a) upsert key (ADR-0010).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy import Boolean, DateTime, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from dataraum.storage import Base
+
+
+class MetricAdditivity(Base):
+    """One metric's additivity verdict, run-versioned (DAT-716).
+
+    Keyed ``(metric_key, run_id)`` where ``metric_key`` is the metric's
+    ``lifecycle_artifacts.artifact_key`` (its ``graph_id``) — the id the drill
+    resolves a canvas node to. ``*_additive`` say whether a breakdown by that
+    axis class reconciles to the unsliced total; ``*_reason`` names the cause
+    when it does not (``stock`` / ``average`` / ``distinct_count`` /
+    ``snapshot_count`` / ``min_max`` / ``ratio`` / ``unknown_aggregate``), NULL
+    when it reconciles.
+    """
+
+    __tablename__ = "metric_additivity"
+    __table_args__ = (
+        UniqueConstraint("metric_key", "run_id", name="uq_metric_additivity_metric_run"),
+    )
+
+    additivity_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    # Snapshot version axis (DAT-413): the operating_model run that computed this.
+    run_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    metric_key: Mapped[str] = mapped_column(String, nullable=False, index=True)
+
+    categorical_additive: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    time_additive: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    categorical_reason: Mapped[str | None] = mapped_column(String)
+    time_reason: Mapped[str | None] = mapped_column(String)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC)
+    )

--- a/packages/engine/src/dataraum/graphs/additivity_db_models.py
+++ b/packages/engine/src/dataraum/graphs/additivity_db_models.py
@@ -1,18 +1,26 @@
-"""SQLAlchemy model for the per-metric additivity verdict (DAT-716).
+"""SQLAlchemy model for the drill additivity verdict (DAT-716).
 
 The durable form of the metric-drill additivity verdict computed at the
 operating_model ``metrics`` phase (logic in :mod:`dataraum.graphs.additivity`).
-One run-versioned row per ``(metric_key, run_id)`` — the drill reads
-``current_metric_additivity`` to decide, for a metric node, whether to offer a
+One run-versioned row per drill target — the drill reads
+``current_metric_additivity`` to decide, for a canvas node, whether to offer a
 time grain and whether a categorical breakdown *reconciles* (sums to the total)
 or shows the honest dash.
 
-Run-versioned like the metric ``lifecycle_artifacts`` it derives from: the
-version axis is the operating_model ``run_id``, current once that run is promoted
-under the ``(catalog, "operating_model")`` head (``current_metric_additivity``,
-DAT-506 read-view machinery). Recomputed every session cascade from the run's
-live ``temporal_behavior`` — never frozen. The ``(metric_key, run_id)`` UNIQUE is
-the run-grain contract's form-(a) upsert key (ADR-0010).
+A drill **target** is either kind of canvas node (a measure is also a metric):
+
+* ``target_kind='metric'`` — a formula metric; ``target_key`` is its
+  ``lifecycle_artifacts.artifact_key`` (``graph_id``), drilled via ``{metricKey}``.
+* ``target_kind='measure'`` — a grounded measure/extract; ``target_key`` is its
+  ``standard_field``, drilled via ``{standardField}``. Its verdict is the
+  measure's single extract classified directly (no formula roll-up).
+
+Run-versioned like the ``lifecycle_artifacts`` it derives from: the version axis
+is the operating_model ``run_id``, current once that run is promoted under the
+``(catalog, "operating_model")`` head (``current_metric_additivity``, DAT-506
+read-view machinery). Recomputed every session cascade from the run's live
+``temporal_behavior`` — never frozen. The ``(target_kind, target_key, run_id)``
+UNIQUE is the run-grain contract's form-(a) upsert key (ADR-0010).
 """
 
 from __future__ import annotations
@@ -27,26 +35,29 @@ from dataraum.storage import Base
 
 
 class MetricAdditivity(Base):
-    """One metric's additivity verdict, run-versioned (DAT-716).
+    """One drill target's additivity verdict, run-versioned (DAT-716).
 
-    Keyed ``(metric_key, run_id)`` where ``metric_key`` is the metric's
-    ``lifecycle_artifacts.artifact_key`` (its ``graph_id``) — the id the drill
-    resolves a canvas node to. ``*_additive`` say whether a breakdown by that
-    axis class reconciles to the unsliced total; ``*_reason`` names the cause
-    when it does not (``stock`` / ``average`` / ``distinct_count`` /
-    ``snapshot_count`` / ``min_max`` / ``ratio`` / ``unknown_aggregate`` /
-    ``unknown_temporal``), NULL when it reconciles.
+    Keyed ``(target_kind, target_key, run_id)`` — a ``metric`` (graph_id) or a
+    ``measure`` (standard_field), the id the drill resolves a canvas node to.
+    ``*_additive`` say whether a breakdown by that axis class reconciles to the
+    unsliced total; ``*_reason`` names the cause when it does not (``stock`` /
+    ``average`` / ``distinct_count`` / ``snapshot_count`` / ``min_max`` /
+    ``ratio`` / ``unknown_aggregate`` / ``unknown_temporal``), NULL when it
+    reconciles.
     """
 
     __tablename__ = "metric_additivity"
     __table_args__ = (
-        UniqueConstraint("metric_key", "run_id", name="uq_metric_additivity_metric_run"),
+        UniqueConstraint("target_kind", "target_key", "run_id", name="uq_metric_additivity_target"),
     )
 
-    additivity_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    additivity_id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=lambda: str(uuid4())
+    )
     # Snapshot version axis (DAT-413): the operating_model run that computed this.
     run_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
-    metric_key: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    target_kind: Mapped[str] = mapped_column(String, nullable=False)  # 'metric' | 'measure'
+    target_key: Mapped[str] = mapped_column(String, nullable=False, index=True)
 
     categorical_additive: Mapped[bool] = mapped_column(Boolean, nullable=False)
     time_additive: Mapped[bool] = mapped_column(Boolean, nullable=False)

--- a/packages/engine/src/dataraum/graphs/additivity_resolver.py
+++ b/packages/engine/src/dataraum/graphs/additivity_resolver.py
@@ -1,0 +1,151 @@
+"""Compute a metric's additivity verdict from persisted grounding state (DAT-716).
+
+Bridges the pure classifier (:mod:`dataraum.graphs.additivity`) to the workspace
+catalog. For each of a metric's EXTRACT leaves it reads the grounded snippet's
+``select_expr`` (the aggregate seam), resolves the base columns to their fact
+``temporal_behavior`` and the fact's periodic-snapshot grain, classifies, and
+rolls the per-extract atoms up through the DAG.
+
+Returns ``None`` when the metric cannot be classified — an extract that never
+grounded (no healthy snippet / no parts) or reads a relation outside the current
+analysis. The caller then writes NO verdict rather than a misleading one.
+
+Run-scoping: the enriched view is latest-only (one row per fact, keyed by name),
+but ``temporal_behavior`` (``column_concepts``) and the fact grain
+(``table_entities``) are run-versioned catalogue artifacts — read at the pinned
+begin_session ``catalogue_run_id``, exactly as the drivers phase pins them, so a
+Temporal redelivery can never pick an arbitrary run's behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from dataraum.analysis.semantic.db_models import ColumnConcept, TableEntity
+from dataraum.analysis.views.db_models import EnrichedView
+from dataraum.graphs.additivity import (
+    MetricVerdict,
+    classify_extract,
+    parse_aggregate_calls,
+    roll_up_metric,
+)
+from dataraum.graphs.models import StepType
+from dataraum.query.snippet_library import SnippetLibrary
+from dataraum.storage import Column
+
+if TYPE_CHECKING:
+    import duckdb
+    from sqlalchemy.orm import Session
+
+    from dataraum.graphs.additivity import AxisClass
+    from dataraum.graphs.models import GraphStep, TransformationGraph
+
+
+def compute_metric_verdict(
+    session: Session,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    *,
+    graph: TransformationGraph,
+    workspace_id: str,
+    catalogue_run_id: str,
+) -> MetricVerdict | None:
+    """A metric's additivity verdict, or ``None`` if it cannot be classified.
+
+    Every EXTRACT leaf must resolve to a grounded ``select_expr`` over a fact of
+    the current analysis; a metric with an unresolved extract (or none at all)
+    yields ``None`` so the caller persists nothing.
+    """
+    library = SnippetLibrary(session, workspace_id=workspace_id)
+    extract_classes: dict[str, AxisClass] = {}
+    for step_id, step in graph.steps.items():
+        if step.step_type != StepType.EXTRACT or step.source is None:
+            continue
+        resolved = _grounded_select(library, workspace_id, step)
+        if resolved is None:
+            return None
+        select_expr, relation = resolved
+        fact_id = _fact_table_id(session, relation)
+        if fact_id is None:
+            return None
+        calls = parse_aggregate_calls(select_expr, duckdb_conn)
+        columns = {col for call in calls for col in call.columns}
+        temporal = _temporal_by_column(session, fact_id, columns, catalogue_run_id)
+        snapshot = _fact_is_snapshot(session, fact_id, catalogue_run_id)
+        extract_classes[step_id] = classify_extract(calls, temporal, snapshot)
+    if not extract_classes:
+        return None
+    return roll_up_metric(graph, extract_classes)
+
+
+def _grounded_select(
+    library: SnippetLibrary, workspace_id: str, step: GraphStep
+) -> tuple[str, str] | None:
+    """The extract's healthy grounded ``(select_expr, relation)`` from its snippet."""
+    if step.source is None:
+        return None
+    match = library.find_by_key(
+        "extract",
+        workspace_id,
+        standard_field=step.source.standard_field,
+        statement=step.source.statement,
+        aggregation=step.aggregation,
+    )
+    if match is None or (match.snippet.failure_count or 0) != 0:
+        return None
+    parts = match.snippet.parts or {}
+    selects = parts.get("select") or []
+    relations = parts.get("from") or []
+    if not selects or not relations:
+        return None
+    expr = selects[0].get("expr")
+    relation = relations[0]
+    if not expr or not relation:
+        return None
+    return expr, relation
+
+
+def _fact_table_id(session: Session, view_name: str) -> str | None:
+    """The fact table behind an enriched view (latest-only, name-keyed)."""
+    row = session.execute(
+        select(EnrichedView.fact_table_id).where(EnrichedView.view_name == view_name)
+    ).first()
+    return row[0] if row else None
+
+
+def _temporal_by_column(
+    session: Session, fact_table_id: str, column_names: set[str], run_id: str
+) -> dict[str, str | None]:
+    """``temporal_behavior`` per fact base column, pinned to the catalogue run."""
+    if not column_names:
+        return {}
+    rows = session.execute(
+        select(Column.column_name, ColumnConcept.temporal_behavior)
+        .join(
+            ColumnConcept,
+            (ColumnConcept.column_id == Column.column_id) & (ColumnConcept.run_id == run_id),
+        )
+        .where(Column.table_id == fact_table_id, Column.column_name.in_(column_names))
+    ).all()
+    return {row[0]: row[1] for row in rows}
+
+
+def _fact_is_snapshot(session: Session, fact_table_id: str, run_id: str) -> bool:
+    """Whether a time column sits in the fact's grain (a periodic snapshot).
+
+    ``grain_columns`` is ``{"columns": [name, ...]}``; ``time_columns`` is a list
+    of ``{"column": name, ...}``. A snapshot fact re-states the same population
+    each period, so a ``COUNT`` over it is non-additive across time.
+    """
+    row = session.execute(
+        select(TableEntity.grain_columns, TableEntity.time_columns).where(
+            TableEntity.table_id == fact_table_id, TableEntity.run_id == run_id
+        )
+    ).first()
+    if row is None:
+        return False
+    grain_columns, time_columns = row
+    grain = set((grain_columns or {}).get("columns", []))
+    times = {tc.get("column") for tc in (time_columns or []) if isinstance(tc, dict)}
+    return bool(grain & times)

--- a/packages/engine/src/dataraum/graphs/additivity_resolver.py
+++ b/packages/engine/src/dataraum/graphs/additivity_resolver.py
@@ -116,7 +116,11 @@ def _fact_table_id(session: Session, relation: str) -> str | None:
     by construction via the `enriched_{duckdb_path}` naming convention, not a DB
     constraint). A fact with no confirmed dimensions has no enriched view, so the
     extract reads the typed table directly (the schema fallback in
-    `GraphAgent._build_schema_info`) — resolve that by table name / duckdb_path.
+    `GraphAgent._build_schema_info`) — resolve that by table name / duckdb_path,
+    scoped to `layer == "typed"`: a fact's raw and typed rows carry the SAME
+    `table_name` AND `duckdb_path` (DAT-639 dropped layer-prefixing), so without
+    the layer filter `.first()` would pick between them arbitrarily; metrics run
+    on the typed layer (as `BasePhase.table_ids_for_ctx` scopes).
     """
     row = session.execute(
         select(EnrichedView.fact_table_id).where(EnrichedView.view_name == relation)
@@ -125,7 +129,8 @@ def _fact_table_id(session: Session, relation: str) -> str | None:
         return str(row[0])
     row = session.execute(
         select(Table.table_id).where(
-            (Table.table_name == relation) | (Table.duckdb_path == relation)
+            Table.layer == "typed",
+            (Table.table_name == relation) | (Table.duckdb_path == relation),
         )
     ).first()
     return str(row[0]) if row else None

--- a/packages/engine/src/dataraum/graphs/additivity_resolver.py
+++ b/packages/engine/src/dataraum/graphs/additivity_resolver.py
@@ -58,6 +58,33 @@ def compute_metric_verdict(
     the current analysis; a metric with an unresolved extract (or none at all)
     yields ``None`` so the caller persists nothing.
     """
+    classes = classify_metric_extracts(
+        session,
+        duckdb_conn,
+        graph=graph,
+        workspace_id=workspace_id,
+        catalogue_run_id=catalogue_run_id,
+    )
+    if classes is None:
+        return None
+    return roll_up_metric(graph, classes)
+
+
+def classify_metric_extracts(
+    session: Session,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    *,
+    graph: TransformationGraph,
+    workspace_id: str,
+    catalogue_run_id: str,
+) -> dict[str, AxisClass] | None:
+    """Classify each EXTRACT leaf of a metric, keyed by ``step_id``.
+
+    Returns ``None`` if any extract is unresolved (no healthy grounded parts / a
+    relation outside the analysis) — the caller then persists nothing. The caller
+    rolls these up for the metric verdict AND maps them by ``standard_field`` for
+    the per-measure verdicts (a measure node is one extract, classified directly).
+    """
     library = SnippetLibrary(session, workspace_id=workspace_id)
     extract_classes: dict[str, AxisClass] = {}
     for step_id, step in graph.steps.items():
@@ -78,7 +105,7 @@ def compute_metric_verdict(
         extract_classes[step_id] = classify_extract(calls, temporal, snapshot, is_ratio=is_ratio)
     if not extract_classes:
         return None
-    return roll_up_metric(graph, extract_classes)
+    return extract_classes
 
 
 def _grounded_select(

--- a/packages/engine/src/dataraum/graphs/additivity_resolver.py
+++ b/packages/engine/src/dataraum/graphs/additivity_resolver.py
@@ -30,10 +30,11 @@ from dataraum.graphs.additivity import (
     classify_extract,
     parse_aggregate_calls,
     roll_up_metric,
+    select_expr_is_ratio,
 )
 from dataraum.graphs.models import StepType
 from dataraum.query.snippet_library import SnippetLibrary
-from dataraum.storage import Column
+from dataraum.storage import Column, Table
 
 if TYPE_CHECKING:
     import duckdb
@@ -73,7 +74,8 @@ def compute_metric_verdict(
         columns = {col for call in calls for col in call.columns}
         temporal = _temporal_by_column(session, fact_id, columns, catalogue_run_id)
         snapshot = _fact_is_snapshot(session, fact_id, catalogue_run_id)
-        extract_classes[step_id] = classify_extract(calls, temporal, snapshot)
+        is_ratio = select_expr_is_ratio(select_expr, duckdb_conn)
+        extract_classes[step_id] = classify_extract(calls, temporal, snapshot, is_ratio=is_ratio)
     if not extract_classes:
         return None
     return roll_up_metric(graph, extract_classes)
@@ -92,6 +94,7 @@ def _grounded_select(
         statement=step.source.statement,
         aggregation=step.aggregation,
     )
+    # find_by_key already filters failure_count == 0; the re-check is belt-and-braces.
     if match is None or (match.snippet.failure_count or 0) != 0:
         return None
     parts = match.snippet.parts or {}
@@ -106,12 +109,26 @@ def _grounded_select(
     return expr, relation
 
 
-def _fact_table_id(session: Session, view_name: str) -> str | None:
-    """The fact table behind an enriched view (latest-only, name-keyed)."""
+def _fact_table_id(session: Session, relation: str) -> str | None:
+    """The fact table an extract reads.
+
+    Usually an enriched view (`EnrichedView.view_name` — latest-only, and unique
+    by construction via the `enriched_{duckdb_path}` naming convention, not a DB
+    constraint). A fact with no confirmed dimensions has no enriched view, so the
+    extract reads the typed table directly (the schema fallback in
+    `GraphAgent._build_schema_info`) — resolve that by table name / duckdb_path.
+    """
     row = session.execute(
-        select(EnrichedView.fact_table_id).where(EnrichedView.view_name == view_name)
+        select(EnrichedView.fact_table_id).where(EnrichedView.view_name == relation)
     ).first()
-    return row[0] if row else None
+    if row:
+        return str(row[0])
+    row = session.execute(
+        select(Table.table_id).where(
+            (Table.table_name == relation) | (Table.duckdb_path == relation)
+        )
+    ).first()
+    return str(row[0]) if row else None
 
 
 def _temporal_by_column(
@@ -131,12 +148,15 @@ def _temporal_by_column(
     return {row[0]: row[1] for row in rows}
 
 
-def _fact_is_snapshot(session: Session, fact_table_id: str, run_id: str) -> bool:
+def _fact_is_snapshot(session: Session, fact_table_id: str, run_id: str) -> bool | None:
     """Whether a time column sits in the fact's grain (a periodic snapshot).
 
     ``grain_columns`` is ``{"columns": [name, ...]}``; ``time_columns`` is a list
     of ``{"column": name, ...}``. A snapshot fact re-states the same population
-    each period, so a ``COUNT`` over it is non-additive across time.
+    each period, so a ``COUNT`` over it is non-additive across time. Returns
+    ``None`` when the fact has no ``TableEntity`` for this run — the grain is
+    unknown, and the classifier denies ``COUNT`` the time axis rather than
+    assuming an event fact.
     """
     row = session.execute(
         select(TableEntity.grain_columns, TableEntity.time_columns).where(
@@ -144,7 +164,7 @@ def _fact_is_snapshot(session: Session, fact_table_id: str, run_id: str) -> bool
         )
     ).first()
     if row is None:
-        return False
+        return None
     grain_columns, time_columns = row
     grain = set((grain_columns or {}).get("columns", []))
     times = {tc.get("column") for tc in (time_columns or []) if isinstance(tc, dict)}

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -446,6 +446,14 @@ def _persist_additivity_verdicts(
     A metric whose verdict can't be computed (an extract without healthy grounded
     parts) is skipped: no row is better than a misleading one. The catalogue run
     pins ``temporal_behavior``/grain; without it (a wiring gap) nothing is written.
+
+    **Fault-isolated (best-effort annotation).** This runs on the shared phase
+    session AFTER every metric's execute bookkeeping is already recorded there; an
+    unhandled failure here would surface as a phase failure and roll that session
+    back — discarding every metric's ``executed`` state and forcing a full Temporal
+    retry of already-successful work. So each verdict computation and the upsert
+    run inside their own SAVEPOINT: a bug (a parse error, a bad query) rolls back
+    only its own annotation, never the metric bookkeeping.
     """
     from dataraum.graphs.additivity_db_models import MetricAdditivity
     from dataraum.graphs.additivity_resolver import compute_metric_verdict
@@ -460,13 +468,18 @@ def _persist_additivity_verdicts(
         graph = graphs.get(graph_id)
         if graph is None:
             continue
-        verdict = compute_metric_verdict(
-            session,
-            duckdb_conn,
-            graph=graph,
-            workspace_id=workspace_id,
-            catalogue_run_id=catalogue_run_id,
-        )
+        try:
+            with session.begin_nested():
+                verdict = compute_metric_verdict(
+                    session,
+                    duckdb_conn,
+                    graph=graph,
+                    workspace_id=workspace_id,
+                    catalogue_run_id=catalogue_run_id,
+                )
+        except Exception as exc:  # noqa: BLE001 - best-effort; never fail the phase
+            _log.warning("metric_additivity_compute_error", graph_id=graph_id, error=str(exc))
+            continue
         if verdict is None:
             continue
         rows.append(
@@ -480,8 +493,15 @@ def _persist_additivity_verdicts(
             }
         )
 
-    if rows:
-        upsert(session, MetricAdditivity, rows, index_elements=["metric_key", "run_id"])
+    if not rows:
+        _log.info("metric_additivity_persisted", count=0, executed=len(executed_keys))
+        return
+    try:
+        with session.begin_nested():
+            upsert(session, MetricAdditivity, rows, index_elements=["metric_key", "run_id"])
+    except Exception as exc:  # noqa: BLE001 - isolate the write from phase bookkeeping
+        _log.warning("metric_additivity_upsert_error", error=str(exc), count=len(rows))
+        return
     _log.info("metric_additivity_persisted", count=len(rows), executed=len(executed_keys))
 
 

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -474,6 +474,9 @@ def _persist_additivity_verdicts(
         graph = graphs.get(graph_id)
         if graph is None:
             continue
+        # ALL fallible work (classify, roll-up, the extract→standard_field access)
+        # runs inside the SAVEPOINT; only the in-memory bookkeeping happens after,
+        # so a bug here rolls back its own annotation, never the phase session.
         try:
             with session.begin_nested():
                 classes = classify_metric_extracts(
@@ -483,20 +486,26 @@ def _persist_additivity_verdicts(
                     workspace_id=workspace_id,
                     catalogue_run_id=catalogue_run_id,
                 )
+                if classes is None:
+                    continue
+                metric_verdict = roll_up_metric(graph, classes)
+                # A measure node is one extract, keyed by standard_field (the drill's
+                # node identity — see analyseTarget); the same field is shared across
+                # metrics via the concept-keyed snippet cache (same class).
+                metric_measures = [
+                    (source.standard_field, cls)
+                    for step_id, cls in classes.items()
+                    if (source := graph.steps[step_id].source) and source.standard_field
+                ]
         except Exception as exc:  # noqa: BLE001 - best-effort; never fail the phase
             _log.warning("metric_additivity_compute_error", graph_id=graph_id, error=str(exc))
             continue
-        if classes is None:
-            continue
-        rows.append(_verdict_row(run_id, "metric", graph_id, roll_up_metric(graph, classes)))
-        # A measure node is one extract; the same standard_field is shared across
-        # metrics (same snippet → same class), deduped most-restrictive defensively.
-        for step_id, cls in classes.items():
-            source = graph.steps[step_id].source
-            field = source.standard_field if source else None
-            if field:
-                prior = measure_classes.get(field)
-                measure_classes[field] = cls if prior is None else most_restrictive(prior, cls)
+        rows.append(_verdict_row(run_id, "metric", graph_id, metric_verdict))
+        for field, cls in metric_measures:
+            # Deduped most-restrictive: identical today (shared snippet), conservative
+            # if a field is ever grounded two ways across metrics — never optimistic.
+            prior = measure_classes.get(field)
+            measure_classes[field] = cls if prior is None else most_restrictive(prior, cls)
 
     rows.extend(
         _verdict_row(run_id, "measure", field, cls) for field, cls in measure_classes.items()

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -123,10 +123,11 @@ class MetricsPhase(BasePhase):
 
     @property
     def db_models(self) -> list[ModuleType]:
+        from dataraum.graphs import additivity_db_models
         from dataraum.lifecycle import db_models as lifecycle_db_models
         from dataraum.query import snippet_models
 
-        return [snippet_models, lifecycle_db_models]
+        return [snippet_models, lifecycle_db_models, additivity_db_models]
 
     def _run(self, ctx: PhaseContext) -> PhaseResult:
         """Declare → compose → execute every declared metric graph."""

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -345,6 +345,21 @@ class MetricsPhase(BasePhase):
                 artifact.state_reason = f"composed but not executed: {result.error}"
                 _log.warning("metric_not_executed", graph_id=graph_id, error=result.error)
 
+        # Additivity verdict (DAT-716): classify how each EXECUTED metric's value
+        # reconciles under aggregation (offer a time grain? does a categorical
+        # breakdown sum or dash?) from the grounded snippets + catalogue
+        # temporal_behavior/grain — no LLM. A metric that can't be classified
+        # writes no row, never a wrong one. Read at the pinned catalogue run.
+        _persist_additivity_verdicts(
+            ctx.session,
+            ctx.duckdb_conn,
+            graphs=graphs,
+            executed_keys={gid for gid, a in artifacts.items() if a.state == "executed"},
+            workspace_id=schema_mapping_id,
+            run_id=run_id,
+            catalogue_run_id=catalogue_run_id,
+        )
+
         executed = sum(1 for a in artifacts.values() if a.state == "executed")
         grounded_stuck = sum(1 for a in artifacts.values() if a.state == "grounded")
         declared_stuck = sum(1 for a in artifacts.values() if a.state == "declared")
@@ -408,6 +423,66 @@ def _low_confidence_reason(execution: GraphExecution | None) -> str | None:
         f"low-confidence grounding ({weakest.confidence:.2f} < {_LOW_CONFIDENCE_FLOOR:.2f}): "
         f"{weakest.assumption}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Additivity verdict (DAT-716)
+# ---------------------------------------------------------------------------
+
+
+def _persist_additivity_verdicts(
+    session: Session,
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    *,
+    graphs: dict[str, TransformationGraph],
+    executed_keys: set[str],
+    workspace_id: str,
+    run_id: str,
+    catalogue_run_id: str | None,
+) -> None:
+    """Persist one additivity verdict per executed, classifiable metric.
+
+    Idempotent per run — ``(metric_key, run_id)`` UPSERTed (ADR-0010 form-(a)).
+    A metric whose verdict can't be computed (an extract without healthy grounded
+    parts) is skipped: no row is better than a misleading one. The catalogue run
+    pins ``temporal_behavior``/grain; without it (a wiring gap) nothing is written.
+    """
+    from dataraum.graphs.additivity_db_models import MetricAdditivity
+    from dataraum.graphs.additivity_resolver import compute_metric_verdict
+    from dataraum.storage.upsert import upsert
+
+    if not catalogue_run_id:
+        _log.warning("metric_additivity_skipped_no_catalogue_run")
+        return
+
+    rows: list[dict[str, object]] = []
+    for graph_id in executed_keys:
+        graph = graphs.get(graph_id)
+        if graph is None:
+            continue
+        verdict = compute_metric_verdict(
+            session,
+            duckdb_conn,
+            graph=graph,
+            workspace_id=workspace_id,
+            catalogue_run_id=catalogue_run_id,
+        )
+        if verdict is None:
+            continue
+        rows.append(
+            {
+                "run_id": run_id,
+                "metric_key": graph_id,
+                "categorical_additive": verdict.categorical_additive,
+                "time_additive": verdict.time_additive,
+                "categorical_reason": verdict.categorical_reason,
+                "time_reason": verdict.time_reason,
+            }
+        )
+
+    if rows:
+        upsert(session, MetricAdditivity, rows, index_elements=["metric_key", "run_id"])
+    _log.info("metric_additivity_persisted", count=len(rows), executed=len(executed_keys))
 
 
 # ---------------------------------------------------------------------------

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -470,7 +470,10 @@ def _persist_additivity_verdicts(
 
     rows: list[dict[str, object]] = []
     measure_classes: dict[str, AxisClass] = {}
-    for graph_id in executed_keys:
+    # sorted(): the measure fold below merges a shared field's class across metrics
+    # `most_restrictive` (order-dependent reason), so a deterministic iteration order
+    # is required — a set's is PYTHONHASHSEED-salted.
+    for graph_id in sorted(executed_keys):
         graph = graphs.get(graph_id)
         if graph is None:
             continue

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -94,6 +94,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from dataraum.core.connections import ConnectionManager
+    from dataraum.graphs.additivity import AxisClass, MetricVerdict
     from dataraum.graphs.agent import ExecutionContext as _ExecutionContext
     from dataraum.graphs.agent import GraphAgent
     from dataraum.graphs.models import GraphExecution, TransformationGraph
@@ -440,23 +441,27 @@ def _persist_additivity_verdicts(
     run_id: str,
     catalogue_run_id: str | None,
 ) -> None:
-    """Persist one additivity verdict per executed, classifiable metric.
+    """Persist additivity verdicts for the executed metrics AND their measures.
 
-    Idempotent per run — ``(metric_key, run_id)`` UPSERTed (ADR-0010 form-(a)).
-    A metric whose verdict can't be computed (an extract without healthy grounded
-    parts) is skipped: no row is better than a misleading one. The catalogue run
-    pins ``temporal_behavior``/grain; without it (a wiring gap) nothing is written.
+    A drill target is either a **metric** node (a formula, keyed by ``graph_id``)
+    or a **measure** node (a grounded extract, keyed by ``standard_field``) — both
+    are drillable, so both get a verdict. A metric's verdict rolls its extract
+    classes up through the DAG; a measure's verdict IS its single extract's class
+    (deduped most-restrictive across the metrics that share it). Idempotent per run
+    — ``(target_kind, target_key, run_id)`` UPSERTed (ADR-0010 form-(a)). A target
+    that can't be classified is skipped: no row is better than a misleading one.
 
     **Fault-isolated (best-effort annotation).** This runs on the shared phase
     session AFTER every metric's execute bookkeeping is already recorded there; an
     unhandled failure here would surface as a phase failure and roll that session
     back — discarding every metric's ``executed`` state and forcing a full Temporal
-    retry of already-successful work. So each verdict computation and the upsert
-    run inside their own SAVEPOINT: a bug (a parse error, a bad query) rolls back
-    only its own annotation, never the metric bookkeeping.
+    retry of already-successful work. So each classification and the upsert run
+    inside their own SAVEPOINT: a bug (a parse error, a bad query) rolls back only
+    its own annotation, never the metric bookkeeping.
     """
+    from dataraum.graphs.additivity import most_restrictive, roll_up_metric
     from dataraum.graphs.additivity_db_models import MetricAdditivity
-    from dataraum.graphs.additivity_resolver import compute_metric_verdict
+    from dataraum.graphs.additivity_resolver import classify_metric_extracts
     from dataraum.storage.upsert import upsert
 
     if not catalogue_run_id:
@@ -464,13 +469,14 @@ def _persist_additivity_verdicts(
         return
 
     rows: list[dict[str, object]] = []
+    measure_classes: dict[str, AxisClass] = {}
     for graph_id in executed_keys:
         graph = graphs.get(graph_id)
         if graph is None:
             continue
         try:
             with session.begin_nested():
-                verdict = compute_metric_verdict(
+                classes = classify_metric_extracts(
                     session,
                     duckdb_conn,
                     graph=graph,
@@ -480,29 +486,57 @@ def _persist_additivity_verdicts(
         except Exception as exc:  # noqa: BLE001 - best-effort; never fail the phase
             _log.warning("metric_additivity_compute_error", graph_id=graph_id, error=str(exc))
             continue
-        if verdict is None:
+        if classes is None:
             continue
-        rows.append(
-            {
-                "run_id": run_id,
-                "metric_key": graph_id,
-                "categorical_additive": verdict.categorical_additive,
-                "time_additive": verdict.time_additive,
-                "categorical_reason": verdict.categorical_reason,
-                "time_reason": verdict.time_reason,
-            }
-        )
+        rows.append(_verdict_row(run_id, "metric", graph_id, roll_up_metric(graph, classes)))
+        # A measure node is one extract; the same standard_field is shared across
+        # metrics (same snippet → same class), deduped most-restrictive defensively.
+        for step_id, cls in classes.items():
+            source = graph.steps[step_id].source
+            field = source.standard_field if source else None
+            if field:
+                prior = measure_classes.get(field)
+                measure_classes[field] = cls if prior is None else most_restrictive(prior, cls)
+
+    rows.extend(
+        _verdict_row(run_id, "measure", field, cls) for field, cls in measure_classes.items()
+    )
 
     if not rows:
         _log.info("metric_additivity_persisted", count=0, executed=len(executed_keys))
         return
     try:
         with session.begin_nested():
-            upsert(session, MetricAdditivity, rows, index_elements=["metric_key", "run_id"])
+            upsert(
+                session,
+                MetricAdditivity,
+                rows,
+                index_elements=["target_kind", "target_key", "run_id"],
+            )
     except Exception as exc:  # noqa: BLE001 - isolate the write from phase bookkeeping
         _log.warning("metric_additivity_upsert_error", error=str(exc), count=len(rows))
         return
-    _log.info("metric_additivity_persisted", count=len(rows), executed=len(executed_keys))
+    _log.info(
+        "metric_additivity_persisted",
+        count=len(rows),
+        measures=len(measure_classes),
+        executed=len(executed_keys),
+    )
+
+
+def _verdict_row(
+    run_id: str, kind: str, key: str, v: MetricVerdict | AxisClass
+) -> dict[str, object]:
+    """One ``metric_additivity`` row from a verdict/AxisClass (both share the fields)."""
+    return {
+        "run_id": run_id,
+        "target_kind": kind,
+        "target_key": key,
+        "categorical_additive": v.categorical_additive,
+        "time_additive": v.time_additive,
+        "categorical_reason": v.categorical_reason,
+        "time_reason": v.time_reason,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/packages/engine/src/dataraum/storage/read_views.py
+++ b/packages/engine/src/dataraum/storage/read_views.py
@@ -93,6 +93,7 @@ _CATALOG_GRAIN: dict[str, str] = {
     "lifecycle_artifacts": "operating_model",
     "validation_results": "operating_model",
     "detected_business_cycles": "operating_model",
+    "metric_additivity": "operating_model",  # operating_model metrics phase (DAT-716)
 }
 
 # Written by THREE detect paths: add_source seals per (table:{id}, GENERATION),

--- a/packages/engine/tests/integration/graphs/test_additivity_resolver.py
+++ b/packages/engine/tests/integration/graphs/test_additivity_resolver.py
@@ -349,6 +349,83 @@ def test_persist_is_fault_isolated(
     assert ("metric", "prior") in keys  # unrelated pending work survived the nested rollback
 
 
+def test_persist_isolates_rollup_failure(
+    session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+) -> None:
+    """A roll-up (or measure-mapping) bug is caught inside the savepoint too.
+
+    Regression: the roll_up_metric call + the extract→standard_field mapping must
+    run INSIDE the per-metric savepoint, not after it — else an exception escapes
+    `_persist_additivity_verdicts` and rolls back the whole phase session.
+    """
+    from unittest.mock import patch
+
+    from dataraum.graphs.additivity import ADDITIVE, MetricVerdict
+
+    def _graph(graph_id: str, field: str) -> TransformationGraph:
+        return TransformationGraph(
+            graph_id=graph_id,
+            version="1",
+            metadata=GraphMetadata(
+                name=graph_id, description="", category="c", source=GraphSource.SYSTEM
+            ),
+            output=OutputDef(output_type=OutputType.SCALAR),
+            steps={
+                "e": GraphStep(
+                    step_id="e",
+                    step_type=StepType.EXTRACT,
+                    source=StepSource(standard_field=field),
+                    aggregation="sum",
+                    output_step=True,
+                )
+            },
+        )
+
+    session.add(
+        MetricAdditivity(
+            run_id=RUN,
+            target_kind="metric",
+            target_key="prior",
+            categorical_additive=True,
+            time_additive=True,
+        )
+    )
+    session.flush()
+
+    def fake_rollup(graph, _classes):  # noqa: ANN001, ANN202
+        if graph.graph_id == "bad":
+            raise RuntimeError("boom - simulated roll_up bug")
+        return MetricVerdict(categorical_additive=True, time_additive=True)
+
+    with (
+        patch(
+            "dataraum.graphs.additivity_resolver.classify_metric_extracts",
+            return_value={"e": ADDITIVE},
+        ),
+        patch("dataraum.graphs.additivity.roll_up_metric", side_effect=fake_rollup),
+    ):
+        _persist_additivity_verdicts(
+            session,
+            duckdb_conn,
+            graphs={"good": _graph("good", "gf"), "bad": _graph("bad", "bf")},
+            executed_keys={"good", "bad"},
+            workspace_id=WS,
+            run_id=RUN,
+            catalogue_run_id=RUN,
+        )
+    session.commit()  # not poisoned by the roll-up failure
+
+    keys = {
+        (r.target_kind, r.target_key)
+        for r in session.execute(select(MetricAdditivity).where(MetricAdditivity.run_id == RUN))
+        .scalars()
+        .all()
+    }
+    assert ("metric", "good") in keys
+    assert ("metric", "bad") not in keys  # the roll-up bug was caught, not escaped
+    assert ("metric", "prior") in keys
+
+
 def test_persist_upserts_idempotently(
     session: Session, duckdb_conn: duckdb.DuckDBPyConnection
 ) -> None:

--- a/packages/engine/tests/integration/graphs/test_additivity_resolver.py
+++ b/packages/engine/tests/integration/graphs/test_additivity_resolver.py
@@ -1,0 +1,189 @@
+"""Additivity resolver against a real catalog (DAT-716).
+
+Exercises the DB plumbing the pure classifier can't: the snippet ``select_expr``
+lookup, fact-column resolution via the enriched view, the run-scoped
+``temporal_behavior`` join, and the periodic-snapshot grain read. Two cases pin
+the two axes that matter — a flow measure over an event fact (fully additive) and
+a stock measure over a periodic-snapshot fact (time stripped, categorical kept) —
+the latter being the cell the live finance workspace has no standalone metric for.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import duckdb
+from sqlalchemy.orm import Session
+
+from dataraum.analysis.semantic.db_models import ColumnConcept, TableEntity
+from dataraum.analysis.views.db_models import EnrichedView
+from dataraum.graphs.additivity_resolver import compute_metric_verdict
+from dataraum.graphs.models import (
+    GraphMetadata,
+    GraphSource,
+    GraphStep,
+    OutputDef,
+    OutputType,
+    StepSource,
+    StepType,
+    TransformationGraph,
+)
+from dataraum.query.snippet_models import SQLSnippetRecord
+from dataraum.storage import Column, Source, Table
+
+WS = "ws-additivity"
+RUN = "run-cat-1"
+
+
+def _seed(
+    session: Session,
+    *,
+    fact_name: str,
+    view_name: str,
+    columns: dict[str, str],
+    grain_columns: list[str],
+    time_columns: list[str],
+    field: str,
+    select_expr: str,
+    aggregation: str,
+) -> TransformationGraph:
+    """Seed one fact + its columns/concepts/view/entity + the extract snippet, and
+    return a single-extract metric graph grounding ``field`` to it."""
+    source = Source(name=f"src_{fact_name}", source_type="csv")
+    session.add(source)
+    session.flush()
+    fact = Table(
+        table_id=str(uuid4()),
+        source_id=source.source_id,
+        table_name=fact_name,
+        layer="typed",
+        duckdb_path=f"typed_{fact_name}",
+        row_count=100,
+    )
+    session.add(fact)
+    session.flush()
+    for pos, (name, behavior) in enumerate(columns.items()):
+        col = Column(
+            table_id=fact.table_id,
+            column_name=name,
+            column_position=pos,
+            raw_type="VARCHAR",
+            resolved_type="DECIMAL",
+        )
+        session.add(col)
+        session.flush()
+        session.add(ColumnConcept(column_id=col.column_id, run_id=RUN, temporal_behavior=behavior))
+    session.add(EnrichedView(fact_table_id=fact.table_id, view_name=view_name, run_id=RUN))
+    session.add(
+        TableEntity(
+            table_id=fact.table_id,
+            run_id=RUN,
+            detected_entity_type="event",
+            is_fact_table=True,
+            grain_columns={"columns": grain_columns},
+            time_columns=[{"column": c, "aspect": "t", "note": ""} for c in time_columns],
+        )
+    )
+    session.add(
+        SQLSnippetRecord(
+            workspace_id=WS,
+            schema_mapping_id=WS,
+            snippet_type="extract",
+            standard_field=field,
+            aggregation=aggregation,
+            sql=f"SELECT {select_expr} AS value FROM {view_name}",
+            source="graph:m",
+            parts={
+                "select": [{"expr": select_expr, "alias": "value"}],
+                "from": [view_name],
+                "where": [],
+            },
+        )
+    )
+    session.commit()
+    return TransformationGraph(
+        graph_id="m",
+        version="1",
+        metadata=GraphMetadata(name="m", description="", category="c", source=GraphSource.SYSTEM),
+        output=OutputDef(output_type=OutputType.SCALAR),
+        steps={
+            "e": GraphStep(
+                step_id="e",
+                step_type=StepType.EXTRACT,
+                source=StepSource(standard_field=field),
+                aggregation=aggregation,
+                output_step=True,
+            )
+        },
+    )
+
+
+def test_flow_over_event_fact_is_fully_additive(
+    session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+) -> None:
+    graph = _seed(
+        session,
+        fact_name="journal_lines",
+        view_name="enriched_journal_lines",
+        columns={"credit": "additive", "debit": "additive"},
+        grain_columns=["line_id"],  # event fact — no time column in the grain
+        time_columns=[],
+        field="revenue",
+        select_expr="COALESCE(SUM(credit), 0) - COALESCE(SUM(debit), 0)",
+        aggregation="sum",
+    )
+    verdict = compute_metric_verdict(
+        session, duckdb_conn, graph=graph, workspace_id=WS, catalogue_run_id=RUN
+    )
+    assert verdict is not None
+    assert verdict.categorical_additive is True
+    assert verdict.time_additive is True
+
+
+def test_stock_over_snapshot_fact_strips_time(
+    session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+) -> None:
+    graph = _seed(
+        session,
+        fact_name="trial_balance",
+        view_name="enriched_trial_balance",
+        columns={"debit_balance": "point_in_time", "credit_balance": "point_in_time"},
+        grain_columns=["account_id", "period"],  # snapshot — period sits in the grain
+        time_columns=["period"],
+        field="current_assets",
+        select_expr="SUM(debit_balance) - SUM(credit_balance)",
+        aggregation="sum",
+    )
+    verdict = compute_metric_verdict(
+        session, duckdb_conn, graph=graph, workspace_id=WS, catalogue_run_id=RUN
+    )
+    assert verdict is not None
+    # A summed balance reconciles across accounts but not across time.
+    assert verdict.categorical_additive is True
+    assert verdict.time_additive is False
+    assert verdict.time_reason == "stock"
+
+
+def test_unresolved_extract_yields_no_verdict(
+    session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+) -> None:
+    """A metric whose extract has no grounded snippet is refused, not guessed."""
+    graph = TransformationGraph(
+        graph_id="m",
+        version="1",
+        metadata=GraphMetadata(name="m", description="", category="c", source=GraphSource.SYSTEM),
+        output=OutputDef(output_type=OutputType.SCALAR),
+        steps={
+            "e": GraphStep(
+                step_id="e",
+                step_type=StepType.EXTRACT,
+                source=StepSource(standard_field="nonexistent"),
+                aggregation="sum",
+                output_step=True,
+            )
+        },
+    )
+    verdict = compute_metric_verdict(
+        session, duckdb_conn, graph=graph, workspace_id=WS, catalogue_run_id=RUN
+    )
+    assert verdict is None

--- a/packages/engine/tests/integration/graphs/test_additivity_resolver.py
+++ b/packages/engine/tests/integration/graphs/test_additivity_resolver.py
@@ -284,9 +284,9 @@ def test_persist_is_fault_isolated(
     """
     from unittest.mock import patch
 
-    from dataraum.graphs.additivity import MetricVerdict
+    from dataraum.graphs.additivity import ADDITIVE
 
-    def _bare_graph(graph_id: str) -> TransformationGraph:
+    def _graph(graph_id: str, field: str) -> TransformationGraph:
         return TransformationGraph(
             graph_id=graph_id,
             version="1",
@@ -294,29 +294,41 @@ def test_persist_is_fault_isolated(
                 name=graph_id, description="", category="c", source=GraphSource.SYSTEM
             ),
             output=OutputDef(output_type=OutputType.SCALAR),
-            steps={},
+            steps={
+                "e": GraphStep(
+                    step_id="e",
+                    step_type=StepType.EXTRACT,
+                    source=StepSource(standard_field=field),
+                    aggregation="sum",
+                    output_step=True,
+                )
+            },
         )
 
-    # An unrelated pending write already on the phase session (a prior metric's row).
+    # An unrelated pending write already on the phase session (a prior verdict row).
     session.add(
         MetricAdditivity(
-            run_id=RUN, metric_key="prior", categorical_additive=True, time_additive=True
+            run_id=RUN,
+            target_kind="metric",
+            target_key="prior",
+            categorical_additive=True,
+            time_additive=True,
         )
     )
     session.flush()
 
-    def fake_verdict(_session, _conn, *, graph, **_kw):
+    def fake_classify(_session, _conn, *, graph, **_kw):
         if graph.graph_id == "bad":
             raise RuntimeError("boom - simulated resolver bug")
-        return MetricVerdict(categorical_additive=True, time_additive=True)
+        return {"e": ADDITIVE}
 
     with patch(
-        "dataraum.graphs.additivity_resolver.compute_metric_verdict", side_effect=fake_verdict
+        "dataraum.graphs.additivity_resolver.classify_metric_extracts", side_effect=fake_classify
     ):
         _persist_additivity_verdicts(
             session,
             duckdb_conn,
-            graphs={"good": _bare_graph("good"), "bad": _bare_graph("bad")},
+            graphs={"good": _graph("good", "good_measure"), "bad": _graph("bad", "bad_measure")},
             executed_keys={"good", "bad"},
             workspace_id=WS,
             run_id=RUN,
@@ -325,20 +337,22 @@ def test_persist_is_fault_isolated(
     session.commit()  # the session is not poisoned by the caught failure
 
     keys = {
-        r.metric_key
+        (r.target_kind, r.target_key)
         for r in session.execute(select(MetricAdditivity).where(MetricAdditivity.run_id == RUN))
         .scalars()
         .all()
     }
-    assert "good" in keys  # the healthy metric persisted
-    assert "bad" not in keys  # the failed one was skipped, not written
-    assert "prior" in keys  # unrelated pending work survived the nested rollback
+    assert ("metric", "good") in keys  # the healthy metric persisted...
+    assert ("measure", "good_measure") in keys  # ...and its measure
+    assert ("metric", "bad") not in keys  # the failed one was skipped, not written
+    assert ("measure", "bad_measure") not in keys
+    assert ("metric", "prior") in keys  # unrelated pending work survived the nested rollback
 
 
 def test_persist_upserts_idempotently(
     session: Session, duckdb_conn: duckdb.DuckDBPyConnection
 ) -> None:
-    """_persist_additivity_verdicts writes one row per (metric_key, run_id); a re-run re-derives it."""
+    """A re-run re-derives the same ``(target_kind, target_key, run_id)`` row (upsert)."""
     graph = _seed(
         session,
         fact_name="journal_lines",
@@ -351,9 +365,13 @@ def test_persist_upserts_idempotently(
         aggregation="sum",
     )
 
-    def rows() -> list[MetricAdditivity]:
+    def metric_rows() -> list[MetricAdditivity]:
         return list(
-            session.execute(select(MetricAdditivity).where(MetricAdditivity.metric_key == "m"))
+            session.execute(
+                select(MetricAdditivity).where(
+                    MetricAdditivity.target_kind == "metric", MetricAdditivity.target_key == "m"
+                )
+            )
             .scalars()
             .all()
         )
@@ -370,7 +388,48 @@ def test_persist_upserts_idempotently(
         )
         session.commit()
 
-    persisted = rows()
+    persisted = metric_rows()
     assert len(persisted) == 1  # upsert, not a duplicate
     assert persisted[0].categorical_additive is True
     assert persisted[0].time_additive is True
+
+
+def test_persist_writes_measure_verdicts(
+    session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+) -> None:
+    """A stock measure gets its own semi-additive MEASURE verdict (the live AC5 cell).
+
+    `current_assets` is a drillable `measure:` node; its verdict is the extract's
+    own class — categorical-additive (sums across accounts) but time-stripped.
+    """
+    graph = _seed(
+        session,
+        fact_name="trial_balance",
+        view_name="enriched_trial_balance",
+        columns={"debit_balance": "point_in_time", "credit_balance": "point_in_time"},
+        grain_columns=["account_id", "period"],
+        time_columns=["period"],
+        field="current_assets",
+        select_expr="SUM(debit_balance) - SUM(credit_balance)",
+        aggregation="sum",
+    )
+    _persist_additivity_verdicts(
+        session,
+        duckdb_conn,
+        graphs={"m": graph},
+        executed_keys={"m"},
+        workspace_id=WS,
+        run_id=RUN,
+        catalogue_run_id=RUN,
+    )
+    session.commit()
+
+    measure = session.execute(
+        select(MetricAdditivity).where(
+            MetricAdditivity.target_kind == "measure",
+            MetricAdditivity.target_key == "current_assets",
+        )
+    ).scalar_one()
+    assert measure.categorical_additive is True
+    assert measure.time_additive is False
+    assert measure.time_reason == "stock"

--- a/packages/engine/tests/integration/graphs/test_additivity_resolver.py
+++ b/packages/engine/tests/integration/graphs/test_additivity_resolver.py
@@ -67,7 +67,7 @@ def _seed(
         source_id=source.source_id,
         table_name=fact_name,
         layer="typed",
-        duckdb_path=f"typed_{fact_name}",
+        duckdb_path=fact_name,  # DAT-639: duckdb_path == table_name (no layer prefix)
         row_count=100,
     )
     session.add(fact)
@@ -228,10 +228,15 @@ def test_unresolved_temporal_strips_time(
     assert verdict.time_reason == UNKNOWN_TEMPORAL
 
 
-def test_dimensionless_fact_resolves_by_table_name(
+def test_dimensionless_fact_resolves_to_typed_layer(
     session: Session, duckdb_conn: duckdb.DuckDBPyConnection
 ) -> None:
-    """A fact with no enriched view is resolved directly by table name, not dropped."""
+    """A fact with no enriched view resolves to its TYPED row, not the raw sibling.
+
+    The typed and raw rows for a fact share the same table_name + duckdb_path
+    (DAT-639), so the fallback must pin `layer == "typed"` — the raw row carries
+    no ColumnConcept/TableEntity, and landing on it would wrongly strip time.
+    """
     graph = _seed(
         session,
         fact_name="journal_lines",
@@ -244,11 +249,90 @@ def test_dimensionless_fact_resolves_by_table_name(
         aggregation="sum",
         create_view=False,
     )
+    # The raw-layer sibling: identical name AND duckdb_path, no concepts.
+    raw_src = Source(name="raw_src", source_type="csv")
+    session.add(raw_src)
+    session.flush()
+    session.add(
+        Table(
+            table_id=str(uuid4()),
+            source_id=raw_src.source_id,
+            table_name="journal_lines",
+            layer="raw",
+            duckdb_path="journal_lines",
+            row_count=100,
+        )
+    )
+    session.commit()
+
     verdict = compute_metric_verdict(
         session, duckdb_conn, graph=graph, workspace_id=WS, catalogue_run_id=RUN
     )
     assert verdict is not None
+    # Additive only if we resolved the TYPED row (which has the flow concepts);
+    # the raw row would yield UNKNOWN_TEMPORAL and strip time.
     assert verdict.time_additive is True
+
+
+def test_persist_is_fault_isolated(
+    session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+) -> None:
+    """One metric's compute failure is skipped, never rolling back the phase session.
+
+    The verdict is a best-effort annotation on the shared phase session; a bug in
+    one metric must not discard another metric's row or unrelated pending work.
+    """
+    from unittest.mock import patch
+
+    from dataraum.graphs.additivity import MetricVerdict
+
+    def _bare_graph(graph_id: str) -> TransformationGraph:
+        return TransformationGraph(
+            graph_id=graph_id,
+            version="1",
+            metadata=GraphMetadata(
+                name=graph_id, description="", category="c", source=GraphSource.SYSTEM
+            ),
+            output=OutputDef(output_type=OutputType.SCALAR),
+            steps={},
+        )
+
+    # An unrelated pending write already on the phase session (a prior metric's row).
+    session.add(
+        MetricAdditivity(
+            run_id=RUN, metric_key="prior", categorical_additive=True, time_additive=True
+        )
+    )
+    session.flush()
+
+    def fake_verdict(_session, _conn, *, graph, **_kw):
+        if graph.graph_id == "bad":
+            raise RuntimeError("boom - simulated resolver bug")
+        return MetricVerdict(categorical_additive=True, time_additive=True)
+
+    with patch(
+        "dataraum.graphs.additivity_resolver.compute_metric_verdict", side_effect=fake_verdict
+    ):
+        _persist_additivity_verdicts(
+            session,
+            duckdb_conn,
+            graphs={"good": _bare_graph("good"), "bad": _bare_graph("bad")},
+            executed_keys={"good", "bad"},
+            workspace_id=WS,
+            run_id=RUN,
+            catalogue_run_id=RUN,
+        )
+    session.commit()  # the session is not poisoned by the caught failure
+
+    keys = {
+        r.metric_key
+        for r in session.execute(select(MetricAdditivity).where(MetricAdditivity.run_id == RUN))
+        .scalars()
+        .all()
+    }
+    assert "good" in keys  # the healthy metric persisted
+    assert "bad" not in keys  # the failed one was skipped, not written
+    assert "prior" in keys  # unrelated pending work survived the nested rollback
 
 
 def test_persist_upserts_idempotently(

--- a/packages/engine/tests/integration/graphs/test_additivity_resolver.py
+++ b/packages/engine/tests/integration/graphs/test_additivity_resolver.py
@@ -13,10 +13,13 @@ from __future__ import annotations
 from uuid import uuid4
 
 import duckdb
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from dataraum.analysis.semantic.db_models import ColumnConcept, TableEntity
 from dataraum.analysis.views.db_models import EnrichedView
+from dataraum.graphs.additivity import UNKNOWN_TEMPORAL
+from dataraum.graphs.additivity_db_models import MetricAdditivity
 from dataraum.graphs.additivity_resolver import compute_metric_verdict
 from dataraum.graphs.models import (
     GraphMetadata,
@@ -28,6 +31,7 @@ from dataraum.graphs.models import (
     StepType,
     TransformationGraph,
 )
+from dataraum.pipeline.phases.metrics_phase import _persist_additivity_verdicts
 from dataraum.query.snippet_models import SQLSnippetRecord
 from dataraum.storage import Column, Source, Table
 
@@ -46,9 +50,15 @@ def _seed(
     field: str,
     select_expr: str,
     aggregation: str,
+    bind_concepts: bool = True,
+    create_view: bool = True,
 ) -> TransformationGraph:
     """Seed one fact + its columns/concepts/view/entity + the extract snippet, and
-    return a single-extract metric graph grounding ``field`` to it."""
+    return a single-extract metric graph grounding ``field`` to it.
+
+    ``bind_concepts=False`` leaves the base columns without a ``ColumnConcept``
+    (an unresolved temporal_behavior); ``create_view=False`` leaves the fact
+    without an enriched view (a dimensionless fact the extract reads directly)."""
     source = Source(name=f"src_{fact_name}", source_type="csv")
     session.add(source)
     session.flush()
@@ -72,8 +82,12 @@ def _seed(
         )
         session.add(col)
         session.flush()
-        session.add(ColumnConcept(column_id=col.column_id, run_id=RUN, temporal_behavior=behavior))
-    session.add(EnrichedView(fact_table_id=fact.table_id, view_name=view_name, run_id=RUN))
+        if bind_concepts:
+            session.add(
+                ColumnConcept(column_id=col.column_id, run_id=RUN, temporal_behavior=behavior)
+            )
+    if create_view:
+        session.add(EnrichedView(fact_table_id=fact.table_id, view_name=view_name, run_id=RUN))
     session.add(
         TableEntity(
             table_id=fact.table_id,
@@ -187,3 +201,92 @@ def test_unresolved_extract_yields_no_verdict(
         session, duckdb_conn, graph=graph, workspace_id=WS, catalogue_run_id=RUN
     )
     assert verdict is None
+
+
+def test_unresolved_temporal_strips_time(
+    session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+) -> None:
+    """A base column with no ColumnConcept (unresolved temporal) → time refused, not assumed flow."""
+    graph = _seed(
+        session,
+        fact_name="journal_lines",
+        view_name="enriched_journal_lines",
+        columns={"credit": "additive", "debit": "additive"},
+        grain_columns=["line_id"],
+        time_columns=[],
+        field="revenue",
+        select_expr="SUM(credit) - SUM(debit)",
+        aggregation="sum",
+        bind_concepts=False,  # no concept rows → temporal unknown
+    )
+    verdict = compute_metric_verdict(
+        session, duckdb_conn, graph=graph, workspace_id=WS, catalogue_run_id=RUN
+    )
+    assert verdict is not None
+    assert verdict.categorical_additive is True
+    assert verdict.time_additive is False
+    assert verdict.time_reason == UNKNOWN_TEMPORAL
+
+
+def test_dimensionless_fact_resolves_by_table_name(
+    session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+) -> None:
+    """A fact with no enriched view is resolved directly by table name, not dropped."""
+    graph = _seed(
+        session,
+        fact_name="journal_lines",
+        view_name="journal_lines",  # the extract reads the typed table directly
+        columns={"credit": "additive", "debit": "additive"},
+        grain_columns=["line_id"],
+        time_columns=[],
+        field="revenue",
+        select_expr="SUM(credit) - SUM(debit)",
+        aggregation="sum",
+        create_view=False,
+    )
+    verdict = compute_metric_verdict(
+        session, duckdb_conn, graph=graph, workspace_id=WS, catalogue_run_id=RUN
+    )
+    assert verdict is not None
+    assert verdict.time_additive is True
+
+
+def test_persist_upserts_idempotently(
+    session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+) -> None:
+    """_persist_additivity_verdicts writes one row per (metric_key, run_id); a re-run re-derives it."""
+    graph = _seed(
+        session,
+        fact_name="journal_lines",
+        view_name="enriched_journal_lines",
+        columns={"credit": "additive", "debit": "additive"},
+        grain_columns=["line_id"],
+        time_columns=[],
+        field="revenue",
+        select_expr="SUM(credit) - SUM(debit)",
+        aggregation="sum",
+    )
+
+    def rows() -> list[MetricAdditivity]:
+        return list(
+            session.execute(select(MetricAdditivity).where(MetricAdditivity.metric_key == "m"))
+            .scalars()
+            .all()
+        )
+
+    for _ in range(2):
+        _persist_additivity_verdicts(
+            session,
+            duckdb_conn,
+            graphs={"m": graph},
+            executed_keys={"m"},
+            workspace_id=WS,
+            run_id=RUN,
+            catalogue_run_id=RUN,
+        )
+        session.commit()
+
+    persisted = rows()
+    assert len(persisted) == 1  # upsert, not a duplicate
+    assert persisted[0].categorical_additive is True
+    assert persisted[0].time_additive is True

--- a/packages/engine/tests/unit/graphs/test_additivity.py
+++ b/packages/engine/tests/unit/graphs/test_additivity.py
@@ -19,11 +19,14 @@ from dataraum.graphs.additivity import (
     RATIO,
     SNAPSHOT_COUNT,
     STOCK,
+    UNKNOWN_AGGREGATE,
+    UNKNOWN_TEMPORAL,
     AggregateCall,
     AxisClass,
     classify_extract,
     parse_aggregate_calls,
     roll_up_metric,
+    select_expr_is_ratio,
 )
 from dataraum.graphs.models import (
     GraphMetadata,
@@ -258,3 +261,59 @@ def test_rollup_sum_of_flow_and_stock_is_semi_additive():
     assert verdict.categorical_additive is True
     assert verdict.time_additive is False
     assert verdict.time_reason == STOCK
+
+
+# --- 4. conservatism when a signal is missing (reviewer findings) ------------
+
+
+def test_sum_of_unresolved_column_strips_time():
+    """A column with no resolved temporal_behavior can't be confirmed a flow — strip time."""
+    cls = classify_extract([AggregateCall("sum", ("mystery",))], {}, fact_is_snapshot=False)
+    assert cls.categorical_additive is True
+    assert cls.time_additive is False
+    assert cls.time_reason == UNKNOWN_TEMPORAL
+
+
+def test_count_on_unknown_grain_strips_time():
+    """An unknown fact grain (no TableEntity) denies COUNT the time axis, not offers it."""
+    cls = classify_extract([AggregateCall("count_star", ())], {}, fact_is_snapshot=None)
+    assert cls.categorical_additive is True
+    assert cls.time_additive is False
+    assert cls.time_reason == UNKNOWN_TEMPORAL
+
+
+def test_is_ratio_flag_overrides_to_non_additive():
+    cls = classify_extract([AggregateCall("sum", ("credit",))], FLOW, False, is_ratio=True)
+    assert cls == AxisClass(False, False, RATIO, RATIO)
+
+
+# --- 5. intra-extract ratio detection (select_expr_is_ratio) -----------------
+
+
+def test_ratio_detection_division_of_measures(con):
+    assert select_expr_is_ratio("SUM(numerator) / SUM(denominator)", con) is True
+
+
+def test_ratio_detection_product_of_measures(con):
+    assert select_expr_is_ratio("SUM(a) * SUM(b)", con) is True
+
+
+def test_ratio_detection_scaling_by_constant_is_not_ratio(con):
+    assert select_expr_is_ratio("SUM(revenue) / 12", con) is False
+    assert select_expr_is_ratio("SUM(revenue) * 1.1", con) is False
+
+
+def test_ratio_detection_difference_is_not_ratio(con):
+    assert select_expr_is_ratio("COALESCE(SUM(credit), 0) - COALESCE(SUM(debit), 0)", con) is False
+
+
+# --- 6. roll-up cycle guard --------------------------------------------------
+
+
+def test_rollup_formula_cycle_is_refused():
+    """A FORMULA referencing itself is refused, not recursed unbounded."""
+    graph = _graph({"a": _formula("a", "a + 1", ["a"])})
+    verdict = roll_up_metric(graph, {})
+    assert verdict.categorical_additive is False
+    assert verdict.time_additive is False
+    assert verdict.time_reason == UNKNOWN_AGGREGATE

--- a/packages/engine/tests/unit/graphs/test_additivity.py
+++ b/packages/engine/tests/unit/graphs/test_additivity.py
@@ -1,0 +1,260 @@
+"""Additivity verdict logic (DAT-716).
+
+Parser cases use the REAL grounded ``select_expr`` shapes from the finance
+workspace (multi-column signed measures, the ``CASE WHEN COUNT(*)=0`` NULL
+guard); classification and roll-up assert the doctrine on representative
+metric DAGs.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from dataraum.graphs.additivity import (
+    ADDITIVE,
+    AVERAGE,
+    DISTINCT_COUNT,
+    MIN_MAX,
+    RATIO,
+    SNAPSHOT_COUNT,
+    STOCK,
+    AggregateCall,
+    AxisClass,
+    classify_extract,
+    parse_aggregate_calls,
+    roll_up_metric,
+)
+from dataraum.graphs.models import (
+    GraphMetadata,
+    GraphSource,
+    GraphStep,
+    OutputDef,
+    OutputType,
+    StepType,
+    TransformationGraph,
+)
+
+
+@pytest.fixture
+def con():
+    connection = duckdb.connect()
+    yield connection
+    connection.close()
+
+
+# --- 1. parse_aggregate_calls over real select_expr shapes -------------------
+
+
+def test_parse_signed_flow_measure(con):
+    """revenue: the CASE COUNT(*) guard + two signed SUMs — all three calls, columns intact."""
+    expr = "CASE WHEN COUNT(*) = 0 THEN NULL ELSE COALESCE(SUM(credit), 0) - COALESCE(SUM(debit), 0) END"
+    calls = parse_aggregate_calls(expr, con)
+    assert AggregateCall("count_star", ()) in calls
+    assert AggregateCall("sum", ("credit",)) in calls
+    assert AggregateCall("sum", ("debit",)) in calls
+    assert len(calls) == 3
+
+
+def test_parse_stock_measure(con):
+    """current_assets: two SUMs over trial-balance stock columns."""
+    calls = parse_aggregate_calls("SUM(debit_balance) - SUM(credit_balance)", con)
+    assert set(calls) == {
+        AggregateCall("sum", ("debit_balance",)),
+        AggregateCall("sum", ("credit_balance",)),
+    }
+
+
+def test_parse_count_distinct_and_avg(con):
+    assert parse_aggregate_calls("COUNT(DISTINCT customer_id)", con) == [
+        AggregateCall("count_distinct", ("customer_id",))
+    ]
+    assert parse_aggregate_calls("AVG(amount)", con) == [AggregateCall("avg", ("amount",))]
+
+
+def test_parse_ignores_non_aggregate_functions(con):
+    """COALESCE and arithmetic operators serialize as FUNCTION nodes too — they must not be counted."""
+    calls = parse_aggregate_calls("COALESCE(SUM(x), 0) + ABS(y)", con)
+    assert calls == [AggregateCall("sum", ("x",))]
+
+
+def test_parse_multi_column_aggregate(con):
+    """An aggregate over an expression collects every base column it touches."""
+    calls = parse_aggregate_calls("SUM(a - b)", con)
+    assert calls == [AggregateCall("sum", ("a", "b"))]
+
+
+# --- 2. classify_extract: function symmetry x temporal x snapshot ------------
+
+FLOW = {"credit": "additive", "debit": "additive"}
+STOCKCOLS = {"debit_balance": "point_in_time", "credit_balance": "point_in_time"}
+
+
+def test_sum_flow_is_fully_additive():
+    cls = classify_extract([AggregateCall("sum", ("credit",))], FLOW, fact_is_snapshot=False)
+    assert cls == AxisClass(True, True)
+
+
+def test_sum_stock_strips_time_only():
+    cls = classify_extract(
+        [AggregateCall("sum", ("debit_balance",))], STOCKCOLS, fact_is_snapshot=True
+    )
+    assert cls.categorical_additive is True
+    assert cls.time_additive is False
+    assert cls.time_reason == STOCK
+
+
+def test_count_star_additive_on_event_fact():
+    assert classify_extract(
+        [AggregateCall("count_star", ())], {}, fact_is_snapshot=False
+    ) == AxisClass(True, True)
+
+
+def test_count_star_strips_time_on_snapshot_fact():
+    cls = classify_extract([AggregateCall("count_star", ())], {}, fact_is_snapshot=True)
+    assert cls.categorical_additive is True
+    assert cls.time_additive is False
+    assert cls.time_reason == SNAPSHOT_COUNT
+
+
+def test_avg_and_distinct_and_minmax_never_reconcile():
+    assert classify_extract([AggregateCall("avg", ("x",))], {}, False) == AxisClass(
+        False, False, AVERAGE, AVERAGE
+    )
+    assert classify_extract([AggregateCall("count_distinct", ("x",))], {}, False) == AxisClass(
+        False, False, DISTINCT_COUNT, DISTINCT_COUNT
+    )
+    assert classify_extract([AggregateCall("min", ("x",))], {}, False) == AxisClass(
+        False, False, MIN_MAX, MIN_MAX
+    )
+
+
+def test_signed_flow_extract_is_additive():
+    """revenue's three calls (count_star + two flow SUMs) on an event fact → fully additive."""
+    calls = [
+        AggregateCall("count_star", ()),
+        AggregateCall("sum", ("credit",)),
+        AggregateCall("sum", ("debit",)),
+    ]
+    assert classify_extract(calls, FLOW, fact_is_snapshot=False) == AxisClass(True, True)
+
+
+def test_mixed_flow_and_stock_takes_most_restrictive():
+    """A SUM touching a stock column strips time even alongside a flow SUM."""
+    calls = [AggregateCall("sum", ("credit",)), AggregateCall("sum", ("debit_balance",))]
+    cls = classify_extract(calls, {**FLOW, **STOCKCOLS}, fact_is_snapshot=True)
+    assert cls.categorical_additive is True
+    assert cls.time_additive is False
+    assert cls.time_reason == STOCK
+
+
+# --- 3. roll_up_metric over the DAG ------------------------------------------
+
+
+def _graph(steps: dict[str, GraphStep]) -> TransformationGraph:
+    return TransformationGraph(
+        graph_id="g",
+        version="1",
+        metadata=GraphMetadata(name="m", description="", category="c", source=GraphSource.SYSTEM),
+        output=OutputDef(output_type=OutputType.SCALAR),
+        steps=steps,
+    )
+
+
+def _extract(step_id: str) -> GraphStep:
+    return GraphStep(step_id=step_id, step_type=StepType.EXTRACT)
+
+
+def _formula(step_id: str, expr: str, deps: list[str], *, output: bool = True) -> GraphStep:
+    return GraphStep(
+        step_id=step_id,
+        step_type=StepType.FORMULA,
+        expression=expr,
+        depends_on=deps,
+        output_step=output,
+    )
+
+
+def test_rollup_difference_of_flows_is_additive():
+    """gross_profit = revenue - cost_of_goods_sold."""
+    graph = _graph(
+        {
+            "revenue": _extract("revenue"),
+            "cost_of_goods_sold": _extract("cost_of_goods_sold"),
+            "gp": _formula("gp", "revenue - cost_of_goods_sold", ["revenue", "cost_of_goods_sold"]),
+        }
+    )
+    verdict = roll_up_metric(graph, {"revenue": ADDITIVE, "cost_of_goods_sold": ADDITIVE})
+    assert verdict.categorical_additive is True
+    assert verdict.time_additive is True
+
+
+def test_rollup_ratio_is_non_additive_everywhere():
+    """current_ratio = current_assets / current_liabilities — non-additive whatever the operands."""
+    graph = _graph(
+        {
+            "current_assets": _extract("current_assets"),
+            "current_liabilities": _extract("current_liabilities"),
+            "cr": _formula(
+                "cr",
+                "current_assets / current_liabilities",
+                ["current_assets", "current_liabilities"],
+            ),
+        }
+    )
+    # Even though the operands are only semi-additive, the ratio verdict is non-additive on BOTH axes.
+    stock = AxisClass(True, False, None, STOCK)
+    verdict = roll_up_metric(graph, {"current_assets": stock, "current_liabilities": stock})
+    assert verdict.categorical_additive is False
+    assert verdict.time_additive is False
+    assert verdict.time_reason == RATIO
+
+
+def test_rollup_ratio_times_constant_stays_non_additive():
+    """dso = (accounts_receivable / revenue) * days_in_period — the constant scale doesn't rescue it."""
+    graph = _graph(
+        {
+            "accounts_receivable": _extract("accounts_receivable"),
+            "revenue": _extract("revenue"),
+            "days_in_period": GraphStep(
+                step_id="days_in_period", step_type=StepType.CONSTANT, value=365
+            ),
+            "dso": _formula(
+                "dso",
+                "(accounts_receivable / revenue) * days_in_period",
+                ["accounts_receivable", "revenue", "days_in_period"],
+            ),
+        }
+    )
+    verdict = roll_up_metric(
+        graph, {"accounts_receivable": AxisClass(True, False, None, STOCK), "revenue": ADDITIVE}
+    )
+    assert verdict.categorical_additive is False
+    assert verdict.time_additive is False
+
+
+def test_rollup_scale_by_constant_preserves_additivity():
+    """A measure scaled by a literal stays additive."""
+    graph = _graph(
+        {"revenue": _extract("revenue"), "scaled": _formula("scaled", "revenue * 1.1", ["revenue"])}
+    )
+    verdict = roll_up_metric(graph, {"revenue": ADDITIVE})
+    assert verdict.categorical_additive is True
+    assert verdict.time_additive is True
+
+
+def test_rollup_sum_of_flow_and_stock_is_semi_additive():
+    """A stock operand in an additive combination strips time but keeps categorical."""
+    graph = _graph(
+        {
+            "flow": _extract("flow"),
+            "stock": _extract("stock"),
+            "total": _formula("total", "flow + stock", ["flow", "stock"]),
+        }
+    )
+    verdict = roll_up_metric(
+        graph, {"flow": ADDITIVE, "stock": AxisClass(True, False, None, STOCK)}
+    )
+    assert verdict.categorical_additive is True
+    assert verdict.time_additive is False
+    assert verdict.time_reason == STOCK

--- a/packages/engine/tests/unit/graphs/test_additivity.py
+++ b/packages/engine/tests/unit/graphs/test_additivity.py
@@ -287,6 +287,22 @@ def test_is_ratio_flag_overrides_to_non_additive():
     assert cls == AxisClass(False, False, RATIO, RATIO)
 
 
+def test_count_star_guard_does_not_taint_stock_reason():
+    """The CASE COUNT(*)=0 guard alongside SUM(stock): time stripped for STOCK, not snapshot_count."""
+    calls = [AggregateCall("count_star", ()), AggregateCall("sum", ("debit_balance",))]
+    cls = classify_extract(calls, STOCKCOLS, fact_is_snapshot=True)
+    assert cls.categorical_additive is True
+    assert cls.time_additive is False
+    assert cls.time_reason == STOCK  # the measure's reason, not the guard's
+
+
+def test_count_star_alone_is_the_measure():
+    """A COUNT(*) with no co-occurring measure IS the measure — snapshot rule applies."""
+    cls = classify_extract([AggregateCall("count_star", ())], {}, fact_is_snapshot=True)
+    assert cls.time_additive is False
+    assert cls.time_reason == SNAPSHOT_COUNT
+
+
 # --- 5. intra-extract ratio detection (select_expr_is_ratio) -----------------
 
 

--- a/packages/engine/tests/unit/graphs/test_additivity.py
+++ b/packages/engine/tests/unit/graphs/test_additivity.py
@@ -68,11 +68,19 @@ def test_parse_stock_measure(con):
     }
 
 
-def test_parse_count_distinct_and_avg(con):
+def test_parse_distinct_flag(con):
     assert parse_aggregate_calls("COUNT(DISTINCT customer_id)", con) == [
-        AggregateCall("count_distinct", ("customer_id",))
+        AggregateCall("count", ("customer_id",), distinct=True)
+    ]
+    assert parse_aggregate_calls("SUM(DISTINCT amount)", con) == [
+        AggregateCall("sum", ("amount",), distinct=True)
     ]
     assert parse_aggregate_calls("AVG(amount)", con) == [AggregateCall("avg", ("amount",))]
+
+
+def test_parse_window_function_yields_no_calls(con):
+    """A window aggregate is not an aggregate FUNCTION node — no calls (refused downstream, F3)."""
+    assert parse_aggregate_calls("SUM(x) OVER ()", con) == []
 
 
 def test_parse_ignores_non_aggregate_functions(con):
@@ -124,9 +132,9 @@ def test_avg_and_distinct_and_minmax_never_reconcile():
     assert classify_extract([AggregateCall("avg", ("x",))], {}, False) == AxisClass(
         False, False, AVERAGE, AVERAGE
     )
-    assert classify_extract([AggregateCall("count_distinct", ("x",))], {}, False) == AxisClass(
-        False, False, DISTINCT_COUNT, DISTINCT_COUNT
-    )
+    assert classify_extract(
+        [AggregateCall("count", ("x",), distinct=True)], {}, False
+    ) == AxisClass(False, False, DISTINCT_COUNT, DISTINCT_COUNT)
     assert classify_extract([AggregateCall("min", ("x",))], {}, False) == AxisClass(
         False, False, MIN_MAX, MIN_MAX
     )
@@ -263,6 +271,15 @@ def test_rollup_sum_of_flow_and_stock_is_semi_additive():
     assert verdict.time_reason == STOCK
 
 
+def test_rollup_without_output_step_is_refused():
+    """A graph missing its output marker can't reveal ratio-vs-sum structure → refuse (F5)."""
+    graph = _graph({"e": _extract("e")})  # no step marked output_step
+    verdict = roll_up_metric(graph, {"e": ADDITIVE})
+    assert verdict.categorical_additive is False
+    assert verdict.time_additive is False
+    assert verdict.time_reason == UNKNOWN_AGGREGATE
+
+
 # --- 4. conservatism when a signal is missing (reviewer findings) ------------
 
 
@@ -301,6 +318,27 @@ def test_count_star_alone_is_the_measure():
     cls = classify_extract([AggregateCall("count_star", ())], {}, fact_is_snapshot=True)
     assert cls.time_additive is False
     assert cls.time_reason == SNAPSHOT_COUNT
+
+
+def test_sum_distinct_never_reconciles():
+    """SUM(DISTINCT) is non-additive — the distinct set overlaps across slices (F1)."""
+    cls = classify_extract([AggregateCall("sum", ("amount",), distinct=True)], FLOW, False)
+    assert cls == AxisClass(False, False, DISTINCT_COUNT, DISTINCT_COUNT)
+
+
+def test_count_1_guard_also_excluded():
+    """A COUNT(1) NULL-guard (parses as count/no-columns) is dropped like COUNT(*) (F2)."""
+    calls = [AggregateCall("count", ()), AggregateCall("sum", ("debit_balance",))]
+    cls = classify_extract(calls, STOCKCOLS, fact_is_snapshot=True)
+    assert cls.time_additive is False
+    assert cls.time_reason == STOCK  # not tainted with snapshot_count by the guard
+
+
+def test_no_aggregate_is_refused():
+    """No aggregate call (bare passthrough / unparsed window) → refused, never additive (F3)."""
+    assert classify_extract([], {}, False) == AxisClass(
+        False, False, UNKNOWN_AGGREGATE, UNKNOWN_AGGREGATE
+    )
 
 
 # --- 5. intra-extract ratio detection (select_expr_is_ratio) -----------------


### PR DESCRIPTION
Phase 1 of the metric-drill grounding rework (epic **DAT-671**). Design: [DD/47710210](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/47710210) · ticket **DAT-716**.

## What

The engine now authors a per-**drill-target** *additivity verdict* at the operating_model `metrics` phase — deterministically, no LLM, from signals the pipeline already computes. The cockpit drill reads it (DAT-717) to decide, for a canvas node, whether to offer a time grain and whether a breakdown sums to the total or shows the honest dash. This replaces the composed-SQL re-parse the flow gate (PR #461) did — the signals were structural all along.

`metric_additivity` (read-view `current_metric_additivity`, operating_model stage) holds one row per drill target, keyed `(target_kind, target_key, run_id)`:
- **`metric`** — a formula node (graph_id); verdict is the DAG roll-up.
- **`measure`** — a grounded-extract node (standard_field); verdict is the extract's own class. *(Both are drillable via `analyseTarget`.)*

## The doctrine (`graphs/additivity.py`)

Parse the extract's `select_expr` (`json_serialize_sql` on one small single-relation expr — **not** the composed metric), then classify two axes:
- **Function symmetry** (every axis): `SUM`/`COUNT(*)`/`COUNT(col)` additive; `AVG`/`COUNT(DISTINCT)`/any `DISTINCT`/ratio non-additive; `MIN`/`MAX` non-summable this cut.
- **Time semi-additivity**: `SUM(stock)` (`temporal_behavior=point_in_time`) not additive across time; `COUNT(*)` additive across time only on a non-snapshot fact (`table_entities.grain_columns`).
- **Formula roll-up** through the metric DAG; per-measure classified directly.
- **Conservative throughout**: a missing signal, an unparsed window, a `CASE WHEN COUNT(*)=0` guard, a bare passthrough, or an absent output marker all *refuse*, never assume additive.

## Verified live on the workspace

10 metric + 9 measure verdicts, all correct: flow measures/metrics → additive; `current_assets`/`current_liabilities` (measures) → semi-additive/time-stripped (`stock`); ratios → non-additive. Write path + read-view head-join exercised end-to-end.

## Tests / gates

41 additivity (unit + real-catalog integration) + full metrics-phase/pipeline suites green; ruff/mypy/vulture clean; `schema.sql` / `schema_read.sql` / cockpit drizzle mirror regenerated in lockstep (`schema-drift`).

## Reviews

Three reviewers (senior · spec-compliance · strict), 8 passes — every pass found a real *silent-permissive* path (conservatism on missing signals, SAVEPOINT fault-isolation, intra-extract ratio, deterministic fact fallback, cycle guard, `DISTINCT`, `COUNT(1)` guard, window/empty, iteration determinism, no-output fallback). All resolved with tests. Final: **all three approved.**

## Scope

Engine-only. **Out of scope, on their tickets:** cockpit consumption → DAT-717 (reads by `target_kind`); the `AVG`/`COUNT`/`COUNT(DISTINCT)` matrix + ground-truth oracle → DAT-718; per-dimension / join-reachability grounding → the deferred IR layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)