### PR TITLE
feat(DAT-718): activity metrics + count_distinct vocabulary for the additivity matrix

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,41 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-718 — activity metrics + `count_distinct` grounding vocabulary
+
+**Branch:** `feat/dat-718-matrix-metrics`. Extends the finance metric catalogue +
+the grounding vocabulary so the DAT-716 additivity matrix fires on real metrics.
+
+### What changed
+
+- **Three new finance metrics** (`packages/dataraum-config/verticals/finance/metrics/activity/`):
+  `transaction_count` (`COUNT` → additive flow), `average_transaction_value`
+  (`AVG` → non-additive), `active_accounts` (`COUNT(DISTINCT)` → non-additive).
+  Single-extract graphs; grounded over the `journal_lines` event fact.
+- **New aggregation `count_distinct`** in the grounding vocabulary
+  (`graph_sql_generation.yaml` `<aggregation_types>` → emit `COUNT(DISTINCT "<col>")`;
+  `GraphStep.aggregation` doc). The DAT-716 classifier already handles the DISTINCT
+  shape; this lets a metric *declare* it.
+
+### For eval (the validation this needs — run in eval / `/smoke`)
+
+- **Grounding recall on the new metrics**: confirm the agent grounds
+  `transaction_count`/`average_transaction_value` over `journal_lines`, and
+  `active_accounts` as `COUNT(DISTINCT account_id)` (the new vocabulary entry).
+  `count`/`avg` are validated by unit test at the config level; the actual SQL the
+  LLM emits is the e2e question.
+- **The additivity oracle** (the DAT-718 core): once grounded, assert the
+  `metric_additivity` per-target verdicts — `transaction_count` → additive,
+  `average_transaction_value`/`active_accounts` → non-additive — against ground truth.
+
+### For testdata
+
+The current corpus already carries `journal_lines` (an event fact) with per-line
+amounts + account FKs, so these should ground without new fixtures — confirm at
+e2e; add fixtures only if the agent can't ground `active_accounts`.
+
+---
+
 ## DAT-716 — metric additivity verdict (new `metric_additivity` read-view)
 
 **Branch:** `feat/dat-716-additivity-verdict`. Engine-internal, **no detector or

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -138,6 +138,9 @@ system_prompt: |
   <aggregation_types>
   The graph step specifies an aggregation that determines HOW to extract the value:
   - "sum" / "avg" / "count" / "min" / "max": aggregate all matching rows.
+  - "count_distinct": COUNT(DISTINCT <the grounded column>) — the number of DISTINCT values of
+    the concept (e.g. distinct accounts transacted, distinct customers). Emit exactly
+    `COUNT(DISTINCT "<column>")`, never a plain COUNT.
   - "end_of_period": point-in-time snapshot — take the value from the LATEST period only; DO NOT
     SUM across periods (these are stock measures: balances, levels at a moment).
     Pattern: a where predicate `"<period>" = (SELECT MAX("<period>") FROM <view>)` alongside

--- a/packages/dataraum-config/verticals/finance/metrics/activity/active_accounts.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/activity/active_accounts.yaml
@@ -1,0 +1,34 @@
+graph_id: active_accounts
+version: '1.0'
+metadata:
+  name: Active Accounts
+  description: Number of distinct ledger accounts transacted in the period
+  category: activity
+  source: system
+  tags:
+  - activity
+  - distinct
+output:
+  type: scalar
+  metric_id: active_accounts
+  unit: count
+  decimal_places: 0
+dependencies:
+  active_accounts:
+    level: 1
+    type: extract
+    source:
+      standard_field: account
+      statement: income_statement
+    aggregation: count_distinct
+    output_step: true
+interpretation:
+  ranges:
+  - min: 0
+    max: 0
+    label: NONE
+    description: No accounts transacted
+  - min: 1
+    max: 999999999
+    label: ACTIVE
+    description: Distinct accounts transacted in the period

--- a/packages/dataraum-config/verticals/finance/metrics/activity/average_transaction_value.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/activity/average_transaction_value.yaml
@@ -1,0 +1,30 @@
+graph_id: average_transaction_value
+version: '1.0'
+metadata:
+  name: Average Transaction Value
+  description: Mean monetary value per ledger transaction
+  category: activity
+  source: system
+  tags:
+  - activity
+  - averages
+output:
+  type: scalar
+  metric_id: average_transaction_value
+  unit: currency
+  decimal_places: 2
+dependencies:
+  average_transaction_value:
+    level: 1
+    type: extract
+    source:
+      standard_field: transaction_amount
+      statement: income_statement
+    aggregation: avg
+    output_step: true
+interpretation:
+  ranges:
+  - min: 0
+    max: 999999999
+    label: POSITIVE
+    description: Average transaction value in the period

