### PR TITLE
fix(lineage): support-first convention selection — Wilson LCB + ΔBIC arity tie-break (DAT-759)

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,39 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-759 — aggregation-lineage convention selection is support-first (Wilson LCB)
+
+**Branch:** `fix/dat-759-convention-selection`. `discover_aggregation_lineage`
+no longer selects the reconciliation convention by minimum median residual —
+that criterion is monotone under the ordered-difference search family, so
+collinear artifacts (`debit − net_amount ≡ credit`) out-raced true singles on
+half-entity subsets and persisted **value-wrong `convention_sql`** into the
+property-graph grounding (the 0.50/0.75 match rates eval surfaced).
+
+### What changed
+
+- **Selection order:** Wilson score LCB (95%) of the vote rate over the
+  pairing's **common entity denominator** → on LCB ties, lower arity unless the
+  difference wins by ΔBIC > 10 (Kass–Raftery) → median residual. Grounded in
+  the eval probe `scripts/probes/dat759-convention-selection` (truth 3/3,
+  LCB margins 0.345–0.620; min-residual was value-wrong on 2/3 real measures).
+- **No schema change.** Persisted `MeasureAggregationLineage` fields are
+  unchanged; only which candidate wins changed. `lineage_reconciled` log lines
+  now also carry `support_lcb` + `n_entities_fired`.
+- `reconcile.py` gains `wilson_lcb`, `classify_series`, `dispose_classified`
+  (pure refactor of `dispose`; `FIRE_RESIDUAL_MAX` vote gate unchanged — the
+  min-over-family permutation-null replacement for it is a follow-up ticket).
+
+### What eval should see
+
+- `trial_balance.debit_balance` / `credit_balance` reconcile with conventions
+  `"debit"` / `"credit"` at match_rate 1.0 (was `debit − net_amount` at 0.50 /
+  `credit` at 0.75) → `test_reconciliation_covers_expected_rollup_measures`
+  goes 3/3. `balance_sheet.ending_balance` may report `"net_amount"` instead of
+  the value-identical `"debit" - "credit"` (arity preference).
+
+---
+
 ## DAT-761 — stack v4 dimension identity: DAT-757 gate stack replaces distinct-ratio g3
 
 **Branch:** `feat/dat-761-stack-v4-dimension-identity`. **The `dimension_hierarchies`

--- a/packages/engine/src/dataraum/analysis/lineage/processor.py
+++ b/packages/engine/src/dataraum/analysis/lineage/processor.py
@@ -18,8 +18,19 @@ and ordered pair differences like ``debit − credit`` — sums are linear, so
 conventions distribute over them), and lets the deterministic reconciliation
 statistic (:mod:`dataraum.analysis.lineage.reconcile`) dispose every pairing. A
 wrong pairing lands at residual ≈ 1 and abstains (probe margins: true ≈ 0.02 vs
-wrong-anchor ≈ 1.0); the best reconciling verdict per measure column persists as
-one run-versioned ``MeasureAggregationLineage`` row.
+wrong-anchor ≈ 1.0).
+
+Convention selection is SUPPORT-FIRST (DAT-759): candidates are ranked by the
+Wilson lower bound of their vote rate over the pairing's COMMON entity
+denominator, LCB ties break to the lower arity unless the difference wins by
+ΔBIC > 10 (Kass–Raftery), then by median residual. Minimum-residual selection
+was the prior criterion and is monotone under search freedom — the ordered
+differences structurally out-raced true singles (``debit − net_amount ≈ credit``
+beat ``debit`` on a half-entity subset), persisting value-wrong ``convention_sql``
+into the property-graph grounding. Grounded in the eval probe
+``scripts/probes/dat759-convention-selection`` (truth 3/3, margins 0.345–0.620
+LCB). The best candidate per measure column persists as one run-versioned
+``MeasureAggregationLineage`` row.
 
 Every abstention logs its stage (``lineage_candidate_dropped``) — visible,
 never silent.
@@ -27,6 +38,7 @@ never silent.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -34,7 +46,12 @@ from sqlalchemy import select
 
 from dataraum.analysis.lineage.db_models import MeasureAggregationLineage
 from dataraum.analysis.lineage.models import CandidateDisposal
-from dataraum.analysis.lineage.reconcile import dispose
+from dataraum.analysis.lineage.reconcile import (
+    MIN_PERIODS,
+    classify_series,
+    dispose_classified,
+    wilson_lcb,
+)
 from dataraum.analysis.relationships.utils import load_defined_relationships
 from dataraum.analysis.semantic.db_models import TableEntity
 from dataraum.analysis.slicing.db_models import SliceDefinition
