### PR TITLE
fix(engine): DAT-758 — orient confirmed FKs to the many→one convention

### DIFF
--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -88,6 +88,48 @@ def _resolve_cardinality(
     return None
 
 
+def _orient_fk_direction(
+    from_table_id: str,
+    from_col_id: str,
+    to_table_id: str,
+    to_col_id: str,
+    cardinality: str | None,
+    evidence: dict[str, Any],
+) -> tuple[str, str, str, str, str | None]:
+    """Orient a confirmed FK to the many→one convention (DAT-758).
+
+    The LLM judge emits the ``from``/``to`` direction and intermittently reverses
+    it (the header/line pair — ``journal_lines`` vs ``journal_entries`` — was seen
+    stored parent→child on the eval oracle). The persisted direction is NOT
+    cosmetic: ``og_references`` binds it verbatim as the graph edge, the cockpit
+    ``<relationships>`` block reads the directional fan-out caution off it, and the
+    referenced-dimension identity resolves ``from_column → to_table`` assuming
+    ``from`` is the fact FK (DAT-756). So orient it deterministically here.
+
+    The MEASURED cardinality (in the judge's ``from→to`` order — the candidate
+    lookup flips it per direction, and the fallback measures it that way) is the
+    reliable signal: when it reads ``one-to-many``, ``from`` is the ONE (parent/dim)
+    side, so swap the endpoints — and the directional evidence — to store
+    ``many-to-one`` child→parent. ``many-to-one`` is already correct; ``one-to-one``
+    is orientation-agnostic; ``many-to-many``/``None`` cannot be oriented. Mutates
+    ``evidence`` in place for the directional fields.
+    """
+    if cardinality != "one-to-many":
+        return from_table_id, from_col_id, to_table_id, to_col_id, cardinality
+    # RI is directional: left = fraction of FROM's values found in TO. After the
+    # swap the old TO becomes FROM, so left/right exchange.
+    left_ri = evidence.pop("left_referential_integrity", None)
+    right_ri = evidence.pop("right_referential_integrity", None)
+    if right_ri is not None:
+        evidence["left_referential_integrity"] = right_ri
+    if left_ri is not None:
+        evidence["right_referential_integrity"] = left_ri
+    # A many-to-one child→parent join matches each child row to exactly one parent
+    # — it never fans out (the one-to-many parent→child join did).
+    evidence["introduces_duplicates"] = False
+    return to_table_id, to_col_id, from_table_id, from_col_id, "many-to-one"
+
+
 def _build_candidate_metrics_lookup(
     relationship_candidates: list[dict[str, Any]] | None,
 ) -> dict[tuple[str, str, str, str], dict[str, Any]]:
@@ -755,6 +797,17 @@ def synthesize_and_store_tables(
                     to_table=rel.to_table,
                     error=str(e),
                 )
+
+        # DAT-758: orient to the FK convention (many→one, child→parent) from the
+        # measured cardinality before persisting. The judge intermittently reverses
+        # the direction, and every consumer that reads it assumes from = the many/
+        # fact side: og_references binds it verbatim, the conformed-dim slice identity
+        # resolves from_column → to_table, and the enrichment prompt's grain-safe
+        # marker (many-to-one/one-to-one) decides whether the join is offered at all —
+        # a reversed one-to-many FK is shown as NOT grain-safe and the dim join is lost.
+        from_table_id, from_col_id, to_table_id, to_col_id, cardinality = _orient_fk_direction(
+            from_table_id, from_col_id, to_table_id, to_col_id, cardinality, evidence
+        )
 
         rel_rows.append(
             {

--- a/packages/engine/tests/unit/analysis/semantic/test_orient_fk_direction.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_orient_fk_direction.py
@@ -1,0 +1,55 @@
+"""_orient_fk_direction — persist a confirmed FK many→one, child→parent (DAT-758).
+
+The LLM judge intermittently reverses the direction; the measured cardinality is
+the reliable signal. Every consumer that reads the stored direction assumes
+``from`` = the many/fact side (og_references, the conformed-dim slice identity, the
+enrichment prompt's grain-safe marker), so the persist orients it deterministically.
+"""
+
+from __future__ import annotations
+
+from dataraum.analysis.semantic.processor import _orient_fk_direction
+
+
+def test_one_to_many_is_flipped_to_many_to_one() -> None:
+    # Judge emitted parent→child (journal_entries → journal_lines): measured
+    # one-to-many. Flip so the row is many-to-one child→parent.
+    ev = {"left_referential_integrity": 0.6, "right_referential_integrity": 1.0}
+    ft, fc, tt, tc, card = _orient_fk_direction(
+        "entries_tbl", "entries_col", "lines_tbl", "lines_col", "one-to-many", ev
+    )
+    assert (ft, fc, tt, tc) == ("lines_tbl", "lines_col", "entries_tbl", "entries_col")
+    assert card == "many-to-one"
+    # Directional evidence follows the swap; RI(from→to) exchanges.
+    assert ev["left_referential_integrity"] == 1.0
+    assert ev["right_referential_integrity"] == 0.6
+    # A many-to-one child→parent join never fans out.
+    assert ev["introduces_duplicates"] is False
+
+
+def test_many_to_one_is_untouched() -> None:
+    ev = {"left_referential_integrity": 1.0}
+    result = _orient_fk_direction("a", "ac", "b", "bc", "many-to-one", ev)
+    assert result == ("a", "ac", "b", "bc", "many-to-one")
+    assert ev == {"left_referential_integrity": 1.0}  # unchanged
+
+
+def test_one_to_one_is_untouched() -> None:
+    # Orientation-agnostic — either endpoint is a valid ``from``.
+    result = _orient_fk_direction("a", "ac", "b", "bc", "one-to-one", {})
+    assert result == ("a", "ac", "b", "bc", "one-to-one")
+
+
+def test_unknown_cardinality_is_untouched() -> None:
+    # Cannot orient without a measured cardinality (no duckdb / not a candidate).
+    result = _orient_fk_direction("a", "ac", "b", "bc", None, {})
+    assert result == ("a", "ac", "b", "bc", None)
+
+
+def test_flip_handles_missing_ri_fields() -> None:
+    # No RI in evidence (metrics unavailable) — flip still swaps endpoints and
+    # sets the non-fan-out flag without inventing RI keys.
+    ev: dict[str, object] = {}
+    ft, fc, tt, tc, card = _orient_fk_direction("a", "ac", "b", "bc", "one-to-many", ev)
+    assert (ft, fc, tt, tc, card) == ("b", "bc", "a", "ac", "many-to-one")
+    assert ev == {"introduces_duplicates": False}


### PR DESCRIPTION
## The bug
The LLM-synthesis relationship persist (`semantic/processor.synthesize_and_store_tables`) stored the judge's `from`/`to` direction **verbatim** — there is no normalization to the FK convention (many→one, child→parent). `_resolve_cardinality` measures cardinality but never flips `from`/`to` to match it. The judge picks the right direction most runs but **intermittently reverses the header/line pair** (`journal_lines` ↔ `journal_entries`), which is the DAT-758 eval finding. Neither of the clean runs I collected reproduced it (confirming it's intermittent), but the reversal is a real engine outcome, not an eval flake.

## Why it's not cosmetic
The stored direction is read verbatim by:
- **`og_references`** — the property-graph edge orientation + its recursive-closure traversal;
- **the referenced-dimension identity** (DAT-756) — resolves `from_column → to_table` assuming `from` = the fact FK; a reversed FK breaks identity resolution for that dim;
- **the enrichment agent's prompt** — a join is marked grain-safe iff `cardinality ∈ {many-to-one, one-to-one}` (`enrichment_agent.py:203`). A reversed FK appears as `one-to-many` → **NOT grain-safe** → the LLM drops the dim join → the fact loses that enrichment (e.g. `journal_lines` loses its `entry_id__date`).

## The fix
Orient deterministically from the **measured** cardinality (reliable, in the judge's `from→to` order — the candidate lookup flips it per direction, the fallback measures it that way): when it reads `one-to-many`, `from` is the ONE/parent side, so swap the endpoints and the directional evidence (left/right RI exchange; a many-to-one child→parent join never fans out → `introduces_duplicates=False`) to store `many-to-one` child→parent. `many-to-one` is already correct; `one-to-one` is orientation-agnostic; `many-to-many`/`None` cannot be oriented.

## Tests
+5 unit tests (`test_orient_fk_direction.py`): flip case, many-to-one/one-to-one/None no-ops, missing-RI flip. 107 semantic unit tests pass; ruff + mypy clean.

Part of the DAT-758/759 umbrella (sibling: the forced-tool-envelope PR). This is the DAT-758 half; the reversal being intermittent is why it needs a deterministic orient rather than a prompt tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)