### PR TITLE
fix(engine): DAT-721 — lineage key-exclusion weighs relationship confidence

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -70,6 +70,36 @@ stock/flow was decided by the two name-based witnesses only.
 
 ---
 
+## DAT-721 — lineage key-exclusion weighs relationship confidence
+
+**Branch:** `fix/dat-721-lineage-confidence-gate`. The SECOND regression behind the
+same witness (independent of DAT-720). Even with the time axis restored,
+`trial_balance.debit_balance` still would not reconcile: the lineage key-exclusion
+(`discover_aggregation_lineage`) treats every endpoint of a *defined* relationship
+as a key (never SUMmed, dropped as a convention term). DAT-699 deliberately removed
+the confidence floor from `load_defined_relationships`, so a judge-DECLINED
+`journal_lines.debit → payments.amount` at **confidence 0.05** (the LLM's own
+"coincidental numeric overlap; decline" verdict) now reaches this consumer and
+stripped `debit`'s only reconciliation convention → `debit_balance` silently
+dropped (only `credit_balance` reconciled → 1/20 witness firing).
+
+### What changed
+- **Consumer-local confidence gate** (`processor.py`, `KEY_CONFIDENCE_MIN = 0.7`):
+  a MEASURED (`llm`/`keeper`) relationship endpoint is a key only at `>= 0.7`
+  (the relationships phase's high-confidence band); `manual` (user-asserted)
+  bypasses the number. Does NOT re-add a global gate to `load_defined_relationships`
+  (that contradicts DAT-699 — confidence is evidence for consumers to weigh).
+
+### For eval (calibration to run)
+- **Both** `trial_balance` measures should now reconcile (debit AND credit), not
+  just credit. Extend the DAT-685 structural check to assert coverage of both, not
+  only the label-correctness of whatever fired.
+- Open follow-up (not this fix): a judge-DECLINED relationship is still persisted
+  as `detection_method='llm'` (defined). Consumers that don't weigh confidence stay
+  exposed — a broader DAT-699 question (honor the verdict vs. every consumer weighs).
+
+---
+
 ## DAT-718 — activity metrics + `count_distinct` grounding vocabulary
 
 **Branch:** `feat/dat-718-matrix-metrics`. Extends the finance metric catalogue +

--- a/packages/dataraum-config/llm/prompts/slicing_analysis.yaml
+++ b/packages/dataraum-config/llm/prompts/slicing_analysis.yaml
@@ -80,8 +80,9 @@ system_prompt: |
     do not re-judge that table.
   - When "time_columns" is EMPTY, look at the enriched columns. If one is flagged
     "is_dimension_time_column": true, name it — it is the table's event date,
-    joined from its header (e.g. journal lines dated by their journal entry, via
-    entry_id__date). A table with such a flag HAS a time axis; report it.
+    joined from its parent/header record (e.g. a line-item table dated by its
+    parent document via a joined `<fk>__<date>` column). A table with such a flag
+    HAS a time axis; report it.
   - Only skip a table whose "time_columns" is empty AND that has no
     is_dimension_time_column candidate.
   </time_axis>

--- a/packages/engine/src/dataraum/analysis/lineage/processor.py
+++ b/packages/engine/src/dataraum/analysis/lineage/processor.py
@@ -54,6 +54,19 @@ logger = get_logger(__name__)
 # names, deterministic) — and the cap is LOGGED, never silent.
 MAX_CONVENTION_COLUMNS = 8
 
+# A MEASURED relationship's endpoint counts as a key (never SUMmed, and dropped
+# as a convention term) only when it clears the engine's high-confidence band
+# (the relationships phase gates high confidence at ``>= 0.7``). DAT-699 dropped
+# the read-path confidence gate, so low-confidence and judge-DECLINED
+# relationships now reach this consumer — a coincidental conf≈0.05 amount↔amount
+# "FK" (the LLM itself declined it) would otherwise flag a real measure like
+# ``journal_lines.debit`` as a key and strip its only reconciliation convention,
+# silently killing ``trial_balance.debit_balance``. Gating here is the consumer
+# weighing confidence-as-evidence (DAT-699's own contract); it restores the
+# stock/flow witness without re-adding a global gate (DAT-721). User-asserted
+# (``manual``) relationships bypass the number (see the loop below).
+KEY_CONFIDENCE_MIN = 0.7
+
 # DuckDB ``date_trunc`` unit + ``strftime`` label per grain — the cross-fact
 # alignment key (ISO semantics; stable across facts of the same grain). Mirrors
 # the retired ``temporal_slicing`` analyzer so period labels are unchanged.
@@ -273,12 +286,21 @@ def discover_aggregation_lineage(
 
     # Key/identifier columns are not quantities: a SUM over a key has no
     # meaning, and identical key sets reconcile trivially (identity noise).
-    # Grounded in the catalog: every endpoint of a defined relationship is a
-    # key — excluded from measure columns AND convention terms.
+    # Grounded in the catalog: every endpoint of a HIGH-CONFIDENCE defined
+    # relationship is a key — excluded from measure columns AND convention terms.
+    # The ``KEY_CONFIDENCE_MIN`` gate weighs the relationship's evidence so a
+    # low-confidence / judge-declined "FK" cannot strip a real measure (DAT-721).
     key_columns_by_table: dict[str, set[str]] = {}
     for rel in load_defined_relationships(
         session, table_ids, run_id=run_id, both_tables=False, eager_columns=True
     ):
+        # A user-asserted key (``manual``) is a key regardless of any confidence
+        # number — decoupled from how ``manual`` rows are materialized. Only
+        # MEASURED endpoints (``llm``/``keeper``) must clear the evidence bar; a
+        # low-confidence keeper is a silently-kept relationship the LLM had scored
+        # weak, not an explicit assertion, so it is correctly NOT treated as a key.
+        if rel.detection_method != "manual" and rel.confidence < KEY_CONFIDENCE_MIN:
+            continue
         key_columns_by_table.setdefault(rel.from_table_id, set()).add(rel.from_column.column_name)
         key_columns_by_table.setdefault(rel.to_table_id, set()).add(rel.to_column.column_name)
 

--- a/packages/engine/src/dataraum/analysis/slicing/models.py
+++ b/packages/engine/src/dataraum/analysis/slicing/models.py
@@ -126,8 +126,9 @@ class SlicingAnalysisOutput(BaseModel):
             "The event-time axis for each analyzed table whose context "
             "'time_columns' is empty. Rule: whenever such a table has an enriched "
             "column flagged is_dimension_time_column, name that column here — it is "
-            "the table's event date, joined from its header (e.g. journal_lines "
-            "dated by its journal_entry via entry_id__date). Skip a table only when "
+            "the table's event date, joined from its parent/header record (e.g. a "
+            "line-item table dated by its parent document via a joined "
+            "`<fk>__<date>` column). Skip a table only when "
             "it already lists axes (kept as-is) or has no is_dimension_time_column "
             "candidate at all."
         ),

--- a/packages/engine/tests/unit/analysis/lineage/test_processor.py
+++ b/packages/engine/tests/unit/analysis/lineage/test_processor.py
@@ -301,6 +301,70 @@ class TestDiscoverAggregationLineage:
         assert row is not None
         assert "account_key" not in row.convention_sql
 
+    def test_low_confidence_relationship_does_not_strip_measure(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """A low-confidence / judge-DECLINED relationship must NOT flag a measure
+        as a key (DAT-721). DAT-699 dropped the read-path confidence gate, so a
+        coincidental conf=0.05 amount↔amount "FK" (the LLM itself declined it)
+        reaches this consumer; ungated it strips ``journal_lines.debit`` from the
+        conventions and silently kills ``trial_balance.balance`` — which can only
+        reconcile via ``"debit"`` (``credit`` is identically zero here). The gate
+        keeps ``debit`` a measure, so the reconciliation survives.
+        """
+        from dataraum.analysis.relationships.db_models import Relationship
+
+        ids = _seed(real_session, duck)
+        real_session.add(
+            Relationship(
+                run_id=_RUN,
+                from_table_id=ids["journal_lines"],
+                from_column_id=ids["journal_lines.debit"],
+                to_table_id=ids["trial_balance"],
+                to_column_id=ids["trial_balance.net_change"],
+                relationship_type="foreign_key",
+                cardinality="many-to-one",
+                confidence=0.05,  # the LLM declined it — coincidental overlap
+                detection_method="llm",
+            )
+        )
+        real_session.flush()
+        _discover(real_session, duck, ids)
+        row = _row_for(real_session, ids["trial_balance.balance"])
+        assert row is not None, "low-confidence FK wrongly stripped debit → no reconciliation"
+        assert row.convention_sql == '"debit"'
+        assert row.match_rate > 0.99
+
+    def test_manual_relationship_is_a_key_regardless_of_confidence(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        # A user-asserted (``manual``) FK is a key even at low confidence — the
+        # gate bypasses the number for manual rows (DAT-721 review). This guards
+        # the ``detection_method != "manual"`` branch so a future change to how
+        # manual confidence is materialized cannot silently start summing a key.
+        from dataraum.analysis.relationships.db_models import Relationship
+
+        ids = _seed(real_session, duck, key_column=True)
+        real_session.add(
+            Relationship(
+                run_id=_RUN,
+                from_table_id=ids["trial_balance"],
+                from_column_id=ids["trial_balance.account_key"],
+                to_table_id=ids["journal_lines"],
+                to_column_id=ids["journal_lines.account_key"],
+                relationship_type="foreign_key",
+                cardinality="one-to-many",
+                confidence=0.0,  # low — but user-asserted, so still a key
+                detection_method="manual",
+            )
+        )
+        real_session.flush()
+        _discover(real_session, duck, ids)
+        assert _row_for(real_session, ids["trial_balance.account_key"]) is None
+        row = _row_for(real_session, ids["trial_balance.balance"])
+        assert row is not None
+        assert "account_key" not in row.convention_sql
+
     def test_no_shared_dimension_abstains(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:

--- a/packages/engine/tests/unit/pipeline/test_slicing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_slicing_phase.py
@@ -551,6 +551,56 @@ class TestRunTimeAxisFill:
             for e in logs
         )
 
+    def test_deterministic_backstop_reads_prefilter_stash_not_filtered_columns(
+        self,
+        mock_load_config: MagicMock,
+        mock_create_provider: MagicMock,
+        mock_renderer_cls: MagicMock,
+        mock_agent_cls: MagicMock,
+        session: Session,
+        duckdb_conn: duckdb.DuckDBPyConnection,
+    ) -> None:
+        """DAT-720: the backstop must read the pre-filter axis stash, not the
+        prompt-filtered columns. A real date axis is high-cardinality, so
+        ``_pre_filter_columns`` drops it from ``context_data["tables"]`` (the
+        ``distinct_count > 200`` slice-dimension cut). The FIRST fix read those
+        filtered columns and fired 0×; the stash (``dimension_time_axes``, built
+        before the filter) is what makes the deterministic fill survive. With the
+        agent returning empty AND the axis pre-filtered, the backstop must still
+        fill it — this guards against a regression to reading the filtered list.
+        """
+        from dataraum.analysis.statistics.db_models import StatisticalProfile
+
+        mock_load_config.return_value = _mock_llm_config()
+        mock_agent_cls.return_value.analyze.return_value = _analysis_result({})
+        seeded = _seed(session)
+        date_col = session.execute(
+            select(Column).where(Column.column_name == "invoice_id__date")
+        ).scalar_one()
+        session.add(
+            StatisticalProfile(
+                column_id=date_col.column_id,
+                total_count=300,
+                null_count=0,
+                distinct_count=300,  # > 200 → dropped from context_data["tables"]
+                null_ratio=0.0,
+                cardinality_ratio=1.0,
+                profile_data={},
+            )
+        )
+        session.flush()
+
+        with capture_logs() as logs:
+            result = SlicingPhase()._run(_ctx(session, duckdb_conn, [seeded["fact"].table_id]))
+
+        assert result.status == PhaseStatus.COMPLETED
+        assert not any(e["event"] == "time_axis_filled" for e in logs)
+        assert [tc["column"] for tc in seeded["fact_entity"].time_columns] == ["invoice_id__date"]
+        assert any(
+            e["event"] == "time_axis_filled_deterministic" and e["table"] == "invoices"
+            for e in logs
+        )
+
 
 @patch("dataraum.pipeline.phases.slicing_phase.SlicingAgent")
 @patch("dataraum.pipeline.phases.slicing_phase.PromptRenderer")


### PR DESCRIPTION
## Problem

The stock/flow structural-reconciliation witness (`discover_aggregation_lineage`) excludes every endpoint of a *defined* relationship from its reconciliation convention set — a real FK must never be SUMmed. **DAT-699 removed the confidence floor from `load_defined_relationships`**, so a judge-**DECLINED** relationship now reaches this consumer:

```
journal_lines.debit -> payments.amount   [conf 0.05, detection_method=llm]
  reasoning: "Very low match rate (18%), amount value overlap is coincidental
              numeric overlap not a real FK; decline."
```

Flagging `debit` as a key stripped its only reconciliation convention → `trial_balance.debit_balance` silently dropped (only `credit_balance` reconciled → 1/20 witness firing). This is the **second, independent regression** behind the same witness; the first (the joined event-time axis) was DAT-720. It is exactly why the witness "used to work on this data" until ~2 days ago (DAT-699 landed 2026-07-07).

## Fix

Gate the key-exclusion on relationship confidence **at the consumer** (`KEY_CONFIDENCE_MIN = 0.7`, the relationships phase's high-confidence band). A `manual` (user-asserted) relationship bypasses the number; `llm`/`keeper` are weighed. This does **not** re-add a global gate to `load_defined_relationships` — that would contradict DAT-699 ("confidence is evidence, not a gate"); the lineage key-exclusion is precisely a consumer that should weigh that evidence.

Proven on the clean finance corpus (ms probe): spurious/declined rels ≤ 0.4, real ≥ 0.98 — a clean separation gap; the gate restores `debit_balance` to a perfect `per_period` (flow) fit, no tuning.

## Tests (folded from senior + strict review)

- `test_low_confidence_relationship_does_not_strip_measure` — fails without the gate.
- `test_manual_relationship_is_a_key_regardless_of_confidence` — guards the `manual` bypass.
- `test_deterministic_backstop_reads_prefilter_stash_not_filtered_columns` — hardens the DAT-720 backstop: a high-cardinality axis dropped by the pre-filter must still fill from the stash (the prior tests didn't exercise this).

Also: vertical-neutral slicing prompt/schema wording (dropped the finance-specific `journal_lines`/`entry_id__date` example) + eval handoff note.

`pytest` (26) + `mypy` + `ruff` green on the changed files.

## Reviews
Senior code reviewer: correct, no critical issues. Strict reviewer: NEEDS WORK → all findings folded (manual/keeper decision, boundary comment, the two missing tests). Spec-compliance: compliant, in scope.

## Open follow-up (not this PR)
A judge-DECLINED relationship is still persisted as `detection_method='llm'` (defined). Consumers that don't weigh confidence stay exposed — a broader DAT-699 question (honor the verdict vs. every consumer weighs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)