### PR TITLE
fix(hierarchies): DAT-761 post-merge review findings

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -35,7 +35,7 @@ into the engine.
   are now eligible axes (null-as-category — the rel-hm FN/Active lesson).
 - **Scan grain:** guards + pair counts from a full-view scan (chunked O(k²)
   aggregates); row statistics on an aligned in-memory sample (≤ 40M cells,
-  seeded reservoir) — a sampled fold key can never trip the near-key guard.
+  seeded bottom-k-by-hash sketch, the DAT-571 drivers idiom) — a sampled fold key can never trip the near-key guard.
 - Phase precondition changed: requires a grain-verified enriched view (was:
   slice definitions this run).
 

--- a/packages/engine/src/dataraum/analysis/hierarchies/db_models.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/db_models.py
@@ -21,17 +21,23 @@ from dataraum.storage import Base
 
 
 class DimensionHierarchy(Base):
-    """One drill-down chain or 1:1 alias group over a fact's enriched view, per run.
+    """One drill-down chain, alias group or role pair over a fact's enriched view, per run.
 
-    The deterministic g3 functional-dependency pass (DAT-537) writes one row per
-    discovered structure. Two kinds share the table via the ``kind`` discriminator:
+    The deterministic FD pass (DAT-537, stack v4 since DAT-761) writes one row
+    per discovered structure. Three kinds share the table via the ``kind``
+    discriminator:
 
     - ``kind='drilldown'``: an ordered drill-down hierarchy. ``members`` lists the
       levels **finest → coarsest** (each FD-determines the next, e.g. ``zip → city
       → state``); ``canonical_label`` renders the chain.
     - ``kind='alias'``: a 1:1 redundant-axis group (bidirectional ``g3 ≈ 0``).
       ``members`` lists the equivalent columns; ``canonical_label`` is the chosen
-      canonical axis name.
+      canonical axis name. A near-copy the role check could not decide surfaces
+      as an alias with ``needs_confirmation=True`` (never silently merged).
+    - ``kind='role'`` (DAT-761): a role-playing near-copy pair (bill-to ⇄ pay-to)
+      whose disagreement set is membership-systematic — the two columns are the
+      SAME domain in different roles: kept as separate axes, never merged, never
+      stacked as levels. ``score`` is the value-disagreement rate.
 
     Run-versioned like ``MeasureAggregationLineage`` (DAT-491): form-(a) writer —
     one row per ``(signature, run_id)``, UPSERTed, so a Temporal success-redelivery
@@ -61,7 +67,7 @@ class DimensionHierarchy(Base):
     # (cross-table levels surface for free on the denormalized view).
     table_id: Mapped[str] = mapped_column(ForeignKey("tables.table_id"), nullable=False)
 
-    kind: Mapped[str] = mapped_column(String, nullable=False)  # 'drilldown' | 'alias'
+    kind: Mapped[str] = mapped_column(String, nullable=False)  # 'drilldown' | 'alias' | 'role'
 
     # Ordered member columns. Each entry: {column_name, column_id, distinct_count}.
     # drilldown: finest → coarsest (the drill path). alias: the equivalent group,

--- a/packages/engine/src/dataraum/analysis/hierarchies/processor.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/processor.py
@@ -77,7 +77,10 @@ FD_MAX_G3 = 0.01
 LAMBDA_MIN = 0.5
 
 # BH false-discovery rate over one view's effect-screened candidate family.
+# Must stay below stats.MAX_SOUND_Q: the permutation early-stop is conservative
+# only while a stopped p can never be BH-rejected (see stats.py).
 Q_FDR = 0.05
+assert Q_FDR < stats.MAX_SOUND_Q, "early-stop soundness requires Q_FDR < MAX_SOUND_Q"
 
 # A near-copy pair (value-equality disagreement in (0, this]) takes the gate-#2
 # role check before it may merge. Above it, a bidirectional pair-g3 match is a
@@ -132,6 +135,24 @@ def _pair_rng(arm: str, a: str, b: str) -> np.random.Generator:
 # pair family across several single-scan queries instead of one giant SELECT.
 _MAX_PAIR_AGGS = 500
 
