### PR TITLE
fix(engine): DAT-720 — restore the structural stock/flow witness (enriched time-axis)

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,43 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-720 — structural stock/flow witness restored (enriched time-axis backfill)
+
+**Branch:** `fix/lineage-enriched-time-axis`. **Re-run stock/flow calibration — the
+data-grounded witness now fires; some labels change (correctly).**
+
+DAT-536's inline-aggregation re-point silently disabled the DAT-491 structural
+reconciliation witness on the finance corpus: a fact whose event date is a JOINED
+column (`journal_lines.entry_id__date`, the header date) had empty
+`TableEntity.time_columns`, so the inline lineage path dropped it → 0
+`measure_aggregation_lineage` rows → the witness abstained on **every** column →
+stock/flow was decided by the two name-based witnesses only.
+`trial_balance.debit_balance/credit_balance` (per-period FLOWS) were mislabeled
+`point_in_time` (stock) by the "balance" name. Found by the DAT-685 eval oracle.
+
+### What changed
+- **Slicing agent** — `slicing_analysis` `effort: low → medium`, prompt/schema
+  framing tightened (dropped the "fallback"/"omit … or genuinely has none" escape).
+  At `effort: low` Sonnet 5 scoped to the literal ask and dropped the secondary
+  enriched time-axis backfill (it's the SLICING agent — not semantic_per_table —
+  that names the enriched `is_dimension_time_column` axis for facts with no own date).
+- **Deterministic backstop** (`slicing_phase.py`) — `TableEntity.time_columns` is
+  now backfilled straight from the deterministic `is_dimension_time_column` flag for
+  any analyzed fact the agent (and semantic) left empty. The witness can no longer
+  go inert on an LLM miss. Fixes every consumer at the source: lineage, drivers,
+  and the drill's time grain.
+
+### For eval (calibration to run)
+- **Stock/flow recall CHANGES, correctly:** the structural witness now fires;
+  `trial_balance.debit_balance/credit_balance` should resolve **`additive` (flow)**,
+  not `point_in_time`. Re-baseline the DAT-685 stock/flow oracle — the trial_balance
+  known-miss should FLIP to correct. Add a **witness-liveness guard** (structural
+  witness fired on ≥1 column); a 0/N is the regression signature.
+- Additivity verdicts on trial_balance measures change accordingly (flow → not
+  time-stripped). No score-threshold change — this restores an inert data witness.
+
+---
+
 ## DAT-718 — activity metrics + `count_distinct` grounding vocabulary
 
 **Branch:** `feat/dat-718-matrix-metrics`. Extends the finance metric catalogue +

--- a/packages/dataraum-config/llm/config.yaml
+++ b/packages/dataraum-config/llm/config.yaml
@@ -32,7 +32,11 @@ features:
   slicing_analysis:
     enabled: true
     model_tier: balanced
-    effort: low
+    # medium, not low (DAT-720): at effort:low Sonnet 5 scopes to the literal ask
+    # and drops the secondary enriched time-axis backfill (a form-fill field it's
+    # motivated enough to complete at medium). Thinking stays off — the data is in
+    # the prompt; it just has to fill the field.
+    effort: medium
 
   validation:
     enabled: true

--- a/packages/dataraum-config/llm/prompts/slicing_analysis.yaml
+++ b/packages/dataraum-config/llm/prompts/slicing_analysis.yaml
@@ -78,10 +78,12 @@ system_prompt: |
   - When a table's context already lists "time_columns" (one or more axes,
     each {column, aspect, note}), INHERIT them — the axes are already decided,
     do not re-judge that table.
-  - Only when "time_columns" is EMPTY, look at the enriched columns: one flagged
-    "is_dimension_time_column": true is the joined header's event date (e.g. journal
-    lines dated by their journal entry) — name that enriched column.
-  - Omit a table only when it genuinely has no time axis.
+  - When "time_columns" is EMPTY, look at the enriched columns. If one is flagged
+    "is_dimension_time_column": true, name it — it is the table's event date,
+    joined from its header (e.g. journal lines dated by their journal entry, via
+    entry_id__date). A table with such a flag HAS a time axis; report it.
+  - Only skip a table whose "time_columns" is empty AND that has no
+    is_dimension_time_column candidate.
   </time_axis>
 
   <output_rules>

--- a/packages/engine/src/dataraum/analysis/slicing/models.py
+++ b/packages/engine/src/dataraum/analysis/slicing/models.py
@@ -123,10 +123,13 @@ class SlicingAnalysisOutput(BaseModel):
     time_columns: list[TableTimeColumnOutput] = Field(
         default_factory=list,
         description=(
-            "A fallback time axis ONLY for analyzed tables whose context "
-            "'time_columns' is empty — pick the enriched column flagged "
-            "is_dimension_time_column. Omit any table that already lists axes "
-            "or genuinely has none."
+            "The event-time axis for each analyzed table whose context "
+            "'time_columns' is empty. Rule: whenever such a table has an enriched "
+            "column flagged is_dimension_time_column, name that column here — it is "
+            "the table's event date, joined from its header (e.g. journal_lines "
+            "dated by its journal_entry via entry_id__date). Skip a table only when "
+            "it already lists axes (kept as-is) or has no is_dimension_time_column "
+            "candidate at all."
         ),
     )
 