@@ -219,12 +236,71 @@ def _paired_row_counts(measure: _SliceSeries, event: _SliceSeries) -> tuple[int,
     return m_total, e_total
 
 
+def _pairing_universe(measure: _SliceSeries, event: _SliceSeries, measure_col: str) -> int:
+    """The COMMON entity denominator for one (measure, event) pairing (DAT-759).
+
+    Entities whose measure series is evaluable at all — ≥ ``MIN_PERIODS`` aligned
+    periods carrying the measure value, not identically zero — independent of any
+    convention's terms. Vote rates are comparable across the family only on this
+    shared denominator: a convention whose terms are absent on some entities must
+    NOT get a shrunken denominator and a flattered rate (the support-gameability
+    trap, probe leg b2 — own-subset LCB 0.722 vs common 0.299 on the same votes).
+    """
+    n = 0
+    for value in measure.sums.keys() & event.sums.keys():
+        m_periods = measure.sums[value]
+        ys = [
+            m_periods[label][measure_col]
+            for label in m_periods.keys() & event.sums[value].keys()
+            if measure_col in m_periods[label]
+        ]
+        if len(ys) >= MIN_PERIODS and any(ys):
+            n += 1
+    return n
+
+
 @dataclass(frozen=True)
 class _Best:
     verdict: CandidateDisposal
     event_table: Table
     convention_sql: str
-    winning_residual: float
+    winning_residual: float  # median winning-pattern voter residual
+    support_lcb: float  # Wilson LCB of voters over the pairing's common denominator
+    arity: int  # convention terms: 1 = single, 2 = ordered difference
+    voter_residuals: tuple[float, ...]  # winning-pattern per-entity residuals (ΔBIC)
+
+
+def _bic(candidate: _Best) -> float:
+    """BIC over the pooled winning-voter residual mass; ``k`` = arity."""
+    n = len(candidate.voter_residuals)
+    if n == 0:
+        return float("inf")
+    rss = max(sum(r * r for r in candidate.voter_residuals), 1e-12)
+    return n * math.log(rss / n) + candidate.arity * math.log(n)
+
+
+def _better(challenger: _Best, incumbent: _Best) -> bool:
+    """DAT-759 selection order: support, then description length, then residual.
+
+    1. Higher Wilson LCB wins — breadth of reconciling entities is the
+       generalization estimate, not residual depth on a subset.
+    2. On an LCB tie across arities, the single wins unless the difference is
+       very strongly better (ΔBIC > 10, Kass–Raftery) — exact collinear twins
+       (``debit − net_amount ≡ credit``) are numerically identical, so only
+       description length can order them.
+    3. Same arity: lower median residual.
+    """
+    if abs(challenger.support_lcb - incumbent.support_lcb) > 1e-12:
+        return challenger.support_lcb > incumbent.support_lcb
+    if challenger.arity != incumbent.arity:
+        single, difference = (
+            (incumbent, challenger)
+            if challenger.arity > incumbent.arity
+            else (challenger, incumbent)
+        )
+        difference_wins = _bic(single) - _bic(difference) > 10.0
+        return difference_wins == (challenger is difference)
+    return challenger.winning_residual < incumbent.winning_residual
 
 
 def discover_aggregation_lineage(
@@ -433,11 +509,18 @@ def discover_aggregation_lineage(
                             [c for c in event.numeric_columns if c not in keys_e]
                         )
                         for measure_col in measure_cols:
+                            # The common denominator every convention's vote rate
+                            # is judged against (DAT-759) — fixed per pairing, so
+                            # a term missing on some entities can't flatter a rate.
+                            universe = _pairing_universe(measure, event, measure_col)
+                            if universe == 0:
+                                continue
                             for convention_sql, terms in conventions:
                                 by_entity = _aligned_series(measure, event, measure_col, terms)
                                 if not by_entity:
                                     continue
-                                verdict = dispose(by_entity)
+                                results = classify_series(by_entity)
+                                verdict = dispose_classified(results)
                                 if verdict is None:
                                     continue
                                 residual = (
@@ -445,16 +528,24 @@ def discover_aggregation_lineage(
                                     if verdict.pattern == "per_period"
                                     else verdict.r_stock_median
                                 )
+                                challenger = _Best(
+                                    verdict=verdict,
+                                    event_table=event.table,
+                                    convention_sql=convention_sql,
+                                    winning_residual=residual,
+                                    support_lcb=wilson_lcb(verdict.n_entities_fired, universe),
+                                    arity=len(terms),
+                                    voter_residuals=tuple(
+                                        min(r.r_flow, r.r_stock)
+                                        for r in results.values()
+                                        if r.label == verdict.pattern
+                                    ),
+                                )
                                 key = columns_by_table[m_tid][measure_col].column_id
                                 prior = best_by_measure.get(key)
-                                if prior is None or residual < prior[0].winning_residual:
+                                if prior is None or _better(challenger, prior[0]):
                                     best_by_measure[key] = (
-                                        _Best(
-                                            verdict=verdict,
-                                            event_table=event.table,
-                                            convention_sql=convention_sql,
-                                            winning_residual=residual,
-                                        ),
+                                        challenger,
                                         measure.table,
                                         measure_col,
                                         slice_label,
@@ -489,6 +580,8 @@ def discover_aggregation_lineage(
             convention=best.convention_sql,
             pattern=best.verdict.pattern,
             match_rate=round(best.verdict.match_rate, 3),
+            support_lcb=round(best.support_lcb, 3),
+            n_entities_fired=best.verdict.n_entities_fired,
         )
     upsert(
         session,

--- a/packages/engine/src/dataraum/analysis/lineage/processor.py
+++ b/packages/engine/src/dataraum/analysis/lineage/processor.py
@@ -32,8 +32,11 @@ into the property-graph grounding. Grounded in the eval probe
 LCB). The best candidate per measure column persists as one run-versioned
 ``MeasureAggregationLineage`` row.
 
-Every abstention logs its stage (``lineage_candidate_dropped``) — visible,
-never silent.
+Every abstention logs its stage (``lineage_no_shared_dimension`` /
+``lineage_no_slice_series`` / ``lineage_direction_gate`` /
+``inline_slice_series_failed`` / ``lineage_convention_columns_capped``) —
+visible, never silent; per-convention abstentions inside a live pairing are
+the search doing its job and stay quiet.
 """
 
 from __future__ import annotations
@@ -271,7 +274,14 @@ class _Best:
 
 
 def _bic(candidate: _Best) -> float:
-    """BIC over the pooled winning-voter residual mass; ``k`` = arity."""
+    """Schwarz BIC over the pooled winning-voter residual mass; ``k`` = arity.
+
+    Winning-pattern voters only — consistent with the verdict's medians (the
+    grounding probe pooled ALL voters; immaterial where it matters, since
+    collinear twins share voter sets). The 1e-12 RSS floor means two exact-fit
+    candidates with different voter counts compare through the floor, not
+    evidence — reachable only on a cross-pairing exact-LCB tie, accepted.
+    """
     n = len(candidate.voter_residuals)
     if n == 0:
         return float("inf")
@@ -283,14 +293,24 @@ def _better(challenger: _Best, incumbent: _Best) -> bool:
     """DAT-759 selection order: support, then description length, then residual.
 
     1. Higher Wilson LCB wins — breadth of reconciling entities is the
-       generalization estimate, not residual depth on a subset.
+       generalization estimate, not residual depth on a subset. Support counts
+       every reconciling voter (a ≤20% pattern-dissenting minority included):
+       support means "this convention reconciles the entity", not "votes my
+       pattern".
     2. On an LCB tie across arities, the single wins unless the difference is
        very strongly better (ΔBIC > 10, Kass–Raftery) — exact collinear twins
        (``debit − net_amount ≡ credit``) are numerically identical, so only
-       description length can order them.
+       description length can order them. ΔBIC is statistically meaningful
+       within one pairing (same entities, same periods); a cross-pairing exact
+       LCB tie compares different data and the step degrades to a heuristic.
     3. Same arity: lower median residual.
+
+    Pairwise, not a strict weak order: mixing BIC (step 2) with median residual
+    (step 3) admits rare tie-surface cycles, so the streaming argmax is defined
+    by enumeration order — which is fully sorted (identities, tables, axes,
+    conventions) and therefore deterministic per run and per re-delivery.
     """
-    if abs(challenger.support_lcb - incumbent.support_lcb) > 1e-12:
+    if challenger.support_lcb != incumbent.support_lcb:
         return challenger.support_lcb > incumbent.support_lcb
     if challenger.arity != incumbent.arity:
         single, difference = (
@@ -314,8 +334,8 @@ def discover_aggregation_lineage(
     """Reconcile every shared-dimension fact pair and persist the verdicts.
 
     Idempotent per run — form-(a) writer (DAT-502): one row per measure
-    column (the best reconciling event table + convention by winning
-    residual), UPSERTed on ``uq_measure_lineage_column_run``. A Temporal
+    column (the best reconciling event table + convention by support-first
+    selection, see :func:`_better`), UPSERTed on ``uq_measure_lineage_column_run``. A Temporal
     success-redelivery (same ``run_id``) converges in place; prior runs'
     rows stay untouched. Deterministic SQL producer: the recomputed batch
     is the same verdict set, so no run-scoped clear is needed.
@@ -328,12 +348,18 @@ def discover_aggregation_lineage(
         for t in session.execute(select(Table).where(Table.table_id.in_(table_ids))).scalars()
     }
     # This run's slice dimensions (grouped by referenced identity below).
+    # Deterministic order: candidate enumeration inherits it, and the streaming
+    # argmax in ``_better`` resolves exact ties by that order — an unordered
+    # scan could let a Temporal success-redelivery pick a different equally-
+    # ranked verdict, breaking the deterministic-producer claim above.
     defs = (
         session.execute(
-            select(SliceDefinition).where(
+            select(SliceDefinition)
+            .where(
                 SliceDefinition.table_id.in_(table_ids),
                 SliceDefinition.run_id == run_id,
             )
+            .order_by(SliceDefinition.slice_priority, SliceDefinition.column_name)
         )
         .scalars()
         .all()

--- a/packages/engine/src/dataraum/analysis/lineage/reconcile.py
+++ b/packages/engine/src/dataraum/analysis/lineage/reconcile.py
@@ -29,6 +29,7 @@ are separation-derived from the probe (provenance above), not fitted to a metric
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from statistics import median
@@ -106,6 +107,38 @@ def classify_entity(y: Sequence[float], m: Sequence[float]) -> EntityReconciliat
     return EntityReconciliation(r_flow=r_flow, r_stock=r_stock, label=label)
 
 
+def classify_series(
+    series: Mapping[str, tuple[Sequence[float], Sequence[float]]],
+) -> dict[str, EntityReconciliation]:
+    """Classify every entity's aligned ``(y, m)`` series (DAT-759 split).
+
+    Exposed separately from :func:`dispose` so the selection layer can read the
+    per-entity residuals (support counting, ΔBIC arity tie-break) without
+    re-running the arithmetic.
+    """
+    return {k: classify_entity(y, m) for k, (y, m) in series.items()}
+
+
+def wilson_lcb(successes: int, n: int, z: float = 1.96) -> float:
+    """Wilson score interval lower bound for a ``successes / n`` rate (DAT-759).
+
+    The support statistic for convention selection: because the reconciliation
+    residual carries no fitted per-entity coefficient, leave-one-entity-out CV
+    degenerates to the vote count — the vote RATE is an out-of-sample
+    generalization estimate, and its Wilson lower bound (Wilson 1927) is the
+    parameter-free way to rank it under small n. ``n`` MUST be the common
+    entity denominator of the pairing, never a convention's own aligned subset
+    (the support-gameability trap — DAT-759 probe leg b2).
+    """
+    if n <= 0:
+        return 0.0
+    p = successes / n
+    denom = 1 + z * z / n
+    centre = p + z * z / (2 * n)
+    margin = z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))
+    return max(0.0, (centre - margin) / denom)
+
+
 def dispose(
     series: Mapping[str, tuple[Sequence[float], Sequence[float]]],
 ) -> CandidateDisposal | None:
@@ -119,9 +152,15 @@ def dispose(
         (``match_rate`` = voting fraction × agreement), else ``None`` — the
         candidate did not reconcile and the witness must abstain.
     """
-    if not series:
+    return dispose_classified(classify_series(series))
+
+
+def dispose_classified(
+    results: Mapping[str, EntityReconciliation],
+) -> CandidateDisposal | None:
+    """:func:`dispose` over pre-classified entities (see :func:`classify_series`)."""
+    if not results:
         return None
-    results = {k: classify_entity(y, m) for k, (y, m) in series.items()}
     voted = [r for r in results.values() if r.label is not None]
     if len(voted) < MIN_ENTITIES_FIRED:
         return None

--- a/packages/engine/tests/unit/analysis/lineage/test_processor.py
+++ b/packages/engine/tests/unit/analysis/lineage/test_processor.py
@@ -277,6 +277,220 @@ def _row_for(session: Session, column_id: str) -> MeasureAggregationLineage | No
     ).scalar_one_or_none()
 
 
+def _seed_series(
+    session: Session,
+    duck: duckdb.DuckDBPyConnection,
+    *,
+    measure_col: str,
+    measure_by_entity: dict[str, list[float]],
+    event_cols: list[str],
+    event_by_entity: dict[str, dict[str, list[float]]],
+) -> dict[str, str]:
+    """Seed one measure fact + one finer event fact with EXPLICIT per-entity series.
+
+    The convention-selection tests (DAT-759) need adversarial numeric shapes the
+    canonical ``_seed`` can't express: per-entity, per-column monthly values for
+    the event side and the measure side independently. Each event cell is written
+    as two half-rows so the direction gate keeps the event side finer-grained.
+    """
+    ids: dict[str, str] = {}
+    entities = sorted(measure_by_entity)
+    months = len(next(iter(measure_by_entity.values())))
+    dim_table = Table(
+        table_id=str(uuid4()),
+        source_id="src-1",
+        table_name="chart_of_accounts",
+        layer="typed",
+        duckdb_path="chart_of_accounts",
+    )
+    session.add(dim_table)
+    ids["chart_of_accounts"] = dim_table.table_id
+    for name, cols in (("monthly_summary", [measure_col]), ("events", event_cols)):
+        table = Table(
+            table_id=str(uuid4()),
+            source_id="src-1",
+            table_name=name,
+            layer="typed",
+            duckdb_path=name,
+        )
+        session.add(table)
+        ids[name] = table.table_id
+        for pos, col in enumerate(cols):
+            column = Column(
+                column_id=str(uuid4()),
+                table_id=table.table_id,
+                column_name=col,
+                column_position=pos,
+                resolved_type="DOUBLE",
+            )
+            session.add(column)
+            ids[f"{name}.{col}"] = column.column_id
+        session.add(
+            TableEntity(
+                run_id=_RUN,
+                table_id=table.table_id,
+                detected_entity_type="fact",
+                time_columns=[{"column": "period_date", "aspect": "period", "note": "Period."}],
+            )
+        )
+        session.add(
+            SliceDefinition(
+                run_id=_RUN,
+                table_id=table.table_id,
+                column_id=ids[f"{name}.{cols[0]}"],
+                column_name=_DIM,
+                dimension_table_id=dim_table.table_id,
+                dimension_attribute="account_type",
+                fk_role="account_id",
+                slice_priority=1,
+                distinct_values=list(entities),
+                value_count=len(entities),
+                detection_source="llm",
+            )
+        )
+    session.flush()
+
+    duck.execute(
+        f'CREATE TABLE monthly_summary ("{_DIM}" VARCHAR, period_date DATE, {measure_col} DOUBLE)'
+    )
+    event_ddl = ", ".join(f"{c} DOUBLE" for c in event_cols)
+    duck.execute(f'CREATE TABLE events ("{_DIM}" VARCHAR, period_date DATE, {event_ddl})')
+    m_rows: list[str] = []
+    e_rows: list[str] = []
+    for entity in entities:
+        for i in range(months):
+            d = f"DATE '2025-{i + 1:02d}-15'"
+            m_rows.append(f"('{entity}', {d}, {measure_by_entity[entity][i]})")
+            cell = [event_by_entity[entity][c][i] for c in event_cols]
+            for half in (0.5, 0.5):
+                e_rows.append(f"('{entity}', {d}, {', '.join(str(v * half) for v in cell)})")
+    duck.execute(f"INSERT INTO monthly_summary VALUES {', '.join(m_rows)}")
+    duck.execute(f"INSERT INTO events VALUES {', '.join(e_rows)}")
+    return ids
+
+
+class TestConventionSelection:
+    """DAT-759: support-first selection (Wilson LCB over the common denominator).
+
+    Grounded by the eval probe ``scripts/probes/dat759-convention-selection``
+    (dataraum-eval): min-residual selection picked value-wrong conventions on
+    2/3 real measures; Wilson-LCB + ΔBIC arity tie-break selects truth 3/3.
+    """
+
+    def test_broad_single_beats_tighter_subset_artifact(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """The headline defect: ``net_amount`` (= debit − credit) fits a 2/4
+        entity subset EXACTLY (credit ≡ 0 there) while the true ``debit`` fits
+        all 4 entities with a small residual. Min-residual selection picked the
+        subset artifact (0 < 0.01); support selection must pick ``debit``
+        (LCB 4/4 ≈ 0.51 ≫ 2/4 ≈ 0.15)."""
+        entities = ("assets", "equity", "expenses", "liabilities")
+        debit = {e: [100.0 + 10 * k + 3 * i for i in range(12)] for k, e in enumerate(entities)}
+        # 'assets'/'equity' carry credit movement; 'expenses'/'liabilities' none.
+        credit = {
+            e: [debit[e][i] / 3 if k < 2 else 0.0 for i in range(12)]
+            for k, e in enumerate(entities)
+        }
+        net = {e: [debit[e][i] - credit[e][i] for i in range(12)] for e in entities}
+        # The measure IS the debit movement — exact where credit is dead, 1%
+        # off where it is not, so the artifact's subset fit is strictly tighter.
+        measure = {
+            e: [debit[e][i] * (1.01 if k < 2 else 1.0) for i in range(12)]
+            for k, e in enumerate(entities)
+        }
+        ids = _seed_series(
+            real_session,
+            duck,
+            measure_col="debit_total",
+            measure_by_entity=measure,
+            event_cols=["credit", "debit", "net_amount"],
+            event_by_entity={
+                e: {"debit": debit[e], "credit": credit[e], "net_amount": net[e]} for e in entities
+            },
+        )
+        assert (
+            discover_aggregation_lineage(
+                real_session,
+                duckdb_conn=duck,
+                table_ids=[ids["monthly_summary"], ids["events"]],
+                run_id=_RUN,
+                period_grain="monthly",
+            )
+            > 0
+        )
+        row = _row_for(real_session, ids["monthly_summary.debit_total"])
+        assert row is not None
+        assert row.convention_sql == '"debit"'
+        assert row.pattern == "per_period"
+        assert row.match_rate > 0.99  # all 4 entities vote, unanimous
+
+    def test_collinear_twin_breaks_to_single(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """``debit − net_amount`` is numerically IDENTICAL to ``credit`` (the
+        roll-forward collinearity) — no data statistic can order the twins, so
+        the LCB tie must break to the lower arity, never to enumeration order."""
+        entities = ("assets", "equity", "expenses", "liabilities")
+        debit = {e: [80.0 + 5 * k + 2 * i for i in range(12)] for k, e in enumerate(entities)}
+        credit = {e: [30.0 + 3 * k + i for i in range(12)] for k, e in enumerate(entities)}
+        net = {e: [debit[e][i] - credit[e][i] for i in range(12)] for e in entities}
+        ids = _seed_series(
+            real_session,
+            duck,
+            measure_col="credit_total",
+            measure_by_entity=credit,
+            event_cols=["credit", "debit", "net_amount"],
+            event_by_entity={
+                e: {"debit": debit[e], "credit": credit[e], "net_amount": net[e]} for e in entities
+            },
+        )
+        discover_aggregation_lineage(
+            real_session,
+            duckdb_conn=duck,
+            table_ids=[ids["monthly_summary"], ids["events"]],
+            run_id=_RUN,
+            period_grain="monthly",
+        )
+        row = _row_for(real_session, ids["monthly_summary.credit_total"])
+        assert row is not None
+        assert row.convention_sql == '"credit"'
+
+    def test_true_difference_wins_by_bic(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """Single-preference must not kill a TRUE difference: the measure is
+        ``gross − fees`` (fees ≈ 10% of gross). ``gross`` alone also votes on
+        every entity (residual ≈ 0.1 < FIRE_RESIDUAL_MAX) so the LCBs tie — the
+        ΔBIC > 10 escape (probe: ΔBIC = 56.6) must keep the difference."""
+        entities = ("assets", "equity", "expenses", "liabilities")
+        gross = {e: [1000.0 + 50 * k + 20 * i for i in range(12)] for k, e in enumerate(entities)}
+        fees = {e: [gross[e][i] * (0.08 + 0.01 * (i % 3)) for i in range(12)] for e in entities}
+        measure = {
+            e: [(gross[e][i] - fees[e][i]) * (1 + 0.001 * (-1) ** i) for i in range(12)]
+            for e in entities
+        }
+        ids = _seed_series(
+            real_session,
+            duck,
+            measure_col="net_revenue",
+            measure_by_entity=measure,
+            event_cols=["fees", "gross"],
+            event_by_entity={e: {"gross": gross[e], "fees": fees[e]} for e in entities},
+        )
+        discover_aggregation_lineage(
+            real_session,
+            duckdb_conn=duck,
+            table_ids=[ids["monthly_summary"], ids["events"]],
+            run_id=_RUN,
+            period_grain="monthly",
+        )
+        row = _row_for(real_session, ids["monthly_summary.net_revenue"])
+        assert row is not None
+        assert row.convention_sql == '"gross" - "fees"'
+        assert row.pattern == "per_period"
+
+
 class TestDiscoverAggregationLineage:
     def test_stock_measure_reconciles_cumulative(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
@@ -291,7 +505,8 @@ class TestDiscoverAggregationLineage:
         assert row.match_rate > 0.99
         assert row.run_id == _RUN
         # The winning convention reproduces the movement exactly: the single
-        # column "debit" (ties with "debit" - "credit" break to singles-first).
+        # column "debit" ("debit" - "credit" is its collinear twin here — the
+        # DAT-759 support-LCB tie breaks to the lower arity).
         assert row.convention_sql == '"debit"'
 
     def test_flow_measure_reconciles_per_period(

--- a/packages/engine/tests/unit/analysis/lineage/test_processor.py
+++ b/packages/engine/tests/unit/analysis/lineage/test_processor.py
@@ -284,7 +284,7 @@ def _seed_series(
     measure_col: str,
     measure_by_entity: dict[str, list[float]],
     event_cols: list[str],
-    event_by_entity: dict[str, dict[str, list[float]]],
+    event_by_entity: dict[str, dict[str, list[float | None]]],
 ) -> dict[str, str]:
     """Seed one measure fact + one finer event fact with EXPLICIT per-entity series.
 
@@ -292,6 +292,8 @@ def _seed_series(
     canonical ``_seed`` can't express: per-entity, per-column monthly values for
     the event side and the measure side independently. Each event cell is written
     as two half-rows so the direction gate keeps the event side finer-grained.
+    ``None`` event values write SQL NULL — an all-NULL month drops that column
+    from the period sums, the shape behind the own-subset-denominator trap.
     """
     ids: dict[str, str] = {}
     entities = sorted(measure_by_entity)
@@ -363,7 +365,8 @@ def _seed_series(
             m_rows.append(f"('{entity}', {d}, {measure_by_entity[entity][i]})")
             cell = [event_by_entity[entity][c][i] for c in event_cols]
             for half in (0.5, 0.5):
-                e_rows.append(f"('{entity}', {d}, {', '.join(str(v * half) for v in cell)})")
+                halves = ", ".join("NULL" if v is None else str(v * half) for v in cell)
+                e_rows.append(f"('{entity}', {d}, {halves})")
     duck.execute(f"INSERT INTO monthly_summary VALUES {', '.join(m_rows)}")
     duck.execute(f"INSERT INTO events VALUES {', '.join(e_rows)}")
     return ids
@@ -489,6 +492,50 @@ class TestConventionSelection:
         assert row is not None
         assert row.convention_sql == '"gross" - "fees"'
         assert row.pattern == "per_period"
+
+    def test_own_subset_denominator_cannot_flatter_support(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """Probe leg b2 at the processor level — pins the LOAD-BEARING caveat
+        that ``wilson_lcb`` is fed the pairing's common denominator, never the
+        convention's own aligned subset (``verdict.n_entities``).
+
+        ``partial`` is NULL for half the entities and fits its own subset
+        perfectly: 5 unanimous voters. The true ``base`` reconciles 7 of the 10
+        entities (three are deliberately off-scale and abstain). On the OWN
+        subset the trap outranks truth — LCB(5/5) ≈ 0.57 > LCB(7/10) ≈ 0.40 —
+        so reverting the denominator flips this test to ``partial``; on the
+        common denominator the trap collapses to LCB(5/10) ≈ 0.24 and ``base``
+        wins."""
+        entities = tuple(f"e{i}" for i in range(10))
+        base = {e: [200.0 + 15 * k + 5 * i for i in range(12)] for k, e in enumerate(entities)}
+        partial: dict[str, list[float | None]] = {
+            e: [base[e][i] if k < 5 else None for i in range(12)] for k, e in enumerate(entities)
+        }
+        # e0–e6 ARE the base movement; e7–e9 are 2× off-scale (residual 1.0 → abstain).
+        measure = {
+            e: [base[e][i] * (1.0 if k < 7 else 2.0) for i in range(12)]
+            for k, e in enumerate(entities)
+        }
+        ids = _seed_series(
+            real_session,
+            duck,
+            measure_col="total",
+            measure_by_entity=measure,
+            event_cols=["base", "partial"],
+            event_by_entity={e: {"base": base[e], "partial": partial[e]} for e in entities},
+        )
+        discover_aggregation_lineage(
+            real_session,
+            duckdb_conn=duck,
+            table_ids=[ids["monthly_summary"], ids["events"]],
+            run_id=_RUN,
+            period_grain="monthly",
+        )
+        row = _row_for(real_session, ids["monthly_summary.total"])
+        assert row is not None
+        assert row.convention_sql == '"base"'
+        assert row.match_rate == pytest.approx(0.7)  # 7 of 10 aligned entities vote
 
 
 class TestDiscoverAggregationLineage:

--- a/packages/engine/tests/unit/analysis/lineage/test_reconcile.py
+++ b/packages/engine/tests/unit/analysis/lineage/test_reconcile.py
@@ -9,7 +9,14 @@ abstain guardrail. Properties and orderings, not fitted thresholds.
 from __future__ import annotations
 
 from dataraum.analysis.lineage.models import PATTERN_CUMULATIVE, PATTERN_PER_PERIOD
-from dataraum.analysis.lineage.reconcile import classify_entity, dispose, reconcile
+from dataraum.analysis.lineage.reconcile import (
+    classify_entity,
+    classify_series,
+    dispose,
+    dispose_classified,
+    reconcile,
+    wilson_lcb,
+)
 
 _T = 12
 
@@ -135,3 +142,32 @@ class TestDispose:
 
     def test_empty_series_is_no_verdict(self) -> None:
         assert dispose({}) is None
+
+    def test_dispose_is_dispose_classified_of_classify_series(self) -> None:
+        # The DAT-759 split is a pure refactor: the composed path is identical.
+        series = {f"acct{i}": _stock_entity(i) for i in range(4)}
+        assert dispose(series) == dispose_classified(classify_series(series))
+
+
+class TestWilsonLcb:
+    """The DAT-759 support statistic: Wilson score lower bound of the vote rate."""
+
+    def test_known_values(self) -> None:
+        assert wilson_lcb(0, 0) == 0.0
+        assert wilson_lcb(0, 10) == 0.0
+        assert abs(wilson_lcb(4, 4) - 0.510) < 0.005
+        assert abs(wilson_lcb(2, 4) - 0.150) < 0.005
+        assert abs(wilson_lcb(20, 20) - 0.839) < 0.005
+
+    def test_breadth_beats_perfect_subset(self) -> None:
+        # The selection property the criterion exists for: 21/21 with the same
+        # rate bound dominates a perfect small subset (the probe's real margins).
+        assert wilson_lcb(21, 21) > wilson_lcb(15, 21) > wilson_lcb(4, 21)
+
+    def test_common_denominator_is_load_bearing(self) -> None:
+        # Probe leg b2: the same 10 votes rank near-top on their own subset
+        # denominator and mid-field on the common one — callers must pass the
+        # pairing universe, never the convention's aligned subset.
+        assert wilson_lcb(10, 10) > 0.7
+        assert wilson_lcb(10, 20) < 0.31
+        assert wilson_lcb(20, 20) > wilson_lcb(10, 10)


### PR DESCRIPTION
## Summary

`discover_aggregation_lineage` selected the reconciliation convention by **minimum median residual** — monotone under the ordered-difference search family, so collinear artifacts (`debit − net_amount ≡ credit`) out-raced true singles on half-entity subsets and persisted **value-wrong `convention_sql`** into the property-graph grounding. This is the defect behind the live 0.50/0.75 trial_balance match rates eval surfaced (DAT-759).

Selection is now **support-first**:

1. **Wilson score LCB (95%)** of the vote rate over the pairing's **common entity denominator** (`_pairing_universe` — never a convention's own aligned subset, which is gameable by a term NULL on some entities: own-subset LCB 0.722 vs common 0.299 for the same 10 votes);
2. exact LCB ties break to the **lower arity unless the difference wins by ΔBIC > 10** (Kass–Raftery) — exact collinear twins are numerically identical, only description length can order them;
3. then median residual.

Vote-rate is a generalization estimate, not a tuned knob: the residual carries no fitted per-entity coefficient, so leave-one-entity-out CV degenerates exactly to the vote count.

**No schema change.** Persisted fields, `dispose()` verdict semantics, `FIRE_RESIDUAL_MAX`, and the direction gate are unchanged (the min-over-family permutation-null fire gate is the ticketed follow-up). `reconcile.py` gains `wilson_lcb` + a `classify_series`/`dispose_classified` split (pure refactor, pinned by test).

## Grounding

Eval probe `scripts/probes/dat759-convention-selection` (dataraum-eval `8e44d26`, engine semantics imported not mirrored): min-residual is value-wrong on 2/3 real measures; Wilson-LCB + ΔBIC selects truth 3/3 (LCB margins 0.345–0.620). Verdict + numbers: DAT-759 comment 16418.

## Tests

- `test_broad_single_beats_tighter_subset_artifact` — reproduces the live defect **verbatim** on the old criterion (`net_amount` wins at 0.50 support) and pins the fix.
- `test_own_subset_denominator_cannot_flatter_support` — the load-bearing common-denominator caveat, **mutation-verified**: flipping the denominator to `verdict.n_entities` fails this test.
- `test_collinear_twin_breaks_to_single`, `test_true_difference_wins_by_bic` (ΔBIC escape), `wilson_lcb` unit tests, dispose-refactor equivalence.
- Full unit suite 2029 passed; ruff/mypy/vulture clean.

## Reviews

Both reviewers ran pre-PR: senior (APPROVE — stale-docstring + determinism findings applied: ORDER BY on the SliceDefinition select, `_better`/`_bic` caveats documented, exact LCB comparison) and spec (REQUEST-CHANGES → resolved: the common-denominator processor-level pin above was its MAJOR).

## Eval impact (handoff updated)

`trial_balance.debit_balance`/`credit_balance` reconcile as `"debit"`/`"credit"` at match_rate 1.0 → the reconciliation-coverage oracle goes 3/3; `balance_sheet.ending_balance` may report `"net_amount"` instead of the value-identical `"debit" - "credit"` (arity preference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)