### PR TITLE
fix(cockpit): deterministic pick for table-band readiness read

### DIFF
--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -574,9 +574,15 @@ async function loadTableBand(
 		})
 		.from(currentEntropyReadiness)
 		.where(eq(currentEntropyReadiness.target, tableTargetKey(tableName)))
-		// Safe without a grain pick: `table:{name}` targets are written only by
-		// catalog-grain runs (add_source persists column targets only), and the
-		// view's latest-promoted-wins dedup leaves ≤1 catalog-grain row per target.
+		// `table:{name}` targets are written only by catalog-grain runs (add_source
+		// persists column targets only), and the view's latest-promoted-wins dedup
+		// leaves ≤1 catalog-grain row per target. But entropy_readiness alone among
+		// the run-versioned tables carries NO (target, run_id) unique constraint, so
+		// that ≤1 rests on a view dedup (strict promoted_at `>`, ties possible), not
+		// a hard invariant — the `computed_at desc` order is the defensive tiebreak,
+		// matching loadTableEntity above and keeping the pick deterministic should the
+		// dedup ever surface two rows for one target.
+		.orderBy(desc(currentEntropyReadiness.computedAt))
 		.limit(1);
 	return row ? projectTableBand(row) : null;
 }


### PR DESCRIPTION
## What

`loadTableBand` (`packages/cockpit/src/tools/look-table.ts`) read `current_entropy_readiness` by `table:{name}` target with a bare `.limit(1)` and no ordering. Added `orderBy(desc(computed_at))` as a defensive tiebreak so the single-row pick is deterministic.

## Why

An audit of all ~30 `.limit(1)` sites in the cockpit (prompted by the "picks the first without logic" concern) found that nearly every one is actually safe — backed by a PK/unique lookup, an explicit `orderBy`, an existence/boolean probe, or a `UNIQUE(<key>, run_id)` constraint sitting behind a single-head `current_*` view (`metadata_snapshot_head` is `UNIQUE(target, stage)`, so each view resolves one head run). The logic lives in the DB constraints, not at the query site.

The **one** exception: `entropy_readiness` is the only run-versioned base table with **no** `(target, run_id)` unique constraint (just a PK on `readiness_id` + FKs). Its ≤1-row-per-target guarantee therefore rests on:
- a soft SQL view dedup (latest `promoted_at`, strict `>` → ties possible), and
- the convention that add_source writes only *column* targets (so `table:{name}` rows are catalog-grain only)

— not a hard invariant. If the dedup ever surfaces two rows for one target, `.limit(1)` picks arbitrarily.

## The fix

`orderBy(desc(computed_at))` mirrors:
- the sibling `loadTableEntity` in the same file, which carries this defensive tiebreak even on a *constraint-backed* unique read (`table_entities` has `UNIQUE(table_id, run_id)`), and
- the fetch-all → `pickCurrentRow` path the `why_*` tools already use for this same multi-grain view.

Comment updated to state the real (soft) invariant rather than the previous "safe without a grain pick" claim.

## Follow-up (not in this PR)

The durable fix is engine-side: add `UNIQUE(target, run_id)` to the `entropy_readiness` SQLAlchemy model (the only run-versioned table missing a run-scoped unique constraint), which turns the soft view-dedup invariant into a hard, write-time-enforced one. Cross-package (model + re-dump `schema.sql` + `db:pull:metadata`); would confirm the intended grain against the readiness writer first.

## Verification

- `tsc --noEmit` — 0 errors
- `biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)