### PR TITLE
fix(semantic): DAT-768 — empty column_concepts falls loud (mechanical salvage of #483)

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,41 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-768 — empty column_concepts falls loud (salvaged from PR #483)
+
+**Branch:** `fix/dat-768-empty-concepts-fall-loud`. The `column_concepts` surface
+(metric grounding, cycles field mappings) could come out EMPTY while the phase
+reported success — observed 2/3 runs on 2026-07-14, one of them fully green.
+Mechanical honesty fixes only; the DAT-769-directed prompt-binding commits from
+PR #483 are dropped (that question is being retired — see DAT-769 redesign).
+
+### What changed
+
+- `TableSynthesisOutput.column_concepts` and `.relationships` are **REQUIRED
+  tool-schema fields** (no `default_factory`): wholesale omission is now a
+  validation error the DAT-710 repair turn catches, instead of schema-legal
+  silence.
+- `persist_column_concepts` returns an emitted/resolved/dropped_unresolved
+  breakdown and logs `column_concepts_persisted` (+ a debug list of the exact
+  unresolved names) — a name-resolution wipeout is diagnosable, not
+  indistinguishable from an empty emission.
+- `synthesize_and_store_tables` **fails begin_session loud** when zero concepts
+  resolve while the batch has measure-role columns — an emptied load-bearing
+  surface, never a plausible judgment. Gates on emptiness only, never on any
+  specific binding (ADR-0009).
+- `semantic_analysis.effort: high` pinned explicitly in `llm/config.yaml`
+  (no-op vs the current API default; removes the hidden dependency).
+
+### What eval should see
+
+- A DAT-768 recurrence now fails the `semantic_per_table` phase with
+  `column_concepts empty despite measure-role columns...` instead of going
+  green with 0 rows; worker.log carries `column_concepts_persisted
+  (emitted=…, resolved=…, dropped_unresolved=…)` per batch.
+- No behavior change when concepts are produced (the common case).
+
+---
+
 ## DAT-759 — aggregation-lineage convention selection is support-first (Wilson LCB)
 
 **Branch:** `fix/dat-759-convention-selection`. `discover_aggregation_lineage`

--- a/packages/dataraum-config/llm/config.yaml
+++ b/packages/dataraum-config/llm/config.yaml
@@ -28,6 +28,14 @@ features:
   semantic_analysis:
     enabled: true
     model_tier: balanced
+    # Pin the API default explicitly (DAT-768). Omitting output_config.effort means
+    # the Anthropic server-side default — currently "high" — so this is a no-op on
+    # behavior, but it removes the hidden dependency on that default and states the
+    # intent: semantic_per_table is a large batched extraction that also authors the
+    # load-bearing column_concepts field, and must stay at high. The structural
+    # anti-crowd-out fix is making column_concepts a REQUIRED tool-schema field
+    # (models.py) so an omission is a validation error the repair turn catches.
+    effort: high
 
   slicing_analysis:
     enabled: true

--- a/packages/dataraum-config/llm/prompts/semantic_per_table.yaml
+++ b/packages/dataraum-config/llm/prompts/semantic_per_table.yaml
@@ -49,8 +49,10 @@ system_prompt: |
   </grain_split>
 
   <column_concepts>
-  Emit a column_concepts entry ONLY for columns that carry at least one of these;
-  omit every other column.
+  Emit a column_concepts entry for EVERY column that carries at least one of these —
+  a measure column always carries a business_concept. Omit only columns that
+  genuinely carry none; returning an empty column_concepts when the schema has
+  measure columns is an error, not a shortcut.
 
   - business_concept: the EXACT ontology concept a column GROUNDS (e.g. 'revenue',
     'accounts_receivable'). Bind ONLY a genuine discriminator the analyst can

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -198,26 +198,40 @@ class SemanticAgent(LLMFeature):
             model=model,
         )
 
-        # converse raises a typed ProviderError on an API failure (DAT-503) —
-        # retryability rides the exception to the worker's durable boundary, so
-        # we don't re-wrap it. A returned Result is always a success.
-        response = self.provider.converse(request).unwrap()
+        result = self._converse_and_validate(request, tool, model)
+        if not result.success:
+            return Result.fail(result.error or "Table synthesis failed")
+        # column_concepts is a REQUIRED field on the tool schema (DAT-768), so a
+        # crowded-out omission surfaces here as a ValidationError that
+        # _converse_and_validate already repaired; a still-empty surface is caught
+        # loud downstream by synthesize_and_store_tables' measure-present gate.
+        return self._build_enrichment_result(result.unwrap())
 
+    def _converse_and_validate(
+        self,
+        request: ConversationRequest,
+        tool: ToolDefinition,
+        model: str,
+    ) -> Result[TableSynthesisOutput]:
+        """One ``analyze_tables`` turn → validated output, with a DAT-710 schema repair.
+
+        ``converse`` raises a typed ProviderError on an API failure (DAT-503) —
+        retryability rides the exception to the worker's durable boundary, so we
+        don't re-wrap it; a returned Result is always a success. One lazy tool
+        output (a relationship missing ``to_column``, a ``"placeholder"`` reasoning)
+        must not fail begin_session whole (DAT-710): it is schema-repaired in one
+        turn — the DAT-699 pattern — instead of a non-retryable PhaseFailed with
+        whole-cascade blast radius. strict grammar is the WRONG lever here: this is
+        a large batched extraction, exactly the shape where strict makes the model
+        legally under-produce (see ``ToolDefinition.strict``), so repair, never strict.
+        """
+        response = self.provider.converse(request).unwrap()
         if not response.tool_calls or response.tool_calls[0].name != "analyze_tables":
             return Result.fail("LLM did not use the analyze_tables tool")
-
         tool_input = response.tool_calls[0].input
         try:
-            synthesis = TableSynthesisOutput.model_validate(tool_input)
+            return Result.ok(TableSynthesisOutput.model_validate(tool_input))
         except ValidationError as e:
-            # One lazy relationship entry (a missing `to_column`, a `"placeholder"`
-            # reasoning) must not fail begin_session whole (DAT-710): enforce the
-            # schema with a repair turn — the DAT-699 pattern — instead of a
-            # non-retryable PhaseFailed with whole-cascade blast radius. strict
-            # grammar is the WRONG lever here: analyze_tables is a large batched
-            # extraction (every table's entity + all relationships), exactly the
-            # shape where strict makes the model legally under-produce (see
-            # `ToolDefinition.strict`), so repair, never strict.
             repaired = repair_tool_output(
                 self.provider,
                 tool,
@@ -230,9 +244,7 @@ class SemanticAgent(LLMFeature):
             )
             if not repaired.success:
                 return Result.fail(f"Failed to parse table synthesis response: {repaired.error}")
-            synthesis = repaired.unwrap()
-
-        return self._build_enrichment_result(synthesis)
+            return Result.ok(repaired.unwrap())
 
     @staticmethod
     def _format_persisted_annotations(annotations: list[dict[str, Any]]) -> str:

--- a/packages/engine/src/dataraum/analysis/semantic/models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/models.py
@@ -329,20 +329,22 @@ class TableSynthesisOutput(BaseModel):
     )
 
     relationships: list[RelationshipOutput] = Field(
-        default_factory=list,
         description=(
-            "Relationships between tables. Evaluate the pre-computed candidates "
-            "and include only confirmed relationships. Add any additional "
-            "relationships you detect that weren't in the candidates."
+            "Relationships between tables — REQUIRED, always emit this field (use [] "
+            "only when there are genuinely none). Evaluate the pre-computed candidates "
+            "and include only confirmed relationships. Add any additional relationships "
+            "you detect that weren't in the candidates."
         ),
     )
 
     column_concepts: list[ColumnConceptOutput] = Field(
-        default_factory=list,
         description=(
             "Catalogue-grain per-column semantics (ontology concept, unit source, "
-            "derived-formula hypothesis). Emit only columns carrying at least one; "
-            "omit the rest."
+            "derived-formula hypothesis) — REQUIRED, always emit this field. Include "
+            "an entry for EVERY column that carries at least one concept — measure "
+            "columns always do. Use [] only when NO column in the batch carries any "
+            "concept; returning [] when the schema has measures is an error, not a "
+            "shortcut."
         ),
     )
 

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -5,6 +5,7 @@ Orchestrates semantic analysis using the SemanticAgent and stores results.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import duckdb
@@ -45,7 +46,12 @@ from dataraum.analysis.semantic.models import (
 from dataraum.analysis.semantic.models import (
     Relationship as SemanticRelationship,
 )
-from dataraum.analysis.semantic.utils import load_column_mappings, load_table_mappings
+from dataraum.analysis.semantic.utils import (
+    annotations_have_measure,
+    load_column_mappings,
+    load_persisted_annotations,
+    load_table_mappings,
+)
 from dataraum.core.logging import get_logger
 from dataraum.core.models.base import DecisionSource, Result
 from dataraum.storage.upsert import upsert
@@ -256,6 +262,22 @@ def persist_column_annotations(
     return len(rows)
 
 
+@dataclass(frozen=True)
+class ConceptPersistCounts:
+    """Emitted vs resolved vs dropped for a ``column_concepts`` persist (DAT-768).
+
+    ``emitted`` = concepts the table agent produced; ``resolved`` = rows actually
+    written (name matched a column, after the same-column dedup); ``dropped_unresolved``
+    = concepts whose ``(table, column)`` name matched no column in the batch. A
+    silently-empty load-bearing surface is now a visible count, not indistinguishable
+    from "no concepts to bind".
+    """
+
+    emitted: int
+    resolved: int
+    dropped_unresolved: int
+
+
 def persist_column_concepts(
     session: Session,
     column_concepts: list[ColumnConceptOutput],
@@ -263,7 +285,7 @@ def persist_column_concepts(
     *,
     annotated_by: str,
     run_id: str,
-) -> int:
+) -> ConceptPersistCounts:
     """Persist the table agent's catalogue-grain per-column semantics (DAT-637).
 
     Writes ``ColumnConcept`` rows under the begin_session (catalogue head) run.
@@ -275,14 +297,19 @@ def persist_column_concepts(
     run's.
 
     Returns:
-        Number of concept rows persisted.
+        A :class:`ConceptPersistCounts` breakdown. The counts are logged so a
+        name-resolution wipeout (every emitted concept dropped as unresolved,
+        DAT-768 path #2) is diagnosable rather than indistinguishable from an
+        empty emission; the caller gates begin_session on ``resolved``.
     """
     column_map = load_column_mappings(session, table_ids)
 
     rows: list[dict[str, Any]] = []
+    dropped: list[tuple[str, str]] = []
     for cc in column_concepts:
         column_id = column_map.get((cc.table_name, cc.column_name))
         if not column_id:
+            dropped.append((cc.table_name, cc.column_name))
             continue
         rows.append(
             {
@@ -306,7 +333,24 @@ def persist_column_concepts(
     rows = list(deduped.values())
 
     upsert(session, ConceptModel, rows, index_elements=["column_id", "run_id"])
-    return len(rows)
+
+    counts = ConceptPersistCounts(
+        emitted=len(column_concepts),
+        resolved=len(rows),
+        dropped_unresolved=len(dropped),
+    )
+    logger.info(
+        "column_concepts_persisted",
+        emitted=counts.emitted,
+        resolved=counts.resolved,
+        dropped_unresolved=counts.dropped_unresolved,
+    )
+    if dropped:
+        # The exact names the agent echoed that resolved to no column — the signal
+        # that distinguishes a naming drift (case, enriched prefix, display name)
+        # from a genuinely empty emission.
+        logger.debug("column_concepts_dropped_unresolved", dropped=dropped)
+    return counts
 
 
 def ground_columns(
@@ -640,6 +684,17 @@ def _build_surrogate_intent(
 REL_CONFIRM_MIN = 0.7
 
 
+def _batch_has_measures(session: Session, table_ids: list[str]) -> bool:
+    """Whether any column in the batch carries the ``measure`` semantic role.
+
+    The upstream per-column phase has already annotated roles. A batch that holds
+    a measure is one that MUST bind at least one ontology concept, so zero resolved
+    ``column_concepts`` for it is an emptied surface, not a plausible judgment
+    (DAT-768). Reads the same persisted annotations the table agent saw.
+    """
+    return annotations_have_measure(load_persisted_annotations(session, table_ids))
+
+
 def synthesize_and_store_tables(
     session: Session,
     agent: SemanticAgent,
@@ -882,12 +937,28 @@ def synthesize_and_store_tables(
         annotated_by = agent.provider.get_model_for_tier(
             agent.config.features.semantic_analysis.model_tier
         )
-        persist_column_concepts(
+        counts = persist_column_concepts(
             session,
             enrichment.column_concepts,
             table_ids,
             annotated_by=annotated_by,
             run_id=run_id,
         )
+        # DAT-768: the column_concepts surface is load-bearing — every metric's
+        # measure→concept binding grounds on it. With measure-role columns in the
+        # batch, ZERO resolved concepts is not a judgment; it is an emptied surface
+        # (the agent under-produced the whole field, or every name it echoed failed
+        # to resolve) that would silently collapse all downstream grounding. Fail
+        # begin_session loud rather than ship it green — the agent already
+        # re-prompted once on an empty emission (see synthesize_tables), so a
+        # still-empty surface here is a real defect, not a flake. This gates on
+        # emptiness of the surface, never on any specific concept judgment.
+        if counts.resolved == 0 and _batch_has_measures(session, table_ids):
+            return Result.fail(
+                "column_concepts empty despite measure-role columns in the batch "
+                f"(emitted={counts.emitted}, resolved=0, "
+                f"dropped_unresolved={counts.dropped_unresolved}) — metric grounding "
+                "would collapse (DAT-768)."
+            )
 
     return Result.ok(enrichment)

--- a/packages/engine/src/dataraum/analysis/semantic/utils.py
+++ b/packages/engine/src/dataraum/analysis/semantic/utils.py
@@ -77,6 +77,16 @@ def load_column_mappings(
     return {(table_name, col_name): col_id for table_name, col_name, col_id in result.all()}
 
 
+def annotations_have_measure(annotations: list[dict[str, Any]]) -> bool:
+    """Whether any loaded annotation carries the ``measure`` semantic role (DAT-768).
+
+    The measure role is what makes an empty ``column_concepts`` surface implausible:
+    a batch holding a measure MUST bind at least one ontology concept, so zero is an
+    emptied surface, not a judgment.
+    """
+    return any(a.get("semantic_role") == "measure" for a in annotations)
+
+
 def load_persisted_annotations(
     session: Session,
     table_ids: list[str],

--- a/packages/engine/tests/unit/analysis/semantic/test_models.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_models.py
@@ -43,6 +43,7 @@ def test_table_entity_output_parses_multi_time_and_identity() -> None:
                 }
             ],
             "relationships": [],
+            "column_concepts": [],
         }
     )
     table = out.tables[0]
@@ -74,7 +75,29 @@ def test_table_synthesis_output_validates_entities_and_relationships() -> None:
                     "reasoning": "FK by name + value overlap.",
                 }
             ],
+            "column_concepts": [],
         }
     )
     assert out.tables[0].is_fact_table is True
     assert out.relationships[0].to_table == "customers"
+
+
+def test_load_bearing_fields_are_required_in_the_tool_schema() -> None:
+    """``column_concepts`` and ``relationships`` are REQUIRED in the tool schema (DAT-768).
+
+    They were ``default_factory=list``, so a crowded-out omission was schema-legal and
+    the DAT-710 repair turn never fired (the DAT-672 class). Marking them required makes
+    an omission a validation error the repair turn catches — the model must emit the
+    field (``[]`` is still allowed, but the key cannot silently vanish).
+    """
+    required = set(TableSynthesisOutput.model_json_schema()["required"])
+    assert {"tables", "relationships", "column_concepts"} <= required
+
+
+def test_omitting_column_concepts_is_a_validation_error() -> None:
+    """Omitting the whole field now raises — the signal the repair turn keys on."""
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        TableSynthesisOutput.model_validate({"tables": [], "relationships": []})

--- a/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
@@ -155,7 +155,7 @@ class TestPersistColumnConcepts:
             ),
         ]
 
-        count = persist_column_concepts(
+        result = persist_column_concepts(
             session,
             concepts,
             [table.table_id],
@@ -164,7 +164,9 @@ class TestPersistColumnConcepts:
         )
         session.flush()
 
-        assert count == 2
+        assert result.resolved == 2
+        assert result.emitted == 2
+        assert result.dropped_unresolved == 0
         rows = {r.column_id: r for r in session.execute(select(ColumnConceptDB)).scalars()}
         cols = {c.column_name: c.column_id for c in session.execute(select(Column)).scalars()}
         total = rows[cols["total"]]
@@ -191,15 +193,37 @@ class TestPersistColumnConcepts:
             ),
         ]
 
-        count = persist_column_concepts(
+        result = persist_column_concepts(
             session, concepts, [table.table_id], annotated_by="m", run_id=baseline_run_id()
         )
         session.flush()
 
-        assert count == 1  # collapsed
+        assert result.resolved == 1  # collapsed
+        assert result.emitted == 2  # both mentions counted as emitted
         rows = list(session.execute(select(ColumnConceptDB)).scalars())
         assert len(rows) == 1
         assert rows[0].business_concept == "net_revenue"  # last mention wins
+
+    def test_unresolvable_concept_dropped_and_counted(self, session) -> None:
+        """DAT-768 path #2: a concept whose (table, column) name resolves to no column
+        is dropped, and the breakdown surfaces it (resolved 0, dropped 1) instead of
+        being indistinguishable from an empty emission."""
+        table = _table_with_columns(session, "orders", ["total"])
+        concepts = [
+            ColumnConceptOutput(
+                table_name="orders", column_name="ghost", business_concept="revenue"
+            )
+        ]
+
+        result = persist_column_concepts(
+            session, concepts, [table.table_id], annotated_by="m", run_id=baseline_run_id()
+        )
+        session.flush()
+
+        assert result.emitted == 1
+        assert result.resolved == 0
+        assert result.dropped_unresolved == 1
+        assert list(session.execute(select(ColumnConceptDB)).scalars()) == []
 
 
 class TestNearConstantFeed:
@@ -685,6 +709,66 @@ class TestSynthesizeAndStoreTables:
         assert not result.success
         assert "LLM down" in (result.error or "")
 
+    @staticmethod
+    def _agent_returning_empty_concepts() -> MagicMock:
+        agent = MagicMock()
+        agent.synthesize_tables = MagicMock(
+            return_value=Result.ok(
+                SemanticEnrichmentResult(
+                    annotations=[], entity_detections=[], relationships=[], column_concepts=[]
+                )
+            )
+        )
+        return agent
+
+    @staticmethod
+    def _annotate(session, table, column: str, role: str) -> None:
+        persist_column_annotations(
+            session,
+            ColumnAnnotationOutput(
+                tables=[
+                    TableColumnAnnotation(table_name=table.table_name, columns=[_col(column, role)])
+                ]
+            ),
+            [table.table_id],
+            annotated_by="m",
+            run_id=baseline_run_id(),
+        )
+        session.flush()
+
+    def test_empty_concepts_with_measures_fails_loud(self, session) -> None:
+        """DAT-768: a measure column in the batch + zero resolved concepts is an
+        emptied grounding surface — begin_session fails loud instead of shipping it
+        green (every metric's measure→concept binding would otherwise collapse)."""
+        tbl = _table_with_columns(session, "trial_balance", ["debit_balance"])
+        self._annotate(session, tbl, "debit_balance", "measure")
+
+        result = synthesize_and_store_tables(
+            session,
+            self._agent_returning_empty_concepts(),
+            [tbl.table_id],
+            run_id=baseline_run_id(),
+        )
+
+        assert not result.success
+        assert "column_concepts empty" in (result.error or "")
+        assert "DAT-768" in (result.error or "")
+
+    def test_empty_concepts_without_measures_succeeds(self, session) -> None:
+        """No measure column → an empty concept surface is a legitimate judgment; the
+        phase must NOT fail (the gate is measure-conditional, not blanket)."""
+        tbl = _table_with_columns(session, "regions", ["region_name"])
+        self._annotate(session, tbl, "region_name", "dimension")
+
+        result = synthesize_and_store_tables(
+            session,
+            self._agent_returning_empty_concepts(),
+            [tbl.table_id],
+            run_id=baseline_run_id(),
+        )
+
+        assert result.success
+
 
 # ---------------------------------------------------------------------------
 # per-table parse / format helpers
@@ -708,6 +792,7 @@ class TestTableSynthesisHelpers:
                     }
                 ],
                 "relationships": [],
