### PR TITLE
fix(engine): DAT-764 — structural reconciliation is authoritative for stock/flow

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -61,6 +61,64 @@ exercises the `role` kind end-to-end.
 
 ---
 
+## DAT-764 — structural reconciliation is authoritative for stock/flow
+
+**Branch:** `fix/dat-764-structural-authoritative`. **Re-run Tier-3 stock/flow — this
+fixes the three `trial_balance` reds WITHOUT a band resweep (the harness was detecting a
+real mislabel, exactly as the ticket said).** The DAT-728 handoff assumed the surviving
+2-witness pool (`llm_claim` + `structural_reconciliation`) would resolve `debit_balance`
+via structural+LLM **agreement**. The eval run showed the LLM intermittently name-reads
+the periodic "balance" columns as **stock**, and the symmetric pool let that confident
+name-read tip a data-grounded `per_period` (flow) verdict — `debit_balance` reconciled at
+match_rate 0.75 → resolved `point_in_time`, while `credit_balance` at 1.0 survived.
+
+### What changed
+
+- **`entropy/measurements/temporal_behavior.py`** — when the `structural_reconciliation`
+  witness fired a gated verdict this run AND the `llm_claim` disagrees, the LLM claim is
+  **pooled OUT** (not pooled against it). Stock/flow is data-determined (DAT-657/491): the
+  reconciliation is the only witness whose input is the data, not the name, so its verdict
+  sets the label regardless of match magnitude. An AGREEING claim is kept (corroborates,
+  lower ignorance); when structural abstained (every add_source detect) the LLM stands
+  alone (unchanged). Verified on the eval match_rates: `debit_balance`@0.75 and
+  `credit_balance`@1.0 both now resolve `additive` with pooled **conflict 0.000**; a
+  genuine cumulative stock (`balance_sheet.ending_balance`) still resolves `point_in_time`.
+- `resolved_behaviour(adj)` now takes the adjudication (was the bare `PoolResult`) so it
+  reads the two witness positions; `contested` records whether the reads disagreed (pure
+  observability — the readiness/loss lane keys on the conflict SCORE, `loss.py`, not this
+  flag). One caller updated (the detector).
+
+### For eval (calibration to run)
+
+- **Re-run Tier-3 stock/flow.** `trial_balance.debit_balance` AND `credit_balance` →
+  `additive`. The `temporal_behavior` disagreement SCORE for these drops to ~0 (the pool no
+  longer manufactures conflict when the data decided), so `test_clean_scores_within_measured_bands`
+  and `test_clean_readiness_no_regression` (query_intent) should recover **without**
+  touching bands or `intent_readiness.yaml`. Keep the witness-liveness guard.
+- **Watch:** a genuinely ambiguous flow the structural witness gets WRONG would now be
+  authoritative with no LLM temper. This is the deliberate DAT-491 stance (the witness is
+  heavily gated: ≥2 voting entities, ≥0.8 agreement, wrong-anchor residual guard). Confirm
+  no CLEAR stock (`balance_sheet`/`ending_balance` family) regresses to flow.
+- **Cross-detector safety invariant to pin (eval-owned test):** making structural
+  authoritative removes the pooled CONFLICT signal, so a WEAK verdict (low match_rate —
+  few entities reconciled) that overrules a confident LLM no longer contributes conflict
+  risk. Safety then rests on IGNORANCE, which scales with match_rate (measured: ~0.998 at
+  match 0.05 → ~0.53 at 1.0) and is unit-tested here. But whether that keeps
+  `aggregation_intent` OUT of "ready" is a CROSS-detector property of `loss.yaml`'s
+  ignorance weight × readiness bands — not enforced in engine code (deliberately: no
+  invented match_rate floor). Add an eval regression: a low-match structural override
+  disagreeing with a confident LLM must NOT band `aggregation_intent` "ready". A future
+  `loss.yaml`/bands edit could otherwise silently reopen the SUM-a-stock failure class.
+
+### testdata hints
+
+None. The finance corpus's `trial_balance` (per-period flows named "balance") + genuine
+`balance_sheet` stocks already exercise both sides. The moderate-match (0.75) verdict is
+the discriminating case — a fact that reconciles on only some entities is what separates
+"data authoritative even at partial match" from the old symmetric tip.
+
+---
+
 ## DAT-756 — referenced-dimension identity + `shared_dims` fix + conformed-dimension
 
 **Branch:** `feat/dat-756-dimension-identity`. **A detector-grouping-key fix (closes a

--- a/packages/engine/src/dataraum/entropy/detectors/computational/temporal_behavior.py
+++ b/packages/engine/src/dataraum/entropy/detectors/computational/temporal_behavior.py
@@ -95,7 +95,7 @@ class TemporalBehaviorDetector(EntropyDetector):
         if not adj.witnesses:
             return []  # neither the claim nor the reconciliation opined → nothing to say
 
-        label, contested = resolved_behaviour(adj.result)
+        label, contested = resolved_behaviour(adj)
         posterior = dict(zip(CLAIM_SPACE, adj.result.posterior, strict=True))
         # No teach_suggestion (DAT-657): stock/flow is data-determined, so the
         # structural witness already wins — nothing for a human to teach. A wrong

--- a/packages/engine/src/dataraum/entropy/measurements/temporal_behavior.py
+++ b/packages/engine/src/dataraum/entropy/measurements/temporal_behavior.py
@@ -91,8 +91,16 @@ class ColumnTemporalAdjudication:
     table: str
     column: str
     claim_field: str  # "temporal_behavior:{table}.{column}" — the claim-slot identity
+    # ALL opinionated witnesses (EntropyObject provenance). NOTE (DAT-764): unlike
+    # every other adjudication detector, this may be a SUPERSET of what feeds
+    # ``result`` — when the data-grounded structural witness overrules a disagreeing
+    # name-based claim, only the authoritative subset is pooled. Do not assume
+    # ``result``'s (C, U) is recomputable from ``witnesses`` for this detector.
     witnesses: tuple[Witness, ...]
     result: PoolResult
+    # The structural witness fired and pooled OUT a disagreeing ``llm_claim`` (DAT-764).
+    # Carried so the resolved layer flags ``contested`` without recomputing the test.
+    overruled: bool = False
 
 
 def _distribution(p_stock: float) -> dict[str, float]:
@@ -113,6 +121,16 @@ def _has_opinion(witness: Witness) -> bool:
     """A witness has an opinion when its distribution is not (≈) uniform."""
     uniform = 1.0 / len(witness.distribution)
     return any(abs(p - uniform) > _OPINION_EPS for p in witness.distribution)
+
+
+def _p_stock(witness: Witness) -> float:
+    """The witness's P(stock) — its position on the stock(≥0.5)/flow(<0.5) line."""
+    return witness.distribution[CLAIM_SPACE.index("stock")]
+
+
+def _find(witnesses: tuple[Witness, ...], witness_id: str) -> Witness | None:
+    """The opinionated witness with this id, or ``None`` if it abstained/absent."""
+    return next((w for w in witnesses if w.witness_id == witness_id), None)
 
 
 def _leaning(p_stock_extreme: float | None, confidence: float | None) -> dict[str, float]:
@@ -144,15 +162,21 @@ def structural_reconciliation_distribution(
     return _leaning(_PATTERN_PSTOCK.get((pattern or "").strip()), match_rate)
 
 
-def resolved_behaviour(result: PoolResult) -> tuple[str | None, bool]:
-    """The resolved temporal behaviour + a contested flag, from a pooled result.
+def resolved_behaviour(adj: ColumnTemporalAdjudication) -> tuple[str | None, bool]:
+    """The resolved temporal behaviour + a contested flag, from an adjudication.
 
     ``(label, contested)`` where label ∈ {"point_in_time", "additive", None} — None
-    when no witness took a position (total ignorance). ``contested`` is True when the
-    pooled conflict is non-trivial: the resolved layer writes the label but flags it
-    so a downstream SQL agent treats a contested stock with caution. Inverse of the
-    ontology vocabulary so the resolve write round-trips onto ColumnConcept (DAT-637).
+    when no witness took a position (total ignorance). Inverse of the ontology
+    vocabulary so the resolve write round-trips onto ColumnConcept (DAT-637).
+
+    The label follows the AUTHORITATIVE posterior — which is the structural
+    reconciliation alone whenever it fired and the name-based ``llm_claim`` disagreed
+    (DAT-764), so the data decides stock/flow. ``contested`` records whether the two
+    reads landed on opposite sides of the stock/flow line: pure observability for the
+    teach/readiness lane (deliberately NOT rendered to SQL agents — resolve.py), and
+    the readiness/loss lane keys on the pooled conflict SCORE, not this flag.
     """
+    result = adj.result
     if not result.posterior:
         return None, False
     p_stock = result.posterior[CLAIM_SPACE.index("stock")]
@@ -162,7 +186,18 @@ def resolved_behaviour(result: PoolResult) -> tuple[str | None, bool]:
         # "uncontested stock" via the >= tie-break.
         return None, False
     label = "point_in_time" if p_stock >= 0.5 else "additive"
-    contested = result.conflict > CONTESTED_MIN_CONFLICT
+    structural = _find(adj.witnesses, "structural_reconciliation")
+    llm = _find(adj.witnesses, "llm_claim")
+    if structural is not None and llm is not None:
+        # Both independent reads present → they contest iff they land on opposite
+        # sides of the stock/flow line. That is exactly the overrule condition
+        # ``measure_temporal_behavior`` already computed — reuse it (single source
+        # of truth), never recompute, so the two can't silently drift.
+        contested = adj.overruled
+    else:
+        # A lone witness (or none) — no second read to contest it; fall back to the
+        # pooled conflict for the llm-only / structural-only cases.
+        contested = result.conflict > CONTESTED_MIN_CONFLICT
     return label, contested
 
 
@@ -212,11 +247,32 @@ def measure_temporal_behavior(
     )
     # Only witnesses that take a position are pooled: an abstaining witness is
     # ignorance, not a conflicting party. Both abstain → pool([]) → C=0, U=1.
-    witnesses = tuple(w for w in candidates if _has_opinion(w))
+    opinionated = tuple(w for w in candidates if _has_opinion(w))
+    # DAT-764 / DAT-657: stock/flow is DATA-DETERMINED, so the structural
+    # reconciliation is authoritative when it fired a gated verdict this run. A
+    # name-anchored ``llm_claim`` that DISAGREES with it is OVERRULED — pooled out,
+    # not against it. The pool's conflict ``C`` is weight-robust (a reliability edge
+    # cannot damp it — reliabilities.py), so a symmetric pool let a confident LLM
+    # "balance"→stock read both flip the label on a moderate-match verdict AND
+    # manufacture a readiness-blocking disagreement (``trial_balance.debit_balance``,
+    # per_period@0.75 → stock). An AGREEING claim is KEPT — it corroborates (lower
+    # ignorance); when structural abstained, the ``llm_claim`` stands alone. This is
+    # the docstring's "the structural witness already wins" made literal.
+    structural = _find(opinionated, "structural_reconciliation")
+    llm = _find(opinionated, "llm_claim")
+    overruled = (
+        structural is not None
+        and llm is not None
+        and (_p_stock(llm) >= 0.5) != (_p_stock(structural) >= 0.5)
+    )
+    pooled = (structural,) if overruled and structural is not None else opinionated
     return ColumnTemporalAdjudication(
         table=table,
         column=column,
         claim_field=f"temporal_behavior:{table}.{column}",
-        witnesses=witnesses,
-        result=pool(witnesses),
+        # Both opinionated reads are recorded (EntropyObject provenance); only the
+        # authoritative set is POOLED into the (C, U) + posterior.
+        witnesses=opinionated,
+        result=pool(pooled),
+        overruled=overruled,
     )

--- a/packages/engine/tests/unit/entropy/test_measurement_temporal_behavior.py
+++ b/packages/engine/tests/unit/entropy/test_measurement_temporal_behavior.py
@@ -2,10 +2,12 @@
 
 Two witnesses: the independent LLM claim + the data-grounded structural
 reconciliation (DAT-491). The ontology prior was DROPPED (DAT-657) — stock/flow is
-a data-format property the ontology cannot declare. Asserts witness direction, the
-data-dissent conflict (the LLM name-reads stock, the data reconciles flow), the
-doc-trap U-routing (a lone witness → ignorance, not low entropy), and that a column
-resolves from the data alone. Properties/orderings, not point thresholds.
+a data-format property the ontology cannot declare. Asserts witness direction; that
+the structural reconciliation is AUTHORITATIVE when it fires and a name-based claim
+disagrees (DAT-764 — the data decides, with no manufactured conflict, so a
+moderate-match verdict is not tipped by a confident-wrong LLM); the doc-trap
+U-routing (a lone witness → ignorance, not low entropy); and that a column resolves
+from the data alone. Properties/orderings, not point thresholds.
 """
 
 from __future__ import annotations
@@ -65,13 +67,14 @@ class TestResolvedBehaviour:
             structural_pattern="cumulative",
             structural_match_rate=0.9,
         )
-        label, contested = resolved_behaviour(adj.result)
+        label, contested = resolved_behaviour(adj)
         assert label == "point_in_time"
         assert contested is False
 
-    def test_conflict_resolves_contested(self) -> None:
-        # The LLM name-reads the periodic trial_balance movement as stock; the data
-        # reconciles it as per-period flow → conflict.
+    def test_structural_overrules_a_disagreeing_llm_but_flags_contested(self) -> None:
+        # DAT-764: the LLM name-reads the periodic trial_balance movement as stock;
+        # the data reconciles it as per-period flow. The data is authoritative → the
+        # label follows the data (additive), and the disagreement is flagged.
         adj = measure_temporal_behavior(
             "trial_balance",
             "debit_balance",
@@ -80,36 +83,102 @@ class TestResolvedBehaviour:
             structural_pattern="per_period",
             structural_match_rate=0.95,
         )
-        _, contested = resolved_behaviour(adj.result)
+        label, contested = resolved_behaviour(adj)
+        assert label == "additive"
         assert contested is True
+
+    def test_structural_authority_is_symmetric_holds_stock(self) -> None:
+        # The mirror of the debit_balance case: the data reconciles CUMULATIVE
+        # (stock) while the LLM wrongly name-reads flow. Authority is direction-
+        # agnostic — the data still decides, so the label stays point_in_time and no
+        # flow-bias sneaks in. Guards against a one-sided overrule.
+        adj = measure_temporal_behavior(
+            "balance_sheet",
+            "ending_balance",
+            llm_claim="flow",
+            llm_confidence=0.9,
+            structural_pattern="cumulative",
+            structural_match_rate=0.9,
+        )
+        label, contested = resolved_behaviour(adj)
+        assert label == "point_in_time"
+        assert contested is True
+        assert adj.result.conflict < 0.05  # LLM pooled out — no manufactured conflict
 
     def test_total_ignorance_resolves_none(self) -> None:
         adj = measure_temporal_behavior("t", "c", llm_claim=None)
-        assert resolved_behaviour(adj.result) == (None, False)
+        assert resolved_behaviour(adj) == (None, False)
 
 
 # --- pooled adjudication -----------------------------------------------------
 class TestMeasure:
-    def test_data_dissent_against_the_name_raises_conflict(self) -> None:
-        """The DAT-491/657 case: the LLM name-reads stock (possibly wrong); the
-        reconciliation says the column equals its per-period movement → flow.
-        Conflict rises — the data witness escapes name-anchoring."""
-        agreed = measure_temporal_behavior(
+    def test_data_dissent_is_resolved_by_data_not_manufactured_conflict(self) -> None:
+        """DAT-764: the LLM name-reads stock (wrong); the reconciliation says the
+        column equals its per-period movement → flow. The data is authoritative, so
+        the disagreeing name-read is pooled OUT — the posterior follows the data
+        (flow) and NO readiness-blocking conflict is manufactured. Both raw reads are
+        still recorded as provenance."""
+        adj = measure_temporal_behavior(
             "tb",
             "debit_balance",
             llm_claim="stock",
-            structural_pattern="cumulative",
-            structural_match_rate=0.9,
-        )
-        dissent = measure_temporal_behavior(
-            "tb",
-            "debit_balance",
-            llm_claim="stock",
+            llm_confidence=0.9,
             structural_pattern="per_period",
             structural_match_rate=0.95,
         )
-        assert dissent.result.conflict > agreed.result.conflict
-        assert dissent.result.conflict > 0.05
+        assert adj.result.posterior[_STOCK] < 0.5  # resolves flow, not stock
+        assert adj.result.conflict < 0.05  # the data decided — no manufactured conflict
+        # …yet the two reads are kept for provenance.
+        assert {w.witness_id for w in adj.witnesses} == {"llm_claim", "structural_reconciliation"}
+
+    def test_moderate_match_structural_overpowers_confident_llm_stock(self) -> None:
+        """The exact regression: trial_balance.debit_balance reconciled per_period at
+        match_rate 0.75 (a real, gated verdict) while the LLM confidently name-read the
+        'balance' column as stock. The symmetric pool tipped this to point_in_time;
+        with structural authoritative it must resolve additive."""
+        adj = measure_temporal_behavior(
+            "trial_balance",
+            "debit_balance",
+            llm_claim="stock",
+            llm_confidence=0.9,
+            structural_pattern="per_period",
+            structural_match_rate=0.75,
+        )
+        label, _ = resolved_behaviour(adj)
+        assert label == "additive"
+        assert adj.result.conflict < 0.05
+
+    def test_weak_overrule_routes_to_ignorance_not_false_confidence(self) -> None:
+        """Safety property of making structural authoritative: it removes the pooled
+        CONFLICT signal, so a WEAK verdict (few entities reconciled → low match_rate)
+        that overrules a confident LLM must NOT masquerade as a confident resolution.
+        Its IGNORANCE stays high — the readiness/loss lane routes it to investigate —
+        and shrinks only as match_rate rises. This is what keeps a near-noise verdict
+        from silently greenlighting SUM-a-stock, WITHOUT an invented match_rate floor;
+        the ignorance mechanism (grounded in the pool) already scales authority by
+        coverage. Guards the cross-module invariant the loss lane depends on."""
+        weak = measure_temporal_behavior(
+            "t",
+            "c",
+            llm_claim="stock",
+            llm_confidence=0.9,
+            structural_pattern="per_period",
+            structural_match_rate=0.05,
+        )
+        strong = measure_temporal_behavior(
+            "t",
+            "c",
+            llm_claim="stock",
+            llm_confidence=0.9,
+            structural_pattern="per_period",
+            structural_match_rate=1.0,
+        )
+        # Both resolve additive (data authoritative) with no manufactured conflict…
+        assert resolved_behaviour(weak)[0] == "additive"
+        assert weak.result.conflict < 0.05
+        # …but the weak verdict carries much higher ignorance than the strong one.
+        assert weak.result.ignorance > 0.9
+        assert weak.result.ignorance > strong.result.ignorance
 
     def test_agreement_is_quiet(self) -> None:
         adj = measure_temporal_behavior(
@@ -149,7 +218,7 @@ class TestMeasure:
             structural_match_rate=0.9,
         )
         assert [w.witness_id for w in adj.witnesses] == ["structural_reconciliation"]
-        label, contested = resolved_behaviour(adj.result)
+        label, contested = resolved_behaviour(adj)
         assert label == "additive"
         assert not contested
 


### PR DESCRIPTION
## DAT-764 — trial_balance debit/credit resolve `point_in_time` (should be `additive`)

Found by the DAT-761 Tier-3 calibration run. **Not caused by DAT-756/758** — this is DAT-728's 2-witness pool exposed.

### Root cause (data-grounded, eval ws_d442…/ws_607…)
The structural reconciliation witness **fired correctly** (`per_period`/flow) for both measures — not the "0/N inert" branch. But the temporal_behavior pool (`llm_claim` 0.838 + `structural_reconciliation` 0.889) is **symmetric**, and the pooled conflict `C` is weight-robust (a reliability edge can't damp it). The LLM name-reads the "balance" columns as **stock**; at `match_rate` 0.75 (`debit_balance`) the confident LLM tipped the verdict to `point_in_time`, while `credit_balance` at 1.0 survived → `additive`. DAT-728 had dropped the `ontology_prior` tiebreaker that used to hold this line.

| measure | structural | match_rate | before | after |
|---|---|---|---|---|
| credit_balance | per_period (flow) | 1.0 | additive ✓ | additive ✓ |
| debit_balance | per_period (flow) | 0.75 | **point_in_time** ✗ | **additive** ✓ |

### Fix
Stock/flow is data-determined (DAT-657/491). When the structural witness fired a gated verdict and a name-based `llm_claim` **disagrees**, the claim is **pooled out** — the data sets the label and no readiness-blocking conflict is manufactured. An **agreeing** claim is kept (corroborates); when structural abstained (every add_source detect) the LLM stands alone (unchanged).

- No invented `match_rate` floor: the overrule zeroes conflict, but **ignorance** stays high for a weak verdict (~0.998 at match 0.05 → ~0.53 at 1.0), routing it to *investigate*. The grounded ignorance mechanism already scales authority by coverage.
- `resolved_behaviour` now takes the adjudication and reads an `overruled` flag (single source of truth for `contested`); both raw witnesses stay on the adjudication for EntropyObject provenance while only the authoritative subset feeds the pool.

### Verification
- On the eval match_rates + shipped reliabilities: `debit`@0.75 and `credit`@1.0 both → `additive`, conflict **0.000**; a genuine cumulative stock (`balance_sheet.ending_balance`) still → `point_in_time` (both overrule directions tested).
- Fixes all three eval reds (label, disagreement score, readiness) **with no band resweep** — the reds keyed on the pooled conflict (`loss.py`), which now collapses.
- 480 entropy unit tests pass · ruff + mypy clean.

### Reviewers
- **spec-compliance:** COMPLIANT · **senior:** APPROVE. Findings addressed: symmetric (stock-direction) test, weak-overrule ignorance-safety test, DRY of the overrule/contested condition, provenance-vs-pooled docstring note, cross-detector readiness invariant flagged for eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)