### PR TITLE
DAT-779/784: harden dimension_hierarchies persist contract

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -156,6 +156,34 @@ swept to `meaning`; vitest unit suite green (1672).
 
 ---
 
+## DAT-779/784 — dimension_hierarchies persist-contract hardening (response shape)
+
+**Branch:** `fix/dat-779-784-hierarchy-contract`. **Persist-shape change only — no
+detector/verdict logic changed, so calibration numbers do NOT move** (`stats.py`
+untouched; the same structures are found with the same g3/verdicts). A reader that
+queries `dimension_hierarchies` columns by name must update:
+
+- **`score` column is RENAMED → `g3`** (kind-invariant: the g3 evidence for
+  drilldown/alias; NULL for `kind='role'` and value_systematic/abstain aliases,
+  which have no functional dependency). Any eval query selecting `.score` on this
+  table breaks — rename to `.g3`.
+- **New column `role_verdict`** (VARCHAR, nullable, `CHECK IN ('abstain','dirt',
+  'role','value_systematic')`): the stack-v4 role-check outcome; NULL on rows with
+  no role check. VALUE_SYSTEMATIC and ABSTAIN aliases are now distinguishable
+  (they used to collapse to one bare `needs_confirmation` alias — DAT-784).
+- **New column `role_evidence`** (JSON, nullable): `{t1_p, t1_context, t2_p,
+  k_disagree, alpha, disagree_rate}` — the role-check evidence (the disagreement
+  rate that was formerly conflated into `score` now lives here).
+- **`members[]` JSON entries gain a `level` int** (0 = coarsest, increasing =
+  finer) and are stored coarse→fine. Drilldown member order is now read by `level`,
+  not array position (DAT-779) — a testdata/eval assertion on drilldown member
+  order should sort by `level`.
+
+No `--reset`/backfill: test DBs recreate (this is a breaking schema change, by
+design). DAT-762 (conform/role judge) will consume `role_verdict` + `role_evidence`.
+
+---
+
 ## DAT-768 — empty column_concepts falls loud (salvaged from PR #483)
 
 **Branch:** `fix/dat-768-empty-concepts-fall-loud`. The `column_concepts` surface

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -205,13 +205,15 @@ export const currentDimensionHierarchies = metadataSchema
 		members: json(),
 		canonicalLabel: varchar("canonical_label"),
 		signature: varchar(),
-		score: doublePrecision(),
+		g3: doublePrecision(),
+		roleVerdict: varchar("role_verdict"),
+		roleEvidence: json("role_evidence"),
 		detectionSource: varchar("detection_source"),
 		needsConfirmation: boolean("needs_confirmation"),
 		createdAt: timestamp("created_at", { withTimezone: true }),
 	})
 	.as(
-		sql`SELECT hierarchy_id, run_id, table_id, kind, members, canonical_label, signature, score, detection_source, needs_confirmation, created_at FROM ws_00000000_0000_0000_0000_000000000001.dimension_hierarchies r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
+		sql`SELECT hierarchy_id, run_id, table_id, kind, members, canonical_label, signature, g3, role_verdict, role_evidence, detection_source, needs_confirmation, created_at FROM ws_00000000_0000_0000_0000_000000000001.dimension_hierarchies r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
 	);
 
 export const currentDriverRankings = metadataSchema

--- a/packages/cockpit/src/tools/query-context.test.ts
+++ b/packages/cockpit/src/tools/query-context.test.ts
@@ -257,21 +257,41 @@ describe("formatCatalog (DAT-538 dimension catalog block)", () => {
 		expect(block).toContain('alias: "region" ≡ "region_code"');
 	});
 