--- a/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
@@ -265,6 +265,52 @@ class SlicingPhase(BasePhase):
                     ]
                     logger.info("time_axis_filled", table=table_name, column=chosen)
 
+        # Deterministic backstop (DAT-720): naming the enriched time axis above is
+        # an LLM step, and at effort:low Sonnet 5 silently returned it empty —
+        # disabling the structural stock/flow witness for header-dated facts
+        # (journal_lines ← entry_id__date). But is_dimension_time_column is computed
+        # deterministically (the joined header's own event date), so fill
+        # TableEntity.time_columns straight from the flag for any analyzed table
+        # the agent AND semantic left empty. Never overrides an existing axis;
+        # fixes every consumer at the source — lineage, drivers, and the drill.
+        from dataraum.analysis.semantic.db_models import TableEntity
+
+        # Read the flag from the pre-filter snapshot, NOT context_data["tables"]:
+        # _pre_filter_columns already dropped the high-cardinality date columns, so
+        # the flag is only preserved in this captured map (DAT-720).
+        flagged_by_table = {
+            name: cols
+            for name, cols in (context_data.get("dimension_time_axes") or {}).items()
+            if cols
+        }
+        if flagged_by_table:
+            id_by_name = {t.table_name: t.table_id for t in unsliced_tables}
+            target_ids = [id_by_name[n] for n in flagged_by_table if n in id_by_name]
+            if target_ids:
+                name_by_id = {tid: n for n, tid in id_by_name.items()}
+                for entity in ctx.session.execute(
+                    select(TableEntity).where(
+                        TableEntity.table_id.in_(target_ids),
+                        TableEntity.run_id == ctx.run_id,
+                    )
+                ).scalars():
+                    if entity.time_columns:
+                        continue  # semantic or the agent already set it — never override
+                    name = name_by_id.get(entity.table_id, "")
+                    cols = flagged_by_table.get(name, [])
+                    entity.time_columns = [
+                        {
+                            "column": col,
+                            "aspect": "event",
+                            "note": (
+                                "Event-time axis from the deterministic "
+                                "is_dimension_time_column flag (DAT-720 backstop)."
+                            ),
+                        }
+                        for col in cols
+                    ]
+                    logger.info("time_axis_filled_deterministic", table=name, columns=cols)
+
         # Store slice definitions — form-(a) idempotent writer (DAT-502):
         # in-batch dedup on ``uq_slice_def_table_column_run`` (the agent can
         # emit a dimension twice; propagation adds more), then UPSERT so a
@@ -619,7 +665,31 @@ class SlicingPhase(BasePhase):
                 }
             )
 
+        # Flagged enriched time axes per table, captured BEFORE _pre_filter_columns
+        # drops high-cardinality columns (a date is exactly that) — the deterministic
+        # backstop in _run reads this so the is_dimension_time_column flag survives
+        # the filter (DAT-720; the filter is why the agent's write-back also has to
+        # validate against the unfiltered col_id_by_name).
+        dimension_time_axes: dict[str, list[str]] = {}
+        for t in tables_data:
+            cols = t["columns"]
+            name = t["table_name"]
+            if not isinstance(cols, list) or not isinstance(name, str):
+                continue
+            axes = sorted(
+                {
+                    c["column_name"]
+                    for c in cols
+                    if isinstance(c, dict)
+                    and c.get("is_dimension_time_column")
+                    and c.get("column_name")
+                }
+            )
+            if axes:
+                dimension_time_axes[name] = axes
+
         return {
             "tables": tables_data,
             "column_count": column_count,
+            "dimension_time_axes": dimension_time_axes,
         }

--- a/packages/engine/tests/unit/pipeline/test_slicing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_slicing_phase.py
@@ -451,11 +451,18 @@ class TestRunTimeAxisFill:
 
         assert result.status == PhaseStatus.COMPLETED
         mock_agent_cls.return_value.analyze.assert_called_once()
-        assert seeded["fact_entity"].time_columns == []
+        # The hallucinated agent pick is rejected by the RI check (never lands)...
         assert any(
             e["event"] == "time_axis_unknown_column" and e["table"] == "invoices" for e in logs
         )
         assert not any(e["event"] == "time_axis_filled" for e in logs)