--- a/packages/dataraum-config/verticals/finance/metrics/activity/transaction_count.yaml
+++ b/packages/dataraum-config/verticals/finance/metrics/activity/transaction_count.yaml
@@ -1,0 +1,34 @@
+graph_id: transaction_count
+version: '1.0'
+metadata:
+  name: Transaction Count
+  description: Number of ledger transactions recorded in the period
+  category: activity
+  source: system
+  tags:
+  - activity
+  - volume
+output:
+  type: scalar
+  metric_id: transaction_count
+  unit: count
+  decimal_places: 0
+dependencies:
+  transaction_count:
+    level: 1
+    type: extract
+    source:
+      standard_field: transaction_amount
+      statement: income_statement
+    aggregation: count
+    output_step: true
+interpretation:
+  ranges:
+  - min: 0
+    max: 0
+    label: NONE
+    description: No transactions recorded
+  - min: 1
+    max: 999999999
+    label: ACTIVE
+    description: Transactions recorded in the period

--- a/packages/engine/src/dataraum/graphs/models.py
+++ b/packages/engine/src/dataraum/graphs/models.py
@@ -109,7 +109,7 @@ class GraphStep:
 
     # For extract steps
     source: StepSource | None = None
-    aggregation: str | None = None  # sum, avg, min, max, count, end_of_period
+    aggregation: str | None = None  # sum, avg, min, max, count, count_distinct, end_of_period
 
     # For constant steps
     value: Any | None = None

--- a/packages/engine/tests/unit/graphs/test_activity_metrics.py
+++ b/packages/engine/tests/unit/graphs/test_activity_metrics.py
@@ -1,0 +1,89 @@
+"""Activity metric graphs — the COUNT / AVG / COUNT(DISTINCT) matrix cells (DAT-718).
+
+These exercise the additivity matrix's function-symmetry cells that the P&L
+catalogue lacked: a COUNT flow (additive), an AVG (non-additive), and a
+COUNT(DISTINCT) (non-additive). ``count_distinct`` required adding the aggregation
+to the grounding vocabulary (``graph_sql_generation.yaml`` ``<aggregation_types>``
++ the ``GraphStep.aggregation`` vocabulary). The verdict itself is proven against
+the grounded SQL shape each aggregation produces.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from dataraum.graphs.additivity import classify_extract, parse_aggregate_calls
+from dataraum.graphs.config import get_metric_definitions
+from dataraum.graphs.loader import GraphLoader
+from dataraum.graphs.models import OutputType
+
+# graph_id -> the extract's declared aggregation.
+ACTIVITY_METRICS = {
+    "transaction_count": "count",
+    "average_transaction_value": "avg",
+    "active_accounts": "count_distinct",
+}
+
+
+@pytest.fixture(scope="module")
+def loader() -> GraphLoader:
+    ldr = GraphLoader()
+    ldr.graphs.update(ldr.graphs_from_definitions(get_metric_definitions("finance")))
+    return ldr
+
+
+@pytest.fixture
+def con():
+    connection = duckdb.connect()
+    yield connection
+    connection.close()
+
+
+class TestActivityMetricsLoad:
+    @pytest.mark.parametrize("graph_id", sorted(ACTIVITY_METRICS))
+    def test_present_and_scalar(self, loader: GraphLoader, graph_id: str) -> None:
+        graph = loader.graphs.get(graph_id)
+        assert graph is not None, f"{graph_id} not loaded from the finance vertical"
+        assert graph.output.output_type == OutputType.SCALAR
+        assert graph.metadata.category == "activity"
+
+    @pytest.mark.parametrize("graph_id,aggregation", sorted(ACTIVITY_METRICS.items()))
+    def test_single_extract_with_declared_aggregation(
+        self, loader: GraphLoader, graph_id: str, aggregation: str
+    ) -> None:
+        graph = loader.graphs.get(graph_id)
+        assert graph is not None
+        extracts = [s for s in graph.steps.values() if s.step_type.value == "extract"]
+        assert len(extracts) == 1
+        assert extracts[0].aggregation == aggregation
+        assert extracts[0].output_step is True
+
+    def test_standard_fields_resolve(self, loader: GraphLoader) -> None:
+        """account + transaction_amount resolve against the finance ontology (no warnings)."""
+        assert loader.validate_standard_fields("finance") == []
+
+
+class TestActivityMetricsAdditivity:
+    """Each aggregation's grounded SQL shape classifies per the DAT-716 doctrine."""
+
+    def test_count_flow_is_additive(self, con: duckdb.DuckDBPyConnection) -> None:
+        # transaction_count → COUNT over an event fact (journal_lines) → additive on both axes.
+        cls = classify_extract(
+            parse_aggregate_calls("COUNT(amount)", con), {"amount": "additive"}, False
+        )
+        assert cls.categorical_additive is True
+        assert cls.time_additive is True
+
+    def test_avg_is_non_additive(self, con: duckdb.DuckDBPyConnection) -> None:
+        cls = classify_extract(
+            parse_aggregate_calls("AVG(amount)", con), {"amount": "additive"}, False
+        )
+        assert cls.categorical_additive is False
+        assert cls.time_additive is False
+
+    def test_count_distinct_is_non_additive(self, con: duckdb.DuckDBPyConnection) -> None:
+        # active_accounts → COUNT(DISTINCT account_id) → non-additive (distinct sets overlap).
+        cls = classify_extract(parse_aggregate_calls("COUNT(DISTINCT account_id)", con), {}, False)
+        assert cls.categorical_additive is False
+        assert cls.time_additive is False

