### PR TITLE
DAT-778: lineage witness persists its winning time axis + physical slice column

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -35,6 +35,14 @@ Six new columns on `MeasureAggregationLineage`:
 This is also the substrate DAT-780 (blocked on this ticket) consumes for the
 K2 measure-anchor designation.
 
+Bundled (reviewer finding, pre-existing gap in a file this change touches):
+`delete_column_dependents` (`pipeline/phases/_column_cleanup.py`) now also
+deletes `driver_rankings` rows by `measure_column_id` — it was the one FK
+child of `columns` missing from the column-level cleanup, so a prior run's
+ranking could FK-block a column delete on the eligibility / surrogate-mint /
+enriched-views paths. The lineage delete there also matches the four new
+witness FKs.
+
 ### Thresholds / new fields
 No score thresholds changed. Six new fields listed above on
 `measure_aggregation_lineage` (and its `current_measure_aggregation_lineage`

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,48 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-778 — lineage now persists the winning axis + slice column (no verdict change)
+
+**Branch:** `fix/dat-778-lineage-witness-persists-winning-axis`. `discover_aggregation_lineage`
+(`analysis/lineage/processor.py`) has always competed every event-time axis per
+fact (DAT-565) and every role-playing physical slice column at a shared
+dimension (DAT-756), but both winners were discarded once the verdict was
+picked — only the human `slice_dimension` label survived. This is a **pure
+persistence fix**: the reconciliation statistic, selection order (`_better`),
+and every persisted verdict field (`pattern`, `match_rate`, `r_flow_median`,
+`r_stock_median`, `n_entities*`, `convention_sql`) are byte-identical to
+before. No detector recall/precision change expected.
+
+### What changed
+Six new columns on `MeasureAggregationLineage`:
+- `measure_time_axis_column` / `event_time_axis_column` (String, NOT NULL) —
+  the winning axis NAME on each side; always populated, it is literally what
+  won DAT-565's competition.
+- `measure_time_axis_column_id` / `event_time_axis_column_id` (FK
+  `columns.column_id`, NULLABLE) — that name resolved against the table's
+  typed columns. `TimeColumn.column` is unvalidated LLM output (DAT-780 adds
+  an enforcement rule), so this is an honest NULL, never a sentinel, when the
+  agent named a column that isn't in `columns`.
+- `measure_slice_column_id` / `event_slice_column_id` (FK `columns.column_id`,
+  NOT NULL) — the winning physical slice column per side (DAT-756
+  role-playing can pick differently per side); always resolvable straight from
+  `SliceDefinition.column_id`.
+
+This is also the substrate DAT-780 (blocked on this ticket) consumes for the
+K2 measure-anchor designation.
+
+### Thresholds / new fields
+No score thresholds changed. Six new fields listed above on
+`measure_aggregation_lineage` (and its `current_measure_aggregation_lineage`
+read view) — additive only, every existing field unchanged.
+
+### Cross-package
+Cockpit drizzle mirror re-pulled in this branch (`bun run db:pull:metadata`) —
+`schema.sql` gained the six columns; the mirror is in lockstep, no further
+action needed downstream.
+
+---
+
 ## DAT-794 — Layer-A relationship detection is now deterministic
 
 **Branch:** `fix/dat-794-layer-a-determinism`. Both unseeded sampling sites in

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -342,6 +342,12 @@ export const currentMeasureAggregationLineage = metadataSchema
 		measureTableId: varchar("measure_table_id"),
 		measureColumnId: varchar("measure_column_id"),
 		eventTableId: varchar("event_table_id"),
+		measureTimeAxisColumn: varchar("measure_time_axis_column"),
+		measureTimeAxisColumnId: varchar("measure_time_axis_column_id"),
+		eventTimeAxisColumn: varchar("event_time_axis_column"),
+		eventTimeAxisColumnId: varchar("event_time_axis_column_id"),
+		measureSliceColumnId: varchar("measure_slice_column_id"),
+		eventSliceColumnId: varchar("event_slice_column_id"),
 		sliceDimension: varchar("slice_dimension"),
 		conventionSql: text("convention_sql"),
 		periodGrain: varchar("period_grain"),
@@ -354,7 +360,7 @@ export const currentMeasureAggregationLineage = metadataSchema
 		createdAt: timestamp("created_at", { withTimezone: true }),
 	})
 	.as(
-		sql`SELECT lineage_id, run_id, measure_table_id, measure_column_id, event_table_id, slice_dimension, convention_sql, period_grain, pattern, match_rate, r_flow_median, r_stock_median, n_entities, n_entities_fired, created_at FROM ws_00000000_0000_0000_0000_000000000001.measure_aggregation_lineage r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
+		sql`SELECT lineage_id, run_id, measure_table_id, measure_column_id, event_table_id, measure_time_axis_column, measure_time_axis_column_id, event_time_axis_column, event_time_axis_column_id, measure_slice_column_id, event_slice_column_id, slice_dimension, convention_sql, period_grain, pattern, match_rate, r_flow_median, r_stock_median, n_entities, n_entities_fired, created_at FROM ws_00000000_0000_0000_0000_000000000001.measure_aggregation_lineage r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
 	);
 
 export const currentMetricAdditivity = metadataSchema

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -497,6 +497,12 @@ CREATE TABLE measure_aggregation_lineage (
 	measure_table_id VARCHAR NOT NULL, 
 	measure_column_id VARCHAR NOT NULL, 
 	event_table_id VARCHAR NOT NULL, 
+	measure_time_axis_column VARCHAR NOT NULL, 
+	measure_time_axis_column_id VARCHAR, 
+	event_time_axis_column VARCHAR NOT NULL, 
+	event_time_axis_column_id VARCHAR, 
+	measure_slice_column_id VARCHAR NOT NULL, 
+	event_slice_column_id VARCHAR NOT NULL, 
 	slice_dimension VARCHAR NOT NULL, 
 	convention_sql TEXT NOT NULL, 
 	period_grain VARCHAR NOT NULL, 
@@ -511,7 +517,11 @@ CREATE TABLE measure_aggregation_lineage (
 	CONSTRAINT uq_measure_lineage_column_run UNIQUE (measure_column_id, run_id), 
 	CONSTRAINT fk_measure_aggregation_lineage_measure_table_id_tables FOREIGN KEY(measure_table_id) REFERENCES tables (table_id), 
 	CONSTRAINT fk_measure_aggregation_lineage_measure_column_id_columns FOREIGN KEY(measure_column_id) REFERENCES columns (column_id), 
-	CONSTRAINT fk_measure_aggregation_lineage_event_table_id_tables FOREIGN KEY(event_table_id) REFERENCES tables (table_id)
+	CONSTRAINT fk_measure_aggregation_lineage_event_table_id_tables FOREIGN KEY(event_table_id) REFERENCES tables (table_id), 
+	CONSTRAINT fk_measure_aggregation_lineage_measure_time_axis_column_ab96 FOREIGN KEY(measure_time_axis_column_id) REFERENCES columns (column_id), 
+	CONSTRAINT fk_measure_aggregation_lineage_event_time_axis_column_i_afd6 FOREIGN KEY(event_time_axis_column_id) REFERENCES columns (column_id), 
+	CONSTRAINT fk_measure_aggregation_lineage_measure_slice_column_id_columns FOREIGN KEY(measure_slice_column_id) REFERENCES columns (column_id), 
+	CONSTRAINT fk_measure_aggregation_lineage_event_slice_column_id_columns FOREIGN KEY(event_slice_column_id) REFERENCES columns (column_id)
 );
 
 CREATE INDEX ix_measure_aggregation_lineage_measure_column_id ON measure_aggregation_lineage (measure_column_id);

--- a/packages/engine/src/dataraum/analysis/lineage/db_models.py
+++ b/packages/engine/src/dataraum/analysis/lineage/db_models.py
@@ -22,6 +22,14 @@ class MeasureAggregationLineage(Base):
     ``cumulative`` ⇒ stock). Read by the ``structural_reconciliation`` witness of
     the ``temporal_behavior`` measurement (exact-run match: the witness fires at
     this run's session detect and abstains everywhere else).
+
+    Discovery competes every event-time axis per fact (DAT-565) and every
+    role-playing physical slice column at a shared dimension (DAT-756); DAT-778
+    persists the WINNING axis/column of each competition on the fields below —
+    previously discarded, which made the "audit + re-run reproducibility" claim
+    unfulfillable. This is also the substrate for the K2 measure-anchor
+    designation (DAT-780): anchor = witness axis where a witness (this row)
+    exists.
     """
 
     __tablename__ = "measure_aggregation_lineage"
@@ -39,9 +47,44 @@ class MeasureAggregationLineage(Base):
     )
     event_table_id: Mapped[str] = mapped_column(ForeignKey("tables.table_id"), nullable=False)
 
-    # The pairing the verdict was computed under (audit + re-run reproducibility):
-    # the shared slice dimension the two facts were partitioned by, the signed
-    # convention over the event fact's per-period sums, and the period grain.
+    # The winning event-time axis per side (DAT-565 competes every axis a table
+    # names; DAT-778 persists the winner). ``*_time_axis_column`` is the raw axis
+    # name — always populated, since it is literally the name that won the
+    # competition. ``*_time_axis_column_id`` is that name resolved against the
+    # table's typed ``columns`` and is NULLABLE: ``TimeColumn.column`` is
+    # unvalidated LLM output (DAT-780 adds the event/attribute rule + a
+    # real-column check at save) and can name a column that isn't in ``columns``
+    # — an honest NULL then, never a sentinel string. Consumed by DAT-780's K2
+    # anchor designation: "witness axis overrides where a witness exists."
+    measure_time_axis_column: Mapped[str] = mapped_column(String, nullable=False)
+    measure_time_axis_column_id: Mapped[str | None] = mapped_column(
+        ForeignKey("columns.column_id"), nullable=True
+    )
+    event_time_axis_column: Mapped[str] = mapped_column(String, nullable=False)
+    event_time_axis_column_id: Mapped[str | None] = mapped_column(
+        ForeignKey("columns.column_id"), nullable=True
+    )
+
+    # The winning PHYSICAL slice column per side (DAT-756: a table can carry
+    # several role-playing ``SliceDefinition``s at the same conformed identity —
+    # e.g. ``debit_account`` vs ``credit_account`` both -> chart_of_accounts —
+    # and the competition can pick either independently per side; collapsing to
+    # one field would silently drop reproducibility on whichever side isn't
+    # captured, the same bug class this row exists to fix). Always resolvable:
+    # sourced from ``SliceDefinition.column_id``, which is NOT NULL by schema.
+    measure_slice_column_id: Mapped[str] = mapped_column(
+        ForeignKey("columns.column_id"), nullable=False
+    )
+    event_slice_column_id: Mapped[str] = mapped_column(
+        ForeignKey("columns.column_id"), nullable=False
+    )
+
+    # The pairing the verdict was computed under (audit + re-run reproducibility,
+    # now honored by the six columns above plus these three): the shared slice
+    # dimension's human-readable label (the conformed identity, not either side's
+    # physical column — see ``measure_slice_column_id``/``event_slice_column_id``
+    # for that), the signed convention over the event fact's per-period sums, and
+    # the period grain.
     slice_dimension: Mapped[str] = mapped_column(String, nullable=False)
     convention_sql: Mapped[str] = mapped_column(Text, nullable=False)
     period_grain: Mapped[str] = mapped_column(String, nullable=False)

--- a/packages/engine/src/dataraum/analysis/lineage/processor.py
+++ b/packages/engine/src/dataraum/analysis/lineage/processor.py
@@ -4,7 +4,11 @@ No LLM call and no slice materialization: the begin_session value layer already
 declared everything this needs. The slicing agent partitioned the facts by
 shared dimensions (the catalog ``SliceDefinition``, propagated across tables)
 and named each fact's event-time axes (``TableEntity.time_columns``); every axis
-is competed and the best-reconciling verdict per measure is kept (DAT-565).
+is competed and the best-reconciling verdict per measure is kept (DAT-565). The
+winning axis on each side, plus the winning physical slice column on each side
+(DAT-756 role-playing), are persisted on the ``MeasureAggregationLineage`` row
+(DAT-778) — the search result is the axis/column that won, not just the
+verdict computed under it.
 
 Discovery aggregates **inline** (DAT-536, one-view model): for each fact × shared
 dimension, a single ``GROUP BY dim, period`` over the fact's enriched view —
@@ -271,6 +275,10 @@ class _Best:
     support_lcb: float  # Wilson LCB of voters over the pairing's common denominator
     arity: int  # convention terms: 1 = single, 2 = ordered difference
     voter_residuals: tuple[float, ...]  # winning-pattern per-entity residuals (ΔBIC)
+    m_axis: str  # winning measure-side time-axis column name (DAT-565/778)
+    e_axis: str  # winning event-side time-axis column name (DAT-565/778)
+    m_slice_column_id: str  # winning physical slice column on the measure table (DAT-756/778)
+    e_slice_column_id: str  # winning physical slice column on the event table (DAT-756/778)
 
 
 def _bic(candidate: _Best) -> float:
@@ -471,13 +479,15 @@ def discover_aggregation_lineage(
         # Each fact groups by its OWN physical slice column (``sd.column_name``) —
         # the shared identity may be reached via differently-named columns (DAT-756),
         # while the VALUE domain is common, so ``_aligned_series`` still pairs them.
-        series_by_table: dict[str, list[tuple[str, _SliceSeries]]] = {}
+        # Each series carries its winning axis name + the physical slice column's
+        # ``column_id`` (DAT-778: both were previously discarded past this point).
+        series_by_table: dict[str, list[tuple[str, str, _SliceSeries]]] = {}
         for tid, sds in shared_dims[identity].items():
             t = tables.get(tid)
             if t is None:
                 continue
             # Every (role-playing slice × time axis) is a distinct lens to bucket by.
-            axis_series: list[tuple[str, _SliceSeries]] = []
+            axis_series: list[tuple[str, str, _SliceSeries]] = []
             for sd in sds:
                 for axis in time_cols_by_table.get(tid, []):
                     s = _slice_series(
@@ -491,7 +501,7 @@ def discover_aggregation_lineage(
                         grain=period_grain,
                     )
                     if s is not None:
-                        axis_series.append((axis, s))
+                        axis_series.append((axis, sd.column_id, s))
             if axis_series:
                 series_by_table[tid] = axis_series
         if len(series_by_table) < 2:
@@ -500,7 +510,7 @@ def discover_aggregation_lineage(
 
         for m_tid, m_axis_series in sorted(series_by_table.items()):
             keys_m = key_columns_by_table.get(m_tid, set())
-            for _m_axis, measure in m_axis_series:
+            for m_axis, m_slice_column_id, measure in m_axis_series:
                 measure_cols = [
                     c
                     for c in measure.numeric_columns
@@ -513,7 +523,7 @@ def discover_aggregation_lineage(
                     if e_tid == m_tid:
                         continue
                     keys_e = key_columns_by_table.get(e_tid, set())
-                    for _e_axis, event in e_axis_series:
+                    for e_axis, e_slice_column_id, event in e_axis_series:
                         # Direction gate: a rollup aggregates MANY event rows into
                         # each measure cell — the event side must be strictly
                         # finer-grained over the paired cells. Symmetric arithmetic
@@ -566,6 +576,10 @@ def discover_aggregation_lineage(
                                         for r in results.values()
                                         if r.label == verdict.pattern
                                     ),
+                                    m_axis=m_axis,
+                                    e_axis=e_axis,
+                                    m_slice_column_id=m_slice_column_id,
+                                    e_slice_column_id=e_slice_column_id,
                                 )
                                 key = columns_by_table[m_tid][measure_col].column_id
                                 prior = best_by_measure.get(key)
@@ -581,12 +595,24 @@ def discover_aggregation_lineage(
     # dedup'd by construction; PK omitted so the model's default applies.
     rows: list[dict[str, object]] = []
     for measure_column_id, (best, m_table, m_col, slice_label) in best_by_measure.items():
+        # The winning axis NAME always resolves (DAT-565); its ``column_id`` is a
+        # best-effort lookup against this table's OWN typed columns and is
+        # honestly NULL when the agent-named axis isn't one of them (DAT-778 —
+        # see the field docstrings on ``MeasureAggregationLineage``).
+        m_axis_col = columns_by_table.get(m_table.table_id, {}).get(best.m_axis)
+        e_axis_col = columns_by_table.get(best.event_table.table_id, {}).get(best.e_axis)
         rows.append(
             {
                 "run_id": run_id,
                 "measure_table_id": m_table.table_id,
                 "measure_column_id": measure_column_id,
                 "event_table_id": best.event_table.table_id,
+                "measure_time_axis_column": best.m_axis,
+                "measure_time_axis_column_id": m_axis_col.column_id if m_axis_col else None,
+                "event_time_axis_column": best.e_axis,
+                "event_time_axis_column_id": e_axis_col.column_id if e_axis_col else None,
+                "measure_slice_column_id": best.m_slice_column_id,
+                "event_slice_column_id": best.e_slice_column_id,
                 "slice_dimension": slice_label,
                 "convention_sql": best.convention_sql,
                 "period_grain": period_grain,

--- a/packages/engine/src/dataraum/pipeline/phases/_column_cleanup.py
+++ b/packages/engine/src/dataraum/pipeline/phases/_column_cleanup.py
@@ -27,6 +27,10 @@ def delete_column_dependents(ctx: PhaseContext, column_ids: list[str]) -> None:
     surrogate, DAT-277), ``slice_definitions``, ``entropy_objects``,
     ``entropy_readiness``, ``claim_witnesses`` (all ``column_id``-keyed), plus the
     differently-named ``derived_columns.derived_column_id``,
+    ``driver_rankings.measure_column_id`` (was MISSING before DAT-778 — a
+    prior run's ranking FK-blocked the column delete on the eligibility /
+    surrogate-mint / enriched-views paths, which only reach this function,
+    never the table-level teardown),
     ``measure_aggregation_lineage`` (reachable through ``measure_column_id`` or
     any of its DAT-778 witness FKs — ``measure_time_axis_column_id``,
     ``event_time_axis_column_id``, ``measure_slice_column_id``,
@@ -42,6 +46,7 @@ def delete_column_dependents(ctx: PhaseContext, column_ids: list[str]) -> None:
     from sqlalchemy import delete, or_
 
     from dataraum.analysis.correlation.db_models import DerivedColumn
+    from dataraum.analysis.drivers.db_models import DriverRankingArtifact
     from dataraum.analysis.lineage.db_models import MeasureAggregationLineage
     from dataraum.analysis.relationships.db_models import Relationship
     from dataraum.analysis.semantic.db_models import ColumnConcept, SemanticAnnotation
@@ -74,6 +79,9 @@ def delete_column_dependents(ctx: PhaseContext, column_ids: list[str]) -> None:
     # Differently-named column FKs.
     ctx.session.execute(
         delete(DerivedColumn).where(DerivedColumn.derived_column_id.in_(column_ids))
+    )
+    ctx.session.execute(
+        delete(DriverRankingArtifact).where(DriverRankingArtifact.measure_column_id.in_(column_ids))
     )
     ctx.session.execute(
         delete(MeasureAggregationLineage).where(

--- a/packages/engine/src/dataraum/pipeline/phases/_column_cleanup.py
+++ b/packages/engine/src/dataraum/pipeline/phases/_column_cleanup.py
@@ -27,8 +27,12 @@ def delete_column_dependents(ctx: PhaseContext, column_ids: list[str]) -> None:
     surrogate, DAT-277), ``slice_definitions``, ``entropy_objects``,
     ``entropy_readiness``, ``claim_witnesses`` (all ``column_id``-keyed), plus the
     differently-named ``derived_columns.derived_column_id``,
-    ``measure_aggregation_lineage.measure_column_id``, and ``relationships``
-    (reachable through either ``from_column_id`` / ``to_column_id`` endpoint).
+    ``measure_aggregation_lineage`` (reachable through ``measure_column_id`` or
+    any of its DAT-778 witness FKs — ``measure_time_axis_column_id``,
+    ``event_time_axis_column_id``, ``measure_slice_column_id``,
+    ``event_slice_column_id``; a column can be a lineage row's *axis/slice*
+    witness without being its measure column), and ``relationships`` (reachable
+    through either ``from_column_id`` / ``to_column_id`` endpoint).
 
     Run BEFORE deleting the ``columns`` rows so the FK constraints are satisfied
     when the column rows go.
@@ -73,7 +77,13 @@ def delete_column_dependents(ctx: PhaseContext, column_ids: list[str]) -> None:
     )
     ctx.session.execute(
         delete(MeasureAggregationLineage).where(
-            MeasureAggregationLineage.measure_column_id.in_(column_ids)
+            or_(
+                MeasureAggregationLineage.measure_column_id.in_(column_ids),
+                MeasureAggregationLineage.measure_time_axis_column_id.in_(column_ids),
+                MeasureAggregationLineage.event_time_axis_column_id.in_(column_ids),
+                MeasureAggregationLineage.measure_slice_column_id.in_(column_ids),
+                MeasureAggregationLineage.event_slice_column_id.in_(column_ids),
+            )
         )
     )
     # Relationships reach a column through either endpoint.

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -127,12 +127,22 @@ def _seed(engine: Engine) -> None:
         "INSERT INTO column_concepts (concept_id, column_id, run_id, temporal_behavior, annotated_at) "
         f"VALUES ('cc_amt', 'c_amt', '{RUN}', 'point_in_time', '{TS}')"
     )
+    # measure_time_axis_column_id / event_time_axis_column_id are left NULL — this
+    # fixture doesn't seed a TableEntity.time_columns axis, so there is nothing to
+    # resolve (DAT-778's honest-NULL case). measure_slice_column_id /
+    # event_slice_column_id are NOT NULL (sourced from SliceDefinition.column_id in
+    # the real writer): 'c_k1' stands in for both, same as the real writer would use
+    # when measure_table_id == event_table_id.
     stmts.append(
         "INSERT INTO measure_aggregation_lineage "
         "(lineage_id, run_id, measure_table_id, measure_column_id, event_table_id, "
+        " measure_time_axis_column, event_time_axis_column, "
+        " measure_slice_column_id, event_slice_column_id, "
         " slice_dimension, convention_sql, period_grain, pattern, match_rate, "
         " r_flow_median, r_stock_median, n_entities, n_entities_fired, created_at) "
-        f"VALUES ('mal_amt', '{RUN}', 't1', 'c_amt', 't1', 'month', 'SUM(amount)', "
+        f"VALUES ('mal_amt', '{RUN}', 't1', 'c_amt', 't1', "
+        f"'period_date', 'period_date', 'c_k1', 'c_k1', "
+        f"'month', 'SUM(amount)', "
         f"'month', 'per_period', 1.0, 0.9, 0.1, 10, 10, '{TS}')"
     )
     for rid, ft, fc, tt, tc in _REFS:

--- a/packages/engine/tests/unit/analysis/lineage/test_processor.py
+++ b/packages/engine/tests/unit/analysis/lineage/test_processor.py
@@ -87,8 +87,10 @@ def _seed(
     tb_dim_col: str = _DIM,
     jl_dim_col: str = _DIM,
     tb_role_play_col: str | None = None,
+    role_play_wins: bool = False,
     folded: bool = False,
     axis_columns: bool = False,
+    values: tuple[str, ...] = _VALUES,
 ) -> dict[str, str]:
     """Seed Tables/Columns/SliceDefinitions/TableEntity + the DuckDB rows.
 
@@ -109,11 +111,18 @@ def _seed(
     name, no cross-table identity, must NOT pair).
 
     ``tb_role_play_col`` adds a SECOND trial_balance slice at the SAME identity (a
-    role-playing FK to the same dim + attribute) whose DuckDB values are degenerate
-    (``'other'`` — outside ``_VALUES``, so its own series is empty). The witness must
+    role-playing FK to the same dim + attribute), carrying its OWN ``Column`` row
+    (a distinct ``column_id``, so the DAT-778 winning-slice assertions can tell the
+    two slices apart). By default its DuckDB values are degenerate (``'other'`` —
+    outside the catalog values, so its own series is empty). The witness must
     still fire off the primary slice: the two role slices must BOTH be tried, never
     collapsed to one (DAT-756 — the identity key groups a list per fact, not a
-    last-write-wins single).
+    last-write-wins single). ``role_play_wins=True`` inverts the competition: the
+    role-play column labels EVERY entity truthfully while the primary covers only
+    the first two ``values`` (rest ``'other'``) — both slices fire, and the
+    role-play, enumerated second, must strictly win on support (Wilson LCB over
+    more reconciling entities). Use with ≥ 4 ``values`` so the primary still
+    clears ``MIN_ENTITIES_FIRED`` and genuinely competes.
 
     ``axis_columns=True`` also registers the time-axis names (``period_date``,
     plus ``ship_date`` under ``multi_axis``) as real typed ``Column`` rows —
