### PR TITLE
DAT-786: remove temporal_behavior_contested from all consumers — the reconciled verdict is authoritative

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,39 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-786 — column_concepts.temporal_behavior_contested removed (verdict is authoritative)
+
+**Branch:** `fix/dat-786-remove-contested-flag`. Lead ruling (DAT-772 Gate 3):
+the reconciled `temporal_behavior` verdict IS the adjudication outcome — a
+parallel "contested" doubt-flag downstream second-guessed a deterministic,
+correct resolution.
+
+### What changed
+
+- **Schema:** `column_concepts.temporal_behavior_contested` (BOOLEAN) is GONE —
+  model column, resolve-pass write, `schema.sql`, and the cockpit Drizzle mirror.
+  Any eval/testdata fixture or assertion reading that column must drop it; test
+  DBs recreate (no migration, per the no-backfill rule).
+- **Resolve pass** (`entropy/resolve.py`): still writes the adjudicated
+  `temporal_behavior`; a witness disagreement now emits a
+  `temporal_behavior_contested` **log line** (column_id, run_id, resolved) —
+  diagnostic only, the resolved value wins unchanged.
+- **Detector unchanged:** the `temporal_behavior` EntropyObject evidence still
+  carries its `contested` key (pooled-conflict observability); only the
+  ColumnConcept persistence + downstream serving were cut.
+- **Cockpit drill flow-gate reversal (DAT-673):** a contested `additive` was
+  treated as stock (time-grain slice withheld); it is now trusted as additive —
+  the drill's axis menu offers the time grain wherever the reconciled verdict
+  says flow.
+
+### What eval should see
+
+- No detector/calibration change: same adjudication, same resolved labels.
+- Downstream shape change only: `column_concepts` has one fewer column; drill
+  axis menus may now offer time-grain on measures the old gate withheld.
+
+---
+
 ## DAT-769 — business_concept retired: meaning-as-context semantic layer
 
 **Branch:** `feat/dat-769-meaning-as-context`. The single categorical

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -103,7 +103,6 @@ export const currentColumnConcepts = metadataSchema
 		runId: varchar("run_id"),
 		meaning: text(),
 		temporalBehavior: varchar("temporal_behavior"),
-		temporalBehaviorContested: boolean("temporal_behavior_contested"),
 		unitSourceColumn: varchar("unit_source_column"),
 		derivedFormulaHypothesis: varchar("derived_formula_hypothesis"),
 		derivedFormulaConfidence: doublePrecision("derived_formula_confidence"),
@@ -113,7 +112,7 @@ export const currentColumnConcepts = metadataSchema
 		confidence: doublePrecision(),
 	})
 	.as(
-		sql`SELECT concept_id, column_id, run_id, meaning, temporal_behavior, temporal_behavior_contested, unit_source_column, derived_formula_hypothesis, derived_formula_confidence, annotation_source, annotated_at, annotated_by, confidence FROM ws_00000000_0000_0000_0000_000000000001.column_concepts r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
+		sql`SELECT concept_id, column_id, run_id, meaning, temporal_behavior, unit_source_column, derived_formula_hypothesis, derived_formula_confidence, annotation_source, annotated_at, annotated_by, confidence FROM ws_00000000_0000_0000_0000_000000000001.column_concepts r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
 	);
 
 export const currentColumnEligibility = metadataSchema

--- a/packages/cockpit/src/tools/drill-axes.test.ts
+++ b/packages/cockpit/src/tools/drill-axes.test.ts
@@ -264,37 +264,36 @@ describe("applyTemporalKinds", () => {
 	});
 });
 