+# The permutation stage's own row ceiling, independent of the cells budget: a
+# narrow-tall view (2-4 columns) would otherwise sample 10-20M rows and pay
+# reps × O(n log n) per ACCEPTED candidate (true edges never early-stop). The
+# test is sample-honest at any subsample, and 1M rows is ample power for
+# candidates that already cleared the g3 + λ screens. The pulled frame is in
+# hash order (bottom-k), so a prefix is itself a valid deterministic sample.
+_MAX_PERM_ROWS = 1_000_000
+
+
+def _quote(name: str) -> str:
+    """Quote a catalog identifier for DuckDB SQL, doubling embedded quotes.
+
+    View column names descend from source CSV headers (VARCHAR-first load), so
+    an embedded ``"`` is possible — the drivers module's convention
+    (``drivers/processor.py::quote``), adopted here.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
 
 @dataclass(frozen=True)
 class _Candidate:
@@ -169,7 +190,7 @@ class _ViewScan:
 def _view_columns(duckdb_conn: duckdb.DuckDBPyConnection, view_name: str) -> list[str] | None:
     """The view's column names, or ``None`` if it is not queryable (logged)."""
     try:
-        rows = duckdb_conn.execute(f'DESCRIBE "{view_name}"').fetchall()
+        rows = duckdb_conn.execute(f"DESCRIBE {_quote(view_name)}").fetchall()
     except Exception as e:  # noqa: BLE001 — any DuckDB error → skip this view, logged
         logger.warning("hierarchy_view_describe_failed", view=view_name, error=str(e))
         return None
