### PR TITLE
feat(hierarchies): DAT-761 — stack v4 dimension identity replaces distinct-ratio g3

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,62 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-761 — stack v4 dimension identity: DAT-757 gate stack replaces distinct-ratio g3
+
+**Branch:** `feat/dat-761-stack-v4-dimension-identity`. **The `dimension_hierarchies`
+phase's decision layer is replaced end-to-end and its candidate universe widened —
+re-run any calibration that consumes hierarchies/aliases (driver de-confounding
+included).** Folds the DAT-757 research verdicts (Jira 16265/66/67, 16300/02/03)
+into the engine.
+
+### What changed
+
+- **The distinct-count-ratio "g3" is GONE.** Edges are now decided by classic
+  row-g3 ≤ 0.01 (Kivinen–Mannila) + Goodman–Kruskal λ ≥ 0.5 (kills the
+  vacuous-skew class: ≥98%-dominant dependents) + a seeded permutation p with
+  Benjamini–Hochberg q ≤ 0.05 over each view's screened family. Aliases keep
+  pair-count g3 (both directions ≤ 0.01) + both-direction perm-p under the same
+  BH family. New pure-stats module `analysis/hierarchies/stats.py`.
+- **New structure kind `role`** (`dimension_hierarchies.kind`): a value-equality
+  near-copy (disagreement in (0, 5%]) is classified via disagreement-set
+  permutation tests (T1 membership vs contexts, T2 value concentration,
+  Bonferroni). ROLE pairs (bill-to vs sold-to) persist as `kind='role'`, are
+  never merged, and never stack as drill-down levels; undecidable near-copies
+  surface as `needs_confirmation` aliases instead of silently merging.
+- **Candidate universe = the enriched view's columns**, no longer the grain-safe
+  slice catalog. Measures are excluded by `semantic_role='measure'` (the
+  additivity lane); everything else is guarded data-grounded (null-aware
+  constant drop, near-key, λ), each exclusion logged. The upstream pipeline
+  `max_columns` limit is the only width cap. Null-coded columns (`{1, NULL}`)
+  are now eligible axes (null-as-category — the rel-hm FN/Active lesson).
+- **Scan grain:** guards + pair counts from a full-view scan (chunked O(k²)
+  aggregates); row statistics on an aligned in-memory sample (≤ 40M cells,
+  seeded reservoir) — a sampled fold key can never trip the near-key guard.
+- Phase precondition changed: requires a grain-verified enriched view (was:
+  slice definitions this run).
+
+### For eval (calibration to run)
+
+- **Hierarchy/alias recall on the calibration corpora** — structures can
+  legitimately CHANGE: spurious chains from the distinct-ratio vanish; role
+  near-copies stop merging; null-coded columns join alias groups. The DAT-757
+  matrix (32/32) + RelBench fold harness re-run against this implementation is
+  the acceptance gate (tracked on DAT-761).
+- **Driver rankings shift (correctly):** `drivers/_candidate_dims` collapses
+  alias groups — role pairs now stay separate competing axes instead of being
+  wrongly collapsed to one canonical.
+- New oracle surface: `kind='role'` rows (role-playing folded dims) — testdata's
+  role-FK fixtures (SALT-style bill-to/ship-to) can be graded directly.
+
+### testdata hints
+
+The 2b generator features already scoped on DAT-757 (partial-inline, false-friend
+collision, disjoint regions, folded-numeric) are exactly the fixtures this stack
+is calibrated against; a role-playing folded pair with channel-driven divergence
+exercises the `role` kind end-to-end.
+
+---
+
 ## DAT-756 — referenced-dimension identity + `shared_dims` fix + conformed-dimension
 
 **Branch:** `feat/dat-756-dimension-identity`. **A detector-grouping-key fix (closes a

--- a/packages/engine/src/dataraum/analysis/hierarchies/processor.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/processor.py
@@ -98,10 +98,10 @@ MIN_SUPPORT_ROWS = 100
 MAX_SAMPLE_CELLS = 40_000_000
 MIN_SAMPLE_ROWS = 50_000
 
-# Fixed seeds: the permutation null and the row sample must be identical across
-# Temporal success-redeliveries so the run-versioned upsert converges.
+# Fixed seed: the permutation null must be identical across Temporal
+# success-redeliveries so the run-versioned upsert converges (the row sample is
+# deterministic by construction — bottom-k-by-hash, see _pull_sample).
 _PERM_SEED = 20260714
-_SAMPLE_SEED = 757
 
 # COUNT(DISTINCT (a, b)) aggregates per scan statement — wide views chunk the
 # pair family across several single-scan queries instead of one giant SELECT.
@@ -273,17 +273,21 @@ def _pull_sample(
 ) -> pl.DataFrame | None:
     """An aligned VARCHAR sample of the candidate columns for the row statistics.
 
-    Full view when it fits ``MAX_SAMPLE_CELLS``; else a seeded reservoir sample
-    (row-level statistics are sample-honest — g3 exactness is subset-invariant —
-    while every guard reads the full-view scan, so a sampled fold key can never
-    trip the near-key guard: the rel-hm lesson).
+    Full view when it fits ``MAX_SAMPLE_CELLS``; else a bottom-k-by-hash sketch
+    (the DAT-571 drivers idiom: ``ORDER BY hash(cols) LIMIT n`` is a uniform
+    per-row sample that stays deterministic on the multi-threaded worker
+    connection, where ``USING SAMPLE … REPEATABLE`` only holds single-threaded).
+    Row-level statistics are sample-honest — g3 exactness is subset-invariant,
+    the permutation null is recomputed on the sample — while every guard reads
+    the full-view scan, so a sampled fold key can never trip the near-key guard
+    (the rel-hm lesson).
     """
     n_sample = max(MIN_SAMPLE_ROWS, MAX_SAMPLE_CELLS // max(len(cols), 1))
-    sample = (
-        f" USING SAMPLE reservoir({n_sample} ROWS) REPEATABLE ({_SAMPLE_SEED})"
-        if n_rows > n_sample
-        else ""
-    )
+    sample = ""
+    if n_rows > n_sample:
+        hash_cols = ", ".join(f'"{c}"' for c in cols)
+        sample = f" ORDER BY hash({hash_cols}) LIMIT {n_sample}"
+        logger.info("hierarchy_view_sampled", view=view_name, full_n=n_rows, sample_n=n_sample)
     select_cols = ", ".join(f'CAST("{c}" AS VARCHAR) AS "{c}"' for c in cols)
     try:
         table = duckdb_conn.execute(

--- a/packages/engine/src/dataraum/analysis/hierarchies/processor.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/processor.py
@@ -520,11 +520,36 @@ def _view_structures(
     strs = {c: frame.get_column(c).fill_null("␀").to_numpy() for c in eligible}
     n_sample = frame.height
 
+    # Null policy, edge arm (DAT-757 lane): a NULL is DATA when the column is
+    # null-coded (its value domain is degenerate — nullness carries the signal)
+    # and MISSINGNESS otherwise (join-miss / ragged rows) — edge statistics then
+    # use pairwise deletion, which rescues true edges under partial nulls
+    # without letting a sparse dependent assert from nothing (support floor).
+    null_coded = {c for c in eligible if scan.d_sql[c] <= 1 < scan.d2[c]}
+    null_mask = {
+        c: frame.get_column(c).is_null().to_numpy() for c in eligible if c not in null_coded
+    }
+
+    pair_arrays_cache: dict[tuple[str, str], tuple[np.ndarray, np.ndarray]] = {}
+
+    def edge_arrays(s: str, t: str) -> tuple[np.ndarray, np.ndarray]:
+        """(codes_s, codes_t) over the pairwise-complete rows for the edge arm."""
+        key = (s, t)
+        if key not in pair_arrays_cache:
+            masks = [null_mask[c] for c in (s, t) if c in null_mask]
+            if masks and (drop := np.logical_or.reduce(masks)).any():
+                keep = ~drop
+                pair_arrays_cache[key] = (codes[s][keep], codes[t][keep])
+            else:
+                pair_arrays_cache[key] = (codes[s], codes[t])
+        return pair_arrays_cache[key]
+
     g3_cache: dict[tuple[str, str], float] = {}
 
     def row_g3(a: str, b: str) -> float:
         if (a, b) not in g3_cache:
-            g3_cache[(a, b)] = stats.row_g3(codes[a], codes[b])
+            ca, cb = edge_arrays(a, b)
+            g3_cache[(a, b)] = stats.row_g3(ca, cb) if len(ca) else 1.0
         return g3_cache[(a, b)]
 
     # Full-scan determinant guards (a column may still be a dependent/coarsest
@@ -559,10 +584,20 @@ def _view_structures(
             for s, t in ((a, b), (b, a)):
                 if scan.d2[s] <= scan.d2[t] or s in bad_det:
                     continue
+                cs, ct = edge_arrays(s, t)
+                if len(cs) < MIN_SUPPORT_ROWS and len(cs) < n_sample:
+                    logger.info(
+                        "hierarchy_edge_excluded",
+                        determinant=s,
+                        dependent=t,
+                        reason="null_support",
+                        complete_rows=len(cs),
+                    )
+                    continue
                 if row_g3(s, t) > FD_MAX_G3:
                     continue
                 # -- 3. λ floor: the vacuous-skew kill (edge arm only) --------
-                lam = stats.gk_lambda(codes[s], codes[t])
+                lam = stats.gk_lambda(cs, ct)
                 if lam < LAMBDA_MIN:
                     logger.info(
                         "hierarchy_edge_excluded",
@@ -575,19 +610,22 @@ def _view_structures(
                 cand_edge.append((s, t))
 
     # -- 4. permutation p + BH over the view's screened family ----------------
-    p_cache: dict[tuple[str, str], float] = {}
+    # Edge tests run on the pairwise-complete rows their screen used; alias
+    # tests on the full null-as-category codes (pair-count semantics).
+    p_cache: dict[tuple[str, str, str], float] = {}
 
-    def perm_p(a: str, b: str) -> float:
-        if (a, b) not in p_cache:
-            p_cache[(a, b)] = stats.perm_pvalue(codes[a], codes[b], rng)
-        return p_cache[(a, b)]
+    def perm_p(arm: str, a: str, b: str) -> float:
+        if (arm, a, b) not in p_cache:
+            ca, cb = edge_arrays(a, b) if arm == "e" else (codes[a], codes[b])
+            p_cache[(arm, a, b)] = stats.perm_pvalue(ca, cb, rng)
+        return p_cache[(arm, a, b)]
 
     pvals: dict[tuple[str, str, str], float] = {}
     for a, b in cand_edge:
-        pvals[("e", a, b)] = perm_p(a, b)
+        pvals[("e", a, b)] = perm_p("e", a, b)
     for a, b in cand_alias:
         # A 1:1 claim needs significant dependence in BOTH directions.
-        pvals[("a", a, b)] = max(perm_p(a, b), perm_p(b, a))
+        pvals[("a", a, b)] = max(perm_p("a", a, b), perm_p("a", b, a))
     accepted = stats.bh_reject(pvals, m_family=max(1, len(pvals)), q=Q_FDR)
     acc_edges = {(a, b) for k, a, b in accepted if k == "e"}
     acc_alias = {(a, b) for k, a, b in accepted if k == "a"}

--- a/packages/engine/src/dataraum/analysis/hierarchies/processor.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/processor.py
@@ -1,33 +1,41 @@
-"""g3 functional-dependency / hierarchy discovery over the enriched views (DAT-537).
+"""Dimension-identity discovery over the enriched views (DAT-761, stack v4 from DAT-757).
 
-Deterministic, no LLM. For each fact's grain-verified enriched view, the catalog's
-grain-safe slice dimensions (DAT-536) are the candidate axes. One DuckDB scan per
-view computes every column's distinct count and every unordered pair's joint
-distinct count; from those the **approximate functional dependency** measure
+Deterministic, no LLM. For each fact's grain-verified enriched view, EVERY
+dimension-like view column is a candidate (measures excluded by their
+``semantic_role`` — the additivity lane: ``revenue → tier`` is reliably asserted
+by every statistic, so measures never enter FD discovery). The upstream pipeline
+``max_columns`` limit is the only width cap; all other exclusions are
+data-grounded guards, each logged (born-loud).
 
-    g3(A → B) = 1 − COUNT(DISTINCT A) / COUNT(DISTINCT (A, B))
+The decision layer is the DAT-757 gate stack (32/32 on the adversarial matrix,
+100% recoverable-truth recall on rel-f1/rel-hm/rel-salt folded by their own FK
+metadata — verdicts on DAT-757, build ticket DAT-761):
 
-is read for both directions of every pair (g3 = 0 ⇔ A determines B exactly). Edges
-become drill-down hierarchies (``zip → city → state``) after transitive reduction;
-bidirectional ``g3 ≈ 0`` pairs collapse into 1:1 alias groups (the redundant-axis
-dedup the DAT-545 driver tree needs to de-confound its ranking).
+1. **Null policy** — eligibility counts NULL as a category (a null-coded binary
+   ``{1, NULL}`` is a lane, not a silent constant-drop); row statistics use
+   null-as-category codes.
+2. **Effect screens** — EDGES: classic row-g3 ≤ 0.01 (``a`` determines ``b`` up
+   to a 1% dirty-row tolerance) + determinant guards; ALIASES: pair-count g3
+   ≤ 0.01 in both directions (the conservative semantics for near-copies).
+3. **Goodman–Kruskal λ ≥ 0.5** (edge arm) — kills the vacuous-skew class
+   (≥98%-dominant dependents pass g3 vacuously; exact FDs keep λ = 1).
+4. **Permutation p + Benjamini–Hochberg** (q ≤ 0.05) over the view's screened
+   family — what discovery ASSERTS. Seeded, so a redelivered run converges.
+5. **Disagreement-set role check** (alias arm) — value-equality near-copies
+   (0 < disagree ≤ 5%) are classified ROLE / VALUE-SYSTEMATIC / ABSTAIN / DIRT
+   from the disagreement set; a ROLE pair (bill-to vs pay-to) is persisted as
+   ``kind='role'`` and never merged; undecidable near-copies surface as
+   ``needs_confirmation`` aliases instead of being silently merged.
 
-Null semantics (documented bias): the per-column distinct counts ignore NULLs
-(SQL ``COUNT(DISTINCT)``) while the joint distinct count over a row literal counts
-``(a, NULL)`` as a present pair, so a column with NULLs inflates its joint count and
-its g3 — biasing toward MISSED dependencies (false negatives), never spurious ones.
-A missed edge is recoverable via teach; a spurious asserted hierarchy is not. Slice
-dimensions are categorical and typically non-null, so for the common case g3 is exact.
+Scan grain (the rel-hm lesson): guards and pair counts come from a FULL-view
+scan (a row sample makes fold keys look near-key); row-level statistics run on
+an aligned sample capped by ``MAX_SAMPLE_CELLS`` — inference is sample-honest,
+guards are exact.
 
-Candidate set = ALL this-run grain-safe catalog dims (deterministic; no priority
-cap — a cap would be arbitrary across runs and would drop axes DAT-545 must rank).
-Pruning is only by data-grounded guards: a constant column (< ``MIN_DISTINCT_DIMENSION``)
-is not an axis at all and is dropped from both roles; a too-coarse determinant
-(≤ 2 distinct) determines anything vacuously and a near-key determinant
-(≥ ``NEAR_KEY_FRAC`` of the rows distinct) manufactures a spurious FD, so both are
-rejected as DETERMINANTS (still allowed as a coarsest level). The candidate count and
-every guard exclusion are logged (born-loud): a pathologically wide view is a measured
-signal, never a silent cut.
+Edges become drill-down hierarchies (``zip → city → state``) after transitive
+reduction; merged alias groups collapse to one canonical axis (the redundant-axis
+dedup the DAT-545 driver tree consumes). Role pairs deliberately stay separate
+axes — collapsing them was the BILLTO↔PAYER over-merge the role check reverses.
 """
 
 from __future__ import annotations
@@ -35,14 +43,18 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+import numpy as np
+import polars as pl
 from sqlalchemy import select
 
+from dataraum.analysis.hierarchies import stats
 from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
 from dataraum.analysis.hierarchies.overlay import hierarchy_overlay_specs
-from dataraum.analysis.slicing.db_models import SliceDefinition
+from dataraum.analysis.hierarchies.stats import RoleVerdict
+from dataraum.analysis.semantic.db_models import SemanticAnnotation
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.core.logging import get_logger
-from dataraum.storage import Table
+from dataraum.storage import Column, Table
 from dataraum.storage.upsert import upsert
 
 if TYPE_CHECKING:
@@ -51,74 +63,218 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# g3 at or below this is treated as an exact functional dependency (allows a
-# small fraction of dirty-data violations). A true FD over clean data is g3 = 0.
+# Effect floor: g3 at or below this is an approximate FD (tolerates a small
+# fraction of dirty-data violations). A true FD over clean data is g3 = 0.
 FD_MAX_G3 = 0.01
 
-# A constant column (1 distinct) is not a usable axis at all: useless as a level
-# and trivially determined by everything (junk ``X → constant`` edges) — dropped
-# from BOTH roles. A 2-value column is a legitimate low-cardinality level (e.g. a
-# binary dimension, or the coarsest level when the data spans 2 states), so the
-# floor for being a candidate is 2.
+# Goodman–Kruskal λ floor for asserted edges: the determinant must explain at
+# least half the baseline (majority-vote) prediction error — the PRE midpoint,
+# pre-registered in DAT-757 before the RelBench run (48 vacuous extras killed,
+# 0 truth lost).
+LAMBDA_MIN = 0.5
+
+# BH false-discovery rate over one view's effect-screened candidate family.
+Q_FDR = 0.05
+
+# A near-copy pair (value-equality disagreement in (0, this]) takes the gate-#2
+# role check before it may merge. Above it, a bidirectional pair-g3 match is a
+# relabeling bijection (code ↔ name), not a near-copy — merge semantics differ.
+ROLE_MAX_DISAGREE = 0.05
+
+# Eligibility (null-aware: NULL counts as a category — the null-policy lane).
+# A 1-category column is not an axis; a 2-value column is a legitimate coarsest
+# level. Determinants must distinguish ≥ 3 values (non-vacuous) and be below the
+# near-key fraction (a near-unique column determines anything — spurious).
 MIN_DISTINCT_DIMENSION = 2
-# A DETERMINANT must distinguish enough values that the FD isn't trivial — a
-# ≤2-distinct determinant "determines" anything coarser vacuously (ticket guard) —
-# and at most ``NEAR_KEY_FRAC`` of the rows: a near-unique column is a key, every
-# value maps to one of anything, a spurious FD.
 MIN_DISTINCT_DETERMINANT = 3
 NEAR_KEY_FRAC = 0.9
 
-# Edges resting on fewer than this many rows are surfaced for confirmation
-# (``needs_confirmation``) rather than auto-asserted — too little support to trust.
+# Structures resting on fewer rows than this are surfaced for confirmation
+# (``needs_confirmation``) rather than auto-asserted.
 MIN_SUPPORT_ROWS = 100
+
+# Row-statistics working set: rows × candidate columns pulled into memory
+# (the DAT-580 drivers precedent). Guards never depend on the sample.
+MAX_SAMPLE_CELLS = 40_000_000
+MIN_SAMPLE_ROWS = 50_000
+
+# Fixed seeds: the permutation null and the row sample must be identical across
+# Temporal success-redeliveries so the run-versioned upsert converges.
+_PERM_SEED = 20260714
+_SAMPLE_SEED = 757
+
+# COUNT(DISTINCT (a, b)) aggregates per scan statement — wide views chunk the
+# pair family across several single-scan queries instead of one giant SELECT.
+_MAX_PAIR_AGGS = 500
 
 
 @dataclass(frozen=True)
-class _Pair:
-    """The g3 evidence for one unordered column pair over the enriched view."""
+class _Candidate:
+    """A resolved candidate dimension column on one enriched view."""
 
-    d_a: int  # distinct values of column a (NULLs ignored)
-    d_b: int  # distinct values of column b
-    d_ab: int  # distinct (a, b) pairs (row literal; NULL field counts as present)
-
-    def g3(self, *, forward: bool) -> float:
-        """The g3 of a → b (``forward``) or b → a. Empty pair → 1.0 (no FD)."""
-        if self.d_ab == 0:
-            return 1.0
-        return 1.0 - (self.d_a if forward else self.d_b) / self.d_ab
+    column_name: str  # the enriched-view column (member identity)
+    column_id: str  # the source column's catalog id (provenance; "" if unresolved)
 
 
-def _g3_scan(
+@dataclass
+class _ViewScan:
+    """Full-view scan facts: everything the guards and the alias arm need."""
+
+    n: int
+    d2: dict[str, int]  # null-aware distinct counts (NULL = one category)
+    d_sql: dict[str, int]  # SQL COUNT(DISTINCT) (null-blind; display metadata)
+    joints: dict[tuple[str, str], int]  # row-literal pair distincts, (a < b) key order
+
+    def pair_g3(self, a: str, b: str) -> tuple[float, float]:
+        """Pair-count g3 for (a → b, b → a), null-aware numerators."""
+        d_ab = self.joints[(a, b) if (a, b) in self.joints else (b, a)]
+        if d_ab == 0:
+            return 1.0, 1.0
+        return 1.0 - self.d2[a] / d_ab, 1.0 - self.d2[b] / d_ab
+
+
+def _view_columns(duckdb_conn: duckdb.DuckDBPyConnection, view_name: str) -> list[str] | None:
+    """The view's column names, or ``None`` if it is not queryable (logged)."""
+    try:
+        rows = duckdb_conn.execute(f'DESCRIBE "{view_name}"').fetchall()
+    except Exception as e:  # noqa: BLE001 — any DuckDB error → skip this view, logged
+        logger.warning("hierarchy_view_describe_failed", view=view_name, error=str(e))
+        return None
+    return [str(r[0]) for r in rows]
+
+
+def _resolve_candidates(
+    session: Session, ev: EnrichedView, view_cols: list[str]
+) -> dict[str, _Candidate]:
+    """Resolve view columns to source-column provenance and drop measures.
+
+    Fact-own columns resolve by name on the fact table; joined dim columns
+    (``{fk}__{attr}``, builder.py convention) resolve to the dim table's ``attr``
+    column via the exposed joins. An unresolvable column keeps ``column_id=""``
+    (it still participates — provenance is metadata, not a gate).
+
+    Measures are excluded BEFORE discovery (the additivity lane):
+    ``semantic_role`` is object-grain, read by ``column_id`` without a run filter
+    (the ``drivers/persistence.py`` convention).
+    """
+    fact_ids = {
+        c.column_name: c.column_id
+        for c in session.execute(
+            select(Column).where(Column.table_id == ev.fact_table_id)
+        ).scalars()
+    }
+    dim_table_by_fk: dict[str, str] = {
+        str(j["fact_fk_column"]): str(j["dim_table_name"])
+        for j in (ev.exposed_dimension_joins or [])
+    }
+    dim_ids: dict[tuple[str, str], str] = {}
+    if ev.dimension_table_ids:
+        name_by_id = {
+            t.table_id: t.table_name
+            for t in session.execute(
+                select(Table).where(Table.table_id.in_(ev.dimension_table_ids))
+            ).scalars()
+        }
+        for c in session.execute(
+            select(Column).where(Column.table_id.in_(ev.dimension_table_ids))
+        ).scalars():
+            tname = name_by_id.get(c.table_id)
+            if tname:
+                dim_ids[(tname, c.column_name)] = c.column_id
+
+    by_name: dict[str, _Candidate] = {}
+    for name in view_cols:
+        column_id = fact_ids.get(name, "")
+        if not column_id and "__" in name:
+            fk, attr = name.split("__", 1)
+            column_id = dim_ids.get((dim_table_by_fk.get(fk, ""), attr), "")
+        by_name[name] = _Candidate(column_name=name, column_id=column_id)
+
+    resolved = [c.column_id for c in by_name.values() if c.column_id]
+    measure_ids: set[str] = set()
+    if resolved:
+        measure_ids = set(
+            session.execute(
+                select(SemanticAnnotation.column_id).where(
+                    SemanticAnnotation.column_id.in_(resolved),
+                    SemanticAnnotation.semantic_role == "measure",
+                )
+            ).scalars()
+        )
+    for name in list(by_name):
+        if by_name[name].column_id in measure_ids:
+            logger.info("hierarchy_column_excluded", column=name, reason="measure")
+            del by_name[name]
+    return by_name
+
+
+def _scan_view(
     duckdb_conn: duckdb.DuckDBPyConnection, view_name: str, cols: list[str]
-) -> tuple[int, dict[str, int], dict[tuple[int, int], int]] | None:
-    """One scan: row count, per-column distinct counts, per-pair joint distincts.
+) -> _ViewScan | None:
+    """Full-view scan: row count, per-column distinct/null counts, pair distincts.
 
-    Returns ``(n_rows, {col: d_col}, {(i, j): d_ij})`` for ``i < j``, or ``None``
-    if the scan fails (logged) — the view is then skipped, a visible abstention.
+    Chunked — the pair family is O(k²) aggregates, split across single-scan
+    queries of ≤ ``_MAX_PAIR_AGGS`` each. Returns ``None`` on failure (logged) —
+    the view is then skipped, a visible abstention.
     """
     parts = ["COUNT(*) AS n"]
     parts += [f'COUNT(DISTINCT "{c}") AS d{i}' for i, c in enumerate(cols)]
-    pair_alias: dict[tuple[int, int], str] = {}
-    for i in range(len(cols)):
-        for j in range(i + 1, len(cols)):
-            alias = f"j_{i}_{j}"
-            pair_alias[(i, j)] = alias
-            parts.append(f'COUNT(DISTINCT ("{cols[i]}", "{cols[j]}")) AS {alias}')
-    sql = f'SELECT {", ".join(parts)} FROM "{view_name}"'  # noqa: S608 — names are catalog dims
+    parts += [f'COUNT("{c}") AS c{i}' for i, c in enumerate(cols)]
     try:
-        row = duckdb_conn.execute(sql).fetchone()
+        row = duckdb_conn.execute(
+            f'SELECT {", ".join(parts)} FROM "{view_name}"'  # noqa: S608 — catalog names
+        ).fetchone()
+        if row is None:
+            return None
+        n = int(row[0])
+        d_sql = {c: int(row[1 + i]) for i, c in enumerate(cols)}
+        non_null = {c: int(row[1 + len(cols) + i]) for i, c in enumerate(cols)}
+        d2 = {c: d_sql[c] + (1 if non_null[c] < n else 0) for c in cols}
+
+        pairs = [(cols[i], cols[j]) for i in range(len(cols)) for j in range(i + 1, len(cols))]
+        joints: dict[tuple[str, str], int] = {}
+        for start in range(0, len(pairs), _MAX_PAIR_AGGS):
+            chunk = pairs[start : start + _MAX_PAIR_AGGS]
+            sql = ", ".join(
+                f'COUNT(DISTINCT ("{a}", "{b}")) AS j{k}' for k, (a, b) in enumerate(chunk)
+            )
+            jrow = duckdb_conn.execute(f'SELECT {sql} FROM "{view_name}"')  # noqa: S608
+            fetched = jrow.fetchone()
+            if fetched is None:
+                return None
+            for k, pair in enumerate(chunk):
+                joints[pair] = int(fetched[k])
     except Exception as e:  # noqa: BLE001 — any DuckDB error → skip this view, logged
-        logger.warning("hierarchy_g3_scan_failed", view=view_name, error=str(e))
+        logger.warning("hierarchy_scan_failed", view=view_name, error=str(e))
         return None
-    if row is None:
+    return _ViewScan(n=n, d2=d2, d_sql=d_sql, joints=joints)
+
+
+def _pull_sample(
+    duckdb_conn: duckdb.DuckDBPyConnection, view_name: str, cols: list[str], n_rows: int
+) -> pl.DataFrame | None:
+    """An aligned VARCHAR sample of the candidate columns for the row statistics.
+
+    Full view when it fits ``MAX_SAMPLE_CELLS``; else a seeded reservoir sample
+    (row-level statistics are sample-honest — g3 exactness is subset-invariant —
+    while every guard reads the full-view scan, so a sampled fold key can never
+    trip the near-key guard: the rel-hm lesson).
+    """
+    n_sample = max(MIN_SAMPLE_ROWS, MAX_SAMPLE_CELLS // max(len(cols), 1))
+    sample = (
+        f" USING SAMPLE reservoir({n_sample} ROWS) REPEATABLE ({_SAMPLE_SEED})"
+        if n_rows > n_sample
+        else ""
+    )
+    select_cols = ", ".join(f'CAST("{c}" AS VARCHAR) AS "{c}"' for c in cols)
+    try:
+        table = duckdb_conn.execute(
+            f'SELECT {select_cols} FROM "{view_name}"{sample}'  # noqa: S608 — catalog names
+        ).arrow()
+    except Exception as e:  # noqa: BLE001 — any DuckDB error → skip this view, logged
+        logger.warning("hierarchy_sample_pull_failed", view=view_name, error=str(e))
         return None
-    n = int(row[0])
-    singles = {c: int(row[1 + i]) for i, c in enumerate(cols)}
-    # ``parts`` is n, then the k singles, then the joints in ``pair_alias`` order —
-    # so the j-th joint sits at offset ``1 + k + j`` (pair_alias is insertion-ordered).
-    offset = 1 + len(cols)
-    joints = {pair: int(row[offset + k]) for k, pair in enumerate(pair_alias)}
-    return n, singles, joints
+    return cast("pl.DataFrame", pl.from_arrow(table))
 
 
 def _transitive_reduction(edges: set[tuple[str, str]]) -> set[tuple[str, str]]:
@@ -178,54 +334,8 @@ def _maximal_chains(edges: set[tuple[str, str]]) -> list[list[str]]:
             walk([*path, nxt])
 
     for start in starts:
-        walk([start])
+        walk(path=[start])
     return chains
-
-
-@dataclass(frozen=True)
-class _Candidate:
-    """A resolved candidate dimension column on one enriched view."""
-
-    column_name: str  # the enriched-view column the g3 pass measures (member identity)
-    column_id: str  # the catalog SliceDefinition's underlying column (provenance)
-
-
-def _alias_groups(
-    names: list[str], pairs: dict[tuple[str, str], _Pair]
-) -> tuple[list[list[str]], dict[str, str]]:
-    """Union-find 1:1 aliases (bidirectional g3 ≈ 0) into groups.
-
-    Returns ``(groups, representative)``: ``groups`` lists each alias set (size ≥ 2,
-    sorted, canonical = first); ``representative`` maps every column to its canonical
-    so hierarchy detection runs on collapsed axes (a redundant axis never appears as
-    its own level).
-    """
-    parent = {n: n for n in names}
-
-    def find(x: str) -> str:
-        while parent[x] != x:
-            parent[x] = parent[parent[x]]
-            x = parent[x]
-        return x
-
-    def union(x: str, y: str) -> None:
-        rx, ry = find(x), find(y)
-        if rx != ry:
-            # Point the lexicographically smaller root at the larger; the group's
-            # canonical is recomputed as ``sorted(group)[0]`` below, so the exact
-            # link direction here is not load-bearing — only connectivity is.
-            parent[min(rx, ry)] = max(rx, ry)
-
-    for (a, b), pair in pairs.items():
-        if pair.g3(forward=True) <= FD_MAX_G3 and pair.g3(forward=False) <= FD_MAX_G3:
-            union(a, b)
-
-    members: dict[str, list[str]] = {}
-    for n in names:
-        members.setdefault(find(n), []).append(n)
-    groups = [sorted(g) for g in members.values() if len(g) >= 2]
-    representative = {n: sorted(g)[0] for g in members.values() for n in g}
-    return groups, representative
 
 
 def discover_dimension_hierarchies(
@@ -235,10 +345,11 @@ def discover_dimension_hierarchies(
     table_ids: list[str],
     run_id: str,
 ) -> int:
-    """Compute g3 hierarchies + aliases over each enriched view; persist run-versioned.
+    """Run the stack-v4 identity pass over each enriched view; persist run-versioned.
 
     Form-(a) writer (DAT-502): one row per ``(signature, run_id)``, UPSERTed;
-    deterministic, so a redelivered run converges. Returns the rows persisted.
+    deterministic (fixed permutation/sample seeds), so a redelivered run
+    converges. Returns the rows persisted.
     """
     enriched = (
         session.execute(
@@ -256,24 +367,15 @@ def discover_dimension_hierarchies(
     }
 
     rows: list[dict[str, object]] = []
+    col_ids_by_table: dict[str, dict[str, str]] = {}
     for ev in enriched:
-        defs = (
-            session.execute(
-                select(SliceDefinition).where(
-                    SliceDefinition.table_id == ev.fact_table_id,
-                    SliceDefinition.run_id == run_id,
-                    SliceDefinition.column_name.isnot(None),
-                )
-            )
-            .scalars()
-            .all()
+        view_cols = _view_columns(duckdb_conn, ev.view_name)
+        if view_cols is None:
+            continue
+        by_name = _resolve_candidates(session, ev, view_cols)
+        col_ids_by_table.setdefault(ev.fact_table_id, {}).update(
+            {c.column_name: c.column_id for c in by_name.values()}
         )
-        # Dedup by enriched column name (the propagation pass can emit a dim twice).
-        by_name: dict[str, _Candidate] = {}
-        for sd in defs:
-            name = sd.column_name or ""
-            if name and name not in by_name:
-                by_name[name] = _Candidate(column_name=name, column_id=sd.column_id)
         cand_names = sorted(by_name)
         if len(cand_names) < 2:
             continue
@@ -286,8 +388,11 @@ def discover_dimension_hierarchies(
             n_candidates=len(cand_names),
         )
 
-        scan = _g3_scan(duckdb_conn, ev.view_name, cand_names)
+        scan = _scan_view(duckdb_conn, ev.view_name, cand_names)
         if scan is None:
+            continue
+        frame = _pull_sample(duckdb_conn, ev.view_name, cand_names, scan.n)
+        if frame is None:
             continue
         rows.extend(
             _view_structures(
@@ -295,60 +400,37 @@ def discover_dimension_hierarchies(
                 view_name=ev.view_name,
                 run_id=run_id,
                 by_name=by_name,
-                cand_names=cand_names,
                 scan=scan,
+                frame=frame,
             )
         )
 
     # Fold the user's durable hierarchy/alias teaches into this run (DAT-537),
     # mirroring relationship-overlay materialization minus keeper-lift-up + witness
-    # (g3 is deterministic). reject suppresses a g3 structure; add/alias assert one.
-    rows = _apply_teaches(session, rows, table_ids=table_ids, run_id=run_id)
+    # (the stack is deterministic). reject suppresses a discovered structure;
+    # add/alias assert one.
+    rows = _apply_teaches(session, rows, col_ids_by_table=col_ids_by_table, run_id=run_id)
 
     upsert(session, DimensionHierarchy, rows, index_elements=["signature", "run_id"])
     return len(rows)
-
-
-def _member_column_ids(
-    session: Session, table_ids: list[str], run_id: str
-) -> dict[str, dict[str, str]]:
-    """``table_id -> {column_name: column_id}`` from this run's slice catalog.
-
-    Resolves a manual teach's member columns to their catalog column ids; a member
-    the catalog doesn't carry (a forced edge on an excluded/unknown column) resolves
-    to ``""`` rather than failing the teach.
-    """
-    out: dict[str, dict[str, str]] = {}
-    for sd in (
-        session.execute(
-            select(SliceDefinition).where(
-                SliceDefinition.table_id.in_(table_ids),
-                SliceDefinition.run_id == run_id,
-                SliceDefinition.column_name.isnot(None),
-            )
-        )
-        .scalars()
-        .all()
-    ):
-        if sd.column_name:
-            out.setdefault(sd.table_id, {})[sd.column_name] = sd.column_id
-    return out
 
 
 def _apply_teaches(
     session: Session,
     rows: list[dict[str, object]],
     *,
-    table_ids: list[str],
+    col_ids_by_table: dict[str, dict[str, str]],
     run_id: str,
 ) -> list[dict[str, object]]:
-    """Apply reject / add / alias hierarchy overlays to the g3 row set.
+    """Apply reject / add / alias hierarchy overlays to the discovered row set.
 
-    reject drops the g3 structure with a matching ``(table_id, member-set)``
-    (kind-agnostic — a member-set is one structure); add asserts a ``manual``
-    drilldown, alias a ``manual`` alias. A manual assert overrides a same-signature
-    g3 row (clears ``needs_confirmation``). Keyed by signature so the result stays
-    one row per ``(signature, run_id)``.
+    reject drops the structure with a matching ``(table_id, member-set)``
+    (kind-agnostic — a member-set is one structure, drilldown, alias or role);
+    add asserts a ``manual`` drilldown, alias a ``manual`` alias. A manual assert
+    overrides a same-signature discovered row (clears ``needs_confirmation``).
+    Member column ids resolve through the candidate maps built during discovery;
+    a member outside the candidate universe resolves to ``""`` rather than
+    failing the teach.
     """
     by_sig: dict[str, dict[str, object]] = {str(r["signature"]): r for r in rows}
 
@@ -360,7 +442,7 @@ def _apply_teaches(
     # re-queries per action, so load each once).
     specs = {a: hierarchy_overlay_specs(session, a) for a in ("reject", "add", "alias")}
 
-    # reject: drop any g3 structure whose table + member-set matches.
+    # reject: drop any discovered structure whose table + member-set matches.
     rejected: set[tuple[str, frozenset[str]]] = {
         (spec.table_id, frozenset(spec.members)) for spec in specs["reject"]
     }
@@ -372,14 +454,13 @@ def _apply_teaches(
         }
 
     # add → manual drilldown, alias → manual alias (ordered members preserved).
-    col_ids = _member_column_ids(session, table_ids, run_id)
     for action, kind in (("add", "drilldown"), ("alias", "alias")):
         for spec in specs[action]:
             members = spec.members
             if kind == "drilldown" and len(members) < 2:
                 logger.info("hierarchy_teach_skipped", reason="drilldown_needs_2_levels", spec=spec)
                 continue
-            names = col_ids.get(spec.table_id, {})
+            names = col_ids_by_table.get(spec.table_id, {})
             sig = f"{kind}:{spec.table_id}:" + "|".join(sorted(members))
             by_sig[sig] = {
                 "run_id": run_id,
@@ -408,98 +489,212 @@ def _view_structures(
     view_name: str,
     run_id: str,
     by_name: dict[str, _Candidate],
-    cand_names: list[str],
-    scan: tuple[int, dict[str, int], dict[tuple[int, int], int]],
+    scan: _ViewScan,
+    frame: pl.DataFrame,
 ) -> list[dict[str, object]]:
-    """The drill-down + alias row dicts for one enriched view from its g3 scan.
+    """The drill-down + alias + role row dicts for one enriched view (stack v4).
 
     A module-level helper (not a closure in the per-view loop) so its inner
     functions bind these parameters, not loop variables.
     """
-    n_rows, singles, joints = scan
-    pairs: dict[tuple[str, str], _Pair] = {
-        (cand_names[i], cand_names[j]): _Pair(
-            d_a=singles[cand_names[i]], d_b=singles[cand_names[j]], d_ab=d_ij
-        )
-        for (i, j), d_ij in joints.items()
-    }
+    cand_names = sorted(by_name)
+    rng = np.random.default_rng(_PERM_SEED)
 
-    # Constant columns (< MIN_DISTINCT_DIMENSION distinct) are dropped from BOTH
-    # roles: not a meaningful axis, and as a DEPENDENT a constant is trivially
-    # determined by everything, manufacturing junk edges. Born-loud on each drop.
-    eligible = [c for c in cand_names if singles[c] >= MIN_DISTINCT_DIMENSION]
+    # -- 1. null policy + eligibility (born-loud on every drop) --------------
+    eligible: list[str] = []
     for c in cand_names:
-        if singles[c] < MIN_DISTINCT_DIMENSION:
+        if scan.d2[c] < MIN_DISTINCT_DIMENSION:
             logger.info(
-                "hierarchy_column_excluded", column=c, reason="constant", distinct=singles[c]
+                "hierarchy_column_excluded", column=c, reason="constant", distinct=scan.d2[c]
             )
+            continue
+        if scan.d_sql[c] <= 1 < scan.d2[c]:
+            # Null-coded column ({value, NULL}): SQL sees a constant, the null
+            # lane keeps it — NULL is a category for every row statistic below.
+            logger.info("hierarchy_null_coded_column", column=c, distinct_sql=scan.d_sql[c])
+        eligible.append(c)
     if len(eligible) < 2:
         return []
-    elig_pairs = {(a, b): p for (a, b), p in pairs.items() if a in eligible and b in eligible}
 
-    # Collapse 1:1 aliases first, then detect hierarchies on canonical axes.
-    groups, rep = _alias_groups(eligible, elig_pairs)
+    codes = {c: stats.codes_of(frame.get_column(c)) for c in eligible}
+    strs = {c: frame.get_column(c).fill_null("␀").to_numpy() for c in eligible}
+    n_sample = frame.height
 
-    # A column is rejected as a DETERMINANT (it may still be a dependent/coarsest
-    # level) when it is too coarse to determine non-trivially (≤2 distinct) or
-    # near-key (each value ~unique → spurious FD). Born-loud on every exclusion.
-    def _bad_determinant(col: str) -> bool:
-        d = singles[col]
+    g3_cache: dict[tuple[str, str], float] = {}
+
+    def row_g3(a: str, b: str) -> float:
+        if (a, b) not in g3_cache:
+            g3_cache[(a, b)] = stats.row_g3(codes[a], codes[b])
+        return g3_cache[(a, b)]
+
+    # Full-scan determinant guards (a column may still be a dependent/coarsest
+    # level), born-loud once per column. Full-view distincts, never the sample —
+    # a sampled fold key must not read as near-key (the rel-hm lesson).
+    bad_det: set[str] = set()
+    for c in eligible:
+        d = scan.d2[c]
         if d < MIN_DISTINCT_DETERMINANT:
             logger.info(
-                "hierarchy_determinant_excluded", column=col, reason="too_coarse", distinct=d
+                "hierarchy_determinant_excluded", column=c, reason="too_coarse", distinct=d
             )
-            return True
-        if n_rows and d >= NEAR_KEY_FRAC * n_rows:
+            bad_det.add(c)
+        elif scan.n and d >= NEAR_KEY_FRAC * scan.n:
             logger.info(
                 "hierarchy_determinant_excluded",
-                column=col,
+                column=c,
                 reason="near_key",
                 distinct=d,
-                rows=n_rows,
+                rows=scan.n,
             )
-            return True
-        return False
+            bad_det.add(c)
 
-    # Directed FD edges on canonical reps: a → b when a determines b (g3 ≈ 0)
-    # AND a is strictly finer (more distinct) — finest → coarsest drill direction.
-    edges: set[tuple[str, str]] = set()
-    for (a, b), pair in elig_pairs.items():
-        ra, rb = rep[a], rep[b]
-        if ra == rb:  # same alias group — not a level relationship
-            continue
-        fwd, bwd = pair.g3(forward=True), pair.g3(forward=False)
-        if fwd <= FD_MAX_G3 and pair.d_a > pair.d_b and not _bad_determinant(a):
-            edges.add((ra, rb))
-        elif bwd <= FD_MAX_G3 and pair.d_b > pair.d_a and not _bad_determinant(b):
-            edges.add((rb, ra))
+    # -- 2. effect screens ----------------------------------------------------
+    cand_alias: list[tuple[str, str]] = []
+    cand_edge: list[tuple[str, str]] = []
+    for i, a in enumerate(eligible):
+        for b in eligible[i + 1 :]:
+            fwd, bwd = scan.pair_g3(a, b)
+            if fwd <= FD_MAX_G3 and bwd <= FD_MAX_G3:
+                cand_alias.append((a, b))
+            for s, t in ((a, b), (b, a)):
+                if scan.d2[s] <= scan.d2[t] or s in bad_det:
+                    continue
+                if row_g3(s, t) > FD_MAX_G3:
+                    continue
+                # -- 3. λ floor: the vacuous-skew kill (edge arm only) --------
+                lam = stats.gk_lambda(codes[s], codes[t])
+                if lam < LAMBDA_MIN:
+                    logger.info(
+                        "hierarchy_edge_excluded",
+                        determinant=s,
+                        dependent=t,
+                        reason="vacuous_skew",
+                        gk_lambda=round(lam, 3),
+                    )
+                    continue
+                cand_edge.append((s, t))
 
-    reduced = _transitive_reduction(edges)
+    # -- 4. permutation p + BH over the view's screened family ----------------
+    p_cache: dict[tuple[str, str], float] = {}
 
-    # Per-edge g3 (on the original measured columns behind each rep) for scoring.
-    # ``pairs`` keys are always (lex-smaller, lex-larger) because
-    # ``cand_names = sorted(by_name)`` — so ``forward=(a, b) in pairs`` resolves
-    # which endpoint is ``d_a`` in the stored ``_Pair``. (If cand_names ever stops
-    # being lexicographically sorted, this direction test must be revisited.)
-    def _edge_g3(a: str, b: str) -> float:
-        pair = pairs.get((a, b)) or pairs.get((b, a))
-        if pair is None:
-            return 0.0
-        return pair.g3(forward=(a, b) in pairs)
+    def perm_p(a: str, b: str) -> float:
+        if (a, b) not in p_cache:
+            p_cache[(a, b)] = stats.perm_pvalue(codes[a], codes[b], rng)
+        return p_cache[(a, b)]
+
+    pvals: dict[tuple[str, str, str], float] = {}
+    for a, b in cand_edge:
+        pvals[("e", a, b)] = perm_p(a, b)
+    for a, b in cand_alias:
+        # A 1:1 claim needs significant dependence in BOTH directions.
+        pvals[("a", a, b)] = max(perm_p(a, b), perm_p(b, a))
+    accepted = stats.bh_reject(pvals, m_family=max(1, len(pvals)), q=Q_FDR)
+    acc_edges = {(a, b) for k, a, b in accepted if k == "e"}
+    acc_alias = {(a, b) for k, a, b in accepted if k == "a"}
+
+    # -- 5. disagreement-set role check on near-copies (alias arm) ------------
+    needs_conf = scan.n < MIN_SUPPORT_ROWS
+    out: list[dict[str, object]] = []
+    merged: list[tuple[str, str]] = []
+    # A near-copy pair that is NOT merged (role / undecidable) is the same domain
+    # seen twice — never a level relationship. Its direct edge (a near-identity FD
+    # that trivially passes the edge screen) is suppressed at assembly.
+    same_domain: set[frozenset[str]] = set()
 
     def _member(col: str) -> dict[str, object]:
         c = by_name[col]
         return {
             "column_name": c.column_name,
             "column_id": c.column_id,
-            "distinct_count": singles[col],
+            "distinct_count": scan.d2[col],
         }
 
-    needs_conf = n_rows < MIN_SUPPORT_ROWS
-    out: list[dict[str, object]] = []
+    for a, b in sorted(acc_alias):
+        dis = (strs[a] != strs[b]).astype(np.int64)
+        rate = float(dis.mean())
+        if rate == 0.0 or rate > ROLE_MAX_DISAGREE:
+            # Exact copy, or a relabeling bijection (code ↔ name): a true alias.
+            merged.append((a, b))
+            continue
+        contexts = {c: codes[c] for c in eligible if c not in (a, b)}
+        result = stats.role_verdict(dis, contexts, codes[b], rng)
+        logger.info(
+            "hierarchy_role_check",
+            a=a,
+            b=b,
+            verdict=result.verdict.value,
+            disagree_rate=round(rate, 5),
+            k=result.k_disagree,
+            t1_p=result.t1_p,
+            t1_context=result.t1_context,
+            t2_p=result.t2_p,
+        )
+        if result.verdict is RoleVerdict.DIRT:
+            merged.append((a, b))
+            continue
+        same_domain.add(frozenset((a, b)))
+        if result.verdict is RoleVerdict.ROLE:
+            group = sorted((a, b))
+            out.append(
+                {
+                    "run_id": run_id,
+                    "table_id": fact_table_id,
+                    "kind": "role",
+                    "members": [_member(c) for c in group],
+                    "canonical_label": f"{group[0]} ⇄ {group[1]}",
+                    "signature": f"role:{fact_table_id}:" + "|".join(group),
+                    "score": rate,
+                    "detection_source": "g3",
+                    "needs_confirmation": needs_conf,
+                }
+            )
+            continue
+        # VALUE_SYSTEMATIC / ABSTAIN: undecidable from data — surface, don't merge.
+        group = sorted((a, b))
+        out.append(
+            {
+                "run_id": run_id,
+                "table_id": fact_table_id,
+                "kind": "alias",
+                "members": [_member(c) for c in group],
+                "canonical_label": group[0],
+                "signature": f"alias:{fact_table_id}:" + "|".join(group),
+                "score": rate,
+                "detection_source": "g3",
+                "needs_confirmation": True,
+            }
+        )
+
+    # -- 6. assemble: union-find → edges on reps → reduction → chains ---------
+    parent = {c: c for c in eligible}
+
+    def find(x: str) -> str:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b in merged:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[min(ra, rb)] = max(ra, rb)
+    members: dict[str, list[str]] = {}
+    for c in eligible:
+        members.setdefault(find(c), []).append(c)
+    groups = [sorted(g) for g in members.values() if len(g) >= 2]
+    rep = {c: sorted(g)[0] for g in members.values() for c in g}
+
+    edges: set[tuple[str, str]] = set()
+    for a, b in acc_edges:
+        if frozenset((a, b)) in same_domain:
+            continue
+        ra, rb = rep[a], rep[b]
+        if ra != rb:
+            edges.add((ra, rb))
+    reduced = _transitive_reduction(edges)
 
     for chain in _maximal_chains(reduced):
-        score = max(_edge_g3(chain[k], chain[k + 1]) for k in range(len(chain) - 1))
+        score = max(row_g3(chain[k], chain[k + 1]) for k in range(len(chain) - 1))
         out.append(
             {
                 "run_id": run_id,
@@ -516,11 +711,12 @@ def _view_structures(
         logger.info("hierarchy_drilldown", view=view_name, chain=chain, score=round(score, 4))
 
     for group in groups:
-        # Representative-pair score. For a 3+ member group every pair already passed
-        # the alias threshold in union-find, so the first pair's g3 bounds the group
-        # (≤ FD_MAX_G3) — a faithful, conservative score.
-        gpair = pairs.get((group[0], group[1])) or pairs.get((group[1], group[0]))
-        score = max(gpair.g3(forward=True), gpair.g3(forward=False)) if gpair else 0.0
+        pair_scores = [
+            max(scan.pair_g3(group[i], group[j]))
+            for i in range(len(group))
+            for j in range(i + 1, len(group))
+            if (group[i], group[j]) in scan.joints or (group[j], group[i]) in scan.joints
+        ]
         out.append(
             {
                 "run_id": run_id,
@@ -529,11 +725,22 @@ def _view_structures(
                 "members": [_member(c) for c in group],
                 "canonical_label": group[0],
                 "signature": f"alias:{fact_table_id}:" + "|".join(sorted(group)),
-                "score": score,
+                "score": max(pair_scores) if pair_scores else 0.0,
                 "detection_source": "g3",
                 "needs_confirmation": needs_conf,
             }
         )
-        logger.info("hierarchy_alias", view=view_name, group=group, score=round(score, 4))
+        logger.info("hierarchy_alias", view=view_name, group=group)
 
+    logger.info(
+        "hierarchy_view_decided",
+        view=view_name,
+        n_rows=scan.n,
+        n_sample=n_sample,
+        eligible=len(eligible),
+        screened_edges=len(cand_edge),
+        screened_aliases=len(cand_alias),
+        asserted_edges=len(acc_edges),
+        merged_aliases=len(merged),
+    )
     return out

--- a/packages/engine/src/dataraum/analysis/hierarchies/processor.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/processor.py
@@ -123,11 +123,19 @@ class _ViewScan:
     n: int
     d2: dict[str, int]  # null-aware distinct counts (NULL = one category)
     d_sql: dict[str, int]  # SQL COUNT(DISTINCT) (null-blind; display metadata)
-    joints: dict[tuple[str, str], int]  # row-literal pair distincts, (a < b) key order
+    # Row-literal pair distincts, (a < b) key order. Only ALIAS-SATISFIABLE pairs
+    # are scanned: d_ab ≥ max(d2) always, so bidirectional pair-g3 ≤ 0.01 forces
+    # the two distinct counts within 1% of each other — every other pair is
+    # pruned from the O(k²) joint family without changing any decision.
+    joints: dict[tuple[str, str], int]
 
     def pair_g3(self, a: str, b: str) -> tuple[float, float]:
-        """Pair-count g3 for (a → b, b → a), null-aware numerators."""
-        d_ab = self.joints[(a, b) if (a, b) in self.joints else (b, a)]
+        """Pair-count g3 for (a → b, b → a), null-aware numerators.
+
+        A pair pruned from the joint scan cannot satisfy the alias screen —
+        it reads as (1.0, 1.0), never an alias.
+        """
+        d_ab = self.joints.get((a, b) if (a, b) in self.joints else (b, a), 0)
         if d_ab == 0:
             return 1.0, 1.0
         return 1.0 - self.d2[a] / d_ab, 1.0 - self.d2[b] / d_ab
@@ -231,7 +239,17 @@ def _scan_view(
         non_null = {c: int(row[1 + len(cols) + i]) for i, c in enumerate(cols)}
         d2 = {c: d_sql[c] + (1 if non_null[c] < n else 0) for c in cols}
 
-        pairs = [(cols[i], cols[j]) for i in range(len(cols)) for j in range(i + 1, len(cols))]
+        # Joint distincts serve ONLY the alias screen, and d_ab ≥ max(d2_a, d2_b)
+        # makes bidirectional g3 ≤ FD_MAX_G3 impossible unless the two distinct
+        # counts sit within that tolerance of each other — prune the rest (on
+        # wide/large views this cuts the O(k²) aggregate family by orders of
+        # magnitude with zero semantic change).
+        pairs = [
+            (cols[i], cols[j])
+            for i in range(len(cols))
+            for j in range(i + 1, len(cols))
+            if max(d2[cols[i]], d2[cols[j]]) <= min(d2[cols[i]], d2[cols[j]]) / (1.0 - FD_MAX_G3)
+        ]
         joints: dict[tuple[str, str], int] = {}
         for start in range(0, len(pairs), _MAX_PAIR_AGGS):
             chunk = pairs[start : start + _MAX_PAIR_AGGS]

--- a/packages/engine/src/dataraum/analysis/hierarchies/processor.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/processor.py
@@ -568,9 +568,7 @@ def _view_structures(
     for c in eligible:
         d = scan.d2[c]
         if d < MIN_DISTINCT_DETERMINANT:
-            logger.info(
-                "hierarchy_determinant_excluded", column=c, reason="too_coarse", distinct=d
-            )
+            logger.info("hierarchy_determinant_excluded", column=c, reason="too_coarse", distinct=d)
             bad_det.add(c)
         elif scan.n and d >= NEAR_KEY_FRAC * scan.n:
             logger.info(

--- a/packages/engine/src/dataraum/analysis/hierarchies/processor.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/processor.py
@@ -530,25 +530,34 @@ def _view_structures(
         c: frame.get_column(c).is_null().to_numpy() for c in eligible if c not in null_coded
     }
 
-    pair_arrays_cache: dict[tuple[str, str], tuple[np.ndarray, np.ndarray]] = {}
+    pair_arrays_cache: dict[tuple[str, str], tuple[np.ndarray, np.ndarray, int, int]] = {}
 
-    def edge_arrays(s: str, t: str) -> tuple[np.ndarray, np.ndarray]:
-        """(codes_s, codes_t) over the pairwise-complete rows for the edge arm."""
+    def edge_arrays(s: str, t: str) -> tuple[np.ndarray, np.ndarray, int, int]:
+        """(codes_s, codes_t, d_s, d_t) over the pairwise-complete rows (edge arm).
+
+        The distinct counts are taken on the SAME rows the statistics run on —
+        full-view null-aware counts would let a null-degraded copy of a level
+        read as strictly finer (its NULL category inflates the count by one) and
+        interpose as a fake level between its base and the base's determinant.
+        """
         key = (s, t)
         if key not in pair_arrays_cache:
             masks = [null_mask[c] for c in (s, t) if c in null_mask]
             if masks and (drop := np.logical_or.reduce(masks)).any():
                 keep = ~drop
-                pair_arrays_cache[key] = (codes[s][keep], codes[t][keep])
+                cs, ct = codes[s][keep], codes[t][keep]
+                d_s = len(np.unique(cs)) if len(cs) else 0
+                d_t = len(np.unique(ct)) if len(ct) else 0
+                pair_arrays_cache[key] = (cs, ct, d_s, d_t)
             else:
-                pair_arrays_cache[key] = (codes[s], codes[t])
+                pair_arrays_cache[key] = (codes[s], codes[t], scan.d2[s], scan.d2[t])
         return pair_arrays_cache[key]
 
     g3_cache: dict[tuple[str, str], float] = {}
 
     def row_g3(a: str, b: str) -> float:
         if (a, b) not in g3_cache:
-            ca, cb = edge_arrays(a, b)
+            ca, cb, _, _ = edge_arrays(a, b)
             g3_cache[(a, b)] = stats.row_g3(ca, cb) if len(ca) else 1.0
         return g3_cache[(a, b)]
 
@@ -582,9 +591,11 @@ def _view_structures(
             if fwd <= FD_MAX_G3 and bwd <= FD_MAX_G3:
                 cand_alias.append((a, b))
             for s, t in ((a, b), (b, a)):
-                if scan.d2[s] <= scan.d2[t] or s in bad_det:
+                if s in bad_det:
                     continue
-                cs, ct = edge_arrays(s, t)
+                cs, ct, d_s, d_t = edge_arrays(s, t)
+                if d_s <= d_t:  # finest → coarsest, on the rows the stats see
+                    continue
                 if len(cs) < MIN_SUPPORT_ROWS and len(cs) < n_sample:
                     logger.info(
                         "hierarchy_edge_excluded",
@@ -616,7 +627,10 @@ def _view_structures(
 
     def perm_p(arm: str, a: str, b: str) -> float:
         if (arm, a, b) not in p_cache:
-            ca, cb = edge_arrays(a, b) if arm == "e" else (codes[a], codes[b])
+            if arm == "e":
+                ca, cb, _, _ = edge_arrays(a, b)
+            else:
+                ca, cb = codes[a], codes[b]
             p_cache[(arm, a, b)] = stats.perm_pvalue(ca, cb, rng)
         return p_cache[(arm, a, b)]
 

--- a/packages/engine/src/dataraum/analysis/hierarchies/processor.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/processor.py
@@ -40,6 +40,9 @@ axes — collapsing them was the BILLTO↔PAYER over-merge the role check revers
 
 from __future__ import annotations
 
+import hashlib
+import os
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
@@ -100,8 +103,30 @@ MIN_SAMPLE_ROWS = 50_000
 
 # Fixed seed: the permutation null must be identical across Temporal
 # success-redeliveries so the run-versioned upsert converges (the row sample is
-# deterministic by construction — bottom-k-by-hash, see _pull_sample).
+# deterministic by construction — bottom-k-by-hash, see _pull_sample). Each
+# candidate derives its OWN generator from this seed + a stable digest of the
+# pair (see _pair_rng), so results are independent of iteration order and of
+# the permutation pool's worker count.
 _PERM_SEED = 20260714
+
+# The screened candidates' permutation tests are pure numpy (no session, no
+# DuckDB) and embarrassingly parallel; numpy's sort kernels release the GIL.
+# Bounded modestly — the Temporal worker already runs phases concurrently.
+_PERM_WORKERS = max(1, min(8, (os.cpu_count() or 2) - 1))
+
+
+def _pair_rng(arm: str, a: str, b: str) -> np.random.Generator:
+    """A per-candidate generator seeded from a stable digest of the pair.
+
+    ``hash()`` is process-salted (PYTHONHASHSEED), so a keyed digest is used —
+    the draw sequence for a candidate is a pure function of the module seed and
+    the (arm, a, b) identity, never of scheduling.
+    """
+    digest = int.from_bytes(
+        hashlib.blake2b(f"{arm}:{a}->{b}".encode(), digest_size=8).digest(), "big"
+    )
+    return np.random.default_rng((_PERM_SEED, digest))
+
 
 # COUNT(DISTINCT (a, b)) aggregates per scan statement — wide views chunk the
 # pair family across several single-scan queries instead of one giant SELECT.
@@ -520,7 +545,6 @@ def _view_structures(
     functions bind these parameters, not loop variables.
     """
     cand_names = sorted(by_name)
-    rng = np.random.default_rng(_PERM_SEED)
 
     # -- 1. null policy + eligibility (born-loud on every drop) --------------
     eligible: list[str] = []
@@ -642,24 +666,33 @@ def _view_structures(
 
     # -- 4. permutation p + BH over the view's screened family ----------------
     # Edge tests run on the pairwise-complete rows their screen used; alias
-    # tests on the full null-as-category codes (pair-count semantics).
-    p_cache: dict[tuple[str, str, str], float] = {}
+    # tests on the full null-as-category codes (pair-count semantics). The
+    # candidates fan across a bounded thread pool: each task derives its own
+    # generator (_pair_rng) and only READS the pre-warmed caches (edge_arrays
+    # was populated for every cand_edge pair during screening), so the results
+    # are byte-identical at any worker count.
+    tasks: list[tuple[str, str, str]] = [("e", a, b) for a, b in cand_edge]
+    for a, b in cand_alias:
+        tasks += [("a", a, b), ("a", b, a)]
 
-    def perm_p(arm: str, a: str, b: str) -> float:
-        if (arm, a, b) not in p_cache:
-            if arm == "e":
-                ca, cb, _, _ = edge_arrays(a, b)
-            else:
-                ca, cb = codes[a], codes[b]
-            p_cache[(arm, a, b)] = stats.perm_pvalue(ca, cb, rng)
-        return p_cache[(arm, a, b)]
+    def perm_task(task: tuple[str, str, str]) -> tuple[tuple[str, str, str], float]:
+        arm, a, b = task
+        if arm == "e":
+            ca, cb, _, _ = edge_arrays(a, b)
+        else:
+            ca, cb = codes[a], codes[b]
+        return task, stats.perm_pvalue(ca, cb, _pair_rng(arm, a, b))
 
-    pvals: dict[tuple[str, str, str], float] = {}
-    for a, b in cand_edge:
-        pvals[("e", a, b)] = perm_p("e", a, b)
+    p_by_task: dict[tuple[str, str, str], float] = {}
+    if tasks:
+        with ThreadPoolExecutor(max_workers=_PERM_WORKERS) as pool:
+            for task, p in pool.map(perm_task, tasks):
+                p_by_task[task] = p
+
+    pvals: dict[tuple[str, str, str], float] = {t: p_by_task[t] for t in p_by_task if t[0] == "e"}
     for a, b in cand_alias:
         # A 1:1 claim needs significant dependence in BOTH directions.
-        pvals[("a", a, b)] = max(perm_p("a", a, b), perm_p("a", b, a))
+        pvals[("a", a, b)] = max(p_by_task[("a", a, b)], p_by_task[("a", b, a)])
     accepted = stats.bh_reject(pvals, m_family=max(1, len(pvals)), q=Q_FDR)
     acc_edges = {(a, b) for k, a, b in accepted if k == "e"}
     acc_alias = {(a, b) for k, a, b in accepted if k == "a"}
@@ -689,7 +722,7 @@ def _view_structures(
             merged.append((a, b))
             continue
         contexts = {c: codes[c] for c in eligible if c not in (a, b)}
-        result = stats.role_verdict(dis, contexts, codes[b], rng)
+        result = stats.role_verdict(dis, contexts, codes[b], _pair_rng("role", a, b))
         logger.info(
             "hierarchy_role_check",
             a=a,

--- a/packages/engine/src/dataraum/analysis/hierarchies/stats.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/stats.py
@@ -174,6 +174,13 @@ class RoleResult:
     alpha: float  # the Bonferroni-corrected threshold both tests were held to
 
 
+# Below this many disagreement rows, the achievable permutation p-floor is
+# α-sensitive (ties dominate: with k=2 the floor sits near 0.02, see the DAT-757
+# gate-#2 probe) — any verdict would be a coin flip, so the honest outcome is
+# ABSTAIN. The probe's measured power boundary starts at k ≈ 10 (n = 20k).
+ROLE_K_FLOOR = 10
+
+
 def role_verdict(
     dis: np.ndarray,
     contexts: dict[str, np.ndarray],
@@ -182,18 +189,30 @@ def role_verdict(
     *,
     reps: int = PERM_REPS,
     alpha_family: float = 0.05,
+    k_floor: int = ROLE_K_FLOOR,
 ) -> RoleResult:
     """Classify one near-copy pair from its disagreement set (DAT-757 gate #2).
 
     ``dis`` is ``1{A≠B}`` per row; ``contexts`` are the other candidate columns'
-    codes. Bonferroni m = n_contexts + 1 (the T1 family plus T2). T1 significant →
-    ROLE; else T2 significant → VALUE_SYSTEMATIC (escalate, never merge-block on
-    its own semantics: real dirt is rarely marginal-random, so T2 alone cannot
-    separate role from concentrated dirt); else if the permutation p-floor cannot
-    reach α the honest verdict is ABSTAIN; else DIRT.
+    codes. Bonferroni m = n_contexts + 1 (the T1 family plus T2). Fewer than
+    ``k_floor`` disagreements → ABSTAIN (the p-floor is α-sensitive there — any
+    decision would be a coin flip). T1 significant → ROLE; else T2 significant →
+    VALUE_SYSTEMATIC (escalate, never merge on its own: real dirt is rarely
+    marginal-random, so T2 alone cannot separate role from concentrated dirt);
+    else if the permutation p-floor cannot reach α → ABSTAIN; else DIRT.
     """
     m = len(contexts) + 1
     alpha = alpha_family / m
+    k = int(dis.sum())
+    if k < k_floor:
+        return RoleResult(
+            verdict=RoleVerdict.ABSTAIN,
+            t1_p=1.0,
+            t1_context=None,
+            t2_p=1.0,
+            k_disagree=k,
+            alpha=alpha,
+        )
     t1_ctx: str | None = None
     t1_p = 1.0
     for name, ctx in contexts.items():

--- a/packages/engine/src/dataraum/analysis/hierarchies/stats.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/stats.py
@@ -60,9 +60,7 @@ def codes_of(series: pl.Series) -> np.ndarray:
     """
     import polars as pl  # noqa: PLC0415 — keep the module importable without polars typing
 
-    return (
-        series.cast(pl.Utf8).fill_null("␀").rank("dense").cast(pl.Int64).to_numpy() - 1
-    )
+    return series.cast(pl.Utf8).fill_null("␀").rank("dense").cast(pl.Int64).to_numpy() - 1
 
 
 def _grouped_sorted(a: np.ndarray, b: np.ndarray) -> tuple[np.ndarray, np.ndarray]:

--- a/packages/engine/src/dataraum/analysis/hierarchies/stats.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/stats.py
@@ -1,0 +1,220 @@
+"""Statistical measures for dimension-identity discovery (DAT-761, from DAT-757).
+
+Every measure is a named, established method — proven against the DAT-757
+adversarial matrix (32/32) and three RelBench databases folded by their own FK
+metadata (100% recoverable-truth recall; verdicts on DAT-757):
+
+- **row-g3** (Kivinen–Mannila): the minimum fraction of rows to delete for the
+  FD ``a → b`` to hold exactly — the effect-size screen for edges. The
+  distinct-count ratio it replaces is NOT row-g3 and mass-asserts on wide data.
+- **FI** (fraction of information, Cavallo–Pittarelli): ``1 − H(b|a)/H(b)`` —
+  the dependence statistic the permutation null is computed on.
+- **permutation p-value** (add-one corrected, early-stop): where the observed
+  FI sits in the shuffled-b null DISTRIBUTION. Replaces RFI's mean-centering
+  (variance-blind, leaked skew×heavy-tail FPs) and the analytic χ²/G null
+  (invalid on our sparse contingency tables).
+- **Benjamini–Hochberg (1995)**: FDR q ≤ 0.05 over one view's effect-screened
+  candidate family — what gets ASSERTED from discovery.
+- **Goodman–Kruskal λ (1954)**: PRE over the majority baseline,
+  ``λ = 1 − g3/minority_mass``. Kills the vacuous-skew class (≥98%-dominant
+  dependents satisfy g3 ≤ 0.01 vacuously; neither perm-p nor RFI blocks them).
+  Exact FDs have λ = 1, so true edges onto skewed flags survive.
+- **disagreement-set role tests** (DAT-757 gate #2): a near-copy pair (A, B) is
+  classified ROLE vs dirty-copy from the only rows carrying information — the
+  disagreement set ``dis = 1{A≠B}``. T1: perm-p of dis vs a context column
+  (membership systematicity — the role-specific signal). T2: dis vs B (value
+  concentration — fires on roles AND value-concentrated dirt, so alone it only
+  escalates). Bonferroni over the family. Wild-validated 9/9 on SAP SALT's
+  role-playing customer FKs.
+
+All functions are pure (numpy in, scalars out); the caller owns caching and the
+seeded RNG (a fixed seed keeps the phase deterministic across redeliveries).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import polars as pl
+
+# Permutation budget: p_min = 1/(reps+1) ≈ 3.3e-4 — resolvable under BH even for
+# a single true hit in a family of ~100 candidates.
+PERM_REPS = 2999
+# Early-stop: once this many null exceedances are seen, no BH threshold at
+# q ≤ 0.05 could ever reject — stop permuting (conservative, exact).
+_EARLY_STOP_COUNT = 20
+_PERM_BLOCK = 100
+
+
+def codes_of(series: pl.Series) -> np.ndarray:
+    """Dense integer codes for one column, NULL as its own category.
+
+    Null-as-category is the row-stat policy (DAT-757 null lane): a null-coded
+    binary like ``{1, NULL}`` carries real structure that SQL ``COUNT(DISTINCT)``
+    is blind to. The sentinel is a non-colliding unicode NUL symbol.
+    """
+    import polars as pl  # noqa: PLC0415 — keep the module importable without polars typing
+
+    return (
+        series.cast(pl.Utf8).fill_null("␀").rank("dense").cast(pl.Int64).to_numpy() - 1
+    )
+
+
+def _grouped_sorted(a: np.ndarray, b: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """(pair_counts, a-group boundaries) over the (a, b) contingency, sorted by a."""
+    packed = a.astype(np.int64) * (int(b.max()) + 1) + b
+    uniq, counts = np.unique(packed, return_counts=True)
+    a_of_pair = uniq // (int(b.max()) + 1)
+    bounds = np.flatnonzero(np.diff(a_of_pair)) + 1
+    return counts, bounds
+
+
+def row_g3(a: np.ndarray, b: np.ndarray) -> float:
+    """Classic g3(a → b): 1 − (Σ over a-groups of the majority-b count)/n."""
+    counts, bounds = _grouped_sorted(a, b)
+    kept = np.maximum.reduceat(counts, np.r_[0, bounds])
+    return float(1.0 - kept.sum() / len(a))
+
+
+def _entropy_from_counts(counts: np.ndarray) -> float:
+    p = counts / counts.sum()
+    return float(-(p * np.log(p)).sum())
+
+
+def fi(a: np.ndarray, b: np.ndarray) -> float:
+    """FI(a → b) = 1 − H(b|a)/H(b), in [0, 1]; 0 when H(b) = 0."""
+    _, b_counts = np.unique(b, return_counts=True)
+    h_b = _entropy_from_counts(b_counts)
+    if h_b == 0.0:
+        return 0.0
+    counts, bounds = _grouped_sorted(a, b)
+    n = len(a)
+    group_tot = np.add.reduceat(counts, np.r_[0, bounds])
+    with np.errstate(divide="ignore", invalid="ignore"):
+        rep = np.repeat(group_tot, np.diff(np.r_[0, bounds, len(counts)]))
+        p = counts / rep
+        plogp = p * np.log(p)
+    h_b_given_a = float(-(np.add.reduceat(plogp, np.r_[0, bounds]) * group_tot / n).sum())
+    return 1.0 - h_b_given_a / h_b
+
+
+def perm_pvalue(
+    a: np.ndarray, b: np.ndarray, rng: np.random.Generator, reps: int = PERM_REPS
+) -> float:
+    """P_perm(FI(a, shuffled b) ≥ FI_obs), add-one corrected, early-stopping.
+
+    Early-stops in blocks once the exceedance count is high enough that no BH
+    threshold (q ≤ 0.05) could ever reject — the stopped p is an underestimate
+    of the true p only on the never-rejected side, so the stop is conservative.
+    """
+    obs = fi(a, b)
+    bc = b.copy()
+    count = done = 0
+    while done < reps:
+        block = min(_PERM_BLOCK, reps - done)
+        for _ in range(block):
+            rng.shuffle(bc)
+            if fi(a, bc) >= obs:
+                count += 1
+        done += block
+        if count >= _EARLY_STOP_COUNT:
+            break
+    return (1 + count) / (1 + done)
+
+
+def bh_reject[K](pvals: dict[K, float], m_family: int, q: float = 0.05) -> set[K]:
+    """Benjamini–Hochberg over a family of size ``m_family``.
+
+    Untested family members implicitly carry p = 1. Returns the keys whose
+    hypotheses are rejected (i.e. the dependence is significant).
+    """
+    ranked = sorted(pvals.items(), key=lambda kv: kv[1])
+    cut = 0
+    for k, (_, p) in enumerate(ranked, start=1):
+        if p <= q * k / m_family:
+            cut = k
+    return {key for key, _ in ranked[:cut]}
+
+
+def minority_mass(codes: np.ndarray) -> float:
+    """1 − (majority value share): the baseline error of always-predicting the mode."""
+    _, counts = np.unique(codes, return_counts=True)
+    return 1.0 - counts.max() / len(codes)
+
+
+def gk_lambda(a: np.ndarray, b: np.ndarray) -> float:
+    """Goodman–Kruskal λ(a → b) = 1 − g3(a → b)/minority_mass(b); 0 when b is constant."""
+    m = minority_mass(b)
+    return 1.0 - row_g3(a, b) / m if m > 0 else 0.0
+
+
+class RoleVerdict(Enum):
+    """Gate #2 outcome for one near-copy pair (see :func:`role_verdict`)."""
+
+    ROLE = "role"  # membership-systematic — keep apart, assert as role pair
+    VALUE_SYSTEMATIC = "value_systematic"  # role OR concentrated dirt — semantic lane
+    ABSTAIN = "abstain"  # too few disagreements to decide (p-floor > α)
+    DIRT = "dirt"  # disagreement is noise — merging as alias is safe
+
+
+@dataclass(frozen=True)
+class RoleResult:
+    """The gate-#2 evidence for one near-copy pair."""
+
+    verdict: RoleVerdict
+    t1_p: float  # best (smallest) membership p across contexts
+    t1_context: str | None  # the context column that produced t1_p
+    t2_p: float  # value-concentration p (dis vs B)
+    k_disagree: int
+    alpha: float  # the Bonferroni-corrected threshold both tests were held to
+
+
+def role_verdict(
+    dis: np.ndarray,
+    contexts: dict[str, np.ndarray],
+    b_codes: np.ndarray,
+    rng: np.random.Generator,
+    *,
+    reps: int = PERM_REPS,
+    alpha_family: float = 0.05,
+) -> RoleResult:
+    """Classify one near-copy pair from its disagreement set (DAT-757 gate #2).
+
+    ``dis`` is ``1{A≠B}`` per row; ``contexts`` are the other candidate columns'
+    codes. Bonferroni m = n_contexts + 1 (the T1 family plus T2). T1 significant →
+    ROLE; else T2 significant → VALUE_SYSTEMATIC (escalate, never merge-block on
+    its own semantics: real dirt is rarely marginal-random, so T2 alone cannot
+    separate role from concentrated dirt); else if the permutation p-floor cannot
+    reach α the honest verdict is ABSTAIN; else DIRT.
+    """
+    m = len(contexts) + 1
+    alpha = alpha_family / m
+    t1_ctx: str | None = None
+    t1_p = 1.0
+    for name, ctx in contexts.items():
+        p = perm_pvalue(dis, ctx, rng, reps=reps)
+        if p < t1_p:
+            t1_ctx, t1_p = name, p
+    t2_p = perm_pvalue(dis, b_codes, rng, reps=reps)
+    floor = 1.0 / (1.0 + reps)
+    if t1_p <= alpha:
+        verdict = RoleVerdict.ROLE
+    elif t2_p <= alpha:
+        verdict = RoleVerdict.VALUE_SYSTEMATIC
+    elif floor > alpha:
+        verdict = RoleVerdict.ABSTAIN
+    else:
+        verdict = RoleVerdict.DIRT
+    return RoleResult(
+        verdict=verdict,
+        t1_p=t1_p,
+        t1_context=t1_ctx,
+        t2_p=t2_p,
+        k_disagree=int(dis.sum()),
+        alpha=alpha,
+    )

--- a/packages/engine/src/dataraum/pipeline/phases/dimension_hierarchies_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/dimension_hierarchies_phase.py
@@ -1,17 +1,18 @@
-"""Dimension-hierarchies phase (DAT-537) — g3 FD / drill-down / alias discovery.
+"""Dimension-hierarchies phase (DAT-761) — stack-v4 FD / drill-down / alias / role discovery.
 
 Session value phase, deterministic and source-free: over each fact's grain-verified
-enriched view it computes the g3 functional-dependency measure across the catalog's
-grain-safe slice dimensions (DAT-536), surfacing drill-down hierarchies and 1:1
-aliases. No LLM — the judgments it builds on (which columns are slice dimensions,
-the enriched joins) were made upstream.
+enriched view it runs the DAT-757 gate stack (row-g3 + λ + permutation-BH edges,
+pair-count aliases with the disagreement-set role check) across every
+dimension-like view column — measures are excluded by their ``semantic_role``,
+everything else is guarded by data-grounded checks, not caps. No LLM — the
+judgments it builds on (semantic roles, the enriched joins) were made upstream.
 
-Runs after ``slicing`` and before ``aggregation_lineage`` (it reads the slice
-catalog; nothing in the value layer depends on it yet — the answer agent consumes
-the hierarchies in DAT-538, the driver tree in DAT-545). It also folds the user's
-durable hierarchy/alias teaches into this run (DAT-537), mirroring the relationship
-overlay materialization minus keeper-lift-up + witness (g3 is deterministic, so
-there is no silent-accept and no detect pool).
+Runs after ``slicing`` and before ``aggregation_lineage`` (the driver tree
+consumes the alias groups in DAT-545; role pairs deliberately stay separate
+axes). It also folds the user's durable hierarchy/alias teaches into this run
+(DAT-537), mirroring the relationship overlay materialization minus
+keeper-lift-up + witness (the stack is deterministic, so there is no
+silent-accept and no detect pool).
 """
 
 from __future__ import annotations
@@ -21,7 +22,7 @@ from types import ModuleType
 from sqlalchemy import select
 
 from dataraum.analysis.hierarchies.processor import discover_dimension_hierarchies
-from dataraum.analysis.slicing.db_models import SliceDefinition
+from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.core.logging import get_logger
 from dataraum.pipeline.base import PhaseContext, PhaseResult
 from dataraum.pipeline.phases.base import BasePhase
@@ -32,7 +33,7 @@ logger = get_logger(__name__)
 
 @analysis_phase
 class DimensionHierarchiesPhase(BasePhase):
-    """Discover g3 drill-down hierarchies + aliases over the slice substrate."""
+    """Discover drill-down hierarchies, aliases and role pairs over the enriched views."""
 
     @property
     def name(self) -> str:
@@ -48,16 +49,16 @@ class DimensionHierarchiesPhase(BasePhase):
         """Skip on genuine preconditions only (a re-run must re-derive, DAT-408)."""
         if not ctx.table_ids:
             return "No tables in session scope"
-        has_defs = ctx.session.execute(
-            select(SliceDefinition.slice_id)
+        has_view = ctx.session.execute(
+            select(EnrichedView.view_id)
             .where(
-                SliceDefinition.table_id.in_(ctx.table_ids),
-                SliceDefinition.run_id == ctx.run_id,
+                EnrichedView.fact_table_id.in_(ctx.table_ids),
+                EnrichedView.is_grain_verified.is_(True),
             )
             .limit(1)
         ).first()
-        if has_defs is None:
-            return "No slice definitions this run (slicing skipped) — no dimensions to relate"
+        if has_view is None:
+            return "No grain-verified enriched views — no substrate to relate"
         return None
 
     def _run(self, ctx: PhaseContext) -> PhaseResult:
@@ -71,5 +72,5 @@ class DimensionHierarchiesPhase(BasePhase):
         return PhaseResult.success(
             outputs={"hierarchies": persisted},
             records_created=persisted,
-            summary=f"{persisted} dimension hierarchy/alias structure(s) discovered",
+            summary=f"{persisted} dimension hierarchy/alias/role structure(s) discovered",
         )

--- a/packages/engine/tests/unit/analysis/hierarchies/conftest.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/conftest.py
@@ -114,9 +114,7 @@ def seed_view(
     session.flush()
 
     names = list(columns)
-    duck.execute(
-        f'CREATE TABLE "{view_name}" (' + ", ".join(f'"{n}" VARCHAR' for n in names) + ")"
-    )
+    duck.execute(f'CREATE TABLE "{view_name}" (' + ", ".join(f'"{n}" VARCHAR' for n in names) + ")")
     rows = list(zip(*columns.values(), strict=True))
     duck.executemany(
         f'INSERT INTO "{view_name}" VALUES ({", ".join("?" for _ in names)})',  # noqa: S608

--- a/packages/engine/tests/unit/analysis/hierarchies/conftest.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/conftest.py
@@ -71,6 +71,60 @@ def duck() -> Iterator[duckdb.DuckDBPyConnection]:
         conn.close()
 
 
+def seed_view(
+    session: Session,
+    duck: duckdb.DuckDBPyConnection,
+    view_name: str,
+    columns: dict[str, list],
+    *,
+    register: set[str] | None = None,
+) -> str:
+    """Seed a fact + grain-verified enriched view from raw column lists.
+
+    ``columns`` maps view column name → values (None = SQL NULL). ``register``
+    names the columns that get catalog ``Column`` rows (default: all) — a column
+    left out exercises the unresolved-provenance path (``column_id=""``).
+    Returns the fact ``table_id``.
+    """
+    table = Table(
+        table_id=str(uuid4()),
+        source_id="src-1",
+        table_name=view_name,
+        layer="typed",
+        duckdb_path=view_name,
+    )
+    session.add(table)
+    for pos, name in enumerate(columns):
+        if register is not None and name not in register:
+            continue
+        session.add(
+            Column(
+                column_id=str(uuid4()),
+                table_id=table.table_id,
+                column_name=name,
+                column_position=pos,
+                resolved_type="VARCHAR",
+            )
+        )
+    session.add(
+        EnrichedView(
+            run_id=RUN, fact_table_id=table.table_id, view_name=view_name, is_grain_verified=True
+        )
+    )
+    session.flush()
+
+    names = list(columns)
+    duck.execute(
+        f'CREATE TABLE "{view_name}" (' + ", ".join(f'"{n}" VARCHAR' for n in names) + ")"
+    )
+    rows = list(zip(*columns.values(), strict=True))
+    duck.executemany(
+        f'INSERT INTO "{view_name}" VALUES ({", ".join("?" for _ in names)})',  # noqa: S608
+        [[None if v is None else str(v) for v in row] for row in rows],
+    )
+    return table.table_id
+
+
 def seed_sales(session: Session, duck: duckdb.DuckDBPyConnection, *, rows_per_zip: int = 20) -> str:
     """Seed the fact, its grain-verified enriched view, the catalog, and DuckDB rows.
 

--- a/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
@@ -1,12 +1,15 @@
-"""g3 dimension-hierarchy / alias discovery — DAT-537.
+"""Stack-v4 dimension-identity discovery — DAT-761 (gate stack from DAT-757).
 
 Deterministic FD pass over a fact's grain-verified enriched view. The shared
 ``seed_sales`` fixture (conftest) encodes a known ``zip → city → state`` chain, two
-1:1 aliases, a constant, and a near-key id, so the verdicts (chain, alias collapse,
-guards) are checkable.
+1:1 aliases, a constant, and a near-key id; the ``TestStackV4`` fixtures encode
+the DAT-757 matrix cells the old distinct-ratio g3 could not decide (vacuous
+skew, dirty-true edges, role pairs, null-coded columns, measure exclusion).
 """
 
 from __future__ import annotations
+
+from uuid import uuid4
 
 import duckdb
 from sqlalchemy import select
@@ -14,9 +17,11 @@ from sqlalchemy.orm import Session
 
 from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
 from dataraum.analysis.hierarchies.processor import discover_dimension_hierarchies
+from dataraum.analysis.semantic.db_models import SemanticAnnotation
 from dataraum.analysis.views.db_models import EnrichedView
+from dataraum.storage import Column
 
-from .conftest import RUN, seed_sales
+from .conftest import RUN, seed_sales, seed_view
 
 
 def _rows(session: Session, table_id: str, kind: str) -> list[DimensionHierarchy]:
@@ -124,6 +129,145 @@ class TestDiscoverDimensionHierarchies:
         )
 
 
+class TestStackV4:
+    """The DAT-757 cells the distinct-ratio g3 could not decide (DAT-761)."""
+
+    def test_vacuous_skew_killed_true_skew_edge_kept(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """λ ≥ 0.5 kills the vacuous-skew edge; the exact FD onto a skewed flag survives.
+
+        ``vacuous`` is 99.5%-dominant with its minority spread evenly across
+        ``det`` groups: row-g3 = 0.005 passes the effect screen vacuously, but
+        λ ≈ 0 (no reduction over the majority baseline). ``flag`` is 98%-dominant
+        but an exact FD of ``det`` — λ = 1, the edge must survive (the naive
+        "skip skewed dependents" rule would have killed it).
+        """
+        n = 10_000
+        det = [f"d{i % 50}" for i in range(n)]
+        vacuous = ["1" if (i // 50) % 200 == 0 else "0" for i in range(n)]
+        flag = ["1" if i % 50 == 0 else "0" for i in range(n)]
+        tid = seed_view(
+            real_session, duck, "skewed", {"det": det, "vacuous": vacuous, "flag": flag}
+        )
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+        chains = [_members(r) for r in _rows(real_session, tid, "drilldown")]
+        assert ["det", "flag"] in chains
+        assert all("vacuous" not in c for c in chains)
+
+    def test_dirty_true_edge_kept(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """A true hierarchy with 0.2% dirty rows stays asserted (row-g3 tolerance)."""
+        n = 5_000
+        city = [f"c{i % 40}" for i in range(n)]
+        state = [f"s{((i % 40) // 5 + 1) % 8}" if i % 500 == 0 else f"s{(i % 40) // 5}" for i in range(n)]
+        tid = seed_view(real_session, duck, "dirty_geo", {"city": city, "state": state})
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+        drills = _rows(real_session, tid, "drilldown")
+        assert [_members(r) for r in drills] == [["city", "state"]]
+        assert 0.0 < drills[0].score <= 0.01
+
+    def test_role_pair_kept_apart(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """A role-playing near-copy (bill-to ≠ sold-to on dropship rows) is persisted
+        as ``kind='role'`` — never merged as an alias, never stacked as an edge.
+
+        Pairwise, ``soldto``/``billto`` agree on 99.25% of rows and pass the alias
+        screen; the disagreement set is fully driven by ``channel`` (T1), which is
+        exactly the SAP SALT BILLTO↔PAYER over-merge the round caught and reversed.
+        """
+        n_cust, rows_per = 800, 10
+        soldto, billto, channel = [], [], []
+        for r in range(n_cust * rows_per):
+            c = r % n_cust
+            drop = c < 6
+            soldto.append(f"c{c}")
+            billto.append("hub" if drop else f"c{c}")
+            channel.append("dropship" if drop else "standard")
+        tid = seed_view(
+            real_session, duck, "orders",
+            {"soldto": soldto, "billto": billto, "channel": channel},
+        )
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+        roles = _rows(real_session, tid, "role")
+        assert [_members(r) for r in roles] == [["billto", "soldto"]]
+        assert roles[0].needs_confirmation is False
+        # Not merged, and no drilldown stacks the two role siblings as levels.
+        for r in _rows(real_session, tid, "alias") + _rows(real_session, tid, "drilldown"):
+            assert not {"soldto", "billto"} <= set(_members(r))
+
+    def test_null_coded_columns_alias(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """The null-policy lane: ``{1, NULL}`` columns are axes, not constants.
+
+        SQL ``COUNT(DISTINCT)`` sees 1 distinct value and the old pass dropped
+        them silently (the rel-hm FN/Active lesson); null-as-category keeps them
+        eligible and the exact copy merges as an alias.
+        """
+        n = 3_000
+        fn = ["1" if i % 7 < 2 else None for i in range(n)]
+        city = [f"c{i % 30}" for i in range(n)]
+        tid = seed_view(
+            real_session, duck, "customers", {"fn": fn, "active": list(fn), "city": city}
+        )
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+        aliases = [_members(r) for r in _rows(real_session, tid, "alias")]
+        assert ["active", "fn"] in aliases
+
+    def test_measure_columns_excluded(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """The additivity lane: a ``semantic_role='measure'`` column never enters
+        FD discovery, even when it would form a perfect structure."""
+        n = 600
+        zips = [f"z{i % 6}" for i in range(n)]
+        amount = [str((i % 6) * 100) for i in range(n)]
+        city = [f"c{i % 3}" for i in range(n)]
+        tid = seed_view(
+            real_session, duck, "billing", {"zip": zips, "amount": amount, "city": city}
+        )
+        amount_id = real_session.execute(
+            select(Column.column_id).where(Column.table_id == tid, Column.column_name == "amount")
+        ).scalar_one()
+        real_session.add(
+            SemanticAnnotation(
+                annotation_id=str(uuid4()), column_id=amount_id, run_id=RUN,
+                semantic_role="measure",
+            )
+        )
+        real_session.flush()
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+        all_members = {
+            m
+            for kind in ("drilldown", "alias", "role")
+            for r in _rows(real_session, tid, kind)
+            for m in _members(r)
+        }
+        assert "amount" not in all_members
+        assert "zip" in all_members  # the zip → city structure itself is found
+
+    def test_unregistered_column_participates(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """A view column with no catalog ``Column`` row still participates —
+        provenance is metadata (``column_id=''``), not a gate (the widened
+        candidate universe is the view, not the slice catalog)."""
+        n = 500
+        state = [f"s{i % 8}" for i in range(n)]
+        tid = seed_view(
+            real_session, duck, "wide", {"state": state, "mystery": list(state)},
+            register={"state"},
+        )
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+        aliases = _rows(real_session, tid, "alias")
+        assert [_members(r) for r in aliases] == [["mystery", "state"]]
+        by_name = {m["column_name"]: m["column_id"] for m in aliases[0].members}
+        assert by_name["mystery"] == "" and by_name["state"] != ""
+
+
 class TestDimensionHierarchiesPhaseSkip:
     """The phase's should_skip preconditions (deterministic re-run discipline)."""
 
@@ -138,14 +282,14 @@ class TestDimensionHierarchiesPhaseSkip:
             config={},
         )
 
-    def test_skips_when_no_slice_definitions(
+    def test_skips_when_no_enriched_view(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
         from dataraum.pipeline.phases.dimension_hierarchies_phase import DimensionHierarchiesPhase
 
-        # A table id with no SliceDefinition rows for this run → nothing to relate.
+        # A table id with no grain-verified enriched view → no substrate.
         reason = DimensionHierarchiesPhase().should_skip(self._ctx(real_session, duck, ["nope"]))
-        assert reason is not None and "slice definitions" in reason
+        assert reason is not None and "enriched views" in reason
 
     def test_does_not_skip_with_catalog(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection

--- a/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
@@ -161,7 +161,9 @@ class TestStackV4:
         """A true hierarchy with 0.2% dirty rows stays asserted (row-g3 tolerance)."""
         n = 5_000
         city = [f"c{i % 40}" for i in range(n)]
-        state = [f"s{((i % 40) // 5 + 1) % 8}" if i % 500 == 0 else f"s{(i % 40) // 5}" for i in range(n)]
+        state = [
+            f"s{((i % 40) // 5 + 1) % 8}" if i % 500 == 0 else f"s{(i % 40) // 5}" for i in range(n)
+        ]
         tid = seed_view(real_session, duck, "dirty_geo", {"city": city, "state": state})
         discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
         drills = _rows(real_session, tid, "drilldown")
@@ -187,7 +189,9 @@ class TestStackV4:
             billto.append("hub" if drop else f"c{c}")
             channel.append("dropship" if drop else "standard")
         tid = seed_view(
-            real_session, duck, "orders",
+            real_session,
+            duck,
+            "orders",
             {"soldto": soldto, "billto": billto, "channel": channel},
         )
         discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
@@ -248,7 +252,9 @@ class TestStackV4:
         ).scalar_one()
         real_session.add(
             SemanticAnnotation(
-                annotation_id=str(uuid4()), column_id=amount_id, run_id=RUN,
+                annotation_id=str(uuid4()),
+                column_id=amount_id,
+                run_id=RUN,
                 semantic_role="measure",
             )
         )
@@ -272,7 +278,10 @@ class TestStackV4:
         n = 500
         state = [f"s{i % 8}" for i in range(n)]
         tid = seed_view(
-            real_session, duck, "wide", {"state": state, "mystery": list(state)},
+            real_session,
+            duck,
+            "wide",
+            {"state": state, "mystery": list(state)},
             register={"state"},
         )
         discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)

--- a/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
@@ -198,6 +198,20 @@ class TestStackV4:
         for r in _rows(real_session, tid, "alias") + _rows(real_session, tid, "drilldown"):
             assert not {"soldto", "billto"} <= set(_members(r))
 
+    def test_partial_null_edge_rescued_by_pairwise_deletion(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """The null-policy lane, edge arm: 10% join-miss NULLs in the dependent
+        used to cost the whole edge (row-g3 = 0.10 under null-as-category);
+        pairwise deletion recovers the exact FD over the complete rows."""
+        n = 5_000
+        city = [f"c{i % 40}" for i in range(n)]
+        state = [None if i % 10 == 0 else f"s{(i % 40) // 5}" for i in range(n)]
+        tid = seed_view(real_session, duck, "null_geo", {"city": city, "state": state})
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+        drills = _rows(real_session, tid, "drilldown")
+        assert [_members(r) for r in drills] == [["city", "state"]]
+
     def test_null_coded_columns_alias(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:

--- a/packages/engine/tests/unit/analysis/hierarchies/test_stats.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_stats.py
@@ -104,12 +104,26 @@ def test_role_verdict_random_disagreement_is_dirt() -> None:
     assert res.verdict is RoleVerdict.DIRT
 
 
-def test_role_verdict_abstains_when_floor_exceeds_alpha() -> None:
-    # A tiny permutation budget cannot resolve the Bonferroni α: the honest
-    # verdict is ABSTAIN, never a coin-flip DIRT.
+def test_role_verdict_abstains_below_k_floor() -> None:
+    # With 2 disagreement rows the achievable p-floor is α-sensitive (ties
+    # dominate the permutation null): the honest verdict is ABSTAIN, never a
+    # coin-flip DIRT — the DAT-757 f6-role-dup cell.
     n = 2_000
     dis = np.zeros(n, dtype=np.int64)
     dis[:2] = 1
+    contexts = {f"c{i}": np.arange(n) % (i + 2) for i in range(4)}
+    res = role_verdict(dis, contexts, np.arange(n) % 7, np.random.default_rng(0))
+    assert res.verdict is RoleVerdict.ABSTAIN
+    assert res.k_disagree == 2
+
+
+def test_role_verdict_abstains_when_floor_exceeds_alpha() -> None:
+    # Above the k-floor but with a tiny permutation budget the p-floor cannot
+    # resolve the Bonferroni α: still ABSTAIN.
+    n = 2_000
+    rng_data = np.random.default_rng(3)
+    dis = np.zeros(n, dtype=np.int64)
+    dis[rng_data.choice(n, 15, replace=False)] = 1
     contexts = {f"c{i}": np.arange(n) % (i + 2) for i in range(4)}
     res = role_verdict(dis, contexts, np.arange(n) % 7, np.random.default_rng(0), reps=30)
     assert res.verdict is RoleVerdict.ABSTAIN

--- a/packages/engine/tests/unit/analysis/hierarchies/test_stats.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_stats.py
@@ -1,0 +1,115 @@
+"""The named statistics behind stack v4 (DAT-761) — pure-function checks.
+
+Each measure's defining property is asserted directly: row-g3 exactness, λ's
+exact-FD-invariance vs vacuous-skew kill, BH's family control, the permutation
+p-value's calibration, and the gate-#2 verdict split (ROLE / DIRT / ABSTAIN).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from dataraum.analysis.hierarchies.stats import (
+    RoleVerdict,
+    bh_reject,
+    codes_of,
+    gk_lambda,
+    minority_mass,
+    perm_pvalue,
+    role_verdict,
+    row_g3,
+)
+
+
+def test_codes_of_null_is_its_own_category() -> None:
+    s = pl.Series(["a", None, "b", "a", None])
+    codes = codes_of(s)
+    assert len(np.unique(codes)) == 3  # a, b, NULL
+    assert codes[1] == codes[4]
+
+
+def test_row_g3_exact_fd_is_zero() -> None:
+    a = np.arange(1000) % 40
+    b = a // 5
+    assert row_g3(a, b) == 0.0
+
+
+def test_row_g3_counts_minimum_violating_rows() -> None:
+    a = np.arange(1000) % 40
+    b = a // 5
+    b[::250] = (b[::250] + 1) % 8  # 4 dirty rows
+    assert row_g3(a, b) == pytest.approx(4 / 1000)
+
+
+def test_lambda_exact_fd_is_one_regardless_of_skew() -> None:
+    # 98%-dominant dependent, but an exact FD of a: λ must be exactly 1.
+    a = np.arange(10_000) % 50
+    b = (a == 0).astype(np.int64)
+    assert gk_lambda(a, b) == 1.0
+
+
+def test_lambda_vacuous_skew_is_near_zero() -> None:
+    # Minority spread evenly across a-groups: g3 ≈ minority mass, λ ≈ 0.
+    n = 10_000
+    a = np.arange(n) % 50
+    b = ((np.arange(n) // 50) % 200 == 0).astype(np.int64)
+    assert row_g3(a, b) <= 0.01  # the effect screen alone would pass it
+    assert gk_lambda(a, b) < 0.1
+
+
+def test_minority_mass() -> None:
+    assert minority_mass(np.array([0, 0, 0, 1])) == 0.25
+    assert minority_mass(np.zeros(5, dtype=np.int64)) == 0.0
+
+
+def test_bh_reject_family_control() -> None:
+    # One real signal among untested-implicit-1.0 family members survives;
+    # a flat family yields nothing.
+    assert bh_reject({"x": 1e-4, "y": 0.9}, m_family=10) == {"x"}
+    assert bh_reject({"x": 0.5, "y": 0.9}, m_family=10) == set()
+
+
+def test_perm_pvalue_separates_dependence_from_noise() -> None:
+    rng_data = np.random.default_rng(7)
+    a = rng_data.integers(0, 30, 5_000)
+    dependent = a // 3
+    independent = rng_data.integers(0, 10, 5_000)
+    assert perm_pvalue(a, dependent, np.random.default_rng(0)) < 0.001
+    assert perm_pvalue(a, independent, np.random.default_rng(0)) > 0.05
+
+
+def test_role_verdict_systematic_disagreement_is_role() -> None:
+    # Disagreements happen exactly on the dropship rows: T1 fires.
+    n = 8_000
+    channel = (np.arange(n) % 100 < 2).astype(np.int64)
+    dis = channel.copy()
+    b = np.arange(n) % 500
+    res = role_verdict(dis, {"channel": channel}, b, np.random.default_rng(0))
+    assert res.verdict is RoleVerdict.ROLE
+    assert res.t1_context == "channel"
+
+
+def test_role_verdict_random_disagreement_is_dirt() -> None:
+    # Disagreements land on rows no context predicts: both tests stay null,
+    # and with the full permutation budget the p-floor is below α → DIRT.
+    n = 8_000
+    rng_data = np.random.default_rng(11)
+    dis = np.zeros(n, dtype=np.int64)
+    dis[rng_data.choice(n, 30, replace=False)] = 1
+    channel = (np.arange(n) % 100 < 2).astype(np.int64)
+    b = np.arange(n) % 500
+    res = role_verdict(dis, {"channel": channel}, b, np.random.default_rng(0))
+    assert res.verdict is RoleVerdict.DIRT
+
+
+def test_role_verdict_abstains_when_floor_exceeds_alpha() -> None:
+    # A tiny permutation budget cannot resolve the Bonferroni α: the honest
+    # verdict is ABSTAIN, never a coin-flip DIRT.
+    n = 2_000
+    dis = np.zeros(n, dtype=np.int64)
+    dis[:2] = 1
+    contexts = {f"c{i}": np.arange(n) % (i + 2) for i in range(4)}
+    res = role_verdict(dis, contexts, np.arange(n) % 7, np.random.default_rng(0), reps=30)
+    assert res.verdict is RoleVerdict.ABSTAIN

--- a/packages/engine/tests/unit/llm/test_anthropic_provider.py
+++ b/packages/engine/tests/unit/llm/test_anthropic_provider.py
@@ -513,14 +513,10 @@ class TestStringifiedArgCoercion:
         )
         assert coerced == {"tables": [{"table_name": "t"}], "note": "ok"}
 
-    def test_single_real_property_key_not_unwrapped(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_single_real_property_key_not_unwrapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # A single-key input whose sole key is a real PROPERTY (not the tool name)
         # is NOT an envelope — leave it (the list value passes coercion untouched).
-        coerced = self._converse_with_tool_use(
-            monkeypatch, {"tables": [{"table_name": "t"}]}
-        )
+        coerced = self._converse_with_tool_use(monkeypatch, {"tables": [{"table_name": "t"}]})
         assert coerced == {"tables": [{"table_name": "t"}]}
 
 


### PR DESCRIPTION
## What

Folds the DAT-757 research verdicts into `analysis/hierarchies/`: the `dimension_hierarchies` phase's decision layer is replaced end-to-end and its candidate universe widened from the grain-safe slice catalog to every dimension-like enriched-view column.

**The stack (v4):** null policy → effect screens (row-g3 ≤ 0.01 edges / pair-count g3 aliases) → Goodman–Kruskal λ ≥ 0.5 skew floor → seeded permutation-p + Benjamini–Hochberg q ≤ 0.05 per view family → disagreement-set role check (new `kind='role'`) → teach overlay (unchanged).

- New pure-stats module `analysis/hierarchies/stats.py` (row-g3, FI, early-stop perm-p, BH, λ, gate-#2 role tests) — every measure a named method.
- Measures excluded via `semantic_role='measure'` (the additivity lane); upstream `max_columns` is the only width cap; all other exclusions are data-grounded and logged.
- Guards + pair counts from a full-view chunked scan (a row sample makes fold keys look near-key — the rel-hm lesson); row statistics on an aligned bottom-k-by-hash sample (≤ 40M cells).
- Null policy: null-coded columns (`{1, NULL}`) are axes, not silent constant-drops; edge statistics use pairwise deletion when nulls are missingness, with a complete-rows support floor and orientation judged on the same rows.
- Role pairs (bill-to ⇄ pay-to) persist as `kind='role'`, never merge, never stack as levels; undecidable near-copies surface as `needs_confirmation` aliases.
- Perm stage: per-pair blake2b-seeded RNGs (order/scheduling-independent determinism) fanned across a bounded ThreadPoolExecutor; pair-joint scan pruned to alias-satisfiable pairs. Decisions byte-identical at any worker count.

## Acceptance (both gates end-to-end through `discover_dimension_hierarchies`, graded on persisted rows)

- **DAT-757 40-cell adversarial matrix**: structural 32/32, null-policy 4/4 (the lane rescue now passes — the research harness could not), additivity 2/2, concept ABSTAIN, planted chains 8/8, aliases 2/2. Sole residue = the recorded LLM-lane cell (statistically-true void id↔text alias).
- **RelBench 3-DB fold** (each DB folded by its own FK metadata): **0 truth lost anywhere** — rel-f1 66 edges + 17 bijections, rel-hm 44 + 8, rel-salt 40 + 5. rel-salt persists `kind='role'` for BILLTOPARTY ⇄ PAYERPARTY and billto__ADDRESSID ⇄ payer__ADDRESSID — the real SAP over-merge the research round caught, reversed in production code.

Full verdicts: DAT-761 comments 16304 / 16337. Research provenance: DAT-757 (16265/66/67, 16300/02/03).

## Downstream

- `drivers/_candidate_dims` consumes the corrected alias groups unchanged — role pairs now stay separate competing axes.
- Phase precondition: grain-verified enriched view (was: slice definitions).
- `.claude/handoff.md` entry added for eval/testdata.
- Deferred follow-up (deliberately coupled): class-routed LLM veto lane + bus-matrix persistence.

## Tests

Engine unit suite green (2013 incl. new `test_stats.py` + `TestStackV4` scenarios); ruff / mypy / vulture clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)