@@ -205,28 +214,38 @@ def _seed(
                 dimension_attribute=attribute,
                 fk_role=role,
                 slice_priority=1,
-                distinct_values=list(_VALUES),
-                value_count=len(_VALUES),
+                distinct_values=list(values),
+                value_count=len(values),
                 detection_source="llm",
             )
         )
     # A second trial_balance slice at the SAME identity (role-playing FK): must NOT
-    # collapse the primary slice (DAT-756). Its DuckDB values are degenerate so only
-    # the primary reconciles — proving both are tried, not one arbitrarily kept.
+    # collapse the primary slice (DAT-756). By default its DuckDB values are
+    # degenerate so only the primary reconciles — proving both are tried, not one
+    # arbitrarily kept; under ``role_play_wins`` the roles flip (see docstring).
     if tb_role_play_col:
         rp_role, _, rp_attr = tb_role_play_col.partition("__")
+        rp_column = Column(
+            column_id=str(uuid4()),
+            table_id=ids["trial_balance"],
+            column_name=tb_role_play_col,
+            column_position=90,
+            resolved_type="VARCHAR",
+        )
+        session.add(rp_column)
+        ids[f"trial_balance.{tb_role_play_col}"] = rp_column.column_id
         session.add(
             SliceDefinition(
                 run_id=_RUN,
                 table_id=ids["trial_balance"],
-                column_id=ids["trial_balance.balance"],
+                column_id=rp_column.column_id,
                 column_name=tb_role_play_col,
                 dimension_table_id=ids["chart_of_accounts"],
                 dimension_attribute=rp_attr or None,
                 fk_role=rp_role,
                 slice_priority=2,
-                distinct_values=list(_VALUES),
-                value_count=len(_VALUES),
+                distinct_values=list(values),
+                value_count=len(values),
                 detection_source="llm",
             )
         )
