### PR TITLE
fix(relationships): DAT-794 — Layer A deterministic; sampling deleted below 1M distinct

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,52 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-794 — Layer-A relationship detection is now deterministic
+
+**Branch:** `fix/dat-794-layer-a-determinism`. Both unseeded sampling sites in
+Layer-A candidate detection are gone — repeated pipeline runs over the same
+data now produce identical relationship candidates and identical LLM evidence.
+
+### What changed
+
+- `joins.py`: the reservoir-sampled middle band (10K–1M distinct) is DELETED —
+  exact Jaccard/containment below 1M distinct, MinHash (deterministic,
+  hash-based) above. The probe showed the sampled band was slower than exact
+  at every scale it covered (59ms vs 17ms at 1M distinct) and dropped subset
+  FKs (true Jaccard below min_score, rescued only by containment≥0.95) in
+  ~30% of runs — on the calibration corpus that was
+  `invoices.entry_id → journal_entries.entry_id` at 35/50 detection.
+- Containment is now FRACTIONAL, exact, ≥0.95 to rescue (uniform across all
+  sizes; still gated at >10 distinct). Previously the exact path required
+  100% containment — a dirty subset FK (a few orphans, e.g. an orphan
+  injection) whose Jaccard sits below the gate would have been dropped
+  deterministically; now it yields a candidate scored at its true containment
+  (e.g. 0.98) so the RI evaluator can quantify the orphans. Expect candidates
+  for dirty FKs that previously vanished, with honest fractional scores
+  instead of a snapped 1.0.
+- `finder.py` `_uniqueness_ratio`: the 10% Bernoulli row sample is DELETED —
+  exact `COUNT(DISTINCT)/COUNT(*)`. The sampled ratio was a *biased* estimator
+  (sample-distinct/sample-rows), overstating uniqueness of FK-like columns at
+  any rate (measured 0.93–0.95 for a true 0.47); the value feeds the semantic
+  LLM prompt as `[uniq: L= R=]` key-vs-measure evidence, so it was both
+  nondeterministic prompt churn AND misinformation.
+- `sample_percent` is gone end-to-end: `detect_relationships` /
+  `find_relationships` signatures, `relationships_phase`, and
+  `phases/relationships.yaml` (key deleted).
+
+### What eval should expect
+
+- Layer-A candidates stable across runs — candidate-set diffs between reps of
+  the same strategy now indicate a real bug, not sampling noise.
+- Uniqueness ratios in candidates/prompts are exact; expect shifted values
+  (e.g. journal_lines.entry_id 0.47, not ~0.94).
+- Two clean-corpus FKs remain undetectable at Layer A by design
+  (`bank_transactions.account_id` and `balance_sheet.account_id` → chart, 2
+  and 7 distinct values): statistically invisible to any overlap measure —
+  LLM-lane territory (DAT-762), documented on DAT-794.
+
+---
+
 ## DAT-769 — business_concept retired: meaning-as-context semantic layer
 
 **Branch:** `feat/dat-769-meaning-as-context`. The single categorical

--- a/docs/concepts/relationships-and-aggregation.md
+++ b/docs/concepts/relationships-and-aggregation.md
@@ -10,9 +10,9 @@ measured uncertainty — the same model as every other
 A join between two tables is established in three steps, each recorded:
 
 1. **Candidates from values.** Column pairs are proposed by value overlap — containment
-   and Jaccard similarity, computed exactly or by sampling on large columns — together
-   with per-column uniqueness, which yields the candidate cardinality (one-to-one,
-   one-to-many, many-to-many).
+   and Jaccard similarity, computed exactly (deterministic MinHash signatures above one
+   million distinct values) — together with per-column uniqueness, which yields the
+   candidate cardinality (one-to-one, one-to-many, many-to-many).
 2. **Evaluation against the data.** Before any semantic step, each candidate is measured:
    referential integrity in both directions, orphan counts, whether the join verifies its
    claimed cardinality, and whether it introduces duplicate rows.

--- a/packages/dataraum-config/phases/relationships.yaml
+++ b/packages/dataraum-config/phases/relationships.yaml
@@ -1,3 +1,2 @@
 # Relationship detection configuration
 min_confidence: 0.5        # Minimum Jaccard/containment score threshold
-sample_percent: 10.0       # Percentage of rows to sample for uniqueness calculation

--- a/packages/engine/src/dataraum/analysis/relationships/detector.py
+++ b/packages/engine/src/dataraum/analysis/relationships/detector.py
@@ -35,7 +35,6 @@ def detect_relationships(
     duckdb_conn: duckdb.DuckDBPyConnection,
     session: Session,
     min_confidence: float = 0.3,
-    sample_percent: float = 10.0,
     evaluate: bool = True,
     run_id: str | None = None,
 ) -> Result[RelationshipDetectionResult]:
