### PR TITLE
DAT-775: grain_columns persists as a bare list — cycle prompt renders real grain

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,31 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-775 — grain_columns persists as a bare list; cycle prompt renders real grain
+
+**Branch:** `fix/dat-775-grain-columns-bare-list`. `table_entities.grain_columns`
+was written as `{"columns": [...]}` — an unenforced wrapper convention. The
+cycle-detection context joined the raw value into its prompt, and joining a dict
+iterates its KEYS, so every table's grain rendered as the literal string
+`grain: columns`. Live prompt corruption.
+
+### What changed
+
+- The writer persists a bare JSON list of column names; the SQLAlchemy column is
+  typed `Mapped[list[str] | None]` (no DDL change — JSON stays JSON).
+- The defensive dict-or-list unwrap in `graphs/context.py` is deleted; the
+  cockpit's `look_table`/`query-context` grain parser is a bare `string[]` only.
+- No backfill: existing workspaces re-run `add_source` (test DBs recreate).
+
+### What eval should see
+
+- The cycle-detection prompt's TABLE CLASSIFICATIONS section now carries each
+  table's actual grain columns (`grain: account_id, period`) instead of
+  `grain: columns` for every table — cycle-detection quality may shift;
+  re-baseline any cycle evals that snapshot prompts or scores.
+
+---
+
 ## DAT-769 — business_concept retired: meaning-as-context semantic layer
 
 **Branch:** `feat/dat-769-meaning-as-context`. The single categorical

