### PR TITLE
DAT-781: Snippet KB dead-surface cut — snippet_usage, last_used_at, llm_model, record_failure, column_hash, field_resolution

### DIFF
--- a/docs/adr/0010-failure-contract-idempotent-writers.md
+++ b/docs/adr/0010-failure-contract-idempotent-writers.md
@@ -49,8 +49,10 @@ re-grain owed to DAT-501 Phase 5 / DAT-506), and `derived_columns` (skip-guarded
 
 - `metrics_phase` commits once **per metric** (`_execute_isolated`). Allowed because
   every per-metric write converges: snippet state is first-writer-wins (DAT-485) and
-  `snippet_usage`/`execution_count` are the documented **telemetry exception** —
-  not run-stamped, may inflate on redelivery, nothing gates on them.
+  `sql_snippets.execution_count` is the documented **telemetry exception** —
+  not run-stamped, may inflate on redelivery, nothing gates on it. (The
+  `snippet_usage` audit table that shared this exception was write-only and
+  removed, DAT-781.)
 - `lifecycle_artifacts` advance state in place within a run; `declare_artifact` is
   **declare-or-reuse**: a redelivered declare RESETS the same `(session, type, key,
   run)` row to `declared` (state_reason/grounded_against cleared) because

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -620,23 +620,6 @@ export const runTables = metadataSchema
 		sql`SELECT run_id, table_id FROM ws_00000000_0000_0000_0000_000000000001.run_tables`,
 	);
 
-export const snippetUsage = metadataSchema
-	.view("snippet_usage", {
-		usageId: varchar("usage_id"),
-		workspaceId: varchar("workspace_id"),
-		executionId: varchar("execution_id"),
-		executionType: varchar("execution_type"),
-		snippetId: varchar("snippet_id"),
-		usageType: varchar("usage_type"),
-		matchConfidence: doublePrecision("match_confidence"),
-		sqlMatchRatio: doublePrecision("sql_match_ratio"),
-		stepId: varchar("step_id"),
-		createdAt: timestamp("created_at"),
-	})
-	.as(
-		sql`SELECT usage_id, workspace_id, execution_id, execution_type, snippet_id, usage_type, match_confidence, sql_match_ratio, step_id, created_at FROM ws_00000000_0000_0000_0000_000000000001.snippet_usage`,
-	);
-
 export const sources = metadataSchema
 	.view("sources", {
 		sourceId: varchar("source_id"),
@@ -670,18 +653,15 @@ export const sqlSnippets = metadataSchema
 		sql: text(),
 		description: text(),
 		source: varchar(),
-		llmModel: varchar("llm_model"),
 		provenance: json(),
 		parts: json(),
 		executionCount: integer("execution_count"),
 		failureCount: integer("failure_count"),
-		lastUsedAt: timestamp("last_used_at"),
-		columnHash: varchar("column_hash"),
 		createdAt: timestamp("created_at"),
 		updatedAt: timestamp("updated_at"),
 	})
 	.as(
-		sql`SELECT snippet_id, workspace_id, snippet_type, standard_field, statement, aggregation, schema_mapping_id, parameter_value, normalized_expression, input_fields, sql, description, source, llm_model, provenance, parts, execution_count, failure_count, last_used_at, column_hash, created_at, updated_at FROM ws_00000000_0000_0000_0000_000000000001.sql_snippets`,
+		sql`SELECT snippet_id, workspace_id, snippet_type, standard_field, statement, aggregation, schema_mapping_id, parameter_value, normalized_expression, input_fields, sql, description, source, provenance, parts, execution_count, failure_count, created_at, updated_at FROM ws_00000000_0000_0000_0000_000000000001.sql_snippets`,
 	);
 
 export const tables = metadataSchema

--- a/packages/cockpit/src/db/metadata/snippet-library.ts
+++ b/packages/cockpit/src/db/metadata/snippet-library.ts
@@ -43,8 +43,8 @@ export interface SnippetRow {
 	inputFields: unknown;
 	sql: string;
 	description: string;
-	// DAT-616: {field_resolution, column_mappings_basis, …} — the agent's own prior
-	// value→concept FILTER decisions, fed back so grounding isn't re-invented.
+	// DAT-616: {column_mappings_basis, …} — the agent's own prior value→concept
+	// FILTER decisions, fed back so grounding isn't re-invented.
 	provenance: unknown;
 	source: string;
 }