+        # ...but the deterministic is_dimension_time_column backstop (DAT-720) still
+        # fills the real axis, so a flagged fact never silently goes empty.
+        assert [tc["column"] for tc in seeded["fact_entity"].time_columns] == ["invoice_id__date"]
+        assert any(
+            e["event"] == "time_axis_filled_deterministic" and e["table"] == "invoices"
+            for e in logs
+        )
 
     def test_existing_time_column_is_inherited_never_overridden(
         self,
@@ -503,9 +510,46 @@ class TestRunTimeAxisFill:
 
         assert result.status == PhaseStatus.COMPLETED
         mock_agent_cls.return_value.analyze.assert_called_once()
-        assert seeded["fact_entity"].time_columns == []
+        # The phantom-table judgment lands nowhere (no agent fill, no RI reject)...
         assert not any(e["event"] == "time_axis_filled" for e in logs)
         assert not any(e["event"] == "time_axis_unknown_column" for e in logs)
+        # ...and the deterministic backstop (DAT-720) still fills invoices' flagged axis.
+        assert [tc["column"] for tc in seeded["fact_entity"].time_columns] == ["invoice_id__date"]
+        assert any(
+            e["event"] == "time_axis_filled_deterministic" and e["table"] == "invoices"
+            for e in logs
+        )
+
+
+    def test_deterministic_backstop_fills_when_agent_returns_empty(
+        self,
+        mock_load_config: MagicMock,
+        mock_create_provider: MagicMock,
+        mock_renderer_cls: MagicMock,
+        mock_agent_cls: MagicMock,
+        session: Session,
+        duckdb_conn: duckdb.DuckDBPyConnection,
+    ) -> None:
+        """DAT-720: the slice agent returned empty time_columns (the Sonnet 5
+        effort:low degradation that silently disabled the structural stock/flow
+        witness). The deterministic is_dimension_time_column backstop fills the
+        axis anyway — the witness can no longer go inert on an LLM miss."""
+        mock_load_config.return_value = _mock_llm_config()
+        mock_agent_cls.return_value.analyze.return_value = _analysis_result({})
+        seeded = _seed(session)
+
+        with capture_logs() as logs:
+            result = SlicingPhase()._run(_ctx(session, duckdb_conn, [seeded["fact"].table_id]))
+
+        assert result.status == PhaseStatus.COMPLETED
+        mock_agent_cls.return_value.analyze.assert_called_once()
+        # No agent judgment landed, yet the flagged axis is filled deterministically.
+        assert not any(e["event"] == "time_axis_filled" for e in logs)
+        assert [tc["column"] for tc in seeded["fact_entity"].time_columns] == ["invoice_id__date"]
+        assert any(
+            e["event"] == "time_axis_filled_deterministic" and e["table"] == "invoices"
+            for e in logs
+        )
 
 
 @patch("dataraum.pipeline.phases.slicing_phase.SlicingAgent")


### PR DESCRIPTION
## The bug (DAT-720)

DAT-536's inline-aggregation re-point (which removed the materialized slice views, as requested) **silently disabled the DAT-491 structural reconciliation witness** on the finance corpus. Symptom: `column_concepts.temporal_behavior` (stock/flow) fired the data-grounded witness on **0 of 20** columns — decided by the two name-based witnesses alone — and `trial_balance.debit_balance`/`credit_balance` (per-period **flows**) were mislabeled `point_in_time`. Found by the DAT-685 eval oracle.

**Root cause:** the inline lineage path builds a fact's per-period series only from `TableEntity.time_columns` (a fact's *own* columns). `journal_lines`' event date is a **joined** column (`entry_id__date`, from `journal_entries` via the FK) — no own axis → dropped from reconciliation → 0 `measure_aggregation_lineage` rows → witness inert. The old materialized slices read enriched views, so they saw the joined date. The DAT-536 equivalence test only seeds an own-date fact, so the coverage loss was invisible to the unit suite.

**Why it degraded now:** naming that joined axis is the **slicing agent's** fallback job (`slicing_analysis`, `effort: low`). At `effort: low`, Sonnet 5 scopes to the literal ask and drops the secondary, escape-hatched (`"omit … or genuinely has none"`) time-axis backfill.

## Fix (both layers)

- **Slicing agent:** `effort: low → medium`; prompt + schema framing tightened — the enriched `is_dimension_time_column` pick is a clear rule, escape hatch removed. (Thinking stays off — the data is in the prompt; it's a form-fill.)
- **Deterministic backstop** (`slicing_phase.py`): `TableEntity.time_columns` is backfilled straight from the deterministic `is_dimension_time_column` flag for any analyzed fact the agent left empty. The witness can no longer go inert on an LLM miss, and it fixes every consumer at the source — **lineage, drivers, and the drill's time grain**.

`journal_lines` → `entry_id__date` → per-period series → `trial_balance.debit_balance ≈ Σ journal_lines.debit` reconciles → `per_period` → **flow**.

## Scope note

Star-schema (enriched-view) joins only — a table not joined into the enriched view can't be evaluated; linking further is an upstream dimensions effort, out of scope here.

## Tests

- Updated the two RI-edge slicing-phase tests (agent bad pick still rejected + the deterministic backstop now fills the real axis) + a dedicated "agent returns empty → backstop fills" test (the DAT-720 case).
- 1109 analysis/pipeline/entropy unit tests green; ruff + mypy clean.

## For eval

Re-baseline the DAT-685 stock/flow oracle — `trial_balance.*` flips to `additive`; add a **witness-liveness guard** (structural witness fired ≥1) so a 0/N inert-safeguard regression fails loudly. Handoff updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)