### PR TITLE
DAT-756: dimension identity — referenced-dim identity + shared_dims fix + conformed dimension

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -31,20 +31,24 @@ reverted for name-matching, rebuilt on the identity.
   now a `<dim table>.<attribute>` label, not a physical column name.
 - **`og_conformed_dimension` edge (NEW) + `og_has_dimension` identity props + a changed
   `og_references`.** `og_has_dimension` carries `dimension_table_id`/`dimension_attribute`/
-  `fk_role`. `og_conformed_dimension` (table→table, TABLE grain, carrying
-  `from_attribute`/`to_attribute`) types two facts sharing a dim table. `og_references`
+  `fk_role`. `og_conformed_dimension` (table→table, ATTRIBUTE grain — same
+  `(dimension_table_id, dimension_attribute)`) types two facts sharing a dimension
+  AXIS (the alignable drill-across GROUP BY the SQL agents author over). `og_references`
   now EXCLUDES the DAT-723 fan trap (a relationship whose both endpoints are slice
-  columns resolving one dim table) — the exact complement of the conformed edge.
+  columns resolving one dim TABLE) — TABLE grain, deliberately DECOUPLED from the
+  attribute-grain edge (a cross-level fan trap is excluded from refs yet correctly has
+  no conformed edge).
 
 ### For eval (oracle surfaces)
 
 - **`og_conformed_dimension` — new graph-edge truth section.** Assert the finance
-  conformed pairs (facts sharing a dim table — e.g. `trial_balance` ↔ `balance_sheet` on
-  the shared account dim) are typed via the shared `dimension_table_id`, both directions,
-  carrying each side's slice attribute. Graded absolutely (generator-known pairs). Note a
-  single fact-table PAIR can emit MULTIPLE edges — one per matching slice-row pair (a fact
-  with several role-playing FKs to one dim) — so assert on the table pair + dim, not a
-  single-edge count.
+  conformed pairs (facts sharing a dimension AXIS — e.g. `trial_balance` ↔ `balance_sheet`
+  both sliced on the accounts dim at the SAME attribute) are typed via the shared
+  `(dimension_table_id, dimension_attribute)`, both directions. Graded absolutely
+  (generator-known pairs). Two caveats: (a) it is ATTRIBUTE grain — two facts sharing the
+  dim TABLE but sliced at DIFFERENT attributes do NOT conform (no alignable axis); (b) a
+  single fact-table PAIR can emit MULTIPLE edges (role-playing FKs at one axis) — assert
+  on the table pair + `(dim, attribute)`, not a single-edge count.
 - **`og_references` — CHANGED surface.** Fan-trap fact↔fact edges between shared-dimension
   slice columns no longer appear as `refs`. Any truth assertion enumerating references
   must expect these excluded (a genuine fact→dim FK still appears — a dim key is never a

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -41,7 +41,10 @@ reverted for name-matching, rebuilt on the identity.
 - **`og_conformed_dimension` — new graph-edge truth section.** Assert the finance
   conformed pairs (facts sharing a dim table — e.g. `trial_balance` ↔ `balance_sheet` on
   the shared account dim) are typed via the shared `dimension_table_id`, both directions,
-  carrying each side's slice attribute. Graded absolutely (generator-known pairs).
+  carrying each side's slice attribute. Graded absolutely (generator-known pairs). Note a
+  single fact-table PAIR can emit MULTIPLE edges — one per matching slice-row pair (a fact
+  with several role-playing FKs to one dim) — so assert on the table pair + dim, not a
+  single-edge count.
 - **`og_references` — CHANGED surface.** Fan-trap fact↔fact edges between shared-dimension
   slice columns no longer appear as `refs`. Any truth assertion enumerating references
   must expect these excluded (a genuine fact→dim FK still appears — a dim key is never a

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,62 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-756 — referenced-dimension identity + `shared_dims` fix + conformed-dimension
+
+**Branch:** `feat/dat-756-dimension-identity`. **A detector-grouping-key fix (closes a
+live stock/flow false-negative AND false-positive) + a new graph-edge oracle surface +
+one changed graph surface.** Foundation tier of the operating-model graph (DAT-725): a
+dimension now has an IDENTITY (the FK-target dim table), so every consumer keys off it
+instead of the column name. Restores the DAT-729 conformed-dimension capability that was
+reverted for name-matching, rebuilt on the identity.
+
+### What changed
+
+- **Referenced-dimension identity persisted on `slice_definitions` (`slicing` phase).**
+  Three new columns — `dimension_table_id` (FK-target dim table, NULL for a folded
+  slice), `dimension_attribute` (the enriched `fk__attr` level), `fk_role` (the FK
+  column) — resolved at slice-write from the enriched view's grain-safe relationship
+  provenance, never from the column name.
+- **`shared_dims` / stock-flow witness (`aggregation_lineage` phase) regrouped by
+  identity.** `analysis/lineage/processor.py` now pairs two facts iff they reference the
+  SAME dim table at the SAME attribute (was: same `column_name`). **Closes a live bug in
+  both directions:** the same dimension reached via differently-named FK columns was
+  never paired (the witness silently never ran); two unrelated same-named FOLDED columns
+  were paired. Role-playing FKs to one dim on a single fact are all kept (list per
+  fact), not collapsed. The persisted `measure_aggregation_lineage.slice_dimension` is
+  now a `<dim table>.<attribute>` label, not a physical column name.
+- **`og_conformed_dimension` edge (NEW) + `og_has_dimension` identity props + a changed
+  `og_references`.** `og_has_dimension` carries `dimension_table_id`/`dimension_attribute`/
+  `fk_role`. `og_conformed_dimension` (table→table, TABLE grain, carrying
+  `from_attribute`/`to_attribute`) types two facts sharing a dim table. `og_references`
+  now EXCLUDES the DAT-723 fan trap (a relationship whose both endpoints are slice
+  columns resolving one dim table) — the exact complement of the conformed edge.
+
+### For eval (oracle surfaces)
+
+- **`og_conformed_dimension` — new graph-edge truth section.** Assert the finance
+  conformed pairs (facts sharing a dim table — e.g. `trial_balance` ↔ `balance_sheet` on
+  the shared account dim) are typed via the shared `dimension_table_id`, both directions,
+  carrying each side's slice attribute. Graded absolutely (generator-known pairs).
+- **`og_references` — CHANGED surface.** Fan-trap fact↔fact edges between shared-dimension
+  slice columns no longer appear as `refs`. Any truth assertion enumerating references
+  must expect these excluded (a genuine fact→dim FK still appears — a dim key is never a
+  slice column, so the exclusion cannot fire on it).
+- **Stock/flow witness may FLIP on existing fixtures.** The `shared_dims` fix can now
+  fire the witness on previously-silent differently-named-FK pairs, and now correctly
+  abstains on previously-firing same-named-folded pairs. Re-run the stock/flow oracle on
+  the finance corpus and check whether any currently passing/failing case flips.
+
+### testdata hints
+
+- A fixture with **two facts joining ONE dim table via differently-named FK columns**
+  (e.g. `gl_account` in one, `account_no` in another, both → `chart_of_accounts`)
+  exercises the false-negative that finance's consistent naming currently hides.
+- A **role-playing** fact (two FKs to one dim — `kontonummer` + `kontonummer_des_gegenkontos`
+  → accounts) exercises the multi-slice-per-identity path.
+
+---
+
 ## DAT-729 — concept edges (`disjoint_with` / `part_of`)
 
 **Branch:** `feat/dat-729-concept-edges`. **New graph-edge oracle surfaces — no

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -427,6 +427,9 @@ export const currentSliceDefinitions = metadataSchema
 		tableId: varchar("table_id"),
 		columnId: varchar("column_id"),
 		columnName: varchar("column_name"),
+		dimensionTableId: varchar("dimension_table_id"),
+		dimensionAttribute: varchar("dimension_attribute"),
+		fkRole: varchar("fk_role"),
 		slicePriority: integer("slice_priority"),
 		sliceType: varchar("slice_type"),
 		distinctValues: json("distinct_values"),
@@ -438,7 +441,7 @@ export const currentSliceDefinitions = metadataSchema
 		createdAt: timestamp("created_at"),
 	})
 	.as(
-		sql`SELECT slice_id, run_id, table_id, column_id, column_name, slice_priority, slice_type, distinct_values, value_count, reasoning, business_context, confidence, detection_source, created_at FROM ws_00000000_0000_0000_0000_000000000001.slice_definitions r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
+		sql`SELECT slice_id, run_id, table_id, column_id, column_name, dimension_table_id, dimension_attribute, fk_role, slice_priority, slice_type, distinct_values, value_count, reasoning, business_context, confidence, detection_source, created_at FROM ws_00000000_0000_0000_0000_000000000001.slice_definitions r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
 	);
 
 export const currentStatisticalProfiles = metadataSchema

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -608,6 +608,9 @@ CREATE TABLE slice_definitions (
 	table_id VARCHAR NOT NULL, 
 	column_id VARCHAR NOT NULL, 
 	column_name VARCHAR, 
+	dimension_table_id VARCHAR, 
+	dimension_attribute VARCHAR, 
+	fk_role VARCHAR, 
 	slice_priority INTEGER NOT NULL, 
 	slice_type VARCHAR NOT NULL, 
 	distinct_values JSON, 
@@ -620,10 +623,13 @@ CREATE TABLE slice_definitions (
 	CONSTRAINT pk_slice_definitions PRIMARY KEY (slice_id), 
 	CONSTRAINT uq_slice_def_table_column_run UNIQUE (table_id, column_name, run_id), 
 	CONSTRAINT fk_slice_definitions_table_id_tables FOREIGN KEY(table_id) REFERENCES tables (table_id), 
-	CONSTRAINT fk_slice_definitions_column_id_columns FOREIGN KEY(column_id) REFERENCES columns (column_id)
+	CONSTRAINT fk_slice_definitions_column_id_columns FOREIGN KEY(column_id) REFERENCES columns (column_id), 
+	CONSTRAINT fk_slice_definitions_dimension_table_id_tables FOREIGN KEY(dimension_table_id) REFERENCES tables (table_id)
 );
 
 CREATE INDEX idx_slice_definitions_column ON slice_definitions (column_id);
+
+CREATE INDEX idx_slice_definitions_dim_table ON slice_definitions (dimension_table_id);
 
 CREATE INDEX idx_slice_definitions_table ON slice_definitions (table_id);
 

--- a/packages/engine/schema_graph.sql
+++ b/packages/engine/schema_graph.sql
@@ -94,11 +94,11 @@ CREATE VIEW __READ__.og_conformed_dimension AS
 SELECT (s1.slice_id || '_' || s2.slice_id)::text AS edge_key,
        s1.table_id::text AS from_table_id, s2.table_id::text AS to_table_id,
        s1.dimension_table_id::text AS dimension_table_id,
-       s1.dimension_attribute AS dimension_attribute
+       s1.dimension_attribute AS from_attribute,
+       s2.dimension_attribute AS to_attribute
 FROM __READ__.current_slice_definitions s1
 JOIN __READ__.current_slice_definitions s2
   ON s1.dimension_table_id = s2.dimension_table_id
- AND COALESCE(s1.dimension_attribute, '') = COALESCE(s2.dimension_attribute, '')
  AND s1.table_id <> s2.table_id
 WHERE s1.dimension_table_id IS NOT NULL;
 
@@ -138,5 +138,5 @@ CREATE PROPERTY GRAPH __READ__.operating_model
       SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)
       DESTINATION KEY (to_table_id) REFERENCES og_tables (table_id)
       LABEL conformed_dimension
-      PROPERTIES (dimension_table_id, dimension_attribute)
+      PROPERTIES (dimension_table_id, from_attribute, to_attribute)
   );

--- a/packages/engine/schema_graph.sql
+++ b/packages/engine/schema_graph.sql
@@ -13,6 +13,7 @@ DROP VIEW IF EXISTS __READ__.og_references;
 DROP VIEW IF EXISTS __READ__.og_has_dimension;
 DROP VIEW IF EXISTS __READ__.og_derived_from;
 DROP VIEW IF EXISTS __READ__.og_concept_edges;
+DROP VIEW IF EXISTS __READ__.og_conformed_dimension;
 
 CREATE VIEW __READ__.og_tables AS
 SELECT t.table_id::text AS table_id, t.table_name, t.layer,