--- a/packages/cockpit/src/db/metadata/snippet-writer.ts
+++ b/packages/cockpit/src/db/metadata/snippet-writer.ts
@@ -42,7 +42,6 @@ export interface SaveQuerySnippetInput extends QuerySnippetKey {
 	description: string;
 	/** Provenance, e.g. `query:<runId>`. */
 	source: string;
-	llmModel?: string | null;
 }
 
 export interface SaveQuerySnippetResult {
@@ -122,7 +121,6 @@ export async function saveQuerySnippet(
 		sql: input.sql,
 		description: input.description,
 		source: input.source,
-		llmModel: input.llmModel ?? null,
 		executionCount: 0,
 		failureCount: 0,
 		createdAt: now,

--- a/packages/cockpit/src/db/metadata/write-surface.ts
+++ b/packages/cockpit/src/db/metadata/write-surface.ts
@@ -99,8 +99,8 @@ export const conceptsWrite = rawSchema.table("concepts", {
  * columns with no DB default — `description`, `execution_count`,
  * `failure_count`, `created_at`, `updated_at` — must be set on every insert
  * (the model's defaults are ORM-side, not server defaults). Identity/quality columns the
- * cockpit never writes (last_used_at, column_hash, provenance, input_fields,
- * normalized_expression) are omitted.
+ * cockpit never writes (provenance, input_fields, normalized_expression) are
+ * omitted.
  */
 export const sqlSnippetsWrite = rawSchema.table("sql_snippets", {
 	snippetId: varchar("snippet_id").primaryKey(),
@@ -114,7 +114,6 @@ export const sqlSnippetsWrite = rawSchema.table("sql_snippets", {
 	sql: text("sql").notNull(),
 	description: text("description").notNull(),
 	source: varchar("source").notNull(),
-	llmModel: varchar("llm_model"),
 	executionCount: integer("execution_count").notNull(),
 	failureCount: integer("failure_count").notNull(),
 	createdAt: timestamp("created_at", { mode: "date" }).notNull(),

--- a/packages/cockpit/src/tools/query.ts
+++ b/packages/cockpit/src/tools/query.ts
@@ -479,7 +479,6 @@ export async function persistLearnedSnippets(
 				sql: c.sql,
 				description: `Learned from a query: ${c.name}`,
 				source,
-				llmModel: MODEL,
 			});
 		}
 	} catch (err) {

--- a/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
+++ b/packages/dataraum-config/llm/prompts/graph_sql_generation.yaml
@@ -278,9 +278,8 @@ user_prompt: |
      the floors of <field_resolution_strategy>; if the concept cannot be grounded, FALL LOUD:
      `select_expr: "NULL"` with no relation and no predicates + a LOW-confidence assumption.
   3. `description` — the one-line human summary.
-  4. `provenance` — field_resolution ("direct" if a field_mapping gave the column, "inferred"
-     if you grounded via Value sets / a join); column_mappings_basis = {concept: {column,
-     filter (the exact values), resolution}}.
+  4. `provenance` — column_mappings_basis = {concept: {column, filter (the exact values),
+     resolution}}.
   5. `assumptions` — genuine interpretation choices only; ALWAYS record one (LOW confidence)
      in the FALL-LOUD case, naming the concept and why it is ungrounded.
 

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -147,17 +147,15 @@ CREATE TABLE sql_snippets (
 	sql TEXT NOT NULL, 
 	description TEXT NOT NULL, 
 	source VARCHAR NOT NULL, 
-	llm_model VARCHAR, 
 	provenance JSON, 
 	parts JSON, 
 	execution_count INTEGER NOT NULL, 
 	failure_count INTEGER NOT NULL, 
-	last_used_at TIMESTAMP WITHOUT TIME ZONE, 
-	column_hash VARCHAR, 
 	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	CONSTRAINT pk_sql_snippets PRIMARY KEY (snippet_id), 
-	CONSTRAINT uq_snippet_semantic_key UNIQUE (snippet_type, standard_field, statement, aggregation, schema_mapping_id, parameter_value)
+	CONSTRAINT uq_snippet_semantic_key UNIQUE (snippet_type, standard_field, statement, aggregation, schema_mapping_id, parameter_value), 
+	CONSTRAINT ck_sql_snippets_snippet_type CHECK (snippet_type IN ('extract', 'constant', 'formula', 'query'))
 );
 
 CREATE INDEX ix_sql_snippets_normalized_expression ON sql_snippets (normalized_expression);
@@ -183,27 +181,6 @@ CREATE TABLE validation_results (
 );
 
 CREATE INDEX ix_validation_results_validation_id ON validation_results (validation_id);
-
-CREATE TABLE snippet_usage (
-	usage_id VARCHAR NOT NULL, 
-	workspace_id VARCHAR NOT NULL, 
-	execution_id VARCHAR NOT NULL, 
-	execution_type VARCHAR NOT NULL, 
-	snippet_id VARCHAR, 
-	usage_type VARCHAR NOT NULL, 
-	match_confidence FLOAT NOT NULL, 
-	sql_match_ratio FLOAT NOT NULL, 
-	step_id VARCHAR, 
-	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
-	CONSTRAINT pk_snippet_usage PRIMARY KEY (usage_id), 
-	CONSTRAINT fk_snippet_usage_snippet_id_sql_snippets FOREIGN KEY(snippet_id) REFERENCES sql_snippets (snippet_id) ON DELETE CASCADE
-);
-
-CREATE INDEX ix_snippet_usage_execution_id ON snippet_usage (execution_id);
-
-CREATE INDEX ix_snippet_usage_snippet_id ON snippet_usage (snippet_id);
-
-CREATE INDEX ix_snippet_usage_workspace_id ON snippet_usage (workspace_id);
 
 CREATE TABLE tables (
 	table_id VARCHAR NOT NULL, 

--- a/packages/engine/schema_read.sql
+++ b/packages/engine/schema_read.sql
@@ -283,10 +283,6 @@ WHERE EXISTS (
     AND h.run_id = r.run_id
 );
 
-DROP VIEW IF EXISTS __READ__.snippet_usage;
-CREATE VIEW __READ__.snippet_usage AS
-SELECT * FROM __WS__.snippet_usage;
-
 DROP VIEW IF EXISTS __READ__.sources;
 CREATE VIEW __READ__.sources AS
 SELECT * FROM __WS__.sources;

--- a/packages/engine/src/dataraum/graphs/agent.py
+++ b/packages/engine/src/dataraum/graphs/agent.py
@@ -294,7 +294,6 @@ class GraphAgent(LLMFeature):
                 # Track usage: all steps were exact reuses
                 self._track_snippet_usage(
                     session=session,
-                    execution_id=generated_code.code_id,
                     cached_snippets=cached_snippets,
                     generated_steps=generated_code.steps,
                     workspace_id=workspace_id,
@@ -316,7 +315,6 @@ class GraphAgent(LLMFeature):
             # Track usage: compare generated steps against provided snippets
             self._track_snippet_usage(
                 session=session,
-                execution_id=generated_code.code_id,
                 cached_snippets=cached_snippets or {},
                 generated_steps=generated_code.steps,
                 workspace_id=workspace_id,
@@ -329,11 +327,14 @@ class GraphAgent(LLMFeature):
         exec_result = self._execute_sql(generated_code, context, graph)
         if not exec_result.success or not exec_result.value:
             # This node is ungroundable — the caller records it in the run's binding
-            # map. Do NOT record_failure the cached DEP snippets: they were
+            # map. Do NOT flag the cached DEP snippets as failed: they were
             # decided-once and grounded by their OWN authoring, so blaming them for
             # THIS node's failure poisons shared extracts (a broken formula would mark
             # `revenue` failed → every metric using it can no longer find it, and
-            # honest metrics like dso silently break). DAT-636 (Bug B).
+            # honest metrics like dso silently break). DAT-636 (Bug B). (The bulk
+            # failure-flag path this warned against, ``record_failure()``, had zero
+            # callers and was removed — DAT-781; this comment records the design
+            # reason it was never wired, not merely dead code.)
             reason = exec_result.error or "SQL execution failed"
             self._save_failed_snippet(
                 session,
@@ -455,7 +456,6 @@ class GraphAgent(LLMFeature):
             return Result.fail(f"metric '{graph.graph_id}': failed to compose from the DAG")
         self._track_snippet_usage(
             session=session,
-            execution_id=generated_code.code_id,
             cached_snippets=cached_snippets,
             generated_steps=generated_code.steps,
             workspace_id=workspace_id,
@@ -982,9 +982,6 @@ class GraphAgent(LLMFeature):
                 "where": output.where,
                 "select_expr": output.select_expr,
                 "sql": rendered_sql,
-                "field_resolution": output.provenance.field_resolution
-                if output.provenance
-                else None,
                 "column_mappings_basis": basis,
                 "assumptions": [
                     {"assumption": a.assumption, "basis": a.basis, "confidence": a.confidence}
@@ -1306,62 +1303,35 @@ class GraphAgent(LLMFeature):
     def _track_snippet_usage(
         self,
         session: Session,
-        execution_id: str,
         cached_snippets: dict[str, dict[str, Any]],
         generated_steps: list[dict[str, str]],
         *,
         workspace_id: str,
     ) -> None:
-        """Track how cached snippets were used in graph execution."""
+        """Bump ``execution_count`` for cached snippets reused in this graph execution.
+
+        Compares each generated step's SQL against the snippet offered for its
+        step_id; ``record_usage`` bumps the count only for ``exact_reuse``/
+        ``adapted`` matches (steps with no provided snippet, or a provided
+        snippet not reflected in the output, are no-ops — DAT-781 removed the
+        per-execution usage audit trail this used to also write).
+        """
         from dataraum.query.snippet_library import SnippetLibrary
         from dataraum.query.snippet_utils import determine_usage_type
 
         library = SnippetLibrary(session, workspace_id=workspace_id)
-        used_snippet_ids: set[str] = set()
 
         for gen_step in generated_steps:
             step_id = gen_step.get("step_id", "")
             provided = cached_snippets.get(step_id)
-
             if provided is None:
-                library.record_usage(
-                    execution_id=execution_id,
-                    execution_type="graph",
-                    usage_type="newly_generated",
-                    step_id=step_id,
-                )
-            else:
-                snippet_id = provided.get("snippet_id")
-                usage_type = determine_usage_type(
-                    gen_step.get("sql", ""),
-                    provided.get("sql", ""),
-                )
-                is_exact = usage_type == "exact_reuse"
-                library.record_usage(
-                    execution_id=execution_id,
-                    execution_type="graph",
-                    usage_type=usage_type,
-                    snippet_id=snippet_id,
-                    match_confidence=1.0,
-                    sql_match_ratio=1.0 if is_exact else 0.0,
-                    step_id=step_id,
-                )
-                if snippet_id:
-                    used_snippet_ids.add(snippet_id)
-
-        # Provided snippets not used by any generated step
-        generated_step_ids = {s.get("step_id", "") for s in generated_steps}
-        for step_id, provided in cached_snippets.items():
-            if step_id not in generated_step_ids:
-                snippet_id = provided.get("snippet_id")
-                if snippet_id and snippet_id not in used_snippet_ids:
-                    library.record_usage(
-                        execution_id=execution_id,
-                        execution_type="graph",
-                        usage_type="provided_not_used",
-                        snippet_id=snippet_id,
-                        step_id=step_id,
-                    )
+                continue
+            snippet_id = provided.get("snippet_id")
+            usage_type = determine_usage_type(
+                gen_step.get("sql", ""),
+                provided.get("sql", ""),
+            )
+            library.record_usage(snippet_id, usage_type)
 
     @staticmethod
     def _build_snippet_provenance(
@@ -1369,8 +1339,8 @@ class GraphAgent(LLMFeature):
     ) -> dict[str, Any] | None:
         """The provenance blob saved alongside a snippet.
 
-        Carries the LLM grounding decisions (field_resolution, column_mappings_basis)
-        and — crucially for the phase confidence gate — the per-input
+        Carries the LLM grounding decision (column_mappings_basis) and —
+        crucially for the phase confidence gate — the per-input
         ``assumptions`` (so a metric ASSEMBLED from cache still surfaces its weakest
         grounding's confidence). Composed FORMULA/CONSTANT snippets have no LLM
         provenance but DO carry forward their extract leaves' assumptions.
@@ -1381,7 +1351,6 @@ class GraphAgent(LLMFeature):
         if generated_code.provenance:
             prov = generated_code.provenance
             provenance = {
-                "field_resolution": prov.field_resolution,
                 "column_mappings_basis": prov.column_mappings_basis,
             }
 
@@ -1463,7 +1432,6 @@ class GraphAgent(LLMFeature):
                 standard_field=graph_step.source.standard_field,
                 statement=graph_step.source.statement,
                 aggregation=graph_step.aggregation,
-                llm_model=generated_code.llm_model,
                 provenance=provenance_dict,
                 parts=gen_step.get("parts"),
             )
@@ -1536,7 +1504,6 @@ class GraphAgent(LLMFeature):
                 standard_field=graph_step.source.standard_field,
                 statement=graph_step.source.statement,
                 aggregation=graph_step.aggregation,
-                llm_model=generated_code.llm_model,
                 provenance=provenance,
                 parts=gen_step.get("parts"),
                 failed=True,
@@ -1607,7 +1574,6 @@ class GraphAgent(LLMFeature):
                     source=source,
                     standard_field=graph_step.parameter or step_id,
                     parameter_value=param_value,
-                    llm_model=generated_code.llm_model,
                     provenance=provenance_dict,
                 )
 
@@ -1636,7 +1602,6 @@ class GraphAgent(LLMFeature):
                     source=source,
                     normalized_expression=normalized,
                     input_fields=input_fields,
-                    llm_model=generated_code.llm_model,
                     provenance=provenance_dict,
                 )
 

--- a/packages/engine/src/dataraum/graphs/models.py
+++ b/packages/engine/src/dataraum/graphs/models.py
@@ -323,10 +323,6 @@ class GraphAssumptionOutput(BaseModel):
 class GraphProvenanceOutput(BaseModel):
     """Provenance of how the LLM grounded business concepts to SQL."""
 
-    field_resolution: str = Field(
-        description="How fields were resolved: 'direct' (taught concept, deterministic mapping) "
-        "or 'inferred' (LLM bridged vocabulary gap using enriched views)"
-    )
     column_mappings_basis: dict[str, dict[str, str]] = Field(
         default_factory=dict,
         description="Per-concept grounding: {concept: {column, filter, resolution}}",
@@ -334,6 +330,10 @@ class GraphProvenanceOutput(BaseModel):
     # No free-text reasoning field: the former `llm_reasoning` was written into the
     # snippet provenance blob and read by nothing (DAT-603 consumer audit) — output
     # tokens are serial-decode latency, so an unread sentence per call is pure cost.
+    # `field_resolution` (direct/inferred) was the same class of write-only field —
+    # emitted by the LLM, stamped into provenance, read by nothing persisted
+    # (DAT-781). Deleted rather than typed for DAT-727 contract v2 (parked at the
+    # time of this cut) — v2 rebases over this if/when it lands.
 
 
 class ValueSearchInput(BaseModel):

--- a/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/metrics_phase.py
@@ -36,10 +36,11 @@ METRIC (``_execute_isolated``). That is under the failure contract because
 every per-metric write converges under at-least-once redelivery: snippet
 state is first-writer-wins (``SnippetLibrary.save_snippet`` keeps a healthy
 existing row, replaces only failed ones — the DAT-485 app-level dedup), and
-the ``snippet_usage`` rows / ``execution_count`` counters are the documented
-TELEMETRY exception — ``sql_snippets``/``snippet_usage`` are not run-stamped,
-so a redelivery can inflate usage telemetry; nothing gates on it (write-only
-since DAT-487/488).
+the ``execution_count`` counter is the documented TELEMETRY exception —
+``sql_snippets`` is not run-stamped, so a redelivery can inflate the count;
+nothing gates on it (write-only since DAT-487/488; the per-execution
+``snippet_usage`` audit trail this once fed was itself write-only —
+removed, DAT-781).
 
 Authoring vs assembly (DAT-636): the LLM is called ONLY in the up-front
 authoring pass (``_warm_shared_nodes``), which decides every unique node once and

--- a/packages/engine/src/dataraum/query/__init__.py
+++ b/packages/engine/src/dataraum/query/__init__.py
@@ -7,7 +7,7 @@ the LIVE producer path depends on:
 
 - ``snippet_library``: ``SnippetLibrary`` (save / find_by_key / record_usage) —
   written by the GraphAgent (``graphs/agent.py``) and ``metrics_phase``.
-- ``snippet_models``: the ``SQLSnippetRecord`` / ``SnippetUsageRecord`` ORM models.
+- ``snippet_models``: the ``SQLSnippetRecord`` ORM model.
 - ``snippet_utils``: ``normalize_sql`` / ``determine_usage_type`` /
   ``normalize_expression``.
 - ``execution``: ``execute_sql_steps`` — the engine's SQL-step executor (GraphAgent).

--- a/packages/engine/src/dataraum/query/snippet_library.py
+++ b/packages/engine/src/dataraum/query/snippet_library.py
@@ -1,8 +1,9 @@
 """SQL Snippet Library — the engine-owned snippet Knowledge Base substrate.
 
 Manages snippet lifecycle for the LIVE producer path (the GraphAgent in
-``graphs/agent.py`` + ``metrics_phase``): upsert, exact-key discovery, and
-usage/failure tracking. The natural-language CONSUMER discovery surface — key-based
+``graphs/agent.py`` + ``metrics_phase``): upsert (including failure retention via
+``save_snippet(failed=True)``), exact-key discovery, and usage tracking. The
+natural-language CONSUMER discovery surface — key-based
 graph search, full-graph injection, vocabulary, stats — moved to the cockpit TS tier
 (the ``answer`` sub-agent, DAT-485/494) and was removed in DAT-487; the cockpit reads
 the same ``sql_snippets`` substrate directly via Drizzle.
@@ -48,7 +49,7 @@ from uuid import uuid4
 from sqlalchemy import select, update
 
 from dataraum.core.logging import get_logger
-from dataraum.query.snippet_models import SnippetUsageRecord, SQLSnippetRecord
+from dataraum.query.snippet_models import SQLSnippetRecord
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -83,9 +84,9 @@ class SnippetLibrary:
         Args:
             session: SQLAlchemy session for snippet metadata
             workspace_id: Workspace id for per-row population.
-                Required for paths that create new rows (snippet upsert,
-                usage recording). Read-only paths (find_by_*, record_failure)
-                may pass None.
+                Required for paths that create new rows (snippet upsert).
+                Paths that create no rows (find_by_*, record_usage) may
+                pass None.
         """
         self.session = session
         self.workspace_id = workspace_id
@@ -253,8 +254,6 @@ class SnippetLibrary:
         parameter_value: str | None = None,
         normalized_expression: str | None = None,
         input_fields: list[str] | None = None,
-        llm_model: str | None = None,
-        column_hash: str | None = None,
         provenance: dict[str, Any] | None = None,
         parts: dict[str, Any] | None = None,
         failed: bool = False,
@@ -283,9 +282,7 @@ class SnippetLibrary:
             parameter_value: Parameter value (for constants)
             normalized_expression: Normalized expression (for formulas)
             input_fields: Input field names (for formulas)
-            llm_model: LLM model used to generate
-            column_hash: Hash for schema change invalidation
-            provenance: Grounding decisions (field_resolution, column_mappings_basis, etc.)
+            provenance: Grounding decisions (column_mappings_basis, etc.)
             parts: Clause parts the extract's ``sql`` was rendered from (DAT-671) —
                 the structured artifact drill composition builds on; extracts only.
 
@@ -332,8 +329,6 @@ class SnippetLibrary:
             existing.sql = sql
             existing.description = description
             existing.source = source
-            existing.llm_model = llm_model
-            existing.column_hash = column_hash
             existing.provenance = provenance
             existing.parts = parts
             existing.failure_count = 1 if failed else 0
@@ -359,8 +354,6 @@ class SnippetLibrary:
                 sql=sql,
                 description=description,
                 source=source,
-                llm_model=llm_model,
-                column_hash=column_hash,
                 provenance=provenance,
                 parts=parts,
                 execution_count=0,
@@ -383,71 +376,25 @@ class SnippetLibrary:
 
     # --- Usage Tracking ---
 
-    def record_usage(
-        self,
-        execution_id: str,
-        execution_type: str,
-        usage_type: str,
-        *,
-        snippet_id: str | None = None,
-        match_confidence: float = 0.0,
-        sql_match_ratio: float = 0.0,
-        step_id: str | None = None,
-    ) -> SnippetUsageRecord:
-        """Record how a snippet was used in an execution.
+    def record_usage(self, snippet_id: str | None, usage_type: str) -> None:
+        """Bump ``execution_count`` when a cached snippet was reused this run.
+
+        The per-execution usage audit trail (``snippet_usage``) was write-only
+        telemetry — never read by anything — and was removed (DAT-781). This is
+        what remains of ``record_usage``: the one side effect that DOES have a
+        live reader (the cockpit's why-metric surface, ``execution_count``).
 
         Args:
-            execution_id: The execution that used (or didn't use) the snippet
-            execution_type: "graph" or "query"
-            usage_type: "exact_reuse", "adapted", "provided_not_used", "newly_generated"
-            snippet_id: The snippet ID (None for newly_generated)
-            match_confidence: Confidence at discovery time
-            sql_match_ratio: Similarity between generated and snippet SQL
-            step_id: The step ID this usage relates to
-
-        Returns:
-            Created SnippetUsageRecord
+            snippet_id: The snippet ID (None when nothing was reused — no-op).
+            usage_type: "exact_reuse", "adapted", "provided_not_used", or
+                "newly_generated" — only the first two bump the count.
         """
-        record = SnippetUsageRecord(
-            usage_id=str(uuid4()),
-            workspace_id=self._require_workspace_id(),
-            execution_id=execution_id,
-            execution_type=execution_type,
-            snippet_id=snippet_id,
-            usage_type=usage_type,
-            match_confidence=match_confidence,
-            sql_match_ratio=sql_match_ratio,
-            step_id=step_id,
-            created_at=datetime.now(UTC),
-        )
-        self.session.add(record)
-
-        # Update snippet usage stats
         if snippet_id and usage_type in ("exact_reuse", "adapted"):
             self.session.execute(
                 update(SQLSnippetRecord)
                 .where(SQLSnippetRecord.snippet_id == snippet_id)
-                .values(
-                    execution_count=SQLSnippetRecord.execution_count + 1,
-                    last_used_at=datetime.now(UTC),
-                )
+                .values(execution_count=SQLSnippetRecord.execution_count + 1)
             )
-
-        return record
-
-    def record_failure(self, snippet_ids: list[str]) -> None:
-        """Increment failure_count for snippets that produced execution errors.
-
-        Args:
-            snippet_ids: Snippet IDs whose SQL failed during execution.
-        """
-        if not snippet_ids:
-            return
-        self.session.execute(
-            update(SQLSnippetRecord)
-            .where(SQLSnippetRecord.snippet_id.in_(snippet_ids))
-            .values(failure_count=SQLSnippetRecord.failure_count + 1)
-        )
 
 
 __all__ = ["SnippetLibrary", "SnippetMatch"]

--- a/packages/engine/src/dataraum/query/snippet_models.py
+++ b/packages/engine/src/dataraum/query/snippet_models.py
@@ -26,15 +26,14 @@ from uuid import uuid4
 
 from sqlalchemy import (
     JSON,
+    CheckConstraint,
     DateTime,
-    Float,
-    ForeignKey,
     Integer,
     String,
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dataraum.storage import Base
 
@@ -59,6 +58,10 @@ class SQLSnippetRecord(Base):
             "schema_mapping_id",
             "parameter_value",
             name="uq_snippet_semantic_key",
+        ),
+        CheckConstraint(
+            "snippet_type IN ('extract', 'constant', 'formula', 'query')",
+            name="snippet_type",
         ),
     )
 
@@ -87,7 +90,6 @@ class SQLSnippetRecord(Base):
     source: Mapped[str] = mapped_column(
         String, nullable=False
     )  # e.g. "graph:dso", "query:exec_456"
-    llm_model: Mapped[str | None] = mapped_column(String, nullable=True)
     provenance: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
     # --- Clause parts (DAT-671, parts-at-source; EXTRACT snippets only) ---
@@ -102,10 +104,6 @@ class SQLSnippetRecord(Base):
     # --- Quality tracking ---
     execution_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     failure_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    column_hash: Mapped[str | None] = mapped_column(
-        String, nullable=True
-    )  # For schema change invalidation
 
     # --- Timestamps ---
     created_at: Mapped[datetime] = mapped_column(
@@ -115,56 +113,5 @@ class SQLSnippetRecord(Base):
         DateTime, nullable=False, default=lambda: datetime.now(UTC)
     )
 
-    # --- Relationships ---
-    usages: Mapped[list[SnippetUsageRecord]] = relationship(
-        "SnippetUsageRecord",
-        back_populates="snippet",
-        cascade="all, delete-orphan",
-    )
 
-
-class SnippetUsageRecord(Base):
-    """Tracks how a snippet was used in a specific execution.
-
-    Records whether the snippet was exactly reused, adapted, provided but
-    not used, or newly generated. This enables stabilization metrics.
-    """
-
-    __tablename__ = "snippet_usage"
-
-    usage_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
-    workspace_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
-
-    # --- Execution link ---
-    execution_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
-    execution_type: Mapped[str] = mapped_column(String, nullable=False)  # "graph" | "query"
-
-    # --- Snippet link ---
-    snippet_id: Mapped[str | None] = mapped_column(
-        ForeignKey("sql_snippets.snippet_id", ondelete="CASCADE"),
-        nullable=True,
-        index=True,
-    )  # NULL for newly_generated (no snippet existed)
-
-    # --- Usage classification ---
-    usage_type: Mapped[str] = mapped_column(
-        String, nullable=False
-    )  # exact_reuse | adapted | provided_not_used | newly_generated
-    match_confidence: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
-    sql_match_ratio: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
-
-    # --- Metadata ---
-    step_id: Mapped[str | None] = mapped_column(String, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, default=lambda: datetime.now(UTC)
-    )
-
-    # --- Relationships ---
-    snippet: Mapped[SQLSnippetRecord | None] = relationship(
-        "SQLSnippetRecord",
-        back_populates="usages",
-        foreign_keys=[snippet_id],
-    )
-
-
-__all__ = ["SQLSnippetRecord", "SnippetUsageRecord"]
+__all__ = ["SQLSnippetRecord"]

--- a/packages/engine/tests/integration/graphs/test_agent.py
+++ b/packages/engine/tests/integration/graphs/test_agent.py
@@ -913,17 +913,21 @@ class TestGraphAgentSnippets:
         assert result.value.output_value == 600.0  # 100 + 200 + 300
         assert agent.provider.converse.call_count == 0  # No LLM call needed
 
-    def test_snippet_usage_tracked_on_assembly(
+    def test_execution_count_incremented_on_assembly(
         self,
         session: Session,
         duckdb_with_data,
         sample_graph,
     ):
-        """Test that snippet usage is tracked when assembled from cache."""
+        """Assembling a metric from a cached (exact-reuse) snippet bumps its
+        execution_count — the one usage-tracking side effect with a live
+        reader (the cockpit's why-metric surface). The per-execution
+        ``snippet_usage`` audit trail this used to also write was write-only
+        telemetry, removed (DAT-781)."""
         from sqlalchemy import select
 
         from dataraum.query.snippet_library import SnippetLibrary
-        from dataraum.query.snippet_models import SnippetUsageRecord
+        from dataraum.query.snippet_models import SQLSnippetRecord
 
         mock_provider = MagicMock()
         mock_provider.get_model_for_tier.return_value = "test-model"
@@ -948,6 +952,7 @@ class TestGraphAgentSnippets:
             aggregation="sum",
         )
         session.flush()
+        assert snippet.execution_count == 0
 
         agent = GraphAgent(
             config=mock_config,
@@ -960,74 +965,11 @@ class TestGraphAgentSnippets:
         result = agent.execute(session, sample_graph, context, workspace_id=baseline_run_id())
         assert result.success
 
-        # Verify usage record was created
-        usages = list(session.execute(select(SnippetUsageRecord)).scalars().all())
-        assert len(usages) >= 1
-
-        # Should be an exact_reuse since snippet was assembled without LLM
-        exact_reuse = next((u for u in usages if u.usage_type == "exact_reuse"), None)
-        assert exact_reuse is not None
-        assert exact_reuse.execution_type == "graph"
-        assert exact_reuse.snippet_id == snippet.snippet_id
-
-    def test_usage_tracked_without_cached_snippets(
-        self,
-        session: Session,
-        duckdb_with_data,
-        sample_graph,
-    ):
-        """Test that usage is tracked on first-time execution (no cached snippets)."""
-        from sqlalchemy import select
-
-        from dataraum.query.snippet_models import SnippetUsageRecord
-
-        mock_provider = MagicMock()
-        mock_provider.get_model_for_tier.return_value = "test-model"
-
-        mock_config = MagicMock()
-        mock_config.limits.max_output_tokens_per_request = 4000
-        mock_config.limits.cache_ttl_seconds = 3600
-        mock_config.features.graph_sql_generation = None
-
-        mock_renderer = MagicMock()
-        mock_renderer.render_split.return_value = ("System prompt", "Test prompt", 0.0)
-
-        agent = GraphAgent(
-            config=mock_config,
-            provider=mock_provider,
-            prompt_renderer=mock_renderer,
-        )
-
-        # Mock LLM response (single-extract clause-parts shape, DAT-603/671)
-        mock_tool_call = MagicMock()
-        mock_tool_call.name = "generate_sql"
-        mock_tool_call.input = {
-            "grounding": "test grounding: served values verified",
-            "relation": "test_data",
-            "where": [],
-            "select_expr": "SUM(amount)",
-            "description": "Sum amounts from test data",
-        }
-
-        mock_response = MagicMock()
-        mock_response.tool_calls = [mock_tool_call]
-        mock_response.content = None
-        agent.provider.converse = MagicMock(return_value=Result.ok(mock_response))
-
-        context = _make_execution_context(duckdb_with_data)
-
-        # Execute — no cached snippets (first time), should still track usage
-        result = agent.execute(session, sample_graph, context, workspace_id=baseline_run_id())
-        assert result.success
-
-        # Verify usage records were created
-        usages = list(session.execute(select(SnippetUsageRecord)).scalars().all())
-        assert len(usages) >= 1
-
-        # All steps should be newly_generated
-        newly_generated = [u for u in usages if u.usage_type == "newly_generated"]
-        assert len(newly_generated) >= 1
-        assert newly_generated[0].execution_type == "graph"
+        # Assembled from cache (exact reuse, no LLM call) → execution_count bumped.
+        refreshed = session.execute(
+            select(SQLSnippetRecord).where(SQLSnippetRecord.snippet_id == snippet.snippet_id)
+        ).scalar_one()
+        assert refreshed.execution_count == 1
 
 
 class TestPriorContextFeedback:

--- a/packages/engine/tests/unit/graphs/test_tool_repair.py
+++ b/packages/engine/tests/unit/graphs/test_tool_repair.py
@@ -33,7 +33,6 @@ _VALID_INPUT = {
     "select_expr": "SUM(amount)",
     "description": "Total revenue",
     "provenance": {
-        "field_resolution": "direct",
         "column_mappings_basis": {"revenue": {"column": "amount", "filter": "Income"}},
     },
 }
@@ -143,7 +142,7 @@ def test_stringified_field_is_repaired_by_the_model(monkeypatch) -> None:
     assert repair_request.label == "graph_sql_generation_repair"
     content = repair_request.messages[0].content
     assert "Validation error" in content
-    assert "field_resolution" in content  # the model's own output rides along
+    assert "column_mappings_basis" in content  # the model's own output rides along
 
 
 def test_second_validation_failure_fails_loud_with_both_errors(monkeypatch) -> None:

--- a/packages/engine/tests/unit/query/test_snippet_library.py
+++ b/packages/engine/tests/unit/query/test_snippet_library.py
@@ -350,10 +350,16 @@ class TestSnippetLibraryFormulaPerMetric:
 
 
 class TestSnippetLibraryRecordUsage:
-    """Tests for usage tracking."""
+    """Tests for ``execution_count`` tracking.
 
-    def test_record_exact_reuse(self, session):
-        """Record an exact reuse and update snippet stats."""
+    DAT-781 removed the per-execution ``snippet_usage`` audit-trail row this
+    used to also insert — write-only telemetry, never read by anything. What
+    remains is the one side effect with a live reader (the cockpit's
+    why-metric surface): bumping ``execution_count`` on exact reuse/adapted.
+    """
+
+    def test_record_exact_reuse_increments_execution_count(self, session):
+        """An exact reuse bumps the snippet's execution_count."""
         library = SnippetLibrary(session, workspace_id=WORKSPACE_ID)
 
         snippet = library.save_snippet(
@@ -367,42 +373,14 @@ class TestSnippetLibraryRecordUsage:
         session.flush()
         assert snippet.execution_count == 0
 
-        usage = library.record_usage(
-            execution_id="exec_001",
-            execution_type="graph",
-            usage_type="exact_reuse",
-            snippet_id=snippet.snippet_id,
-            match_confidence=1.0,
-            sql_match_ratio=1.0,
-            step_id="revenue",
-        )
+        library.record_usage(snippet.snippet_id, "exact_reuse")
         session.flush()
 
-        assert usage.usage_type == "exact_reuse"
-        assert usage.step_id == "revenue"
-
-        # Snippet stats should be updated
         session.refresh(snippet)
         assert snippet.execution_count == 1
-        assert snippet.last_used_at is not None
 
-    def test_record_newly_generated(self, session):
-        """Record a newly generated step (no snippet)."""
-        library = SnippetLibrary(session, workspace_id=WORKSPACE_ID)
-
-        usage = library.record_usage(
-            execution_id="exec_002",
-            execution_type="query",
-            usage_type="newly_generated",
-            step_id="monthly_revenue",
-        )
-        session.flush()
-
-        assert usage.snippet_id is None
-        assert usage.usage_type == "newly_generated"
-
-    def test_record_provided_not_used(self, session):
-        """Record when snippet was provided but LLM ignored it."""
+    def test_record_adapted_increments_execution_count(self, session):
+        """An adapted reuse also bumps execution_count."""
         library = SnippetLibrary(session, workspace_id=WORKSPACE_ID)
 
         snippet = library.save_snippet(
@@ -415,17 +393,35 @@ class TestSnippetLibraryRecordUsage:
         )
         session.flush()
 
-        library.record_usage(
-            execution_id="exec_003",
-            execution_type="query",
-            usage_type="provided_not_used",
-            snippet_id=snippet.snippet_id,
-            match_confidence=0.7,
-            sql_match_ratio=0.3,
+        library.record_usage(snippet.snippet_id, "adapted")
+        session.flush()
+
+        session.refresh(snippet)
+        assert snippet.execution_count == 1
+
+    def test_record_newly_generated_is_noop(self, session):
+        """No snippet was reused (snippet_id=None) — must not raise."""
+        library = SnippetLibrary(session, workspace_id=WORKSPACE_ID)
+
+        library.record_usage(None, "newly_generated")
+
+    def test_record_provided_not_used_does_not_increment(self, session):
+        """Snippet was offered but the generated SQL ignored it — no bump."""
+        library = SnippetLibrary(session, workspace_id=WORKSPACE_ID)
+
+        snippet = library.save_snippet(
+            snippet_type="extract",
+            sql="SELECT 1",
+            description="test",
+            schema_mapping_id="schema_abc",
+            source="graph:test",
+            standard_field="revenue",
         )
         session.flush()
 
-        # provided_not_used should NOT increment execution_count
+        library.record_usage(snippet.snippet_id, "provided_not_used")
+        session.flush()
+
         session.refresh(snippet)
         assert snippet.execution_count == 0
 

--- a/packages/engine/tests/unit/query/test_snippet_models.py
+++ b/packages/engine/tests/unit/query/test_snippet_models.py
@@ -3,7 +3,7 @@
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from dataraum.query.snippet_models import SnippetUsageRecord, SQLSnippetRecord
+from dataraum.query.snippet_models import SQLSnippetRecord
 
 
 class TestSQLSnippetRecord:
@@ -148,98 +148,18 @@ class TestSQLSnippetRecord:
         )
         session.flush()  # Should not raise
 
-
-class TestSnippetUsageRecord:
-    """Tests for SnippetUsageRecord model."""
-
-    def _create_snippet(self, session) -> SQLSnippetRecord:
-        """Helper to create a snippet for usage tests."""
+    def test_snippet_type_check_constraint(self, session):
+        """An unrecognized snippet_type is rejected at the DB layer (DAT-781: the
+        two-layer enforcement standard — a closed-vocabulary column gets a
+        CheckConstraint whenever it's touched)."""
         record = SQLSnippetRecord(
             workspace_id="ws_test",
-            snippet_type="extract",
-            standard_field="revenue",
+            snippet_type="bogus",
             schema_mapping_id="schema_abc",
             sql="SELECT 1",
             description="test",
-            source="graph:test",
+            source="graph:dso",
         )
         session.add(record)
-        session.flush()
-        return record
-
-    def test_create_exact_reuse(self, session):
-        """Record an exact reuse."""
-        snippet = self._create_snippet(session)
-        usage = SnippetUsageRecord(
-            workspace_id="ws_test",
-            execution_id="exec_001",
-            execution_type="graph",
-            snippet_id=snippet.snippet_id,
-            usage_type="exact_reuse",
-            match_confidence=1.0,
-            sql_match_ratio=1.0,
-            step_id="revenue",
-        )
-        session.add(usage)
-        session.flush()
-
-        assert usage.usage_id is not None
-        assert usage.usage_type == "exact_reuse"
-
-    def test_create_newly_generated(self, session):
-        """Record a newly generated step (no snippet)."""
-        usage = SnippetUsageRecord(
-            workspace_id="ws_test",
-            execution_id="exec_002",
-            execution_type="query",
-            snippet_id=None,
-            usage_type="newly_generated",
-            match_confidence=0.0,
-            sql_match_ratio=0.0,
-            step_id="monthly_revenue",
-        )
-        session.add(usage)
-        session.flush()
-
-        assert usage.snippet_id is None
-        assert usage.usage_type == "newly_generated"
-
-    def test_snippet_relationship(self, session):
-        """Usage record links back to snippet."""
-        snippet = self._create_snippet(session)
-        usage = SnippetUsageRecord(
-            workspace_id="ws_test",
-            execution_id="exec_003",
-            execution_type="graph",
-            snippet_id=snippet.snippet_id,
-            usage_type="adapted",
-            match_confidence=0.9,
-            sql_match_ratio=0.85,
-        )
-        session.add(usage)
-        session.flush()
-
-        # Navigate relationship
-        assert usage.snippet is not None
-        assert usage.snippet.snippet_id == snippet.snippet_id
-
-    def test_cascade_delete(self, session):
-        """Deleting snippet cascades to usage records."""
-        snippet = self._create_snippet(session)
-        usage = SnippetUsageRecord(
-            workspace_id="ws_test",
-            execution_id="exec_004",
-            execution_type="graph",
-            snippet_id=snippet.snippet_id,
-            usage_type="exact_reuse",
-            match_confidence=1.0,
-            sql_match_ratio=1.0,
-        )
-        session.add(usage)
-        session.flush()
-
-        usage_id = usage.usage_id
-        session.delete(snippet)
-        session.flush()
-
-        assert session.get(SnippetUsageRecord, usage_id) is None
+        with pytest.raises(IntegrityError):
+            session.flush()

--- a/packages/engine/tests/unit/query/test_snippet_provenance.py
+++ b/packages/engine/tests/unit/query/test_snippet_provenance.py
@@ -49,7 +49,6 @@ class TestSnippetProvenance:
         """Provenance dict roundtrips through save_snippet."""
         library = SnippetLibrary(session, workspace_id=WORKSPACE_ID)
         provenance = {
-            "field_resolution": "inferred",
             "was_repaired": False,
             "column_mappings_basis": {
                 "revenue": {"column": "t.amount", "resolution": "inferred_from_enriched_view"}
@@ -69,7 +68,7 @@ class TestSnippetProvenance:
         )
 
         assert record.provenance == provenance
-        assert record.provenance["field_resolution"] == "inferred"
+        assert record.provenance["column_mappings_basis"]["revenue"]["column"] == "t.amount"
 
     def test_save_snippet_without_provenance(self, session: Session) -> None:
         """Provenance is None when not provided."""
@@ -87,7 +86,7 @@ class TestSnippetProvenance:
 
     def test_provenance_survives_find_by_key(self, session: Session) -> None:
         """Provenance is available after finding snippet by key."""
-        provenance = {"field_resolution": "direct", "was_repaired": False}
+        provenance = {"column_mappings_basis": {}, "was_repaired": False}
         _add_snippet(session, SOURCE_ID, provenance=provenance)
 
         library = SnippetLibrary(session, workspace_id=WORKSPACE_ID)
@@ -104,12 +103,12 @@ class TestSnippetProvenance:
 
     def test_provenance_updated_on_failed_snippet_replace(self, session: Session) -> None:
         """When a failed snippet is replaced, provenance is updated."""
-        record = _add_snippet(session, SOURCE_ID, provenance={"field_resolution": "inferred"})
+        record = _add_snippet(session, SOURCE_ID, provenance={"column_mappings_basis": {}})
         record.failure_count = 1
         session.flush()
 
         library = SnippetLibrary(session, workspace_id=WORKSPACE_ID)
-        new_provenance = {"field_resolution": "direct", "was_repaired": True}
+        new_provenance = {"column_mappings_basis": {"revenue": {}}, "was_repaired": True}
         updated = library.save_snippet(
             snippet_type="extract",
             sql="SELECT SUM(new_amount) FROM t",


### PR DESCRIPTION
## Task

DAT-781 — https://real-dataraum.atlassian.net/browse/DAT-781 (Wave-1 delete lane of the DAT-772 substrate hardening plan)

## What was cut

Write-only snippet-KB telemetry surface, confirmed dead by the DAT-772 audit (lane A4):

- **`snippet_usage` table (whole)** — `SnippetUsageRecord` model, the `usages` relationship, the `record_usage` row insert, the cockpit Drizzle view (imported nowhere). Write-only since DAT-487/488; `match_confidence`/`sql_match_ratio` were hardcoded constants.
- **`sql_snippets.last_used_at` + `llm_model`** — no reader in either package; `llm_model` writers removed in both (engine `save_snippet`, cockpit `saveQuerySnippet`/`write-surface.ts`/`tools/query.ts`).
- **`record_failure()`** — zero callers; deleted outright per the coordinator's call (wiring it would be new behavior; the staleness gap is recorded in the DD v4 gap list). The `agent.py` comment documenting why it was deliberately never wired (DAT-636 Bug B) is preserved.
- **`column_hash`** — never computed, never read; `save_snippet` parameter plumbing removed end-to-end.
- **`provenance.field_resolution`** — write-only key: `GraphProvenanceOutput.field_resolution`, both `graphs/agent.py` writers (snippet-provenance stamp + debug dump), and the `graph_sql_generation.yaml` prompt instruction telling the LLM to emit it. DAT-727 contract v2 is parked and rebases over this.

**Kept:** `sql_snippets.execution_count` (live reader `why-metric.ts:172`) — increment survives as the slimmed `record_usage(snippet_id, usage_type)`; behavior-preservation re-derived by the senior reviewer (the deleted branches could never touch it).

**Added (two-layer enforcement standard, touched column only):** `CHECK (snippet_type IN ('extract','constant','formula','query'))` on `sql_snippets` + constraint test.

Also folded in: ADR-0010's telemetry-exception prose now names only `execution_count` (spec-reviewer finding).

## Generated files

`packages/engine/schema.sql`, `schema_read.sql`, and the cockpit Drizzle mirror were re-dumped via `bun run db:pull:metadata` — never hand-edited. Spec reviewer independently re-ran both generators and confirmed byte-identical output (schema-drift clean, idempotent).

## Acceptance criteria (from ticket)

- [x] `snippet_usage` removed (model, writer, Drizzle view, schema dumps)
- [x] `sql_snippets.last_used_at` + `llm_model` removed (both packages)
- [x] `record_failure()` deleted (decision: delete outright, not wire)
- [x] `column_hash` column + parameter plumbing removed
- [x] `provenance.field_resolution` removed (model field, writers, prompt YAML)
- [x] `execution_count` kept; increment survives `record_usage` slimming
- [x] Cross-package schema re-dumps; tests adapted/deleted in the same commit

## Lane smoke / verification

```
engine:  ruff format + ruff check + mypy (267 files)   clean
         pytest tests/unit  -n auto                    2034 passed
         pytest tests/integration                      250 passed, 8 skipped
         vulture                                       clean
cockpit: biome check                                   clean (486 files)
         tsc --noEmit                                  clean
         vitest (unit project)                         1672 passed (177 files)
         vite build                                    success
schema:  db:pull:metadata re-run                       idempotent, zero drift
```

## Reviewers

- senior-code-reviewer: **APPROVE** (one docstring nit — fixed)
- spec-compliance-reviewer: **APPROVE** (one low ADR-0010 stale reference — fixed in this PR)

## Other lanes in flight

- #488 DAT-769 meaning-as-context semantic layer
- #487 DAT-727 grounding reification (PAUSED per status board; contract v2 parked — this PR deletes `field_resolution` cleanly, v2 rebases over it)
- #486 DAT-730 temporal coverage (NOT READY per lead review)
- DAT-782 (sibling Wave-1 delete lane, no PR yet) also touches `schema.sql` — whichever merges second must re-dump via `db:pull:metadata`, never hand-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)