@@ -43,13 +42,14 @@ def detect_relationships(
 
     Uses value overlap (Jaccard/containment) to find joinable column pairs.
     Candidates are stored for semantic analysis to confirm/reject.
+    Fully deterministic (DAT-794): no sampling anywhere below 1M distinct
+    values, so repeated runs over the same data produce identical candidates.
 
     Args:
         table_ids: List of table IDs to analyze
         duckdb_conn: DuckDB connection
         session: SQLAlchemy async session
         min_confidence: Minimum join_confidence threshold (default 0.3)
-        sample_percent: Percentage of rows to sample for uniqueness calculation
         evaluate: Whether to evaluate candidates with quality metrics (default True)
 
     Returns:
@@ -79,9 +79,7 @@ def detect_relationships(
             )
 
         # Find relationships via value overlap
-        raw_results = find_relationships(
-            duckdb_conn, tables_data, min_confidence, sample_percent=sample_percent
-        )
+        raw_results = find_relationships(duckdb_conn, tables_data, min_confidence)
 
         # Convert to typed models
         candidates = [

--- a/packages/engine/src/dataraum/analysis/relationships/finder.py
+++ b/packages/engine/src/dataraum/analysis/relationships/finder.py
@@ -21,7 +21,6 @@ def find_relationships(
     conn: duckdb.DuckDBPyConnection,
     tables: dict[str, TableData],  # name -> (duckdb_path, column_names, column_types)
     min_confidence: float = 0.3,
-    sample_percent: float = 10.0,
 ) -> list[dict[str, Any]]:
     """Find relationships between tables via value overlap.
 
@@ -30,7 +29,6 @@ def find_relationships(
         tables: Dict of table_name -> (duckdb_path, column_names, column_types)
             where column_types maps column_name -> resolved_type
         min_confidence: Minimum join_confidence threshold (default 0.3)
-        sample_percent: Row-sample percentage for the uniqueness ratio (default 10%)
 
     Returns:
         List of relationship candidates with join columns
@@ -66,7 +64,7 @@ def find_relationships(
                 same_table=same,
             )
 
-            # Enrich with uniqueness ratios (SQL, sampled)
+            # Enrich with uniqueness ratios (exact SQL)
             enriched_candidates = []
             for jc in join_candidates:
                 col1_name, col2_name = jc["column1"], jc["column2"]
@@ -78,10 +76,10 @@ def find_relationships(
                         "join_confidence": jc["join_confidence"],
                         "cardinality": jc["cardinality"],
                         "left_uniqueness": _uniqueness_ratio(
-                            conn, path1, col1_name, sample_percent, uniqueness_cache
+                            conn, path1, col1_name, uniqueness_cache
                         ),
                         "right_uniqueness": _uniqueness_ratio(
-                            conn, path2, col2_name, sample_percent, uniqueness_cache
+                            conn, path2, col2_name, uniqueness_cache
                         ),
                         "statistical_confidence": jc.get("statistical_confidence", 1.0),
                         "algorithm": jc.get("algorithm", "exact"),
@@ -107,13 +105,17 @@ def _uniqueness_ratio(
     conn: duckdb.DuckDBPyConnection,
     duckdb_path: str,
     column: str,
-    sample_percent: float,
     cache: dict[tuple[str, str], float],
 ) -> float:
-    """Distinct values / total rows for a column, over a Bernoulli row sample.
+    """Distinct values / total rows for a column, computed exactly in SQL.
 
-    Computed in SQL (no DataFrame materialization). ``COUNT(DISTINCT)`` already ignores
-    NULLs, so the ratio is over observed values; an empty sample yields 0.0.
+    Exact by design (DAT-794): a row-sampled ratio is a biased estimator of the
+    wrong quantity — sample-distinct/sample-rows systematically overstates the
+    uniqueness of repeated-value (FK-like) columns at ANY sample rate (measured
+    0.93–0.95 for a true 0.47 at 10%), and the value is served to the semantic
+    LLM as key-vs-measure evidence. A full COUNT(DISTINCT) costs ~26ms at 1M
+    rows. ``COUNT(DISTINCT)`` ignores NULLs, so the ratio is over observed
+    values; an empty table yields 0.0.
     """
     key = (duckdb_path, column)
     if key in cache:
@@ -121,10 +123,10 @@ def _uniqueness_ratio(
     quoted = '"' + column.replace('"', '""') + '"'
     row = conn.execute(
         f"SELECT COUNT(DISTINCT {quoted})::DOUBLE / NULLIF(COUNT(*), 0) "  # noqa: S608 — catalog identifiers
-        f"FROM (SELECT {quoted} FROM {duckdb_path} USING SAMPLE {sample_percent}% (bernoulli))"
+        f"FROM {duckdb_path}"
     ).fetchone()
     # fetchone() on a bare aggregate always returns one row; row[0] is None only when
-    # NULLIF zeroes an empty sample.
+    # NULLIF zeroes an empty table.
     ratio = round(row[0], 4) if row and row[0] is not None else 0.0
     cache[key] = ratio
     return ratio

--- a/packages/engine/src/dataraum/analysis/relationships/joins.py
+++ b/packages/engine/src/dataraum/analysis/relationships/joins.py
@@ -6,13 +6,19 @@ Performance optimizations:
 1. Pre-compute column stats (distinct count, total count) once per column
 2. Filter column pairs by cardinality compatibility before expensive intersection
 3. Adaptive algorithm selection based on cardinality:
-   - Small (<10K distinct): Exact computation
-   - Medium (10K-1M distinct): Sampling with error bounds
-   - Large (>1M distinct): MinHash signatures
+   - Below 1M distinct: Exact computation
+   - At or above 1M distinct: MinHash signatures
 4. Use parallel processing for intersection queries
 
+Both algorithms are fully deterministic. A reservoir-sampled middle band
+(10K–1M distinct) was deleted in DAT-794: it ran on top of a DISTINCT
+subquery (so the expensive materialization was already paid, making it
+SLOWER than exact — 59ms vs 17ms at 1M distinct), and its unseeded sampling
+made candidate detection nondeterministic — a subset FK whose true Jaccard
+sits below min_score survives only through the containment>=0.95 rescue,
+and the sampled containment estimate dropped such pairs in ~30% of runs.
+
 References:
-- Sampling-based Jaccard estimation: arXiv:2507.10019v3
 - MinHash: Broder, A. (1997) "On the resemblance and containment of documents"
 """
 
@@ -30,11 +36,8 @@ logger = get_logger(__name__)
 
 
 # Thresholds for algorithm selection
-SMALL_CARDINALITY_THRESHOLD = 10_000  # Use exact computation
-LARGE_CARDINALITY_THRESHOLD = 1_000_000  # Use MinHash
+LARGE_CARDINALITY_THRESHOLD = 1_000_000  # Exact below, MinHash above
 DEFAULT_NUM_HASHES = 128  # MinHash signature size
-MIN_SAMPLE_SIZE = 1000  # Minimum sample for sampling algorithm
-DEFAULT_SAMPLE_RATE = 0.1  # 10% sample rate
 MIN_CONFIDENCE_THRESHOLD = 0.5  # Minimum statistical confidence to accept
 
 # Type compatibility groups for join detection
@@ -160,7 +163,6 @@ class JoinAlgorithm(Enum):
     """Algorithm used for Jaccard computation."""
 
     EXACT = "exact"
-    SAMPLED = "sampled"
     MINHASH = "minhash"
 
 
@@ -281,15 +283,16 @@ def _determine_cardinality(stats1: ColumnStats, stats2: ColumnStats) -> str:
 
 
 def _select_algorithm(stats1: ColumnStats, stats2: ColumnStats) -> JoinAlgorithm:
-    """Select the best algorithm based on cardinality."""
+    """Select the best algorithm based on cardinality.
+
+    Exact below 1M distinct (faster than sampling at every scale it would
+    cover, and deterministic — DAT-794); MinHash at or above.
+    """
     max_distinct = max(stats1.distinct_count, stats2.distinct_count)
 
-    if max_distinct < SMALL_CARDINALITY_THRESHOLD:
+    if max_distinct < LARGE_CARDINALITY_THRESHOLD:
         return JoinAlgorithm.EXACT
-    elif max_distinct < LARGE_CARDINALITY_THRESHOLD:
-        return JoinAlgorithm.SAMPLED
-    else:
-        return JoinAlgorithm.MINHASH
+    return JoinAlgorithm.MINHASH
 
 
 def _compute_exact_jaccard(
@@ -303,7 +306,7 @@ def _compute_exact_jaccard(
 ) -> JoinScoreResult:
     """Compute exact Jaccard using full distinct values.
 
-    Used for small datasets (<10K distinct values).
+    Used below 1M distinct values (DAT-794).
     Returns confidence=1.0 since this is exact.
     """
     with conn.cursor() as cursor:
@@ -332,13 +335,17 @@ def _compute_exact_jaccard(
             union = count1 + count2 - intersection
             jaccard = intersection / union if union > 0 else 0.0
 
-            # Check containment (full inclusion of one set in another).
-            # Only meaningful when the smaller set has enough distinct values —
-            # low-cardinality columns (e.g., 2-3 values) trivially contain each other.
+            # Containment (near-inclusion of one distinct set in another): a dirty
+            # subset FK (a few orphan values) is still an FK — the candidate must
+            # exist for the referential-integrity evaluator to quantify the orphans —
+            # so rescue at >=0.95 fractional containment, the threshold the deleted
+            # sampled band used, now computed exactly (DAT-794). Only meaningful when
+            # the smaller set has enough distinct values — low-cardinality columns
+            # (e.g., 2-3 values) trivially contain each other. The fractional value
+            # (not a snapped 1.0) is the score: honest evidence for the LLM.
             min_distinct = min(count1, count2)
-            if min_distinct > 10 and (intersection == count1 or intersection == count2):
-                containment = 1.0
-            else:
+            containment = intersection / min_distinct if min_distinct > 10 else 0.0
+            if containment < 0.95:
                 containment = 0.0
             score = max(jaccard, containment)
 
@@ -355,132 +362,6 @@ def _compute_exact_jaccard(
 
         except Exception:
             return JoinScoreResult(col1, col2, 0.0, "unknown", 0.0, JoinAlgorithm.EXACT)
-
-
-def _compute_sampled_jaccard(
-    conn: duckdb.DuckDBPyConnection,
-    table1_path: str,
-    table2_path: str,
-    col1: str,
-    col2: str,
-    stats1: ColumnStats,
-    stats2: ColumnStats,
-    sample_rate: float = DEFAULT_SAMPLE_RATE,
-    min_samples: int = MIN_SAMPLE_SIZE,
-) -> JoinScoreResult:
-    """Compute Jaccard using sampling with statistical error bounds.
-
-    Uses uniform random sampling from distinct values.
-    Based on arXiv:2507.10019v3 - unbiased estimator with O(1/sqrt(x)) error.
-
-    Args:
-        sample_rate: Fraction of distinct values to sample
-        min_samples: Minimum number of samples to take
-
-    Returns:
-        JoinScoreResult with estimated Jaccard and statistical confidence
-    """
-    with conn.cursor() as cursor:
-        try:
-            n1, n2 = stats1.distinct_count, stats2.distinct_count
-
-            # Calculate sample sizes - ensure minimum samples for statistical validity
-            m1 = max(min_samples, int(n1 * sample_rate))
-            m2 = max(min_samples, int(n2 * sample_rate))
-
-            # Cap at actual distinct counts
-            m1 = min(m1, n1)
-            m2 = min(m2, n2)
-
-            # Use RESERVOIR sampling for uniform random sampling
-            # RESERVOIR is the only method that supports fixed row counts and
-            # provides truly uniform random samples (DuckDB docs)
-            # Note: We sample distinct values directly using a subquery
-            # For temporal types, cast to TIMESTAMP for cross-type comparison
-            col1_expr = _get_cast_expression(col1, stats1.resolved_type)
-            col2_expr = _get_cast_expression(col2, stats2.resolved_type)
-
-            result = cursor.execute(f"""
-                WITH
-                sampled1 AS (
-                    SELECT v FROM (
-                        SELECT DISTINCT {col1_expr} AS v
-                        FROM {table1_path}
-                        WHERE "{col1}" IS NOT NULL
-                    ) USING SAMPLE reservoir({m1} ROWS)
-                ),
-                sampled2 AS (
-                    SELECT v FROM (
-                        SELECT DISTINCT {col2_expr} AS v
-                        FROM {table2_path}
-                        WHERE "{col2}" IS NOT NULL
-                    ) USING SAMPLE reservoir({m2} ROWS)
-                ),
-                actual_counts AS (
-                    SELECT
-                        (SELECT COUNT(*) FROM sampled1) AS m1_actual,
-                        (SELECT COUNT(*) FROM sampled2) AS m2_actual,
-                        (SELECT COUNT(*) FROM sampled1 WHERE v IN (SELECT v FROM sampled2)) AS x
-                )
-                SELECT m1_actual, m2_actual, x FROM actual_counts
-            """).fetchone()
-
-            if result is None:
-                return JoinScoreResult(col1, col2, 0.0, "unknown", 0.0, JoinAlgorithm.SAMPLED)
-
-            m1_actual, m2_actual, x = result
-
-            if m1_actual == 0 or m2_actual == 0:
-                return JoinScoreResult(col1, col2, 0.0, "unknown", 0.0, JoinAlgorithm.SAMPLED)
-
-            # Unbiased intersection estimate: I_hat = x * N1 * N2 / (M1 * M2)
-            # From arXiv:2507.10019v3
-            intersection_estimate = x * n1 * n2 / (m1_actual * m2_actual)
-
-            # Jaccard estimate
-            union_estimate = n1 + n2 - intersection_estimate
-            jaccard_estimate = intersection_estimate / union_estimate if union_estimate > 0 else 0.0
-
-            # Check for full containment (one set fully contained in another).
-            # Only meaningful when the smaller set has enough distinct values —
-            # low-cardinality columns trivially contain each other.
-            min_distinct = min(n1, n2)
-            if min_distinct > 10:
-                containment1 = intersection_estimate / n1 if n1 > 0 else 0.0
-                containment2 = intersection_estimate / n2 if n2 > 0 else 0.0
-                containment = 1.0 if (containment1 >= 0.95 or containment2 >= 0.95) else 0.0
-            else:
-                containment = 0.0
-
-            score = max(jaccard_estimate, containment)
-
-            # Clamp to valid range (sampling can produce values slightly outside [0,1])
-            score = max(0.0, min(1.0, score))
-
-            # Calculate statistical confidence
-            # Fractional standard error is O(1/sqrt(x))
-            # Confidence = 1 - SE (rough approximation)
-            if x > 0:
-                fractional_se = 1.0 / math.sqrt(x)
-                confidence = max(0.0, min(1.0, 1.0 - fractional_se))
-            else:
-                # No observed overlap - low confidence
-                confidence = 0.1
-
-            cardinality = _determine_cardinality(stats1, stats2)
-
-            return JoinScoreResult(
-                column1=col1,
-                column2=col2,
-                score=score,
-                cardinality=cardinality,
-                confidence=confidence,
-                algorithm=JoinAlgorithm.SAMPLED,
-            )
-
-        except Exception as e:
-            logger.debug(f"Sampled Jaccard failed for {col1}-{col2}: {e}")
-            return JoinScoreResult(col1, col2, 0.0, "unknown", 0.0, JoinAlgorithm.SAMPLED)
 
 
 def _compute_minhash_jaccard(
@@ -588,18 +469,14 @@ def _compute_join_score_adaptive(
     """Compute join score using adaptive algorithm selection.
 
     Selects the best algorithm based on cardinality:
-    - Small (<10K): Exact computation (confidence=1.0)
-    - Medium (10K-1M): Sampling with error bounds
-    - Large (>1M): MinHash signatures
+    - Below 1M distinct: Exact computation (confidence=1.0)
+    - At or above 1M distinct: MinHash signatures
     """
     algorithm = _select_algorithm(stats1, stats2)
 
     if algorithm == JoinAlgorithm.EXACT:
         return _compute_exact_jaccard(conn, table1_path, table2_path, col1, col2, stats1, stats2)
-    elif algorithm == JoinAlgorithm.SAMPLED:
-        return _compute_sampled_jaccard(conn, table1_path, table2_path, col1, col2, stats1, stats2)
-    else:  # MINHASH
-        return _compute_minhash_jaccard(conn, table1_path, table2_path, col1, col2, stats1, stats2)
+    return _compute_minhash_jaccard(conn, table1_path, table2_path, col1, col2, stats1, stats2)
 
 
 def find_join_columns(
@@ -621,9 +498,8 @@ def find_join_columns(
     1. Pre-compute column statistics (distinct count, total count) once per column
     2. Filter column pairs by type compatibility and cardinality
     3. Compute Jaccard using the best algorithm for each pair's cardinality:
-       - Small (<10K distinct): Exact computation
-       - Medium (10K-1M): Sampling with error bounds
-       - Large (>1M): MinHash signatures
+       - Below 1M distinct: Exact computation
+       - At or above 1M distinct: MinHash signatures
 
     Args:
         conn: DuckDB connection
@@ -651,7 +527,7 @@ def find_join_columns(
         - join_confidence: value overlap score (Jaccard/containment)
         - cardinality: one-to-one, one-to-many, etc.
         - statistical_confidence: confidence in the score (0-1)
-        - algorithm: which algorithm was used (exact, sampled, minhash)
+        - algorithm: which algorithm was used (exact, minhash)
     """
     # Phase 1: Pre-compute column statistics (with type info for filtering)
     stats1 = _precompute_column_stats(conn, table1_path, columns1, column_types1)

--- a/packages/engine/src/dataraum/analysis/relationships/models.py
+++ b/packages/engine/src/dataraum/analysis/relationships/models.py
@@ -21,7 +21,7 @@ class JoinCandidate(BaseModel):
     - cardinality: detected relationship cardinality
     - left/right_uniqueness: distinct/total ratio for each column
     - statistical_confidence: confidence in the Jaccard estimate (0-1)
-    - algorithm: which algorithm was used (exact, sampled, minhash)
+    - algorithm: which algorithm was used (exact, minhash)
 
     Evaluation metrics (populated by evaluator.py):
     - left_referential_integrity: % of FK values with matching PK
@@ -41,11 +41,11 @@ class JoinCandidate(BaseModel):
 
     # Statistical confidence in the Jaccard estimate (0-1)
     # Higher = more certain the score is accurate
-    # 1.0 = exact computation, <1.0 = sampling/minhash estimate
+    # 1.0 = exact computation, <1.0 = minhash estimate
     statistical_confidence: float = 1.0
 
     # Algorithm used for computation
-    algorithm: str = "exact"  # exact, sampled, or minhash
+    algorithm: str = "exact"  # exact or minhash ("sampled" only in pre-DAT-794 persisted evidence)
 
     # Evaluation metrics (populated by evaluator.py)
     left_referential_integrity: float | None = None  # 0-100%

--- a/packages/engine/src/dataraum/pipeline/phases/relationships_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/relationships_phase.py
@@ -99,7 +99,6 @@ class RelationshipsPhase(BasePhase):
         else:
             config = load_phase_config("relationships")
         min_confidence = config["min_confidence"]
-        sample_percent = config["sample_percent"]
 
         # Run relationship detection
         detection_result = detect_relationships(
@@ -107,7 +106,6 @@ class RelationshipsPhase(BasePhase):
             duckdb_conn=ctx.duckdb_conn,
             session=ctx.session,
             min_confidence=min_confidence,
-            sample_percent=sample_percent,
             evaluate=True,
             run_id=ctx.run_id,
         )

--- a/packages/engine/src/dataraum/worker/activity.py
+++ b/packages/engine/src/dataraum/worker/activity.py
@@ -804,8 +804,8 @@ def _build_session_phase_config(phase_name: str, vertical: str | None) -> dict[s
     """Phase static config + the session's frame ``vertical`` (DAT-401).
 
     Source-free analogue of :func:`_build_phase_config`: a begin_session phase
-    needs its pipeline.yaml static config (e.g. relationships' ``min_confidence``
-    / ``sample_percent``) plus the ``vertical`` the LLM table-synthesis reads —
+    needs its pipeline.yaml static config (e.g. relationships' ``min_confidence``)
+    plus the ``vertical`` the LLM table-synthesis reads —
     sourced from the session's frame, defaulting to ``"_adhoc"`` on a cold-start
     session (mirrors add_source's ``identity.vertical or "_adhoc"``).
     """

--- a/packages/engine/tests/unit/analysis/relationships/test_join_determinism.py
+++ b/packages/engine/tests/unit/analysis/relationships/test_join_determinism.py
@@ -1,0 +1,95 @@
+"""DAT-794 regression: Layer-A candidate detection is deterministic.
+
+Before DAT-794, pairs whose max distinct count fell in 10K–1M went through an
+unseeded reservoir-sampling estimator: a subset FK whose true Jaccard sits
+below ``min_score`` (child ⊂ parent, |child| ≪ |parent|) survived only through
+the containment>=0.95 rescue, and the sampled containment estimate dropped it
+in ~30% of runs (measured on the calibration corpus, 50 reps). With the
+sampled band deleted, the same pair must be found by the exact algorithm,
+identically, every run.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import duckdb
+import pytest
+
+from dataraum.analysis.relationships.joins import find_join_columns
+
+PARENT_DISTINCT = 15_000  # above the old 10K exact-computation ceiling
+CHILD_DISTINCT = 4_000  # subset: true Jaccard 4000/15000 ≈ 0.27 < min_score 0.3
+
+
+@pytest.fixture
+def conn() -> Iterator[duckdb.DuckDBPyConnection]:
+    c = duckdb.connect(":memory:")
+    c.execute(f"CREATE TABLE parent AS SELECT range AS pk FROM range({PARENT_DISTINCT})")
+    c.execute(f"CREATE TABLE child AS SELECT range AS fk FROM range({CHILD_DISTINCT})")
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def test_subset_fk_above_10k_detected_via_exact_containment(
+    conn: duckdb.DuckDBPyConnection,
+) -> None:
+    results = [
+        find_join_columns(
+            conn,
+            "child",
+            "parent",
+            ["fk"],
+            ["pk"],
+            column_types1={"fk": "BIGINT"},
+            column_types2={"pk": "BIGINT"},
+        )
+        for _ in range(5)
+    ]
+
+    first = results[0]
+    assert len(first) == 1
+    (candidate,) = first
+    # Containment rescues the below-gate Jaccard (~0.27): child ⊂ parent → 1.0,
+    # computed exactly (confidence 1.0), not estimated from a random sample.
+    assert candidate["join_confidence"] == 1.0
+    assert candidate["algorithm"] == "exact"
+    assert candidate["statistical_confidence"] == 1.0
+    # Deterministic: every repetition returns the identical candidate list.
+    assert all(r == first for r in results[1:])
+
+
+def test_dirty_subset_fk_rescued_at_fractional_containment(
+    conn: duckdb.DuckDBPyConnection,
+) -> None:
+    # A dirty FK: 2% of child values are orphans (absent from parent). True
+    # containment 0.98 >= 0.95 must still produce the candidate — the
+    # referential-integrity evaluator needs it to exist to quantify the
+    # orphans. The old exact path required 100% containment and would drop
+    # this pair deterministically; the old sampled band rescued it only
+    # noisily. Jaccard stays below the gate (3920/(19000-3920) ≈ 0.26).
+    orphans = int(CHILD_DISTINCT * 0.02)
+    conn.execute(
+        f"CREATE TABLE dirty_child AS SELECT range + {PARENT_DISTINCT} AS fk "
+        f"FROM range({orphans}) UNION ALL "
+        f"SELECT range AS fk FROM range({CHILD_DISTINCT - orphans})"
+    )
+
+    candidates = find_join_columns(
+        conn,
+        "dirty_child",
+        "parent",
+        ["fk"],
+        ["pk"],
+        column_types1={"fk": "BIGINT"},
+        column_types2={"pk": "BIGINT"},
+    )
+
+    assert len(candidates) == 1
+    (candidate,) = candidates
+    # Score is the honest fractional containment, not a snapped 1.0.
+    assert candidate["join_confidence"] == pytest.approx(0.98)
+    assert candidate["algorithm"] == "exact"
+    assert candidate["statistical_confidence"] == 1.0

--- a/packages/engine/tests/unit/analysis/relationships/test_joins.py
+++ b/packages/engine/tests/unit/analysis/relationships/test_joins.py
@@ -145,8 +145,10 @@ class TestSelectAlgorithm:
     def test_small_uses_exact(self):
         assert _select_algorithm(self._stats(100), self._stats(500)) == JoinAlgorithm.EXACT
 
-    def test_medium_uses_sampled(self):
-        assert _select_algorithm(self._stats(50_000), self._stats(50_000)) == JoinAlgorithm.SAMPLED
+    def test_medium_uses_exact(self):
+        # The 10K–1M reservoir-sampled band was deleted in DAT-794 (slower than
+        # exact AND nondeterministic); everything below 1M distinct is exact.
+        assert _select_algorithm(self._stats(50_000), self._stats(50_000)) == JoinAlgorithm.EXACT
 
     def test_large_uses_minhash(self):
         assert (

--- a/packages/engine/tests/unit/analysis/relationships/test_uniqueness_ratio.py
+++ b/packages/engine/tests/unit/analysis/relationships/test_uniqueness_ratio.py
@@ -1,9 +1,10 @@
-"""Unit tests for the SQL uniqueness ratio (DAT-580 follow-up: pandas → DuckDB SQL).
+"""Unit tests for the SQL uniqueness ratio.
 
-``_uniqueness_ratio`` replaced ``pd.Series.nunique()/len()`` with an in-SQL
-``COUNT(DISTINCT)/NULLIF(COUNT(*),0)`` over a Bernoulli sample. These pin the three
-result paths (normal, all-null, empty) and the per-(path,column) cache. Uses
-``sample_percent=100`` so the assertions are deterministic (no Bernoulli draw).
+``_uniqueness_ratio`` is an exact in-SQL ``COUNT(DISTINCT)/NULLIF(COUNT(*),0)``
+— the Bernoulli row sample was removed in DAT-794 (a sampled ratio is a biased
+estimator that overstates uniqueness of repeated-value columns at any rate).
+These pin the three result paths (normal, all-null, empty) and the
+per-(path,column) cache.
 """
 
 from __future__ import annotations
@@ -27,33 +28,33 @@ def conn() -> Iterator[duckdb.DuckDBPyConnection]:
 
 def test_all_distinct_column_is_one(conn: duckdb.DuckDBPyConnection) -> None:
     conn.execute("CREATE TABLE t AS SELECT * FROM (VALUES (1), (2), (3), (4)) AS v(id)")
-    assert _uniqueness_ratio(conn, "t", "id", 100.0, {}) == 1.0
+    assert _uniqueness_ratio(conn, "t", "id", {}) == 1.0
 
 
 def test_repeated_values_ratio(conn: duckdb.DuckDBPyConnection) -> None:
     # 2 distinct over 4 rows → 0.5.
     conn.execute("CREATE TABLE t AS SELECT * FROM (VALUES (1), (1), (2), (2)) AS v(id)")
-    assert _uniqueness_ratio(conn, "t", "id", 100.0, {}) == 0.5
+    assert _uniqueness_ratio(conn, "t", "id", {}) == 0.5
 
 
 def test_all_null_column_is_zero(conn: duckdb.DuckDBPyConnection) -> None:
-    # COUNT(DISTINCT) ignores NULLs → 0 distinct over a non-empty sample → 0.0.
+    # COUNT(DISTINCT) ignores NULLs → 0 distinct over a non-empty table → 0.0.
     conn.execute("CREATE TABLE t (id INTEGER)")
     conn.execute("INSERT INTO t VALUES (NULL), (NULL), (NULL)")
-    assert _uniqueness_ratio(conn, "t", "id", 100.0, {}) == 0.0
+    assert _uniqueness_ratio(conn, "t", "id", {}) == 0.0
 
 
 def test_empty_table_is_zero(conn: duckdb.DuckDBPyConnection) -> None:
     # NULLIF(COUNT(*), 0) → NULL → 0.0 (no divide-by-zero).
     conn.execute("CREATE TABLE t (id INTEGER)")
-    assert _uniqueness_ratio(conn, "t", "id", 100.0, {}) == 0.0
+    assert _uniqueness_ratio(conn, "t", "id", {}) == 0.0
 
 
 def test_quotes_identifiers(conn: duckdb.DuckDBPyConnection) -> None:
     # A column name needing quoting (reserved word / mixed case) must not break the SQL.
     conn.execute('CREATE TABLE t ("Select" INTEGER)')
     conn.execute('INSERT INTO t ("Select") VALUES (1), (2)')
-    assert _uniqueness_ratio(conn, "t", "Select", 100.0, {}) == 1.0
+    assert _uniqueness_ratio(conn, "t", "Select", {}) == 1.0
 
 
 def test_cache_hit_skips_requery(conn: duckdb.DuckDBPyConnection) -> None:
@@ -62,9 +63,9 @@ def test_cache_hit_skips_requery(conn: duckdb.DuckDBPyConnection) -> None:
     # proving the second call never re-queried.
     conn.execute("CREATE TABLE t AS SELECT * FROM (VALUES (1), (2)) AS v(id)")
     cache: dict[tuple[str, str], float] = {}
-    assert _uniqueness_ratio(conn, "t", "id", 100.0, cache) == 1.0
+    assert _uniqueness_ratio(conn, "t", "id", cache) == 1.0
 
     conn.execute("DROP TABLE t")
     conn.execute("CREATE TABLE t (id INTEGER)")
     conn.execute("INSERT INTO t VALUES (NULL), (NULL)")
-    assert _uniqueness_ratio(conn, "t", "id", 100.0, cache) == 1.0  # cached, not 0.0
+    assert _uniqueness_ratio(conn, "t", "id", cache) == 1.0  # cached, not 0.0


### PR DESCRIPTION
## Problem (DAT-794)

Layer-A relationship candidate detection was nondeterministic. A 50-rep probe over the calibration corpora (clean + detection-v1, zero LLM spend — full verdict on [DAT-794](https://real-dataraum.atlassian.net/browse/DAT-794)) isolated two unseeded sampling sites and quantified the damage:

1. **Reservoir-sampled Jaccard band (10K–1M distinct)** — `invoices.entry_id → journal_entries.entry_id` (2,860 ⊂ 11,754 distinct) has true Jaccard 0.243, below the score gate; it survived only via the containment≥0.95 rescue, whose sampled estimate flapped: **35/50 detection** at engine defaults, still 49/50 at 5× the sample rate. The band was also **slower than exact** at every scale it covered (59ms vs 17ms at 1M distinct — it sampled on top of an already-materialized DISTINCT subquery).
2. **10% Bernoulli uniqueness ratio** — a biased estimator of the wrong quantity: sample-distinct/sample-rows read **0.93–0.95 for a true 0.47** (`journal_lines.entry_id`), and the value feeds the semantic LLM prompt as key-vs-measure evidence. The bias vanishes at no sample rate below 100%; the exact scan costs ≤26ms at 1M rows.

## Fix

- **Delete the sampled band**: exact Jaccard/containment below `LARGE_CARDINALITY_THRESHOLD` (1M distinct), MinHash (hash-based, deterministic) at or above. `_compute_sampled_jaccard`, `JoinAlgorithm.SAMPLED`, and the sampling constants removed.
- **Exact uniqueness ratio**: `COUNT(DISTINCT)/COUNT(*)`, no sampling; `sample_percent` removed end-to-end (detector, finder, phase, `phases/relationships.yaml`).
- **Containment is now fractional, exact, ≥0.95 to rescue** (review finding): the old exact path required 100% containment, which would have deterministically dropped dirty subset FKs (orphan values) whose Jaccard sits below the gate — the RI evaluator needs those candidates to exist to quantify the orphans. Scores now carry the honest fraction (e.g. 0.98) instead of a snapped 1.0.

## Evidence

- Corpus acceptance: 3/3 identical `find_relationships` runs over the clean corpus, 7/9 true FKs found deterministically — including the previously-flaky invoices pair. The 2 misses (2 and 7 distinct values ⊂ 60) are statistically invisible to any overlap measure — LLM-lane territory (DAT-762), documented in the handoff.
- New regression tests: subset FK above the old 10K ceiling detected via exact containment, identically across repetitions; dirty subset FK (2% orphans) rescued at fractional containment 0.98.
- 112 relationships unit tests green; full testmon sweep 2,286 passed; ruff + mypy clean.
- Reviews: spec-compliance (compliant; stale-prose findings fixed) + senior review (no blockers; containment-semantics finding addressed as above).

Temporal's own `sample_percent` is a different subsystem, deliberately untouched (flagged on DAT-795).

🤖 Generated with [Claude Code](https://claude.com/claude-code)