@@ -251,11 +272,11 @@ def _scan_view(
     the view is then skipped, a visible abstention.
     """
     parts = ["COUNT(*) AS n"]
-    parts += [f'COUNT(DISTINCT "{c}") AS d{i}' for i, c in enumerate(cols)]
-    parts += [f'COUNT("{c}") AS c{i}' for i, c in enumerate(cols)]
+    parts += [f"COUNT(DISTINCT {_quote(c)}) AS d{i}" for i, c in enumerate(cols)]
+    parts += [f"COUNT({_quote(c)}) AS c{i}" for i, c in enumerate(cols)]
     try:
         row = duckdb_conn.execute(
-            f'SELECT {", ".join(parts)} FROM "{view_name}"'  # noqa: S608 — catalog names
+            f"SELECT {', '.join(parts)} FROM {_quote(view_name)}"  # noqa: S608 — catalog names
         ).fetchone()
         if row is None:
             return None
@@ -279,9 +300,10 @@ def _scan_view(
         for start in range(0, len(pairs), _MAX_PAIR_AGGS):
             chunk = pairs[start : start + _MAX_PAIR_AGGS]
             sql = ", ".join(
-                f'COUNT(DISTINCT ("{a}", "{b}")) AS j{k}' for k, (a, b) in enumerate(chunk)
+                f"COUNT(DISTINCT ({_quote(a)}, {_quote(b)})) AS j{k}"
+                for k, (a, b) in enumerate(chunk)
             )
-            jrow = duckdb_conn.execute(f'SELECT {sql} FROM "{view_name}"')  # noqa: S608
+            jrow = duckdb_conn.execute(f"SELECT {sql} FROM {_quote(view_name)}")  # noqa: S608
             fetched = jrow.fetchone()
             if fetched is None:
                 return None
@@ -299,24 +321,27 @@ def _pull_sample(
     """An aligned VARCHAR sample of the candidate columns for the row statistics.
 
     Full view when it fits ``MAX_SAMPLE_CELLS``; else a bottom-k-by-hash sketch
-    (the DAT-571 drivers idiom: ``ORDER BY hash(cols) LIMIT n`` is a uniform
-    per-row sample that stays deterministic on the multi-threaded worker
-    connection, where ``USING SAMPLE … REPEATABLE`` only holds single-threaded).
-    Row-level statistics are sample-honest — g3 exactness is subset-invariant,
-    the permutation null is recomputed on the sample — while every guard reads
-    the full-view scan, so a sampled fold key can never trip the near-key guard
+    (the DAT-571 drivers idiom: ``ORDER BY hash(cols) LIMIT n`` stays
+    deterministic on the multi-threaded worker connection, where ``USING SAMPLE
+    … REPEATABLE`` only holds single-threaded — LIMIT ties are content-identical
+    rows, so the cut is stable). Note the sample is tuple-clustered, not iid:
+    all copies of a low-hash value-tuple enter together — first-order unbiased,
+    but the variance structure differs from row-iid sampling. Row-level
+    statistics are sample-honest — g3 exactness is subset-invariant, the
+    permutation null is recomputed on the sample — while every guard reads the
+    full-view scan, so a sampled fold key can never trip the near-key guard
     (the rel-hm lesson).
     """
     n_sample = max(MIN_SAMPLE_ROWS, MAX_SAMPLE_CELLS // max(len(cols), 1))
     sample = ""
     if n_rows > n_sample:
-        hash_cols = ", ".join(f'"{c}"' for c in cols)
+        hash_cols = ", ".join(_quote(c) for c in cols)
         sample = f" ORDER BY hash({hash_cols}) LIMIT {n_sample}"
         logger.info("hierarchy_view_sampled", view=view_name, full_n=n_rows, sample_n=n_sample)
-    select_cols = ", ".join(f'CAST("{c}" AS VARCHAR) AS "{c}"' for c in cols)
+    select_cols = ", ".join(f"CAST({_quote(c)} AS VARCHAR) AS {_quote(c)}" for c in cols)
     try:
         table = duckdb_conn.execute(
-            f'SELECT {select_cols} FROM "{view_name}"{sample}'  # noqa: S608 — catalog names
+            f"SELECT {select_cols} FROM {_quote(view_name)}{sample}"  # noqa: S608 — catalog names
         ).arrow()
     except Exception as e:  # noqa: BLE001 — any DuckDB error → skip this view, logged
         logger.warning("hierarchy_sample_pull_failed", view=view_name, error=str(e))
@@ -324,13 +349,49 @@ def _pull_sample(
     return cast("pl.DataFrame", pl.from_arrow(table))
 
 
+def _break_cycles(edges: set[tuple[str, str]]) -> set[tuple[str, str]]:
+    """Drop the edges inside directed cycles (Kahn peel), born-loud.
+
+    The old pass's acyclicity premise (one global distinct count orients every
+    edge) weakened when orientation moved to pairwise-complete row subsets: a
+    rep-level cycle is constructible when cardinalities sit within the screen
+    tolerances. A cycle is contradictory determination evidence — the honest
+    output is NO chain through it, logged loudly, never a hang or a crash.
+    Edges from acyclic nodes INTO the cycle survive (their target becomes a
+    sink); edges within the cyclic core are dropped.
+    """
+    nodes = {n for e in edges for n in e}
+    indeg = dict.fromkeys(nodes, 0)
+    succ: dict[str, list[str]] = {n: [] for n in nodes}
+    for a, b in edges:
+        succ[a].append(b)
+        indeg[b] += 1
+    queue = [n for n in nodes if indeg[n] == 0]
+    while queue:
+        n = queue.pop()
+        for m in succ[n]:
+            indeg[m] -= 1
+            if indeg[m] == 0:
+                queue.append(m)
+    cyclic = {n for n, d in indeg.items() if d > 0}
+    if not cyclic:
+        return edges
+    kept = {(a, b) for a, b in edges if not (a in cyclic and b in cyclic)}
+    logger.warning(
+        "hierarchy_cycle_detected",
+        cyclic_columns=sorted(cyclic),
+        dropped_edges=sorted(edges - kept),
+    )
+    return kept
+
+
 def _transitive_reduction(edges: set[tuple[str, str]]) -> set[tuple[str, str]]:
     """Remove edges implied by a longer path (DAG; ``a → b`` = a determines b).
 
     Drops ``a → c`` whenever ``a → … → c`` exists through an intermediate, so a
-    chain ``zip → city → state`` keeps only the adjacent links. Determination is a
-    partial order (acyclic once aliases are collapsed), so a simple reachability
-    test per edge suffices.
+    chain ``zip → city → state`` keeps only the adjacent links. Input must be
+    acyclic (``_break_cycles`` runs first), so a simple reachability test per
+    edge suffices.
     """
     succ: dict[str, set[str]] = {}
     for a, b in edges:
@@ -354,12 +415,20 @@ def _transitive_reduction(edges: set[tuple[str, str]]) -> set[tuple[str, str]]:
     return {(a, b) for (a, b) in edges if not reaches(a, b, skip=(a, b))}
 
 
+# Path enumeration is worst-case exponential on dense DAGs, and the widened
+# candidate universe makes dense decided DAGs reachable — cap the emitted
+# chains and say so, never hang.
+_MAX_CHAINS_PER_VIEW = 500
+
+
 def _maximal_chains(edges: set[tuple[str, str]]) -> list[list[str]]:
     """Every maximal path (length ≥ 2 nodes) through the reduced DAG, finest→coarsest.
 
     A node with no incoming reduced edge is a chain start (the finest level); a
     node with no outgoing edge is the end (coarsest). Branching yields multiple
