### PR TITLE
feat(engine): DAT-729 P4 — concept edges (disjoint_with + part_of)

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,14 +5,14 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
-## DAT-729 — concept edges (`disjoint_with` / `part_of`) + conformed-dimension typing (DAT-723 fan-trap)
+## DAT-729 — concept edges (`disjoint_with` / `part_of`)
 
 **Branch:** `feat/dat-729-concept-edges`. **New graph-edge oracle surfaces — no
 detector-score change.** Phase 4 of the operating-model graph (DAT-725): the concept
-vocabulary gains typed edges, and two facts sharing a dimension are typed as a
-drill-across path instead of a false-positive FK. All three are **seed/derivation
-structure**, not a detector recalibration — the eval work is **new `metadata_truth.yaml`
-sections + oracle assertions**, graded absolutely.
+vocabulary gains typed edges. Both are **seed structure**, not a detector
+recalibration — the eval work is **new `metadata_truth.yaml` sections + oracle
+assertions**, graded absolutely. (Conformed-dimension typing was pulled from this phase
+— it needs a real dimension-identity design, tracked separately; see the DAT-725 thread.)
 
 ### What changed
 
@@ -30,14 +30,6 @@ sections + oracle assertions**, graded absolutely.
   {accounts_payable}` (4 edges). Concept-grain composition ONLY — the account-instance
   chart-of-accounts tree stays the physical `references` topology (P1) / `rolls_up_to`
   (P5). Transitive ancestry is a bounded recursive-CTE (max-depth 4 + cycle guard).
-- **`conformed_dimension` graph edge + DAT-723 fan-trap fix (graph-level, NO detector
-  change).** Two facts sharing a same-named slice (dimension) column now surface as a
-  derived `conformed_dimension` edge (e.g. `trial_balance.period ↔ balance_sheet.period`),
-  and `og_references` EXCLUDES those pairs — the shared dimension is typed conformed,
-  never a reference. Purely graph views over existing `slice_definitions`; the
-  relationship detector, evaluator, and `relationships` table are **untouched** (zero
-  calibration risk). A real fact→dimension FK survives (the dimension key is not a fact
-  slice, so at most one endpoint is a slice — the exclusion cannot match).
 - **`reconciles_with` DEFERRED to P2 (DAT-727).** Its producers are all Grounding-node-
   dependent (the aggregation-lineage witness reconciles a measure against its event
   aggregation = two groundings of ONE concept; the "4 generator pairs" are dataset-level,
@@ -54,25 +46,19 @@ sections + oracle assertions**, graded absolutely.
   `inventory` part_of `current_assets`; `accounts_payable` part_of `current_liabilities`),
   directed (whole is NOT part_of its part), and that the recursive-CTE ancestor closure
   is transitive + cycle-guarded (the graph query, not a stored transitive edge).
-- **`conformed_dimension` truth section (the DAT-723 acceptance).** `trial_balance.period ↔
-  balance_sheet.period` must appear as a `conformed_dimension` edge and must **NOT** appear
-  as a `refs` (references) edge. This is the fan-trap fix, gradable directly off the graph.
 - **No stock/flow, additivity, or grounding recalibration** — no detector inputs, scores,
   or thresholds changed. `reconciles_with` is NOT in this truth set (lands with P2).
 
 ### testdata hints
 
-None. The finance corpus already carries the disjoint/compose partitions (in the shipped
-ontology) and two period-sliced facts (`trial_balance`, `balance_sheet`) — the
-conformed-dimension + fan-trap case is exercised without new fixtures. (Per the ticket:
-reconciliation pairs read from existing generator code; no export needed for v1.)
+None. The finance corpus already carries the disjoint/compose partitions in the shipped
+ontology, so both edge types are exercised without new fixtures.
 
 ### Cross-package / schema
 
 `schema.sql` gained the `concept_edges` table; `schema_graph.sql` gained the
-`og_concept_edges` + `og_conformed_dimension` graph elements and the `og_references`
-conformed-dim exclusion; the cockpit drizzle mirror gained the `conceptEdges` view
-(`schema-drift` CI enforces). No read-view (`current_*`) shape change beyond the new
+`og_concept_edges` graph element; the cockpit drizzle mirror gained the `conceptEdges`
+view (`schema-drift` CI enforces). No read-view (`current_*`) shape change beyond the new
 `concept_edges` passthrough.
 
 ---

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,78 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-729 — concept edges (`disjoint_with` / `part_of`) + conformed-dimension typing (DAT-723 fan-trap)
+
+**Branch:** `feat/dat-729-concept-edges`. **New graph-edge oracle surfaces — no
+detector-score change.** Phase 4 of the operating-model graph (DAT-725): the concept
+vocabulary gains typed edges, and two facts sharing a dimension are typed as a
+drill-across path instead of a false-positive FK. All three are **seed/derivation
+structure**, not a detector recalibration — the eval work is **new `metadata_truth.yaml`
+sections + oracle assertions**, graded absolutely.
+
+### What changed
+
+- **`disjoint_with` concept edges (seed).** A new `concept_edges` table (workspace-
+  persistent, supersede-on-edit — same identity contract as `concepts`) seeded from
+  convention `concept_groups`: concepts in DIFFERENT groups of one convention are
+  disjoint (an account is an asset xor a liability). Finance's `sign_natural_balance`
+  (credit-normal 4 × debit-normal 8) yields **32 unordered = 64 directed** edges,
+  including the DD's named examples `accounts_payable ⊥ accounts_receivable` and
+  `current_assets ⊥ current_liabilities`. Bound into the property graph as the
+  `concept_edge` edge (predicate property).
+- **`part_of` concept edges (seed).** A new `compositions` ontology block (`whole ←
+  parts`, lint-validated) seeds directed `part → whole` edges: finance authors
+  `current_assets ← {cash, accounts_receivable, inventory}` and `current_liabilities ←
+  {accounts_payable}` (4 edges). Concept-grain composition ONLY — the account-instance
+  chart-of-accounts tree stays the physical `references` topology (P1) / `rolls_up_to`
+  (P5). Transitive ancestry is a bounded recursive-CTE (max-depth 4 + cycle guard).
+- **`conformed_dimension` graph edge + DAT-723 fan-trap fix (graph-level, NO detector
+  change).** Two facts sharing a same-named slice (dimension) column now surface as a
+  derived `conformed_dimension` edge (e.g. `trial_balance.period ↔ balance_sheet.period`),
+  and `og_references` EXCLUDES those pairs — the shared dimension is typed conformed,
+  never a reference. Purely graph views over existing `slice_definitions`; the
+  relationship detector, evaluator, and `relationships` table are **untouched** (zero
+  calibration risk). A real fact→dimension FK survives (the dimension key is not a fact
+  slice, so at most one endpoint is a slice — the exclusion cannot match).
+- **`reconciles_with` DEFERRED to P2 (DAT-727).** Its producers are all Grounding-node-
+  dependent (the aggregation-lineage witness reconciles a measure against its event
+  aggregation = two groundings of ONE concept; the "4 generator pairs" are dataset-level,
+  not Concept↔Concept). The `ConceptEdge` model carries the `reconciles_with` predicate
+  + `tolerance` for P2 to populate — see the DAT-727 note.
+
+### For eval (new oracle surfaces to add)
+
+- **`disjoint_with` truth section.** Assert the finance disjoint set against the sign
+  partition RULE (any credit-normal concept ⊥ any debit-normal concept), not a hand-
+  picked list — the engine emits the full cross-product, both directions. Named
+  anchors: `accounts_payable ↔ accounts_receivable`, `current_assets ↔ current_liabilities`.
+- **`part_of` truth section.** Assert the composition edges (`cash`/`accounts_receivable`/
+  `inventory` part_of `current_assets`; `accounts_payable` part_of `current_liabilities`),
+  directed (whole is NOT part_of its part), and that the recursive-CTE ancestor closure
+  is transitive + cycle-guarded (the graph query, not a stored transitive edge).
+- **`conformed_dimension` truth section (the DAT-723 acceptance).** `trial_balance.period ↔
+  balance_sheet.period` must appear as a `conformed_dimension` edge and must **NOT** appear
+  as a `refs` (references) edge. This is the fan-trap fix, gradable directly off the graph.
+- **No stock/flow, additivity, or grounding recalibration** — no detector inputs, scores,
+  or thresholds changed. `reconciles_with` is NOT in this truth set (lands with P2).
+
+### testdata hints
+
+None. The finance corpus already carries the disjoint/compose partitions (in the shipped
+ontology) and two period-sliced facts (`trial_balance`, `balance_sheet`) — the
+conformed-dimension + fan-trap case is exercised without new fixtures. (Per the ticket:
+reconciliation pairs read from existing generator code; no export needed for v1.)
+
+### Cross-package / schema
+
+`schema.sql` gained the `concept_edges` table; `schema_graph.sql` gained the
+`og_concept_edges` + `og_conformed_dimension` graph elements and the `og_references`
+conformed-dim exclusion; the cockpit drizzle mirror gained the `conceptEdges` view
+(`schema-drift` CI enforces). No read-view (`current_*`) shape change beyond the new
+`concept_edges` passthrough.
+
+---
+
 ## DAT-728 — typed concept vocabulary (config→DB) + `ontology_prior` witness drop + 4-way table role
 
 **Branch:** `feat/dat-728-typed-concept-vocabulary`. Three eval-facing changes: a

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -29,6 +29,22 @@ export const columns = metadataSchema
 		sql`SELECT column_id, table_id, column_name, original_name, column_position, raw_type, resolved_type FROM ws_00000000_0000_0000_0000_000000000001.columns`,
 	);
 
+export const conceptEdges = metadataSchema
+	.view("concept_edges", {
+		edgeId: varchar("edge_id"),
+		vertical: varchar(),
+		predicate: varchar(),
+		fromConcept: varchar("from_concept"),
+		toConcept: varchar("to_concept"),
+		tolerance: doublePrecision(),
+		source: varchar(),
+		createdAt: timestamp("created_at"),
+		supersededAt: timestamp("superseded_at"),
+	})
+	.as(
+		sql`SELECT edge_id, vertical, predicate, from_concept, to_concept, tolerance, source, created_at, superseded_at FROM ws_00000000_0000_0000_0000_000000000001.concept_edges`,
+	);
+
 export const concepts = metadataSchema
 	.view("concepts", {
 		conceptId: varchar("concept_id"),

--- a/packages/dataraum-config/verticals/finance/ontology.yaml
+++ b/packages/dataraum-config/verticals/finance/ontology.yaml
@@ -372,3 +372,18 @@ conventions:
       current_liability_family:
         - current_liabilities
         - accounts_payable
+
+# Concept composition (DAT-729) → part_of edges. Mereological roll-up at the CONCEPT
+# grain: a balance-sheet aggregate is composed of its constituent measures. The seed
+# promotes each `part → whole` into a typed part_of ConceptEdge, and the transitive
+# closure walks the bounded recursive CTE. Concept-grain ONLY — the account-instance
+# chart-of-accounts tree is the physical `references` topology, not re-authored here.
+compositions:
+  - whole: current_assets
+    parts:
+      - cash
+      - accounts_receivable
+      - inventory
+  - whole: current_liabilities
+    parts:
+      - accounts_payable

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -2,6 +2,21 @@
 -- Source of truth: the SQLAlchemy models (storage.base.load_all_models).
 -- Schema-less on purpose: apply with search_path set to the target ws_<id>.
 
+CREATE TABLE concept_edges (
+	edge_id VARCHAR NOT NULL, 
+	vertical VARCHAR NOT NULL, 
+	predicate VARCHAR NOT NULL, 
+	from_concept VARCHAR NOT NULL, 
+	to_concept VARCHAR NOT NULL, 
+	tolerance FLOAT, 
+	source VARCHAR, 
+	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
+	superseded_at TIMESTAMP WITHOUT TIME ZONE, 
+	CONSTRAINT pk_concept_edges PRIMARY KEY (edge_id)
+);
+
+CREATE UNIQUE INDEX uq_concept_edge_active ON concept_edges (vertical, predicate, from_concept, to_concept) WHERE superseded_at IS NULL;
+
 CREATE TABLE concepts (
 	concept_id VARCHAR NOT NULL, 
 	vertical VARCHAR NOT NULL, 

--- a/packages/engine/schema_graph.sql
+++ b/packages/engine/schema_graph.sql
@@ -13,6 +13,7 @@ DROP VIEW IF EXISTS __READ__.og_references;
 DROP VIEW IF EXISTS __READ__.og_has_dimension;
 DROP VIEW IF EXISTS __READ__.og_derived_from;
 DROP VIEW IF EXISTS __READ__.og_concept_edges;
+DROP VIEW IF EXISTS __READ__.og_conformed_dimension;
 
 CREATE VIEW __READ__.og_tables AS
 SELECT t.table_id::text AS table_id, t.table_name, t.layer,
@@ -44,7 +45,13 @@ SELECT relationship_id::text AS relationship_id,
        from_table_id::text AS from_table_id, to_table_id::text AS to_table_id,
        from_column_id, to_column_id, cardinality, relationship_type,
        confidence, is_confirmed
-FROM __READ__.current_relationships;
+FROM __READ__.current_relationships r
+WHERE NOT EXISTS (
+  SELECT 1 FROM __READ__.current_slice_definitions s1
+  JOIN __READ__.current_slice_definitions s2 ON s1.column_name = s2.column_name
+  WHERE s1.column_id = r.from_column_id AND s2.column_id = r.to_column_id
+    AND s1.table_id <> s2.table_id
+);
 
 CREATE VIEW __READ__.og_has_dimension AS
 SELECT slice_id::text AS slice_id, table_id::text AS table_id,
@@ -80,6 +87,14 @@ JOIN __READ__.concepts ct
  AND ct.superseded_at IS NULL
 WHERE e.superseded_at IS NULL;
 
+CREATE VIEW __READ__.og_conformed_dimension AS
+SELECT (s1.slice_id || '_' || s2.slice_id)::text AS edge_key,
+       s1.table_id::text AS from_table_id, s2.table_id::text AS to_table_id,
+       s1.column_name AS dimension
+FROM __READ__.current_slice_definitions s1
+JOIN __READ__.current_slice_definitions s2
+  ON s1.column_name = s2.column_name AND s1.table_id <> s2.table_id;
+
 CREATE PROPERTY GRAPH __READ__.operating_model
   VERTEX TABLES (
     __READ__.og_tables KEY (table_id) LABEL table_node
@@ -110,5 +125,10 @@ CREATE PROPERTY GRAPH __READ__.operating_model
       SOURCE KEY (from_concept_id) REFERENCES og_concepts (concept_id)
       DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)
       LABEL concept_edge
-      PROPERTIES (predicate, tolerance)
+      PROPERTIES (predicate, tolerance),
+    __READ__.og_conformed_dimension KEY (edge_key)
+      SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)
+      DESTINATION KEY (to_table_id) REFERENCES og_tables (table_id)
+      LABEL conformed_dimension
+      PROPERTIES (dimension)
   );

--- a/packages/engine/schema_graph.sql
+++ b/packages/engine/schema_graph.sql
@@ -13,7 +13,6 @@ DROP VIEW IF EXISTS __READ__.og_references;
 DROP VIEW IF EXISTS __READ__.og_has_dimension;
 DROP VIEW IF EXISTS __READ__.og_derived_from;
 DROP VIEW IF EXISTS __READ__.og_concept_edges;
-DROP VIEW IF EXISTS __READ__.og_conformed_dimension;
 
 CREATE VIEW __READ__.og_tables AS
 SELECT t.table_id::text AS table_id, t.table_name, t.layer,
@@ -45,13 +44,7 @@ SELECT relationship_id::text AS relationship_id,
        from_table_id::text AS from_table_id, to_table_id::text AS to_table_id,
        from_column_id, to_column_id, cardinality, relationship_type,
        confidence, is_confirmed
-FROM __READ__.current_relationships r
-WHERE NOT EXISTS (
-  SELECT 1 FROM __READ__.current_slice_definitions s1
-  JOIN __READ__.current_slice_definitions s2 ON s1.column_name = s2.column_name
-  WHERE s1.column_id = r.from_column_id AND s2.column_id = r.to_column_id
-    AND s1.table_id <> s2.table_id
-);
+FROM __READ__.current_relationships;
 
 CREATE VIEW __READ__.og_has_dimension AS
 SELECT slice_id::text AS slice_id, table_id::text AS table_id,
@@ -87,14 +80,6 @@ JOIN __READ__.concepts ct
  AND ct.superseded_at IS NULL
 WHERE e.superseded_at IS NULL;
 
-CREATE VIEW __READ__.og_conformed_dimension AS
-SELECT (s1.slice_id || '_' || s2.slice_id)::text AS edge_key,
-       s1.table_id::text AS from_table_id, s2.table_id::text AS to_table_id,
-       s1.column_name AS dimension
-FROM __READ__.current_slice_definitions s1
-JOIN __READ__.current_slice_definitions s2
-  ON s1.column_name = s2.column_name AND s1.table_id <> s2.table_id;
-
 CREATE PROPERTY GRAPH __READ__.operating_model
   VERTEX TABLES (
     __READ__.og_tables KEY (table_id) LABEL table_node
@@ -125,10 +110,5 @@ CREATE PROPERTY GRAPH __READ__.operating_model
       SOURCE KEY (from_concept_id) REFERENCES og_concepts (concept_id)
       DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)
       LABEL concept_edge
-      PROPERTIES (predicate, tolerance),
-    __READ__.og_conformed_dimension KEY (edge_key)
-      SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)
-      DESTINATION KEY (to_table_id) REFERENCES og_tables (table_id)
-      LABEL conformed_dimension
-      PROPERTIES (dimension)
+      PROPERTIES (predicate, tolerance)
   );

--- a/packages/engine/schema_graph.sql
+++ b/packages/engine/schema_graph.sql
@@ -12,6 +12,7 @@ DROP VIEW IF EXISTS __READ__.og_concepts;
 DROP VIEW IF EXISTS __READ__.og_references;
 DROP VIEW IF EXISTS __READ__.og_has_dimension;
 DROP VIEW IF EXISTS __READ__.og_derived_from;
+DROP VIEW IF EXISTS __READ__.og_concept_edges;
 
 CREATE VIEW __READ__.og_tables AS
 SELECT t.table_id::text AS table_id, t.table_name, t.layer,
@@ -65,6 +66,20 @@ CROSS JOIN LATERAL json_array_elements_text(
      COALESCE(ev.dimension_table_ids, '[]'::json)) AS dt(value)
 WHERE ev.view_table_id IS NOT NULL;
 
+CREATE VIEW __READ__.og_concept_edges AS
+SELECT e.edge_id::text AS edge_id,
+       cf.concept_id::text AS from_concept_id,
+       ct.concept_id::text AS to_concept_id,
+       e.predicate, e.tolerance
+FROM __READ__.concept_edges e
+JOIN __READ__.concepts cf
+  ON cf.vertical = e.vertical AND cf.name = e.from_concept
+ AND cf.superseded_at IS NULL
+JOIN __READ__.concepts ct
+  ON ct.vertical = e.vertical AND ct.name = e.to_concept
+ AND ct.superseded_at IS NULL
+WHERE e.superseded_at IS NULL;
+
 CREATE PROPERTY GRAPH __READ__.operating_model
   VERTEX TABLES (
     __READ__.og_tables KEY (table_id) LABEL table_node
@@ -90,5 +105,10 @@ CREATE PROPERTY GRAPH __READ__.operating_model
       SOURCE KEY (view_table_id) REFERENCES og_tables (table_id)
       DESTINATION KEY (base_table_id) REFERENCES og_tables (table_id)
       LABEL derived_from
-      PROPERTIES (base_role)
+      PROPERTIES (base_role),
+    __READ__.og_concept_edges KEY (edge_id)
+      SOURCE KEY (from_concept_id) REFERENCES og_concepts (concept_id)
+      DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)
+      LABEL concept_edge
+      PROPERTIES (predicate, tolerance)
   );

--- a/packages/engine/schema_read.sql
+++ b/packages/engine/schema_read.sql
@@ -59,6 +59,10 @@ DROP VIEW IF EXISTS __READ__.columns;
 CREATE VIEW __READ__.columns AS
 SELECT * FROM __WS__.columns;
 
+DROP VIEW IF EXISTS __READ__.concept_edges;
+CREATE VIEW __READ__.concept_edges AS
+SELECT * FROM __WS__.concept_edges;
+
 DROP VIEW IF EXISTS __READ__.concepts;
 CREATE VIEW __READ__.concepts AS
 SELECT * FROM __WS__.concepts;

--- a/packages/engine/src/dataraum/analysis/semantic/concept_edge_store.py
+++ b/packages/engine/src/dataraum/analysis/semantic/concept_edge_store.py
@@ -8,13 +8,20 @@ phases derive more edges (``reconciles_with`` from the aggregation-lineage witne
 and ``frame`` authors them for novel datasets (P13); this module owns the SEED
 authoring from the vertical's own declarations.
 
-``disjoint_with`` is read straight off convention ``concept_groups``: a convention
-partitions concepts into named, mutually-exclusive sets (finance's
-``sign_natural_balance`` splits measures credit- vs debit-normal), and two concepts
-in DIFFERENT groups of one convention cannot co-classify — an account is an asset xor
-a liability. That is exactly ``disjoint_with``, over the partition the engine already
-parses and lint-validates (:class:`~dataraum.analysis.semantic.ontology.OntologyConvention`)
-— no new authoring surface, the config→DB lever again.
+``disjoint_with`` is read off convention ``concept_groups``: a convention partitions
+concepts into named, mutually-exclusive sets (finance's ``sign_natural_balance`` splits
+measures credit- vs debit-normal), and two concepts in DIFFERENT groups of one
+convention cannot co-classify — an account is an asset xor a liability. That is exactly
+``disjoint_with``.
+
+``part_of`` is read off the vertical's ``compositions`` (DAT-729): each ``whole ←
+parts`` declaration promotes ``part → whole`` mereological edges (``cash`` part_of
+``current_assets``) — concept-grain composition, distinct from the account-instance
+chart-of-accounts tree (that is the physical ``references`` topology). Both read off
+declarations the engine already parses + lint-validates
+(:class:`~dataraum.analysis.semantic.ontology.OntologyConvention` /
+:class:`~dataraum.analysis.semantic.ontology.OntologyComposition`) — no new authoring
+surface, the config→DB lever again.
 """
 
 from __future__ import annotations
@@ -52,7 +59,7 @@ def ensure_concept_edges_seeded(session: Session, vertical: str) -> int:
     definition = OntologyLoader().load(vertical)
     if definition is None:
         return 0
-    rows = _disjoint_with_rows(vertical, definition)
+    rows = _disjoint_with_rows(vertical, definition) + _part_of_rows(vertical, definition)
     if not rows:
         return 0
     seeded = insert_if_absent(
@@ -98,6 +105,29 @@ def _disjoint_with_rows(vertical: str, definition: OntologyDefinition) -> list[d
                             }
                         )
     return rows
+
+
+def _part_of_rows(vertical: str, definition: OntologyDefinition) -> list[dict[str, Any]]:
+    """``part_of`` edge rows from the vertical's concept ``compositions``.
+
+    Each declared composition (``whole`` ← ``parts``) promotes one directed
+    ``part → whole`` edge per part — mereological containment at the concept grain
+    (``cash`` part_of ``current_assets``). Directed and single-row (unlike the
+    symmetric ``disjoint_with``): the transitive ancestry is walked by the bounded
+    recursive CTE, never materialized. Endpoints are declared concepts (lint-checked
+    at load), so the ``og_concept_edges`` JOIN always resolves them.
+    """
+    return [
+        {
+            "vertical": vertical,
+            "predicate": ConceptEdgePredicate.PART_OF.value,
+            "from_concept": part,
+            "to_concept": comp.whole,
+            "source": "seed",
+        }
+        for comp in definition.compositions
+        for part in comp.parts
+    ]
 
 
 __all__ = ["ensure_concept_edges_seeded"]

--- a/packages/engine/src/dataraum/analysis/semantic/concept_edge_store.py
+++ b/packages/engine/src/dataraum/analysis/semantic/concept_edge_store.py
@@ -1,0 +1,103 @@
+"""Concept edges — the operating-model graph's vocabulary relations (DAT-729).
+
+The typed home for ``part_of`` / ``disjoint_with`` / ``reconciles_with`` concept
+edges, seeded the same way concepts were (config→DB, DAT-728): the shipped vertical
+YAML is the seed, the runtime reads the typed ``concept_edges`` table, the property
+graph binds it as the ``concept_edge`` edge over the ``og_concepts`` vertex. Later
+phases derive more edges (``reconciles_with`` from the aggregation-lineage witness)
+and ``frame`` authors them for novel datasets (P13); this module owns the SEED
+authoring from the vertical's own declarations.
+
+``disjoint_with`` is read straight off convention ``concept_groups``: a convention
+partitions concepts into named, mutually-exclusive sets (finance's
+``sign_natural_balance`` splits measures credit- vs debit-normal), and two concepts
+in DIFFERENT groups of one convention cannot co-classify — an account is an asset xor
+a liability. That is exactly ``disjoint_with``, over the partition the engine already
+parses and lint-validates (:class:`~dataraum.analysis.semantic.ontology.OntologyConvention`)
+— no new authoring surface, the config→DB lever again.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from dataraum.analysis.semantic.db_models import ConceptEdge, ConceptEdgePredicate
+from dataraum.analysis.semantic.ontology import OntologyDefinition, OntologyLoader
+from dataraum.core.logging import get_logger
+from dataraum.storage.upsert import insert_if_absent
+
+logger = get_logger(__name__)
+
+_EDGE_INDEX_ELEMENTS = ["vertical", "predicate", "from_concept", "to_concept"]
+
+
+def ensure_concept_edges_seeded(session: Session, vertical: str) -> int:
+    """Idempotently seed the shipped vertical's concept edges as typed rows.
+
+    Reads the vertical's YAML (the seed source) and inserts a :class:`ConceptEdge`
+    row for every declared edge with no active row yet, via ``INSERT … ON CONFLICT
+    DO NOTHING`` on the active-row partial-unique index — so a re-run is a no-op, a
+    ``frame`` edit (which supersedes) is never clobbered, and a concurrent seed / write
+    can no longer collide on the index (the same race-safety as
+    :func:`~dataraum.analysis.semantic.concept_store.ensure_concepts_seeded`).
+
+    A framed vertical (no on-disk YAML) seeds nothing here — its edges arrive through
+    ``frame``'s typed writes, not the shipped seed. Returns the number of rows actually
+    inserted (conflicts skipped).
+    """
+    definition = OntologyLoader().load(vertical)
+    if definition is None:
+        return 0
+    rows = _disjoint_with_rows(vertical, definition)
+    if not rows:
+        return 0
+    seeded = insert_if_absent(
+        session,
+        ConceptEdge,
+        rows,
+        index_elements=_EDGE_INDEX_ELEMENTS,
+        index_where=text("superseded_at IS NULL"),
+    )
+    if seeded:
+        logger.info("concept_edges_seeded", vertical=vertical, count=seeded)
+    return seeded
+
+
+def _disjoint_with_rows(vertical: str, definition: OntologyDefinition) -> list[dict[str, Any]]:
+    """``disjoint_with`` edge rows from every convention's ``concept_groups`` partition.
+
+    Two concepts in DIFFERENT groups of ONE convention cannot co-classify (groups are
+    validated mutually-exclusive at load), so they are ``disjoint_with``. Emitted in
+    BOTH directions — the predicate is symmetric, the property graph is directed — and
+    de-duplicated across conventions, since the same pair can fall out of two
+    partitions (finance's asset/liability split shows up in both the sign convention
+    and the balance-sheet-composition convention).
+    """
+    seen: set[tuple[str, str]] = set()
+    rows: list[dict[str, Any]] = []
+    for conv in definition.conventions:
+        groups = [members for members in conv.concept_groups.values() if members]
+        for group_a, group_b in combinations(groups, 2):
+            for a in group_a:
+                for b in group_b:
+                    for src, dst in ((a, b), (b, a)):
+                        if (src, dst) in seen:
+                            continue
+                        seen.add((src, dst))
+                        rows.append(
+                            {
+                                "vertical": vertical,
+                                "predicate": ConceptEdgePredicate.DISJOINT_WITH.value,
+                                "from_concept": src,
+                                "to_concept": dst,
+                                "source": "seed",
+                            }
+                        )
+    return rows
+
+
+__all__ = ["ensure_concept_edges_seeded"]

--- a/packages/engine/src/dataraum/analysis/semantic/db_models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/db_models.py
@@ -197,6 +197,11 @@ class ConceptEdge(Base):
     view resolves those names to the active concepts' ids for the PGQ vertex binding,
     so a superseded/absent endpoint drops the edge from the graph automatically.
 
+    Rename caveat (future): keying endpoints by ``name`` means a concept RENAME (a new
+    ``(vertical, name)`` identity, not a supersede-in-place) would orphan its edges —
+    they'd silently vanish from the graph. No rename path exists today; when ``frame``
+    adds one (P13) it must re-point or supersede the affected edges, not just the concept.
+
     Symmetric predicates (``disjoint_with``, ``reconciles_with``) are stored in BOTH
     directions — the graph is directed and PG19 SQL/PGQ ``MATCH`` is directed, so two
     rows let a walk from either endpoint enumerate the relation. ``part_of`` is

--- a/packages/engine/src/dataraum/analysis/semantic/db_models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/db_models.py
@@ -70,6 +70,32 @@ class TableRole(StrEnum):
     DIMENSION = "dimension"
 
 
+class ConceptEdgePredicate(StrEnum):
+    """The typed relation a concept edge asserts (DAT-729).
+
+    The operating-model graph's *vocabulary* edges — concept → concept, distinct
+    from the physical ``references`` / ``has_dimension`` edges over tables/columns.
+
+    - ``PART_OF`` — mereological composition, DIRECTED: the source concept is a
+      component that rolls up into the target (``accounts_payable`` part_of
+      ``current_liabilities``). Its transitive closure (all ancestors of a concept)
+      is walked by the bounded recursive CTE, never a PGQ path quantifier.
+    - ``DISJOINT_WITH`` — SYMMETRIC: no instance classifies as both (an account is
+      an asset xor a liability). Derived from a convention's ``concept_groups``
+      partition — concepts in different groups of one convention are disjoint.
+    - ``RECONCILES_WITH`` — SYMMETRIC: two measures/groundings must tie out within a
+      ``tolerance`` (trial-balance ↔ general-ledger). Declared, or witnessed by the
+      aggregation-lineage reconciliation, or free from a concept's two groundings.
+
+    Symmetric predicates are materialized in BOTH directions (see
+    :class:`ConceptEdge`) so a directed PGQ ``MATCH`` from either endpoint finds them.
+    """
+
+    PART_OF = "part_of"
+    DISJOINT_WITH = "disjoint_with"
+    RECONCILES_WITH = "reconciles_with"
+
+
 def derive_table_role(
     is_fact: bool,
     grain_columns: Sequence[str],
@@ -146,6 +172,68 @@ class Concept(Base):
 
     # Lifecycle: workspace-persistent with supersession (NULL superseded_at = active).
     source: Mapped[str | None] = mapped_column(String)  # 'seed' | 'frame' | 'teach'
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(UTC)
+    )
+    superseded_at: Mapped[datetime | None] = mapped_column(DateTime)
+
+
+class ConceptEdge(Base):
+    """A typed edge between two concepts — the operating-model graph's vocabulary (DAT-729).
+
+    The concept-level relations ``part_of`` / ``disjoint_with`` / ``reconciles_with``
+    (:class:`ConceptEdgePredicate`), promoted to typed rows the same way concepts were
+    (config→DB): the shipped vertical seeds them, the pipeline derives more, ``frame``
+    authors them for novel datasets (P13). Bound into the property graph as the
+    ``concept_edge`` edge over the ``og_concepts`` vertex.
+
+    **Same identity contract as :class:`Concept` (P3) — NOT run-versioned.** An edge
+    is a stable node keyed over ACTIVE rows by
+    ``(vertical, predicate, from_concept, to_concept)`` (the ``uq_concept_edge_active``
+    partial-unique index); an edit supersedes (stamp ``superseded_at`` + insert a new
+    active row) rather than colliding. Endpoints are the concepts' stable
+    ``name`` within ``vertical`` — NEVER ``concept_id`` (a per-seed surrogate the
+    grounding contract already forbids keying on). The ``og_concept_edges`` element
+    view resolves those names to the active concepts' ids for the PGQ vertex binding,
+    so a superseded/absent endpoint drops the edge from the graph automatically.
+
+    Symmetric predicates (``disjoint_with``, ``reconciles_with``) are stored in BOTH
+    directions — the graph is directed and PG19 SQL/PGQ ``MATCH`` is directed, so two
+    rows let a walk from either endpoint enumerate the relation. ``part_of`` is
+    directed (one row, source → target). ``tolerance`` is set only for
+    ``reconciles_with`` (the tie-out band); NULL otherwise.
+    """
+
+    __tablename__ = "concept_edges"
+    __table_args__ = (
+        # At most one ACTIVE edge per (vertical, predicate, from, to) — the concept-
+        # edge analogue of Concept.uq_concept_active, so a head-free read of the
+        # active graph is unambiguous and the seed's ON CONFLICT DO NOTHING is
+        # race-safe against a concurrent seed / frame write.
+        Index(
+            "uq_concept_edge_active",
+            "vertical",
+            "predicate",
+            "from_concept",
+            "to_concept",
+            unique=True,
+            postgresql_where=text("superseded_at IS NULL"),
+            sqlite_where=text("superseded_at IS NULL"),
+        ),
+    )
+
+    edge_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    vertical: Mapped[str] = mapped_column(String, nullable=False)
+    predicate: Mapped[str] = mapped_column(String, nullable=False)  # ConceptEdgePredicate
+    # Endpoints are concept NAMES within `vertical` (the stable (vertical, name) key),
+    # NOT concept_id — the element view joins them to the active concepts for the graph.
+    from_concept: Mapped[str] = mapped_column(String, nullable=False)
+    to_concept: Mapped[str] = mapped_column(String, nullable=False)
+    # reconciles_with tie-out band (e.g. 0.01 = 1%); NULL for part_of / disjoint_with.
+    tolerance: Mapped[float | None] = mapped_column(Float)
+
+    # Lifecycle: workspace-persistent with supersession (mirrors Concept).
+    source: Mapped[str | None] = mapped_column(String)  # 'seed' | 'derived' | 'frame'
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=lambda: datetime.now(UTC)
     )
@@ -332,6 +420,8 @@ class TableEntity(Base):
 
 __all__ = [
     "Concept",
+    "ConceptEdge",
+    "ConceptEdgePredicate",
     "ConceptKind",
     "SemanticAnnotation",
     "TableEntity",

--- a/packages/engine/src/dataraum/analysis/semantic/ontology.py
+++ b/packages/engine/src/dataraum/analysis/semantic/ontology.py
@@ -58,6 +58,23 @@ class OntologyConvention(BaseModel):
     concept_groups: dict[str, list[str]] = Field(default_factory=dict)  # label -> concept names
 
 
+class OntologyComposition(BaseModel):
+    """A concept-composition declaration → ``part_of`` edges (DAT-729).
+
+    Mereological composition at the CONCEPT grain: a ``whole`` concept is composed of
+    its ``parts`` (``current_assets`` = cash + receivables + inventory). The seed
+    promotes each ``part → whole`` into a typed ``part_of`` :class:`ConceptEdge`; the
+    transitive closure (all ancestors of a concept) is a bounded recursive CTE.
+
+    This is the concept-grain composition ONLY — the account-instance chart-of-accounts
+    tree is the physical ``references`` topology (P1) and the dimension-member roll-up
+    is ``rolls_up_to`` (P5); neither is re-expressed here.
+    """
+
+    whole: str  # the composite concept
+    parts: list[str] = Field(default_factory=list)  # concepts that compose the whole
+
+
 class OntologyDefinition(BaseModel):
     """A complete ontology definition from YAML."""
 
@@ -66,6 +83,7 @@ class OntologyDefinition(BaseModel):
     description: str | None = None
     concepts: list[OntologyConcept] = Field(default_factory=list)
     conventions: list[OntologyConvention] = Field(default_factory=list)
+    compositions: list[OntologyComposition] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def _validate_conventions(self) -> OntologyDefinition:
@@ -102,6 +120,32 @@ class OntologyDefinition(BaseModel):
                             f"'{placed[member]}' and '{group}' — groups must be disjoint"
                         )
                     placed[member] = group
+        return self
+
+    @model_validator(mode="after")
+    def _validate_compositions(self) -> OntologyDefinition:
+        """Lint composition declarations against the vocabulary (DAT-729), born-loud.
+
+        A ``part_of`` edge is only meaningful between declared concepts, so both the
+        ``whole`` and every ``part`` must resolve; a concept cannot be part of itself
+        (a trivial self-loop the graph must never carry). Deeper cycles are guarded by
+        the closure traversal at read time, not here.
+        """
+        if not self.compositions:
+            return self
+        concept_names = {c.name for c in self.concepts}
+        for comp in self.compositions:
+            for name in (comp.whole, *comp.parts):
+                if name not in concept_names:
+                    raise ValueError(
+                        f"composition of '{comp.whole}' references '{name}', "
+                        f"which is not a declared concept"
+                    )
+            if comp.whole in comp.parts:
+                raise ValueError(
+                    f"composition of '{comp.whole}' lists itself as a part — "
+                    f"a concept cannot be part_of itself"
+                )
         return self
 
 
@@ -240,6 +284,7 @@ class OntologyLoader:
 
 
 __all__ = [
+    "OntologyComposition",
     "OntologyConcept",
     "OntologyConvention",
     "OntologyDefinition",

--- a/packages/engine/src/dataraum/pipeline/phases/semantic_per_column_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/semantic_per_column_phase.py
@@ -16,6 +16,7 @@ from types import ModuleType
 
 from sqlalchemy import func, select
 
+from dataraum.analysis.semantic.concept_edge_store import ensure_concept_edges_seeded
 from dataraum.analysis.semantic.concept_store import (
     ensure_concepts_seeded,
     load_workspace_concepts,
@@ -156,6 +157,10 @@ class SemanticPerColumnPhase(BasePhase):
         # finance seeds from its shipped ontology; a framed vertical seeds nothing
         # here and relies on frame's typed writes.
         ensure_concepts_seeded(ctx.session, ontology)
+        # Concept edges (DAT-729): seed the vertical's typed vocabulary edges
+        # (disjoint_with from the convention partitions) into `concept_edges` right
+        # after the concepts they reference — same idempotent config→DB seed.
+        ensure_concept_edges_seeded(ctx.session, ontology)
         # Cold-start fail-loud (DAT-382, generalized): grounding against zero
         # concepts is a silent no-op. Refuse it, naming the missing step.
         if not load_workspace_concepts(ctx.session, ontology).concepts:

--- a/packages/engine/src/dataraum/storage/property_graph.py
+++ b/packages/engine/src/dataraum/storage/property_graph.py
@@ -22,18 +22,15 @@ and ``Table``; the vocabulary ``Concept`` vertices are P3. Edges/props carried:
     column_node  (KEY column_id)  props: semantic_role (has_role),
                                           materialization (materializes_as)
     table_node   (KEY table_id)   props: table_role (fact/periodic_snapshot/dimension)
-    refs               table → table     [relationships]      FK topology (conformed dims excluded)
-    has_dimension      table → column    [slice_definitions]  a fact's slice columns
-    derived_from       table → table     [enriched_views]     view → fact + dim bases
-    concept_edge       concept → concept [concept_edges]      part_of / disjoint_with (P4)
-    conformed_dimension table → table    [slice_definitions]  two facts sharing a dimension (P4)
+    refs          table → table     [relationships]      FK topology + cardinality
+    has_dimension table → column    [slice_definitions]  a fact's slice columns
+    derived_from  table → table     [enriched_views]     view → fact + dim bases
+    concept_edge  concept → concept [concept_edges]      part_of/disjoint/reconciles (P4)
 
 ``rolls_up_to`` (dimension_hierarchies' JSON members) lands in P5 where its
 consumer does. The ``concept_edge`` edge (DAT-729) carries the vocabulary relations
-``part_of`` / ``disjoint_with`` as a ``predicate`` property; its transitive closure
-(``part_of`` ancestry) is walked by the bounded recursive CTE. ``conformed_dimension``
-(DAT-729) types two facts sharing a dimension as a drill-across path — NOT a fact-to-fact
-FK (the DAT-723 fan trap), which is why those pairs are excluded from ``refs``.
+``part_of`` / ``disjoint_with`` / ``reconciles_with`` as a ``predicate`` property;
+its transitive closure (``part_of`` ancestry) is walked by the bounded recursive CTE.
 
 **Bootstrap ordering is load-bearing.** A property graph *depends on* its element
 views, and an element view depends on the ``current_*`` views. Postgres refuses to
@@ -80,7 +77,6 @@ _ELEMENT_VIEWS: tuple[str, ...] = (
     "og_has_dimension",
     "og_derived_from",
     "og_concept_edges",
-    "og_conformed_dimension",
 )
 
 
@@ -170,44 +166,13 @@ def _element_view_sql(name: str) -> str:
         # per-run and unique within one head-resolved view — a fine LOCAL edge key
         # inside one promoted state (never keyed on across runs). Self-referential
         # and multi-hop chains here are what the recursive-CTE closure walks.
-        #
-        # DAT-723 fan-trap fix (DAT-729): a relationship whose BOTH endpoints are
-        # same-named slice (dimension) columns of DIFFERENT tables is not an FK — it
-        # is a CONFORMED DIMENSION (two facts sharing a dimension, e.g.
-        # trial_balance.period ↔ balance_sheet.period), typed as the og_conformed_dimension
-        # edge below. Excluded here so the shared dimension is never ALSO presented as a
-        # reference (a real fact→dimension FK survives: the dimension table's key is not a
-        # fact slice column, so at most one endpoint is a slice — the filter cannot match).
         return (
             f"CREATE VIEW {READ_TOKEN}.og_references AS\n"
             f"SELECT relationship_id::text AS relationship_id,\n"
             f"       from_table_id::text AS from_table_id, to_table_id::text AS to_table_id,\n"
             f"       from_column_id, to_column_id, cardinality, relationship_type,\n"
             f"       confidence, is_confirmed\n"
-            f"FROM {READ_TOKEN}.current_relationships r\n"
-            f"WHERE NOT EXISTS (\n"
-            f"  SELECT 1 FROM {READ_TOKEN}.current_slice_definitions s1\n"
-            f"  JOIN {READ_TOKEN}.current_slice_definitions s2 ON s1.column_name = s2.column_name\n"
-            f"  WHERE s1.column_id = r.from_column_id AND s2.column_id = r.to_column_id\n"
-            f"    AND s1.table_id <> s2.table_id\n"
-            f");"
-        )
-    if name == "og_conformed_dimension":
-        # conformed_dimension edge (table → table): two facts sharing a dimension
-        # (DAT-729). Derived from paired slice (has_dimension) columns of the same name
-        # on DIFFERENT tables — the drill-across path (compare over the shared dim),
-        # explicitly NOT a fact-to-fact FK (that would be the DAT-723 fan trap). Symmetric,
-        # so both directions are emitted (edge_key = the ordered slice-id pair, '_'-joined
-        # — NOT ':', a bind-param sigil to text()). A fact partitioned by N shared
-        # dimensions yields one edge per shared dimension.
-        return (
-            f"CREATE VIEW {READ_TOKEN}.og_conformed_dimension AS\n"
-            f"SELECT (s1.slice_id || '_' || s2.slice_id)::text AS edge_key,\n"
-            f"       s1.table_id::text AS from_table_id, s2.table_id::text AS to_table_id,\n"
-            f"       s1.column_name AS dimension\n"
-            f"FROM {READ_TOKEN}.current_slice_definitions s1\n"
-            f"JOIN {READ_TOKEN}.current_slice_definitions s2\n"
-            f"  ON s1.column_name = s2.column_name AND s1.table_id <> s2.table_id;"
+            f"FROM {READ_TOKEN}.current_relationships;"
         )
     if name == "og_has_dimension":
         # has_dimension edge (table → column): a fact table's slice (dimension)
@@ -284,12 +249,7 @@ def _property_graph_sql() -> str:
         f"      SOURCE KEY (from_concept_id) REFERENCES og_concepts (concept_id)\n"
         f"      DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)\n"
         f"      LABEL concept_edge\n"
-        f"      PROPERTIES (predicate, tolerance),\n"
-        f"    {READ_TOKEN}.og_conformed_dimension KEY (edge_key)\n"
-        f"      SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)\n"
-        f"      DESTINATION KEY (to_table_id) REFERENCES og_tables (table_id)\n"
-        f"      LABEL conformed_dimension\n"
-        f"      PROPERTIES (dimension)\n"
+        f"      PROPERTIES (predicate, tolerance)\n"
         f"  );"
     )
 

--- a/packages/engine/src/dataraum/storage/property_graph.py
+++ b/packages/engine/src/dataraum/storage/property_graph.py
@@ -22,12 +22,15 @@ and ``Table``; the vocabulary ``Concept`` vertices are P3. Edges/props carried:
     column_node  (KEY column_id)  props: semantic_role (has_role),
                                           materialization (materializes_as)
     table_node   (KEY table_id)   props: table_role (fact/periodic_snapshot/dimension)
-    refs          table → table   [relationships]      FK topology + cardinality
-    has_dimension table → column  [slice_definitions]  a fact's slice columns
-    derived_from  table → table   [enriched_views]     view → fact + dim bases
+    refs          table → table     [relationships]      FK topology + cardinality
+    has_dimension table → column    [slice_definitions]  a fact's slice columns
+    derived_from  table → table     [enriched_views]     view → fact + dim bases
+    concept_edge  concept → concept [concept_edges]      part_of/disjoint/reconciles (P4)
 
 ``rolls_up_to`` (dimension_hierarchies' JSON members) lands in P5 where its
-consumer does; concept edges (part_of / disjoint_with / reconciles_with) in P4.
+consumer does. The ``concept_edge`` edge (DAT-729) carries the vocabulary relations
+``part_of`` / ``disjoint_with`` / ``reconciles_with`` as a ``predicate`` property;
+its transitive closure (``part_of`` ancestry) is walked by the bounded recursive CTE.
 
 **Bootstrap ordering is load-bearing.** A property graph *depends on* its element
 views, and an element view depends on the ``current_*`` views. Postgres refuses to
@@ -73,6 +76,7 @@ _ELEMENT_VIEWS: tuple[str, ...] = (
     "og_references",
     "og_has_dimension",
     "og_derived_from",
+    "og_concept_edges",
 )
 
 
@@ -126,13 +130,36 @@ def _element_view_sql(name: str) -> str:
     if name == "og_concepts":
         # Concept vertex: the workspace's typed vocabulary (DAT-728). Active rows
         # only (superseded_at IS NULL) — the partial-unique index makes concept_id
-        # unique among them, so it is a valid KEY. The vocabulary edges
-        # (grounded_by, part_of) arrive in later phases; the vertex stands alone here.
+        # unique among them, so it is a valid KEY. Its vocabulary edges are the
+        # `concept_edge` edge below (DAT-729); `grounded_by` arrives with P2.
         return (
             f"CREATE VIEW {READ_TOKEN}.og_concepts AS\n"
             f"SELECT concept_id::text AS concept_id, vertical, name, kind\n"
             f"FROM {READ_TOKEN}.concepts\n"
             f"WHERE superseded_at IS NULL;"
+        )
+    if name == "og_concept_edges":
+        # concept_edge (concept → concept): the vocabulary relations part_of /
+        # disjoint_with / reconciles_with (DAT-729), predicate carried as a property.
+        # concept_edges stores endpoints by the stable (vertical, name) key — the P3
+        # identity contract — so each endpoint JOINs to its ACTIVE concept to resolve
+        # the concept_id the PGQ vertex KEY needs. The INNER JOINs drop an edge whose
+        # endpoint concept is superseded/absent (the graph never dangles). edge_id is
+        # the per-edge local key (unique among active rows via the partial index).
+        return (
+            f"CREATE VIEW {READ_TOKEN}.og_concept_edges AS\n"
+            f"SELECT e.edge_id::text AS edge_id,\n"
+            f"       cf.concept_id::text AS from_concept_id,\n"
+            f"       ct.concept_id::text AS to_concept_id,\n"
+            f"       e.predicate, e.tolerance\n"
+            f"FROM {READ_TOKEN}.concept_edges e\n"
+            f"JOIN {READ_TOKEN}.concepts cf\n"
+            f"  ON cf.vertical = e.vertical AND cf.name = e.from_concept\n"
+            f" AND cf.superseded_at IS NULL\n"
+            f"JOIN {READ_TOKEN}.concepts ct\n"
+            f"  ON ct.vertical = e.vertical AND ct.name = e.to_concept\n"
+            f" AND ct.superseded_at IS NULL\n"
+            f"WHERE e.superseded_at IS NULL;"
         )
     if name == "og_references":
         # refs edge (table → table): the detected FK topology. relationship_id is
@@ -217,7 +244,12 @@ def _property_graph_sql() -> str:
         f"      SOURCE KEY (view_table_id) REFERENCES og_tables (table_id)\n"
         f"      DESTINATION KEY (base_table_id) REFERENCES og_tables (table_id)\n"
         f"      LABEL derived_from\n"
-        f"      PROPERTIES (base_role)\n"
+        f"      PROPERTIES (base_role),\n"
+        f"    {READ_TOKEN}.og_concept_edges KEY (edge_id)\n"
+        f"      SOURCE KEY (from_concept_id) REFERENCES og_concepts (concept_id)\n"
+        f"      DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)\n"
+        f"      LABEL concept_edge\n"
+        f"      PROPERTIES (predicate, tolerance)\n"
         f"  );"
     )
 

--- a/packages/engine/src/dataraum/storage/property_graph.py
+++ b/packages/engine/src/dataraum/storage/property_graph.py
@@ -22,15 +22,18 @@ and ``Table``; the vocabulary ``Concept`` vertices are P3. Edges/props carried:
     column_node  (KEY column_id)  props: semantic_role (has_role),
                                           materialization (materializes_as)
     table_node   (KEY table_id)   props: table_role (fact/periodic_snapshot/dimension)
-    refs          table → table     [relationships]      FK topology + cardinality
-    has_dimension table → column    [slice_definitions]  a fact's slice columns
-    derived_from  table → table     [enriched_views]     view → fact + dim bases
-    concept_edge  concept → concept [concept_edges]      part_of/disjoint/reconciles (P4)
+    refs               table → table     [relationships]      FK topology (conformed dims excluded)
+    has_dimension      table → column    [slice_definitions]  a fact's slice columns
+    derived_from       table → table     [enriched_views]     view → fact + dim bases
+    concept_edge       concept → concept [concept_edges]      part_of / disjoint_with (P4)
+    conformed_dimension table → table    [slice_definitions]  two facts sharing a dimension (P4)
 
 ``rolls_up_to`` (dimension_hierarchies' JSON members) lands in P5 where its
 consumer does. The ``concept_edge`` edge (DAT-729) carries the vocabulary relations
-``part_of`` / ``disjoint_with`` / ``reconciles_with`` as a ``predicate`` property;
-its transitive closure (``part_of`` ancestry) is walked by the bounded recursive CTE.
+``part_of`` / ``disjoint_with`` as a ``predicate`` property; its transitive closure
+(``part_of`` ancestry) is walked by the bounded recursive CTE. ``conformed_dimension``
+(DAT-729) types two facts sharing a dimension as a drill-across path — NOT a fact-to-fact
+FK (the DAT-723 fan trap), which is why those pairs are excluded from ``refs``.
 
 **Bootstrap ordering is load-bearing.** A property graph *depends on* its element
 views, and an element view depends on the ``current_*`` views. Postgres refuses to
@@ -77,6 +80,7 @@ _ELEMENT_VIEWS: tuple[str, ...] = (
     "og_has_dimension",
     "og_derived_from",
     "og_concept_edges",
+    "og_conformed_dimension",
 )
 
 
@@ -166,13 +170,44 @@ def _element_view_sql(name: str) -> str:
         # per-run and unique within one head-resolved view — a fine LOCAL edge key
         # inside one promoted state (never keyed on across runs). Self-referential
         # and multi-hop chains here are what the recursive-CTE closure walks.
+        #
+        # DAT-723 fan-trap fix (DAT-729): a relationship whose BOTH endpoints are
+        # same-named slice (dimension) columns of DIFFERENT tables is not an FK — it
+        # is a CONFORMED DIMENSION (two facts sharing a dimension, e.g.
+        # trial_balance.period ↔ balance_sheet.period), typed as the og_conformed_dimension
+        # edge below. Excluded here so the shared dimension is never ALSO presented as a
+        # reference (a real fact→dimension FK survives: the dimension table's key is not a
+        # fact slice column, so at most one endpoint is a slice — the filter cannot match).
         return (
             f"CREATE VIEW {READ_TOKEN}.og_references AS\n"
             f"SELECT relationship_id::text AS relationship_id,\n"
             f"       from_table_id::text AS from_table_id, to_table_id::text AS to_table_id,\n"
             f"       from_column_id, to_column_id, cardinality, relationship_type,\n"
             f"       confidence, is_confirmed\n"
-            f"FROM {READ_TOKEN}.current_relationships;"
+            f"FROM {READ_TOKEN}.current_relationships r\n"
+            f"WHERE NOT EXISTS (\n"
+            f"  SELECT 1 FROM {READ_TOKEN}.current_slice_definitions s1\n"
+            f"  JOIN {READ_TOKEN}.current_slice_definitions s2 ON s1.column_name = s2.column_name\n"
+            f"  WHERE s1.column_id = r.from_column_id AND s2.column_id = r.to_column_id\n"
+            f"    AND s1.table_id <> s2.table_id\n"
+            f");"
+        )
+    if name == "og_conformed_dimension":
+        # conformed_dimension edge (table → table): two facts sharing a dimension
+        # (DAT-729). Derived from paired slice (has_dimension) columns of the same name
+        # on DIFFERENT tables — the drill-across path (compare over the shared dim),
+        # explicitly NOT a fact-to-fact FK (that would be the DAT-723 fan trap). Symmetric,
+        # so both directions are emitted (edge_key = the ordered slice-id pair, '_'-joined
+        # — NOT ':', a bind-param sigil to text()). A fact partitioned by N shared
+        # dimensions yields one edge per shared dimension.
+        return (
+            f"CREATE VIEW {READ_TOKEN}.og_conformed_dimension AS\n"
+            f"SELECT (s1.slice_id || '_' || s2.slice_id)::text AS edge_key,\n"
+            f"       s1.table_id::text AS from_table_id, s2.table_id::text AS to_table_id,\n"
+            f"       s1.column_name AS dimension\n"
+            f"FROM {READ_TOKEN}.current_slice_definitions s1\n"
+            f"JOIN {READ_TOKEN}.current_slice_definitions s2\n"
+            f"  ON s1.column_name = s2.column_name AND s1.table_id <> s2.table_id;"
         )
     if name == "og_has_dimension":
         # has_dimension edge (table → column): a fact table's slice (dimension)
@@ -249,7 +284,12 @@ def _property_graph_sql() -> str:
         f"      SOURCE KEY (from_concept_id) REFERENCES og_concepts (concept_id)\n"
         f"      DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)\n"
         f"      LABEL concept_edge\n"
-        f"      PROPERTIES (predicate, tolerance)\n"
+        f"      PROPERTIES (predicate, tolerance),\n"
+        f"    {READ_TOKEN}.og_conformed_dimension KEY (edge_key)\n"
+        f"      SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)\n"
+        f"      DESTINATION KEY (to_table_id) REFERENCES og_tables (table_id)\n"
+        f"      LABEL conformed_dimension\n"
+        f"      PROPERTIES (dimension)\n"
         f"  );"
     )
 

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -181,6 +181,25 @@ def _seed(engine: Engine) -> None:
             "(edge_id, vertical, predicate, from_concept, to_concept, source, created_at) "
             f"VALUES ('{eid}', 'finance', 'disjoint_with', '{frm}', '{to}', 'seed', '{TS}')"
         )
+    # A part_of concept spine (DAT-729): a 3-level chain comp_a → comp_b → comp_c PLUS a
+    # back edge comp_c → comp_a (a pathological cycle bad authoring could introduce). The
+    # concept_ids are the readable 'cmp_*' so the closure can assert on them; the
+    # og_concept_edges view resolves the (vertical, name) endpoints to exactly these ids.
+    for cid, cname in [("cmp_a", "comp_a"), ("cmp_b", "comp_b"), ("cmp_c", "comp_c")]:
+        stmts.append(
+            "INSERT INTO concepts (concept_id, vertical, name, kind, created_at) "
+            f"VALUES ('{cid}', 'finance', '{cname}', 'measure', '{TS}')"
+        )
+    for eid, frm, to in [
+        ("pe_1", "comp_a", "comp_b"),
+        ("pe_2", "comp_b", "comp_c"),
+        ("pe_3", "comp_c", "comp_a"),  # back edge → cycle comp_a→comp_b→comp_c→comp_a
+    ]:
+        stmts.append(
+            "INSERT INTO concept_edges "
+            "(edge_id, vertical, predicate, from_concept, to_concept, source, created_at) "
+            f"VALUES ('{eid}', 'finance', 'part_of', '{frm}', '{to}', 'seed', '{TS}')"
+        )
     with engine.begin() as conn:
         for s in stmts:
             conn.execute(text(s))
@@ -289,6 +308,54 @@ def test_concept_edge_disjoint_with_matches(graph_engine: Engine) -> None:
         ("accounts_payable", "accounts_receivable"),
         ("accounts_receivable", "accounts_payable"),
     }
+
+
+def test_concept_edge_part_of_matches(graph_engine: Engine) -> None:
+    """part_of is a directed 1-hop concept→concept edge, selected by the predicate filter."""
+    sql = (
+        f"SELECT a, b FROM GRAPH_TABLE ({_graph_ref()} "
+        "MATCH (a IS concept_node)-[e IS concept_edge WHERE e.predicate = 'part_of']"
+        "->(b IS concept_node) "
+        "COLUMNS (a.name AS a, b.name AS b))"
+    )
+    with graph_engine.connect() as conn:
+        rows = {(r.a, r.b) for r in conn.execute(text(sql))}
+    # The 3-level spine + its back edge, and NOTHING from the disjoint_with edges.
+    assert rows == {("comp_a", "comp_b"), ("comp_b", "comp_c"), ("comp_c", "comp_a")}
+
+
+def _part_of_closure(conn, read: str, start: str) -> list[tuple[str, int]]:
+    """Bounded recursive-CTE ancestor closure over the part_of concept edges.
+
+    The P1 mechanism (test_property_graph ``_closure_from``) applied to the concept_edge
+    view: depth < 4 caps traversal, ``NOT to_concept_id = ANY(path)`` is the cycle guard,
+    ``predicate = 'part_of'`` selects the one relation. Returns (ancestor_id, depth).
+    """
+    sql = (
+        "WITH RECURSIVE reach(src, dst, depth, path) AS ("
+        "  SELECT from_concept_id, to_concept_id, 1, ARRAY[from_concept_id, to_concept_id] "
+        f"  FROM \"{read}\".og_concept_edges WHERE predicate = 'part_of' "
+        "  UNION ALL "
+        "  SELECT r.src, e.to_concept_id, r.depth + 1, r.path || e.to_concept_id "
+        f"  FROM reach r JOIN \"{read}\".og_concept_edges e "
+        "    ON e.from_concept_id = r.dst AND e.predicate = 'part_of' "
+        "  WHERE r.depth < 4 AND NOT e.to_concept_id = ANY(r.path)"
+        ") SELECT dst, depth FROM reach WHERE src = :s ORDER BY depth, dst"
+    )
+    return [(r.dst, r.depth) for r in conn.execute(text(sql), {"s": start})]
+
+
+def test_part_of_closure_walks_ancestors_and_guards_cycle(graph_engine: Engine) -> None:
+    """part_of ancestry via the recursive CTE: transitive ancestors, cycle-guarded (P4 AC).
+
+    From comp_a the closure reaches its transitive wholes comp_b (depth 1) and comp_c
+    (depth 2); the back edge comp_c→comp_a does NOT re-enter comp_a — the cycle guard
+    fires and the walk terminates.
+    """
+    with graph_engine.connect() as conn:
+        rows = _part_of_closure(conn, _read_schema(), "cmp_a")
+    assert rows == [("cmp_b", 1), ("cmp_c", 2)]
+    assert "cmp_a" not in {dst for dst, _ in rows}  # cycle guard blocked the back edge
 
 
 def test_reader_role_can_query_the_graph(graph_engine: Engine) -> None:

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -200,6 +200,42 @@ def _seed(engine: Engine) -> None:
             "(edge_id, vertical, predicate, from_concept, to_concept, source, created_at) "
             f"VALUES ('{eid}', 'finance', 'part_of', '{frm}', '{to}', 'seed', '{TS}')"
         )
+    # Two facts sharing a 'period' dimension (DAT-729 conformed dim / DAT-723 fan trap):
+    # trial_balance + balance_sheet both slice by period. The period↔period link the
+    # detector emits must type as conformed_dimension, NOT references.
+    for tid, name in [("tb", "trial_balance"), ("bs", "balance_sheet")]:
+        stmts.append(
+            "INSERT INTO tables (table_id, source_id, table_name, layer, created_at) "
+            f"VALUES ('{tid}', '{SRC}', '{name}', 'typed', '{TS}')"
+        )
+        stmts.append(
+            "INSERT INTO metadata_snapshot_head (head_id, target, stage, run_id, promoted_at) "
+            f"VALUES ('h_{tid}', 'table:{tid}', 'generation', '{RUN}', '{TS}')"
+        )
+        stmts.append(
+            "INSERT INTO columns (column_id, table_id, column_name, column_position) "
+            f"VALUES ('c_{tid}_p', '{tid}', 'period', 1)"
+        )
+        stmts.append(
+            "INSERT INTO table_entities "
+            "(entity_id, table_id, run_id, detected_entity_type, table_role, detected_at) "
+            f"VALUES ('e_{tid}', '{tid}', '{RUN}', 'transaction', 'periodic_snapshot', '{TS}')"
+        )
+        stmts.append(
+            "INSERT INTO slice_definitions "
+            "(slice_id, run_id, table_id, column_id, column_name, slice_priority, "
+            " slice_type, detection_source, created_at) "
+            f"VALUES ('sl_{tid}_p', '{RUN}', '{tid}', 'c_{tid}_p', 'period', 1, "
+            f"'categorical', 'llm', '{TS}')"
+        )
+    # The DAT-723 false positive: period↔period detected as a fan-trap FK between two facts.
+    stmts.append(
+        "INSERT INTO relationships "
+        "(relationship_id, run_id, from_table_id, from_column_id, to_table_id, "
+        " to_column_id, relationship_type, cardinality, confidence, is_confirmed, detected_at) "
+        f"VALUES ('r_period', '{RUN}', 'tb', 'c_tb_p', 'bs', 'c_bs_p', "
+        f"'foreign_key', 'many_to_many', 0.8, true, '{TS}')"
+    )
     with engine.begin() as conn:
         for s in stmts:
             conn.execute(text(s))
@@ -286,7 +322,12 @@ def test_has_dimension_edge(graph_engine: Engine) -> None:
     )
     with graph_engine.connect() as conn:
         rows = {(r.tname, r.cname) for r in conn.execute(text(sql))}
-    assert rows == {("journal", "account_id")}
+    # journal's account_id slice + the two facts' shared period slice (DAT-729 seed).
+    assert rows == {
+        ("journal", "account_id"),
+        ("trial_balance", "period"),
+        ("balance_sheet", "period"),
+    }
 
 
 def test_concept_edge_disjoint_with_matches(graph_engine: Engine) -> None:
@@ -356,6 +397,47 @@ def test_part_of_closure_walks_ancestors_and_guards_cycle(graph_engine: Engine) 
         rows = _part_of_closure(conn, _read_schema(), "cmp_a")
     assert rows == [("cmp_b", 1), ("cmp_c", 2)]
     assert "cmp_a" not in {dst for dst, _ in rows}  # cycle guard blocked the back edge
+
+
+def test_conformed_dimension_edge_pairs_facts_on_shared_dim(graph_engine: Engine) -> None:
+    """DAT-729: two facts sharing a dimension surface as a conformed_dimension edge.
+
+    trial_balance and balance_sheet both slice by period → a drill-across edge both ways,
+    carrying the shared dimension name. Only THIS pair (not the CoA account_id slice, which
+    no second fact shares) is conformed.
+    """
+    sql = (
+        f"SELECT a, b, dim FROM GRAPH_TABLE ({_graph_ref()} "
+        "MATCH (a IS table_node)-[e IS conformed_dimension]->(b IS table_node) "
+        "COLUMNS (a.table_name AS a, b.table_name AS b, e.dimension AS dim))"
+    )
+    with graph_engine.connect() as conn:
+        rows = {(r.a, r.b, r.dim) for r in conn.execute(text(sql))}
+    assert rows == {
+        ("trial_balance", "balance_sheet", "period"),
+        ("balance_sheet", "trial_balance", "period"),
+    }
+
+
+def test_shared_dimension_excluded_from_references(graph_engine: Engine) -> None:
+    """The DAT-723 fan-trap fix: the period↔period link is a conformed dim, NOT a reference.
+
+    The false-positive FK between the two facts' period columns is filtered out of refs,
+    while every real CoA fact→dimension FK (only one endpoint is a slice column) survives.
+    """
+    sql = (
+        f"SELECT a, b FROM GRAPH_TABLE ({_graph_ref()} "
+        "MATCH (a IS table_node)-[e IS refs]->(b IS table_node) "
+        "COLUMNS (a.table_name AS a, b.table_name AS b))"
+    )
+    with graph_engine.connect() as conn:
+        refs = {(r.a, r.b) for r in conn.execute(text(sql))}
+    # The conformed-dimension pair is NOT a reference edge.
+    assert ("trial_balance", "balance_sheet") not in refs
+    # The real FK topology is untouched — the CoA chain still resolves.
+    assert ("journal", "accounts") in refs
+    assert ("accounts", "account_group") in refs
+    assert len(refs) == 6  # the six CoA edges only; the period link is excluded
 
 
 def test_reader_role_can_query_the_graph(graph_engine: Engine) -> None:

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -162,6 +162,25 @@ def _seed(engine: Engine) -> None:
         f"VALUES ('v_1', 't1', 't_enr', 'journal_enriched', '{RUN}', "
         f"'[\"t2\"]'::json, true, '{TS}')"
     )
+    # Concept vertices + a disjoint_with concept edge (DAT-729): the vocabulary graph.
+    # Concepts/edges are workspace-persistent (NOT run-versioned) — plain active rows,
+    # no head to promote. The og_concept_edges view resolves the edge's (vertical, name)
+    # endpoints to these concepts' ids for the concept→concept PGQ binding.
+    for cid, cname in [("con_ap", "accounts_payable"), ("con_ar", "accounts_receivable")]:
+        stmts.append(
+            "INSERT INTO concepts (concept_id, vertical, name, kind, created_at) "
+            f"VALUES ('{cid}', 'finance', '{cname}', 'measure', '{TS}')"
+        )
+    # disjoint_with is symmetric → both directions, so a directed MATCH finds it either way.
+    for eid, frm, to in [
+        ("ce_1", "accounts_payable", "accounts_receivable"),
+        ("ce_2", "accounts_receivable", "accounts_payable"),
+    ]:
+        stmts.append(
+            "INSERT INTO concept_edges "
+            "(edge_id, vertical, predicate, from_concept, to_concept, source, created_at) "
+            f"VALUES ('{eid}', 'finance', 'disjoint_with', '{frm}', '{to}', 'seed', '{TS}')"
+        )
     with engine.begin() as conn:
         for s in stmts:
             conn.execute(text(s))
@@ -249,6 +268,27 @@ def test_has_dimension_edge(graph_engine: Engine) -> None:
     with graph_engine.connect() as conn:
         rows = {(r.tname, r.cname) for r in conn.execute(text(sql))}
     assert rows == {("journal", "account_id")}
+
+
+def test_concept_edge_disjoint_with_matches(graph_engine: Engine) -> None:
+    """DAT-729: the concept→concept binding — a disjoint_with edge is enumerable via PGQ.
+
+    This is the P4 de-risk: P1 bound only table→table and table→column edges; a concept
+    edge over the og_concepts vertex is a new element shape. A directed MATCH filtering on
+    the predicate property must return both stored directions of the symmetric edge.
+    """
+    sql = (
+        f"SELECT a, b FROM GRAPH_TABLE ({_graph_ref()} "
+        "MATCH (a IS concept_node)-[e IS concept_edge WHERE e.predicate = 'disjoint_with']"
+        "->(b IS concept_node) "
+        "COLUMNS (a.name AS a, b.name AS b))"
+    )
+    with graph_engine.connect() as conn:
+        rows = {(r.a, r.b) for r in conn.execute(text(sql))}
+    assert rows == {
+        ("accounts_payable", "accounts_receivable"),
+        ("accounts_receivable", "accounts_payable"),
+    }
 
 
 def test_reader_role_can_query_the_graph(graph_engine: Engine) -> None:

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -200,42 +200,6 @@ def _seed(engine: Engine) -> None:
             "(edge_id, vertical, predicate, from_concept, to_concept, source, created_at) "
             f"VALUES ('{eid}', 'finance', 'part_of', '{frm}', '{to}', 'seed', '{TS}')"
         )
-    # Two facts sharing a 'period' dimension (DAT-729 conformed dim / DAT-723 fan trap):
-    # trial_balance + balance_sheet both slice by period. The period↔period link the
-    # detector emits must type as conformed_dimension, NOT references.
-    for tid, name in [("tb", "trial_balance"), ("bs", "balance_sheet")]:
-        stmts.append(
-            "INSERT INTO tables (table_id, source_id, table_name, layer, created_at) "
-            f"VALUES ('{tid}', '{SRC}', '{name}', 'typed', '{TS}')"
-        )
-        stmts.append(
-            "INSERT INTO metadata_snapshot_head (head_id, target, stage, run_id, promoted_at) "
-            f"VALUES ('h_{tid}', 'table:{tid}', 'generation', '{RUN}', '{TS}')"
-        )
-        stmts.append(
-            "INSERT INTO columns (column_id, table_id, column_name, column_position) "
-            f"VALUES ('c_{tid}_p', '{tid}', 'period', 1)"
-        )
-        stmts.append(
-            "INSERT INTO table_entities "
-            "(entity_id, table_id, run_id, detected_entity_type, table_role, detected_at) "
-            f"VALUES ('e_{tid}', '{tid}', '{RUN}', 'transaction', 'periodic_snapshot', '{TS}')"
-        )
-        stmts.append(
-            "INSERT INTO slice_definitions "
-            "(slice_id, run_id, table_id, column_id, column_name, slice_priority, "
-            " slice_type, detection_source, created_at) "
-            f"VALUES ('sl_{tid}_p', '{RUN}', '{tid}', 'c_{tid}_p', 'period', 1, "
-            f"'categorical', 'llm', '{TS}')"
-        )
-    # The DAT-723 false positive: period↔period detected as a fan-trap FK between two facts.
-    stmts.append(
-        "INSERT INTO relationships "
-        "(relationship_id, run_id, from_table_id, from_column_id, to_table_id, "
-        " to_column_id, relationship_type, cardinality, confidence, is_confirmed, detected_at) "
-        f"VALUES ('r_period', '{RUN}', 'tb', 'c_tb_p', 'bs', 'c_bs_p', "
-        f"'foreign_key', 'many_to_many', 0.8, true, '{TS}')"
-    )
     with engine.begin() as conn:
         for s in stmts:
             conn.execute(text(s))
@@ -322,12 +286,7 @@ def test_has_dimension_edge(graph_engine: Engine) -> None:
     )
     with graph_engine.connect() as conn:
         rows = {(r.tname, r.cname) for r in conn.execute(text(sql))}
-    # journal's account_id slice + the two facts' shared period slice (DAT-729 seed).
-    assert rows == {
-        ("journal", "account_id"),
-        ("trial_balance", "period"),
-        ("balance_sheet", "period"),
-    }
+    assert rows == {("journal", "account_id")}
 
 
 def test_concept_edge_disjoint_with_matches(graph_engine: Engine) -> None:
@@ -397,47 +356,6 @@ def test_part_of_closure_walks_ancestors_and_guards_cycle(graph_engine: Engine) 
         rows = _part_of_closure(conn, _read_schema(), "cmp_a")
     assert rows == [("cmp_b", 1), ("cmp_c", 2)]
     assert "cmp_a" not in {dst for dst, _ in rows}  # cycle guard blocked the back edge
-
-
-def test_conformed_dimension_edge_pairs_facts_on_shared_dim(graph_engine: Engine) -> None:
-    """DAT-729: two facts sharing a dimension surface as a conformed_dimension edge.
-
-    trial_balance and balance_sheet both slice by period → a drill-across edge both ways,
-    carrying the shared dimension name. Only THIS pair (not the CoA account_id slice, which
-    no second fact shares) is conformed.
-    """
-    sql = (
-        f"SELECT a, b, dim FROM GRAPH_TABLE ({_graph_ref()} "
-        "MATCH (a IS table_node)-[e IS conformed_dimension]->(b IS table_node) "
-        "COLUMNS (a.table_name AS a, b.table_name AS b, e.dimension AS dim))"
-    )
-    with graph_engine.connect() as conn:
-        rows = {(r.a, r.b, r.dim) for r in conn.execute(text(sql))}
-    assert rows == {
-        ("trial_balance", "balance_sheet", "period"),
-        ("balance_sheet", "trial_balance", "period"),
-    }
-
-
-def test_shared_dimension_excluded_from_references(graph_engine: Engine) -> None:
-    """The DAT-723 fan-trap fix: the period↔period link is a conformed dim, NOT a reference.
-
-    The false-positive FK between the two facts' period columns is filtered out of refs,
-    while every real CoA fact→dimension FK (only one endpoint is a slice column) survives.
-    """
-    sql = (
-        f"SELECT a, b FROM GRAPH_TABLE ({_graph_ref()} "
-        "MATCH (a IS table_node)-[e IS refs]->(b IS table_node) "
-        "COLUMNS (a.table_name AS a, b.table_name AS b))"
-    )
-    with graph_engine.connect() as conn:
-        refs = {(r.a, r.b) for r in conn.execute(text(sql))}
-    # The conformed-dimension pair is NOT a reference edge.
-    assert ("trial_balance", "balance_sheet") not in refs
-    # The real FK topology is untouched — the CoA chain still resolves.
-    assert ("journal", "accounts") in refs
-    assert ("accounts", "account_group") in refs
-    assert len(refs) == 6  # the six CoA edges only; the period link is excluded
 
 
 def test_reader_role_can_query_the_graph(graph_engine: Engine) -> None:

--- a/packages/engine/tests/unit/analysis/semantic/test_concept_edge_store.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_concept_edge_store.py
@@ -1,9 +1,10 @@
-"""Concept-edge seed — disjoint_with from convention partitions (DAT-729).
+"""Concept-edge seed — disjoint_with + part_of from the vertical (DAT-729).
 
 Pins the config→DB seam for the graph's vocabulary edges: the shipped vertical's
-convention ``concept_groups`` seed typed ``disjoint_with`` rows (both directions,
-idempotently), the same lever that promoted concepts in DAT-728. The live PGQ binding
-is exercised in ``tests/integration/storage/test_property_graph.py``.
+convention ``concept_groups`` seed typed ``disjoint_with`` rows (both directions) and
+its ``compositions`` seed directed ``part_of`` rows — idempotently, the same lever that
+promoted concepts in DAT-728. The live PGQ binding + closure are exercised in
+``tests/integration/storage/test_property_graph.py``.
 """
 
 from __future__ import annotations
@@ -17,6 +18,19 @@ from dataraum.analysis.semantic.concept_edge_store import ensure_concept_edges_s
 from dataraum.analysis.semantic.concept_store import ensure_concepts_seeded
 from dataraum.analysis.semantic.db_models import Concept, ConceptEdge, ConceptEdgePredicate
 
+_DISJOINT = ConceptEdgePredicate.DISJOINT_WITH.value
+_PART_OF = ConceptEdgePredicate.PART_OF.value
+
+# finance has two group-bearing conventions: sign_natural_balance (credit_normal 4 ×
+# debit_normal 8 = 32 unordered cross-pairs) and balance_sheet_composition (asset
+# family 4 × liability family 2 = 8) — but every balance pair is ALSO a sign pair
+# (the asset family is wholly debit-normal, the liability family wholly credit-normal),
+# so the union is 32 unordered = 64 directed disjoint edges. Compositions add 4 part_of
+# edges: current_assets ← {cash, accounts_receivable, inventory}, current_liabilities ← {AP}.
+_FINANCE_DISJOINT = 64
+_FINANCE_PART_OF = 4
+_FINANCE_TOTAL = _FINANCE_DISJOINT + _FINANCE_PART_OF
+
 
 def _active_edges(session: Session, vertical: str) -> list[ConceptEdge]:
     return list(
@@ -28,34 +42,31 @@ def _active_edges(session: Session, vertical: str) -> list[ConceptEdge]:
     )
 
 
-def _pairs(session: Session, vertical: str) -> set[tuple[str, str]]:
-    return {(e.from_concept, e.to_concept) for e in _active_edges(session, vertical)}
+def _pairs(session: Session, vertical: str, predicate: str) -> set[tuple[str, str]]:
+    return {
+        (e.from_concept, e.to_concept)
+        for e in _active_edges(session, vertical)
+        if e.predicate == predicate
+    }
 
 
-# finance has two group-bearing conventions: sign_natural_balance (credit_normal 4 ×
-# debit_normal 8 = 32 unordered cross-pairs) and balance_sheet_composition (asset
-# family 4 × liability family 2 = 8) — but every balance pair is ALSO a sign pair
-# (the asset family is wholly debit-normal, the liability family wholly credit-normal),
-# so the union is 32 unordered = 64 directed edges.
-_FINANCE_DIRECTED_DISJOINT = 64
-
-
-def test_seed_finance_creates_bidirectional_disjoint_edges(session: Session) -> None:
+def test_seed_finance_creates_disjoint_and_part_of_edges(session: Session) -> None:
     n = ensure_concept_edges_seeded(session, "finance")
-    assert n == _FINANCE_DIRECTED_DISJOINT
+    assert n == _FINANCE_TOTAL
     edges = _active_edges(session, "finance")
-    # Every edge is a seeded disjoint_with — this phase authors only that predicate.
-    assert {e.predicate for e in edges} == {ConceptEdgePredicate.DISJOINT_WITH.value}
+    assert {e.predicate for e in edges} == {_DISJOINT, _PART_OF}
     assert {e.source for e in edges} == {"seed"}
     assert all(e.tolerance is None for e in edges)
-    # No self-loops (groups are validated mutually exclusive, so a != b always).
+    # No self-loops (groups are mutually exclusive; a whole is never its own part).
     assert all(e.from_concept != e.to_concept for e in edges)
+    assert sum(1 for e in edges if e.predicate == _DISJOINT) == _FINANCE_DISJOINT
+    assert sum(1 for e in edges if e.predicate == _PART_OF) == _FINANCE_PART_OF
 
 
 def test_seed_disjoint_is_symmetric(session: Session) -> None:
     """A symmetric predicate is stored both ways so a directed MATCH finds it either side."""
     ensure_concept_edges_seeded(session, "finance")
-    pairs = _pairs(session, "finance")
+    pairs = _pairs(session, "finance", _DISJOINT)
     assert pairs, "no disjoint edges seeded"
     assert all((b, a) in pairs for (a, b) in pairs), "disjoint_with must be bidirectional"
 
@@ -63,7 +74,7 @@ def test_seed_disjoint_is_symmetric(session: Session) -> None:
 def test_seed_captures_the_named_disjoint_examples(session: Session) -> None:
     """The DD's illustrative pairs fall out of the sign/family partitions, both ways."""
     ensure_concept_edges_seeded(session, "finance")
-    pairs = _pairs(session, "finance")
+    pairs = _pairs(session, "finance", _DISJOINT)
     # AP ⊥ AR (payable is credit-normal, receivable debit-normal).
     assert ("accounts_payable", "accounts_receivable") in pairs
     assert ("accounts_receivable", "accounts_payable") in pairs
@@ -72,11 +83,25 @@ def test_seed_captures_the_named_disjoint_examples(session: Session) -> None:
     assert ("current_liabilities", "current_assets") in pairs
 
 
+def test_seed_part_of_is_directed_composition(session: Session) -> None:
+    """Each composition part rolls up into its whole — directed, one row, no reverse."""
+    ensure_concept_edges_seeded(session, "finance")
+    part_of = _pairs(session, "finance", _PART_OF)
+    assert part_of == {
+        ("cash", "current_assets"),
+        ("accounts_receivable", "current_assets"),
+        ("inventory", "current_assets"),
+        ("accounts_payable", "current_liabilities"),
+    }
+    # Directed: the whole is NOT part_of its part.
+    assert ("current_assets", "cash") not in part_of
+
+
 def test_seed_is_idempotent(session: Session) -> None:
-    assert ensure_concept_edges_seeded(session, "finance") == _FINANCE_DIRECTED_DISJOINT
+    assert ensure_concept_edges_seeded(session, "finance") == _FINANCE_TOTAL
     # A re-run inserts nothing — never duplicates, never clobbers an edited edge.
     assert ensure_concept_edges_seeded(session, "finance") == 0
-    assert len(_active_edges(session, "finance")) == _FINANCE_DIRECTED_DISJOINT
+    assert len(_active_edges(session, "finance")) == _FINANCE_TOTAL
 
 
 def test_seed_does_not_clobber_a_superseded_edge(session: Session) -> None:
@@ -86,7 +111,7 @@ def test_seed_does_not_clobber_a_superseded_edge(session: Session) -> None:
     edit (same active partial-unique index as concepts), never overwriting it and
     never RAISING on the collision.
     """
-    assert ensure_concept_edges_seeded(session, "finance") == _FINANCE_DIRECTED_DISJOINT
+    assert ensure_concept_edges_seeded(session, "finance") == _FINANCE_TOTAL
     # Supersede one active edge and insert a new active row in its place (source=frame).
     session.execute(
         update(ConceptEdge)
@@ -101,7 +126,7 @@ def test_seed_does_not_clobber_a_superseded_edge(session: Session) -> None:
     session.add(
         ConceptEdge(
             vertical="finance",
-            predicate=ConceptEdgePredicate.DISJOINT_WITH.value,
+            predicate=_DISJOINT,
             from_concept="accounts_payable",
             to_concept="accounts_receivable",
             source="frame",
@@ -124,7 +149,7 @@ def test_seed_does_not_clobber_a_superseded_edge(session: Session) -> None:
 def test_seed_edges_reference_seeded_concept_names(session: Session) -> None:
     """Every edge endpoint is a real concept name — the element view's JOIN resolves it.
 
-    The convention linter already guarantees group members are declared concepts; this
+    The convention/composition linters guarantee members are declared concepts; this
     pins that the seeded edges stay within the seeded concept vocabulary, so the
     ``og_concept_edges`` JOIN to ``concepts`` never silently drops a seed edge.
     """

--- a/packages/engine/tests/unit/analysis/semantic/test_concept_edge_store.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_concept_edge_store.py
@@ -1,0 +1,142 @@
+"""Concept-edge seed — disjoint_with from convention partitions (DAT-729).
+
+Pins the config→DB seam for the graph's vocabulary edges: the shipped vertical's
+convention ``concept_groups`` seed typed ``disjoint_with`` rows (both directions,
+idempotently), the same lever that promoted concepts in DAT-728. The live PGQ binding
+is exercised in ``tests/integration/storage/test_property_graph.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+
+from dataraum.analysis.semantic.concept_edge_store import ensure_concept_edges_seeded
+from dataraum.analysis.semantic.concept_store import ensure_concepts_seeded
+from dataraum.analysis.semantic.db_models import Concept, ConceptEdge, ConceptEdgePredicate
+
+
+def _active_edges(session: Session, vertical: str) -> list[ConceptEdge]:
+    return list(
+        session.execute(
+            select(ConceptEdge).where(
+                ConceptEdge.vertical == vertical, ConceptEdge.superseded_at.is_(None)
+            )
+        ).scalars()
+    )
+
+
+def _pairs(session: Session, vertical: str) -> set[tuple[str, str]]:
+    return {(e.from_concept, e.to_concept) for e in _active_edges(session, vertical)}
+
+
+# finance has two group-bearing conventions: sign_natural_balance (credit_normal 4 ×
+# debit_normal 8 = 32 unordered cross-pairs) and balance_sheet_composition (asset
+# family 4 × liability family 2 = 8) — but every balance pair is ALSO a sign pair
+# (the asset family is wholly debit-normal, the liability family wholly credit-normal),
+# so the union is 32 unordered = 64 directed edges.
+_FINANCE_DIRECTED_DISJOINT = 64
+
+
+def test_seed_finance_creates_bidirectional_disjoint_edges(session: Session) -> None:
+    n = ensure_concept_edges_seeded(session, "finance")
+    assert n == _FINANCE_DIRECTED_DISJOINT
+    edges = _active_edges(session, "finance")
+    # Every edge is a seeded disjoint_with — this phase authors only that predicate.
+    assert {e.predicate for e in edges} == {ConceptEdgePredicate.DISJOINT_WITH.value}
+    assert {e.source for e in edges} == {"seed"}
+    assert all(e.tolerance is None for e in edges)
+    # No self-loops (groups are validated mutually exclusive, so a != b always).
+    assert all(e.from_concept != e.to_concept for e in edges)
+
+
+def test_seed_disjoint_is_symmetric(session: Session) -> None:
+    """A symmetric predicate is stored both ways so a directed MATCH finds it either side."""
+    ensure_concept_edges_seeded(session, "finance")
+    pairs = _pairs(session, "finance")
+    assert pairs, "no disjoint edges seeded"
+    assert all((b, a) in pairs for (a, b) in pairs), "disjoint_with must be bidirectional"
+
+
+def test_seed_captures_the_named_disjoint_examples(session: Session) -> None:
+    """The DD's illustrative pairs fall out of the sign/family partitions, both ways."""
+    ensure_concept_edges_seeded(session, "finance")
+    pairs = _pairs(session, "finance")
+    # AP ⊥ AR (payable is credit-normal, receivable debit-normal).
+    assert ("accounts_payable", "accounts_receivable") in pairs
+    assert ("accounts_receivable", "accounts_payable") in pairs
+    # ASSET ⊥ LIABILITY at the concept level.
+    assert ("current_assets", "current_liabilities") in pairs
+    assert ("current_liabilities", "current_assets") in pairs
+
+
+def test_seed_is_idempotent(session: Session) -> None:
+    assert ensure_concept_edges_seeded(session, "finance") == _FINANCE_DIRECTED_DISJOINT
+    # A re-run inserts nothing — never duplicates, never clobbers an edited edge.
+    assert ensure_concept_edges_seeded(session, "finance") == 0
+    assert len(_active_edges(session, "finance")) == _FINANCE_DIRECTED_DISJOINT
+
+
+def test_seed_does_not_clobber_a_superseded_edge(session: Session) -> None:
+    """A frame edit (supersede + insert) survives a re-seed — the race-safety contract.
+
+    The re-seed's ``ON CONFLICT DO NOTHING`` skips the edge whose active row is the
+    edit (same active partial-unique index as concepts), never overwriting it and
+    never RAISING on the collision.
+    """
+    assert ensure_concept_edges_seeded(session, "finance") == _FINANCE_DIRECTED_DISJOINT
+    # Supersede one active edge and insert a new active row in its place (source=frame).
+    session.execute(
+        update(ConceptEdge)
+        .where(
+            ConceptEdge.vertical == "finance",
+            ConceptEdge.from_concept == "accounts_payable",
+            ConceptEdge.to_concept == "accounts_receivable",
+            ConceptEdge.superseded_at.is_(None),
+        )
+        .values(superseded_at=datetime.now(UTC))
+    )
+    session.add(
+        ConceptEdge(
+            vertical="finance",
+            predicate=ConceptEdgePredicate.DISJOINT_WITH.value,
+            from_concept="accounts_payable",
+            to_concept="accounts_receivable",
+            source="frame",
+        )
+    )
+    session.flush()
+    # Re-seed: that pair collides on the active index → skipped, no error.
+    assert ensure_concept_edges_seeded(session, "finance") == 0
+    edited = session.execute(
+        select(ConceptEdge).where(
+            ConceptEdge.vertical == "finance",
+            ConceptEdge.from_concept == "accounts_payable",
+            ConceptEdge.to_concept == "accounts_receivable",
+            ConceptEdge.superseded_at.is_(None),
+        )
+    ).scalar_one()
+    assert edited.source == "frame"  # the edit kept, not clobbered
+
+
+def test_seed_edges_reference_seeded_concept_names(session: Session) -> None:
+    """Every edge endpoint is a real concept name — the element view's JOIN resolves it.
+
+    The convention linter already guarantees group members are declared concepts; this
+    pins that the seeded edges stay within the seeded concept vocabulary, so the
+    ``og_concept_edges`` JOIN to ``concepts`` never silently drops a seed edge.
+    """
+    ensure_concepts_seeded(session, "finance")
+    ensure_concept_edges_seeded(session, "finance")
+    endpoints = {e.from_concept for e in _active_edges(session, "finance")} | {
+        e.to_concept for e in _active_edges(session, "finance")
+    }
+    seeded_concepts = {
+        c.name
+        for c in session.execute(
+            select(Concept).where(Concept.vertical == "finance", Concept.superseded_at.is_(None))
+        ).scalars()
+    }
+    assert endpoints <= seeded_concepts

--- a/packages/engine/tests/unit/analysis/semantic/test_ontology_loader.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_ontology_loader.py
@@ -251,3 +251,56 @@ def test_convention_model_defaults() -> None:
     """A convention needs only id + statement; groups/targets default empty."""
     conv = OntologyConvention(id="c", statement="s")
     assert conv.targets == [] and conv.concept_groups == {}
+
+
+class TestCompositions:
+    """Concept compositions → part_of edges (DAT-729)."""
+
+    @staticmethod
+    def _ontology(compositions: list[dict]) -> dict:
+        return {
+            "name": "t",
+            "concepts": [
+                {"name": "current_assets", "typical_role": "measure"},
+                {"name": "cash", "typical_role": "measure"},
+                {"name": "inventory", "typical_role": "measure"},
+            ],
+            "compositions": compositions,
+        }
+
+    def test_finance_ships_compositions(self) -> None:
+        """The shipped finance vertical declares the balance-sheet compositions."""
+        ontology = OntologyLoader().load("finance")
+        wholes = {c.whole for c in ontology.compositions}
+        assert {"current_assets", "current_liabilities"} <= wholes
+        current_assets = next(c for c in ontology.compositions if c.whole == "current_assets")
+        assert set(current_assets.parts) == {"cash", "accounts_receivable", "inventory"}
+
+    def test_valid_composition_resolves(self) -> None:
+        ont = OntologyDefinition(
+            **self._ontology([{"whole": "current_assets", "parts": ["cash", "inventory"]}])
+        )
+        assert len(ont.compositions) == 1
+
+    def test_lint_rejects_unknown_part(self) -> None:
+        """A part that is not a declared concept fails loud at load."""
+        with pytest.raises(ValueError, match="not a declared concept"):
+            OntologyDefinition(
+                **self._ontology([{"whole": "current_assets", "parts": ["nonexistent"]}])
+            )
+
+    def test_lint_rejects_unknown_whole(self) -> None:
+        """The whole must also be a declared concept."""
+        with pytest.raises(ValueError, match="not a declared concept"):
+            OntologyDefinition(**self._ontology([{"whole": "nonexistent", "parts": ["cash"]}]))
+
+    def test_lint_rejects_self_part(self) -> None:
+        """A concept cannot be part_of itself — a self-loop the graph must never carry."""
+        with pytest.raises(ValueError, match="cannot be part_of itself"):
+            OntologyDefinition(
+                **self._ontology([{"whole": "current_assets", "parts": ["cash", "current_assets"]}])
+            )
+
+    def test_no_compositions_is_valid(self) -> None:
+        ont = OntologyDefinition(name="t", concepts=[OntologyConcept(name="x")])
+        assert ont.compositions == []

--- a/packages/engine/tests/unit/storage/test_property_graph.py
+++ b/packages/engine/tests/unit/storage/test_property_graph.py
@@ -41,10 +41,9 @@ def test_graph_statement_binds_each_element_view_with_keys() -> None:
     # Views have no primary key, so vertex KEY + edge SOURCE/DESTINATION KEY are mandatory.
     assert "KEY (table_id) LABEL table_node" in graph_sql
     assert "KEY (column_id) LABEL column_node" in graph_sql
-    # Five edges: refs, has_dimension, derived_from (P1) + concept_edge +
-    # conformed_dimension (DAT-729).
-    assert graph_sql.count("SOURCE KEY") == 5
-    assert graph_sql.count("DESTINATION KEY") == 5
+    # Four edges: refs, has_dimension, derived_from (P1) + concept_edge (DAT-729).
+    assert graph_sql.count("SOURCE KEY") == 4
+    assert graph_sql.count("DESTINATION KEY") == 4
     # The measure→materialization MATCH (the P1 AC) reads these vertex properties.
     assert "semantic_role, materialization" in graph_sql
     # The concept_edge edge binds concept → concept, carrying the predicate property.
@@ -53,9 +52,6 @@ def test_graph_statement_binds_each_element_view_with_keys() -> None:
     assert "DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)" in graph_sql
     assert "LABEL concept_edge" in graph_sql
     assert "PROPERTIES (predicate, tolerance)" in graph_sql
-    # The conformed_dimension edge binds table → table, carrying the shared dimension.
-    assert "LABEL conformed_dimension" in graph_sql
-    assert "PROPERTIES (dimension)" in graph_sql
 
 
 def test_dump_drops_graph_before_its_element_views() -> None:

--- a/packages/engine/tests/unit/storage/test_property_graph.py
+++ b/packages/engine/tests/unit/storage/test_property_graph.py
@@ -41,10 +41,17 @@ def test_graph_statement_binds_each_element_view_with_keys() -> None:
     # Views have no primary key, so vertex KEY + edge SOURCE/DESTINATION KEY are mandatory.
     assert "KEY (table_id) LABEL table_node" in graph_sql
     assert "KEY (column_id) LABEL column_node" in graph_sql
-    assert graph_sql.count("SOURCE KEY") == 3
-    assert graph_sql.count("DESTINATION KEY") == 3
+    # Four edges: refs, has_dimension, derived_from (P1) + concept_edge (DAT-729).
+    assert graph_sql.count("SOURCE KEY") == 4
+    assert graph_sql.count("DESTINATION KEY") == 4
     # The measure→materialization MATCH (the P1 AC) reads these vertex properties.
     assert "semantic_role, materialization" in graph_sql
+    # The concept_edge edge binds concept → concept, carrying the predicate property.
+    assert "KEY (concept_id) LABEL concept_node" in graph_sql
+    assert "SOURCE KEY (from_concept_id) REFERENCES og_concepts (concept_id)" in graph_sql
+    assert "DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)" in graph_sql
+    assert "LABEL concept_edge" in graph_sql
+    assert "PROPERTIES (predicate, tolerance)" in graph_sql
 
 
 def test_dump_drops_graph_before_its_element_views() -> None:

--- a/packages/engine/tests/unit/storage/test_property_graph.py
+++ b/packages/engine/tests/unit/storage/test_property_graph.py
@@ -41,9 +41,10 @@ def test_graph_statement_binds_each_element_view_with_keys() -> None:
     # Views have no primary key, so vertex KEY + edge SOURCE/DESTINATION KEY are mandatory.
     assert "KEY (table_id) LABEL table_node" in graph_sql
     assert "KEY (column_id) LABEL column_node" in graph_sql
-    # Four edges: refs, has_dimension, derived_from (P1) + concept_edge (DAT-729).
-    assert graph_sql.count("SOURCE KEY") == 4
-    assert graph_sql.count("DESTINATION KEY") == 4
+    # Five edges: refs, has_dimension, derived_from (P1) + concept_edge +
+    # conformed_dimension (DAT-729).
+    assert graph_sql.count("SOURCE KEY") == 5
+    assert graph_sql.count("DESTINATION KEY") == 5
     # The measure→materialization MATCH (the P1 AC) reads these vertex properties.
     assert "semantic_role, materialization" in graph_sql
     # The concept_edge edge binds concept → concept, carrying the predicate property.
@@ -52,6 +53,9 @@ def test_graph_statement_binds_each_element_view_with_keys() -> None:
     assert "DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)" in graph_sql
     assert "LABEL concept_edge" in graph_sql
     assert "PROPERTIES (predicate, tolerance)" in graph_sql
+    # The conformed_dimension edge binds table → table, carrying the shared dimension.
+    assert "LABEL conformed_dimension" in graph_sql
+    assert "PROPERTIES (dimension)" in graph_sql
 
 
 def test_dump_drops_graph_before_its_element_views() -> None:


### PR DESCRIPTION
## DAT-729 P4 — Concept edges

Adds the operating-model graph's vocabulary-relation substrate ([DD/49152002](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/49152002)): a workspace-persistent `ConceptEdge` table, seeded from the vertical's own declarations, bound into the property graph as a `concept → concept` edge.

### What ships
- **`ConceptEdge` substrate** — workspace-persistent, supersede-on-edit, partial-unique active index; same identity contract as `Concept` (DAT-728). Endpoints keyed by stable `(vertical, name)`, never a per-run uuid. Carries `predicate` + `tolerance` (the latter for P2 to populate).
- **`disjoint_with` (seed)** — derived from convention `concept_groups`: concepts in different groups of one convention are disjoint. Finance's `sign_natural_balance` (4 credit-normal × 8 debit-normal) yields 32 unordered = **64 directed** edges, incl. the DD's named `accounts_payable ⊥ accounts_receivable` and `current_assets ⊥ current_liabilities`.
- **`part_of` (seed)** — new `compositions` ontology block (`whole ← parts`, lint-validated) → directed `part → whole` edges (4 on finance). Concept-grain only; the account-instance CoA tree stays the physical `references` topology. Transitive ancestry walked by the bounded recursive CTE (max-depth 4 + cycle guard), proven on PG19 in the integration suite.
- **Property-graph binding** — `og_concept_edges` element view resolves name endpoints → active concept ids; `concept_edge` edge table binds `concept → concept` with the `predicate` property. Schema artifacts (`schema.sql`/`schema_read.sql`/`schema_graph.sql`) + cockpit drizzle mirror re-dumped; schema-drift green.

### Descoped from this phase (see Jira)
- **`reconciles_with` → DAT-727 (P2).** Its producers are all Grounding-node-dependent (the aggregation-lineage witness = two groundings of one concept). The `ConceptEdge` model already carries the predicate + `tolerance`, so P2 only populates rows — no schema work.
- **conformed-dim → DAT-756.** Implemented here as name-equality matching (commits b8925288 + revert feb15013), reviewer-flagged Critical, reverted. Its real blocker is that the engine has no dimension identity — now designed ([DD/49938435](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/49938435)) and homed in the new DAT-756 foundation. **The feat+revert commit pair is intentional history; squash-merge is fine.**

### Verification
- 35 unit + 12 integration (real PG19 testcontainer) green; mypy clean.
- Both reviewers ran: spec-compliance ✅, senior ✅ (Critical only on the now-reverted conformed-dim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)