@@ -252,7 +271,7 @@ def _seed(
 
     tb_rows: list[str] = []
     jl_rows: list[str] = []
-    for k, value in enumerate(_VALUES, start=1):
+    for k, value in enumerate(values, start=1):
         running = 0.0
         for i, month in enumerate(_MONTHS):
             net = _net(k, i)
@@ -262,11 +281,21 @@ def _seed(
             # Degenerate second axis: every row shares one ship_date, collapsing
             # the per-period series to a single bucket so this axis cannot win.
             tb_axis_val = ", DATE '2025-01-15'" if multi_axis else ""
-            # Degenerate role-play value: 'other' is outside _VALUES, so this second
-            # same-identity slice contributes no series — only the primary reconciles.
-            tb_role_val = ", 'other'" if tb_role_play_col else ""
+            if role_play_wins:
+                # The role-play column labels every entity truthfully; the primary
+                # covers only the first two (rest 'other', outside the catalog
+                # values → excluded from its series). Both slices fire; the
+                # role-play reconciles MORE entities and must win on support.
+                tb_dim_val = value if k <= 2 else "other"
+                tb_role_val = f", '{value}'"
+            else:
+                # Degenerate role-play value: 'other' is outside the catalog values,
+                # so this second same-identity slice contributes no series — only
+                # the primary reconciles.
+                tb_dim_val = value
+                tb_role_val = ", 'other'" if tb_role_play_col else ""
             tb_rows.append(
-                f"('{value}', {d}, {running}, {net}{tb_extra}{tb_axis_val}{tb_role_val})"
+                f"('{tb_dim_val}', {d}, {running}, {net}{tb_extra}{tb_axis_val}{tb_role_val})"
             )
             # Two finer-grained event rows summing to the movement.
             for half in (net / 2, net - net / 2):
@@ -750,6 +779,40 @@ class TestDiscoverAggregationLineage:
         assert row is not None
         assert row.pattern == "cumulative"
         assert row.event_table_id == ids["journal_lines"]
+        # DAT-778: the degenerate role-play slice contributes no series, so the
+        # primary's physical column is the (only possible) persisted winner.
+        assert row.measure_slice_column_id == ids["trial_balance.balance"]
+
+    def test_winning_role_playing_slice_column_persists(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """DAT-778: when TWO role-playing slices at the same identity BOTH fire,
+        the persisted ``measure_slice_column_id`` is the competition WINNER's,
+        never the first-enumerated slice's. The primary slice (priority 1, tried
+        first, incumbent) covers only 2 of the 4 catalog values (support
+        LCB(2,2) ≈ 0.34); the role-play column labels all 4 truthfully
+        (LCB(4,4) ≈ 0.51) and strictly wins on support — so a persist path that
+        kept the first (or an arbitrary) slice's column_id fails here, which the
+        all-degenerate role-play fixture above cannot detect (its losing slice
+        never produces a live candidate at all).
+        """
+        ids = _seed(
+            real_session,
+            duck,
+            tb_role_play_col="counter_account_id__account_type",
+            role_play_wins=True,
+            values=("assets", "liabilities", "equity", "revenue"),
+        )
+        assert _discover(real_session, duck, ids) > 0
+        row = _row_for(real_session, ids["trial_balance.balance"])
+        assert row is not None
+        assert row.pattern == "cumulative"
+        assert row.event_table_id == ids["journal_lines"]
+        rp_column_id = ids["trial_balance.counter_account_id__account_type"]
+        assert row.measure_slice_column_id == rp_column_id
+        assert row.measure_slice_column_id != ids["trial_balance.balance"]  # primary lost
+        # The event fact carries a single slice; its physical column persists too.
+        assert row.event_slice_column_id == ids["journal_lines.debit"]
 
     def test_rerun_is_idempotent(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection

--- a/packages/engine/tests/unit/analysis/lineage/test_processor.py
+++ b/packages/engine/tests/unit/analysis/lineage/test_processor.py
@@ -88,6 +88,7 @@ def _seed(
     jl_dim_col: str = _DIM,
     tb_role_play_col: str | None = None,
     folded: bool = False,
+    axis_columns: bool = False,
 ) -> dict[str, str]:
     """Seed Tables/Columns/SliceDefinitions/TableEntity + the DuckDB rows.
 
@@ -113,6 +114,14 @@ def _seed(
     still fire off the primary slice: the two role slices must BOTH be tried, never
     collapsed to one (DAT-756 — the identity key groups a list per fact, not a
     last-write-wins single).
+
+    ``axis_columns=True`` also registers the time-axis names (``period_date``,
+    plus ``ship_date`` under ``multi_axis``) as real typed ``Column`` rows —
+    resolvable, like a real profiled date column would be. Off by default (the
+    minimal fixture): a table's agent-named axis is unvalidated LLM output
+    (DAT-780) and commonly WON'T resolve, so the default shape doubles as the
+    DAT-778 NULL-``*_time_axis_column_id`` case every other test already
+    exercises without asking for it.
     """
     ids: dict[str, str] = {}
     dim_table = Table(
@@ -154,6 +163,17 @@ def _seed(
         axes = [{"column": "period_date", "aspect": "period", "note": "Period."}]
         if multi_axis and name == "trial_balance":
             axes.append({"column": "ship_date", "aspect": "ship", "note": "Shipped."})
+        if axis_columns:
+            for pos, tc in enumerate(axes, start=len(cols)):
+                axis_column = Column(
+                    column_id=str(uuid4()),
+                    table_id=table.table_id,
+                    column_name=tc["column"],
+                    column_position=pos,
+                    resolved_type="DATE",
+                )
+                session.add(axis_column)
+                ids[f"{name}.{tc['column']}"] = axis_column.column_id
         session.add(
             TableEntity(
                 run_id=_RUN,
@@ -573,8 +593,16 @@ class TestDiscoverAggregationLineage:
         keeps the best-reconciling verdict. The degenerate ``ship_date`` axis (all
         rows in one period) cannot reconcile; the good ``period_date`` axis still
         wins, identical to the single-axis verdict — a bad axis never degrades it.
+
+        DAT-778: the WINNER of that competition persists — on both the measure
+        and event side — instead of being discarded once the verdict is picked.
+        ``axis_columns=True`` registers ``period_date``/``ship_date`` as real
+        typed columns (as a profiled date column would be), so the winning
+        axis's ``column_id`` resolves too, proving the persisted id is the
+        winner's, never the loser's (``ship_date`` would also resolve here, so
+        a wrong pick would silently pass without this fixture).
         """
-        ids = _seed(real_session, duck, multi_axis=True)
+        ids = _seed(real_session, duck, multi_axis=True, axis_columns=True)
         assert _discover(real_session, duck, ids) > 0
         row = _row_for(real_session, ids["trial_balance.balance"])
         assert row is not None
@@ -582,6 +610,43 @@ class TestDiscoverAggregationLineage:
         assert row.event_table_id == ids["journal_lines"]
         assert row.match_rate > 0.99
         assert row.convention_sql == '"debit"'
+        # The measure-side axis competition picked "period_date", never the
+        # degenerate "ship_date" — resolved to the real Column axis_columns
+        # registered, not the loser's.
+        assert row.measure_time_axis_column == "period_date"
+        assert row.measure_time_axis_column_id == ids["trial_balance.period_date"]
+        # journal_lines only ever had one axis, but it must still be CAPTURED,
+        # not silently dropped — the bug this ticket fixes discarded both sides.
+        assert row.event_time_axis_column == "period_date"
+        assert row.event_time_axis_column_id == ids["journal_lines.period_date"]
+        # The winning physical slice column resolves straight off the
+        # catalog's own SliceDefinition.column_id (schema-guaranteed NOT NULL).
+        assert row.measure_slice_column_id == ids["trial_balance.balance"]
+        assert row.event_slice_column_id == ids["journal_lines.debit"]
+
+    def test_time_axis_column_id_is_null_when_axis_name_unresolvable(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """DAT-778 NULL case: ``TimeColumn.column`` is unvalidated LLM output
+        (DAT-780 tightens this at save) — the winning axis NAME always persists
+        (it is literally what won the competition), but when that name doesn't
+        resolve to a real ``Column`` on the table, the id is an honest NULL,
+        never a sentinel string. The default (minimal) fixture doesn't register
+        ``period_date`` as a ``Column`` — the natural shape of "a witness with
+        no [resolvable] axis" this table can produce.
+        """
+        ids = _seed(real_session, duck)
+        assert _discover(real_session, duck, ids) > 0
+        row = _row_for(real_session, ids["trial_balance.balance"])
+        assert row is not None
+        assert row.measure_time_axis_column == "period_date"
+        assert row.measure_time_axis_column_id is None
+        assert row.event_time_axis_column == "period_date"
+        assert row.event_time_axis_column_id is None
+        # The physical slice column is unaffected by the axis-name gap — it is
+        # always resolvable, straight from SliceDefinition.column_id.
+        assert row.measure_slice_column_id == ids["trial_balance.balance"]
+        assert row.event_slice_column_id == ids["journal_lines.debit"]
 
     def test_junk_numeric_column_does_not_win(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection


### PR DESCRIPTION
## Task

[DAT-778](https://real-dataraum.atlassian.net/browse/DAT-778) — Lineage witness discards its winning time axis and physical slice column — pairing not reproducible. Wave-3 of the DAT-772 substrate hardening (epic DAT-725).

`discover_aggregation_lineage` competes every event-time axis per fact (DAT-565) and every role-playing physical slice column at a shared dimension (DAT-756), but both axis loop variables were underscore-discarded and the winning physical slice column was dropped — only the human `slice_dimension` label survived. The row's docstring claimed "audit + re-run reproducibility"; that claim was unfulfillable. This is a **pure persistence fix**: the reconciliation statistic, `_better` selection order, and every existing verdict field are byte-identical to before.

## For DAT-780 (consumes these columns — K2 measure-anchor designation)

Six new columns on `measure_aggregation_lineage` (and its `current_measure_aggregation_lineage` read view, which is `SELECT r.*` and inherits them automatically):

| Column | Type | Semantics |
|---|---|---|
| `measure_time_axis_column` | `VARCHAR NOT NULL` | The measure-side time-axis NAME that won the DAT-565 competition — always populated (it is literally the winning loop value from `TableEntity.time_columns`). |
| `measure_time_axis_column_id` | `VARCHAR NULL`, FK `columns.column_id` | That name resolved against the measure table's typed `columns`. **NULL = the agent-named axis is not a real column** (unvalidated LLM output; DAT-780 adds the save-time rule). Honest NULL, never a sentinel. |
| `event_time_axis_column` | `VARCHAR NOT NULL` | Same, event side. |
| `event_time_axis_column_id` | `VARCHAR NULL`, FK `columns.column_id` | Same, event side. |
| `measure_slice_column_id` | `VARCHAR NOT NULL`, FK `columns.column_id` | The winning PHYSICAL slice column on the measure table — sourced from `SliceDefinition.column_id` (schema NOT NULL), always resolvable. |
| `event_slice_column_id` | `VARCHAR NOT NULL`, FK `columns.column_id` | Same, event side. |

**Anchor rule for DAT-780:** anchor = `measure_time_axis_column`(`_id`) of the measure table's lineage row where a witness (a lineage row) exists; a row's existence already means the reconciliation fired. No anchor-designation logic was built here — persist only.

### Two deliberate deviations from the literal spec text (flagging for sign-off, not presenting as asked-for)

1. **Slice column is TWO fields, not one.** The spec said "the winning physical slice column" (singular). The code allows a table to carry multiple role-playing `SliceDefinition`s at the same conformed identity (DAT-756 — e.g. `account_id` vs `counter_account_id` both → `chart_of_accounts`), and the competition picks the winning slice **independently per side** (measure vs event loop iterations). Collapsing to one field would need an unspecified tie-break and silently drop reproducibility on the uncaptured side — the same bug class this ticket fixes. DAT-780's K2 consumption only needs the time-axis columns, so this is orthogonal to the blocked ticket.
2. **The NULL case is "unresolvable axis name", not "a row that never competed axes".** Traced the code: `best_by_measure` is only populated from live axis competitions, so a lineage row without any axis cannot exist — every row carries the winning axis NAME. The only genuinely occurring NULL is the name failing to resolve to a typed `Column` (LLM-hallucinated/stale axis name). The NULL-case test exercises exactly that.

### Bundled (senior-review finding, pre-existing gap in a touched file)

`delete_column_dependents` (`pipeline/phases/_column_cleanup.py`) was missing `driver_rankings.measure_column_id` — the one FK child of `columns` not covered by column-level cleanup (verified: 15 child tables in `schema.sql`). A prior run's ranking could FK-block a column delete on the eligibility / surrogate-mint / enriched-views paths, which never reach table-level teardown. Same-shape one-line fix. The lineage delete there also matches the four new witness FKs.

## Acceptance criteria

- [x] Winning measure-side + event-side time-axis columns persisted, typed at `column_id` grain plus the name (row convention)
- [x] Winning physical slice column persisted at `column_id` grain (per side, see deviation 1)
- [x] Loop variables captured into the winning result (`_Best`) instead of discarded — `grep 'for _'` on processor.py is empty
- [x] Honest NULL where the axis genuinely can't resolve; no sentinel strings
- [x] Run-versioned form-(a) contract intact — new columns ride the same `(measure_column_id, run_id)` upsert, no second write path
- [x] `db_models.py` docstring updated; reproducibility claim now true, each column's meaning stated
- [x] Discovery test proves the persisted winner IS the competition winner (known-winner fixture: `period_date` beats degenerate `ship_date`; both resolvable, so a wrong pick cannot pass silently) — plus a mutation-verified test that the winning role-playing slice column (not the first-enumerated) persists
- [x] NULL-case test (`test_time_axis_column_id_is_null_when_axis_name_unresolvable`)
- [x] No backfill/migration machinery; `schema.sql` + Drizzle mirror re-dumped, never hand-edited (re-dumped again post-rebase — byte-identical)

## Reviews

Both reviewers ran against the diff; **double-approve**.
- senior-code-reviewer: PASS — threading logic correct, nullability split independently re-derived, `_source_teardown` reasoning verified. Two findings (driver_rankings cleanup gap; winning-slice test gap) — both fixed in the second commit.
- spec-compliance-reviewer: compliant — all 16 spec bullets traced to code; the two deviations above flagged for explicit sign-off (done here).

## Gates

```
engine:  ruff format/check clean · mypy 0 new errors (9 pre-existing on main, verified via stash)
         vulture clean · tests/unit 2057 passed (-n auto, post-rebase)
         integration: test_property_graph.py 14 passed (real PG19), test_begin_session_progress_query.py 2 passed
cockpit: biome check clean · tsc clean · 1671 tests passed · build green (mirror changed)
extra:   mutation check — "first-slice" bug injected → new test FAILS; reverted → passes
```

## Other lanes in flight

```
#487 DAT-727: Phase 2 — Grounding reification (PARKED draft — do not merge)
#486 DAT-730: Phase 5 — temporal coverage & calendar (PARKED draft — do not merge; re-enters via P5 salvage after DAT-778→780)
```

Rebased onto origin/main at 9571d130 (post-#495); generated files re-dumped post-rebase, no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)