--- a/packages/engine/tests/unit/graphs/test_config.py
+++ b/packages/engine/tests/unit/graphs/test_config.py
@@ -20,9 +20,11 @@ class TestGetMetricDefinitionsProduction:
     def teardown_method(self) -> None:
         reset_overlay_resolver_for_tests()
 
-    def test_returns_all_13_finance_metrics(self) -> None:
+    def test_returns_all_finance_metrics(self) -> None:
         defs = get_metric_definitions("finance")
-        assert len(defs) == 13
+        # 13 P&L / working-capital / liquidity metrics + 3 activity metrics
+        # (transaction_count, average_transaction_value, active_accounts — DAT-718).
+        assert len(defs) == 16
 
     def test_keyed_by_graph_id_with_known_metrics(self) -> None:
         defs = get_metric_definitions("finance")
@@ -67,7 +69,7 @@ class TestGetMetricsConfigOverlay:
         )
         defs = get_metric_definitions("finance")
         assert "custom_kpi" in defs
-        assert len(defs) == 14  # the 13 shipped + the taught one
+        assert len(defs) == 17  # the 16 shipped + the taught one
         assert "vertical" not in defs["custom_kpi"]
 
     def test_overlay_row_replaces_shipped_metric_by_graph_id(self) -> None:
@@ -85,7 +87,7 @@ class TestGetMetricsConfigOverlay:
             ]
         )
         defs = get_metric_definitions("finance")
-        assert len(defs) == 13  # replace, not append
+        assert len(defs) == 16  # replace, not append
         assert defs["dso"]["metadata"]["name"] == "DSO (taught)"
 
 


### PR DESCRIPTION
Phase 3 (config slice) of the metric-drill grounding rework (epic **DAT-671**, ticket **DAT-718**). Builds on DAT-716 (the additivity verdict, merged in #463).

## What

The DAT-716 additivity matrix needs real metrics that exercise each function-symmetry cell. The P&L catalogue only had `SUM`/ratio shapes; this adds the missing ones and closes the one vocabulary gap that blocked `COUNT(DISTINCT)`.

**Three new finance metrics** (`verticals/finance/metrics/activity/`), single-extract, grounded over the `journal_lines` event fact:
- `transaction_count` — `COUNT` → **additive** flow
- `average_transaction_value` — `AVG` → **non-additive**
- `active_accounts` — `COUNT(DISTINCT account)` → **non-additive**

**New aggregation `count_distinct`** in the grounding vocabulary. Aggregation is entirely prompt-driven for extracts (like `end_of_period` — no enum or deterministic composer), so the change is: `graph_sql_generation.yaml` `<aggregation_types>` (instruct the agent to emit `COUNT(DISTINCT \"<col>\")`) + the `GraphStep.aggregation` doc-comment. The DAT-716 classifier already handled the DISTINCT shape; this lets a metric *declare* it.

## Tests

- `test_activity_metrics.py` — the three metrics load with `count`/`avg`/`count_distinct`, `standard_field`s resolve against the finance ontology, and each aggregation's grounded SQL shape classifies per the DAT-716 doctrine (`COUNT`→additive, `AVG`/`COUNT(DISTINCT)`→non-additive).
- `test_config.py` — finance catalogue is now 16 metrics.
- 283 graphs+metrics + 1972 unit tests green.

## Not covered here (runs in dataraum-eval / `/smoke`)

The **e2e grounding validation** (does the agent actually ground these over `journal_lines`, and emit `COUNT(DISTINCT ...)` for the new vocabulary entry) and the **additivity oracle** (assert the per-target `metric_additivity` verdicts against ground truth) — the SQL the LLM emits is not unit-testable. See `.claude/handoff.md` for the eval/testdata bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)