-    chains. Deterministic: starts and successors are sorted.
+    chains. Deterministic: starts and successors are sorted; the walk is
+    iterative (no recursion limit) and capped born-loud at
+    ``_MAX_CHAINS_PER_VIEW``. Input must be a DAG (``_break_cycles`` runs first).
     """
     succ: dict[str, list[str]] = {}
     has_incoming: set[str] = set()
@@ -369,19 +438,23 @@ def _maximal_chains(edges: set[tuple[str, str]]) -> list[list[str]]:
     starts = sorted({a for a, _ in edges} - has_incoming)
 
     chains: list[list[str]] = []
-
-    def walk(path: list[str]) -> None:
-        tail = path[-1]
-        nexts = succ.get(tail)
+    stack: list[list[str]] = [[s] for s in reversed(starts)]
+    while stack:
+        path = stack.pop()
+        nexts = succ.get(path[-1])
         if not nexts:
             if len(path) >= 2:
                 chains.append(path)
-            return
-        for nxt in nexts:
-            walk([*path, nxt])
-
-    for start in starts:
-        walk(path=[start])
+                if len(chains) >= _MAX_CHAINS_PER_VIEW:
+                    logger.warning(
+                        "hierarchy_chains_truncated",
+                        cap=_MAX_CHAINS_PER_VIEW,
+                        pending_paths=len(stack),
+                    )
+                    break
+            continue
+        for nxt in reversed(nexts):
+            stack.append([*path, nxt])
     return chains
 
 
@@ -563,7 +636,6 @@ def _view_structures(
         return []
 
     codes = {c: stats.codes_of(frame.get_column(c)) for c in eligible}
-    strs = {c: frame.get_column(c).fill_null("␀").to_numpy() for c in eligible}
     n_sample = frame.height
 
     # Null policy, edge arm (DAT-757 lane): a NULL is DATA when the column is
@@ -601,7 +673,7 @@ def _view_structures(
 
     g3_cache: dict[tuple[str, str], float] = {}
 
-    def row_g3(a: str, b: str) -> float:
+    def edge_g3(a: str, b: str) -> float:
         if (a, b) not in g3_cache:
             ca, cb, _, _ = edge_arrays(a, b)
             g3_cache[(a, b)] = stats.row_g3(ca, cb) if len(ca) else 1.0
@@ -629,6 +701,10 @@ def _view_structures(
     # -- 2. effect screens ----------------------------------------------------
     cand_alias: list[tuple[str, str]] = []
     cand_edge: list[tuple[str, str]] = []
+    # Edges whose pairwise-complete support fell below the floor are surfaced
+    # (needs_confirmation on any chain that uses them), never silently dropped —
+    # the same posture the tiny-view MIN_SUPPORT_ROWS flag takes.
+    low_support: set[tuple[str, str]] = set()
     for i, a in enumerate(eligible):
         for b in eligible[i + 1 :]:
             fwd, bwd = scan.pair_g3(a, b)
@@ -642,14 +718,13 @@ def _view_structures(
                     continue
                 if len(cs) < MIN_SUPPORT_ROWS and len(cs) < n_sample:
                     logger.info(
-                        "hierarchy_edge_excluded",
+                        "hierarchy_edge_low_support",
                         determinant=s,
                         dependent=t,
-                        reason="null_support",
                         complete_rows=len(cs),
                     )
-                    continue
-                if row_g3(s, t) > FD_MAX_G3:
+                    low_support.add((s, t))
+                if edge_g3(s, t) > FD_MAX_G3:
                     continue
                 # -- 3. λ floor: the vacuous-skew kill (edge arm only) --------
                 lam = stats.gk_lambda(cs, ct)
@@ -681,6 +756,10 @@ def _view_structures(
             ca, cb, _, _ = edge_arrays(a, b)
         else:
             ca, cb = codes[a], codes[b]
+        if len(ca) > _MAX_PERM_ROWS:
+            # Frame rows are in hash order — a prefix is a deterministic sample,
+            # and the permutation test is sample-honest at any subsample.
+            ca, cb = ca[:_MAX_PERM_ROWS], cb[:_MAX_PERM_ROWS]
         return task, stats.perm_pvalue(ca, cb, _pair_rng(arm, a, b))
 
     p_by_task: dict[tuple[str, str, str], float] = {}
@@ -711,18 +790,42 @@ def _view_structures(
         return {
             "column_name": c.column_name,
             "column_id": c.column_id,
+            # Null-aware d2 (NULL = one category) — deliberately differs from the
+            # pre-DAT-761 null-blind SQL count; the null lane made d2 the honest
+            # "values this axis distinguishes".
             "distinct_count": scan.d2[col],
         }
 
+    # Disagreement vectors are built lazily per BH-accepted pair — an up-front
+    # object-array for every eligible column is gigabytes at the cells budget,
+    # for a handful of consumers.
+    to_check: list[tuple[str, str, np.ndarray, float]] = []
     for a, b in sorted(acc_alias):
-        dis = (strs[a] != strs[b]).astype(np.int64)
+        dis = (
+            (frame.get_column(a).fill_null("␀") != frame.get_column(b).fill_null("␀"))
+            .to_numpy()
+            .astype(np.int64)
+        )
         rate = float(dis.mean())
         if rate == 0.0 or rate > ROLE_MAX_DISAGREE:
             # Exact copy, or a relabeling bijection (code ↔ name): a true alias.
             merged.append((a, b))
             continue
+        to_check.append((a, b, dis, rate))
+
+    def role_task(item: tuple[str, str, np.ndarray, float]) -> stats.RoleResult:
+        a, b, dis, _rate = item
         contexts = {c: codes[c] for c in eligible if c not in (a, b)}
-        result = stats.role_verdict(dis, contexts, codes[b], _pair_rng("role", a, b))
+        return stats.role_verdict(dis, contexts, codes[b], _pair_rng("role", a, b))
+
+    verdicts: list[stats.RoleResult] = []
+    if to_check:
+        # Same pool discipline as the perm stage: pure numpy, read-only shared
+        # codes, per-pair generators — deterministic at any worker count.
+        with ThreadPoolExecutor(max_workers=_PERM_WORKERS) as pool:
+            verdicts = list(pool.map(role_task, to_check))
+
+    for (a, b, _dis, rate), result in zip(to_check, verdicts, strict=True):
         logger.info(
             "hierarchy_role_check",
             a=a,
@@ -790,16 +893,20 @@ def _view_structures(
     rep = {c: sorted(g)[0] for g in members.values() for c in g}
 
     edges: set[tuple[str, str]] = set()
+    thin_edges: set[tuple[str, str]] = set()  # rep-level image of low_support
     for a, b in acc_edges:
         if frozenset((a, b)) in same_domain:
             continue
         ra, rb = rep[a], rep[b]
         if ra != rb:
             edges.add((ra, rb))
-    reduced = _transitive_reduction(edges)
+            if (a, b) in low_support:
+                thin_edges.add((ra, rb))
+    reduced = _transitive_reduction(_break_cycles(edges))
 
     for chain in _maximal_chains(reduced):
-        score = max(row_g3(chain[k], chain[k + 1]) for k in range(len(chain) - 1))
+        hops = [(chain[k], chain[k + 1]) for k in range(len(chain) - 1)]
+        score = max(edge_g3(x, y) for x, y in hops)
         out.append(
             {
                 "run_id": run_id,
@@ -810,7 +917,9 @@ def _view_structures(
                 "signature": f"drilldown:{fact_table_id}:" + "|".join(sorted(chain)),
                 "score": score,
                 "detection_source": "g3",
-                "needs_confirmation": needs_conf,
+                # Surface, don't decide: a chain resting on a sub-floor
+                # pairwise-complete edge is flagged, same as a tiny view.
+                "needs_confirmation": needs_conf or any(h in thin_edges for h in hops),
             }
         )
         logger.info("hierarchy_drilldown", view=view_name, chain=chain, score=round(score, 4))

--- a/packages/engine/src/dataraum/analysis/hierarchies/stats.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/stats.py
@@ -45,10 +45,14 @@ if TYPE_CHECKING:
 # Permutation budget: p_min = 1/(reps+1) ≈ 3.3e-4 — resolvable under BH even for
 # a single true hit in a family of ~100 candidates.
 PERM_REPS = 2999
-# Early-stop: once this many null exceedances are seen, no BH threshold at
-# q ≤ 0.05 could ever reject — stop permuting (conservative, exact).
+# Early-stop: once this many null exceedances are seen, stop permuting. The stop
+# is conservative ONLY while the minimum stoppable p — (1+count)/(1+block) —
+# exceeds every rejectable BH threshold: a stopped p can then never be rejected,
+# so P(p̃ ≤ α) ≤ α is preserved for all rejectable α. ``MAX_SOUND_Q`` is that
+# bound; callers must assert their q stays below it (the processor does).
 _EARLY_STOP_COUNT = 20
 _PERM_BLOCK = 100
+MAX_SOUND_Q = (1 + _EARLY_STOP_COUNT) / (1 + _PERM_BLOCK)  # ≈ 0.208
 
 
 def codes_of(series: pl.Series) -> np.ndarray:
@@ -56,7 +60,9 @@ def codes_of(series: pl.Series) -> np.ndarray:
 
     Null-as-category is the row-stat policy (DAT-757 null lane): a null-coded
     binary like ``{1, NULL}`` carries real structure that SQL ``COUNT(DISTINCT)``
-    is blind to. The sentinel is a non-colliding unicode NUL symbol.
+    is blind to. The sentinel is the unicode NUL *symbol* (U+2400) — a genuine
+    U+2400 in the data would collide, merging that value with NULL; accepted as
+    vanishingly rare rather than guarded.
     """
     import polars as pl  # noqa: PLC0415 — keep the module importable without polars typing
 