@@ -44,11 +45,20 @@ SELECT relationship_id::text AS relationship_id,
        from_table_id::text AS from_table_id, to_table_id::text AS to_table_id,
        from_column_id, to_column_id, cardinality, relationship_type,
        confidence, is_confirmed
-FROM __READ__.current_relationships;
+FROM __READ__.current_relationships r
+WHERE NOT EXISTS (
+  SELECT 1 FROM __READ__.current_slice_definitions s1
+  JOIN __READ__.current_slice_definitions s2
+    ON s1.dimension_table_id = s2.dimension_table_id
+  WHERE s1.column_id = r.from_column_id AND s2.column_id = r.to_column_id
+    AND s1.table_id <> s2.table_id AND s1.dimension_table_id IS NOT NULL
+);
 
 CREATE VIEW __READ__.og_has_dimension AS
 SELECT slice_id::text AS slice_id, table_id::text AS table_id,
-       column_id::text AS column_id, column_name, slice_type, slice_priority
+       column_id::text AS column_id, column_name, slice_type, slice_priority,
+       dimension_table_id::text AS dimension_table_id,
+       dimension_attribute, fk_role
 FROM __READ__.current_slice_definitions;
 
 CREATE VIEW __READ__.og_derived_from AS
@@ -80,6 +90,18 @@ JOIN __READ__.concepts ct
  AND ct.superseded_at IS NULL
 WHERE e.superseded_at IS NULL;
 
+CREATE VIEW __READ__.og_conformed_dimension AS
+SELECT (s1.slice_id || '_' || s2.slice_id)::text AS edge_key,
+       s1.table_id::text AS from_table_id, s2.table_id::text AS to_table_id,
+       s1.dimension_table_id::text AS dimension_table_id,
+       s1.dimension_attribute AS dimension_attribute
+FROM __READ__.current_slice_definitions s1
+JOIN __READ__.current_slice_definitions s2
+  ON s1.dimension_table_id = s2.dimension_table_id
+ AND COALESCE(s1.dimension_attribute, '') = COALESCE(s2.dimension_attribute, '')
+ AND s1.table_id <> s2.table_id
+WHERE s1.dimension_table_id IS NOT NULL;
+
 CREATE PROPERTY GRAPH __READ__.operating_model
   VERTEX TABLES (
     __READ__.og_tables KEY (table_id) LABEL table_node
@@ -100,7 +122,8 @@ CREATE PROPERTY GRAPH __READ__.operating_model
       SOURCE KEY (table_id) REFERENCES og_tables (table_id)
       DESTINATION KEY (column_id) REFERENCES og_columns (column_id)
       LABEL has_dimension
-      PROPERTIES (column_name, slice_type, slice_priority),
+      PROPERTIES (column_name, slice_type, slice_priority,
+                  dimension_table_id, dimension_attribute, fk_role),
     __READ__.og_derived_from KEY (edge_key)
       SOURCE KEY (view_table_id) REFERENCES og_tables (table_id)
       DESTINATION KEY (base_table_id) REFERENCES og_tables (table_id)
@@ -110,5 +133,10 @@ CREATE PROPERTY GRAPH __READ__.operating_model
       SOURCE KEY (from_concept_id) REFERENCES og_concepts (concept_id)
       DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)
       LABEL concept_edge
-      PROPERTIES (predicate, tolerance)
+      PROPERTIES (predicate, tolerance),
+    __READ__.og_conformed_dimension KEY (edge_key)
+      SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)
+      DESTINATION KEY (to_table_id) REFERENCES og_tables (table_id)
+      LABEL conformed_dimension
+      PROPERTIES (dimension_table_id, dimension_attribute)
   );

--- a/packages/engine/schema_graph.sql
+++ b/packages/engine/schema_graph.sql
@@ -94,11 +94,11 @@ CREATE VIEW __READ__.og_conformed_dimension AS
 SELECT (s1.slice_id || '_' || s2.slice_id)::text AS edge_key,
        s1.table_id::text AS from_table_id, s2.table_id::text AS to_table_id,
        s1.dimension_table_id::text AS dimension_table_id,
-       s1.dimension_attribute AS from_attribute,
-       s2.dimension_attribute AS to_attribute
+       s1.dimension_attribute AS dimension_attribute
 FROM __READ__.current_slice_definitions s1
 JOIN __READ__.current_slice_definitions s2
   ON s1.dimension_table_id = s2.dimension_table_id
+ AND COALESCE(s1.dimension_attribute, '') = COALESCE(s2.dimension_attribute, '')
  AND s1.table_id <> s2.table_id
 WHERE s1.dimension_table_id IS NOT NULL;
 
@@ -138,5 +138,5 @@ CREATE PROPERTY GRAPH __READ__.operating_model
       SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)
       DESTINATION KEY (to_table_id) REFERENCES og_tables (table_id)
       LABEL conformed_dimension
-      PROPERTIES (dimension_table_id, from_attribute, to_attribute)
+      PROPERTIES (dimension_table_id, dimension_attribute)
   );

