### PR TITLE
fix(engine): DAT-763 — deterministic self-referential FK candidate detection

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -61,6 +61,55 @@ exercises the `role` kind end-to-end.
 
 ---
 
+## DAT-763 — deterministic self-referential FK candidate detection
+
+**Branch:** `fix/dat-763-self-fk-candidate`. **Re-run relationship recall — a
+self-referential FK is now a DETERMINISTIC Layer-A candidate (was LLM-draw-dependent).**
+The finder (`relationships/finder.py`) iterated `table_names[i+1:]` — distinct
+cross-table pairs only — since the v1 restructure, so a self-FK
+(`chart_of_accounts.parent_id -> account_id`, both endpoints in ONE table) was never a
+structural candidate; it reached the judge only when the LLM spontaneously proposed it
+(the DAT-761 Tier-3 run caught it missing — recall 8/9).
+
+### What changed
+
+- **`relationships/finder.py`** — the finder now probes each table against ITSELF
+  (`table_names[i:]`, the diagonal), not just distinct pairs.
+- **`relationships/joins.py`** — `find_join_columns` gained `same_table: bool`
+  (default False, cross-table unchanged): the self-probe is restricted to the upper
+  triangle (i < j) so a column is never matched to itself (trivial identity) and each
+  unordered pair is tried once. Direction is normalized downstream at persist (DAT-758).
+- **`relationships/graph_topology.py`** — the undirected structure graph now SKIPS
+  self-loops: a NetworkX self-loop double-counts degree (+2) and lists a table as its
+  own neighbor, which would misclassify a dimension carrying one external FK + a self-FK
+  as a `hub` and corrupt the ContextDocument. (Cycle detection already skipped self-loops
+  via `len >= 2`.) A single-table workspace can now detect its own self-FK
+  (`detector.py` no longer early-returns below 2 tables). The evaluator needs no change
+  (self-joins already alias `t1`/`t2` on one path); the persist keys on the column pair,
+  so a `(table, table)` candidate stores correctly.
+
+### For eval (calibration to run)
+
+- **Relationship recall now includes self-FKs every run.** `chart_of_accounts.parent_id
+  -> account_id` (the DAT-763 miss) should be a confirmed `llm` relationship on the
+  finance corpus deterministically. Verified at Layer-A grain: the finder emits it at
+  join_confidence 1.0 (containment), so it always reaches the judge — the remaining
+  variance is only the judge's confirm/decline, not candidate existence.
+- **Expect MORE intra-table candidates reaching the judge** on wide tables (any two
+  same-table columns whose values overlap). The DEFINED catalog is unaffected — a
+  spurious self-pair the judge declines persists as `candidate` (below REL_CONFIRM_MIN),
+  never `llm`. Precision on the defined catalog is unchanged; the judge is the filter.
+
+### testdata hints
+
+A dimension table with a genuine hierarchy column (`parent_id`, `manager_id`,
+`reports_to`) referencing its own PK is the fixture; the finance `chart_of_accounts`
+already carries `parent_id`. A negative — two same-table columns that overlap in values
+but are NOT a FK (two user-id audit columns) — exercises the judge-declines-to-candidate
+path.
+
+---
+
 ## DAT-756 — referenced-dimension identity + `shared_dims` fix + conformed-dimension
 
 **Branch:** `feat/dat-756-dimension-identity`. **A detector-grouping-key fix (closes a

--- a/packages/engine/src/dataraum/analysis/relationships/detector.py
+++ b/packages/engine/src/dataraum/analysis/relationships/detector.py
@@ -66,7 +66,9 @@ def detect_relationships(
         # Load table paths + column metadata (no row data — uniqueness is computed in SQL)
         tables_data = _load_tables(session, table_ids)
 
-        if len(tables_data) < 2:
+        # A single table can still carry a self-referential FK (DAT-763), so one
+        # table is enough to detect; only an empty scope has nothing to probe.
+        if not tables_data:
             return Result.ok(
                 RelationshipDetectionResult(
                     candidates=[],

--- a/packages/engine/src/dataraum/analysis/relationships/finder.py
+++ b/packages/engine/src/dataraum/analysis/relationships/finder.py
@@ -41,8 +41,15 @@ def find_relationships(
     # every table-pair it participates in, and the ratio doesn't depend on the pair.
     uniqueness_cache: dict[tuple[str, str], float] = {}
 
+    # ``table_names[i:]`` includes the DIAGONAL (name1 == name1): a self-referential
+    # FK (``chart_of_accounts.parent_id -> account_id``) lives inside ONE table, so it
+    # is only ever a candidate when the finder probes a table against itself. The
+    # ``same_table`` flag restricts the self-probe to distinct-column pairs (the
+    # upper triangle) — deterministic Layer-A detection, no LLM needed to propose it
+    # (DAT-763).
     for i, name1 in enumerate(table_names):
-        for name2 in table_names[i + 1 :]:
+        for name2 in table_names[i:]:
+            same = name1 == name2
             path1, cols1, types1 = tables[name1]
             path2, cols2, types2 = tables[name2]
 
@@ -56,6 +63,7 @@ def find_relationships(
                 min_score=min_confidence,
                 column_types1=types1,
                 column_types2=types2,
+                same_table=same,
             )
 
             # Enrich with uniqueness ratios (SQL, sampled)

--- a/packages/engine/src/dataraum/analysis/relationships/graph_topology.py
+++ b/packages/engine/src/dataraum/analysis/relationships/graph_topology.py
@@ -156,6 +156,16 @@ def analyze_graph_topology(
     for from_id, to_id in edges:
         # Only add edges between tables in our analysis scope
         if from_id in table_ids and to_id in table_ids:
+            # A self-referential FK (a within-table hierarchy, e.g.
+            # chart_of_accounts.parent_id -> account_id, now a routine Layer-A
+            # candidate — DAT-763) is NOT an inter-table structural edge. A
+            # NetworkX self-loop double-counts degree (+2) and lists a table as
+            # its own neighbor, so it would misclassify hub/bridge/dimension roles
+            # and corrupt the ContextDocument. Topology measures inter-table
+            # connectivity; the self-FK still lives in the relationship catalog.
+            # (Cycle detection below already skips self-loops via len >= 2.)
+            if from_id == to_id:
+                continue
             G.add_edge(from_id, to_id)
             G_directed.add_edge(from_id, to_id)
 

--- a/packages/engine/src/dataraum/analysis/relationships/joins.py
+++ b/packages/engine/src/dataraum/analysis/relationships/joins.py
@@ -613,6 +613,7 @@ def find_join_columns(
     max_workers: int = 8,
     column_types1: dict[str, str | None] | None = None,
     column_types2: dict[str, str | None] | None = None,
+    same_table: bool = False,
 ) -> list[dict[str, Any]]:
     """Find join columns using adaptive algorithm selection.
 
@@ -635,6 +636,14 @@ def find_join_columns(
         max_workers: Number of parallel workers
         column_types1: Optional dict mapping column name -> resolved type for table1
         column_types2: Optional dict mapping column name -> resolved type for table2
+        same_table: True when table1 and table2 are the SAME table (a self-
+            referential FK probe, e.g. ``chart_of_accounts.parent_id -> account_id``).
+            Restricts the pairs to the upper triangle (index i < j): a column never
+            references itself (the diagonal is trivial identity), and each unordered
+            pair is tried once — direction is normalized downstream at persist
+            (DAT-758). Cross-table detection is unaffected. Assumes ``columns1 ==
+            columns2`` (the caller passes one table's columns as both sides); the
+            upper-triangle index guard and the Phase-1 stats reuse both rely on it.
 
     Returns:
         List of dicts with:
@@ -646,15 +655,26 @@ def find_join_columns(
     """
     # Phase 1: Pre-compute column statistics (with type info for filtering)
     stats1 = _precompute_column_stats(conn, table1_path, columns1, column_types1)
-    stats2 = _precompute_column_stats(conn, table2_path, columns2, column_types2)
+    # A self-probe (same_table) passes the identical table/columns as both sides —
+    # reuse the stats instead of recomputing the same distinct-count queries.
+    stats2 = (
+        stats1
+        if same_table
+        else _precompute_column_stats(conn, table2_path, columns2, column_types2)
+    )
 
     # Phase 2: Filter column pairs
     pairs_to_check = []
-    for col1 in columns1:
+    for i, col1 in enumerate(columns1):
         if col1 not in stats1:
             continue
-        for col2 in columns2:
+        for j, col2 in enumerate(columns2):
             if col2 not in stats2:
+                continue
+            # Self-referential probe: only the upper triangle. i == j is a column
+            # matched to itself (trivial identity); i > j is the reverse of a pair
+            # already queued (direction is normalized at persist, DAT-758).
+            if same_table and i >= j:
                 continue
             if _should_compare_columns(stats1[col1], stats2[col2]):
                 pairs_to_check.append((col1, col2))

--- a/packages/engine/tests/integration/analysis/relationships/test_self_referential_fk.py
+++ b/packages/engine/tests/integration/analysis/relationships/test_self_referential_fk.py
@@ -1,0 +1,108 @@
+"""Self-referential FK detection at Layer-A grain (DAT-763).
+
+A self-FK (``chart_of_accounts.parent_id -> account_id``) lives inside ONE table,
+so it is only ever a candidate when the finder probes a table against itself. The
+finder used to iterate ``table_names[i+1:]`` — distinct cross-table pairs only — so
+the self-FK never reached the judge; it entered the catalog only when the LLM
+happened to propose it (nondeterministic). These tests pin the DETERMINISTIC
+candidate-existence half: no LLM, real data, the diagonal probe must emit the pair
+and must NOT emit a column matched against itself.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from dataraum.analysis.relationships.finder import find_relationships
+from dataraum.analysis.relationships.joins import find_join_columns
+
+COA_COLUMNS = ["account_id", "parent_id", "name", "account_type"]
+COA_TYPES = {
+    "account_id": "BIGINT",
+    "parent_id": "BIGINT",
+    "name": "VARCHAR",
+    "account_type": "VARCHAR",
+}
+
+
+@pytest.fixture
+def coa_duckdb(tmp_path):
+    """A chart_of_accounts table with a self-referential ``parent_id -> account_id``.
+
+    60 accounts; ids 1..15 are roots (NULL parent), ids 16..60 point at a parent in
+    1..15. So ``parent_id`` (15 distinct, non-unique, with NULLs) is a strict subset
+    of the unique ``account_id`` (60) — a textbook many-to-one self-FK.
+    """
+    db_path = str(tmp_path / "coa.duckdb")
+    conn = duckdb.connect(db_path)
+    conn.execute("""
+        CREATE TABLE chart_of_accounts AS
+        SELECT
+            i AS account_id,
+            CASE WHEN i <= 15 THEN NULL ELSE ((i - 1) % 15) + 1 END AS parent_id,
+            'account_' || i AS name,
+            CASE WHEN i % 4 = 0 THEN 'Asset'
+                 WHEN i % 4 = 1 THEN 'Liability'
+                 WHEN i % 4 = 2 THEN 'Income'
+                 ELSE 'Expense' END AS account_type
+        FROM generate_series(1, 60) AS t(i)
+    """)
+    conn.close()
+    conn = duckdb.connect(db_path, read_only=True)
+    yield conn
+    conn.close()
+
+
+def test_self_referential_fk_is_a_candidate(coa_duckdb):
+    """The finder emits the parent_id<->account_id self-FK as a Layer-A candidate."""
+    results = find_relationships(
+        coa_duckdb,
+        {"chart_of_accounts": ("chart_of_accounts", COA_COLUMNS, COA_TYPES)},
+    )
+    # A single-table workspace still yields a self-referential relationship entry.
+    self_rels = [r for r in results if r["table1"] == "chart_of_accounts" == r["table2"]]
+    assert self_rels, "no self-referential relationship emitted for chart_of_accounts"
+    pairs = {frozenset((j["column1"], j["column2"])) for r in self_rels for j in r["join_columns"]}
+    assert frozenset(("parent_id", "account_id")) in pairs
+
+
+def test_self_probe_excludes_identity_and_duplicate_direction(coa_duckdb):
+    """A column is never matched to itself, and each unordered pair appears once."""
+    candidates = find_join_columns(
+        coa_duckdb,
+        "chart_of_accounts",
+        "chart_of_accounts",
+        COA_COLUMNS,
+        COA_COLUMNS,
+        min_score=0.3,
+        column_types1=COA_TYPES,
+        column_types2=COA_TYPES,
+        same_table=True,
+    )
+    # No diagonal identity match (account_id == account_id → jaccard 1.0 otherwise).
+    assert all(c["column1"] != c["column2"] for c in candidates)
+    # Each unordered column pair is tried at most once (upper triangle).
+    seen = [frozenset((c["column1"], c["column2"])) for c in candidates]
+    assert len(seen) == len(set(seen))
+    # The self-FK pair is present.
+    assert frozenset(("parent_id", "account_id")) in set(seen)
+
+
+def test_cross_table_default_is_unaffected(coa_duckdb):
+    """same_table defaults False — cross-table detection compares the full grid,
+    including a same-named pair, exactly as before."""
+    candidates = find_join_columns(
+        coa_duckdb,
+        "chart_of_accounts",
+        "chart_of_accounts",
+        ["account_id"],
+        ["account_id"],
+        min_score=0.3,
+        column_types1={"account_id": "BIGINT"},
+        column_types2={"account_id": "BIGINT"},
+    )
+    # With same_table left False the diagonal identity pair IS compared (the
+    # cross-table contract: account_id joins account_id). Guard against a regression
+    # that would make the default path skip same-named columns.
+    assert any(c["column1"] == "account_id" and c["column2"] == "account_id" for c in candidates)

--- a/packages/engine/tests/unit/analysis/relationships/test_graph_topology.py
+++ b/packages/engine/tests/unit/analysis/relationships/test_graph_topology.py
@@ -195,6 +195,27 @@ class TestAnalyzeGraphTopology:
         assert roles["customers"] == "dimension"  # 1 connection
         assert roles["products"] == "isolated"  # 0 connections
 
+    def test_self_referential_fk_does_not_inflate_role(self):
+        # DAT-763: a self-FK (chart_of_accounts.parent_id -> account_id) is a
+        # within-table hierarchy, not an inter-table edge. A NetworkX self-loop
+        # counts degree +2 and lists the table as its own neighbor, which would
+        # misclassify a dimension carrying ONE external FK + a self-FK as a hub.
+        table_ids = ["coa", "journal"]
+        relationships = [
+            {"from_table_id": "journal", "to_table_id": "coa"},  # one external FK
+            {"from_table_id": "coa", "to_table_id": "coa"},  # self-referential FK
+        ]
+        names = {"coa": "chart_of_accounts", "journal": "journal_lines"}
+
+        result = analyze_graph_topology(table_ids, relationships, table_names=names)
+
+        by_name = {r.table_name: r for r in result.tables}
+        coa = by_name["chart_of_accounts"]
+        assert coa.role == "dimension"  # degree 1, NOT hub (would be 3 with the loop)
+        assert coa.connection_count == 1
+        assert "chart_of_accounts" not in coa.connects_to  # never its own neighbor
+        assert "chart_of_accounts" not in result.hub_tables
+
 
 class TestFormatGraphStructure:
     """Tests for format_graph_structure_for_context."""


### PR DESCRIPTION
## DAT-763 — CoA self-FK (`parent_id → account_id`) missing, not even a candidate

Found by the DAT-761 Tier-3 calibration run (relationship recall 8/9). **Not caused by DAT-756/758** — a long-standing Layer-A gap.

### Root cause (data-grounded, eval ws_d442… + code)
`find_relationships` iterated `table_names[i+1:]` — **distinct cross-table pairs only** — since the v1 restructure, so a self-referential FK (both endpoints in one table) was never a structural Layer-A candidate. It entered the catalog only when the LLM judge *spontaneously* proposed it (nondeterministic). Confirmed absent in the workspace: no `llm` and no `candidate` row for `parent_id`; not swallowed as a surrogate intent; `parent_id` exists as a typed column. My three merged PRs never touched `analysis/relationships/`.

### Fix
The finder now probes each table against **itself** (`table_names[i:]`, the diagonal). `find_join_columns` gains `same_table` (default `False`, cross-table byte-identical): the self-probe is restricted to the upper triangle so a column is never matched to itself (trivial identity) and each unordered pair is tried once — direction is normalized downstream at persist (DAT-758).

Downstream consumers made self-loop-safe:
- **`graph_topology`** now skips self-loops on the undirected structure graph — a NetworkX self-loop double-counts degree (+2) and lists a table as its own neighbor, which would misclassify a dimension carrying one external FK + a self-FK as a `hub` and corrupt the ContextDocument (found by review; cycle detection already skipped self-loops).
- **`detector`** no longer early-returns below 2 tables (one table suffices for a self-FK).
- The evaluator already self-joins via `t1`/`t2` aliases; the persist keys on the column pair, so a `(table, table)` candidate stores correctly.

### Verification
- Layer-A regression test (no LLM): the `chart_of_accounts` self-FK is emitted at `join_confidence` **1.0** (containment), reaching the judge every run; a column-vs-itself identity is excluded; cross-table default unaffected.
- Topology regression test: a dimension with one external FK + a self-FK stays `dimension` (not `hub`).
- 119 relationships tests + 806 analysis/graph tests pass · ruff + mypy clean.
- A spurious same-table overlap the judge declines persists as `candidate` (below `REL_CONFIRM_MIN`), never `llm` — the defined catalog is unaffected.

### Reviewers
- **spec-compliance:** COMPLIANT · **senior:** NEEDS WORK → all findings addressed (Critical NetworkX self-loop fix + topology test, single-table guard, redundant-stats reuse, documented `same_table ⟹ columns1 == columns2` invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)