+                "column_concepts": [],
             }
         )
         result = agent._build_enrichment_result(synthesis)


### PR DESCRIPTION
## Summary

Salvages the **DAT-768 mechanical half** of #483; drops every DAT-769-directed prompt change (that question — the single-slot `business_concept` binding — is being retired by the DAT-769 meaning-as-context redesign; rationale on the ticket).

The `column_concepts` surface (metric grounding feed, cycles field mappings) could come out **empty while the phase reported success** — observed on 2 of 3 runs 2026-07-14, one of them fully green end-to-end. Three honesty mechanisms, none touching any binding judgment (ADR-0009):

1. **Required tool-schema fields**: `TableSynthesisOutput.column_concepts` + `.relationships` lose `default_factory` — wholesale omission becomes a validation error the DAT-710 repair turn catches, instead of schema-legal silence. (Supersedes the bespoke re-prompt an earlier #483 commit added and a later one removed.)
2. **Persist accounting**: `persist_column_concepts` returns emitted / resolved / dropped_unresolved and logs `column_concepts_persisted` (+ debug list of the exact unresolved names) — a name-resolution wipeout is diagnosable, not indistinguishable from an empty emission.
3. **Fall-loud backstop**: `synthesize_and_store_tables` fails begin_session when zero concepts resolve while the batch has measure-role columns — an emptied load-bearing surface is a defect, never a judgment. Gates on emptiness only.

Plus: `semantic_analysis.effort: high` pinned explicitly in `llm/config.yaml` (no-op vs the current API default; removes the hidden dependency).

Prompt delta is exactly one paragraph (anti-emptiness instruction); the #483 binding-discipline / indicator-pointer text is not included.

## Verification

- Full unit suite 2036 passed; semantic suite 112 passed; ruff / mypy / vulture clean; rebased on `origin/main`.
- Salvage selection verified against the #483 net diff commit-by-commit (kept: d15d33f3 processor/utils + 7c3f65d8 models/config + #483's own agent simplification; dropped: ed9a46e6 / 3f29691f prompt content). Given the content was already iterated under review in #483 and this PR is a strict subset, I ran the quality gates but not a fresh two-reviewer pass — flagging that explicitly for the merge decision.
- Handoff updated: a DAT-768 recurrence now fails `semantic_per_table` loud with the counts in the message; worker.log carries `column_concepts_persisted` per batch.

Closes #483 (split per the disposition comment there). Ref DAT-768, DAT-769.

🤖 Generated with [Claude Code](https://claude.com/claude-code)