### PR TITLE
fix(engine): forced-tool envelope unwrap + provider-level prompt dump (DAT-758/759)

### DIFF
--- a/packages/engine/src/dataraum/llm/providers/anthropic.py
+++ b/packages/engine/src/dataraum/llm/providers/anthropic.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import time
 from typing import Any, cast
@@ -14,6 +15,7 @@ from pydantic import BaseModel
 
 from dataraum.core.logging import get_logger
 from dataraum.core.models.base import Result
+from dataraum.llm.prompt_log import dump_prompt, dump_response
 from dataraum.llm.providers.base import (
     ConversationRequest,
     ConversationResponse,
@@ -503,10 +505,29 @@ class AnthropicProvider(LLMProvider):
                         }
                     )
                     coerced = original_input
+                    # Envelope unwrap (Sonnet 5 under a forced tool_choice): the model
+                    # intermittently wraps the WHOLE argument object under a single key
+                    # equal to the tool name — {"analyze_slicing": {<the real args>}}.
+                    # It is a valid tool call, but schema-validation at the call site
+                    # then finds no known top-level field and silently defaults every
+                    # field to empty (an empty ``recommendations`` list is
+                    # indistinguishable from "model declined"). This silently zeroed
+                    # slicing on a sampling-dependent fraction of runs → no slices →
+                    # dimension_hierarchies/aggregation_lineage/drivers all skipped, and
+                    # it hits EVERY forced-tool extractor (relationship judge,
+                    # reconciliation). Unwrap it here, once, for all of them.
+                    enveloped = coerced.get(block.name)
+                    if len(coerced) == 1 and isinstance(enveloped, dict):
+                        logger.warning(
+                            "tool_output_envelope_unwrapped",
+                            label=request.label,
+                            tool=block.name,
+                        )
+                        coerced = dict(enveloped)
                     tool_schema = schemas_by_name.get(block.name)
                     if tool_schema is not None:
                         coerced = _coerce_stringified_args(
-                            original_input, tool_schema, label=request.label
+                            coerced, tool_schema, label=request.label
                         )
                     tool_calls.append(
                         ToolCall(
@@ -539,6 +560,34 @@ class AnthropicProvider(LLMProvider):
                 output_tokens=usage.output_tokens,
                 cache_read_input_tokens=cache_read,
                 cache_creation_input_tokens=cache_creation,
+            )
+
+            # Dump the ACTUAL rendered prompt + the model's raw response (incl. the
+            # tool-call input) for EVERY call at the provider chokepoint — not just
+            # the graph agent (DAT-758/759 diag). Gated by settings.prompt_dump_dir
+            # (no-op otherwise); best-effort. This is the only way to see what a
+            # forced-tool extractor really returned: an EMPTY tool call is invisible
+            # in the token log (it reads the same as a rich one).
+            _label = request.label or "unlabeled"
+            _user = "\n\n".join(m.content for m in request.messages if isinstance(m.content, str))
+            _phash = hashlib.sha256(_user.encode("utf-8")).hexdigest()[:16]
+            dump_prompt(
+                label=_label,
+                key=_label,
+                prompt_hash=_phash,
+                system=request.system,
+                user=_user,
+                model=response.model,
+            )
+            _resp_body = text_content + "".join(
+                f"\n[tool_use {tc.name}]\n{json.dumps(tc.input, indent=2, default=str)}"
+                for tc in tool_calls
+            )
+            dump_response(
+                label=_label,
+                key=_label,
+                prompt_hash=_phash,
+                body=f"stop_reason={response.stop_reason}\n{_resp_body}",
             )
 
             return Result.ok(

--- a/packages/engine/tests/unit/llm/test_anthropic_provider.py
+++ b/packages/engine/tests/unit/llm/test_anthropic_provider.py
@@ -494,6 +494,35 @@ class TestStringifiedArgCoercion:
         )
         assert coerced == {"tables": [{"table_name": "t"}], "note": "n"}
 
+    def test_tool_name_envelope_is_unwrapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Sonnet 5 under a forced tool_choice intermittently wraps the WHOLE
+        # argument object under a single key equal to the TOOL NAME
+        # ({"emit": {<real args>}}). Left alone, schema-validation at the call
+        # site finds no known field and silently defaults every field to empty
+        # (the slicing "0 recommendations" flake). Unwrap it.
+        coerced = self._converse_with_tool_use(
+            monkeypatch, {"emit": {"tables": [{"table_name": "t"}], "note": "ok"}}
+        )
+        assert coerced == {"tables": [{"table_name": "t"}], "note": "ok"}
+
+    def test_envelope_unwrap_then_coerces_inner(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Unwrap composes with stringified-arg coercion: an enveloped inner whose
+        # container was itself stringified is still parsed.
+        coerced = self._converse_with_tool_use(
+            monkeypatch, {"emit": {"tables": '[{"table_name": "t"}]', "note": "ok"}}
+        )
+        assert coerced == {"tables": [{"table_name": "t"}], "note": "ok"}
+
+    def test_single_real_property_key_not_unwrapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A single-key input whose sole key is a real PROPERTY (not the tool name)
+        # is NOT an envelope — leave it (the list value passes coercion untouched).
+        coerced = self._converse_with_tool_use(
+            monkeypatch, {"tables": [{"table_name": "t"}]}
+        )
+        assert coerced == {"tables": [{"table_name": "t"}]}
+
 
 class TestPromptCaching:
     """The system prompt ships as a cached block (DAT-601): tools render before


### PR DESCRIPTION
## The bug (silent data loss)
Under a forced `tool_choice`, Sonnet 5 **intermittently wraps its output in a `{"<tool_name>": {...actual args...}}` envelope**. The provider passed that straight to `<Output>.model_validate(tool_call.input)`, which found no top-level field and — because the slicing output model's fields are all `default_factory=list` — **silently validated to zero recommendations**. No error, no dropped-record warning, indistinguishable in the token log from a rich response.

Consequence: the slicing agent produced **0 slices on a sampling-dependent fraction of runs** → `dimension_hierarchies` / `aggregation_lineage` / `drivers` all silently skipped ("no substrate"). It masqueraded as a nondeterministic LLM flake (Sonnet 5 ignores `temperature=0`), which is why it was hard to pin.

## Blast radius — all forced-tool extractors
Every forced-tool agent uses the same `model_validate(tool_call.input)` pattern, so all shared the vulnerability. Severity split:

| Agent | Output model | Envelope (before fix) |
|---|---|---|
| **slicing** | all-default | **SILENT zero** ← the failure |
| semantic (analyze_tables / annotate_columns) | `tables` required | loud `ValidationError` |
| cycles / validation / enrichment | required field | loud fail |

Only slicing was silent; the rest crash loud. The fix makes **all six** robust.

## The fix
1. **Unwrap the `{tool_name: {...}}` envelope at the provider chokepoint** (`converse`), before schema validation — one place, all agents.
2. **Wire prompt + response dumping at the same chokepoint** (was `graphs/agent.py`-only) so every agent's real prompt AND raw tool-call response are inspectable under `PROMPT_DUMP_DIR`. This is the observability that caught the bug (the raw response had all 6 recommendations, just enveloped).

## Verification
- `agent.analyze` on the real finance context: **0/5 → 5/5** returning recommendations.
- Full finance `begin_session` smoke: **0 → 15 slices**, stock/flow witness fires (`trial_balance` debit+credit reconcile at 1.0).
- +3 unit tests (envelope unwrap, unwrap-then-coerce, non-envelope single key); 50/50 provider tests pass; ruff + mypy clean.

## Relation to DAT-758/759
- **DAT-759** (trial_balance debit+credit reconciliation partial): both measures reconcile at 1.0 in the fixed smoke — worth confirming this closes it.
- **DAT-758** (header/line FK reversed): **separate** — the semantic output model has a `required` field, so an envelope crashes rather than reverses. The reversed direction is the judge genuinely mis-picking; it needs its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)