### PR TITLE
fix(engine): DAT-766 — typing re-run must not delete minted _sk__ columns

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,37 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-766 — addSource re-run: typing no longer deletes minted `_sk__*` (FK crash fixed)
+
+**Branch:** `fix/dat-766-typing-preserve-surrogate-columns`. Typing-phase behavior
+change on **re-runs only** (a fresh run is unaffected).
+
+### What changed
+
+- `reconcile_typed_columns` (`analysis/typing/resolution.py`) now **never deletes a
+  minted surrogate** (`_sk__*`, DAT-277). `resolve_types` builds its `desired` set
+  from the RAW source's columns only, so a surrogate minted onto the typed table by
+  a prior run looked "dropped" and was DELETEd — violating the FK from the surrogate
+  relationship that still referenced it (`ForeignKeyViolation` → `PhaseFailed: No
+  tables were successfully typed` → the whole sibling-table cascade cancelled). The
+  surrogate mint owns the `_sk__*` lifecycle; typing leaves those columns alone.
+
+### For eval
+
+- **The DAT-766 repro is fixed:** `python -m calibration.run -s clean` twice without
+  `--reset` (any corpus that mints a surrogate) now proceeds **past typing** on the
+  re-run instead of dying at the FK violation. Re-running addSource over an
+  already-completed (minted) workspace is now safe.
+- **Sibling DAT-767 is still open:** the `detection-v1` re-run can still fail typing
+  with a DuckDB binder error (`"…" cannot be referenced before it is defined`) on a
+  mixed-case noise column. That mechanism is NOT closed — the engine loaders all
+  normalize physical raw columns to lowercase, so the reported "physical column is
+  mixed-case" doesn't hold against the loader code; closing it needs a trace of the
+  exact failing SQL + the raw table's true physical column case from a failing
+  workspace. Until then, expect `detection-v1` re-run (no `--reset`) to still break.
+
+---
+
 ## DAT-761 — stack v4 dimension identity: DAT-757 gate stack replaces distinct-ratio g3
 
 **Branch:** `feat/dat-761-stack-v4-dimension-identity`. **The `dimension_hierarchies`

