### PR TITLE
fix(engine): DAT-710 — semantic_per_table schema-repair turn

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,36 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-710 — `semantic_per_table` schema-repair turn (begin_session survives a shape flake)
+
+**Branch:** `fix/dat-710-semantic-repair-turn`. **No calibration action required — a
+robustness fix; recall/precision unchanged.**
+
+One malformed `analyze_tables` relationship entry (a missing `to_column`, a literal
+`"placeholder"` reasoning) used to fail `begin_session` WHOLE: strict Pydantic
+validation → non-retryable `PhaseFailed`, whole-cascade blast radius (a manual re-run
+passed clean — a pure LLM shape flake). `semantic_per_table` now gets the same one-turn
+schema repair `generate_sql` got in DAT-699 — on a `TableSynthesisOutput` validation
+failure the model fixes its own tool output under a forced tool choice, and only a
+SECOND failure fails loud.
+
+- The repair turn is now a shared helper (`llm/tool_repair.py::repair_tool_output`,
+  generic over the output model); both `graphs/agent.py` (grounding) and
+  `analysis/semantic/agent.py` (synthesis) call it. `GraphAgent._repair_tool_output`
+  was inlined + deleted — behavior byte-identical (`test_tool_repair.py` unchanged, green).
+- **Not `strict`:** `analyze_tables` is a large batched extraction, exactly the shape
+  where `ToolDefinition.strict` makes the model legally under-produce (the
+  column_annotation 1-of-8-tables collapse); the repair turn, not strict, is the
+  recall-safe lever.
+
+### For eval
+No detector or response-shape change. The only observable delta is on the FAILURE path:
+a semantic shape flake that used to kill a calibration run's `begin_session` now
+self-repairs, so wide / real-LLM eval runs see one fewer spurious failure. Nothing to
+recalibrate.
+
+---
+
 ## DAT-718 — activity metrics + `count_distinct` grounding vocabulary
 
 **Branch:** `feat/dat-718-matrix-metrics`. Extends the finance metric catalogue +

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -52,6 +53,7 @@ from dataraum.llm.providers.base import (
     Message,
     ToolDefinition,
 )
+from dataraum.llm.tool_repair import repair_tool_output
 from dataraum.storage import Column, Table
 
 if TYPE_CHECKING:
@@ -205,10 +207,33 @@ class SemanticAgent(LLMFeature):
         if not response.tool_calls or response.tool_calls[0].name != "analyze_tables":
             return Result.fail("LLM did not use the analyze_tables tool")
 
+        tool_input = response.tool_calls[0].input
         try:
-            return self._parse_table_synthesis_output(response.tool_calls[0].input, response.model)
-        except Exception as e:
-            return Result.fail(f"Failed to parse table synthesis response: {e}")
+            synthesis = TableSynthesisOutput.model_validate(tool_input)
+        except ValidationError as e:
+            # One lazy relationship entry (a missing `to_column`, a `"placeholder"`
+            # reasoning) must not fail begin_session whole (DAT-710): enforce the
+            # schema with a repair turn — the DAT-699 pattern — instead of a
+            # non-retryable PhaseFailed with whole-cascade blast radius. strict
+            # grammar is the WRONG lever here: analyze_tables is a large batched
+            # extraction (every table's entity + all relationships), exactly the
+            # shape where strict makes the model legally under-produce (see
+            # `ToolDefinition.strict`), so repair, never strict.
+            repaired = repair_tool_output(
+                self.provider,
+                tool,
+                tool_input,
+                e,
+                TableSynthesisOutput,
+                model=model,
+                label="semantic_per_table",
+                max_tokens=self.config.limits.max_output_tokens_per_request,
+            )
+            if not repaired.success:
+                return Result.fail(f"Failed to parse table synthesis response: {repaired.error}")
+            synthesis = repaired.unwrap()
+
+        return self._build_enrichment_result(synthesis)
 
     @staticmethod
     def _format_persisted_annotations(annotations: list[dict[str, Any]]) -> str:
@@ -239,14 +264,15 @@ class SemanticAgent(LLMFeature):
                 )
         return "\n".join(lines)
 
