### PR TITLE
chore: parallelize the test suite with pytest-xdist (-n auto)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,12 @@ jobs:
                   fi
 
             - name: Run tests with coverage
-              run: uv run pytest tests/unit tests/integration -q --cov --cov-report=term-missing --cov-report=xml
+              # -n auto fans the suite across the runner's cores (pytest-xdist).
+              # --dist loadscope (pyproject addopts) keeps each module on one
+              # worker, so module-scoped fixtures + the per-worker Postgres/
+              # Temporal testcontainers stay correct; pytest-cov aggregates
+              # coverage across workers. Measured ~2.5x on the unit suite.
+              run: uv run pytest tests/unit tests/integration -q -n auto --cov --cov-report=term-missing --cov-report=xml
 
             - name: Upload coverage report
               if: always()

--- a/packages/engine/CLAUDE.md
+++ b/packages/engine/CLAUDE.md
@@ -41,9 +41,11 @@ Correctness over speed. The product is **analytical correctness** — the system
 uv run pytest tests/unit/path/to/test_file.py -v   # during dev
 uv run pytest --testmon tests/unit -q              # after a change
 uv run pytest --testmon tests -q                   # before declaring done
+uv run pytest tests/unit -q -n auto                # full unit suite, parallel (~37s vs ~90s)
 ```
 
-- Never run the full suite without `--testmon` (2+ min). Run specific integration files only when you touched integration code.
+- `--testmon` re-runs only affected tests — keep those runs **serial** (no `-n`). testmon already runs the few tests a change touched; xdist's per-worker startup (~1.4s each) makes a testmon run *slower*, so the end-of-turn hook and every `--testmon` flow stay single-process.
+- For a **full-suite or whole-directory** run (no `--testmon`), add `-n auto` — pytest-xdist fans it across cores (~2.5× on the unit suite; `--dist loadscope` in `pyproject.toml` keeps module-scoped fixtures + per-worker testcontainers correct). Run specific integration files only when you touched integration code.
 - **Calibration tests live in `dataraum-eval`** and are the ultimate measure of detector correctness.
 - **e2e tests make real LLM calls — never run them without asking.**
 - The end-of-turn hook runs ruff + mypy + vulture + testmon automatically; don't duplicate it.

--- a/packages/engine/pyproject.toml
+++ b/packages/engine/pyproject.toml
@@ -82,11 +82,19 @@ packages = ["src/dataraum"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 # --dist loadscope: inert without -n, but when a parallel run is requested
-# (e.g. `uv run pytest -n auto`) it keeps every module's tests on one worker.
-# Module-scoped read-only fixtures (e.g. analyzed_small_finance) depend on
-# this — splitting a module across workers would rebuild the shared dataset
-# per worker and defeat the optimization. Parallelism stays opt-in (-n) so CI
-# / unit runs don't each spin up a per-worker Postgres testcontainer.
+# (`-n auto` — used by CI and full-suite / whole-directory dev runs) it keeps
+# every module's tests on one worker. Module-scoped read-only fixtures (e.g.
+# analyzed_small_finance) depend on this — splitting a module across workers
+# would rebuild the shared dataset per worker and defeat the optimization; and
+# each xdist worker boots its OWN Postgres/Temporal testcontainer, so loadscope
+# also bounds container fan-out to one set per module-worker.
+#
+# Parallelism stays OPT-IN (deliberately NOT in addopts): the end-of-turn hook
+# and every `--testmon` flow run serially. testmon selects only the FEW tests a
+# change touched, and xdist's per-worker startup (~1.4s each) dwarfs that — a
+# no-op `--testmon` run measured 0.05s serial vs 1.45s under `-n auto`. xdist
+# pays off only when running MANY tests, i.e. the non-testmon full-suite/CI path
+# (measured: tests/unit 90.9s serial → 36.6s under `-n auto`, a 2.5× win).
 addopts = "-v --tb=short --dist loadscope"
 markers = [
     "integration: marks tests as integration tests (may be slower)",


### PR DESCRIPTION
## What

Turn on `pytest-xdist` (`-n auto`) where it pays off. xdist was already a dep and `--dist loadscope` was already configured in `pyproject.toml` — parallelism just was never enabled anywhere.

- **CI** (`ci.yml`): add `-n auto` to the unit+integration run. `--dist loadscope` keeps each module on one worker, so module-scoped fixtures + the per-worker Postgres/Temporal testcontainers stay correct; `pytest-cov` aggregates coverage across workers.
- **Docs** (`packages/engine/CLAUDE.md`): document `-n auto` for full-suite / whole-directory runs and why `--testmon` flows stay serial.
- **`pyproject.toml`**: keep parallelism **opt-in** (out of `addopts`) so the end-of-turn hook and every `--testmon` flow stay single-process — comment records the reasoning.

## Why (measured, not assumed)

Investigating "tests are slow — maybe it's data create/teardown": profiling ruled that out. The unit suite is CPU-bound (permutation-null Monte Carlo in the driver tree dominates); fixture setup/teardown is negligible.

| Suite | Serial | `-n auto` |
|---|---|---|
| `tests/unit` | 90.9s | **36.6s** (2.5×) |
| `tests/unit tests/integration` + cov (exact CI cmd) | ~130s | **50.9s** |
| `tests/integration` | 39.0s | 31.9s |

## The one deliberate non-enablement

`-n auto` is **not** added to the end-of-turn hook / `--testmon` flows. testmon runs only the *few* tests a change touched; xdist's per-worker startup dwarfs that — a no-op `--testmon` run measured **0.05s serial vs 1.45s under `-n auto`**. xdist wins only on many-test runs, i.e. the non-testmon full-suite/CI path. That reasoning is captured in the `pyproject.toml` comment + CLAUDE.md so it won't get "fixed" later.

## Follow-up

xdist caps the drivers dir at ~31s because the 4 `test_tree.py` tests are ~10s each and can't be split within a test function. The real fix is vectorizing the permutation-null kernel — tracked as **DAT-719** (calibration-critical: re-validate recall/FDR in `dataraum-eval`, re-baseline the DAT-580 golden).

## Validation

Ran the exact CI command locally: **2155 passed, 8 skipped in 50.9s**, `coverage.xml` written and valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)