--- a/packages/engine/src/dataraum/analysis/typing/resolution.py
+++ b/packages/engine/src/dataraum/analysis/typing/resolution.py
@@ -150,13 +150,29 @@ def reconcile_typed_columns(
     Keeping ids stable is what lets a re-type avoid orphaning another stage's
     per-Column rows (DAT-373 Option A).
     """
+    # Local import: a module-scope import would pull the whole downstream
+    # ``relationships`` package (its ``__init__`` eagerly loads the detector/
+    # evaluator tree) onto every load of this upstream typing module. No cycle
+    # today — just keeping that layering dependency lazy.
+    from dataraum.analysis.relationships.surrogate import is_surrogate_column
+
     current = {c.column_name: c for c in typed_table.columns}
     desired_names = {d[0] for d in desired}
 
-    # Delete columns that are no longer present in the re-typed table.
+    # Delete columns no longer present in the re-typed table — but NEVER a
+    # mint-owned surrogate (``_sk__*``). ``desired`` is built from the RAW
+    # source's columns only, which by construction never include an engine-minted
+    # surrogate (DAT-277); the surrogate mint owns their full lifecycle on the
+    # typed table (``surrogate_mint_phase`` re-materializes the physical column
+    # and reconciles the row, and is the ONLY writer that deletes a surrogate —
+    # clearing its FK children first). Deleting one here on a re-type would
+    # instead violate the FK from the surrogate relationship that still
+    # references it, failing the typing phase and killing the whole re-run
+    # cascade (DAT-766). Typing must not delete a column it did not create.
     for name, col in list(current.items()):
-        if name not in desired_names:
-            session.delete(col)
+        if name in desired_names or is_surrogate_column(name):
+            continue
+        session.delete(col)
 
     column_map: dict[str, str] = {}
     for column_name, original_name, position, raw_type, resolved_type in desired:

--- a/packages/engine/tests/unit/analysis/typing/test_reconcile_columns.py
+++ b/packages/engine/tests/unit/analysis/typing/test_reconcile_columns.py
@@ -1,0 +1,127 @@
+"""``reconcile_typed_columns`` must never delete a minted surrogate (DAT-766).
+
+A re-run of ``addSource`` over a workspace that already minted a surrogate key
+failed the typing phase: ``resolve_types`` builds its ``desired`` column set from
+the RAW source's columns only, so an engine-minted ``_sk__*`` column (DAT-277)
+present on the typed table from a prior run looks "dropped" and the reconcile
+tried to DELETE it — while the surrogate relationship the mint persisted still
+referenced it (``ForeignKeyViolation`` → ``PhaseFailed`` → cascade dead). The
+surrogate mint owns the ``_sk__*`` lifecycle; typing must leave those columns
+alone.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine, event, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from dataraum.analysis.relationships.surrogate import SURROGATE_PREFIX
+from dataraum.analysis.typing.resolution import reconcile_typed_columns
+from dataraum.storage import Column, Table, init_database
+
+SURROGATE_COL = f"{SURROGATE_PREFIX}date__entry_id"
+
+
+@pytest.fixture
+def session_factory():
+    """In-memory SQLite engine with all tables; FKs off so parent rows are optional."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _pragma(dbapi_conn, _record):  # noqa: ANN001, ANN202
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=OFF")
+        cur.close()
+
+    init_database(engine)
+    factory = sessionmaker(bind=engine)
+    try:
+        yield factory
+    finally:
+        engine.dispose()
+
+
+def _seed_typed_table(factory: Any) -> None:
+    """A typed table carrying a raw-derived column, a stale column, and a surrogate."""
+    with factory() as session:
+        session.add(
+            Table(
+                table_id="typed-1",
+                source_id="src-1",
+                table_name="journal_entries",
+                layer="typed",
+                duckdb_path="journal_entries",
+            )
+        )
+        # ``entry_id`` still comes from the raw source; ``stale_col`` was dropped
+        # from the source; ``_sk__*`` was minted onto the typed table by DAT-277.
+        for pos, name in enumerate(("entry_id", "stale_col", SURROGATE_COL)):
+            session.add(
+                Column(
+                    column_id=f"col-{name}",
+                    table_id="typed-1",
+                    column_name=name,
+                    column_position=pos,
+                    raw_type="VARCHAR",
+                    resolved_type="VARCHAR",
+                )
+            )
+        session.commit()
+
+
+def _typed_column_names(factory: Any) -> set[str]:
+    with factory() as session:
+        return {
+            c.column_name
+            for c in session.execute(select(Column).where(Column.table_id == "typed-1")).scalars()
+        }
+
+
+def test_reconcile_preserves_surrogate_deletes_stale(session_factory: Any) -> None:
+    """A re-type keeps the raw-derived + minted columns, deletes only the stale one."""
+    _seed_typed_table(session_factory)
+
+    # ``desired`` mirrors ``resolve_types``: it is built from the raw source and
+    # therefore names ``entry_id`` only — neither the stale source column nor the
+    # engine-minted surrogate appears in it.
+    desired = [("entry_id", "entry_id", 0, "VARCHAR", "BIGINT")]
+
+    with session_factory() as session:
+        typed_table = session.execute(select(Table).where(Table.table_id == "typed-1")).scalar_one()
+        column_map = reconcile_typed_columns(session, typed_table, desired)
+        session.commit()
+
+    survivors = _typed_column_names(session_factory)
+    assert SURROGATE_COL in survivors, "minted surrogate must survive a re-type (DAT-766)"
+    assert "stale_col" not in survivors, "a genuinely dropped source column is still deleted"
+    assert "entry_id" in survivors
+    # The reconcile only reports the reconciled (raw-desired) set; the surrogate is
+    # left untouched, not re-owned by typing.
+    assert set(column_map) == {"entry_id"}
+
+
+def test_reconcile_updates_surviving_column_in_place(session_factory: Any) -> None:
+    """The raw-derived column is UPDATED (id preserved), not re-created."""
+    _seed_typed_table(session_factory)
+    desired = [("entry_id", "entry_id", 0, "VARCHAR", "BIGINT")]
+
+    with session_factory() as session:
+        typed_table = session.execute(select(Table).where(Table.table_id == "typed-1")).scalar_one()
+        column_map = reconcile_typed_columns(session, typed_table, desired)
+        session.commit()
+
+    assert column_map["entry_id"] == "col-entry_id"  # stable id, updated in place
+    with session_factory() as session:
+        entry = session.execute(
+            select(Column).where(Column.column_id == "col-entry_id")
+        ).scalar_one()
+        assert entry.resolved_type == "BIGINT"  # re-typed value applied


### PR DESCRIPTION
## DAT-766

On an `addSource` re-run over a workspace that already minted a surrogate key, the typing phase crashed with a `ForeignKeyViolation` → `PhaseFailed: No tables were successfully typed` → the whole sibling-table cascade was cancelled.

### Root cause
`reconcile_typed_columns` (`analysis/typing/resolution.py`) builds its "delete dropped" set from the **raw** source's columns only. An engine-minted surrogate (`_sk__*`, DAT-277) lives on the *typed* table but never in the raw specs, so a re-type saw it as "dropped" and issued `DELETE FROM columns` — while the surrogate relationship the mint persisted still referenced it. The `relationships → columns` FKs carry **no `ON DELETE CASCADE`**, so the delete raised at flush.

### Fix
The delete branch now skips any `is_surrogate_column(name)` (`_sk__*`) column — typing must not delete a column it did not create. The surrogate mint owns the full `_sk__*` lifecycle: it re-materializes the physical column from a live `DESCRIBE` (so the surviving metadata row introduces no gap) and is the only writer that deletes a surrogate, clearing its FK children first.

### Tests
`tests/unit/analysis/typing/test_reconcile_columns.py` — a re-type keeps the minted surrogate + raw-derived column (updated in place, stable id) and deletes only a genuinely-dropped source column. Fails without the fix. Full typing suite green; ruff + mypy clean.

### Reviewers
Senior + spec-compliance reviewers both approved (no critical issues); both independently confirmed the missing `ON DELETE CASCADE` and that the mint re-materialization gates on physical state, not metadata.

### Scope
Behavior change on **re-runs only** — a fresh run is unaffected. Sibling **DAT-767** (mixed-case binder error on re-run) is a separate, still-open bug and does not depend on this. Handoff note added for eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)