-    def _parse_table_synthesis_output(
+    def _build_enrichment_result(
         self,
-        tool_output: dict[str, Any],
-        model_name: str,
+        synthesis: TableSynthesisOutput,
     ) -> Result[SemanticEnrichmentResult]:
-        """Parse ``analyze_tables`` output into entities + relationships (no annotations)."""
-        synthesis = TableSynthesisOutput.model_validate(tool_output)
+        """Build entities + relationships from a validated ``analyze_tables`` output.
 
+        Validation (with a DAT-710 repair turn on failure) happens at the call
+        site; this transforms the validated model into the enrichment result.
+        """
         entity_detections = [
             EntityDetection(
                 table_id="",  # Filled by caller

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -50,7 +50,6 @@ from .verifier import verify_execution
 
 if TYPE_CHECKING:
     from dataraum.graphs.node_warming import NodeDecision, NodeKey
-    from dataraum.llm.providers.base import ToolDefinition
 
 logger = get_logger(__name__)
 
@@ -924,7 +923,18 @@ class GraphAgent(LLMFeature):
             # output in one cheap repair turn. A finished, correct grounding was
             # previously discarded whole on a single stringified `provenance`
             # field — losing the metric to a serialization slip, silently.
-            repaired = self._repair_tool_output(tool, tool_call.input, e, model, prompt_name)
+            from dataraum.llm.tool_repair import repair_tool_output
+
+            repaired = repair_tool_output(
+                self.provider,
+                tool,
+                tool_call.input,
+                e,
+                ExtractGroundingOutput,
+                model=model,
+                label=prompt_name,
+                max_tokens=self.config.limits.max_output_tokens_per_request,
+            )
             if not repaired.success:
                 return Result.fail(repaired.error or "schema repair failed")
             output = repaired.unwrap()
@@ -1045,62 +1055,6 @@ class GraphAgent(LLMFeature):
             f"values matching '{params.pattern}' in "
             f"{params.table}.{params.column}:\n{listed}{truncated}"
         )
-
-    def _repair_tool_output(
-        self,
-        tool: ToolDefinition,
-        invalid_input: dict[str, Any],
-        error: ValidationError,
-        model: str,
-        label: str,
-    ) -> Result[ExtractGroundingOutput]:
-        """One schema-repair turn: the model fixes its own tool output (DAT-699).
-
-        The output schema is ENFORCED, never coerced: a validation failure
-        re-prompts the model with its own serialized output plus the exact
-        validation error, under a forced tool choice — a stringified nested
-        object or a mistyped field is the model's to fix, not ours to
-        ``json.loads`` behind its back. The repair request is a fresh
-        single-turn conversation (no dataset context, so it is cheap, and no
-        assistant-turn continuation, so it cannot trip the thinking-block
-        continuation constraint). One repair attempt: a model that cannot
-        satisfy the schema twice fails loud with both errors.
-        """
-        from dataraum.llm.providers.base import ConversationRequest, Message
-
-        repair_prompt = (
-            "Your previous call to the tool below failed schema validation.\n\n"
-            f"Validation error:\n{error}\n\n"
-            f"Your tool input was:\n{json.dumps(invalid_input, indent=2)}\n\n"
-            f"Call {tool.name} again with the SAME content, corrected to satisfy "
-            "the schema exactly — e.g. a field you emitted as a JSON-encoded "
-            "string must be a structured object. Fix only the schema "
-            "violations; do not change the substance of any field."
-        )
-        request = ConversationRequest(
-            messages=[Message(role="user", content=repair_prompt)],
-            system="You repair tool-call arguments to satisfy their JSON schema exactly.",
-            tools=[tool],
-            tool_choice={"type": "tool", "name": tool.name},
-            label=f"{label}_repair",
-            max_tokens=self.config.limits.max_output_tokens_per_request,
-            temperature=0.0,
-            model=model,
-        )
-        logger.warning("tool_output_schema_repair", tool=tool.name, error=str(error)[:200])
-        response = self.provider.converse(request).unwrap()
-        if not response.tool_calls:
-            return Result.fail(
-                f"Failed to validate tool response ({error}); the schema-repair "
-                "turn produced no tool call"
-            )
-        try:
-            return Result.ok(ExtractGroundingOutput.model_validate(response.tool_calls[0].input))
-        except ValidationError as second:
-            return Result.fail(
-                f"Failed to validate tool response after a repair turn: {second} "
-                f"(original error: {error})"
-            )
 
     def _execute_sql(
         self,

--- a/packages/engine/src/dataraum/llm/tool_repair.py
+++ b/packages/engine/src/dataraum/llm/tool_repair.py
@@ -82,7 +82,6 @@ def repair_tool_output[T: BaseModel](
         tool_choice={"type": "tool", "name": tool.name},
         label=f"{label}_repair",
         max_tokens=max_tokens,
-        temperature=0.0,
         model=model,
     )
     logger.warning("tool_output_schema_repair", tool=tool.name, error=str(error)[:200])

--- a/packages/engine/src/dataraum/llm/tool_repair.py
+++ b/packages/engine/src/dataraum/llm/tool_repair.py
@@ -1,0 +1,101 @@
+"""One-turn tool-output schema repair (DAT-699, DAT-710).
+
+When a model's forced tool call returns arguments that fail Pydantic validation,
+re-prompt the model with its own serialized output plus the exact validation
+error under a forced tool choice, and validate again. A finished, correct call
+is never discarded on a serialization slip, and a single malformed element never
+fails the whole phase. Enforcement, not coercion: the model fixes its own output;
+the schema is not ``json.loads``-ed behind its back.
+
+This is the recall-safe alternative to ``ToolDefinition.strict`` for **large
+batched extractions** — a strict grammar makes the model legally under-produce on
+those (see ``ToolDefinition.strict``), so the repair turn, not strict, is the
+right lever for tools like ``generate_sql`` and ``analyze_tables`` that emit a
+variable-length set. Generic over the output model so every structured-output
+agent shares one implementation.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import structlog
+from pydantic import BaseModel, ValidationError
+
+from dataraum.core.models.base import Result
+from dataraum.llm.providers.base import (
+    ConversationRequest,
+    LLMProvider,
+    Message,
+    ToolDefinition,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+def repair_tool_output[T: BaseModel](
+    provider: LLMProvider,
+    tool: ToolDefinition,
+    invalid_input: dict[str, Any],
+    error: ValidationError,
+    output_cls: type[T],
+    *,
+    model: str,
+    label: str,
+    max_tokens: int,
+) -> Result[T]:
+    """One schema-repair turn: the model fixes its own tool output.
+
+    The repair request is a fresh single-turn conversation (no dataset context,
+    so it is cheap, and no assistant-turn continuation, so it cannot trip the
+    thinking-block continuation constraint) under a forced tool choice. One
+    attempt: a model that cannot satisfy the schema twice fails loud with both
+    errors, so the caller degrades gracefully instead of crashing the phase.
+
+    Args:
+        provider: The LLM provider to re-prompt.
+        tool: The tool whose arguments failed validation.
+        invalid_input: The model's rejected tool input.
+        error: The validation error to feed back to the model.
+        output_cls: The Pydantic model the repaired input must validate against.
+        model: The model id to run the repair on.
+        label: Base label for the call (``"_repair"`` is appended).
+        max_tokens: Output token ceiling for the repair call.
+
+    Returns:
+        The validated output, or a loud failure carrying both errors.
+    """
+    repair_prompt = (
+        "Your previous call to the tool below failed schema validation.\n\n"
+        f"Validation error:\n{error}\n\n"
+        f"Your tool input was:\n{json.dumps(invalid_input, indent=2)}\n\n"
+        f"Call {tool.name} again with the SAME content, corrected to satisfy "
+        "the schema exactly — e.g. a field you emitted as a JSON-encoded "
+        "string must be a structured object. Fix only the schema "
+        "violations; do not change the substance of any field."
+    )
+    request = ConversationRequest(
+        messages=[Message(role="user", content=repair_prompt)],
+        system="You repair tool-call arguments to satisfy their JSON schema exactly.",
+        tools=[tool],
+        tool_choice={"type": "tool", "name": tool.name},
+        label=f"{label}_repair",
+        max_tokens=max_tokens,
+        temperature=0.0,
+        model=model,
+    )
+    logger.warning("tool_output_schema_repair", tool=tool.name, error=str(error)[:200])
+    response = provider.converse(request).unwrap()
+    if not response.tool_calls:
+        return Result.fail(
+            f"Failed to validate tool response ({error}); the schema-repair "
+            "turn produced no tool call"
+        )
+    try:
+        return Result.ok(output_cls.model_validate(response.tool_calls[0].input))
+    except ValidationError as second:
+        return Result.fail(
+            f"Failed to validate tool response after a repair turn: {second} "
+            f"(original error: {error})"
+        )

--- a/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
@@ -24,6 +24,7 @@ from dataraum.analysis.semantic.models import (
     Relationship,
     SemanticEnrichmentResult,
     TableColumnAnnotation,
+    TableSynthesisOutput,
     TimeColumn,
 )
 from dataraum.analysis.semantic.processor import (
@@ -479,9 +480,11 @@ class TestSynthesizeAndStoreTables:
 
 
 class TestTableSynthesisHelpers:
-    def test_parse_table_synthesis_output_yields_no_annotations(self) -> None:
+    def test_build_enrichment_result_yields_no_annotations(self) -> None:
         agent = SemanticAgent.__new__(SemanticAgent)  # no LLM init needed
-        result = agent._parse_table_synthesis_output(
+        # Validation (with the DAT-710 repair turn on failure) is the call site's
+        # job; _build_enrichment_result transforms an already-validated output.
+        synthesis = TableSynthesisOutput.model_validate(
             {
                 "tables": [
                     {
@@ -493,9 +496,9 @@ class TestTableSynthesisHelpers:
                     }
                 ],
                 "relationships": [],
-            },
-            "test-model",
+            }
         )
+        result = agent._build_enrichment_result(synthesis)
         enrichment = result.unwrap()
         assert enrichment.annotations == []
         assert len(enrichment.entity_detections) == 1

--- a/packages/engine/tests/unit/analysis/semantic/test_synthesis_repair.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_synthesis_repair.py
@@ -1,0 +1,143 @@
+"""semantic_per_table schema enforcement with a repair turn (DAT-710).
+
+One lazy relationship entry (a missing ``to_column``, a ``"placeholder"``
+reasoning) used to fail ``begin_session`` whole — strict Pydantic validation →
+non-retryable ``PhaseFailed`` with a whole-cascade blast radius. The
+``analyze_tables`` output now gets the same one-turn schema repair as
+``generate_sql`` (DAT-699): the model fixes its own tool output instead of the
+phase dying. strict grammar is the wrong lever here — a large batched extraction
+makes the model legally under-produce under strict — so this is repair, not
+strict.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from dataraum.analysis.semantic.agent import SemanticAgent
+
+_COMPLETE_REL = {
+    "from_table": "payments",
+    "from_column": "invoice_id",
+    "to_table": "invoices",
+    "to_column": "id",
+    "relationship_type": "foreign_key",
+    "confidence": 0.9,
+    "reasoning": "payments.invoice_id references invoices.id",
+}
+# The live DAT-710 failure shape: a relationship entry missing `to_column`.
+_MALFORMED_REL = {k: v for k, v in _COMPLETE_REL.items() if k != "to_column"}
+
+_VALID_INPUT = {"tables": [], "relationships": [_COMPLETE_REL], "column_concepts": []}
+_MALFORMED_INPUT = {"tables": [], "relationships": [_MALFORMED_REL], "column_concepts": []}
+
+
+def _response(tool_input: dict | None) -> MagicMock:
+    response = MagicMock()
+    response.model = "model-x"
+    if tool_input is None:
+        response.tool_calls = []
+    else:
+        call = MagicMock()
+        call.name = "analyze_tables"
+        call.input = tool_input
+        response.tool_calls = [call]
+    return response
+
+
+def _provider(*responses: MagicMock) -> MagicMock:
+    provider = MagicMock()
+    provider.get_model_for_tier.side_effect = lambda tier: "model-x"
+    provider.converse.side_effect = [
+        MagicMock(unwrap=MagicMock(return_value=r)) for r in responses
+    ]
+    return provider
+
+
+def _agent_with(provider: MagicMock, monkeypatch) -> SemanticAgent:
+    # Everything before the converse call is mocked so the test drives only the
+    # validate → repair → build seam (mirrors tests/unit/graphs/test_tool_repair.py).
+    monkeypatch.setattr("dataraum.analysis.semantic.agent.DataSampler", MagicMock())
+    monkeypatch.setattr(
+        "dataraum.analysis.semantic.agent.load_persisted_annotations", lambda s, t: []
+    )
+
+    agent = SemanticAgent.__new__(SemanticAgent)
+    agent.provider = provider  # type: ignore[attr-defined]
+    renderer = MagicMock()
+    renderer.render_split.return_value = ("system", "user", 0.0)
+    agent.renderer = renderer  # type: ignore[attr-defined]
+
+    config = MagicMock()
+    config.features.semantic_analysis.enabled = True
+    config.features.semantic_analysis.model_tier = "balanced"
+    config.features.semantic_analysis.effort = None
+    config.limits.max_output_tokens_per_request = 4000
+    agent.config = config  # type: ignore[attr-defined]
+
+    ontology_loader = MagicMock()
+    ontology_loader.load.return_value = object()
+    ontology_loader.format_concepts_for_prompt.return_value = ""
+    agent._ontology_loader = ontology_loader  # type: ignore[attr-defined]
+
+    agent._load_profiles = MagicMock(  # type: ignore[method-assign]
+        return_value=MagicMock(success=True, value=[MagicMock()], error=None)
+    )
+    agent._build_tables_json = MagicMock(return_value=[])  # type: ignore[method-assign]
+    agent._format_relationship_candidates = MagicMock(return_value="")  # type: ignore[method-assign]
+    agent._format_persisted_annotations = MagicMock(return_value="")  # type: ignore[method-assign]
+    return agent
+
+
+def test_valid_output_needs_no_repair(monkeypatch) -> None:
+    provider = _provider(_response(_VALID_INPUT))
+    agent = _agent_with(provider, monkeypatch)
+
+    result = agent.synthesize_tables(MagicMock(), ["t1"])
+
+    assert result.success
+    assert provider.converse.call_count == 1
+    assert result.value.relationships[0].to_column == "id"
+
+
+def test_missing_field_is_repaired_by_the_model(monkeypatch) -> None:
+    """The DAT-710 kill: a relationship missing `to_column`. The repair turn
+    carries the invalid input + validation error, forces the tool, and the
+    repaired output builds the relationship — begin_session is never failed."""
+    provider = _provider(_response(_MALFORMED_INPUT), _response(_VALID_INPUT))
+    agent = _agent_with(provider, monkeypatch)
+
+    result = agent.synthesize_tables(MagicMock(), ["t1"])
+
+    assert result.success
+    assert result.value.relationships[0].to_column == "id"
+    assert provider.converse.call_count == 2
+
+    repair_request = provider.converse.call_args_list[1].args[0]
+    assert repair_request.tool_choice == {"type": "tool", "name": "analyze_tables"}
+    assert repair_request.label == "semantic_per_table_repair"
+    content = repair_request.messages[0].content
+    assert "Validation error" in content
+    assert "to_column" in content  # the model's own broken output rides along
+
+
+def test_second_validation_failure_fails_loud(monkeypatch) -> None:
+    provider = _provider(_response(_MALFORMED_INPUT), _response(_MALFORMED_INPUT))
+    agent = _agent_with(provider, monkeypatch)
+
+    result = agent.synthesize_tables(MagicMock(), ["t1"])
+
+    assert not result.success
+    assert "after a repair turn" in result.error
+    assert provider.converse.call_count == 2
+
+
+def test_repair_turn_without_tool_call_fails_loud(monkeypatch) -> None:
+    provider = _provider(_response(_MALFORMED_INPUT), _response(None))
+    agent = _agent_with(provider, monkeypatch)
+
+    result = agent.synthesize_tables(MagicMock(), ["t1"])
+
+    assert not result.success
+    assert "no tool call" in result.error
+    assert provider.converse.call_count == 2


### PR DESCRIPTION
## Problem (DAT-710)

One malformed `analyze_tables` relationship entry — a missing `to_column`, a literal `"placeholder"` reasoning — failed `begin_session` **whole**: strict Pydantic validation → non-retryable `PhaseFailed`, whole-cascade blast radius. A manual re-run passed clean: a pure LLM shape flake with far too large a blast radius.

## Fix

`semantic_per_table` now gets the same one-turn schema repair `generate_sql` got in DAT-699 — on a `TableSynthesisOutput` validation failure the model fixes its own tool output under a forced tool choice, and only a **second** failure fails loud.

- **`llm/tool_repair.py`** — the repair turn extracted to a shared generic helper `repair_tool_output` (PEP 695, generic over the output model). Both the grounding agent (`ExtractGroundingOutput`) and the synthesis agent (`TableSynthesisOutput`) call it. `GraphAgent._repair_tool_output` is inlined + deleted — **byte-identical behavior** (`test_tool_repair.py` unchanged, green).
- **`semantic/agent.py`** — `synthesize_tables` validates (with the repair turn on failure); `_build_enrichment_result` transforms an already-validated output.

## Why repair, not `strict`

`strict: true` guarantees conformance, but `ToolDefinition.strict` documents that on **large batched extractions** the strict grammar makes the model *legally under-produce* (column_annotation collapsed to 1 of 8 tables). `analyze_tables` is exactly that shape (every table's entity + all relationships), so `strict` would trade an intermittent crash for a systematic recall loss. The repair turn preserves full production and only intervenes on the rare malformed output.

## For eval / testdata

No detector or response-shape change — a robustness fix, recall/precision unchanged. The only observable delta is on the FAILURE path: a semantic shape flake that used to kill a calibration run's `begin_session` now self-repairs. Handoff updated.

## Tests

- New `tests/unit/analysis/semantic/test_synthesis_repair.py` (no-repair, missing-`to_column`-repaired, second-failure-loud, no-tool-call-loud).
- Existing `test_tool_repair.py` unchanged and green (extraction is behavior-preserving).
- Full graphs + semantic + llm unit suites green (407); ruff + mypy + vulture clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)