@@ -84,12 +90,8 @@ def _entropy_from_counts(counts: np.ndarray) -> float:
     return float(-(p * np.log(p)).sum())
 
 
-def fi(a: np.ndarray, b: np.ndarray) -> float:
-    """FI(a → b) = 1 − H(b|a)/H(b), in [0, 1]; 0 when H(b) = 0."""
-    _, b_counts = np.unique(b, return_counts=True)
-    h_b = _entropy_from_counts(b_counts)
-    if h_b == 0.0:
-        return 0.0
+def _h_conditional(a: np.ndarray, b: np.ndarray) -> float:
+    """H(b|a) over the (a, b) contingency."""
     counts, bounds = _grouped_sorted(a, b)
     n = len(a)
     group_tot = np.add.reduceat(counts, np.r_[0, bounds])
@@ -97,8 +99,16 @@ def fi(a: np.ndarray, b: np.ndarray) -> float:
         rep = np.repeat(group_tot, np.diff(np.r_[0, bounds, len(counts)]))
         p = counts / rep
         plogp = p * np.log(p)
-    h_b_given_a = float(-(np.add.reduceat(plogp, np.r_[0, bounds]) * group_tot / n).sum())
-    return 1.0 - h_b_given_a / h_b
+    return float(-(np.add.reduceat(plogp, np.r_[0, bounds]) * group_tot / n).sum())
+
+
+def fi(a: np.ndarray, b: np.ndarray) -> float:
+    """FI(a → b) = 1 − H(b|a)/H(b), in [0, 1]; 0 when H(b) = 0."""
+    _, b_counts = np.unique(b, return_counts=True)
+    h_b = _entropy_from_counts(b_counts)
+    if h_b == 0.0:
+        return 0.0
+    return 1.0 - _h_conditional(a, b) / h_b
 
 
 def perm_pvalue(
@@ -106,18 +116,26 @@ def perm_pvalue(
 ) -> float:
     """P_perm(FI(a, shuffled b) ≥ FI_obs), add-one corrected, early-stopping.
 
-    Early-stops in blocks once the exceedance count is high enough that no BH
-    threshold (q ≤ 0.05) could ever reject — the stopped p is an underestimate
-    of the true p only on the never-rejected side, so the stop is conservative.
+    Early-stops in blocks once the exceedance count guarantees no rejectable
+    BH threshold could ever accept the candidate (see ``MAX_SOUND_Q``) — the
+    stopped p is an underestimate of the true p only on the never-rejected
+    side, so the stop is conservative while q ≤ ``MAX_SOUND_Q``.
+
+    H(b) and FI_obs are hoisted out of the loop — b's marginal is
+    shuffle-invariant, so each rep pays only the H(b|a) contingency pass.
     """
-    obs = fi(a, b)
+    _, b_counts = np.unique(b, return_counts=True)
+    h_b = _entropy_from_counts(b_counts)
+    if h_b == 0.0:
+        return 1.0  # a constant b carries no dependence to test
+    obs = 1.0 - _h_conditional(a, b) / h_b
     bc = b.copy()
     count = done = 0
     while done < reps:
         block = min(_PERM_BLOCK, reps - done)
         for _ in range(block):
             rng.shuffle(bc)
-            if fi(a, bc) >= obs:
+            if 1.0 - _h_conditional(a, bc) / h_b >= obs:
                 count += 1
         done += block
         if count >= _EARLY_STOP_COUNT:
@@ -198,6 +216,12 @@ def role_verdict(
     VALUE_SYSTEMATIC (escalate, never merge on its own: real dirt is rarely
     marginal-random, so T2 alone cannot separate role from concentrated dirt);
     else if the permutation p-floor cannot reach α → ABSTAIN; else DIRT.
+
+    Width-driven boundary (documented, deliberate): with the default budget the
+    permutation p-floor is 1/(reps+1) ≈ 3.3e-4, so once m ≳ 150 contexts push
+    α = alpha_family/m below that floor, the verdict is unconditionally ABSTAIN
+    — on very wide views the role question honestly defers to the semantic lane
+    rather than deciding from an unresolvable test.
     """
     m = len(contexts) + 1
     alpha = alpha_family / m

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -158,18 +158,20 @@ class SliceContext:
 
 @dataclass
 class HierarchyContext:
-    """A discovered drill-down hierarchy or 1:1 alias group (DAT-537).
+    """A discovered drill-down hierarchy, alias group or role pair (DAT-537/761).
 
-    The g3 functional-dependency pass surfaces these over a fact's enriched view:
-    a ``drilldown`` carries ordered levels finest → coarsest (``zip → city →
-    state``), an ``alias`` a redundant-axis group collapsed to one canonical label.
-    Exposed for the answer agent / GraphAgent to drill and de-duplicate axes; the
-    prompt CONSUMPTION lands in DAT-538 (this is the expose seam, not the use).
+    The FD pass surfaces these over a fact's enriched view: a ``drilldown``
+    carries ordered levels finest → coarsest (``zip → city → state``), an
+    ``alias`` a redundant-axis group collapsed to one canonical label, a
+    ``role`` (DAT-761) a role-playing near-copy pair (bill-to ⇄ pay-to) that
+    must stay two separate axes. Exposed for the answer agent / GraphAgent to
+    drill and de-duplicate axes; the prompt CONSUMPTION lands in DAT-538 (this
+    is the expose seam, not the use).
     """
 
-    kind: str  # 'drilldown' | 'alias'
+    kind: str  # 'drilldown' | 'alias' | 'role'
     table_name: str
-    members: list[str]  # ordered level names (drilldown) or the group (alias)
+    members: list[str]  # ordered levels (drilldown) or the group/pair (alias, role)
     canonical_label: str
     needs_confirmation: bool = False
 

--- a/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
@@ -16,7 +16,11 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
-from dataraum.analysis.hierarchies.processor import discover_dimension_hierarchies
+from dataraum.analysis.hierarchies.processor import (
+    _break_cycles,
+    _maximal_chains,
+    discover_dimension_hierarchies,
+)
 from dataraum.analysis.semantic.db_models import SemanticAnnotation
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.storage import Column
@@ -216,6 +220,23 @@ class TestStackV4:
         drills = _rows(real_session, tid, "drilldown")
         assert [_members(r) for r in drills] == [["city", "state"]]
 
+    def test_sub_floor_null_support_surfaces_not_drops(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """An edge whose pairwise-complete support falls below the floor is
+        surfaced with ``needs_confirmation`` — never silently dropped (the
+        review-finding posture: same as the tiny-view flag)."""
+        n = 400
+        city = [f"c{i % 20}" for i in range(n)]
+        # Nulls in 20-row blocks (coprime with the city cycle): 80 complete rows
+        # covering every city, so only SUPPORT is thin — not the FD structure.
+        state = [f"s{(i % 20) // 5}" if (i // 20) % 5 == 0 else None for i in range(n)]
+        tid = seed_view(real_session, duck, "sparse_geo", {"city": city, "state": state})
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+        drills = _rows(real_session, tid, "drilldown")
+        assert [_members(r) for r in drills] == [["city", "state"]]
+        assert drills[0].needs_confirmation is True
+
     def test_null_coded_columns_alias(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
@@ -289,6 +310,29 @@ class TestStackV4:
         assert [_members(r) for r in aliases] == [["mystery", "state"]]
         by_name = {m["column_name"]: m["column_id"] for m in aliases[0].members}
         assert by_name["mystery"] == "" and by_name["state"] != ""
+
+
+class TestChainAssemblyGuards:
+    """Cycle and scale guards on the decided-DAG walk (DAT-761 review findings)."""
+
+    def test_break_cycles_drops_cyclic_core_keeps_spur(self) -> None:
+        # A rep-level 2-cycle is contradictory determination evidence: its
+        # internal edges go (loudly), the spur INTO it survives as a chain to
+        # a now-sink node — never a hang, never a silent full drop.
+        kept = _break_cycles({("s", "a"), ("a", "b"), ("b", "a")})
+        assert kept == {("s", "a")}
+        assert _maximal_chains(kept) == [["s", "a"]]
+
+    def test_pure_two_cycle_yields_no_chains_loudly(self) -> None:
+        assert _break_cycles({("a", "b"), ("b", "a")}) == set()
+
+    def test_maximal_chains_is_iterative_beyond_recursion_depth(self) -> None:
+        # The old recursive walk died at ~1000 nodes; the iterative walk must
+        # handle a path far deeper than any recursion limit.
+        edges = {(f"n{i:04d}", f"n{i + 1:04d}") for i in range(5000)}
+        chains = _maximal_chains(edges)
+        assert len(chains) == 1
+        assert len(chains[0]) == 5001
 
 
 class TestDimensionHierarchiesPhaseSkip:


### PR DESCRIPTION
## What

Philipp asked for the project's two reviewers (`senior-code-reviewer`, `spec-compliance-reviewer`) to run on the merged DAT-761 change. Verdicts: **no critical issues** (concurrency design, numpy kernels vs brute force, early-stop soundness, and the pruning math all verified) / **spec compliant** (full traceability, DAT-762 deferrals absent). This PR lands every surviving finding.

## Fixes (senior review, ranked)

1. **Cycle guard in chain assembly** — the pairwise-complete edge orientation weakened the old single-count acyclicity premise; a rep-level cycle could hang the recursive walk (`RecursionError` kills the phase) or silently emit no chains. Now: `_break_cycles` (Kahn peel) drops cyclic-core edges born-loud (`hierarchy_cycle_detected`), spurs into the cycle survive as chains; `_maximal_chains` is iterative and capped (500, `hierarchy_chains_truncated`).
2. **Perm-stage cost on narrow-tall views** — own row ceiling (1M, independent of the 40M-cells budget; hash-ordered prefix = deterministic sample) + H(b)/FI_obs hoisted out of the permutation loop (shuffle-invariant, ~40% of the hot path).
3. **Memory** — disagreement vectors built lazily per BH-accepted near-copy pair instead of materializing every eligible column as a Python-object array.
4. **SQL identifier quoting** — `_quote()` with embedded-quote doubling (the drivers convention) at all 7 interpolation sites.
5. **Early-stop soundness coupling** — `stats.MAX_SOUND_Q` + module assert (`Q_FDR < MAX_SOUND_Q`); the invariant is now written down, not implicit.
6. **Role stage parallelized** — same bounded pool + per-pair generator discipline as the perm stage; the m ≳ 150 contexts → unconditional ABSTAIN width boundary documented.
7. **`kind='role'` contract docs** — `db_models.py` docstring + column comment, `graphs/context.py::HierarchyContext`; handoff sampling wording (bottom-k-by-hash, not reservoir).
8. **Sub-floor pairwise-complete edges surfaced** (`needs_confirmation` on chains using them), not silently dropped — consistent with the tiny-view posture.

Plus nits: `edge_g3` closure rename, tuple-clustered sampling comment, honest U+2400 sentinel claim, d2 display-semantics comment.

## Decision impact

None on the acceptance corpora: no cycles arise there, all fit under the perm ceiling, quoting is identity for clean names, the H(b) hoist is algebraically identical, and lazy disagreement vectors compute the same values. The only behavior change is sub-floor-support edges now surfacing flagged instead of disappearing — covered by a new test.

## Tests

3 new (cycle guard spur/core, iterative walk at 5001 nodes, sub-floor surfacing); 35 hierarchy tests green; testmon fallout clean; ruff/mypy/vulture clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)