--- a/packages/engine/src/dataraum/analysis/lineage/processor.py
+++ b/packages/engine/src/dataraum/analysis/lineage/processor.py
@@ -269,12 +269,19 @@ def discover_aggregation_lineage(
     # silently disabled this witness), and two unrelated same-named FOLDED columns
     # are not (the false-positive). A folded slice (null ``dimension_table_id``)
     # has no cross-table identity in Phase A and abstains (DAT-757).
-    defs_by_dim: dict[tuple[str, str], dict[str, SliceDefinition]] = {}
+    # ``{table -> [slices]}`` per identity: one fact can carry MULTIPLE slices at the
+    # same identity — role-playing FKs to one dim (``kontonummer`` vs
+    # ``kontonummer_des_gegenkontos``, both -> accounts at ``land``). Keep them all
+    # (a list, not last-write-wins): each is a distinct bucketing lens the search
+    # competes; dropping one would silently lose a reconciliation candidate. Role
+    # disambiguation itself (bill-to vs ship-to as SEPARATE dimensions) is DAT-757 —
+    # here they share the Phase-A identity and are simply both tried.
+    defs_by_dim: dict[tuple[str, str], dict[str, list[SliceDefinition]]] = {}
     for sd in defs:
         if not sd.dimension_table_id:
             continue
         identity = (sd.dimension_table_id, sd.dimension_attribute or "")
-        defs_by_dim.setdefault(identity, {})[sd.table_id] = sd
+        defs_by_dim.setdefault(identity, {}).setdefault(sd.table_id, []).append(sd)
     shared_dims = {ident: by_table for ident, by_table in defs_by_dim.items() if len(by_table) >= 2}
     if not shared_dims:
         logger.info("lineage_no_shared_dimension", identities=sorted(defs_by_dim))
@@ -363,24 +370,26 @@ def discover_aggregation_lineage(
         # the shared identity may be reached via differently-named columns (DAT-756),
         # while the VALUE domain is common, so ``_aligned_series`` still pairs them.
         series_by_table: dict[str, list[tuple[str, _SliceSeries]]] = {}
-        for tid, sd in shared_dims[identity].items():
+        for tid, sds in shared_dims[identity].items():
             t = tables.get(tid)
             if t is None:
                 continue
+            # Every (role-playing slice × time axis) is a distinct lens to bucket by.
             axis_series: list[tuple[str, _SliceSeries]] = []
-            for axis in time_cols_by_table.get(tid, []):
-                s = _slice_series(
-                    duckdb_conn,
-                    t,
-                    sd,
-                    sd.column_name or "",
-                    source_name=source_by_table.get(tid),
-                    time_col=axis,
-                    numeric_cols=numeric_cols_by_table.get(tid, []),
-                    grain=period_grain,
-                )
-                if s is not None:
-                    axis_series.append((axis, s))
+            for sd in sds:
+                for axis in time_cols_by_table.get(tid, []):
+                    s = _slice_series(
+                        duckdb_conn,
+                        t,
+                        sd,
+                        sd.column_name or "",
+                        source_name=source_by_table.get(tid),
+                        time_col=axis,
+                        numeric_cols=numeric_cols_by_table.get(tid, []),
+                        grain=period_grain,
+                    )
+                    if s is not None:
+                        axis_series.append((axis, s))
             if axis_series:
                 series_by_table[tid] = axis_series
         if len(series_by_table) < 2:

--- a/packages/engine/src/dataraum/analysis/lineage/processor.py
+++ b/packages/engine/src/dataraum/analysis/lineage/processor.py
@@ -251,7 +251,7 @@ def discover_aggregation_lineage(
         t.table_id: t
         for t in session.execute(select(Table).where(Table.table_id.in_(table_ids))).scalars()
     }
-    # This run's slice dimensions, grouped by dimension column name.
+    # This run's slice dimensions (grouped by referenced identity below).
     defs = (
         session.execute(
             select(SliceDefinition).where(
@@ -262,15 +262,41 @@ def discover_aggregation_lineage(
         .scalars()
         .all()
     )
-    defs_by_dim: dict[str, dict[str, SliceDefinition]] = {}
+    # Group by the slice's REFERENCED-dimension identity (DAT-756), not its
+    # ``column_name``. Two facts share a dimension iff they reference the SAME
+    # dim table at the SAME attribute — so the same conformed dimension reached
+    # via differently-named FK columns is paired (the false-negative that
+    # silently disabled this witness), and two unrelated same-named FOLDED columns
+    # are not (the false-positive). A folded slice (null ``dimension_table_id``)
+    # has no cross-table identity in Phase A and abstains (DAT-757).
+    defs_by_dim: dict[tuple[str, str], dict[str, SliceDefinition]] = {}
     for sd in defs:
-        name = sd.column_name or ""
-        if name:
-            defs_by_dim.setdefault(name, {})[sd.table_id] = sd
-    shared_dims = {d: by_table for d, by_table in defs_by_dim.items() if len(by_table) >= 2}
+        if not sd.dimension_table_id:
+            continue
+        identity = (sd.dimension_table_id, sd.dimension_attribute or "")
+        defs_by_dim.setdefault(identity, {})[sd.table_id] = sd
+    shared_dims = {ident: by_table for ident, by_table in defs_by_dim.items() if len(by_table) >= 2}
     if not shared_dims:
-        logger.info("lineage_no_shared_dimension", dimensions=sorted(defs_by_dim))
+        logger.info("lineage_no_shared_dimension", identities=sorted(defs_by_dim))
         return 0
+
+    # Readable label per identity for the persisted ``slice_dimension`` + logs:
+    # ``<dim table>.<attribute>`` (the conformed axis), not a per-fact column name
+    # (which now differs across the paired facts).
+    dim_names = {
+        t.table_id: t.table_name
+        for t in session.execute(
+            select(Table).where(Table.table_id.in_({ident[0] for ident in shared_dims}))
+        ).scalars()
+    }
+    labels = {
+        ident: (
+            f"{dim_names.get(ident[0], ident[0])}.{ident[1]}"
+            if ident[1]
+            else dim_names.get(ident[0], ident[0])
+        )
+        for ident in shared_dims
+    }
 
     # Key/identifier columns are not quantities: a SUM over a key has no
     # meaning, and identical key sets reconcile trivially (identity noise).
@@ -328,12 +354,16 @@ def discover_aggregation_lineage(
     # Best verdict per measure column across dimensions, event tables, conventions.
     best_by_measure: dict[str, tuple[_Best, Table, str, str]] = {}
 
-    for dim_col in sorted(shared_dims):
+    for identity in sorted(shared_dims):
+        slice_label = labels[identity]
         # One series per (table, time-axis): each event-time column the catalog
         # named for the table is a distinct lens to bucket by (DAT-565). A table
         # contributes a series for every axis; the search below competes them.
+        # Each fact groups by its OWN physical slice column (``sd.column_name``) —
+        # the shared identity may be reached via differently-named columns (DAT-756),
+        # while the VALUE domain is common, so ``_aligned_series`` still pairs them.
         series_by_table: dict[str, list[tuple[str, _SliceSeries]]] = {}
-        for tid, sd in shared_dims[dim_col].items():
+        for tid, sd in shared_dims[identity].items():
             t = tables.get(tid)
             if t is None:
                 continue
@@ -343,7 +373,7 @@ def discover_aggregation_lineage(
                     duckdb_conn,
                     t,
                     sd,
-                    dim_col,
+                    sd.column_name or "",
                     source_name=source_by_table.get(tid),
                     time_col=axis,
                     numeric_cols=numeric_cols_by_table.get(tid, []),
@@ -354,7 +384,7 @@ def discover_aggregation_lineage(
             if axis_series:
                 series_by_table[tid] = axis_series
         if len(series_by_table) < 2:
-            logger.info("lineage_no_slice_series", dimension=dim_col)
+            logger.info("lineage_no_slice_series", dimension=slice_label)
             continue
 
         for m_tid, m_axis_series in sorted(series_by_table.items()):
@@ -383,7 +413,7 @@ def discover_aggregation_lineage(
                         if e_rows <= m_rows:
                             logger.info(
                                 "lineage_direction_gate",
-                                dimension=dim_col,
+                                dimension=slice_label,
                                 measure_table=measure.table.table_name,
                                 event_table=event.table.table_name,
                                 measure_rows=m_rows,
@@ -418,20 +448,20 @@ def discover_aggregation_lineage(
                                         ),
                                         measure.table,
                                         measure_col,
-                                        dim_col,
+                                        slice_label,
                                     )
 
     # ``best_by_measure`` is keyed by measure_column_id, so the batch is
     # dedup'd by construction; PK omitted so the model's default applies.
     rows: list[dict[str, object]] = []
-    for measure_column_id, (best, m_table, m_col, dim_col) in best_by_measure.items():
+    for measure_column_id, (best, m_table, m_col, slice_label) in best_by_measure.items():
         rows.append(
             {
                 "run_id": run_id,
                 "measure_table_id": m_table.table_id,
                 "measure_column_id": measure_column_id,
                 "event_table_id": best.event_table.table_id,
-                "slice_dimension": dim_col,
+                "slice_dimension": slice_label,
                 "convention_sql": best.convention_sql,
                 "period_grain": period_grain,
                 "pattern": best.verdict.pattern,
@@ -446,7 +476,7 @@ def discover_aggregation_lineage(
             "lineage_reconciled",
             measure=f"{m_table.table_name}.{m_col}",
             event_table=best.event_table.table_name,
-            dimension=dim_col,
+            dimension=slice_label,
             convention=best.convention_sql,
             pattern=best.verdict.pattern,
             match_rate=round(best.verdict.match_rate, 3),

--- a/packages/engine/src/dataraum/analysis/slicing/db_models.py
+++ b/packages/engine/src/dataraum/analysis/slicing/db_models.py
@@ -52,6 +52,7 @@ class SliceDefinition(Base):
         UniqueConstraint("table_id", "column_name", "run_id", name="uq_slice_def_table_column_run"),
         Index("idx_slice_definitions_table", "table_id"),
         Index("idx_slice_definitions_column", "column_id"),
+        Index("idx_slice_definitions_dim_table", "dimension_table_id"),
     )
 
     slice_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
@@ -65,6 +66,24 @@ class SliceDefinition(Base):
     # slice dimension is an enriched FK-prefixed dim col (e.g. "kontonummer_des_gegenkontos__land")
     # while column_id points to the underlying FK column record.
     column_name: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    # Referenced-dimension identity (DAT-756): what makes two slices "the same
+    # dimension" — resolved structurally from the confirmed relationship catalog,
+    # never from ``column_name``. For an enriched slice (``column_id`` is the fact's
+    # FK column), ``dimension_table_id`` is the FK-target dim table, ``fk_role`` is
+    # the FK column name (carried for role-playing dims — NOT yet a Phase-A identity
+    # key), and ``dimension_attribute`` is the enriched suffix (the level, e.g.
+    # ``account_type``; NULL when grouping by the FK key itself). All three are NULL
+    # for a folded slice (an own categorical column with no grain-safe FK): a folded
+    # dimension has no cross-table identity in Phase A and abstains from conformed
+    # pairing (that residual is DAT-757). The identity ``(dimension_table_id,
+    # dimension_attribute)`` is the single key both the lineage stock/flow witness
+    # (``shared_dims``) and the operating-model ``conformed_dimension`` edge group on.
+    dimension_table_id: Mapped[str | None] = mapped_column(
+        ForeignKey("tables.table_id"), nullable=True
+    )
+    dimension_attribute: Mapped[str | None] = mapped_column(String, nullable=True)
+    fk_role: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # Slice configuration
     slice_priority: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -83,8 +102,10 @@ class SliceDefinition(Base):
         DateTime, nullable=False, default=lambda: datetime.now(UTC)
     )
 
-    # Relationships
-    table: Mapped[Table] = relationship()
+    # Relationships. ``table_id`` and ``dimension_table_id`` both FK to
+    # ``tables.table_id`` (DAT-756), so the fact-table relationship must name its
+    # column explicitly; the dimension table is read as a plain id, no ORM edge.
+    table: Mapped[Table] = relationship(foreign_keys=[table_id])
     column: Mapped[Column] = relationship()
 
 

--- a/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
@@ -317,13 +317,32 @@ class SlicingPhase(BasePhase):
         # Temporal success-redelivery (same run_id) converges. PK omitted so
         # the model's Python-side default applies.
         run_id = ctx.require_run_id()
+        # Referenced-dimension identity (DAT-756): the slice's ``column_id`` is the
+        # fact's FK column; resolve its FK-target dim table from the enriched view's
+        # relationship provenance. An enriched slice name is ``fk__attr`` — the prefix
+        # is the FK column (``fk_role``), the suffix is the dim attribute/level. A
+        # slice with no grain-safe FK resolves a null identity (folded — DAT-757).
+        dim_table_by_fk_col: dict[str, str] = context_data.get("dim_table_by_fk_col", {})
         rows: dict[tuple[str, str | None, str], dict[str, Any]] = {}
         for rec in slicing.recommendations:
+            dimension_table_id = dim_table_by_fk_col.get(rec.column_id)
+            dimension_attribute: str | None = None
+            fk_role: str | None = None
+            if dimension_table_id:
+                name = rec.column_name or ""
+                if "__" in name:
+                    fk_role, dimension_attribute = name.split("__", 1)
+                else:
+                    # Slicing directly by the FK key itself — no enriched attribute.
+                    fk_role = name or None
             rows[(rec.table_id, rec.column_name, run_id)] = {
                 "run_id": run_id,
                 "table_id": rec.table_id,
                 "column_id": rec.column_id,
                 "column_name": rec.column_name,
+                "dimension_table_id": dimension_table_id,
+                "dimension_attribute": dimension_attribute,
+                "fk_role": fk_role,
                 "slice_priority": rec.slice_priority,
                 "slice_type": "categorical",
                 "distinct_values": rec.distinct_values,
@@ -531,7 +550,12 @@ class SlicingPhase(BasePhase):
             e.table_id: (e.time_columns or []) for e in ctx.session.execute(entity_stmt).scalars()
         }
         # FK column -> joined dimension table, from the enriched views' own
-        # relationship provenance (never name-inferred).
+        # relationship provenance (never name-inferred). This is also the referenced-
+        # dimension identity source (DAT-756): the slice's ``column_id`` is the fact's
+        # FK column, so this map resolves ``FK column -> dim table``. The relationships
+        # an enriched view references are grain-safe BY CONSTRUCTION — a view is only
+        # built from grain-verified many-to-one joins — so a fan-out join can never
+        # mint a dimension identity here; no extra cardinality filter is needed.
         rel_ids = [rid for ev in ev_by_fact.values() if ev for rid in (ev.relationship_ids or [])]
         dim_table_by_fk_col: dict[str, str] = {}
         if rel_ids:
@@ -692,4 +716,7 @@ class SlicingPhase(BasePhase):
             "tables": tables_data,
             "column_count": column_count,
             "dimension_time_axes": dimension_time_axes,
+            # FK column_id -> dim table_id (DAT-756): the referenced-dimension
+            # identity source, consumed at slice-write time in ``_run``.
+            "dim_table_by_fk_col": dim_table_by_fk_col,
         }

--- a/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
@@ -331,6 +331,11 @@ class SlicingPhase(BasePhase):
             if dimension_table_id:
                 name = rec.column_name or ""
                 if "__" in name:
+                    # The enriched dim column is ``{fk_column}__{attr}`` (builder.py):
+                    # the FK column is the segment before the FIRST ``__``, matching
+                    # the codebase convention (``_propagate_enriched_dimensions``,
+                    # ``_build_context_data``). Assumes the FK column name itself has
+                    # no ``__`` — the same assumption every other split site makes.
                     fk_role, dimension_attribute = name.split("__", 1)
                 else:
                     # Slicing directly by the FK key itself — no enriched attribute.

--- a/packages/engine/src/dataraum/storage/property_graph.py
+++ b/packages/engine/src/dataraum/storage/property_graph.py
@@ -33,9 +33,11 @@ consumer does. The ``concept_edge`` edge (DAT-729) carries the vocabulary relati
 ``part_of`` / ``disjoint_with`` / ``reconciles_with`` as a ``predicate`` property;
 its transitive closure (``part_of`` ancestry) is walked by the bounded recursive CTE.
 ``conformed_dimension`` (DAT-756) types two facts sharing a dimension (the same
-resolved ``(dimension_table_id, attribute)`` identity — NOT a column name) as a
-drill-across path, explicitly NOT a fact-to-fact FK (the DAT-723 fan trap), which is
-why those pairs are excluded from ``refs``.
+resolved ``dimension_table_id`` — NOT a column name) as a drill-across path,
+explicitly NOT a fact-to-fact FK (the DAT-723 fan trap), which is why those pairs are
+excluded from ``refs`` — the edge is the exact table-grain complement of that
+exclusion (every excluded pair is explained here), with each side's slice level
+carried as ``from_attribute`` / ``to_attribute``.
 
 **Bootstrap ordering is load-bearing.** A property graph *depends on* its element
 views, and an element view depends on the ``current_*`` views. Postgres refuses to
@@ -238,28 +240,31 @@ def _element_view_sql(name: str) -> str:
     if name == "og_conformed_dimension":
         # conformed_dimension edge (table → table): two facts sharing a dimension
         # (DAT-756, rebuilding the reverted DAT-729 edge on referenced identity).
-        # Derived by self-joining slice (has_dimension) rows on the SAME resolved
-        # identity — (dimension_table_id, dimension_attribute), NEVER column names —
-        # of DIFFERENT tables. Attribute grain: the same dim table AT the same level,
-        # so it is the EXACT identity the lineage stock/flow witness groups on (one
-        # identity, two consumers). This is the drill-across path (compare over the
-        # shared conformed axis), explicitly NOT a fact-to-fact FK (the DAT-723 fan
-        # trap, excluded from og_references above). Folded slices (NULL
-        # dimension_table_id) have no dim table to conform over and are excluded.
-        # COALESCE pairs the slice-by-FK-key case (NULL attribute) with itself.
-        # Symmetric, so both directions are emitted (edge_key = the ordered slice-id
-        # pair, '_'-joined — NOT ':', a bind-param sigil to text()). A fact partitioned
-        # by N shared dimensions yields one edge per shared dimension.
+        # Derived by self-joining slice (has_dimension) rows on the SAME
+        # dimension_table_id — the resolved identity, NEVER column names — of
+        # DIFFERENT tables. TABLE grain deliberately: a conformed dimension is the
+        # shared dim TABLE (Kimball), and this must be the EXACT complement of the
+        # og_references fan-trap exclusion (also table grain) — every pair excluded
+        # there is explained by an edge here, none vanish from the graph. Each side's
+        # slice attribute (the level it is sliced at) rides along as from_/to_attribute
+        # so a consumer can tell a same-axis pair (from_attribute = to_attribute) from
+        # a cross-level one; the lineage stock/flow witness does its OWN finer
+        # attribute-grain grouping (value-domain reconciliation needs it). Folded
+        # slices (NULL dimension_table_id) have no dim table to conform over and are
+        # excluded. Symmetric — both directions emitted (edge_key = the ordered
+        # slice-id pair, '_'-joined, NOT ':' a bind-param sigil to text()). A fact with
+        # multiple role-playing FKs to one dim yields one edge PER slice-row pair, so a
+        # table pair can carry several conformed edges (one per shared axis/role).
         return (
             f"CREATE VIEW {READ_TOKEN}.og_conformed_dimension AS\n"
             f"SELECT (s1.slice_id || '_' || s2.slice_id)::text AS edge_key,\n"
             f"       s1.table_id::text AS from_table_id, s2.table_id::text AS to_table_id,\n"
             f"       s1.dimension_table_id::text AS dimension_table_id,\n"
-            f"       s1.dimension_attribute AS dimension_attribute\n"
+            f"       s1.dimension_attribute AS from_attribute,\n"
+            f"       s2.dimension_attribute AS to_attribute\n"
             f"FROM {READ_TOKEN}.current_slice_definitions s1\n"
             f"JOIN {READ_TOKEN}.current_slice_definitions s2\n"
             f"  ON s1.dimension_table_id = s2.dimension_table_id\n"
-            f" AND COALESCE(s1.dimension_attribute, '') = COALESCE(s2.dimension_attribute, '')\n"
             f" AND s1.table_id <> s2.table_id\n"
             f"WHERE s1.dimension_table_id IS NOT NULL;"
         )
@@ -313,7 +318,7 @@ def _property_graph_sql() -> str:
         f"      SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)\n"
         f"      DESTINATION KEY (to_table_id) REFERENCES og_tables (table_id)\n"
         f"      LABEL conformed_dimension\n"
-        f"      PROPERTIES (dimension_table_id, dimension_attribute)\n"
+        f"      PROPERTIES (dimension_table_id, from_attribute, to_attribute)\n"
         f"  );"
     )
 

--- a/packages/engine/src/dataraum/storage/property_graph.py
+++ b/packages/engine/src/dataraum/storage/property_graph.py
@@ -22,15 +22,20 @@ and ``Table``; the vocabulary ``Concept`` vertices are P3. Edges/props carried:
     column_node  (KEY column_id)  props: semantic_role (has_role),
                                           materialization (materializes_as)
     table_node   (KEY table_id)   props: table_role (fact/periodic_snapshot/dimension)
-    refs          table → table     [relationships]      FK topology + cardinality
-    has_dimension table → column    [slice_definitions]  a fact's slice columns
-    derived_from  table → table     [enriched_views]     view → fact + dim bases
-    concept_edge  concept → concept [concept_edges]      part_of/disjoint/reconciles (P4)
+    refs               table → table     [relationships]      FK topology (conformed dims excluded)
+    has_dimension      table → column    [slice_definitions]  a fact's slice cols + dim identity
+    derived_from       table → table     [enriched_views]     view → fact + dim bases
+    concept_edge       concept → concept [concept_edges]      part_of/disjoint/reconciles (P4)
+    conformed_dimension table → table    [slice_definitions]  two facts sharing a dimension (DAT-756)
 
 ``rolls_up_to`` (dimension_hierarchies' JSON members) lands in P5 where its
 consumer does. The ``concept_edge`` edge (DAT-729) carries the vocabulary relations
 ``part_of`` / ``disjoint_with`` / ``reconciles_with`` as a ``predicate`` property;
 its transitive closure (``part_of`` ancestry) is walked by the bounded recursive CTE.
+``conformed_dimension`` (DAT-756) types two facts sharing a dimension (the same
+resolved ``(dimension_table_id, attribute)`` identity — NOT a column name) as a
+drill-across path, explicitly NOT a fact-to-fact FK (the DAT-723 fan trap), which is
+why those pairs are excluded from ``refs``.
 
 **Bootstrap ordering is load-bearing.** A property graph *depends on* its element
 views, and an element view depends on the ``current_*`` views. Postgres refuses to
@@ -77,6 +82,7 @@ _ELEMENT_VIEWS: tuple[str, ...] = (
     "og_has_dimension",
     "og_derived_from",
     "og_concept_edges",
+    "og_conformed_dimension",
 )
 
 
@@ -166,21 +172,45 @@ def _element_view_sql(name: str) -> str:
         # per-run and unique within one head-resolved view — a fine LOCAL edge key
         # inside one promoted state (never keyed on across runs). Self-referential
         # and multi-hop chains here are what the recursive-CTE closure walks.
+        #
+        # Conformed-dimension exclusion (DAT-756, rebuilding DAT-729 on identity): a
+        # relationship whose BOTH endpoints are fact SLICE columns resolving the SAME
+        # dimension_table_id is not an FK — it is two facts sharing a dimension (the
+        # DAT-723 fan trap), typed as the og_conformed_dimension edge below and dropped
+        # here. Keyed on the resolved dimension IDENTITY, never column names (the wrong
+        # signal the revert removed). A genuine fact→dim FK survives: a dimension's key
+        # is never a fact slice column, so at most one endpoint matches a slice row and
+        # the NOT EXISTS cannot fire.
         return (
             f"CREATE VIEW {READ_TOKEN}.og_references AS\n"
             f"SELECT relationship_id::text AS relationship_id,\n"
             f"       from_table_id::text AS from_table_id, to_table_id::text AS to_table_id,\n"
             f"       from_column_id, to_column_id, cardinality, relationship_type,\n"
             f"       confidence, is_confirmed\n"
-            f"FROM {READ_TOKEN}.current_relationships;"
+            f"FROM {READ_TOKEN}.current_relationships r\n"
+            f"WHERE NOT EXISTS (\n"
+            f"  SELECT 1 FROM {READ_TOKEN}.current_slice_definitions s1\n"
+            f"  JOIN {READ_TOKEN}.current_slice_definitions s2\n"
+            f"    ON s1.dimension_table_id = s2.dimension_table_id\n"
+            f"  WHERE s1.column_id = r.from_column_id AND s2.column_id = r.to_column_id\n"
+            f"    AND s1.table_id <> s2.table_id AND s1.dimension_table_id IS NOT NULL\n"
+            f");"
         )
     if name == "og_has_dimension":
         # has_dimension edge (table → column): a fact table's slice (dimension)
-        # columns. slice_id is the per-run local edge key.
+        # columns, CARRYING the resolved referenced-dimension identity (DAT-756):
+        # dimension_table_id (the FK-target dim table — NULL for a folded slice),
+        # dimension_attribute (the level), fk_role (the FK column). This is where the
+        # edge "binds to identity": two facts whose has_dimension edges share
+        # (dimension_table_id, dimension_attribute) reference one conformed dimension,
+        # which the og_conformed_dimension edge derives. slice_id is the per-run local
+        # edge key.
         return (
             f"CREATE VIEW {READ_TOKEN}.og_has_dimension AS\n"
             f"SELECT slice_id::text AS slice_id, table_id::text AS table_id,\n"
-            f"       column_id::text AS column_id, column_name, slice_type, slice_priority\n"
+            f"       column_id::text AS column_id, column_name, slice_type, slice_priority,\n"
+            f"       dimension_table_id::text AS dimension_table_id,\n"
+            f"       dimension_attribute, fk_role\n"
             f"FROM {READ_TOKEN}.current_slice_definitions;"
         )
     if name == "og_derived_from":
@@ -204,6 +234,34 @@ def _element_view_sql(name: str) -> str:
             f"CROSS JOIN LATERAL json_array_elements_text(\n"
             f"     COALESCE(ev.dimension_table_ids, '[]'::json)) AS dt(value)\n"
             f"WHERE ev.view_table_id IS NOT NULL;"
+        )
+    if name == "og_conformed_dimension":
+        # conformed_dimension edge (table → table): two facts sharing a dimension
+        # (DAT-756, rebuilding the reverted DAT-729 edge on referenced identity).
+        # Derived by self-joining slice (has_dimension) rows on the SAME resolved
+        # identity — (dimension_table_id, dimension_attribute), NEVER column names —
+        # of DIFFERENT tables. Attribute grain: the same dim table AT the same level,
+        # so it is the EXACT identity the lineage stock/flow witness groups on (one
+        # identity, two consumers). This is the drill-across path (compare over the
+        # shared conformed axis), explicitly NOT a fact-to-fact FK (the DAT-723 fan
+        # trap, excluded from og_references above). Folded slices (NULL
+        # dimension_table_id) have no dim table to conform over and are excluded.
+        # COALESCE pairs the slice-by-FK-key case (NULL attribute) with itself.
+        # Symmetric, so both directions are emitted (edge_key = the ordered slice-id
+        # pair, '_'-joined — NOT ':', a bind-param sigil to text()). A fact partitioned
+        # by N shared dimensions yields one edge per shared dimension.
+        return (
+            f"CREATE VIEW {READ_TOKEN}.og_conformed_dimension AS\n"
+            f"SELECT (s1.slice_id || '_' || s2.slice_id)::text AS edge_key,\n"
+            f"       s1.table_id::text AS from_table_id, s2.table_id::text AS to_table_id,\n"
+            f"       s1.dimension_table_id::text AS dimension_table_id,\n"
+            f"       s1.dimension_attribute AS dimension_attribute\n"
+            f"FROM {READ_TOKEN}.current_slice_definitions s1\n"
+            f"JOIN {READ_TOKEN}.current_slice_definitions s2\n"
+            f"  ON s1.dimension_table_id = s2.dimension_table_id\n"
+            f" AND COALESCE(s1.dimension_attribute, '') = COALESCE(s2.dimension_attribute, '')\n"
+            f" AND s1.table_id <> s2.table_id\n"
+            f"WHERE s1.dimension_table_id IS NOT NULL;"
         )
     raise AssertionError(f"unreachable: {name} not an element view")
 
@@ -239,7 +297,8 @@ def _property_graph_sql() -> str:
         f"      SOURCE KEY (table_id) REFERENCES og_tables (table_id)\n"
         f"      DESTINATION KEY (column_id) REFERENCES og_columns (column_id)\n"
         f"      LABEL has_dimension\n"
-        f"      PROPERTIES (column_name, slice_type, slice_priority),\n"
+        f"      PROPERTIES (column_name, slice_type, slice_priority,\n"
+        f"                  dimension_table_id, dimension_attribute, fk_role),\n"
         f"    {READ_TOKEN}.og_derived_from KEY (edge_key)\n"
         f"      SOURCE KEY (view_table_id) REFERENCES og_tables (table_id)\n"
         f"      DESTINATION KEY (base_table_id) REFERENCES og_tables (table_id)\n"
@@ -249,7 +308,12 @@ def _property_graph_sql() -> str:
         f"      SOURCE KEY (from_concept_id) REFERENCES og_concepts (concept_id)\n"
         f"      DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)\n"
         f"      LABEL concept_edge\n"
-        f"      PROPERTIES (predicate, tolerance)\n"
+        f"      PROPERTIES (predicate, tolerance),\n"
+        f"    {READ_TOKEN}.og_conformed_dimension KEY (edge_key)\n"
+        f"      SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)\n"
+        f"      DESTINATION KEY (to_table_id) REFERENCES og_tables (table_id)\n"
+        f"      LABEL conformed_dimension\n"
+        f"      PROPERTIES (dimension_table_id, dimension_attribute)\n"
         f"  );"
     )
 

--- a/packages/engine/src/dataraum/storage/property_graph.py
+++ b/packages/engine/src/dataraum/storage/property_graph.py
@@ -32,12 +32,13 @@ and ``Table``; the vocabulary ``Concept`` vertices are P3. Edges/props carried:
 consumer does. The ``concept_edge`` edge (DAT-729) carries the vocabulary relations
 ``part_of`` / ``disjoint_with`` / ``reconciles_with`` as a ``predicate`` property;
 its transitive closure (``part_of`` ancestry) is walked by the bounded recursive CTE.
-``conformed_dimension`` (DAT-756) types two facts sharing a dimension (the same
-resolved ``dimension_table_id`` — NOT a column name) as a drill-across path,
-explicitly NOT a fact-to-fact FK (the DAT-723 fan trap), which is why those pairs are
-excluded from ``refs`` — the edge is the exact table-grain complement of that
-exclusion (every excluded pair is explained here), with each side's slice level
-carried as ``from_attribute`` / ``to_attribute``.
+``conformed_dimension`` (DAT-756) types two facts sharing a dimension AXIS — the same
+resolved ``(dimension_table_id, attribute)`` identity, NOT a column name — as a
+drill-across path (an alignable GROUP BY the SQL agents can author over). It is
+ATTRIBUTE grain (the actionable unit for SQL is a shared axis, not a shared table),
+deliberately DECOUPLED from the table-grain ``refs`` fan-trap exclusion below — the two
+serve different consumers, so a cross-level fan trap is excluded from ``refs`` yet
+correctly has no conformed edge (see the edge's own note).
 
 **Bootstrap ordering is load-bearing.** A property graph *depends on* its element
 views, and an element view depends on the ``current_*`` views. Postgres refuses to
@@ -238,33 +239,43 @@ def _element_view_sql(name: str) -> str:
             f"WHERE ev.view_table_id IS NOT NULL;"
         )
     if name == "og_conformed_dimension":
-        # conformed_dimension edge (table → table): two facts sharing a dimension
+        # conformed_dimension edge (table → table): two facts sharing a dimension AXIS
         # (DAT-756, rebuilding the reverted DAT-729 edge on referenced identity).
-        # Derived by self-joining slice (has_dimension) rows on the SAME
-        # dimension_table_id — the resolved identity, NEVER column names — of
-        # DIFFERENT tables. TABLE grain deliberately: a conformed dimension is the
-        # shared dim TABLE (Kimball), and this must be the EXACT complement of the
-        # og_references fan-trap exclusion (also table grain) — every pair excluded
-        # there is explained by an edge here, none vanish from the graph. Each side's
-        # slice attribute (the level it is sliced at) rides along as from_/to_attribute
-        # so a consumer can tell a same-axis pair (from_attribute = to_attribute) from
-        # a cross-level one; the lineage stock/flow witness does its OWN finer
-        # attribute-grain grouping (value-domain reconciliation needs it). Folded
-        # slices (NULL dimension_table_id) have no dim table to conform over and are
-        # excluded. Symmetric — both directions emitted (edge_key = the ordered
-        # slice-id pair, '_'-joined, NOT ':' a bind-param sigil to text()). A fact with
-        # multiple role-playing FKs to one dim yields one edge PER slice-row pair, so a
-        # table pair can carry several conformed edges (one per shared axis/role).
+        # Derived by self-joining slice (has_dimension) rows on the SAME resolved
+        # identity — (dimension_table_id, dimension_attribute), NEVER column names —
+        # of DIFFERENT tables.
+        #
+        # ATTRIBUTE grain, and deliberately DECOUPLED from the og_references fan-trap
+        # exclusion (which is TABLE grain) — they serve different consumers:
+        #   - This edge exists to hand a SQL author an ALIGNABLE drill-across axis. Both
+        #     agents (engine GraphAgent, cockpit answer agent) author SQL over COLUMNS,
+        #     GROUP BY-ing slice columns — you cannot GROUP BY a table. The actionable
+        #     unit is therefore "fact A's column and fact B's column are the SAME axis"
+        #     = a shared (dim table, attribute); that is exactly the within-fact `alias`
+        #     hierarchy ("region ≡ region_code") lifted across facts. So two facts
+        #     conform iff they expose the same axis at the same level.
+        #   - The refs exclusion hides a fan trap, defined by two fact FKs sharing a dim
+        #     TABLE regardless of how each is sliced — a table-grain fact.
+        # A cross-level fan trap (fact-A-by-type ↔ fact-B-by-region) is thus excluded
+        # from refs (correct — not an FK) AND has no conformed edge (correct — no common
+        # axis to drill across); the facts' shared dimension is still visible via their
+        # genuine fact→dim FKs, and this edge only asserts the stronger, actionable
+        # "drill these across THIS axis." COALESCE pairs the slice-by-FK-key case (NULL
+        # attribute) with itself. Folded slices (NULL dimension_table_id) have no dim
+        # table to conform over and are excluded. Symmetric — both directions emitted
+        # (edge_key = the ordered slice-id pair, '_'-joined, NOT ':' a bind-param sigil
+        # to text()). A fact with multiple role-playing FKs at one axis yields one edge
+        # per slice-row pair, so a table pair can carry several conformed edges.
         return (
             f"CREATE VIEW {READ_TOKEN}.og_conformed_dimension AS\n"
             f"SELECT (s1.slice_id || '_' || s2.slice_id)::text AS edge_key,\n"
             f"       s1.table_id::text AS from_table_id, s2.table_id::text AS to_table_id,\n"
             f"       s1.dimension_table_id::text AS dimension_table_id,\n"
-            f"       s1.dimension_attribute AS from_attribute,\n"
-            f"       s2.dimension_attribute AS to_attribute\n"
+            f"       s1.dimension_attribute AS dimension_attribute\n"
             f"FROM {READ_TOKEN}.current_slice_definitions s1\n"
             f"JOIN {READ_TOKEN}.current_slice_definitions s2\n"
             f"  ON s1.dimension_table_id = s2.dimension_table_id\n"
+            f" AND COALESCE(s1.dimension_attribute, '') = COALESCE(s2.dimension_attribute, '')\n"
             f" AND s1.table_id <> s2.table_id\n"
             f"WHERE s1.dimension_table_id IS NOT NULL;"
         )
@@ -318,7 +329,7 @@ def _property_graph_sql() -> str:
         f"      SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)\n"
         f"      DESTINATION KEY (to_table_id) REFERENCES og_tables (table_id)\n"
         f"      LABEL conformed_dimension\n"
-        f"      PROPERTIES (dimension_table_id, from_attribute, to_attribute)\n"
+        f"      PROPERTIES (dimension_table_id, dimension_attribute)\n"
         f"  );"
     )
 

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -68,6 +68,7 @@ _COLUMNS = [
     ("c_k1", "t1", "account_id", 2),
     ("c_k2", "t2", "account_id", 1),
     ("c_k3", "t3", "group_id", 1),
+    ("c_k3b", "t3", "account_id", 2),  # t3's own account_id — a cross-LEVEL accounts slice
     ("c_k4", "t4", "statement_id", 1),
     ("c_k4b", "t4", "account_id", 2),  # t4's own account_id — a 2nd fact→accounts slice
     ("c_k5", "t5", "division_id", 1),
@@ -142,16 +143,17 @@ def _seed(engine: Engine) -> None:
             f"VALUES ('{rid}', '{RUN}', '{ft}', '{fc}', '{tt}', '{tc}', "
             f"'foreign_key', 'many_to_one', 0.9, true, '{TS}')"
         )
-    # has_dimension: two facts (journal t1, statement t4) each sliced by their own
-    # account_id FK, BOTH resolving the referenced identity dimension_table_id='t2'
-    # (the accounts dim) — but at DIFFERENT attributes (account_type vs region). That
-    # is a same-dimension, CROSS-LEVEL conformed pair: the conformed edge is TABLE
-    # grain (it exists regardless of the level each fact is sliced at), the exact
-    # complement of the table-grain og_references fan-trap exclusion. fk_role is the
-    # FK column name, carried but not a Phase-A identity key.
+    # has_dimension: three facts each sliced by their own account_id FK, all resolving
+    # the referenced identity dimension_table_id='t2' (the accounts dim). journal (t1)
+    # and statement (t4) slice the SAME attribute (account_type) → a CONFORMED pair
+    # (an alignable drill-across axis). account_group (t3) slices a DIFFERENT attribute
+    # (region) → shares the dim TABLE but NOT the axis, so it does NOT conform (the
+    # conformed edge is ATTRIBUTE grain). fk_role is the FK column name, carried but not
+    # a Phase-A identity key.
     for sid, tid, cid, colname, attr in [
         ("sl_1", "t1", "c_k1", "account_id__account_type", "account_type"),
-        ("sl_2", "t4", "c_k4b", "account_id__region", "region"),
+        ("sl_2", "t4", "c_k4b", "account_id__account_type", "account_type"),
+        ("sl_3", "t3", "c_k3b", "account_id__region", "region"),
     ]:
         stmts.append(
             "INSERT INTO slice_definitions "
@@ -160,17 +162,23 @@ def _seed(engine: Engine) -> None:
             f"VALUES ('{sid}', '{RUN}', '{tid}', '{cid}', '{colname}', 't2', "
             f"'{attr}', 'account_id', 1, 'categorical', 'llm', '{TS}')"
         )
-    # A SPURIOUS fact↔fact relationship between the two account_id slice columns
-    # (the DAT-723 fan trap): both endpoints resolve dimension_table_id='t2', so it
-    # is a conformed dimension, NOT an FK — og_references must drop it and
-    # og_conformed_dimension must carry the pair.
-    stmts.append(
-        "INSERT INTO relationships "
-        "(relationship_id, run_id, from_table_id, from_column_id, to_table_id, "
-        " to_column_id, relationship_type, cardinality, confidence, is_confirmed, detected_at) "
-        f"VALUES ('r_fan', '{RUN}', 't1', 'c_k1', 't4', 'c_k4b', "
-        f"'foreign_key', 'many_to_one', 0.9, true, '{TS}')"
-    )
+    # SPURIOUS fact↔fact relationships between account_id slice columns (the DAT-723
+    # fan trap): both endpoints resolve dimension_table_id='t2', so each is a conformed
+    # dimension, NOT an FK — og_references must drop BOTH (table grain, regardless of
+    # slice attribute). r_fan links the same-attribute pair (t1↔t4, which DOES get a
+    # conformed edge); r_fan_xlevel links the cross-level pair (t1↔t3, which does NOT —
+    # proving the exclusion and the edge are decoupled: excluded yet unedged is correct).
+    for rid, ft, fc, tt, tc in [
+        ("r_fan", "t1", "c_k1", "t4", "c_k4b"),
+        ("r_fan_xlevel", "t1", "c_k1", "t3", "c_k3b"),
+    ]:
+        stmts.append(
+            "INSERT INTO relationships "
+            "(relationship_id, run_id, from_table_id, from_column_id, to_table_id, "
+            " to_column_id, relationship_type, cardinality, confidence, is_confirmed, detected_at) "
+            f"VALUES ('{rid}', '{RUN}', '{ft}', '{fc}', '{tt}', '{tc}', "
+            f"'foreign_key', 'many_to_one', 0.9, true, '{TS}')"
+        )
     for eid, tid, role in [("e_j", "t1", "fact"), ("e_a", "t2", "dimension")]:
         stmts.append(
             "INSERT INTO table_entities "
@@ -311,35 +319,44 @@ def test_has_dimension_edge(graph_engine: Engine) -> None:
     )
     with graph_engine.connect() as conn:
         rows = {(r.tname, r.cname, r.dim) for r in conn.execute(text(sql))}
-    # Both facts slice their own account_id, each bound to the accounts dim (t2).
-    assert rows == {("journal", "account_id", "t2"), ("statement", "account_id", "t2")}
+    # All three facts slice their own account_id, each bound to the accounts dim (t2).
+    assert rows == {
+        ("journal", "account_id", "t2"),
+        ("statement", "account_id", "t2"),
+        ("account_group", "account_id", "t2"),
+    }
 
 
-def test_conformed_dimension_pairs_facts_sharing_a_dim(graph_engine: Engine) -> None:
-    """conformed_dimension (DAT-756): the two facts sharing the accounts dim are
-    typed as a conformed pair — TABLE grain, so it fires even though they are sliced
-    at DIFFERENT levels (account_type vs region), each level carried on the edge.
-    Both directions of the symmetric edge. Under an attribute-grain edge this
-    cross-level pair would silently have NO edge (the gap this grain closes)."""
+def test_conformed_dimension_is_attribute_grain(graph_engine: Engine) -> None:
+    """conformed_dimension (DAT-756): ATTRIBUTE grain — two facts conform iff they
+    share the same AXIS (dim table + attribute), the alignable drill-across GROUP BY
+    a SQL author needs. journal and statement both slice accounts by account_type →
+    they conform (both directions, carrying the shared attribute). account_group slices
+    accounts by REGION — same dim table, different axis — so it conforms with NEITHER
+    (a shared table is not an alignable axis)."""
     sql = (
-        f"SELECT src, dst, dim, fa, ta FROM GRAPH_TABLE ({_graph_ref()} "
+        f"SELECT src, dst, dim, attr FROM GRAPH_TABLE ({_graph_ref()} "
         "MATCH (a IS table_node)-[e IS conformed_dimension]->(b IS table_node) "
         "COLUMNS (a.table_name AS src, b.table_name AS dst, "
-        "e.dimension_table_id AS dim, e.from_attribute AS fa, e.to_attribute AS ta))"
+        "e.dimension_table_id AS dim, e.dimension_attribute AS attr))"
     )
     with graph_engine.connect() as conn:
-        rows = {(r.src, r.dst, r.dim, r.fa, r.ta) for r in conn.execute(text(sql))}
+        rows = {(r.src, r.dst, r.dim, r.attr) for r in conn.execute(text(sql))}
     assert rows == {
-        ("journal", "statement", "t2", "account_type", "region"),
-        ("statement", "journal", "t2", "region", "account_type"),
+        ("journal", "statement", "t2", "account_type"),
+        ("statement", "journal", "t2", "account_type"),
     }
 
 
 def test_conformed_pair_excluded_from_refs(graph_engine: Engine) -> None:
-    """The DAT-723 fan trap: the spurious fact↔fact relationship whose endpoints both
-    resolve the accounts dim is NOT surfaced as a reference — it is a conformed
-    dimension. The genuine fact→dim FK (journal→accounts) survives (a dim key is
-    never a slice column, so the exclusion cannot fire on it)."""
+    """The DAT-723 fan trap: a spurious fact↔fact relationship whose endpoints both
+    resolve the accounts dim is NOT surfaced as a reference. The exclusion is TABLE
+    grain — it fires on BOTH the same-attribute pair (journal↔statement) and the
+    cross-level pair (journal↔account_group), regardless of slice attribute. This is
+    deliberately DECOUPLED from the attribute-grain conformed edge: the cross-level
+    pair is excluded from refs yet has no conformed edge, and that is correct. The
+    genuine fact→dim FK (journal→accounts) survives (a dim key is never a slice
+    column, so the exclusion cannot fire on it)."""
     sql = (
         f"SELECT src, dst FROM GRAPH_TABLE ({_graph_ref()} "
         "MATCH (a IS table_node)-[e IS refs]->(b IS table_node) "
@@ -347,7 +364,8 @@ def test_conformed_pair_excluded_from_refs(graph_engine: Engine) -> None:
     )
     with graph_engine.connect() as conn:
         rows = {(r.src, r.dst) for r in conn.execute(text(sql))}
-    assert ("journal", "statement") not in rows, "conformed pair leaked into refs"
+    assert ("journal", "statement") not in rows, "same-attribute fan trap leaked into refs"
+    assert ("journal", "account_group") not in rows, "cross-level fan trap leaked into refs"
     assert ("journal", "accounts") in rows, "genuine fact→dim FK was wrongly excluded"
 
 

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -69,6 +69,7 @@ _COLUMNS = [
     ("c_k2", "t2", "account_id", 1),
     ("c_k3", "t3", "group_id", 1),
     ("c_k4", "t4", "statement_id", 1),
+    ("c_k4b", "t4", "account_id", 2),  # t4's own account_id — a 2nd fact→accounts slice
     ("c_k5", "t5", "division_id", 1),
     ("c_k6", "t6", "root_id", 1),
 ]
@@ -141,12 +142,29 @@ def _seed(engine: Engine) -> None:
             f"VALUES ('{rid}', '{RUN}', '{ft}', '{fc}', '{tt}', '{tc}', "
             f"'foreign_key', 'many_to_one', 0.9, true, '{TS}')"
         )
-    # has_dimension: journal's account_id slice.
+    # has_dimension: two facts (journal t1, statement t4) each sliced by their own
+    # account_id, BOTH resolving the referenced identity dimension_table_id='t2'
+    # (the accounts dim) at a NULL attribute (grouping by the FK key itself) — a
+    # CONFORMED dimension (DAT-756). fk_role is the FK column name, carried but not
+    # a Phase-A identity key.
+    for sid, tid, cid in [("sl_1", "t1", "c_k1"), ("sl_2", "t4", "c_k4b")]:
+        stmts.append(
+            "INSERT INTO slice_definitions "
+            "(slice_id, run_id, table_id, column_id, column_name, dimension_table_id, "
+            " dimension_attribute, fk_role, slice_priority, slice_type, detection_source, created_at) "
+            f"VALUES ('{sid}', '{RUN}', '{tid}', '{cid}', 'account_id', 't2', "
+            f"NULL, 'account_id', 1, 'categorical', 'llm', '{TS}')"
+        )
+    # A SPURIOUS fact↔fact relationship between the two account_id slice columns
+    # (the DAT-723 fan trap): both endpoints resolve dimension_table_id='t2', so it
+    # is a conformed dimension, NOT an FK — og_references must drop it and
+    # og_conformed_dimension must carry the pair.
     stmts.append(
-        "INSERT INTO slice_definitions "
-        "(slice_id, run_id, table_id, column_id, column_name, slice_priority, "
-        " slice_type, detection_source, created_at) "
-        f"VALUES ('sl_1', '{RUN}', 't1', 'c_k1', 'account_id', 1, 'categorical', 'llm', '{TS}')"
+        "INSERT INTO relationships "
+        "(relationship_id, run_id, from_table_id, from_column_id, to_table_id, "
+        " to_column_id, relationship_type, cardinality, confidence, is_confirmed, detected_at) "
+        f"VALUES ('r_fan', '{RUN}', 't1', 'c_k1', 't4', 'c_k4b', "
+        f"'foreign_key', 'many_to_one', 0.9, true, '{TS}')"
     )
     for eid, tid, role in [("e_j", "t1", "fact"), ("e_a", "t2", "dimension")]:
         stmts.append(
@@ -278,15 +296,49 @@ def test_derived_from_edges_enumerable(graph_engine: Engine) -> None:
 
 
 def test_has_dimension_edge(graph_engine: Engine) -> None:
-    """has_dimension: a fact table points at its slice (dimension) columns."""
+    """has_dimension: each fact points at its slice column, CARRYING the referenced
+    identity (DAT-756) — dimension_table_id resolves to the shared accounts dim."""
     sql = (
-        f"SELECT tname, cname FROM GRAPH_TABLE ({_graph_ref()} "
+        f"SELECT tname, cname, dim FROM GRAPH_TABLE ({_graph_ref()} "
         "MATCH (t IS table_node)-[e IS has_dimension]->(c IS column_node) "
-        "COLUMNS (t.table_name AS tname, c.column_name AS cname))"
+        "COLUMNS (t.table_name AS tname, c.column_name AS cname, "
+        "e.dimension_table_id AS dim))"
     )
     with graph_engine.connect() as conn:
-        rows = {(r.tname, r.cname) for r in conn.execute(text(sql))}
-    assert rows == {("journal", "account_id")}
+        rows = {(r.tname, r.cname, r.dim) for r in conn.execute(text(sql))}
+    # Both facts slice their own account_id, each bound to the accounts dim (t2).
+    assert rows == {("journal", "account_id", "t2"), ("statement", "account_id", "t2")}
+
+
+def test_conformed_dimension_pairs_facts_sharing_a_dim(graph_engine: Engine) -> None:
+    """conformed_dimension (DAT-756): the two facts sharing the accounts dim are
+    typed as a conformed pair — derived from the SHARED dimension identity, both
+    directions of the symmetric edge, carrying the dim table it conforms over."""
+    sql = (
+        f"SELECT src, dst, dim FROM GRAPH_TABLE ({_graph_ref()} "
+        "MATCH (a IS table_node)-[e IS conformed_dimension]->(b IS table_node) "
+        "COLUMNS (a.table_name AS src, b.table_name AS dst, "
+        "e.dimension_table_id AS dim))"
+    )
+    with graph_engine.connect() as conn:
+        rows = {(r.src, r.dst, r.dim) for r in conn.execute(text(sql))}
+    assert rows == {("journal", "statement", "t2"), ("statement", "journal", "t2")}
+
+
+def test_conformed_pair_excluded_from_refs(graph_engine: Engine) -> None:
+    """The DAT-723 fan trap: the spurious fact↔fact relationship whose endpoints both
+    resolve the accounts dim is NOT surfaced as a reference — it is a conformed
+    dimension. The genuine fact→dim FK (journal→accounts) survives (a dim key is
+    never a slice column, so the exclusion cannot fire on it)."""
+    sql = (
+        f"SELECT src, dst FROM GRAPH_TABLE ({_graph_ref()} "
+        "MATCH (a IS table_node)-[e IS refs]->(b IS table_node) "
+        "COLUMNS (a.table_name AS src, b.table_name AS dst))"
+    )
+    with graph_engine.connect() as conn:
+        rows = {(r.src, r.dst) for r in conn.execute(text(sql))}
+    assert ("journal", "statement") not in rows, "conformed pair leaked into refs"
+    assert ("journal", "accounts") in rows, "genuine fact→dim FK was wrongly excluded"
 
 
 def test_concept_edge_disjoint_with_matches(graph_engine: Engine) -> None:
@@ -337,7 +389,7 @@ def _part_of_closure(conn, read: str, start: str) -> list[tuple[str, int]]:
         f"  FROM \"{read}\".og_concept_edges WHERE predicate = 'part_of' "
         "  UNION ALL "
         "  SELECT r.src, e.to_concept_id, r.depth + 1, r.path || e.to_concept_id "
-        f"  FROM reach r JOIN \"{read}\".og_concept_edges e "
+        f'  FROM reach r JOIN "{read}".og_concept_edges e '
         "    ON e.from_concept_id = r.dst AND e.predicate = 'part_of' "
         "  WHERE r.depth < 4 AND NOT e.to_concept_id = ANY(r.path)"
         ") SELECT dst, depth FROM reach WHERE src = :s ORDER BY depth, dst"

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -143,17 +143,22 @@ def _seed(engine: Engine) -> None:
             f"'foreign_key', 'many_to_one', 0.9, true, '{TS}')"
         )
     # has_dimension: two facts (journal t1, statement t4) each sliced by their own
-    # account_id, BOTH resolving the referenced identity dimension_table_id='t2'
-    # (the accounts dim) at a NULL attribute (grouping by the FK key itself) — a
-    # CONFORMED dimension (DAT-756). fk_role is the FK column name, carried but not
-    # a Phase-A identity key.
-    for sid, tid, cid in [("sl_1", "t1", "c_k1"), ("sl_2", "t4", "c_k4b")]:
+    # account_id FK, BOTH resolving the referenced identity dimension_table_id='t2'
+    # (the accounts dim) — but at DIFFERENT attributes (account_type vs region). That
+    # is a same-dimension, CROSS-LEVEL conformed pair: the conformed edge is TABLE
+    # grain (it exists regardless of the level each fact is sliced at), the exact
+    # complement of the table-grain og_references fan-trap exclusion. fk_role is the
+    # FK column name, carried but not a Phase-A identity key.
+    for sid, tid, cid, colname, attr in [
+        ("sl_1", "t1", "c_k1", "account_id__account_type", "account_type"),
+        ("sl_2", "t4", "c_k4b", "account_id__region", "region"),
+    ]:
         stmts.append(
             "INSERT INTO slice_definitions "
             "(slice_id, run_id, table_id, column_id, column_name, dimension_table_id, "
             " dimension_attribute, fk_role, slice_priority, slice_type, detection_source, created_at) "
-            f"VALUES ('{sid}', '{RUN}', '{tid}', '{cid}', 'account_id', 't2', "
-            f"NULL, 'account_id', 1, 'categorical', 'llm', '{TS}')"
+            f"VALUES ('{sid}', '{RUN}', '{tid}', '{cid}', '{colname}', 't2', "
+            f"'{attr}', 'account_id', 1, 'categorical', 'llm', '{TS}')"
         )
     # A SPURIOUS fact↔fact relationship between the two account_id slice columns
     # (the DAT-723 fan trap): both endpoints resolve dimension_table_id='t2', so it
@@ -312,17 +317,22 @@ def test_has_dimension_edge(graph_engine: Engine) -> None:
 
 def test_conformed_dimension_pairs_facts_sharing_a_dim(graph_engine: Engine) -> None:
     """conformed_dimension (DAT-756): the two facts sharing the accounts dim are
-    typed as a conformed pair — derived from the SHARED dimension identity, both
-    directions of the symmetric edge, carrying the dim table it conforms over."""
+    typed as a conformed pair — TABLE grain, so it fires even though they are sliced
+    at DIFFERENT levels (account_type vs region), each level carried on the edge.
+    Both directions of the symmetric edge. Under an attribute-grain edge this
+    cross-level pair would silently have NO edge (the gap this grain closes)."""
     sql = (
-        f"SELECT src, dst, dim FROM GRAPH_TABLE ({_graph_ref()} "
+        f"SELECT src, dst, dim, fa, ta FROM GRAPH_TABLE ({_graph_ref()} "
         "MATCH (a IS table_node)-[e IS conformed_dimension]->(b IS table_node) "
         "COLUMNS (a.table_name AS src, b.table_name AS dst, "
-        "e.dimension_table_id AS dim))"
+        "e.dimension_table_id AS dim, e.from_attribute AS fa, e.to_attribute AS ta))"
     )
     with graph_engine.connect() as conn:
-        rows = {(r.src, r.dst, r.dim) for r in conn.execute(text(sql))}
-    assert rows == {("journal", "statement", "t2"), ("statement", "journal", "t2")}
+        rows = {(r.src, r.dst, r.dim, r.fa, r.ta) for r in conn.execute(text(sql))}
+    assert rows == {
+        ("journal", "statement", "t2", "account_type", "region"),
+        ("statement", "journal", "t2", "region", "account_type"),
+    }
 
 
 def test_conformed_pair_excluded_from_refs(graph_engine: Engine) -> None:

--- a/packages/engine/tests/unit/analysis/lineage/test_processor.py
+++ b/packages/engine/tests/unit/analysis/lineage/test_processor.py
@@ -86,6 +86,7 @@ def _seed(
     multi_axis: bool = False,
     tb_dim_col: str = _DIM,
     jl_dim_col: str = _DIM,
+    tb_role_play_col: str | None = None,
     folded: bool = False,
 ) -> dict[str, str]:
     """Seed Tables/Columns/SliceDefinitions/TableEntity + the DuckDB rows.
@@ -105,6 +106,13 @@ def _seed(
     still pair (the false-negative). ``folded=True`` nulls the identity on both
     slices — an own-column dimension with no dim table (the false-positive: same
     name, no cross-table identity, must NOT pair).
+
+    ``tb_role_play_col`` adds a SECOND trial_balance slice at the SAME identity (a
+    role-playing FK to the same dim + attribute) whose DuckDB values are degenerate
+    (``'other'`` — outside ``_VALUES``, so its own series is empty). The witness must
+    still fire off the primary slice: the two role slices must BOTH be tried, never
+    collapsed to one (DAT-756 — the identity key groups a list per fact, not a
+    last-write-wins single).
     """
     ids: dict[str, str] = {}
     dim_table = Table(
@@ -182,6 +190,26 @@ def _seed(
                 detection_source="llm",
             )
         )
+    # A second trial_balance slice at the SAME identity (role-playing FK): must NOT
+    # collapse the primary slice (DAT-756). Its DuckDB values are degenerate so only
+    # the primary reconciles — proving both are tried, not one arbitrarily kept.
+    if tb_role_play_col:
+        rp_role, _, rp_attr = tb_role_play_col.partition("__")
+        session.add(
+            SliceDefinition(
+                run_id=_RUN,
+                table_id=ids["trial_balance"],
+                column_id=ids["trial_balance.balance"],
+                column_name=tb_role_play_col,
+                dimension_table_id=ids["chart_of_accounts"],
+                dimension_attribute=rp_attr or None,
+                fk_role=rp_role,
+                slice_priority=2,
+                distinct_values=list(_VALUES),
+                value_count=len(_VALUES),
+                detection_source="llm",
+            )
+        )
     session.flush()
 
     # DuckDB sources — one table per fact (typed-fact fallback). Columns mirror
@@ -189,12 +217,13 @@ def _seed(
     # differ between facts (DAT-756 — the identity is the dim table, not the name).
     tb_extra_cols = ", account_key DOUBLE" if key_column else ""
     tb_axis_col = ", ship_date DATE" if multi_axis else ""
+    tb_role_col = f', "{tb_role_play_col}" VARCHAR' if tb_role_play_col else ""
     jl_extra_cols = (", account_key DOUBLE" if key_column else "") + (
         ", line_id DOUBLE" if junk_column else ""
     )
     duck.execute(
         f'CREATE TABLE trial_balance ("{tb_dim_col}" VARCHAR, period_date DATE,'
-        f" balance DOUBLE, net_change DOUBLE{tb_extra_cols}{tb_axis_col})"
+        f" balance DOUBLE, net_change DOUBLE{tb_extra_cols}{tb_axis_col}{tb_role_col})"
     )
     duck.execute(
         f'CREATE TABLE journal_lines ("{jl_dim_col}" VARCHAR, period_date DATE,'
@@ -213,7 +242,12 @@ def _seed(
             # Degenerate second axis: every row shares one ship_date, collapsing
             # the per-period series to a single bucket so this axis cannot win.
             tb_axis_val = ", DATE '2025-01-15'" if multi_axis else ""
-            tb_rows.append(f"('{value}', {d}, {running}, {net}{tb_extra}{tb_axis_val})")
+            # Degenerate role-play value: 'other' is outside _VALUES, so this second
+            # same-identity slice contributes no series — only the primary reconciles.
+            tb_role_val = ", 'other'" if tb_role_play_col else ""
+            tb_rows.append(
+                f"('{value}', {d}, {running}, {net}{tb_extra}{tb_axis_val}{tb_role_val})"
+            )
             # Two finer-grained event rows summing to the movement.
             for half in (net / 2, net - net / 2):
                 jl_extra = f", {float(k * 100)}" if key_column else ""
@@ -372,6 +406,21 @@ class TestDiscoverAggregationLineage:
         a folded dimension has no cross-table identity in Phase A (DAT-757)."""
         ids = _seed(real_session, duck, tb_dim_col="status", jl_dim_col="status", folded=True)
         assert _discover(real_session, duck, ids) == 0
+
+    def test_role_playing_slices_are_all_kept(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """DAT-756: a fact carrying TWO slices at the SAME identity (role-playing FKs
+        to one dim — ``account_id__account_type`` + ``counter_account_id__account_type``)
+        must keep BOTH as bucketing lenses, never collapse to one. The role-play slice
+        here is degenerate (values outside _VALUES); the witness must still fire off the
+        primary. A last-write-wins grouping could drop the primary and silence it."""
+        ids = _seed(real_session, duck, tb_role_play_col="counter_account_id__account_type")
+        assert _discover(real_session, duck, ids) > 0
+        row = _row_for(real_session, ids["trial_balance.balance"])
+        assert row is not None
+        assert row.pattern == "cumulative"
+        assert row.event_table_id == ids["journal_lines"]
 
     def test_rerun_is_idempotent(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection

--- a/packages/engine/tests/unit/analysis/lineage/test_processor.py
+++ b/packages/engine/tests/unit/analysis/lineage/test_processor.py
@@ -31,6 +31,9 @@ from dataraum.storage import Column, Table, init_database
 
 _RUN = "session-run-1"
 _DIM = "account_id__account_type"
+# The persisted ``slice_dimension`` is now the conformed-identity label
+# (``<dim table>.<attribute>``), not the per-fact physical column name (DAT-756).
+_DIM_LABEL = "chart_of_accounts.account_type"
 _VALUES = ("assets", "liabilities")
 _MONTHS = list(range(1, 13))
 
@@ -81,6 +84,9 @@ def _seed(
     junk_column: bool = False,
     key_column: bool = False,
     multi_axis: bool = False,
+    tb_dim_col: str = _DIM,
+    jl_dim_col: str = _DIM,
+    folded: bool = False,
 ) -> dict[str, str]:
     """Seed Tables/Columns/SliceDefinitions/TableEntity + the DuckDB rows.
 
@@ -90,8 +96,26 @@ def _seed(
     cell vs 1) so the direction gate orders it as the event side. Both facts
     sliced by the same dimension. The DuckDB rows are authored so the inline
     ``GROUP BY`` reproduces the canonical per-period sums.
+
+    Dimension identity (DAT-756): each fact's slice carries its referenced identity
+    ``(dimension_table_id -> chart_of_accounts, attribute = the ``fk__attr`` suffix,
+    fk_role = the prefix)`` — so the pairing keys on the SHARED dim table + attribute,
+    not the physical column name. ``tb_dim_col`` / ``jl_dim_col`` set each fact's
+    physical slice column (default equal): differing FK names with the same suffix
+    still pair (the false-negative). ``folded=True`` nulls the identity on both
+    slices — an own-column dimension with no dim table (the false-positive: same
+    name, no cross-table identity, must NOT pair).
     """
     ids: dict[str, str] = {}
+    dim_table = Table(
+        table_id=str(uuid4()),
+        source_id="src-1",
+        table_name="chart_of_accounts",
+        layer="typed",
+        duckdb_path="chart_of_accounts",
+    )
+    session.add(dim_table)
+    ids["chart_of_accounts"] = dim_table.table_id
     extra = ["account_key"] if key_column else []
     for name, cols in (
         ("trial_balance", ["balance", "net_change", *extra]),
@@ -132,13 +156,26 @@ def _seed(
         )
 
     sliced_tables = ["trial_balance", "journal_lines"] if shared_dimension else ["trial_balance"]
+    dim_col_by_fact = {"trial_balance": tb_dim_col, "journal_lines": jl_dim_col}
     for name in sliced_tables:
+        dim_col = dim_col_by_fact[name]
+        if folded:
+            dim_table_id: str | None = None
+            attribute: str | None = None
+            role: str | None = None
+        else:
+            dim_table_id = ids["chart_of_accounts"]
+            role, _, attribute = dim_col.partition("__")
+            attribute = attribute or None
         session.add(
             SliceDefinition(
                 run_id=_RUN,
                 table_id=ids[name],
                 column_id=ids[f"{name}.{'balance' if name == 'trial_balance' else 'debit'}"],
-                column_name=_DIM,
+                column_name=dim_col,
+                dimension_table_id=dim_table_id,
+                dimension_attribute=attribute,
+                fk_role=role,
                 slice_priority=1,
                 distinct_values=list(_VALUES),
                 value_count=len(_VALUES),
@@ -148,18 +185,19 @@ def _seed(
     session.flush()
 
     # DuckDB sources — one table per fact (typed-fact fallback). Columns mirror
-    # the metadata above; the dimension is an enriched-style "fk__attr" name.
+    # the metadata above; the dimension is an enriched-style "fk__attr" name and may
+    # differ between facts (DAT-756 — the identity is the dim table, not the name).
     tb_extra_cols = ", account_key DOUBLE" if key_column else ""
     tb_axis_col = ", ship_date DATE" if multi_axis else ""
     jl_extra_cols = (", account_key DOUBLE" if key_column else "") + (
         ", line_id DOUBLE" if junk_column else ""
     )
     duck.execute(
-        f'CREATE TABLE trial_balance ("{_DIM}" VARCHAR, period_date DATE,'
+        f'CREATE TABLE trial_balance ("{tb_dim_col}" VARCHAR, period_date DATE,'
         f" balance DOUBLE, net_change DOUBLE{tb_extra_cols}{tb_axis_col})"
     )
     duck.execute(
-        f'CREATE TABLE journal_lines ("{_DIM}" VARCHAR, period_date DATE,'
+        f'CREATE TABLE journal_lines ("{jl_dim_col}" VARCHAR, period_date DATE,'
         f" debit DOUBLE, credit DOUBLE{jl_extra_cols})"
     )
 
@@ -215,7 +253,7 @@ class TestDiscoverAggregationLineage:
         assert row is not None
         assert row.pattern == "cumulative"
         assert row.event_table_id == ids["journal_lines"]
-        assert row.slice_dimension == _DIM
+        assert row.slice_dimension == _DIM_LABEL
         assert row.match_rate > 0.99
         assert row.run_id == _RUN
         # The winning convention reproduces the movement exactly: the single
@@ -305,6 +343,34 @@ class TestDiscoverAggregationLineage:
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
         ids = _seed(real_session, duck, shared_dimension=False)
+        assert _discover(real_session, duck, ids) == 0
+
+    def test_differently_named_fks_pair_via_dim_identity(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """False-negative closes (DAT-756): two facts joining ONE dim table through
+        DIFFERENTLY-NAMED FK columns (``gl_account__type`` / ``account_no__type``)
+        share the dimension by referenced identity (chart_of_accounts.type), so the
+        stock/flow witness runs. Under the old ``column_name`` grouping the pair was
+        never formed and the witness was silently inert."""
+        ids = _seed(
+            real_session, duck, tb_dim_col="gl_account__type", jl_dim_col="account_no__type"
+        )
+        assert _discover(real_session, duck, ids) > 0
+        row = _row_for(real_session, ids["trial_balance.balance"])
+        assert row is not None
+        assert row.pattern == "cumulative"
+        assert row.event_table_id == ids["journal_lines"]
+        assert row.slice_dimension == "chart_of_accounts.type"
+
+    def test_folded_same_named_columns_do_not_pair(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """False-positive closes (DAT-756): two unrelated same-named FOLDED columns
+        (own ``status`` column, no dim table -> null identity) are NOT paired. The
+        bare name collision that would have fired a spurious witness now abstains —
+        a folded dimension has no cross-table identity in Phase A (DAT-757)."""
+        ids = _seed(real_session, duck, tb_dim_col="status", jl_dim_col="status", folded=True)
         assert _discover(real_session, duck, ids) == 0
 
     def test_rerun_is_idempotent(

--- a/packages/engine/tests/unit/pipeline/test_slicing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_slicing_phase.py
@@ -775,3 +775,99 @@ class TestSliceDefinitionWriterIdempotent:
         assert set(by_run) == {"run-A", "run-B"}
         assert by_run["run-A"].confidence == 0.8, "prior run untouched"
         assert by_run["run-B"].confidence == 0.7
+
+
+@patch("dataraum.pipeline.phases.slicing_phase.SlicingAgent")
+@patch("dataraum.pipeline.phases.slicing_phase.PromptRenderer")
+@patch("dataraum.pipeline.phases.slicing_phase.create_provider")
+@patch("dataraum.pipeline.phases.slicing_phase.load_llm_config")
+class TestReferencedDimensionIdentity:
+    """DAT-756: each slice resolves its referenced-dimension identity at write.
+
+    An enriched slice (``column_id`` is the fact's FK column) resolves
+    ``(dimension_table_id, dimension_attribute, fk_role)`` from the enriched view's
+    grain-safe relationship provenance — NOT from ``column_name``. A folded slice
+    (an own categorical column with no grain-safe FK) resolves a null identity: it
+    has no cross-table dimension identity in Phase A and abstains from conformed
+    pairing (that residual is DAT-757).
+    """
+
+    @staticmethod
+    def _rec(table_id: str, column_id: str, column_name: str) -> Result[SlicingAnalysisResult]:
+        from dataraum.analysis.slicing.models import SliceRecommendation
+
+        rec = SliceRecommendation(
+            table_id=table_id,
+            table_name="invoices",
+            column_id=column_id,
+            column_name=column_name,
+            slice_priority=1,
+            distinct_values=["a", "b"],
+            value_count=2,
+            reasoning="partitions",
+            confidence=0.9,
+        )
+        return Result.ok(SlicingAnalysisResult(recommendations=[rec], time_columns={}))
+
+    def test_enriched_slice_resolves_dim_table_identity(
+        self,
+        mock_load_config: MagicMock,
+        mock_create_provider: MagicMock,
+        mock_renderer_cls: MagicMock,
+        mock_agent_cls: MagicMock,
+        session: Session,
+        duckdb_conn: duckdb.DuckDBPyConnection,
+    ) -> None:
+        """The FK-backed slice resolves (dim table, attribute=suffix, fk_role=prefix)."""
+        mock_load_config.return_value = _mock_llm_config()
+        seeded = _seed(session)
+        mock_agent_cls.return_value.analyze.return_value = self._rec(
+            seeded["fact"].table_id, seeded["fk_col"].column_id, "invoice_id__status"
+        )
+
+        result = SlicingPhase()._run(_ctx(session, duckdb_conn, [seeded["fact"].table_id], "run-A"))
+        assert result.status == PhaseStatus.COMPLETED
+        mock_agent_cls.return_value.analyze.assert_called_once()
+        session.commit()
+
+        row = session.execute(
+            select(SliceDefinition).where(SliceDefinition.column_name == "invoice_id__status")
+        ).scalar_one()
+        assert row.dimension_table_id == seeded["dim"].table_id
+        assert row.dimension_attribute == "status"
+        assert row.fk_role == "invoice_id"
+
+    def test_folded_slice_resolves_null_identity(
+        self,
+        mock_load_config: MagicMock,
+        mock_create_provider: MagicMock,
+        mock_renderer_cls: MagicMock,
+        mock_agent_cls: MagicMock,
+        session: Session,
+        duckdb_conn: duckdb.DuckDBPyConnection,
+    ) -> None:
+        """An own categorical column with no grain-safe FK resolves no identity."""
+        mock_load_config.return_value = _mock_llm_config()
+        seeded = _seed(session)
+        region = Column(
+            table_id=seeded["fact"].table_id,
+            column_name="region",
+            column_position=9,
+            resolved_type="VARCHAR",
+        )
+        session.add(region)
+        session.flush()
+        mock_agent_cls.return_value.analyze.return_value = self._rec(
+            seeded["fact"].table_id, region.column_id, "region"
+        )
+
+        result = SlicingPhase()._run(_ctx(session, duckdb_conn, [seeded["fact"].table_id], "run-A"))
+        assert result.status == PhaseStatus.COMPLETED
+        session.commit()
+
+        row = session.execute(
+            select(SliceDefinition).where(SliceDefinition.column_name == "region")
+        ).scalar_one()
+        assert row.dimension_table_id is None
+        assert row.dimension_attribute is None
+        assert row.fk_role is None

--- a/packages/engine/tests/unit/pipeline/test_slicing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_slicing_phase.py
@@ -871,3 +871,32 @@ class TestReferencedDimensionIdentity:
         assert row.dimension_table_id is None
         assert row.dimension_attribute is None
         assert row.fk_role is None
+
+    def test_slice_by_fk_key_itself_has_null_attribute(
+        self,
+        mock_load_config: MagicMock,
+        mock_create_provider: MagicMock,
+        mock_renderer_cls: MagicMock,
+        mock_agent_cls: MagicMock,
+        session: Session,
+        duckdb_conn: duckdb.DuckDBPyConnection,
+    ) -> None:
+        """Slicing directly by the FK key (no ``__`` enriched suffix) resolves the dim
+        table with a NULL attribute and fk_role = the column name — not a folded slice
+        (it still carries a referenced identity)."""
+        mock_load_config.return_value = _mock_llm_config()
+        seeded = _seed(session)
+        mock_agent_cls.return_value.analyze.return_value = self._rec(
+            seeded["fact"].table_id, seeded["fk_col"].column_id, "invoice_id"
+        )
+
+        result = SlicingPhase()._run(_ctx(session, duckdb_conn, [seeded["fact"].table_id], "run-A"))
+        assert result.status == PhaseStatus.COMPLETED
+        session.commit()
+
+        row = session.execute(
+            select(SliceDefinition).where(SliceDefinition.column_name == "invoice_id")
+        ).scalar_one()
+        assert row.dimension_table_id == seeded["dim"].table_id
+        assert row.dimension_attribute is None
+        assert row.fk_role == "invoice_id"

--- a/packages/engine/tests/unit/storage/test_property_graph.py
+++ b/packages/engine/tests/unit/storage/test_property_graph.py
@@ -41,9 +41,10 @@ def test_graph_statement_binds_each_element_view_with_keys() -> None:
     # Views have no primary key, so vertex KEY + edge SOURCE/DESTINATION KEY are mandatory.
     assert "KEY (table_id) LABEL table_node" in graph_sql
     assert "KEY (column_id) LABEL column_node" in graph_sql
-    # Four edges: refs, has_dimension, derived_from (P1) + concept_edge (DAT-729).
-    assert graph_sql.count("SOURCE KEY") == 4
-    assert graph_sql.count("DESTINATION KEY") == 4
+    # Five edges: refs, has_dimension, derived_from (P1), concept_edge (DAT-729),
+    # conformed_dimension (DAT-756).
+    assert graph_sql.count("SOURCE KEY") == 5
+    assert graph_sql.count("DESTINATION KEY") == 5
     # The measure→materialization MATCH (the P1 AC) reads these vertex properties.
     assert "semantic_role, materialization" in graph_sql
     # The concept_edge edge binds concept → concept, carrying the predicate property.
@@ -52,6 +53,10 @@ def test_graph_statement_binds_each_element_view_with_keys() -> None:
     assert "DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)" in graph_sql
     assert "LABEL concept_edge" in graph_sql
     assert "PROPERTIES (predicate, tolerance)" in graph_sql
+    # The conformed_dimension edge binds fact → fact over the shared dim identity.
+    assert "SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)" in graph_sql
+    assert "LABEL conformed_dimension" in graph_sql
+    assert "PROPERTIES (dimension_table_id, dimension_attribute)" in graph_sql
 
 
 def test_dump_drops_graph_before_its_element_views() -> None:

--- a/packages/engine/tests/unit/storage/test_property_graph.py
+++ b/packages/engine/tests/unit/storage/test_property_graph.py
@@ -53,11 +53,11 @@ def test_graph_statement_binds_each_element_view_with_keys() -> None:
     assert "DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)" in graph_sql
     assert "LABEL concept_edge" in graph_sql
     assert "PROPERTIES (predicate, tolerance)" in graph_sql
-    # The conformed_dimension edge binds fact → fact over the shared dim identity,
-    # carrying each side's slice level (table-grain complement of the refs exclusion).
+    # The conformed_dimension edge binds fact → fact over the shared dim AXIS
+    # (attribute grain — the alignable drill-across GROUP BY the SQL agents author).
     assert "SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)" in graph_sql
     assert "LABEL conformed_dimension" in graph_sql
-    assert "PROPERTIES (dimension_table_id, from_attribute, to_attribute)" in graph_sql
+    assert "PROPERTIES (dimension_table_id, dimension_attribute)" in graph_sql
 
 
 def test_dump_drops_graph_before_its_element_views() -> None:

--- a/packages/engine/tests/unit/storage/test_property_graph.py
+++ b/packages/engine/tests/unit/storage/test_property_graph.py
@@ -53,10 +53,11 @@ def test_graph_statement_binds_each_element_view_with_keys() -> None:
     assert "DESTINATION KEY (to_concept_id) REFERENCES og_concepts (concept_id)" in graph_sql
     assert "LABEL concept_edge" in graph_sql
     assert "PROPERTIES (predicate, tolerance)" in graph_sql
-    # The conformed_dimension edge binds fact → fact over the shared dim identity.
+    # The conformed_dimension edge binds fact → fact over the shared dim identity,
+    # carrying each side's slice level (table-grain complement of the refs exclusion).
     assert "SOURCE KEY (from_table_id) REFERENCES og_tables (table_id)" in graph_sql
     assert "LABEL conformed_dimension" in graph_sql
-    assert "PROPERTIES (dimension_table_id, dimension_attribute)" in graph_sql
+    assert "PROPERTIES (dimension_table_id, from_attribute, to_attribute)" in graph_sql
 
 
 def test_dump_drops_graph_before_its_element_views() -> None:


### PR DESCRIPTION
Foundation tier of the operating-model graph (DAT-725). Gives a dimension an **identity** — the FK-target dim table — so every consumer keys off it instead of the column name. Design: [DD/49938435](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/49938435).

## What changed
- **Referenced-dimension identity persisted on `slice_definitions`** (`slicing` phase): `dimension_table_id` / `dimension_attribute` / `fk_role`, resolved at slice-write from the enriched view's grain-safe relationship provenance — never from `column_name`. Folded slices resolve none.
- **`shared_dims` fix** (`analysis/lineage/processor.py`): the stock/flow witness now pairs facts by identity, not `column_name`. Closes a **live bug both ways** — the same dimension via differently-named FKs was never paired (witness silently never ran); unrelated same-named folded columns were paired. Role-playing FKs on one fact are all kept.
- **Operating-model graph**: new typed `conformed_dimension` edge (table→table, **attribute grain** — the alignable drill-across axis the SQL agents author over), identity properties on `has_dimension`, and the DAT-723 fan trap excluded from `references` (table-grain, decoupled). Rebuilds the DAT-729 capability that was reverted for name-matching.
- Schema re-dumped (`schema.sql` + `schema_graph.sql`), drizzle mirror re-pulled, `.claude/handoff.md` updated for eval.

## Verification
- 1986 unit + 14 integration (real PG19) green; mypy + ruff clean; schema-drift clean.
- **Both reviewers APPROVE** (senior + spec-compliance); the two review-round criticals (role-playing collision, conformed-edge grain) fixed with regression tests.
- **Live-smoke on the finance corpus** (once slicing was unblocked — see the sibling forced-tool-envelope PR): 15 slices with correct identity, stock-flow witness fires (`trial_balance` debit+credit reconcile), **12 conformed-dimension edges** at attribute grain via live PGQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)