--- a/packages/cockpit/src/tools/look-table.test.ts
+++ b/packages/cockpit/src/tools/look-table.test.ts
@@ -184,11 +184,9 @@ function entityRow(overrides: Partial<TableEntityRow> = {}): TableEntityRow {
 		// Raw row carries the engine's role string (DAT-728); the projection
 		// surfaces it verbatim as table_role, never flattened to a boolean.
 		tableRole: "fact",
-		// The engine ALWAYS persists grain as the DICT shape `{"columns": [...]}`
-		// (`analysis/semantic/processor.py`), NOT a bare array — fixture it that way
-		// so the projection's real-shape parse is exercised (the bare-array form
-		// only ever shows up as a tolerated fallback).
-		grainColumns: { columns: ["order_id", "line_no"] },
+		// The engine persists grain as a bare array of column names (DAT-775;
+		// `analysis/semantic/processor.py`).
+		grainColumns: ["order_id", "line_no"],
 		timeColumns: [
 			{
 				column: "order_date",
@@ -205,7 +203,7 @@ function entityRow(overrides: Partial<TableEntityRow> = {}): TableEntityRow {
 }
 
 describe("projectTableEntity (DAT-476)", () => {
-	it("maps the descriptive header through, grain from the engine's {columns:[…]} dict", () => {
+	it("maps the descriptive header through, grain from the engine's bare array", () => {
 		expect(projectTableEntity(entityRow())).toEqual({
 			entity_type: "transaction",
 			table_role: "fact",
@@ -243,23 +241,19 @@ describe("projectTableEntity (DAT-476)", () => {
 		).toEqual([]);
 	});
 
-	it("tolerates a bare string[] grain (defensive fallback)", () => {
-		expect(
-			projectTableEntity(entityRow({ grainColumns: ["order_id"] })).grain,
-		).toEqual(["order_id"]);
-	});
-
 	it("degrades a genuinely malformed/absent grain blob to an empty grain rather than throwing", () => {
 		expect(projectTableEntity(entityRow({ grainColumns: null })).grain).toEqual(
 			[],
 		);
-		// Neither the dict-with-`columns` nor the bare-array shape.
 		expect(
 			projectTableEntity(entityRow({ grainColumns: { not: "an array" } }))
 				.grain,
 		).toEqual([]);
+		// DAT-775: the retired `{"columns": [...]}` wrapper is no longer a
+		// recognized shape — it degrades to [] like any other malformed blob,
+		// it is NOT unwrapped.
 		expect(
-			projectTableEntity(entityRow({ grainColumns: { columns: "nope" } }))
+			projectTableEntity(entityRow({ grainColumns: { columns: ["order_id"] } }))
 				.grain,
 		).toEqual([]);
 	});
@@ -269,7 +263,7 @@ describe("projectTableEntity (DAT-476)", () => {
 		// renders them as-is and the result stays digest-free.
 		const out = projectTableEntity(
 			entityRow({
-				grainColumns: { columns: [`order_id`, "line_no"] },
+				grainColumns: [`order_id`, "line_no"],
 				timeColumns: [
 					{ column: `order_date`, aspect: "order", note: "Placed." },
 				],

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -295,10 +295,11 @@ export function projectTableBand(row: TableBandRow): TableReadiness {
 }
 
 /** One `current_table_entities` row, as Drizzle returns it. grainColumns is the
- * persisted grain — the engine writes the DICT shape `{"columns": [...]}`
- * (`semantic/processor.py`), so the parser below accepts that (and tolerates a
- * bare `string[]` for safety). `tableRole` is the engine's single role string
- * (DAT-728), surfaced verbatim on the tool output. */
+ * persisted grain — the engine writes a BARE `string[]` of column names
+ * (`semantic/processor.py`; DAT-775 — a prior `{"columns": [...]}` wrapper was
+ * an unenforced convention that corrupted a different engine reader's prompt).
+ * `tableRole` is the engine's single role string (DAT-728), surfaced verbatim
+ * on the tool output. */
 export interface TableEntityRow {
 	detectedEntityType: string | null;
 	tableRole: string | null;
@@ -322,20 +323,16 @@ const IdentityColumns = z.array(
 	z.object({ column: z.string(), note: z.string() }),
 );
 
-// The persisted grain shape. The engine ALWAYS writes the dict form
-// `{"columns": [...]}` (`analysis/semantic/processor.py:343`; the engine's own
-// reader `graphs/context.py` accepts both), so the dict is the real shape; the
-// bare array is tolerated as a fallback. Anything else degrades to [].
-const GrainColumns = z.union([
-	z.object({ columns: z.array(z.string()) }).transform((g) => g.columns),
-	z.array(z.string()),
-]);
+// The persisted grain shape (DAT-775): the engine writes a bare JSON array of
+// column names (`analysis/semantic/processor.py`; `db_models.py`
+// `TableEntity.grain_columns`). Anything else (null, malformed) degrades to [].
+const GrainColumns = z.array(z.string());
 
 /**
  * Project the table-entity header row to the tool shape (DAT-476). Pure (no DB).
- * `grain_columns` is the engine's persisted dict `{"columns": [...]}` (bare
- * array tolerated); a genuinely malformed/absent blob degrades to an empty grain
- * rather than throwing. The remaining fields map straight through (the view is
+ * `grain_columns` is the engine's persisted bare array of column names; a
+ * genuinely malformed/absent blob degrades to an empty grain rather than
+ * throwing. The remaining fields map straight through (the view is
  * head-resolved, so a present row IS the promoted detect run), but the engine
  * free-text fields (description / business name surrogate) can carry raw
  * `src_<digest>__` prefixes, so they're digest-stripped before reaching the

--- a/packages/engine/src/dataraum/analysis/cycles/context.py
+++ b/packages/engine/src/dataraum/analysis/cycles/context.py
@@ -182,6 +182,8 @@ def build_cycle_detection_context(
             "entity_type": ent.detected_entity_type,
             "description": ent.description,
             "table_role": ent.table_role,
+            # A bare list of column names (DAT-775) — ``format_context_for_prompt``
+            # below joins this directly into the prompt's "grain: ..." text.
             "grain_columns": ent.grain_columns,
         }
         for ent, table_name in entities

--- a/packages/engine/src/dataraum/analysis/semantic/db_models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/db_models.py
@@ -393,10 +393,13 @@ class TableEntity(Base):
     )  # 'customer', 'order', 'product', etc.
     description: Mapped[str | None] = mapped_column(Text)
 
-    # Grain analysis
-    grain_columns: Mapped[dict[str, Any] | None] = mapped_column(
-        JSON
-    )  # List of column IDs that define grain
+    # Grain analysis. A bare JSON list of column NAMES that uniquely identify
+    # each row (DAT-775) — NOT a ``{"columns": [...]}`` wrapper. The wrapper
+    # shape was an unenforced convention: one reader (``cycles/context.py``)
+    # joined the persisted value directly, so a wrapped dict rendered its sole
+    # key ("columns") as the grain in the cycle-detection prompt instead of the
+    # real columns. Nullable: an unclassified stub has no grain.
+    grain_columns: Mapped[list[str] | None] = mapped_column(JSON)
     # The table's operating-model role (DAT-728): fact | periodic_snapshot |
     # dimension (see :class:`TableRole`). Replaces the two booleans; the
     # PeriodicSnapshot subtype is derived from grain∩time at classification and

--- a/packages/engine/src/dataraum/analysis/semantic/processor.py
+++ b/packages/engine/src/dataraum/analysis/semantic/processor.py
@@ -745,7 +745,7 @@ def synthesize_and_store_tables(
                 table_id=table_id,
                 detected_entity_type=entity.entity_type,
                 description=entity.description,
-                grain_columns={"columns": entity.grain_columns},
+                grain_columns=entity.grain_columns,
                 table_role=entity.table_role,
                 time_columns=[tc.model_dump() for tc in entity.time_columns],
                 identity_columns=[ic.model_dump() for ic in entity.identity_columns],

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -1057,15 +1057,13 @@ def build_execution_context(
         # Get table entropy data
         tbl_entropy = table_entropy_lookup.get(table.table_name)
 
-        # Extract grain_columns: stored as JSON (may be list of column IDs or names)
-        grain_cols: list[str] = []
-        if table_entity and table_entity.grain_columns:
-            raw_grain = table_entity.grain_columns
-            if isinstance(raw_grain, list):
-                grain_cols = list(raw_grain)
-            elif isinstance(raw_grain, dict):
-                # Some formats store as {"columns": [...]}
-                grain_cols = list(raw_grain.get("columns", []))
+        # grain_columns is persisted as a bare JSON list of column names
+        # (analysis/semantic/db_models.py TableEntity.grain_columns; DAT-775 —
+        # a prior ``{"columns": [...]}`` wrapper was an unenforced convention
+        # that corrupted a different reader's prompt).
+        grain_cols: list[str] = (
+            list(table_entity.grain_columns) if table_entity and table_entity.grain_columns else []
+        )
 
         table_contexts.append(
             TableContext(

--- a/packages/engine/tests/integration/graphs/test_additivity_resolver.py
+++ b/packages/engine/tests/integration/graphs/test_additivity_resolver.py
@@ -94,7 +94,7 @@ def _seed(
             run_id=RUN,
             detected_entity_type="event",
             table_role=derive_table_role(True, grain_columns, time_columns),
-            grain_columns={"columns": grain_columns},
+            grain_columns=grain_columns,
             time_columns=[{"column": c, "aspect": "t", "note": ""} for c in time_columns],
         )
     )

--- a/packages/engine/tests/unit/analysis/cycles/test_context.py
+++ b/packages/engine/tests/unit/analysis/cycles/test_context.py
@@ -18,7 +18,10 @@ import duckdb
 import pytest
 
 from dataraum.analysis.correlation.db_models import DerivedColumn
-from dataraum.analysis.cycles.context import build_cycle_detection_context
+from dataraum.analysis.cycles.context import (
+    build_cycle_detection_context,
+    format_context_for_prompt,
+)
 from dataraum.analysis.relationships.db_models import Relationship
 from dataraum.analysis.semantic.db_models import TableEntity
 from dataraum.analysis.slicing.db_models import SliceDefinition
@@ -79,9 +82,9 @@ def two_tables_two_runs(session):
     session.add_all([txn_account_col, acct_id_col])
     session.flush()
 
-    for run_id, conf, is_fact, desc in (
-        ("run-current", 0.95, True, "CURRENT classification"),
-        ("run-stale", 0.10, False, "STALE classification"),
+    for run_id, conf, is_fact, desc, grain in (
+        ("run-current", 0.95, True, "CURRENT classification", ["account_id", "period"]),
+        ("run-stale", 0.10, False, "STALE classification", ["stale_id"]),
     ):
         session.add(
             Relationship(
@@ -104,6 +107,7 @@ def two_tables_two_runs(session):
                 detected_entity_type="fact" if is_fact else "dimension",
                 description=desc,
                 table_role="fact" if is_fact else "dimension",
+                grain_columns=grain,
             )
         )
     session.commit()
@@ -153,6 +157,33 @@ def test_scopes_to_pinned_run(session, two_tables_two_runs) -> None:
     assert len(entities) == 1
     assert entities[0]["table_role"] == "fact"
     assert entities[0]["description"] == "CURRENT classification"
+    # DAT-775: a bare list of column names, never a {"columns": [...]} wrapper —
+    # format_context_for_prompt joins this straight into the LLM prompt.
+    assert entities[0]["grain_columns"] == ["account_id", "period"]
+
+
+def test_format_context_for_prompt_renders_grain_column_names() -> None:
+    """DAT-775 regression: the cycle-detection prompt renders the table's ACTUAL
+    grain columns, never the literal string "columns" — the symptom of the fixed
+    bug, where a persisted ``{"columns": [...]}`` wrapper had its sole dict key
+    joined into the prompt instead of the real grain."""
+    context = {
+        "tables": [{"table_name": "accounts", "row_count": 50, "columns": []}],
+        "entity_classifications": [
+            {
+                "table_name": "accounts",
+                "entity_type": "account",
+                "description": "Chart of accounts.",
+                "table_role": "dimension",
+                "grain_columns": ["account_id", "period"],
+            }
+        ],
+    }
+
+    rendered = format_context_for_prompt(context)
+
+    assert "grain: account_id, period" in rendered
+    assert "grain: columns" not in rendered
 
 
 @pytest.fixture

--- a/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
@@ -330,6 +330,11 @@ class TestSynthesizeAndStoreTables:
         )
         anns = session.execute(select(AnnotationDB)).scalars().all()
         assert len(entities) == 1 and entities[0].table_role == "fact"
+        # DAT-775: grain_columns persists as a BARE list, never a {"columns": [...]}
+        # wrapper — a downstream reader (cycles/context.py) joins it directly into
+        # an LLM prompt, so a wrapped dict would render its key ("columns") instead
+        # of the real grain.
+        assert entities[0].grain_columns == ["order_id"]
         # DAT-565: all event-time axes + identities persisted run-versioned (JSON).
         assert [tc["column"] for tc in entities[0].time_columns] == ["order_date", "ship_date"]
         assert entities[0].time_columns[1]["aspect"] == "ship"


### PR DESCRIPTION
## Task

DAT-775 — https://real-dataraum.atlassian.net/browse/DAT-775 (epic DAT-725, Wave-2 of the DAT-772 substrate hardening)

## Bug

`table_entities.grain_columns` was written as `{"columns": [...]}` (semantic/processor.py) — an unenforced wrapper convention. `graphs/context.py` defensively unwrapped dict AND list, but `cycles/context.py` stored the raw value and did `', '.join(ent['grain_columns'])`; joining a dict iterates its KEYS, so the cycle-detection prompt rendered the literal string `grain: columns` as every table's grain. Live prompt corruption.

## Fix (normalize at the DB boundary, no backfill)

- **Writer** (`semantic/processor.py`): persists `entity.grain_columns` directly — the upstream `EntityDetection.grain_columns` contract is already a strict `list[str]`.
- **Typed contract** (`semantic/db_models.py`): `TableEntity.grain_columns` tightened `Mapped[dict[str, Any] | None]` → `Mapped[list[str] | None]`. JSON column type unchanged — `schema.sql` re-dump verified **zero diff** (no `comment=` per the dump_ddl convention), so no cockpit `db:pull:metadata` re-pull.
- **Engine reader 1** (`graphs/context.py`): defensive dual-shape unwrap deleted; bare list is the only shape.
- **Engine reader 2** (`cycles/context.py`): correct by construction now — clarifying comment only.
- **Cockpit** (`tools/look-table.ts`): `GrainColumns` zod schema simplified from a dict/array union to a bare `z.array(z.string())`; the retired wrapper degrades to `[]` like any malformed blob. `query-context.ts`'s `buildEntitiesBlock` inherits via `projectTableEntity` (no separate edit needed). Drizzle mirror (`db/metadata/schema.ts`) untouched — `json("grain_columns")` is shape-agnostic.
- **Tests**: new regression test asserts the rendered cycle prompt contains the real column names (`grain: account_id, period`) and never `grain: columns`; write-path round-trip pins the persisted bare-list shape; cockpit test proves the old dict shape is rejected, not unwrapped. Fixtures in `test_additivity_resolver.py` adapted.
- **handoff.md**: entry for eval — cycle-detection prompt content changes; re-baseline cycle evals that snapshot prompts/scores.

No migration machinery (repo rule): pre-existing rows in a live dev DB parse-fail to an empty grain until reprocessed via `add_source`.

## Acceptance criteria

- [x] Writer persists a bare list; strict typed contract (no dict-or-list tolerance)
- [x] All consumers adapted (engine graphs/cycles + cockpit look-table/query-context); defensive dual-shape handling deleted
- [x] Repo-wide grep for grain_columns/grainColumns — every reader accounted for
- [x] Regression test: cycle-detection context renders actual column names, never the literal "columns"
- [x] Column comment updated; schema.sql re-dump verified zero diff (no re-dump needed)

## Verification (post-rebase onto 9e2c6f02, which merged DAT-769)

```
engine:  ruff format/check clean · mypy clean (4 touched files) · vulture clean
         pytest tests/unit -n auto → 2035 passed
         test_model_integration.py + test_additivity_resolver.py → 21 passed
cockpit: biome check clean · tsc clean · vitest → 1671 passed (177 files) · build green
schema:  dump_ddl → zero diff vs checked-in schema.sql
```

Reviewers: senior-code-reviewer **approve** (no must-fix; traced every consumer end-to-end) · spec-compliance-reviewer **approve with nits** (all 5 scope points compliant; nit = handoff.md entry, addressed).

## Other lanes in flight

```
#487 feat/dat-727-grounding-reification — PARKED (draft, do not merge)
#486 feat/dat-730-temporal-coverage-calendar — NOT READY (rework pending)
```

No open lane touches grain_columns or these files; #488 (DAT-769) already merged and this branch is rebased over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)