-describe("temporalGate (DAT-673)", () => {
+describe("temporalGate (DAT-673, contested handling reversed by DAT-786)", () => {
 	const behavior = (
-		entries: [string, string | null, boolean][],
+		entries: [string, string | null][],
 	): Map<string, TemporalBehavior> =>
-		new Map(
-			entries.map(([col, b, contested]) => [col, { behavior: b, contested }]),
-		);
+		new Map(entries.map(([col, b]) => [col, { behavior: b }]));
 
-	it("passes a plain additive (uncontested) flow — grain stays", () => {
+	it("passes a plain additive flow — grain stays", () => {
 		const gate = temporalGate(
 			new Set(["credit"]),
-			behavior([["credit", "additive", false]]),
+			behavior([["credit", "additive"]]),
 		);
 		expect(gate).toEqual({ safe: true, offending: [] });
 	});
 
-	it("flags a contested additive column with the 'contested' cause", () => {
+	it("trusts a reconciled additive verdict at face value — no contested gate (DAT-786 reversal of DAT-673)", () => {
+		// DAT-673 used to treat a "contested" additive verdict as stock (fail
+		// closed). DAT-786 removed the contested flag entirely — the stock/flow
+		// resolve pass already adjudicates the LLM claim vs the structural
+		// witness, so the reconciled `additive` verdict is trusted outright.
 		const gate = temporalGate(
 			new Set(["credit"]),
-			behavior([["credit", "additive", true]]),
+			behavior([["credit", "additive"]]),
 		);
-		expect(gate).toEqual({
-			safe: false,
-			offending: [{ column: "credit", cause: "contested" }],
-		});
+		expect(gate).toEqual({ safe: true, offending: [] });
 	});
 
 	it("distinguishes stock (point_in_time) from unclassified (missing)", () => {
 		const gate = temporalGate(
 			new Set(["balance", "mystery"]),
-			behavior([["balance", "point_in_time", false]]),
+			behavior([["balance", "point_in_time"]]),
 		);
 		expect(gate.safe).toBe(false);
 		expect(gate.offending).toEqual([
@@ -304,18 +303,8 @@ describe("temporalGate (DAT-673)", () => {
 	});
 
 	it("reports a present-but-null behavior as unclassified", () => {
-		const gate = temporalGate(new Set(["x"]), behavior([["x", null, false]]));
+		const gate = temporalGate(new Set(["x"]), behavior([["x", null]]));
 		expect(gate.offending).toEqual([{ column: "x", cause: "unclassified" }]);
-	});
-
-	it("contested outranks the behavior value in the reported cause", () => {
-		// A point_in_time that is ALSO contested reports as contested — the
-		// higher-order fact (the detectors disagreed).
-		const gate = temporalGate(
-			new Set(["x"]),
-			behavior([["x", "point_in_time", true]]),
-		);
-		expect(gate.offending).toEqual([{ column: "x", cause: "contested" }]);
 	});
 
 	it("is safe only when EVERY aggregated column is a clean flow", () => {
@@ -323,8 +312,8 @@ describe("temporalGate (DAT-673)", () => {
 			temporalGate(
 				new Set(["credit", "debit"]),
 				behavior([
-					["credit", "additive", false],
-					["debit", "additive", false],
+					["credit", "additive"],
+					["debit", "additive"],
 				]),
 			),
 		).toEqual({ safe: true, offending: [] });
@@ -332,43 +321,37 @@ describe("temporalGate (DAT-673)", () => {
 			temporalGate(
 				new Set(["credit", "debit"]),
 				behavior([
-					["credit", "additive", false],
-					["debit", "additive", true],
+					["credit", "additive"],
+					["debit", "point_in_time"],
 				]),
 			),
 		).toEqual({
 			safe: false,
-			offending: [{ column: "debit", cause: "contested" }],
+			offending: [{ column: "debit", cause: "stock" }],
 		});
 	});
 
 	it("fails closed when the aggregated set is empty (unparseable expr)", () => {
-		expect(
-			temporalGate(new Set(), behavior([["credit", "additive", false]])),
-		).toEqual({
-			safe: false,
-			offending: [],
-		});
+		expect(temporalGate(new Set(), behavior([["credit", "additive"]]))).toEqual(
+			{
+				safe: false,
+				offending: [],
+			},
+		);
 	});
 });
 
 describe("describeTemporalGate (DAT-673)", () => {
-	it("phrases each cause honestly — a balance, a dispute, a gap", () => {
+	it("phrases each cause honestly — a balance, a gap", () => {
 		expect(
 			describeTemporalGate([{ column: "debit_balance", cause: "stock" }]),
 		).toMatch(/debit_balance.*balance.*not a flow/);
-		expect(
-			describeTemporalGate([{ column: "net_position", cause: "contested" }]),
-		).toMatch(/net_position.*contested.*detectors disagreed/);
 		expect(
 			describeTemporalGate([{ column: "mystery", cause: "unclassified" }]),
 		).toMatch(/mystery.*no stock\/flow classification/);
 	});
 
-	it("does NOT call a contested or unclassified column a balance", () => {
-		expect(
-			describeTemporalGate([{ column: "net_position", cause: "contested" }]),
-		).not.toContain("balance");
+	it("does NOT call an unclassified column a balance", () => {
 		expect(
 			describeTemporalGate([{ column: "mystery", cause: "unclassified" }]),
 		).not.toContain("balance");
@@ -489,8 +472,8 @@ const seed = () => {
 	]);
 	// The catalog types behind temporal detection: the VIEW table (vt1) carries
 	// the FK-projected dims; customer__segment is a DATE there. The FACT (fact1)
-	// carries the aggregated measure `amount` — additive AND uncontested (a clean
-	// flow), so the flow gate leaves the temporal grain on.
+	// carries the aggregated measure `amount` — additive (a clean flow), so the
+	// flow gate leaves the temporal grain on.
 	rowsByTable.set(columns, [
 		{ tableId: "vt1", columnName: "customer__region", resolvedType: "VARCHAR" },
 		{ tableId: "vt1", columnName: "customer__segment", resolvedType: "DATE" },
@@ -499,7 +482,6 @@ const seed = () => {
 			columnName: "amount",
 			resolvedType: "DOUBLE",
 			temporalBehavior: "additive",
-			temporalBehaviorContested: false,
 		},
 	]);
 };
@@ -648,7 +630,12 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 		expect(res.temporalGateReason).not.toContain("balance");
 	});
 
-	it("FLOW GATE: a CONTESTED additive measure counts as stock — grain stripped (DAT-673)", async () => {
+	it("FLOW GATE: a reconciled additive measure keeps its grain — no contested second-guessing (DAT-786 reversal of DAT-673)", async () => {
+		// DAT-673 used to fail this closed when the detectors "contested" the
+		// additive verdict. DAT-786 removed that flag: the stock/flow resolve
+		// pass already adjudicated the LLM claim vs the structural witness, so
+		// the reconciled `additive` verdict on `net_position` is now trusted
+		// outright and the time-grain slice is NOT withheld.
 		seed();
 		rowsByTable.set(sqlSnippets, [
 			{
@@ -661,8 +648,6 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 				failureCount: 0,
 			},
 		]);
-		// `net_position` is additive, but the detectors CONTESTED it — we can't
-		// stand behind "summable flow", so the grain must fail closed.
 		rowsByTable.set(columns, [
 			{ tableId: "vt1", columnName: "customer__segment", resolvedType: "DATE" },
 			{
@@ -670,18 +655,13 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 				columnName: "net_position",
 				resolvedType: "DOUBLE",
 				temporalBehavior: "additive",
-				temporalBehaviorContested: true,
 			},
 		]);
 		const res = await resolveDrillAxes({ standardField: "revenue" });
 		const dateAxis = res.axes.find((a) => a.column === "customer__segment");
-		// Still offered as a raw slice, but the grain is gated off.
 		expect(dateAxis).toBeDefined();
-		expect(dateAxis?.temporal).toBeNull();
-		expect(res.temporalGateReason).toContain("net_position");
-		// Accurate cause: a contested verdict is reported as such, NOT as a balance.
-		expect(res.temporalGateReason).toContain("contested");
-		expect(res.temporalGateReason).not.toContain("balance");
+		expect(dateAxis?.temporal).toBe("date");
+		expect(res.temporalGateReason).toBeUndefined();
 	});
 
 	it("FLOW GATE: a stale multi-measure snippet does NOT strip a safe measure's grain (scope leak, DAT-673)", async () => {
@@ -759,7 +739,6 @@ describe("resolveDrillAxes (mocked metadata client)", () => {
 				columnName: "credit",
 				resolvedType: "DOUBLE",
 				temporalBehavior: "additive",
-				temporalBehaviorContested: false,
 			},
 		]);
 		const res = await resolveDrillAxes({ metricKey: "gross_margin" });

--- a/packages/cockpit/src/tools/drill-axes.ts
+++ b/packages/cockpit/src/tools/drill-axes.ts
@@ -234,17 +234,17 @@ async function targetFields(req: DrillAxesRequest): Promise<string[]> {
 }
 
 /** A column's stock/flow adjudication as the flow gate reads it: the
- *  `temporal_behavior` verdict plus whether that verdict is CONTESTED (the
- *  detectors disagreed). A contested or point_in_time input counts as stock. */
+ *  `temporal_behavior` verdict. The reconciled verdict is authoritative on its
+ *  own (DAT-786) — the stock/flow resolve pass already adjudicates the LLM
+ *  claim vs the structural witness, so there is no separate "contested" doubt
+ *  to second-guess it with downstream. */
 export interface TemporalBehavior {
 	behavior: string | null;
-	contested: boolean;
 }
 
 /** Why an aggregated column disqualifies the node's grain: a point-in-time
- *  `stock`, a `contested` verdict (detectors disagreed), or `unclassified`
- *  (no — or a non-flow — stock/flow classification). */
-export type OffendingCause = "stock" | "contested" | "unclassified";
+ *  `stock`, or `unclassified` (no — or a non-flow — stock/flow classification). */
+export type OffendingCause = "stock" | "unclassified";
 
 /** An aggregated column that fails the flow gate, with the reason it fails —
  *  so the caller can phrase an accurate refusal per cause (DAT-673). */
@@ -253,26 +253,24 @@ export interface OffendingColumn {
 	cause: OffendingCause;
 }
 
-/** Why a non-flow column offends (pure). Contested outranks the behavior value:
- *  a disputed verdict is reported as such even if the last-written behavior was
- *  a balance; a plain `point_in_time` is a stock; anything else — null, missing,
- *  or an unrecognized value — is unclassified. */
+/** Why a non-flow column offends (pure): a plain `point_in_time` is a stock;
+ *  anything else — null, missing, or an unrecognized value — is unclassified. */
 function offendingCause(b: TemporalBehavior | undefined): OffendingCause {
-	if (b?.contested) return "contested";
 	if (b?.behavior === "point_in_time") return "stock";
 	return "unclassified";
 }
 
 /**
- * The FLOW GATE (DAT-673): a node's measures may be summed into time buckets
- * only when every base column they aggregate is a summable FLOW —
- * `temporal_behavior = additive` AND NOT `temporal_behavior_contested`. A stock
+ * The FLOW GATE (DAT-673, contested handling reversed by DAT-786): a node's
+ * measures may be summed into time buckets only when every base column they
+ * aggregate is a summable FLOW — `temporal_behavior = additive`. A stock
  * (point-in-time balance) summed per period double-counts — arithmetically
- * consistent, semantically fabricated; a CONTESTED verdict counts as stock too
- * (we can't stand behind "summable flow" when the detectors disagreed).
- * Unclassified (null) fails CLOSED for the same reason. Returns the offending
- * columns WITH their cause so the caller phrases an accurate refusal. Pure →
- * unit-tested; the aggregated-column extraction is the AST read (`sql-ast.ts`).
+ * consistent, semantically fabricated. Unclassified (null) fails CLOSED for
+ * the same reason. The reconciled `additive` verdict is trusted at face value
+ * — the resolve pass already adjudicated it, so there is no separate
+ * contested state to gate on here. Returns the offending columns WITH their
+ * cause so the caller phrases an accurate refusal. Pure → unit-tested; the
+ * aggregated-column extraction is the AST read (`sql-ast.ts`).
  */
 export function temporalGate(
 	aggregatedCols: ReadonlySet<string>,
@@ -285,21 +283,19 @@ export function temporalGate(
 	const offending: OffendingColumn[] = [];
 	for (const column of aggregatedCols) {
 		const b = behaviorByColumn.get(column);
-		// A clean flow — additive AND uncontested — is the ONLY safe shape.
-		if (b !== undefined && b.behavior === "additive" && !b.contested) continue;
+		// A flow — additive — is the ONLY safe shape.
+		if (b !== undefined && b.behavior === "additive") continue;
 		offending.push({ column, cause: offendingCause(b) });
 	}
 	return { safe: offending.length === 0, offending };
 }
 
-/** One offending column's honest phrasing — a contested verdict is NOT a
- *  "balance", and an unclassified column has no classification at all. */
+/** One offending column's honest phrasing — an unclassified column has no
+ *  classification at all. */
 function phraseOffender({ column, cause }: OffendingColumn): string {
 	switch (cause) {
 		case "stock":
 			return `${column} is a balance (point-in-time stock), not a flow`;
-		case "contested":
-			return `${column} has a contested stock/flow verdict (the detectors disagreed)`;
 		case "unclassified":
 			return `${column} has no stock/flow classification`;
 	}
@@ -328,9 +324,9 @@ export interface DrillAxesResult {
 	axes: DrillAxis[];
 	reason?: string;
 	/** Set when the flow gate stripped time grain from the temporal axes — the
-	 *  node aggregates a stock / contested / unclassified measure that can't be
-	 *  summed into periods (DAT-673). The date axis stays as a raw slice. This is
-	 *  a SERVER-SIDE signal only — no client reads it yet; surfacing it in the
+	 *  node aggregates a stock / unclassified measure that can't be summed into
+	 *  periods (DAT-673). The date axis stays as a raw slice. This is a
+	 *  SERVER-SIDE signal only — no client reads it yet; surfacing it in the
 	 *  drill UI (so the missing grain chip reads as a decision, not a gap) is
 	 *  deferred to DAT-715. */
 	temporalGateReason?: string;
@@ -489,11 +485,8 @@ export async function resolveDrillAxes(
 				resolvedType: columns.resolvedType,
 				// The adjudicated stock/flow verdict for the flow gate (DAT-673) —
 				// null when the column has no concept (unclassified → fail closed).
+				// Trusted at face value (DAT-786) — no separate contested flag.
 				temporalBehavior: currentColumnConcepts.temporalBehavior,
-				// …and whether that verdict is CONTESTED: a contested `additive` is
-				// treated as stock (fail closed — the detectors disagreed).
-				temporalBehaviorContested:
-					currentColumnConcepts.temporalBehaviorContested,
 			})
 			.from(columns)
 			.leftJoin(
@@ -540,19 +533,16 @@ export async function resolveDrillAxes(
 		const behaviorByColumn = new Map<string, TemporalBehavior>();
 		for (const r of columnRows) {
 			if (!r.columnName || !r.tableId || !factIdSet.has(r.tableId)) continue;
-			// First-wins per name (rows are ordered); an OFFENDING verdict (stock,
-			// unclassified, or contested) is sticky — never overwritten by a later
-			// flow-safe (additive & uncontested) row for the same name, so a shared
-			// column can only lose grain, never regain it across facts.
+			// First-wins per name (rows are ordered); an OFFENDING verdict (stock or
+			// unclassified) is sticky — never overwritten by a later flow-safe
+			// (additive) row for the same name, so a shared column can only lose
+			// grain, never regain it across facts.
 			const current = behaviorByColumn.get(r.columnName);
 			const currentFlowSafe =
-				current !== undefined &&
-				current.behavior === "additive" &&
-				!current.contested;
+				current !== undefined && current.behavior === "additive";
 			if (current === undefined || currentFlowSafe) {
 				behaviorByColumn.set(r.columnName, {
 					behavior: r.temporalBehavior ?? null,
-					contested: r.temporalBehaviorContested ?? false,
 				});
 			}
 		}

--- a/packages/cockpit/src/tools/query-context.test.ts
+++ b/packages/cockpit/src/tools/query-context.test.ts
@@ -124,11 +124,6 @@ describe("formatSchema", () => {
 		expect(accountLine).toBe('  - "account_type" :: VARCHAR (additive)');
 		// The instruction header explains the markers to the sub-agent.
 		expect(block).toContain("never SUM it across periods");
-		// The contested flag is DELIBERATELY absent (decision 2026-07-07, mirrors
-		// the engine GraphAgent): the adjudication outperforms an LLM
-		// second-guessing stock/flow from metadata — the verdict is settled fact.
-		// Contested surfaces on the human teach lane (why_column), never here.
-		expect(block).not.toContain("contested");
 	});
 
 	it("omits the concept tag for an unmapped column", () => {

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -137,12 +137,9 @@ export interface SchemaColumnRow {
  * plus the resolved stock/flow adjudication (DAT-509): `temporalBehavior` is
  * the pooled-resolved value the resolve layer wrote onto the annotation
  * (`additive` = flow, `point_in_time` = stock — never SUM a stock across
- * periods). The contested flag is DELIBERATELY NOT served to the agent
- * (decision 2026-07-07, mirrors the engine GraphAgent): the adjudication
- * outperforms an LLM reading stock/flow from metadata alone, so the agent
- * gets the resolved verdict as settled fact — a contested tag would invite
- * second-guessing by the weaker judge. The flag's consumer is the human
- * teach lane (why_column renders it). */
+ * periods). This is the reconciled verdict served as settled fact: the resolve
+ * pass already adjudicated the LLM claim vs the data-grounded structural
+ * witness (DAT-786), so there is no separate doubt flag to carry here. */
 export interface SchemaConceptRow {
 	columnId: string;
 	meaning: string | null;
@@ -193,7 +190,7 @@ export function formatSchema(
 				: "";
 			// Mirror the engine's render (graphs/context.py): the resolved
 			// stock/flow behaviour as a parenthesized marker, served as settled
-			// fact (no contested tag — see SchemaConceptRow).
+			// fact (see SchemaConceptRow).
 			const temporalTag = semantic?.temporalBehavior
 				? ` (${semantic.temporalBehavior})`
 				: "";

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -376,7 +376,6 @@ CREATE TABLE column_concepts (
 	run_id VARCHAR NOT NULL, 
 	meaning TEXT, 
 	temporal_behavior VARCHAR, 
-	temporal_behavior_contested BOOLEAN, 
 	unit_source_column VARCHAR, 
 	derived_formula_hypothesis VARCHAR, 
 	derived_formula_confidence FLOAT, 

--- a/packages/engine/src/dataraum/analysis/semantic/db_models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/db_models.py
@@ -13,7 +13,6 @@ from uuid import uuid4
 
 from sqlalchemy import (
     JSON,
-    Boolean,
     DateTime,
     Float,
     ForeignKey,
@@ -331,10 +330,10 @@ class ColumnConcept(Base):
         temporal_behavior: the resolved stock/flow ('additive' / 'point_in_time')
             for this column — data-determined (DAT-657): the resolved-layer pass
             writes the LLM claim reconciled with the data-grounded structural
-            witness.
-        temporal_behavior_contested: set by the resolved-layer pass when the LLM's
-            ``temporal_behavior_claim`` and the data-grounded structural witness
-            pool to a non-trivial conflict.
+            witness. This verdict is authoritative on its own — DAT-786 removed
+            the parallel "contested" doubt flag; a disagreement between the LLM
+            claim and the structural witness is logged at the resolve site, not
+            persisted downstream.
         unit_source_column: the column (possibly ``table.column`` via a confirmed
             FK) that defines this measure's unit.
         derived_formula_hypothesis / _confidence: the arithmetic this column
@@ -356,7 +355,6 @@ class ColumnConcept(Base):
 
     meaning: Mapped[str | None] = mapped_column(Text)
     temporal_behavior: Mapped[str | None] = mapped_column(String)
-    temporal_behavior_contested: Mapped[bool | None] = mapped_column(Boolean)
     unit_source_column: Mapped[str | None] = mapped_column(String)
     derived_formula_hypothesis: Mapped[str | None] = mapped_column(String)
     derived_formula_confidence: Mapped[float | None] = mapped_column(Float)

--- a/packages/engine/src/dataraum/entropy/resolve.py
+++ b/packages/engine/src/dataraum/entropy/resolve.py
@@ -8,9 +8,9 @@ generated SQL. This runs inside the terminal ``detect`` transaction (same
 already wrote for this run; ``current_semantic_annotations`` then surfaces it.
 
 Two measurements resolve today: ``null_semantics`` → ``null_tokens`` and
-``temporal_behavior`` → ``temporal_behavior`` + ``temporal_behavior_contested``.
-Each is a no-op when a run wrote no objects of its detector (e.g. begin_session),
-so both can live unconditionally in the generic terminal detect step.
+``temporal_behavior`` → ``temporal_behavior``. Each is a no-op when a run wrote
+no objects of its detector (e.g. begin_session), so both can live unconditionally
+in the generic terminal detect step.
 """
 
 from __future__ import annotations
@@ -19,11 +19,14 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import CursorResult, select, update
 
+from dataraum.core.logging import get_logger
 from dataraum.entropy.db_models import EntropyObjectRecord
 from dataraum.entropy.measurements.null_semantics import resolved_null_tokens
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+logger = get_logger(__name__)
 
 
 def resolve_null_tokens(session: Session, run_id: str | None) -> int:
@@ -73,20 +76,19 @@ def resolve_temporal_behavior(session: Session, run_id: str | None) -> int:
     DAT-445) and, for each column whose adjudication resolved to a behaviour, UPDATEs
     the matching ``(column_id, run_id)`` annotation: ``temporal_behavior`` becomes the
     pooled-resolved value (the LLM stock/flow claim reconciled with the data-grounded
-    structural witness — the ontology prior was dropped, DAT-657) and
-    ``temporal_behavior_contested`` records whether the witnesses disagreed.
-    The contested flag is DELIBERATELY NOT rendered to the SQL-authoring agents
-    (decision 2026-07-07): the adjudication outperforms an LLM reading stock/flow
-    from metadata alone, so the agents get the resolved verdict as settled fact —
-    a "(contested)" tag would invite second-guessing by the weaker judge. The
-    flag's consumers are the teach/readiness lane. Columns that resolved to total
-    ignorance (no witness) are left untouched, preserving any prior value. Idempotent
-    on retry (same run_id → same UPDATE). Returns the number of annotations updated.
+    structural witness — the ontology prior was dropped, DAT-657). This verdict is
+    authoritative on its own — DAT-786 removed the parallel ``temporal_behavior_contested``
+    column: propagating a doubt-flag downstream second-guessed a resolution that is
+    already deterministic and correct. A disagreement between the LLM claim and the
+    structural witness is logged here for observability, not persisted. Columns that
+    resolved to total ignorance (no witness) are left untouched, preserving any prior
+    value. Idempotent on retry (same run_id → same UPDATE). Returns the number of
+    annotations updated.
     """
-    # temporal_behavior + contested are catalogue-grain (DAT-637): on ColumnConcept,
-    # authored by the table agent and resolved here at session_detect (the run that
-    # holds ColumnConcept). At add_source detect no ColumnConcept exists under the
-    # run, so the UPDATE matches nothing — a harmless no-op, the correct grain.
+    # temporal_behavior is catalogue-grain (DAT-637): on ColumnConcept, authored by
+    # the table agent and resolved here at session_detect (the run that holds
+    # ColumnConcept). At add_source detect no ColumnConcept exists under the run, so
+    # the UPDATE matches nothing — a harmless no-op, the correct grain.
     from dataraum.analysis.semantic.db_models import ColumnConcept
 
     records = session.execute(
@@ -107,16 +109,22 @@ def resolve_temporal_behavior(session: Session, run_id: str | None) -> int:
         resolved = first.get("resolved")
         if resolved is None:
             continue  # total ignorance — leave any prior value in place
+        if first.get("contested"):
+            # Diagnostic only (DAT-786) — the resolved value below still wins.
+            # debug, not info: per-item log inside a loop (entropy/ convention).
+            logger.debug(
+                "temporal_behavior_contested",
+                column_id=record.column_id,
+                run_id=run_id,
+                resolved=resolved,
+            )
         result: CursorResult[Any] = session.execute(  # type: ignore[assignment]
             update(ColumnConcept)
             .where(
                 ColumnConcept.column_id == record.column_id,
                 ColumnConcept.run_id == run_id,
             )
-            .values(
-                temporal_behavior=resolved,
-                temporal_behavior_contested=bool(first.get("contested", False)),
-            )
+            .values(temporal_behavior=resolved)
         )
         updated += int(result.rowcount or 0)  # see resolve_null_tokens — no-ops stay visible
     return updated

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -1016,8 +1016,8 @@ def build_execution_context(
                     meaning=concept.meaning if concept else None,
                     # The RESOLVED stock/flow verdict (entropy/resolve.py re-bases
                     # the ColumnConcept row at session_detect). Served as settled
-                    # fact — temporal_behavior_contested is deliberately NOT
-                    # rendered here (see resolve_temporal_behavior's docstring).
+                    # fact — authoritative on its own (DAT-786 dropped the
+                    # parallel contested flag; see resolve_temporal_behavior).
                     temporal_behavior=concept.temporal_behavior if concept else None,
                     business_name=sem_ann.business_name if sem_ann else None,
                     business_description=sem_ann.business_description if sem_ann else None,

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -515,7 +515,8 @@ def run_detectors(
         # Resolved layer (ADR-0009 / DAT-457): collapse this run's adjudications
         # onto the semantic rows semantic_per_column already wrote — null_semantics
         # → SemanticAnnotation.null_tokens, temporal_behavior → the adjudicated
-        # stock/flow + contested flag (DAT-445). No-op when no adjudication ran.
+        # stock/flow verdict (DAT-445; the parallel contested flag was dropped
+        # DAT-786). No-op when no adjudication ran.
         resolved = resolve_null_tokens(session, run_id)
         resolved_tb = resolve_temporal_behavior(session, run_id)
         readiness_rows = persist_readiness(session, table_ids, run_id=run_id)

--- a/packages/engine/tests/unit/entropy/test_resolve_temporal_behavior.py
+++ b/packages/engine/tests/unit/entropy/test_resolve_temporal_behavior.py
@@ -1,11 +1,13 @@
-"""Resolved layer for temporal_behavior — ADR-0009 / DAT-445 / DAT-657.
+"""Resolved layer for temporal_behavior — ADR-0009 / DAT-445 / DAT-657 / DAT-786.
 
 ``resolve_temporal_behavior`` collapses each column's stock/flow adjudication onto
 its ``ColumnConcept`` row: ``temporal_behavior`` becomes the pooled-resolved value
 (the LLM claim reconciled with the data-grounded structural witness — the ontology
-prior was dropped, DAT-657) and ``temporal_behavior_contested`` records the
-disagreement. Total ignorance (no witness) leaves any prior value untouched.
-In-memory SQLite, FKs off so we skip parent rows — same pattern as the loader tests.
+prior was dropped, DAT-657). This verdict is authoritative on its own — DAT-786
+removed the parallel ``temporal_behavior_contested`` column; a disagreement between
+the witnesses is only logged, never persisted. Total ignorance (no witness) leaves
+any prior value untouched. In-memory SQLite, FKs off so we skip parent rows — same
+pattern as the loader tests.
 """
 
 from __future__ import annotations
@@ -104,8 +106,9 @@ def _read(session: Session, column_id: str, run_id: str = _RUN) -> ColumnConcept
     ).scalar_one()
 
 
-def test_conflict_overwrites_behaviour_and_flags_contested(real_session: Session) -> None:
-    """concept said stock, the pool resolved to flow under contest → write both."""
+def test_conflict_overwrites_behaviour_trusted_despite_contest(real_session: Session) -> None:
+    """concept said stock, the pool resolved to flow under contest → the resolved value
+    wins outright (DAT-786): the contest is a diagnostic log line, never persisted."""
     _seed_annotation(real_session, "col-a", behaviour="point_in_time")
     _seed_object(real_session, "col-a", resolved="additive", contested=True)
 
@@ -114,7 +117,6 @@ def test_conflict_overwrites_behaviour_and_flags_contested(real_session: Session
     assert updated == 1
     row = _read(real_session, "col-a")
     assert row.temporal_behavior == "additive"  # the adjudicated value replaced the prior
-    assert row.temporal_behavior_contested is True
 
 
 def test_uncontested_agreement_writes_behaviour_quietly(real_session: Session) -> None:
@@ -124,7 +126,6 @@ def test_uncontested_agreement_writes_behaviour_quietly(real_session: Session) -
     assert resolve_temporal_behavior(real_session, _RUN) == 1
     row = _read(real_session, "col-b")
     assert row.temporal_behavior == "point_in_time"
-    assert row.temporal_behavior_contested is False
 
 
 def test_total_ignorance_leaves_prior_value_untouched(real_session: Session) -> None:
@@ -135,7 +136,6 @@ def test_total_ignorance_leaves_prior_value_untouched(real_session: Session) -> 
     assert resolve_temporal_behavior(real_session, _RUN) == 0
     row = _read(real_session, "col-c")
     assert row.temporal_behavior == "point_in_time"  # unchanged
-    assert row.temporal_behavior_contested is None  # never written
 
 
 def test_only_this_runs_objects_resolve(real_session: Session) -> None:


### PR DESCRIPTION
## Task

[DAT-786](https://real-dataraum.atlassian.net/browse/DAT-786) — Wave 2 of the DAT-772 substrate hardening (epic DAT-725).

Lead ruling (DAT-772 Gate 3): *"remove it from both, it is noise. The contestant always wins (which is correct)."* The stock/flow resolve pass already adjudicates the semantic LLM claim against the data-grounded structural witness; the persisted `temporal_behavior` verdict IS the outcome. Propagating a "contested" doubt-flag downstream second-guessed a deterministic, correct resolution.

## ⚠️ DELIBERATE REVERSAL OF DAT-673's FAIL-CLOSED CONTESTED HANDLING

DAT-673's drill flow gate treated a contested `additive` verdict as a stock: the time-grain slice was **withheld** ("we can't stand behind summable-flow when the detectors disagreed"). After this cut, a reconciled `additive` is **trusted as additive outright** — the time-grain slice is offered. This is the decided design, not a regression: the resolve pass's adjudication is authoritative, and a downstream doubt-flag only invited second-guessing of a resolution that is deterministic and correct. The DAT-673 tests were adapted to pin the reversal (the old "contested additive → grain stripped" case is now a positive "reconciled additive keeps its grain" assertion, with the reversal documented in the test name and comments). All other DAT-673 behavior is unchanged: stock (`point_in_time`) and unclassified (null) still fail closed, and the unparseable/windowed-expr cases still fail the whole gate closed.

## What changed

**Cockpit**
- `src/tools/drill-axes.ts` — flow gate: `TemporalBehavior.contested`, the `"contested"` `OffendingCause`, the `!b.contested` check, and the `temporalBehaviorContested` column read are gone; the cross-fact "sticky offending" fold simplified accordingly. Tests adapted (see reversal above).
- `src/tools/query-context.ts` — the flag was never served to the answer agent; deleted the stale withholding comment/plumbing rather than ever serving it.
- `src/db/metadata/schema.ts` — regenerated (`bun run db:pull:metadata`).

**Engine**
- After the cockpit cuts, `column_concepts.temporal_behavior_contested` was write-only (repo-wide grep, both packages) → removed per the write-only rule: model column (`analysis/semantic/db_models.py`) + the resolve-pass write (`entropy/resolve.py`). No Pydantic contract carried it.
- The witness disagreement is now a `temporal_behavior_contested` **debug log line** at the resolve site (column_id, run_id, resolved) — diagnostic only, the resolved value wins unchanged. The detector's per-run EntropyObject evidence keeps its `contested` key (that's what the log line reads).
- `schema.sql` re-dumped (`uv run python -m dataraum.storage.dump_ddl`); `schema_read.sql`/`schema_graph.sql` unchanged (SELECT-* views). No migration — test DBs recreate.
- `.claude/handoff.md` entry added for dataraum-eval/testdata (schema shape change + drill behavior reversal).

## Verification

```
engine:  ruff format/check clean · mypy clean (touched files) · vulture clean
         tests/unit: 2034 passed (-n auto)
         integration (temporal_behavior/column_concepts consumers): 25 passed
cockpit: biome check clean · tsc clean · vitest: 1671 passed (177 files) · bun run build green
```

All gates re-run AFTER rebasing onto origin/main (9e2c6f02, which landed DAT-769's `business_concept` → `meaning` rename on the same model — generated files re-dumped on the new base, never hand-merged). No prebuilt drill-smoke test DB exists in the repo; behavioral verification beyond the adapted unit/integration tests would need a live finance-corpus run (real LLM) and was deliberately not run.

Reviewers: senior-code-reviewer + spec-compliance-reviewer both approved (no blocking findings; their two should-fix items — handoff.md entry, log level demoted to debug per the entropy/ in-loop convention — are applied).

## Other lanes in flight

- #486 (DAT-730, temporal coverage & calendar graph elements) — touches `analysis/semantic/db_models.py` too, but a disjoint model (`Concept.dimension_order`); no conflict with this diff.
- #487 (DAT-727, grounding reification) — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)