-	it("renders a non-alias hierarchy as an ordered drill-down chain", () => {
+	it("renders a drill-down chain coarse→fine, ordered by member level", () => {
 		const hierarchies: CatalogHierarchyRow[] = [
 			{
 				tableId: "t1",
-				kind: "functional_dependency",
-				canonicalLabel: null,
+				kind: "drilldown",
+				canonicalLabel: "country → region → city",
 				members: [
-					{ column_name: "city" },
-					{ column_name: "region" },
-					{ column_name: "country" },
+					{ column_name: "country", level: 0 },
+					{ column_name: "region", level: 1 },
+					{ column_name: "city", level: 2 },
 				],
 			},
 		];
 		const block = formatCatalog(axes, hierarchies, addr);
-		expect(block).toContain('drill-down: "city" → "region" → "country"');
+		expect(block).toContain('drill-down: "country" → "region" → "city"');
+	});
+
+	it("orders a drill-down by member level, not array position (DAT-779 contract)", () => {
+		// Mirrors the engine's persisted shape (schema.sql seam): `level` (0 =
+		// coarsest) is the authoritative order. Feed a SCRAMBLED array to prove the
+		// reader sorts by level and never trusts array position.
+		const hierarchies: CatalogHierarchyRow[] = [
+			{
+				tableId: "t1",
+				kind: "drilldown",
+				canonicalLabel: "state → city → zip",
+				members: [
+					{ column_name: "zip", level: 2 },
+					{ column_name: "state", level: 0 },
+					{ column_name: "city", level: 1 },
+				],
+			},
+		];
+		const block = formatCatalog(axes, hierarchies, addr);
+		expect(block).toContain('drill-down: "state" → "city" → "zip"');
 	});
 
 	it("notes an empty catalog", () => {

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -340,11 +340,13 @@ export interface CatalogAxisRow {
 }
 
 /** One dimension hierarchy: an `alias` group (1:1 redundant columns) or a
- * drill-down chain. `members` is the engine's JSON array of `{column_name}`. */
+ * drill-down chain. `members` is the engine's JSON array; order is carried by each
+ * member's `level` (the engine's HierarchyMember contract, DAT-779), NOT by array
+ * position — read ascending by level. */
 export interface CatalogHierarchyRow {
 	tableId: string;
 	kind: string;
-	members: Array<{ column_name?: string | null }>;
+	members: Array<{ column_name?: string | null; level?: number | null }>;
 	canonicalLabel: string | null;
 }
 
@@ -359,8 +361,15 @@ function hierarchyLine(h: CatalogHierarchyRow): string | null {
 		if (others.length === 0) return null;
 		return `  alias: "${canonical}" ≡ ${others.map((n) => `"${n}"`).join(", ")} (group by the canonical only)`;
 	}
-	// Drill-down / FD chain — members are ordered coarse→fine by the engine.
-	return `  drill-down: ${names.map((n) => `"${n}"`).join(" → ")}`;
+	// Drill-down / FD chain. Order is `level`, not array position (DAT-779) — sort
+	// ascending by level before joining; fall back to the array index only if a
+	// level is somehow absent.
+	const ordered = h.members
+		.map((m, i) => ({ name: m.column_name, level: m.level ?? i }))
+		.sort((a, b) => a.level - b.level)
+		.map((m) => m.name)
+		.filter((n): n is string => typeof n === "string" && n.length > 0);
+	return `  drill-down: ${ordered.map((n) => `"${n}"`).join(" → ")}`;
 }
 
 /**

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -249,12 +249,15 @@ CREATE TABLE dimension_hierarchies (
 	members JSON NOT NULL, 
 	canonical_label VARCHAR NOT NULL, 
 	signature VARCHAR NOT NULL, 
-	score FLOAT NOT NULL, 
+	g3 FLOAT, 
+	role_verdict VARCHAR, 
+	role_evidence JSON, 
 	detection_source VARCHAR NOT NULL, 
 	needs_confirmation BOOLEAN NOT NULL, 
 	created_at TIMESTAMP WITH TIME ZONE NOT NULL, 
 	CONSTRAINT pk_dimension_hierarchies PRIMARY KEY (hierarchy_id), 
 	CONSTRAINT uq_dimension_hierarchy_signature_run UNIQUE (signature, run_id), 
+	CONSTRAINT ck_dimension_hierarchies_role_verdict CHECK (role_verdict IN ('abstain', 'dirt', 'role', 'value_systematic')), 
 	CONSTRAINT fk_dimension_hierarchies_table_id_tables FOREIGN KEY(table_id) REFERENCES tables (table_id)
 );
 

--- a/packages/engine/src/dataraum/analysis/hierarchies/db_models.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/db_models.py
@@ -1,13 +1,21 @@
-"""SQLAlchemy model for dimension-hierarchy discovery (DAT-537)."""
+"""SQLAlchemy model for dimension-hierarchy discovery (DAT-537).
+
+The JSON interiors carry a two-layer contract (DAT-779/784): a strict Pydantic
+submodel validates the shape at every writer (a ``CheckConstraint`` cannot reach
+into a JSON array/object), and the scalar closed-vocabulary column ``role_verdict``
+additionally gets a DB ``CheckConstraint`` (the DAT-781 two-layer standard).
+"""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
 from uuid import uuid4
 
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import (
     JSON,
     Boolean,
+    CheckConstraint,
     DateTime,
     Float,
     ForeignKey,
@@ -17,7 +25,64 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column
 
+from dataraum.analysis.hierarchies.stats import RoleVerdict
 from dataraum.storage import Base
+
+# The closed vocabulary of ``role_verdict``, derived from the single source of
+# truth — the stack-v4 verdict enum (DAT-784). Sorted for a deterministic CHECK
+# string in the offline DDL dump. DIRT is part of the enum's vocabulary though it
+# is never persisted as its own row (a DIRT pair is merged into its alias group),
+# so the column only ever holds ``role`` / ``value_systematic`` / ``abstain`` or
+# NULL — the CHECK enforces the full enum domain as the forward-safe backstop.
+_ROLE_VERDICT_VALUES: tuple[str, ...] = tuple(sorted(v.value for v in RoleVerdict))
+
+
+class HierarchyMember(BaseModel):
+    """One member column of a dimension-hierarchy structure's ordered ``members``.
+
+    Persisted as one element of the ``dimension_hierarchies.members`` JSON array.
+    **``level`` is the sole carrier of drill-down direction** — array position is
+    incidental and MUST NOT be read by any consumer (DAT-779, the bug this closes):
+
+        level 0 = the COARSEST level; increasing level = FINER.
+
+    So a ``state → city → zip`` drill path stores ``state`` at level 0, ``city`` at
+    1, ``zip`` at 2. For ``alias`` / ``role`` structures the members are a peer set
+    with no coarse/fine axis; ``level`` is then a stable ordinal only
+    (canonical / sorted-first = 0) and carries no drill meaning.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    column_name: str
+    # The catalog SliceDefinition's underlying column (provenance); "" when the
+    # enriched-view column has no catalog row, or a manual teach could not resolve it.
+    column_id: str
+    # Null-aware d2 distinct count (DAT-761 null lane); None on a manual teach
+    # (no measured scan).
+    distinct_count: int | None
+    level: int = Field(ge=0)
+
+
+class RoleEvidence(BaseModel):
+    """The stack-v4 role-check evidence for one near-copy pair (DAT-784).
+
+    Persisted as ``dimension_hierarchies.role_evidence`` JSON on rows whose kind was
+    decided by the role check (``kind='role'``, or a ``kind='alias'`` surfaced from a
+    VALUE_SYSTEMATIC / ABSTAIN verdict). Mirrors ``stats.RoleResult`` plus the
+    disagreement rate (formerly conflated into ``score``) so nothing the verdict
+    object carries is lost — DAT-762's conform/role judge consumes exactly this.
+    NULL on rows with no role check (genuine drilldown / alias group / manual teach).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    t1_p: float  # best (smallest) membership p across contexts
+    t1_context: str | None  # the context column that produced t1_p
+    t2_p: float  # value-concentration p (dis vs B)
+    k_disagree: int  # disagreement count |{A ≠ B}|
+    alpha: float  # the Bonferroni-corrected threshold both tests were held to
+    disagree_rate: float  # fraction of rows where A ≠ B (was overloaded into score)
 
 
 class DimensionHierarchy(Base):
@@ -27,17 +92,20 @@ class DimensionHierarchy(Base):
     per discovered structure. Three kinds share the table via the ``kind``
     discriminator:
 
-    - ``kind='drilldown'``: an ordered drill-down hierarchy. ``members`` lists the
-      levels **finest → coarsest** (each FD-determines the next, e.g. ``zip → city
-      → state``); ``canonical_label`` renders the chain.
+    - ``kind='drilldown'``: an ordered drill-down hierarchy. ``members`` carries the
+      levels ordered by each member's ``level`` (see :class:`HierarchyMember` — the
+      ONE place the direction is defined), e.g. ``state → city → zip``;
+      ``canonical_label`` renders the same order.
     - ``kind='alias'``: a 1:1 redundant-axis group (bidirectional ``g3 ≈ 0``).
       ``members`` lists the equivalent columns; ``canonical_label`` is the chosen
       canonical axis name. A near-copy the role check could not decide surfaces
-      as an alias with ``needs_confirmation=True`` (never silently merged).
+      as an alias with ``needs_confirmation=True`` (never silently merged) —
+      ``role_verdict`` = value_systematic / abstain and ``role_evidence`` carries why.
     - ``kind='role'`` (DAT-761): a role-playing near-copy pair (bill-to ⇄ pay-to)
       whose disagreement set is membership-systematic — the two columns are the
       SAME domain in different roles: kept as separate axes, never merged, never
-      stacked as levels. ``score`` is the value-disagreement rate.
+      stacked as levels. ``role_verdict='role'`` with the full ``role_evidence``
+      (p-values, discriminating context column, disagreement count + rate).
 
     Run-versioned like ``MeasureAggregationLineage`` (DAT-491): form-(a) writer —
     one row per ``(signature, run_id)``, UPSERTed, so a Temporal success-redelivery
@@ -56,6 +124,14 @@ class DimensionHierarchy(Base):
         UniqueConstraint("signature", "run_id", name="uq_dimension_hierarchy_signature_run"),
         Index("idx_dimension_hierarchies_table", "table_id"),
         Index("idx_dimension_hierarchies_run", "run_id"),
+        # Closed-vocabulary enforcement (DAT-784, the DAT-781 two-layer standard):
+        # the producer sets ``role_verdict`` from the ``RoleVerdict`` enum (layer 1);
+        # the CHECK — derived from that same enum so the two can never drift — is the
+        # DB-enforced backstop (layer 2). NULL passes (non-role-check rows).
+        CheckConstraint(
+            "role_verdict IN (" + ", ".join(f"'{v}'" for v in _ROLE_VERDICT_VALUES) + ")",
+            name="role_verdict",
+        ),
     )
 
     hierarchy_id: Mapped[str] = mapped_column(
@@ -69,11 +145,13 @@ class DimensionHierarchy(Base):
 
     kind: Mapped[str] = mapped_column(String, nullable=False)  # 'drilldown' | 'alias' | 'role'
 
-    # Ordered member columns. Each entry: {column_name, column_id, distinct_count}.
-    # drilldown: finest → coarsest (the drill path). alias: the equivalent group,
-    # canonical first. ``column_id`` is the catalog SliceDefinition's underlying
-    # column (provenance); ``column_name`` is the enriched-view column the g3 pass
-    # measured (may be an FK-prefixed dim col) and is the member identity.
+    # Ordered member columns, each validated by :class:`HierarchyMember` at write
+    # (the two-layer standard for a JSON interior — a CHECK cannot reach inside).
+    # Each entry: {column_name, column_id, distinct_count, level}. ORDER IS CARRIED
+    # BY ``level`` (see :class:`HierarchyMember`), NOT by array position (DAT-779).
+    # ``column_id`` is the catalog SliceDefinition's underlying column
+    # (provenance); ``column_name`` is the enriched-view column the g3 pass measured
+    # (may be an FK-prefixed dim col) and is the member identity.
     members: Mapped[list[dict[str, object]]] = mapped_column(JSON, nullable=False)
     canonical_label: Mapped[str] = mapped_column(String, nullable=False)
 
@@ -81,11 +159,22 @@ class DimensionHierarchy(Base):
     # JSON ``members`` column cannot be a conflict target.
     signature: Mapped[str] = mapped_column(String, nullable=False)
 
-    # The g3 evidence: the highest edge g3 in a drilldown chain (the weakest link;
-    # max over edges), or the bidirectional g3 for an alias. Lower = stronger
-    # (0 = every edge is an exact FD). Audit + the support/confidence ordering for
-    # downstream consumers.
-    score: Mapped[float] = mapped_column(Float, nullable=False)
+    # The g3 evidence, kind-INVARIANT (DAT-784): the highest edge g3 in a drilldown
+    # chain (the weakest link; max over edges), or the bidirectional g3 for an alias
+    # group. Lower = stronger (0 = every edge is an exact FD; a manual teach asserts
+    # 0). NULL on a role-check-derived row (kind='role', or a value_systematic /
+    # abstain alias) — those have no g3; their disagreement rate lives in
+    # ``role_evidence.disagree_rate``, never here (that overload was the bug).
+    g3: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # The stack-v4 role-check outcome (DAT-784), from the ``RoleVerdict`` enum:
+    # 'role' | 'value_systematic' | 'abstain'. NULL on rows with no role check
+    # (genuine drilldown / alias group / manual teach). Closed vocab: see the CHECK.
+    role_verdict: Mapped[str | None] = mapped_column(String, nullable=True)
+    # The role-check evidence, validated by :class:`RoleEvidence` at write (the
+    # two-layer JSON standard). NULL whenever ``role_verdict`` is NULL. DAT-762's
+    # conform/role judge consumes this; this task only PERSISTS it.
+    role_evidence: Mapped[dict[str, object] | None] = mapped_column(JSON, nullable=True)
 
     # 'g3' (auto-discovered) | 'manual' (a teach add/alias assertion).
     detection_source: Mapped[str] = mapped_column(String, nullable=False, default="g3")

--- a/packages/engine/src/dataraum/analysis/hierarchies/processor.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/processor.py
@@ -51,7 +51,11 @@ import polars as pl
 from sqlalchemy import select
 
 from dataraum.analysis.hierarchies import stats
-from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
+from dataraum.analysis.hierarchies.db_models import (
+    DimensionHierarchy,
+    HierarchyMember,
+    RoleEvidence,
+)
 from dataraum.analysis.hierarchies.overlay import hierarchy_overlay_specs
 from dataraum.analysis.hierarchies.stats import RoleVerdict
 from dataraum.analysis.semantic.db_models import SemanticAnnotation
@@ -535,6 +539,72 @@ def discover_dimension_hierarchies(
     return len(rows)
 
 
+def _validated_members(members: list[HierarchyMember]) -> list[dict[str, object]]:
+    """Validate the level set and dump the members to their JSON form (DAT-779).
+
+    The write-side assertion of the direction contract: ``level`` is the sole
+    carrier of order (see :class:`HierarchyMember`), so it must be a permutation of
+    ``range(len)`` for a consumer to read a total order. Raises on a gap or a
+    duplicate — a writer that mis-numbers the levels fails loud, never silently.
+    """
+    levels = sorted(m.level for m in members)
+    if levels != list(range(len(members))):
+        raise ValueError(
+            f"hierarchy member levels must be a contiguous 0..{len(members) - 1}; got {levels}"
+        )
+    return [m.model_dump() for m in members]
+
+
+def _hierarchy_row(
+    *,
+    run_id: str,
+    table_id: str,
+    kind: str,
+    members: list[dict[str, object]],
+    canonical_label: str,
+    signature: str,
+    detection_source: str,
+    needs_confirmation: bool,
+    g3: float | None = None,
+    role: stats.RoleResult | None = None,
+    disagree_rate: float | None = None,
+) -> dict[str, object]:
+    """One dimension_hierarchies row dict with a HOMOGENEOUS key set (DAT-784).
+
+    Every writer produces the same keys so the multi-values upsert renders one
+    consistent INSERT. The nullable role/g3 columns default to None; when ``role``
+    is given (a role-check-derived row) ``role_verdict`` + the validated
+    ``role_evidence`` are filled and ``disagree_rate`` is required.
+    """
+    role_evidence: dict[str, object] | None = None
+    role_verdict: str | None = None
+    if role is not None:
+        if disagree_rate is None:
+            raise ValueError("disagree_rate is required when a role verdict is persisted")
+        role_verdict = role.verdict.value
+        role_evidence = RoleEvidence(
+            t1_p=role.t1_p,
+            t1_context=role.t1_context,
+            t2_p=role.t2_p,
+            k_disagree=role.k_disagree,
+            alpha=role.alpha,
+            disagree_rate=disagree_rate,
+        ).model_dump()
+    return {
+        "run_id": run_id,
+        "table_id": table_id,
+        "kind": kind,
+        "members": members,
+        "canonical_label": canonical_label,
+        "signature": signature,
+        "g3": g3,
+        "role_verdict": role_verdict,
+        "role_evidence": role_evidence,
+        "detection_source": detection_source,
+        "needs_confirmation": needs_confirmation,
+    }
+
+
 def _apply_teaches(
     session: Session,
     rows: list[dict[str, object]],
@@ -573,7 +643,7 @@ def _apply_teaches(
             if (str(r["table_id"]), _row_member_names(r)) not in rejected
         }
 
-    # add → manual drilldown, alias → manual alias (ordered members preserved).
+    # add → manual drilldown, alias → manual alias.
     for action, kind in (("add", "drilldown"), ("alias", "alias")):
         for spec in specs[action]:
             members = spec.members
@@ -582,20 +652,32 @@ def _apply_teaches(
                 continue
             names = col_ids_by_table.get(spec.table_id, {})
             sig = f"{kind}:{spec.table_id}:" + "|".join(sorted(members))
-            by_sig[sig] = {
-                "run_id": run_id,
-                "table_id": spec.table_id,
-                "kind": kind,
-                "members": [
-                    {"column_name": n, "column_id": names.get(n, ""), "distinct_count": None}
-                    for n in members
-                ],
-                "canonical_label": " → ".join(members) if kind == "drilldown" else members[0],
-                "signature": sig,
-                "score": 0.0,
-                "detection_source": "manual",
-                "needs_confirmation": False,
-            }
+            # The teach INPUT is finest → coarsest for a drilldown (the user-facing
+            # convention); STORAGE is coarse → fine with an explicit ``level`` so
+            # array position never has to be trusted (DAT-779).
+            ordered = list(reversed(members)) if kind == "drilldown" else list(members)
+            by_sig[sig] = _hierarchy_row(
+                run_id=run_id,
+                table_id=spec.table_id,
+                kind=kind,
+                members=_validated_members(
+                    [
+                        HierarchyMember(
+                            column_name=n,
+                            column_id=names.get(n, ""),
+                            distinct_count=None,
+                            level=i,
+                        )
+                        for i, n in enumerate(ordered)
+                    ]
+                ),
+                canonical_label=" → ".join(ordered) if kind == "drilldown" else ordered[0],
+                signature=sig,
+                # A manual assert asserts an exact FD / bijection — g3 = 0 (strongest).
+                g3=0.0,
+                detection_source="manual",
+                needs_confirmation=False,
+            )
             logger.info(
                 "hierarchy_teach_applied", action=action, table_id=spec.table_id, members=members
             )
@@ -785,16 +867,17 @@ def _view_structures(
     # that trivially passes the edge screen) is suppressed at assembly.
     same_domain: set[frozenset[str]] = set()
 
-    def _member(col: str) -> dict[str, object]:
+    def _member(col: str, level: int) -> HierarchyMember:
         c = by_name[col]
-        return {
-            "column_name": c.column_name,
-            "column_id": c.column_id,
+        return HierarchyMember(
+            column_name=c.column_name,
+            column_id=c.column_id,
             # Null-aware d2 (NULL = one category) — deliberately differs from the
             # pre-DAT-761 null-blind SQL count; the null lane made d2 the honest
             # "values this axis distinguishes".
-            "distinct_count": scan.d2[col],
-        }
+            distinct_count=scan.d2[col],
+            level=level,
+        )
 
     # Disagreement vectors are built lazily per BH-accepted pair — an up-front
     # object-array for every eligible column is gigabytes at the cells budget,
@@ -841,36 +924,44 @@ def _view_structures(
             merged.append((a, b))
             continue
         same_domain.add(frozenset((a, b)))
+        # A near-copy pair is a peer set, not a hierarchy: ``level`` is the sorted
+        # ordinal only (no coarse/fine axis). ``g3`` is None — the role check
+        # measures disagreement, not a functional dependency; the rate + p-values
+        # live in ``role_evidence`` (DAT-784), never overloaded into ``g3``.
+        group = sorted((a, b))
+        pair_members = _validated_members([_member(c, level=i) for i, c in enumerate(group)])
         if result.verdict is RoleVerdict.ROLE:
-            group = sorted((a, b))
             out.append(
-                {
-                    "run_id": run_id,
-                    "table_id": fact_table_id,
-                    "kind": "role",
-                    "members": [_member(c) for c in group],
-                    "canonical_label": f"{group[0]} ⇄ {group[1]}",
-                    "signature": f"role:{fact_table_id}:" + "|".join(group),
-                    "score": rate,
-                    "detection_source": "g3",
-                    "needs_confirmation": needs_conf,
-                }
+                _hierarchy_row(
+                    run_id=run_id,
+                    table_id=fact_table_id,
+                    kind="role",
+                    members=pair_members,
+                    canonical_label=f"{group[0]} ⇄ {group[1]}",
+                    signature=f"role:{fact_table_id}:" + "|".join(group),
+                    role=result,
+                    disagree_rate=rate,
+                    detection_source="g3",
+                    needs_confirmation=needs_conf,
+                )
             )
             continue
-        # VALUE_SYSTEMATIC / ABSTAIN: undecidable from data — surface, don't merge.
-        group = sorted((a, b))
+        # VALUE_SYSTEMATIC / ABSTAIN: undecidable from data — surface as an alias to
+        # confirm, but persist the verdict + evidence so the two stay DISTINGUISHABLE
+        # (the DAT-784 bug: both used to collapse to a bare needs_confirmation alias).
         out.append(
-            {
-                "run_id": run_id,
-                "table_id": fact_table_id,
-                "kind": "alias",
-                "members": [_member(c) for c in group],
-                "canonical_label": group[0],
-                "signature": f"alias:{fact_table_id}:" + "|".join(group),
-                "score": rate,
-                "detection_source": "g3",
-                "needs_confirmation": True,
-            }
+            _hierarchy_row(
+                run_id=run_id,
+                table_id=fact_table_id,
+                kind="alias",
+                members=pair_members,
+                canonical_label=group[0],
+                signature=f"alias:{fact_table_id}:" + "|".join(group),
+                role=result,
+                disagree_rate=rate,
+                detection_source="g3",
+                needs_confirmation=True,
+            )
         )
 
     # -- 6. assemble: union-find → edges on reps → reduction → chains ---------
@@ -907,22 +998,26 @@ def _view_structures(
     for chain in _maximal_chains(reduced):
         hops = [(chain[k], chain[k + 1]) for k in range(len(chain) - 1)]
         score = max(edge_g3(x, y) for x, y in hops)
+        # ``_maximal_chains`` yields finest → coarsest; store coarse → fine with
+        # ``level`` = array index (see :class:`HierarchyMember`) so array, level and
+        # label agree (DAT-779). ``signature`` sorts, so the flip never re-dedups.
+        chain_ctf = list(reversed(chain))
         out.append(
-            {
-                "run_id": run_id,
-                "table_id": fact_table_id,
-                "kind": "drilldown",
-                "members": [_member(c) for c in chain],
-                "canonical_label": " → ".join(chain),
-                "signature": f"drilldown:{fact_table_id}:" + "|".join(sorted(chain)),
-                "score": score,
-                "detection_source": "g3",
+            _hierarchy_row(
+                run_id=run_id,
+                table_id=fact_table_id,
+                kind="drilldown",
+                members=_validated_members([_member(c, level=i) for i, c in enumerate(chain_ctf)]),
+                canonical_label=" → ".join(chain_ctf),
+                signature=f"drilldown:{fact_table_id}:" + "|".join(sorted(chain)),
+                g3=score,
+                detection_source="g3",
                 # Surface, don't decide: a chain resting on a sub-floor
                 # pairwise-complete edge is flagged, same as a tiny view.
-                "needs_confirmation": needs_conf or any(h in thin_edges for h in hops),
-            }
+                needs_confirmation=needs_conf or any(h in thin_edges for h in hops),
+            )
         )
-        logger.info("hierarchy_drilldown", view=view_name, chain=chain, score=round(score, 4))
+        logger.info("hierarchy_drilldown", view=view_name, chain=chain_ctf, score=round(score, 4))
 
     for group in groups:
         pair_scores = [
@@ -932,17 +1027,19 @@ def _view_structures(
             if (group[i], group[j]) in scan.joints or (group[j], group[i]) in scan.joints
         ]
         out.append(
-            {
-                "run_id": run_id,
-                "table_id": fact_table_id,
-                "kind": "alias",
-                "members": [_member(c) for c in group],
-                "canonical_label": group[0],
-                "signature": f"alias:{fact_table_id}:" + "|".join(sorted(group)),
-                "score": max(pair_scores) if pair_scores else 0.0,
-                "detection_source": "g3",
-                "needs_confirmation": needs_conf,
-            }
+            _hierarchy_row(
+                run_id=run_id,
+                table_id=fact_table_id,
+                kind="alias",
+                # A redundant-axis group is a peer set: ``level`` is the sorted
+                # ordinal (canonical = group[0] = level 0), no coarse/fine meaning.
+                members=_validated_members([_member(c, level=i) for i, c in enumerate(group)]),
+                canonical_label=group[0],
+                signature=f"alias:{fact_table_id}:" + "|".join(sorted(group)),
+                g3=max(pair_scores) if pair_scores else 0.0,
+                detection_source="g3",
+                needs_confirmation=needs_conf,
+            )
         )
         logger.info("hierarchy_alias", view=view_name, group=group)
 

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -161,17 +161,18 @@ class HierarchyContext:
     """A discovered drill-down hierarchy, alias group or role pair (DAT-537/761).
 
     The FD pass surfaces these over a fact's enriched view: a ``drilldown``
-    carries ordered levels finest → coarsest (``zip → city → state``), an
-    ``alias`` a redundant-axis group collapsed to one canonical label, a
-    ``role`` (DAT-761) a role-playing near-copy pair (bill-to ⇄ pay-to) that
-    must stay two separate axes. Exposed for the answer agent / GraphAgent to
-    drill and de-duplicate axes; the prompt CONSUMPTION lands in DAT-538 (this
-    is the expose seam, not the use).
+    carries levels in ``level`` order (``state → city → zip``), an ``alias`` a
+    redundant-axis group collapsed to one canonical label, a ``role`` (DAT-761) a
+    role-playing near-copy pair (bill-to ⇄ pay-to) that must stay two separate
+    axes. Exposed for the answer agent / GraphAgent to drill and de-duplicate
+    axes; the prompt CONSUMPTION lands in DAT-538 (this is the expose seam).
     """
 
     kind: str  # 'drilldown' | 'alias' | 'role'
     table_name: str
-    members: list[str]  # ordered levels (drilldown) or the group/pair (alias, role)
+    # ``members`` are read by each member's ``level`` (see the engine's
+    # HierarchyMember contract), NOT by the persisted array position (DAT-779).
+    members: list[str]
     canonical_label: str
     needs_confirmation: bool = False
 
@@ -616,7 +617,9 @@ def build_execution_context(
                 DimensionHierarchy.table_id.in_(table_ids),
                 DimensionHierarchy.run_id == run_id,
             )
-            .order_by(DimensionHierarchy.score)  # strongest (lowest g3) first
+            # Strongest (lowest g3) first; role-check rows have no g3 (NULL) and
+            # sort last, deterministically across Postgres/SQLite (DAT-784).
+            .order_by(DimensionHierarchy.g3.asc().nulls_last())
         )
         for hier in session.execute(hier_stmt).scalars().all():
             hier_tbl = table_map.get(hier.table_id)
@@ -625,7 +628,14 @@ def build_execution_context(
                     HierarchyContext(
                         kind=hier.kind,
                         table_name=hier_tbl.table_name,
-                        members=[str(m.get("column_name", "")) for m in hier.members],
+                        # Read by ``level`` (the HierarchyMember contract), never
+                        # array position (DAT-779).
+                        members=[
+                            str(m.get("column_name", ""))
+                            for m in sorted(
+                                hier.members, key=lambda m: cast("int", m.get("level", 0))
+                            )
+                        ],
                         canonical_label=hier.canonical_label,
                         needs_confirmation=hier.needs_confirmation,
                     )

--- a/packages/engine/tests/unit/analysis/drivers/test_processor.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_processor.py
@@ -82,12 +82,17 @@ def _seed(
             table_id=fact.table_id,
             kind="alias",
             members=[
-                {"column_name": "D_e25", "column_id": col_id["D_e25"], "distinct_count": 4},
-                {"column_name": ALIAS, "column_id": col_id[ALIAS], "distinct_count": 4},
+                {
+                    "column_name": "D_e25",
+                    "column_id": col_id["D_e25"],
+                    "distinct_count": 4,
+                    "level": 0,
+                },
+                {"column_name": ALIAS, "column_id": col_id[ALIAS], "distinct_count": 4, "level": 1},
             ],
             canonical_label="D_e25",
             signature=f"alias:{fact.table_id}:D_e25|{ALIAS}",
-            score=0.0,
+            g3=0.0,
         )
     )
     session.add(

--- a/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
@@ -12,15 +12,24 @@ from __future__ import annotations
 from uuid import uuid4
 
 import duckdb
+import pytest
+from pydantic import ValidationError
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
+from dataraum.analysis.hierarchies.db_models import (
+    DimensionHierarchy,
+    HierarchyMember,
+    RoleEvidence,
+)
 from dataraum.analysis.hierarchies.processor import (
     _break_cycles,
     _maximal_chains,
+    _validated_members,
     discover_dimension_hierarchies,
 )
+from dataraum.analysis.hierarchies.stats import RoleResult, RoleVerdict
 from dataraum.analysis.semantic.db_models import SemanticAnnotation
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.storage import Column
@@ -40,11 +49,17 @@ def _rows(session: Session, table_id: str, kind: str) -> list[DimensionHierarchy
 
 
 def _members(row: DimensionHierarchy) -> list[str]:
+    """Member column names in persisted array order (coarse → fine for a drilldown)."""
     return [m["column_name"] for m in row.members]
 
 
+def _levels(row: DimensionHierarchy) -> list[int]:
+    """The ``level`` of each member, in persisted array order."""
+    return [m["level"] for m in row.members]
+
+
 class TestDiscoverDimensionHierarchies:
-    def test_drilldown_chain_finest_to_coarsest(
+    def test_drilldown_chain_coarsest_to_finest_by_level(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
         tid = seed_sales(real_session, duck)
@@ -58,12 +73,34 @@ class TestDiscoverDimensionHierarchies:
         assert len(drills) == 1
         row = drills[0]
         # Aliases collapse to canonical (zip < zip_code, state < state_name); the
-        # chain is finest → coarsest with the transitive zip → state edge reduced out.
-        assert _members(row) == ["zip", "city", "state"]
-        assert row.canonical_label == "zip → city → state"
-        assert row.score <= 0.01
+        # chain is stored coarse → fine with the transitive state → zip edge reduced
+        # out. ``level`` carries the direction: 0 = coarsest (DAT-779).
+        assert _members(row) == ["state", "city", "zip"]
+        assert _levels(row) == [0, 1, 2]
+        assert row.canonical_label == "state → city → zip"
+        # g3 replaces the overloaded ``score`` (kind-invariant, DAT-784).
+        assert row.g3 is not None and row.g3 <= 0.01
+        assert row.role_verdict is None and row.role_evidence is None
         assert row.run_id == RUN
         assert row.needs_confirmation is False
+
+    def test_drilldown_member_shape_matches_cockpit_contract(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """The persisted ``members`` JSON is exactly the shape the cockpit reader
+        (query-context.ts ``CatalogHierarchyRow``) expects — the offline-DDL seam
+        contract (DAT-779): each entry is {column_name, column_id, distinct_count,
+        level}, and ``level`` (0 = coarsest) is the authoritative order, not array
+        position."""
+        tid = seed_sales(real_session, duck)
+        discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
+        row = _rows(real_session, tid, "drilldown")[0]
+        for member in row.members:
+            assert set(member) == {"column_name", "column_id", "distinct_count", "level"}
+        # level is a contiguous 0..n-1 permutation; sorting by it yields coarse → fine.
+        assert sorted(m["level"] for m in row.members) == list(range(len(row.members)))
+        by_level = [m["column_name"] for m in sorted(row.members, key=lambda m: m["level"])]
+        assert by_level == ["state", "city", "zip"]
 
     def test_one_to_one_aliases_collapse(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
@@ -156,7 +193,9 @@ class TestStackV4:
         )
         discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
         chains = [_members(r) for r in _rows(real_session, tid, "drilldown")]
-        assert ["det", "flag"] in chains
+        # Stored coarse → fine: ``flag`` (2 distinct, coarsest) determines nothing
+        # finer than ``det`` (50 distinct) — det → flag reversed for storage.
+        assert ["flag", "det"] in chains
         assert all("vacuous" not in c for c in chains)
 
     def test_dirty_true_edge_kept(
@@ -171,8 +210,9 @@ class TestStackV4:
         tid = seed_view(real_session, duck, "dirty_geo", {"city": city, "state": state})
         discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
         drills = _rows(real_session, tid, "drilldown")
-        assert [_members(r) for r in drills] == [["city", "state"]]
-        assert 0.0 < drills[0].score <= 0.01
+        # Coarse → fine: state (coarser) before city (finer).
+        assert [_members(r) for r in drills] == [["state", "city"]]
+        assert drills[0].g3 is not None and 0.0 < drills[0].g3 <= 0.01
 
     def test_role_pair_kept_apart(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
@@ -202,6 +242,16 @@ class TestStackV4:
         roles = _rows(real_session, tid, "role")
         assert [_members(r) for r in roles] == [["billto", "soldto"]]
         assert roles[0].needs_confirmation is False
+        # The verdict + evidence are persisted, not lost to a log line (DAT-784):
+        # 'role' with T1 (channel) as the discriminating context, no g3 (a role pair
+        # has no functional dependency), and the disagreement rate in the evidence.
+        row = roles[0]
+        assert row.role_verdict == "role"
+        assert row.g3 is None
+        assert row.role_evidence is not None
+        assert row.role_evidence["t1_context"] == "channel"
+        assert row.role_evidence["k_disagree"] > 0
+        assert 0.0 < row.role_evidence["disagree_rate"] < 0.05
         # Not merged, and no drilldown stacks the two role siblings as levels.
         for r in _rows(real_session, tid, "alias") + _rows(real_session, tid, "drilldown"):
             assert not {"soldto", "billto"} <= set(_members(r))
@@ -218,7 +268,7 @@ class TestStackV4:
         tid = seed_view(real_session, duck, "null_geo", {"city": city, "state": state})
         discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
         drills = _rows(real_session, tid, "drilldown")
-        assert [_members(r) for r in drills] == [["city", "state"]]
+        assert [_members(r) for r in drills] == [["state", "city"]]  # coarse → fine
 
     def test_sub_floor_null_support_surfaces_not_drops(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
@@ -234,7 +284,7 @@ class TestStackV4:
         tid = seed_view(real_session, duck, "sparse_geo", {"city": city, "state": state})
         discover_dimension_hierarchies(real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN)
         drills = _rows(real_session, tid, "drilldown")
-        assert [_members(r) for r in drills] == [["city", "state"]]
+        assert [_members(r) for r in drills] == [["state", "city"]]  # coarse → fine
         assert drills[0].needs_confirmation is True
 
     def test_null_coded_columns_alias(
@@ -365,3 +415,125 @@ class TestDimensionHierarchiesPhaseSkip:
 
         tid = seed_sales(real_session, duck)
         assert DimensionHierarchiesPhase().should_skip(self._ctx(real_session, duck, [tid])) is None
+
+
+def _member_json(name: str, level: int) -> dict[str, object]:
+    return {"column_name": name, "column_id": "", "distinct_count": None, "level": level}
+
+
+def _bare_row(**overrides: object) -> DimensionHierarchy:
+    """A minimal well-formed row; overrides poke one field for a rejection test."""
+    fields: dict[str, object] = {
+        "run_id": RUN,
+        "table_id": "t1",
+        "kind": "alias",
+        "members": [_member_json("a", 0), _member_json("b", 1)],
+        "canonical_label": "a",
+        "signature": f"alias:t1:{uuid4()}",
+    }
+    fields.update(overrides)
+    return DimensionHierarchy(**fields)
+
+
+class TestPersistenceContract:
+    """The verdict/evidence persistence contract (DAT-784) and the member-level
+    JSON contract (DAT-779) — the two-layer standard: a DB CheckConstraint on the
+    closed-vocabulary column, and strict Pydantic submodels on the JSON interiors."""
+
+    def test_role_verdict_check_rejects_unknown(self, real_session: Session) -> None:
+        """An out-of-vocabulary ``role_verdict`` is rejected at the DB layer
+        (the DAT-781 two-layer standard flush-rejection test)."""
+        real_session.add(_bare_row(role_verdict="bogus"))
+        with pytest.raises(IntegrityError):
+            real_session.flush()
+
+    def test_value_systematic_and_abstain_are_distinguishable(self, real_session: Session) -> None:
+        """The exact DAT-784 bug: the two undecidable verdicts used to collapse to
+        one bare ``needs_confirmation`` alias. Now the column tells them apart, and
+        the evidence survives."""
+        vs = RoleEvidence(
+            t1_p=0.3, t1_context="ctx", t2_p=0.01, k_disagree=40, alpha=0.01, disagree_rate=0.02
+        ).model_dump()
+        ab = RoleEvidence(
+            t1_p=1.0, t1_context=None, t2_p=1.0, k_disagree=3, alpha=0.01, disagree_rate=0.003
+        ).model_dump()
+        real_session.add(
+            _bare_row(role_verdict="value_systematic", role_evidence=vs, needs_confirmation=True)
+        )
+        real_session.add(
+            _bare_row(role_verdict="abstain", role_evidence=ab, needs_confirmation=True)
+        )
+        real_session.flush()
+        real_session.expire_all()
+        verdicts = {
+            r.role_verdict: r
+            for r in real_session.execute(select(DimensionHierarchy)).scalars().all()
+        }
+        assert set(verdicts) == {"value_systematic", "abstain"}
+        assert verdicts["value_systematic"].role_evidence["k_disagree"] == 40
+        assert verdicts["abstain"].role_evidence["t1_context"] is None
+
+    def test_hierarchy_member_submodel_rejects_bad_shape(self) -> None:
+        # extra key forbidden, negative level rejected, level required.
+        with pytest.raises(ValidationError):
+            HierarchyMember(column_name="a", column_id="", distinct_count=1, level=0, extra="x")  # type: ignore[call-arg]
+        with pytest.raises(ValidationError):
+            HierarchyMember(column_name="a", column_id="", distinct_count=1, level=-1)
+        with pytest.raises(ValidationError):
+            HierarchyMember(column_name="a", column_id="", distinct_count=1)  # type: ignore[call-arg]
+
+    def test_role_evidence_submodel_rejects_bad_shape(self) -> None:
+        with pytest.raises(ValidationError):
+            RoleEvidence(  # type: ignore[call-arg]
+                t1_p=0.1, t1_context=None, t2_p=0.1, k_disagree=1, alpha=0.01
+            )  # missing disagree_rate
+        with pytest.raises(ValidationError):
+            RoleEvidence(
+                t1_p=0.1,
+                t1_context=None,
+                t2_p=0.1,
+                k_disagree=1,
+                alpha=0.01,
+                disagree_rate=0.1,
+                extra="x",  # type: ignore[call-arg]
+            )
+
+    def test_validated_members_requires_contiguous_levels(self) -> None:
+        # A gap in the level set is a mis-numbered writer → loud failure (DAT-779).
+        good = [
+            HierarchyMember(column_name="a", column_id="", distinct_count=None, level=0),
+            HierarchyMember(column_name="b", column_id="", distinct_count=None, level=1),
+        ]
+        assert [m["column_name"] for m in _validated_members(good)] == ["a", "b"]
+        gapped = [
+            HierarchyMember(column_name="a", column_id="", distinct_count=None, level=0),
+            HierarchyMember(column_name="b", column_id="", distinct_count=None, level=2),
+        ]
+        with pytest.raises(ValueError, match="contiguous"):
+            _validated_members(gapped)
+
+    def test_role_row_helper_requires_disagree_rate(self) -> None:
+        """``_hierarchy_row`` refuses to persist a verdict without its rate — the
+        evidence must never be half-formed."""
+        from dataraum.analysis.hierarchies.processor import _hierarchy_row
+
+        result = RoleResult(
+            verdict=RoleVerdict.ROLE,
+            t1_p=0.001,
+            t1_context="ctx",
+            t2_p=0.5,
+            k_disagree=20,
+            alpha=0.01,
+        )
+        with pytest.raises(ValueError, match="disagree_rate"):
+            _hierarchy_row(
+                run_id=RUN,
+                table_id="t1",
+                kind="role",
+                members=[_member_json("a", 0)],
+                canonical_label="a ⇄ b",
+                signature="role:t1:a|b",
+                role=result,
+                detection_source="g3",
+                needs_confirmation=False,
+            )

--- a/packages/engine/tests/unit/analysis/hierarchies/test_teach.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_teach.py
@@ -45,24 +45,27 @@ class TestHierarchyTeach:
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
         tid = seed_sales(real_session, duck)
-        # The g3 pass finds zip → city → state; rejecting it (by member set, any
-        # order) drops the structure this run.
+        # The g3 pass finds the zip/city/state chain; rejecting it (by member set,
+        # any order) drops the structure this run. Stored coarse → fine (DAT-779).
         _teach(real_session, "reject", tid, ["state", "zip", "city"])
         _discover(real_session, duck, tid)
-        assert ("zip", "city", "state") not in _by_members(real_session, "drilldown")
+        assert ("state", "city", "zip") not in _by_members(real_session, "drilldown")
 
     def test_add_materializes_manual_drilldown(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:
         tid = seed_sales(real_session, duck)
-        # Assert a chain the g3 pass would not surface on its own (city alone → state
-        # is found, but an explicit add of a 2-level chain lands as a manual row).
+        # Assert a chain the g3 pass would not surface on its own. The teach INPUT is
+        # finest → coarsest (``city, state``); STORAGE is coarse → fine with explicit
+        # levels (DAT-779), so it lands as ``state → city``.
         _teach(real_session, "add", tid, ["city", "state"])
         _discover(real_session, duck, tid)
-        row = _by_members(real_session, "drilldown")[("city", "state")]
+        row = _by_members(real_session, "drilldown")[("state", "city")]
         assert row.detection_source == "manual"
         assert row.needs_confirmation is False
-        assert row.canonical_label == "city → state"
+        assert row.canonical_label == "state → city"
+        assert [m["level"] for m in row.members] == [0, 1]
+        assert row.g3 == 0.0  # a manual add asserts an exact FD
         # The catalog resolves the member column ids (provenance), not left blank.
         assert all(m["column_id"] for m in row.members)
 
@@ -90,5 +93,5 @@ class TestHierarchyTeach:
         real_session.add(overlay)
         real_session.flush()
         _discover(real_session, duck, tid)
-        # The reject was undone (superseded) → the g3 chain survives.
-        assert ("zip", "city", "state") in _by_members(real_session, "drilldown")
+        # The reject was undone (superseded) → the g3 chain survives (coarse → fine).
+        assert ("state", "city", "zip") in _by_members(real_session, "drilldown")

--- a/packages/engine/tests/unit/graphs/test_context_builder.py
+++ b/packages/engine/tests/unit/graphs/test_context_builder.py
@@ -419,14 +419,16 @@ class TestBuilderExtractsDimensionHierarchies:
                 run_id="run-1",
                 table_id=table_id,
                 kind="drilldown",
+                # SCRAMBLED array order with explicit ``level`` (0 = coarsest): the
+                # builder must read by level, not position (DAT-779).
                 members=[
-                    {"column_name": "zip", "column_id": column_id, "distinct_count": 6},
-                    {"column_name": "city", "column_id": "", "distinct_count": 4},
-                    {"column_name": "state", "column_id": "", "distinct_count": 2},
+                    {"column_name": "zip", "column_id": column_id, "distinct_count": 6, "level": 2},
+                    {"column_name": "state", "column_id": "", "distinct_count": 2, "level": 0},
+                    {"column_name": "city", "column_id": "", "distinct_count": 4, "level": 1},
                 ],
-                canonical_label="zip → city → state",
+                canonical_label="state → city → zip",
                 signature="drilldown:t:city|state|zip",
-                score=0.0,
+                g3=0.0,
             )
         )
         head = MetadataSnapshotHead(
@@ -439,11 +441,76 @@ class TestBuilderExtractsDimensionHierarchies:
         assert len(ctx.dimension_hierarchies) == 1
         hier = ctx.dimension_hierarchies[0]
         assert hier.kind == "drilldown"
-        assert hier.members == ["zip", "city", "state"]
-        assert hier.canonical_label == "zip → city → state"
+        # Read by level → coarse → fine, regardless of array position.
+        assert hier.members == ["state", "city", "zip"]
+        assert hier.canonical_label == "state → city → zip"
         assert hier.table_name == "invoices"
 
         # Flip the head to a run with no hierarchy rows → fail-closed empty.
         head.run_id = "run-2"
         session.flush()
         assert build_execution_context(session, [table_id]).dimension_hierarchies == []
+
+    def test_role_rows_without_g3_sort_last(self, session: Session) -> None:
+        """The builder orders by ``g3`` ascending with NULLs last (DAT-784): a g3-less
+        role row sorts AFTER a g3-scored drilldown, deterministically (the ordering the
+        prompt reads 'strongest first'). Locks the cross-dialect ``nulls_last``."""
+        from dataraum.analysis.hierarchies.db_models import DimensionHierarchy
+        from dataraum.storage.snapshot_head import (
+            MetadataSnapshotHead,
+            catalog_head_target,
+        )
+
+        _source_id, table_id, column_id = _insert_source_table_column(session)
+        session.add(
+            DimensionHierarchy(
+                run_id="run-1",
+                table_id=table_id,
+                kind="drilldown",
+                members=[
+                    {
+                        "column_name": "state",
+                        "column_id": column_id,
+                        "distinct_count": 2,
+                        "level": 0,
+                    },
+                    {"column_name": "city", "column_id": "", "distinct_count": 4, "level": 1},
+                ],
+                canonical_label="state → city",
+                signature="drilldown:t:city|state",
+                g3=0.005,
+            )
+        )
+        session.add(
+            DimensionHierarchy(
+                run_id="run-1",
+                table_id=table_id,
+                kind="role",
+                members=[
+                    {"column_name": "billto", "column_id": "", "distinct_count": 9, "level": 0},
+                    {"column_name": "soldto", "column_id": "", "distinct_count": 9, "level": 1},
+                ],
+                canonical_label="billto ⇄ soldto",
+                signature="role:t:billto|soldto",
+                g3=None,  # a role pair has no functional dependency
+                role_verdict="role",
+                role_evidence={
+                    "t1_p": 0.001,
+                    "t1_context": "channel",
+                    "t2_p": 0.5,
+                    "k_disagree": 30,
+                    "alpha": 0.01,
+                    "disagree_rate": 0.008,
+                },
+            )
+        )
+        session.add(
+            MetadataSnapshotHead(
+                head_id=_id(), target=catalog_head_target(), stage="catalog", run_id="run-1"
+            )
+        )
+        session.flush()
+
+        ctx = build_execution_context(session, [table_id])
+        # Drilldown (g3=0.005) first; the g3-less role row sorts last (NULLS LAST).
+        assert [h.kind for h in ctx.dimension_hierarchies] == ["drilldown", "role"]


### PR DESCRIPTION
Wave-2 substrate hardening (epic DAT-725, lane A3 audit). Two audited persist-contract bugs on `dimension_hierarchies`, in one PR.

## DAT-779 — member order was an unenforced convention (engine ⇄ cockpit disagreed on direction)

The engine wrote members finest→coarsest; the cockpit comment claimed coarse→fine; nothing checked. `signature` sorts names, so ordering was never validated anywhere.

- Order is now an **explicit typed fact**: `members` JSON entries are validated by a strict Pydantic `HierarchyMember` submodel at **every** writer (the two-layer standard for a JSON interior — a CHECK can't reach inside), each with an integer **`level`**. Direction is documented in **exactly one place** — the `HierarchyMember` docstring: **level 0 = coarsest, increasing = finer**. `_validated_members` asserts levels form a contiguous `0..n-1` at write.
- Members are stored **coarse→fine** (array = level order = `canonical_label` order — all point one way). Array position no longer carries meaning; **both packages read by `level`** (engine `context.py`, cockpit `hierarchyLine`).
- Fixed the stale cockpit comment (`query-context.ts`). Added a **cross-package contract test** on both sides (engine asserts the persisted `{column_name, column_id, distinct_count, level}` shape; cockpit feeds a *scrambled* array with levels and asserts level-ordered render — the offline-DDL seam discipline).

## DAT-784 — role verdict persisted lossily; `score` column overloaded

The stack-v4 role check produces ROLE / VALUE_SYSTEMATIC / ABSTAIN / DIRT with p-values, discriminating context column, and disagreement count — but at persist, VALUE_SYSTEMATIC and ABSTAIN both collapsed to `(kind='alias', needs_confirmation=True)`, the evidence surviving only in a log line.

- Persist the verdict as a typed **`role_verdict`** enum column, with a `CheckConstraint` **derived from the `RoleVerdict` enum** (producer + CHECK can't drift) + a flush-rejection regression test — the DAT-781 two-layer standard.
- Persist the evidence as a strict Pydantic **`RoleEvidence`** JSON submodel — loses nothing vs `stats.RoleResult` (`t1_p`, `t1_context`, `t2_p`, `k_disagree`, `alpha`) plus the disagreement rate.
- **VALUE_SYSTEMATIC and ABSTAIN are now distinguishable by reading the table** (regression test inserts both and reloads).
- Fixed `score`'s kind-dependent meaning: renamed → **`g3`** (kind-invariant; NULL for role-check rows, whose disagreement rate now lives in `role_evidence`, not conflated into g3).

## For DAT-762

DAT-762's conform/role judge will consume these rows. **This PR does NOT build or modify any conform/role judge logic** (`stats.py` untouched; `rolls_up_to` in `property_graph.py` left deferred). Surface = persist contract + tests only. New/changed on `dimension_hierarchies`:

| Change | Column | Type | Notes |
|---|---|---|---|
| **renamed** | `score` → `g3` | Float, **nullable** | kind-invariant g3 evidence; NULL for role-check rows |
| **new** | `role_verdict` | VARCHAR, nullable | `CHECK IN ('abstain','dirt','role','value_systematic')`; NULL when no role check |
| **new** | `role_evidence` | JSON, nullable | `{t1_p, t1_context, t2_p, k_disagree, alpha, disagree_rate}` |
| **new field** | `members[].level` | int (inside the existing `members` JSON) | 0 = coarsest; the authoritative drill order |

(DIRT is in the enum vocabulary/CHECK but never persisted as its own row — a DIRT pair merges into its alias group.)

## Contract / generated artifacts

`schema.sql` + `schema_read.sql` + `schema_graph.sql` re-dumped via `dataraum.storage.dump_ddl`; cockpit drizzle mirror via `bun run db:pull:metadata` — never hand-edited. No backfill/migration: test DBs recreate on this breaking schema change (by design). `.claude/handoff.md` notes the response-shape change for eval/testdata.

## Verification

- Engine: `ruff format`/`check`, `mypy`, `vulture` clean; **2058 unit + integration tests pass** (incl. `test_property_graph` materializing the new CHECK in real Postgres).
- Cockpit: `bun run check`, `typecheck`, **1673 tests**, `build` all green.
- Both reviewers (senior-code-reviewer + spec-compliance-reviewer) ran against the diff — double-approved (no critical/must-fix); their findings (single-source the direction docs, stale comment, add a nulls_last ordering test, add the handoff entry) are all addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)