### PR TITLE
DAT-780: time_columns contract — event/attribute rule + typed anchor

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,54 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-780 — `time_columns` contract: event/attribute role + typed anchor (BREAKING LLM contract)
+
+**Branch:** `fix/dat-780-time-columns-event-attribute-anchor`. Hardens the
+`semantic_per_table` (`analyze_tables`) LLM output contract and the persisted
+`TableEntity.time_columns` JSON. **Breaking** — test DBs must be recreated (no
+backfill); an eval corpus captured before this ships will fail schema validation.
+
+### What changed (LLM output + persisted shape)
+Each `TimeColumn` now carries two REQUIRED fields beyond `{column, aspect, note}`:
+- `role: 'event' | 'attribute'` — the LLM commits per column. `event` = when the
+  row's own event occurred (a real trend/rollup axis). `attribute` = a date the
+  row merely refers to (due_date, valid_until) — kept for coverage, never a trend
+  axis. Record metadata (created_at) stays excluded from `time_columns` entirely.
+- `is_anchor: bool` — exactly ONE `role='event'` column per table is the anchor
+  (the primary trend axis) whenever the table has any event date.
+
+Both are enforced at SAVE by a Pydantic `TableEntityOutput` validator routed
+through the existing DAT-710 repair turn: zero anchors with events present, two
+anchors, or an attribute-role anchor → one repair turn, then fall loud. The
+`semantic_per_table` prompt was updated in lockstep.
+
+### Consumers adapted (filter role='event')
+- `analysis/lineage/processor.py` — rollup axes are event-only (an attribute date
+  can no longer become a reconciliation axis).
+- `analysis/semantic/agent.py::derive_table_role` — periodic-snapshot detection
+  counts only event dates in the grain.
+- `graphs/context.py` + cockpit `tools/query-context.ts` — the two SQL agents'
+  time-lens context renders event axes only (anchor marked); attribute dates drop.
+- `pipeline/phases/slicing_phase.py` — the event-axis backstops guard on
+  `role='event'` (an attribute-only table still gets its backstop axis), preserve
+  attribute dates on fill, and the `is_dimension_time_column` flag matches only a
+  dim's EVENT dates.
+
+### New read seam (property graph)
+`og_columns` gained an `anchor_time_axis` property (`schema_graph.sql` re-dumped):
+`COALESCE(witness event-side axis, table declared anchor)` — the DAT-778 lineage
+witness axis wins where a witness exists, else the typed `is_anchor` declared
+axis. This is the anchor's single home; nothing reads array position. (Replaces
+the parked #486's positional `tc.ord = 1` pick — not resurrected.)
+
+### Thresholds / cross-package
+No score thresholds changed. `time_columns` is a JSON column, so `schema.sql` and
+the cockpit drizzle mirror are UNCHANGED (verified `db:pull:metadata` clean); only
+`schema_graph.sql` changed. Cockpit `look-table.ts` mirrors the two new fields
+(optional, tolerant).
+
+---
+
 ## DAT-778 — lineage now persists the winning axis + slice column (no verdict change)
 
 **Branch:** `fix/dat-778-lineage-witness-persists-winning-axis`. `discover_aggregation_lineage`

--- a/packages/cockpit/src/tools/look-table.test.ts
+++ b/packages/cockpit/src/tools/look-table.test.ts
@@ -277,6 +277,45 @@ describe("projectTableEntity (DAT-476)", () => {
 		// The 40-hex digest is gone from every projected field.
 		expect(JSON.stringify(out)).not.toMatch(/src_[0-9a-f]{40}/);
 	});
+
+	it("carries the DAT-780 typed role + is_anchor through the projection", () => {
+		const out = projectTableEntity(
+			entityRow({
+				timeColumns: [
+					{
+						column: "order_date",
+						aspect: "order",
+						role: "event",
+						is_anchor: true,
+						note: "Placed.",
+					},
+					{
+						column: "due_date",
+						aspect: "due",
+						role: "attribute",
+						is_anchor: false,
+						note: "Owed.",
+					},
+				],
+			}),
+		);
+		expect(out.time_columns).toEqual([
+			{
+				column: "order_date",
+				aspect: "order",
+				role: "event",
+				is_anchor: true,
+				note: "Placed.",
+			},
+			{
+				column: "due_date",
+				aspect: "due",
+				role: "attribute",
+				is_anchor: false,
+				note: "Owed.",
+			},
+		]);
+	});
 });
 
 // The drizzle SQL predicate is a self-referential object whose bound literals

--- a/packages/cockpit/src/tools/look-table.ts
+++ b/packages/cockpit/src/tools/look-table.ts
@@ -105,11 +105,16 @@ export type TableReadiness = z.infer<typeof TableReadiness>;
 // dimension), its grain, its time/identity columns, and a short description.
 // begin_session's `detect` writes it; `current_table_entities` head-resolves to
 // the promoted run. Null when no detect run has promoted (pre-session).
-// One event-time axis (DAT-565): a denormalized table commonly has several
-// (order vs ship vs delivery), each a distinct lens with a one-line note.
+// One date axis (DAT-565): a denormalized table commonly has several (order vs
+// ship vs delivery), each a distinct lens with a one-line note. DAT-780 adds the
+// typed `role` (event = a genuine trend axis, attribute = a date the row merely
+// refers to) and `is_anchor` (the table's one primary event axis). Both optional
+// here — the engine stamps them on every row, but this reader stays tolerant.
 const TimeColumn = z.object({
 	column: z.string(),
 	aspect: z.string(),
+	role: z.enum(["event", "attribute"]).optional(),
+	is_anchor: z.boolean().optional(),
 	note: z.string(),
 });
 
@@ -310,10 +315,18 @@ export interface TableEntityRow {
 }
 
 // The persisted time-axis shape (DAT-565): the engine writes a JSON list of
-// `{column, aspect, note}` (`analysis/semantic/processor.py`); null/malformed
-// degrades to []. Anything else is dropped rather than thrown.
+// `{column, aspect, role, is_anchor, note}` (`analysis/semantic/processor.py`;
+// DAT-780 added the typed role + anchor); null/malformed degrades to []. Anything
+// else is dropped rather than thrown. `role`/`is_anchor` are optional here so the
+// reader tolerates rows the engine hasn't re-stamped.
 const TimeColumns = z.array(
-	z.object({ column: z.string(), aspect: z.string(), note: z.string() }),
+	z.object({
+		column: z.string(),
+		aspect: z.string(),
+		role: z.enum(["event", "attribute"]).optional(),
+		is_anchor: z.boolean().optional(),
+		note: z.string(),
+	}),
 );
 
 // The persisted identity shape (DAT-565): the engine writes a JSON list of

--- a/packages/cockpit/src/tools/query-context.test.ts
+++ b/packages/cockpit/src/tools/query-context.test.ts
@@ -496,6 +496,45 @@ describe("formatEntities (DAT-607)", () => {
 		);
 	});
 
+	it("offers event axes only, marks the anchor, hides attribute dates (DAT-780)", () => {
+		const out = formatEntities([
+			{
+				address: entAddr("wwi_orders"),
+				entity: entity({
+					time_columns: [
+						{
+							column: "OrderDate",
+							aspect: "order",
+							role: "event",
+							is_anchor: true,
+							note: "Placed.",
+						},
+						{
+							column: "ShipDate",
+							aspect: "ship",
+							role: "event",
+							is_anchor: false,
+							note: "Shipped.",
+						},
+						{
+							column: "DueDate",
+							aspect: "due",
+							role: "attribute",
+							is_anchor: false,
+							note: "Owed.",
+						},
+					],
+				}),
+			},
+		]);
+		// The anchor is marked; ShipDate is a plain event lens; DueDate (attribute)
+		// is never offered as a time axis.
+		expect(out).toContain(
+			"  time: OrderDate (order) [anchor], ShipDate (ship)",
+		);
+		expect(out).not.toContain("DueDate");
+	});
+
 	it("labels a dimension table and omits the kind when neither flag is set", () => {
 		const dim = formatEntities([
 			{

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -722,10 +722,19 @@ export function formatEntities(rows: EntityBlockRow[]): string {
 	)) {
 		const lines: string[] = [];
 		if (entity.grain.length) lines.push(`  grain: ${entity.grain.join(", ")}`);
-		if (entity.time_columns.length)
+		// EVENT axes only (DAT-780): the answer agent trends/groups by these, so an
+		// attribute date (role='attribute' — due_date, valid_until) must never be
+		// offered as a time axis. Tolerant of un-roled rows (shown), strict against
+		// explicit attributes (hidden). The is_anchor axis is marked as the primary
+		// lens. Mirrors the engine's graphs/context.py treatment (two SQL agents).
+		const eventAxes = entity.time_columns.filter((t) => t.role !== "attribute");
+		if (eventAxes.length)
 			lines.push(
-				`  time: ${entity.time_columns
-					.map((t) => (t.aspect ? `${t.column} (${t.aspect})` : t.column))
+				`  time: ${eventAxes
+					.map((t) => {
+						const label = t.aspect ? `${t.column} (${t.aspect})` : t.column;
+						return t.is_anchor ? `${label} [anchor]` : label;
+					})
 					.join(", ")}`,
 			);
 		if (entity.identity_columns.length)

--- a/packages/dataraum-config/llm/prompts/semantic_per_table.yaml
+++ b/packages/dataraum-config/llm/prompts/semantic_per_table.yaml
@@ -21,11 +21,17 @@ system_prompt: |
   - Decide whether each table is a fact table (events/transactions/measurements)
     or a dimension table (reference/lookup data)
   - Identify the grain (the column set that uniquely identifies a row)
-  - Identify ALL event-time columns — every column recording WHEN a row's event
-    occurred. A denormalized table commonly has several distinct lenses
-    (order_date vs ship_date vs delivery_date); emit each with a short aspect
-    label and a one-sentence note. Exclude attribute dates (due_date,
-    valid_until) and record metadata (created_at).
+  - Identify ALL date columns and tag each with a typed role. An EVENT date
+    records WHEN a row's own event occurred (order_date, ship_date, a
+    periodic-statement period date) — role='event'; a denormalized table commonly
+    has several distinct lenses, emit each. An ATTRIBUTE date is one the row
+    merely refers to, not when its event happened (due_date, valid_until,
+    effective_from) — role='attribute'; emit these too so they get coverage, but
+    they are never a trend axis. Leave record metadata (created_at, updated_at,
+    load timestamps) OUT of time_columns entirely. Give each a short aspect label
+    and a one-sentence note. Whenever the table has any event date, mark EXACTLY
+    ONE event column is_anchor=true (its primary trend axis) and every other
+    time_column false; an attribute date can never be the anchor.
   - Identify recurring identity columns — high-cardinality columns that recur
     across rows and identify a real entity (customer, account, vehicle), i.e.
     would-be foreign keys. These are distinct from grain: an identity may be a

--- a/packages/engine/schema_graph.sql
+++ b/packages/engine/schema_graph.sql
@@ -28,12 +28,20 @@ SELECT c.column_id::text AS column_id, c.table_id::text AS table_id, c.column_na
          CASE mal.pattern WHEN 'per_period' THEN 'flow' WHEN 'cumulative' THEN 'stock' END,
          CASE cc.temporal_behavior WHEN 'additive' THEN 'flow'
                                    WHEN 'point_in_time' THEN 'stock' END
-       ) AS materialization
+       ) AS materialization,
+       COALESCE(mal.event_time_axis_column, declared_anchor.column_name) AS anchor_time_axis
 FROM __READ__.current_columns c
 LEFT JOIN __READ__.current_semantic_annotations sa ON sa.column_id = c.column_id
 LEFT JOIN __READ__.current_column_concepts cc ON cc.column_id = c.column_id
 LEFT JOIN __READ__.current_measure_aggregation_lineage mal
-       ON mal.measure_column_id = c.column_id;
+       ON mal.measure_column_id = c.column_id
+LEFT JOIN __READ__.current_table_entities te ON te.table_id = c.table_id
+LEFT JOIN LATERAL (
+    SELECT elem->>'column' AS column_name
+    FROM json_array_elements(COALESCE(te.time_columns, '[]'::json)) AS elem
+    WHERE elem->>'role' = 'event' AND (elem->>'is_anchor')::boolean IS TRUE
+    LIMIT 1
+  ) declared_anchor ON TRUE;
 
 CREATE VIEW __READ__.og_concepts AS
 SELECT concept_id::text AS concept_id, vertical, name, kind
@@ -107,7 +115,8 @@ CREATE PROPERTY GRAPH __READ__.operating_model
     __READ__.og_tables KEY (table_id) LABEL table_node
       PROPERTIES (table_id, table_name, layer, table_role, detected_entity_type),
     __READ__.og_columns KEY (column_id) LABEL column_node
-      PROPERTIES (column_id, table_id, column_name, semantic_role, materialization),
+      PROPERTIES (column_id, table_id, column_name, semantic_role, materialization,
+                  anchor_time_axis),
     __READ__.og_concepts KEY (concept_id) LABEL concept_node
       PROPERTIES (concept_id, vertical, name, kind)
   )

--- a/packages/engine/src/dataraum/analysis/lineage/processor.py
+++ b/packages/engine/src/dataraum/analysis/lineage/processor.py
@@ -460,7 +460,15 @@ def discover_aggregation_lineage(
         time_entity_stmt = time_entity_stmt.where(TableEntity.run_id == run_id)
     time_cols_by_table: dict[str, list[str]] = {}
     for entity in session.execute(time_entity_stmt).scalars():
-        axes = [tc["column"] for tc in (entity.time_columns or []) if tc.get("column")]
+        # EVENT axes only (DAT-780): the reconciliation rolls up event rows into a
+        # measure, so an attribute date (role='attribute' — due_date, valid_until)
+        # is never a valid rollup axis. The save-time contract stamps every
+        # persisted TimeColumn with a role, so filter strictly on it.
+        axes = [
+            tc["column"]
+            for tc in (entity.time_columns or [])
+            if tc.get("column") and tc.get("role") == "event"
+        ]
         if axes:
             time_cols_by_table[entity.table_id] = axes
     numeric_cols_by_table = {

--- a/packages/engine/src/dataraum/analysis/semantic/agent.py
+++ b/packages/engine/src/dataraum/analysis/semantic/agent.py
@@ -295,7 +295,11 @@ class SemanticAgent(LLMFeature):
                 table_role=derive_table_role(
                     table.is_fact_table,
                     table.grain,
-                    [tc.column for tc in table.time_columns],
+                    # EVENT axes only (DAT-780): a periodic snapshot is a fact whose
+                    # grain holds a genuine event date (the snapshot period), so an
+                    # attribute date (due_date) landing in the grain must not flip a
+                    # plain fact to periodic_snapshot.
+                    [tc.column for tc in table.time_columns if tc.role == "event"],
                 ),
                 time_columns=table.time_columns,
                 identity_columns=table.identity_columns,

--- a/packages/engine/src/dataraum/analysis/semantic/db_models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/db_models.py
@@ -403,9 +403,13 @@ class TableEntity(Base):
     # PeriodicSnapshot subtype is derived from grain∩time at classification and
     # feeds the additivity COUNT rule. Nullable: an unclassified stub has no role.
     table_role: Mapped[str | None] = mapped_column(String)
-    # DAT-565: all event-time axes (multi-temporal) and recurring identity columns,
-    # each carrying a one-line note. JSON list[dict]; run-versioned like the rest.
-    #   time_columns:     [{"column": str, "aspect": str, "note": str}, ...]
+    # DAT-565: all date axes (multi-temporal) and recurring identity columns, each
+    # carrying a one-line note. JSON list[dict]; run-versioned like the rest. The
+    # event/attribute rule + single anchor are enforced at save by the TimeColumn
+    # submodel + TableEntityOutput validator (DAT-780) — this JSON interior is the
+    # typed home, so no scalar column / CheckConstraint carries the vocabulary.
+    #   time_columns:     [{"column": str, "aspect": str, "role": "event"|"attribute",
+    #                       "is_anchor": bool, "note": str}, ...]
     #   identity_columns: [{"column": str, "note": str}, ...]
     time_columns: Mapped[list[dict[str, Any]] | None] = mapped_column(JSON)
     identity_columns: Mapped[list[dict[str, Any]] | None] = mapped_column(JSON)

--- a/packages/engine/src/dataraum/analysis/semantic/models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/models.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from dataraum.core.models.base import (
     ColumnRef,
@@ -177,18 +177,43 @@ class RelationshipOutput(BaseModel):
 
 
 class TimeColumn(BaseModel):
-    """One event-time axis of a table (DAT-565 multi-temporal).
+    """One date axis of a table (DAT-565 multi-temporal; DAT-780 event/attribute rule).
 
-    A denormalized table commonly has several — each a distinct temporal lens
-    (order vs ship vs delivery). Carries a one-line note so downstream
-    formatters and the answer agent can pick the right lens per question."""
+    A denormalized table commonly has several date columns — each a distinct
+    temporal lens (order vs ship vs delivery). Carries a one-line note so
+    downstream formatters and the answer agent can pick the right lens per
+    question. The typed ``role`` splits genuine event axes (a trend/rollup can be
+    keyed on them) from attribute dates (dates the row merely refers to — never a
+    trend axis); ``is_anchor`` names the table's single primary event axis."""
 
     column: str = Field(description="Exact column name from the provided schema.")
     aspect: str = Field(
         description=(
             "The temporal aspect this column records, as a short lowercase label "
-            "(e.g. 'order', 'ship', 'delivery', 'payment') — distinguishes one "
-            "event date from another on the same row."
+            "(e.g. 'order', 'ship', 'delivery', 'payment', 'due') — distinguishes "
+            "one date from another on the same row."
+        )
+    )
+    role: Literal["event", "attribute"] = Field(
+        description=(
+            "The kind of date this column holds — a CLOSED vocabulary the LLM "
+            "commits per column (DAT-780). 'event' = WHEN the row's own event "
+            "occurred (order_date, ship_date, payment_date, a periodic-statement "
+            "period date) — a genuine time axis analysis may segment or roll up by. "
+            "'attribute' = a date the row merely REFERS to, not when the row's "
+            "event happened (due_date, valid_until, effective_from) — it gets "
+            "coverage like any column but must never be used as a trend/event axis. "
+            "Record metadata (created_at, updated_at, load timestamps) is NOT a "
+            "time column at all — leave it out of time_columns entirely."
+        )
+    )
+    is_anchor: bool = Field(
+        description=(
+            "True for the ONE primary event axis of this table — the default date "
+            "to trend/roll up by when a question names no specific lens. Exactly "
+            "one time_column with role='event' must set this true whenever the "
+            "table has any event date; every other time_column sets it false. An "
+            "attribute-role column can never be the anchor."
         )
     )
     note: str = Field(description="One sentence describing what this time column represents.")
@@ -242,14 +267,47 @@ class TableEntityOutput(BaseModel):
     time_columns: list[TimeColumn] = Field(
         default_factory=list,
         description=(
-            "EVERY column recording WHEN a row's event occurred (booking/transaction/"
-            "observation date) — each a distinct temporal lens the analysis can "
-            "segment by (e.g. order_date, ship_date, delivery_date). A denormalized "
-            "table commonly has several; emit all. Exclude attribute dates such as "
-            "due_date or valid_until, and record metadata like created_at. Empty if "
-            "the table has no event-time column."
+            "EVERY date column of the table, each tagged with a typed ``role`` "
+            "(DAT-780). Emit event dates — when a row's own event occurred "
+            "(order_date, ship_date, delivery_date, a periodic-statement period "
+            "date) — with role='event'; a denormalized table commonly has several, "
+            "emit all. Emit attribute dates — a date the row merely refers to "
+            "(due_date, valid_until, effective_from) — with role='attribute' so "
+            "they get coverage yet are never used as a trend axis. Leave record "
+            "metadata (created_at, updated_at, load timestamps) OUT entirely. "
+            "Whenever any event date exists, mark exactly ONE of them "
+            "is_anchor=true (the primary axis) and every other time_column false; "
+            "an attribute date can never be the anchor. Empty only if the table has "
+            "no date column at all."
         ),
     )
+
+    @model_validator(mode="after")
+    def _validate_time_anchor(self) -> TableEntityOutput:
+        """Enforce the DAT-780 anchor invariant at validation (the DAT-710 save seam).
+
+        A ValidationError here rides the existing ``_converse_and_validate`` repair
+        turn: the model re-emits a corrected anchor commitment, and a second failure
+        falls loud (``synthesize_tables`` → ``Result.fail`` → phase fails). The rules:
+
+        - every ``is_anchor`` column must be role='event' (an attribute anchor is a
+          contract violation) — this also rules out an anchor when no event date
+          exists, since any anchor would then be attribute-role;
+        - a table with any event date has EXACTLY ONE anchor.
+        """
+        anchors = [tc for tc in self.time_columns if tc.is_anchor]
+        if any(tc.role != "event" for tc in anchors):
+            raise ValueError(
+                f"table '{self.table_name}': an anchor time_column must have role='event' "
+                "(an attribute date can never be the trend anchor)"
+            )
+        events = [tc for tc in self.time_columns if tc.role == "event"]
+        if events and len(anchors) != 1:
+            raise ValueError(
+                f"table '{self.table_name}': exactly one event time_column must set "
+                f"is_anchor=true (found {len(anchors)} among {len(events)} event dates)"
+            )
+        return self
 
     identity_columns: list[IdentityColumn] = Field(
         default_factory=list,
@@ -412,7 +470,9 @@ class EntityDetection(BaseModel):
     # (``TableRole``). Derived at classification from the LLM's fact/dimension bit
     # + grain∩time; replaces the two booleans.
     table_role: str
-    time_columns: list[TimeColumn] = Field(default_factory=list)  # all event-time axes (DAT-565)
+    # All date axes (DAT-565), each typed role='event'|'attribute' with one
+    # is_anchor per table among the event axes (DAT-780).
+    time_columns: list[TimeColumn] = Field(default_factory=list)
     identity_columns: list[IdentityColumn] = Field(default_factory=list)  # recurring identities
 
 

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -1336,11 +1336,13 @@ def format_metadata_document(
             meta_parts.append(f"**Grain**: {', '.join(table.grain_columns)}.")
         if table.row_count:
             meta_parts.append(f"**Rows**: {table.row_count:,}.")
-        # All event-time axes (DAT-565): the answer agent picks the lens per
-        # question, so render each with its granularity/range and one-line note.
+        # Event-time axes (DAT-565): the answer agent picks the lens per question,
+        # so render each with its granularity/range and one-line note. EVENT-role
+        # only (DAT-780) — an attribute date (role='attribute') is a normal column
+        # in the table below, never presented here as a trend/time lens.
         for tc in table.time_columns:
             name = tc.get("column")
-            if not name:
+            if not name or tc.get("role") != "event":
                 continue
             time_col = next((c for c in table.columns if c.column_name == name), None)
             label = f"by {tc['aspect']}" if tc.get("aspect") else None

--- a/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
@@ -255,11 +255,15 @@ class SlicingPhase(BasePhase):
                         continue
                     # Fallback fires only when semantic found NO axis, so a fresh
                     # single-element list is correct; reassign (not append) so the
-                    # JSON column is marked dirty for the flush.
+                    # JSON column is marked dirty for the flush. Typed per DAT-780:
+                    # the one synthesized axis is a genuine event axis and, being the
+                    # only one, the table's anchor.
                     entity.time_columns = [
                         {
                             "column": chosen,
                             "aspect": "event",
+                            "role": "event",
+                            "is_anchor": True,
                             "note": "Event-time axis identified by the slice-agent fallback (semantic phase found none).",
                         }
                     ]
@@ -298,16 +302,22 @@ class SlicingPhase(BasePhase):
                         continue  # semantic or the agent already set it — never override
                     name = name_by_id.get(entity.table_id, "")
                     cols = flagged_by_table.get(name, [])
+                    # Typed per DAT-780: each flagged column is a genuine event axis;
+                    # ``cols`` is deterministically sorted (see ``dimension_time_axes``),
+                    # so anchoring the first is a stable, non-positional-accident choice
+                    # for a backstop that has no ranking signal — exactly one anchor.
                     entity.time_columns = [
                         {
                             "column": col,
                             "aspect": "event",
+                            "role": "event",
+                            "is_anchor": i == 0,
                             "note": (
                                 "Event-time axis from the deterministic "
                                 "is_dimension_time_column flag (DAT-720 backstop)."
                             ),
                         }
-                        for col in cols
+                        for i, col in enumerate(cols)
                     ]
                     logger.info("time_axis_filled_deterministic", table=name, columns=cols)
 

--- a/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
@@ -33,6 +33,18 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _has_event_axis(time_columns: list[dict[str, Any]] | None) -> bool:
+    """True when the entity already carries a genuine EVENT time axis (DAT-780).
+
+    The backstops fill an event axis only when semantic found none. Under the
+    event/attribute contract an attribute-only ``time_columns`` list is NOT an
+    event axis, so the guard must test role='event' membership — a bare
+    truthiness check would let an attribute date (due_date) suppress a real
+    event-axis backstop.
+    """
+    return any(tc.get("role") == "event" for tc in (time_columns or []))
+
+
 @analysis_phase
 class SlicingPhase(BasePhase):
     """LLM-powered slicing analysis phase.
@@ -244,8 +256,8 @@ class SlicingPhase(BasePhase):
                     for t in context_data.get("tables", [])
                 }
                 for entity in entities:
-                    if entity.time_columns:
-                        continue  # the table already has axes — inherit, never override
+                    if _has_event_axis(entity.time_columns):
+                        continue  # already has an EVENT axis — inherit, never override
                     table_name = name_by_id.get(entity.table_id, "")
                     chosen = slicing.time_columns.get(table_name)
                     if not chosen:
@@ -253,19 +265,21 @@ class SlicingPhase(BasePhase):
                     if chosen not in known_cols_by_table.get(table_name, set()):
                         logger.warning("time_axis_unknown_column", table=table_name, column=chosen)
                         continue
-                    # Fallback fires only when semantic found NO axis, so a fresh
-                    # single-element list is correct; reassign (not append) so the
-                    # JSON column is marked dirty for the flush. Typed per DAT-780:
-                    # the one synthesized axis is a genuine event axis and, being the
-                    # only one, the table's anchor.
+                    # Fires only when semantic found no EVENT axis (DAT-780): the one
+                    # synthesized axis is a genuine event axis and, being the only
+                    # event axis, the table's anchor. PRESERVE any attribute-role
+                    # dates semantic did emit (they get coverage; they are not event
+                    # axes); reassign a new list (not in-place append) so the JSON
+                    # column is marked dirty for the flush.
                     entity.time_columns = [
+                        *(entity.time_columns or []),
                         {
                             "column": chosen,
                             "aspect": "event",
                             "role": "event",
                             "is_anchor": True,
                             "note": "Event-time axis identified by the slice-agent fallback (semantic phase found none).",
-                        }
+                        },
                     ]
                     logger.info("time_axis_filled", table=table_name, column=chosen)
 
@@ -298,26 +312,31 @@ class SlicingPhase(BasePhase):
                         TableEntity.run_id == ctx.run_id,
                     )
                 ).scalars():
-                    if entity.time_columns:
-                        continue  # semantic or the agent already set it — never override
+                    if _has_event_axis(entity.time_columns):
+                        continue  # already has an EVENT axis — never override (DAT-780)
                     name = name_by_id.get(entity.table_id, "")
                     cols = flagged_by_table.get(name, [])
                     # Typed per DAT-780: each flagged column is a genuine event axis;
                     # ``cols`` is deterministically sorted (see ``dimension_time_axes``),
                     # so anchoring the first is a stable, non-positional-accident choice
                     # for a backstop that has no ranking signal — exactly one anchor.
+                    # PRESERVE any attribute-role dates semantic emitted (coverage-only,
+                    # never event axes).
                     entity.time_columns = [
-                        {
-                            "column": col,
-                            "aspect": "event",
-                            "role": "event",
-                            "is_anchor": i == 0,
-                            "note": (
-                                "Event-time axis from the deterministic "
-                                "is_dimension_time_column flag (DAT-720 backstop)."
-                            ),
-                        }
-                        for i, col in enumerate(cols)
+                        *(entity.time_columns or []),
+                        *(
+                            {
+                                "column": col,
+                                "aspect": "event",
+                                "role": "event",
+                                "is_anchor": i == 0,
+                                "note": (
+                                    "Event-time axis from the deterministic "
+                                    "is_dimension_time_column flag (DAT-720 backstop)."
+                                ),
+                            }
+                            for i, col in enumerate(cols)
+                        ),
                     ]
                     logger.info("time_axis_filled_deterministic", table=name, columns=cols)
 
@@ -659,12 +678,18 @@ class SlicingPhase(BasePhase):
                     dim_table_id = dim_table_by_fk_col.get(fk_col_id or "")
                     dim_suffix = dim_col.column_name.split("__", 1)[1] if fk_prefix else None
                     # Plural (DAT-565): the enriched suffix is a time axis if it
-                    # matches ANY of the dim table's event-time columns. (`x in
-                    # set` already short-circuits on a falsy ``dim_suffix``.)
+                    # matches ANY of the dim table's EVENT-time columns. EVENT-role
+                    # only (DAT-780) — an attribute date on the dim (valid_until) must
+                    # never be promoted to a fact's event axis by the backstop below.
+                    # (`x in set` already short-circuits on a falsy ``dim_suffix``.)
                     is_dim_time = bool(
                         dim_table_id
                         and dim_suffix
-                        in {tc.get("column") for tc in time_col_by_table.get(dim_table_id, [])}
+                        in {
+                            tc.get("column")
+                            for tc in time_col_by_table.get(dim_table_id, [])
+                            if tc.get("role") == "event"
+                        }
                     )
                     dim_entry: dict[str, Any] = {
                         "column_id": fk_col_id or dim_col.column_id,

--- a/packages/engine/src/dataraum/storage/property_graph.py
+++ b/packages/engine/src/dataraum/storage/property_graph.py
@@ -20,7 +20,8 @@ supported. So every read splits:
 and ``Table``; the vocabulary ``Concept`` vertices are P3. Edges/props carried:
 
     column_node  (KEY column_id)  props: semantic_role (has_role),
-                                          materialization (materializes_as)
+                                          materialization (materializes_as),
+                                          anchor_time_axis (witness axis ▸ declared anchor)
     table_node   (KEY table_id)   props: table_role (fact/periodic_snapshot/dimension)
     refs               table → table     [relationships]      FK topology (conformed dims excluded)
     has_dimension      table → column    [slice_definitions]  a fact's slice cols + dim identity
@@ -111,9 +112,11 @@ def _element_view_sql(name: str) -> str:
             f"LEFT JOIN {READ_TOKEN}.current_table_entities te ON te.table_id = t.table_id;"
         )
     if name == "og_columns":
-        # Column vertex: the physical column with its semantic role (has_role) and
-        # materialization (materializes_as → flow | stock). The two source columns
-        # carry DIFFERENT raw vocabularies and must be normalized, NOT COALESCEd raw:
+        # Column vertex: the physical column with its semantic role (has_role),
+        # materialization (materializes_as → flow | stock), and the anchor event-time
+        # axis a measure trends by (anchor_time_axis). The two materialization source
+        # columns carry DIFFERENT raw vocabularies and must be normalized, NOT
+        # COALESCEd raw:
         #   measure_aggregation_lineage.pattern ∈ {per_period, cumulative}  (DAT-491
         #     witness posterior — per_period ⇒ flow, cumulative ⇒ stock),
         #   column_concepts.temporal_behavior ∈ {additive, point_in_time}   (ontology
@@ -121,6 +124,18 @@ def _element_view_sql(name: str) -> str:
         # Prefer the data-reconciled witness posterior over the prior claim; NULL when
         # neither is present. Each LEFT-joined table is (column_id, run) unique after
         # head resolution, so the join is 1:1 and column_id is a valid KEY.
+        #
+        # anchor_time_axis — THE anchor event-time axis for this (measure) column, the
+        # ONE documented home of the DAT-780 witness-precedence rule (replaces the
+        # parked #486's positional `tc.ord = 1` pick; nothing reads array position):
+        #   1. the DAT-778 lineage-witness event-side axis (mal.event_time_axis_column)
+        #      where a witness reconciled this measure — the data-proven rollup axis;
+        #   2. else the table's DECLARED anchor — the one time_columns entry the LLM
+        #      committed with role='event' AND is_anchor=true (the typed field, NOT
+        #      list position). Read from current_table_entities' JSON interior via a
+        #      lateral; the save-time contract guarantees at most one such row.
+        # NULL when neither exists. The COALESCE order IS the precedence, exactly like
+        # materialization prefers the witness posterior over the concept prior.
         return (
             f"CREATE VIEW {READ_TOKEN}.og_columns AS\n"
             f"SELECT c.column_id::text AS column_id, c.table_id::text AS table_id, c.column_name,\n"
@@ -129,12 +144,20 @@ def _element_view_sql(name: str) -> str:
             f"         CASE mal.pattern WHEN 'per_period' THEN 'flow' WHEN 'cumulative' THEN 'stock' END,\n"
             f"         CASE cc.temporal_behavior WHEN 'additive' THEN 'flow'\n"
             f"                                   WHEN 'point_in_time' THEN 'stock' END\n"
-            f"       ) AS materialization\n"
+            f"       ) AS materialization,\n"
+            f"       COALESCE(mal.event_time_axis_column, declared_anchor.column_name) AS anchor_time_axis\n"
             f"FROM {READ_TOKEN}.current_columns c\n"
             f"LEFT JOIN {READ_TOKEN}.current_semantic_annotations sa ON sa.column_id = c.column_id\n"
             f"LEFT JOIN {READ_TOKEN}.current_column_concepts cc ON cc.column_id = c.column_id\n"
             f"LEFT JOIN {READ_TOKEN}.current_measure_aggregation_lineage mal\n"
-            f"       ON mal.measure_column_id = c.column_id;"
+            f"       ON mal.measure_column_id = c.column_id\n"
+            f"LEFT JOIN {READ_TOKEN}.current_table_entities te ON te.table_id = c.table_id\n"
+            f"LEFT JOIN LATERAL (\n"
+            f"    SELECT elem->>'column' AS column_name\n"
+            f"    FROM json_array_elements(COALESCE(te.time_columns, '[]'::json)) AS elem\n"
+            f"    WHERE elem->>'role' = 'event' AND (elem->>'is_anchor')::boolean IS TRUE\n"
+            f"    LIMIT 1\n"
+            f"  ) declared_anchor ON TRUE;"
         )
     if name == "og_concepts":
         # Concept vertex: the workspace's typed vocabulary (DAT-728). Active rows
@@ -298,7 +321,8 @@ def _property_graph_sql() -> str:
         f"    {READ_TOKEN}.og_tables KEY (table_id) LABEL table_node\n"
         f"      PROPERTIES (table_id, table_name, layer, table_role, detected_entity_type),\n"
         f"    {READ_TOKEN}.og_columns KEY (column_id) LABEL column_node\n"
-        f"      PROPERTIES (column_id, table_id, column_name, semantic_role, materialization),\n"
+        f"      PROPERTIES (column_id, table_id, column_name, semantic_role, materialization,\n"
+        f"                  anchor_time_axis),\n"
         f"    {READ_TOKEN}.og_concepts KEY (concept_id) LABEL concept_node\n"
         f"      PROPERTIES (concept_id, vertical, name, kind)\n"
         f"  )\n"

--- a/packages/engine/src/dataraum/storage/property_graph.py
+++ b/packages/engine/src/dataraum/storage/property_graph.py
@@ -125,9 +125,11 @@ def _element_view_sql(name: str) -> str:
         # neither is present. Each LEFT-joined table is (column_id, run) unique after
         # head resolution, so the join is 1:1 and column_id is a valid KEY.
         #
-        # anchor_time_axis — THE anchor event-time axis for this (measure) column, the
-        # ONE documented home of the DAT-780 witness-precedence rule (replaces the
-        # parked #486's positional `tc.ord = 1` pick; nothing reads array position):
+        # anchor_time_axis — THE anchor event-time axis for this column, the ONE
+        # documented home of the DAT-780 witness-precedence rule (replaces the parked
+        # #486's positional `tc.ord = 1` pick; nothing reads array position). Computed
+        # for EVERY column vertex but only meaningful for a MEASURE (its trend axis) —
+        # a non-measure resolves to its table's declared anchor, harmlessly unread:
         #   1. the DAT-778 lineage-witness event-side axis (mal.event_time_axis_column)
         #      where a witness reconciled this measure — the data-proven rollup axis;
         #   2. else the table's DECLARED anchor — the one time_columns entry the LLM

--- a/packages/engine/tests/integration/graphs/test_additivity_resolver.py
+++ b/packages/engine/tests/integration/graphs/test_additivity_resolver.py
@@ -95,7 +95,16 @@ def _seed(
             detected_entity_type="event",
             table_role=derive_table_role(True, grain_columns, time_columns),
             grain_columns=grain_columns,
-            time_columns=[{"column": c, "aspect": "t", "note": ""} for c in time_columns],
+            time_columns=[
+                {
+                    "column": c,
+                    "aspect": "t",
+                    "role": "event",
+                    "is_anchor": i == 0,
+                    "note": "",
+                }
+                for i, c in enumerate(time_columns)
+            ],
         )
     )
     session.add(

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -65,6 +65,9 @@ _TABLES = [
 ]
 _COLUMNS = [
     ("c_amt", "t1", "amount", 1),
+    # A 2nd measure on t1 with NO lineage witness — its anchor_time_axis must fall
+    # back to t1's DECLARED anchor (DAT-780 witness-precedence fallback path).
+    ("c_amt2", "t1", "amount_declared", 3),
     ("c_k1", "t1", "account_id", 2),
     ("c_k2", "t2", "account_id", 1),
     ("c_k3", "t3", "group_id", 1),
@@ -112,8 +115,8 @@ def _seed(engine: Engine) -> None:
             f"INSERT INTO columns (column_id, table_id, column_name, column_position) "
             f"VALUES ('{cid}', '{tid}', '{name}', {pos})"
         )
-    # has_role: amount is a measure, account_id a key.
-    for cid, role in [("c_amt", "measure"), ("c_k1", "key")]:
+    # has_role: amount / amount_declared are measures, account_id a key.
+    for cid, role in [("c_amt", "measure"), ("c_amt2", "measure"), ("c_k1", "key")]:
         stmts.append(
             f"INSERT INTO semantic_annotations "
             f"(annotation_id, column_id, run_id, semantic_role, annotated_at) "
@@ -191,12 +194,35 @@ def _seed(engine: Engine) -> None:
             f"VALUES ('{rid}', '{RUN}', '{ft}', '{fc}', '{tt}', '{tc}', "
             f"'foreign_key', 'many_to_one', 0.9, 'judge', '{TS}')"
         )
+    # t1 carries a DECLARED time-axis set with the anchor at index 1 (NOT 0) and an
+    # attribute date mixed in — the scrambled-order proof (DAT-780): a positional
+    # reader would wrongly pick 'created_date' at index 0, the view must pick the
+    # is_anchor='txn_date' regardless of position, and never the attribute 'due_date'.
+    t1_time_columns = (
+        '[{"column": "created_date", "aspect": "created", "role": "event", '
+        '"is_anchor": false, "note": "x"}, '
+        '{"column": "txn_date", "aspect": "txn", "role": "event", '
+        '"is_anchor": true, "note": "x"}, '
+        '{"column": "due_date", "aspect": "due", "role": "attribute", '
+        '"is_anchor": false, "note": "x"}]'
+    )
+    time_cols_by_entity = {"t1": t1_time_columns}
     for eid, tid, role in [("e_j", "t1", "fact"), ("e_a", "t2", "dimension")]:
-        stmts.append(
-            "INSERT INTO table_entities "
-            "(entity_id, table_id, run_id, detected_entity_type, table_role, detected_at) "
-            f"VALUES ('{eid}', '{tid}', '{RUN}', 'entity', '{role}', '{TS}')"
-        )
+        tcs = time_cols_by_entity.get(tid)
+        if tcs is not None:
+            stmts.append(
+                "INSERT INTO table_entities "
+                "(entity_id, table_id, run_id, detected_entity_type, table_role, "
+                " time_columns, detected_at) "
+                f"VALUES ('{eid}', '{tid}', '{RUN}', 'entity', '{role}', "
+                f"'{tcs}'::json, '{TS}')"
+            )
+        else:
+            stmts.append(
+                "INSERT INTO table_entities "
+                "(entity_id, table_id, run_id, detected_entity_type, table_role, detected_at) "
+                f"VALUES ('{eid}', '{tid}', '{RUN}', 'entity', '{role}', '{TS}')"
+            )
     # derived_from: journal_enriched view over the journal fact + the accounts dim.
     stmts.append(
         "INSERT INTO enriched_views "
@@ -283,10 +309,46 @@ def test_measure_column_matches_its_materialization(graph_engine: Engine) -> Non
         "COLUMNS (c.column_name AS column_name, c.materialization AS materialization))"
     )
     with graph_engine.connect() as conn:
+        rows = dict(conn.execute(text(sql)).all())
+    # 'amount' has a witness: 'per_period' normalizes to flow and beats the
+    # 'point_in_time' concept claim (→ stock). 'amount_declared' has neither witness
+    # nor concept claim → NULL materialization.
+    assert rows == {"amount": "flow", "amount_declared": None}
+
+
+def test_measure_anchor_time_axis_prefers_the_witness(graph_engine: Engine) -> None:
+    """DAT-780 Gap 2: a measure's anchor is the DAT-778 witness event-side axis where
+    a witness exists — precedence over the table's declared anchor, expressed by the
+    COALESCE order (mirrors materialization's witness-over-claim precedence)."""
+    sql = (
+        f"SELECT anchor FROM GRAPH_TABLE ({_graph_ref()} "
+        "MATCH (c IS column_node WHERE c.column_name = 'amount') "
+        "COLUMNS (c.anchor_time_axis AS anchor))"
+    )
+    with graph_engine.connect() as conn:
         rows = conn.execute(text(sql)).all()
-    # amount is the only measure; the witness 'per_period' normalizes to flow and
-    # beats the 'point_in_time' concept claim (→ stock).
-    assert rows == [("amount", "flow")]
+    # c_amt's witness row set event_time_axis_column='period_date'; it wins over t1's
+    # declared anchor 'txn_date'.
+    assert rows == [("period_date",)]
+
+
+def test_measure_anchor_time_axis_falls_back_to_declared_anchor(graph_engine: Engine) -> None:
+    """DAT-780 Gap 2: with no witness, the anchor is the table's TYPED declared anchor
+    (is_anchor=true, role='event') — never array position, never an attribute date.
+
+    t1's declared time_columns list the anchor 'txn_date' at index 1, with
+    'created_date' at index 0 (a positional reader's wrong pick) and the attribute
+    'due_date' present. 'amount_declared' has no witness, so it resolves the declared
+    anchor — proving the scrambled-order case and the attribute exclusion at once.
+    """
+    sql = (
+        f"SELECT anchor FROM GRAPH_TABLE ({_graph_ref()} "
+        "MATCH (c IS column_node WHERE c.column_name = 'amount_declared') "
+        "COLUMNS (c.anchor_time_axis AS anchor))"
+    )
+    with graph_engine.connect() as conn:
+        rows = conn.execute(text(sql)).all()
+    assert rows == [("txn_date",)]
 
 
 def test_references_edges_match_the_fk_topology(graph_engine: Engine) -> None:

--- a/packages/engine/tests/unit/analysis/lineage/test_processor.py
+++ b/packages/engine/tests/unit/analysis/lineage/test_processor.py
@@ -91,6 +91,7 @@ def _seed(
     folded: bool = False,
     axis_columns: bool = False,
     values: tuple[str, ...] = _VALUES,
+    measure_axis_role: str = "event",
 ) -> dict[str, str]:
     """Seed Tables/Columns/SliceDefinitions/TableEntity + the DuckDB rows.
 
@@ -169,9 +170,29 @@ def _seed(
         # The agent-named time axes the inline producer resolves (DAT-491/565).
         # multi_axis adds a SECOND, degenerate axis (``ship_date``, constant) on
         # the measure fact: the search must compete both and keep the good one.
-        axes = [{"column": "period_date", "aspect": "period", "note": "Period."}]
+        # DAT-780: the measure fact's axis role is parametrized so a test can prove
+        # an attribute-role date is filtered out of the event-axis set. is_anchor is
+        # only meaningful for an event axis; keep it false when the role is attribute.
+        m_role = measure_axis_role if name == "trial_balance" else "event"
+        axes = [
+            {
+                "column": "period_date",
+                "aspect": "period",
+                "role": m_role,
+                "is_anchor": m_role == "event",
+                "note": "Period.",
+            }
+        ]
         if multi_axis and name == "trial_balance":
-            axes.append({"column": "ship_date", "aspect": "ship", "note": "Shipped."})
+            axes.append(
+                {
+                    "column": "ship_date",
+                    "aspect": "ship",
+                    "role": "event",
+                    "is_anchor": False,
+                    "note": "Shipped.",
+                }
+            )
         if axis_columns:
             for pos, tc in enumerate(axes, start=len(cols)):
                 axis_column = Column(
@@ -381,7 +402,15 @@ def _seed_series(
                 run_id=_RUN,
                 table_id=table.table_id,
                 detected_entity_type="fact",
-                time_columns=[{"column": "period_date", "aspect": "period", "note": "Period."}],
+                time_columns=[
+                    {
+                        "column": "period_date",
+                        "aspect": "period",
+                        "role": "event",
+                        "is_anchor": True,
+                        "note": "Period.",
+                    }
+                ],
             )
         )
         session.add(
@@ -652,6 +681,21 @@ class TestDiscoverAggregationLineage:
         # catalog's own SliceDefinition.column_id (schema-guaranteed NOT NULL).
         assert row.measure_slice_column_id == ids["trial_balance.balance"]
         assert row.event_slice_column_id == ids["journal_lines.debit"]
+
+    def test_attribute_role_axis_is_excluded_from_rollup(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """DAT-780 Gap 1: an attribute-role date is never a rollup axis.
+
+        The measure fact's only date is tagged role='attribute' (a due_date-style
+        column). The consumer filters strictly on role='event', so trial_balance
+        contributes no time axis, no measure series can form, and discovery
+        abstains — proving the event/attribute rule is enforced at the consumer,
+        not merely documented. With role='event' the SAME fixture reconciles.
+        """
+        ids_attr = _seed(real_session, duck, measure_axis_role="attribute")
+        assert _discover(real_session, duck, ids_attr) == 0
+        assert _row_for(real_session, ids_attr["trial_balance.balance"]) is None
 
     def test_time_axis_column_id_is_null_when_axis_name_unresolvable(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection

--- a/packages/engine/tests/unit/analysis/semantic/test_models.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_models.py
@@ -2,7 +2,29 @@
 
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
 from dataraum.analysis.semantic.models import TableSynthesisOutput
+
+
+def _table(time_columns: list[dict], **overrides: object) -> dict:
+    """A minimal valid TableEntityOutput dict with the given time_columns."""
+    base = {
+        "table_name": "orders",
+        "entity_type": "orders",
+        "description": "Customer orders.",
+        "is_fact_table": True,
+        "grain": ["order_id"],
+        "time_columns": time_columns,
+        "identity_columns": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _synthesis(table: dict) -> dict:
+    return {"tables": [table], "relationships": [], "column_concepts": []}
 
 
 def test_table_synthesis_output_has_no_column_field() -> None:
@@ -22,8 +44,9 @@ def test_table_synthesis_output_has_no_column_field() -> None:
 
 
 def test_table_entity_output_parses_multi_time_and_identity() -> None:
-    """A denormalized table emits every event-time axis (aspect + note) plus its
-    recurring identity columns, each with a one-line note (DAT-565)."""
+    """A denormalized table emits every event-time axis (aspect + role + anchor +
+    note) plus its recurring identity columns, each with a one-line note
+    (DAT-565/780)."""
     out = TableSynthesisOutput.model_validate(
         {
             "tables": [
@@ -34,8 +57,27 @@ def test_table_entity_output_parses_multi_time_and_identity() -> None:
                     "is_fact_table": True,
                     "grain": ["order_id"],
                     "time_columns": [
-                        {"column": "order_date", "aspect": "order", "note": "When placed."},
-                        {"column": "ship_date", "aspect": "ship", "note": "When shipped."},
+                        {
+                            "column": "order_date",
+                            "aspect": "order",
+                            "role": "event",
+                            "is_anchor": True,
+                            "note": "When placed.",
+                        },
+                        {
+                            "column": "ship_date",
+                            "aspect": "ship",
+                            "role": "event",
+                            "is_anchor": False,
+                            "note": "When shipped.",
+                        },
+                        {
+                            "column": "due_date",
+                            "aspect": "due",
+                            "role": "attribute",
+                            "is_anchor": False,
+                            "note": "When payment is owed.",
+                        },
                     ],
                     "identity_columns": [
                         {"column": "customer_id", "note": "Buying account; recurs across orders."}
@@ -47,9 +89,155 @@ def test_table_entity_output_parses_multi_time_and_identity() -> None:
         }
     )
     table = out.tables[0]
-    assert [tc.column for tc in table.time_columns] == ["order_date", "ship_date"]
+    assert [tc.column for tc in table.time_columns] == ["order_date", "ship_date", "due_date"]
     assert table.time_columns[1].aspect == "ship"
+    # role + anchor are committed per column (DAT-780).
+    assert [tc.role for tc in table.time_columns] == ["event", "event", "attribute"]
+    assert [tc.is_anchor for tc in table.time_columns] == [True, False, False]
     assert table.identity_columns[0].column == "customer_id"
+
+
+def test_anchor_defaults_to_position_are_rejected_scrambled_order() -> None:
+    """The anchor is the TYPED is_anchor flag, never array position (DAT-780).
+
+    The anchor sits at index 1 here; a positional reader would wrongly pick
+    order_date at index 0. The model accepts it because is_anchor names ship_date,
+    proving position carries no meaning.
+    """
+    out = TableSynthesisOutput.model_validate(
+        _synthesis(
+            _table(
+                [
+                    {
+                        "column": "order_date",
+                        "aspect": "order",
+                        "role": "event",
+                        "is_anchor": False,
+                        "note": "When placed.",
+                    },
+                    {
+                        "column": "ship_date",
+                        "aspect": "ship",
+                        "role": "event",
+                        "is_anchor": True,
+                        "note": "When shipped.",
+                    },
+                ]
+            )
+        )
+    )
+    anchors = [tc.column for tc in out.tables[0].time_columns if tc.is_anchor]
+    assert anchors == ["ship_date"]
+
+
+def test_zero_anchor_with_events_present_is_rejected() -> None:
+    """A table with event dates but no anchor fails validation → repair turn."""
+    with pytest.raises(ValidationError, match="exactly one event time_column"):
+        TableSynthesisOutput.model_validate(
+            _synthesis(
+                _table(
+                    [
+                        {
+                            "column": "order_date",
+                            "aspect": "order",
+                            "role": "event",
+                            "is_anchor": False,
+                            "note": "When placed.",
+                        },
+                    ]
+                )
+            )
+        )
+
+
+def test_two_anchors_is_rejected() -> None:
+    """A table with two anchors fails validation → repair turn."""
+    with pytest.raises(ValidationError, match="exactly one event time_column"):
+        TableSynthesisOutput.model_validate(
+            _synthesis(
+                _table(
+                    [
+                        {
+                            "column": "order_date",
+                            "aspect": "order",
+                            "role": "event",
+                            "is_anchor": True,
+                            "note": "When placed.",
+                        },
+                        {
+                            "column": "ship_date",
+                            "aspect": "ship",
+                            "role": "event",
+                            "is_anchor": True,
+                            "note": "When shipped.",
+                        },
+                    ]
+                )
+            )
+        )
+
+
+def test_attribute_role_anchor_is_rejected() -> None:
+    """An anchor with role='attribute' is a contract violation (DAT-780)."""
+    with pytest.raises(ValidationError, match="anchor time_column must have role='event'"):
+        TableSynthesisOutput.model_validate(
+            _synthesis(
+                _table(
+                    [
+                        {
+                            "column": "order_date",
+                            "aspect": "order",
+                            "role": "event",
+                            "is_anchor": False,
+                            "note": "When placed.",
+                        },
+                        {
+                            "column": "due_date",
+                            "aspect": "due",
+                            "role": "attribute",
+                            "is_anchor": True,
+                            "note": "When owed.",
+                        },
+                    ]
+                )
+            )
+        )
+
+
+def test_attribute_only_table_needs_no_anchor() -> None:
+    """A table whose only dates are attributes has no event axis, so no anchor."""
+    out = TableSynthesisOutput.model_validate(
+        _synthesis(
+            _table(
+                [
+                    {
+                        "column": "valid_until",
+                        "aspect": "valid",
+                        "role": "attribute",
+                        "is_anchor": False,
+                        "note": "Contract expiry.",
+                    },
+                ]
+            )
+        )
+    )
+    assert all(not tc.is_anchor for tc in out.tables[0].time_columns)
+
+
+def test_no_time_columns_is_clean() -> None:
+    """A table with no date column at all validates with an empty list."""
+    ok = TableSynthesisOutput.model_validate(_synthesis(_table([])))
+    assert ok.tables[0].time_columns == []
+
+
+def test_missing_role_is_a_validation_error() -> None:
+    """`role` is required — an omission raises so the DAT-710 repair turn fires."""
+    with pytest.raises(ValidationError):
+        TableSynthesisOutput.model_validate(
+            _synthesis(
+                _table([{"column": "order_date", "aspect": "order", "note": "When placed."}])
+            )
+        )
 
 
 def test_table_synthesis_output_validates_entities_and_relationships() -> None:

--- a/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_phase_split.py
@@ -288,8 +288,20 @@ class TestSynthesizeAndStoreTables:
                             grain_columns=["order_id"],
                             table_role="fact",
                             time_columns=[
-                                TimeColumn(column="order_date", aspect="order", note="Placed."),
-                                TimeColumn(column="ship_date", aspect="ship", note="Shipped."),
+                                TimeColumn(
+                                    column="order_date",
+                                    aspect="order",
+                                    role="event",
+                                    is_anchor=True,
+                                    note="Placed.",
+                                ),
+                                TimeColumn(
+                                    column="ship_date",
+                                    aspect="ship",
+                                    role="event",
+                                    is_anchor=False,
+                                    note="Shipped.",
+                                ),
                             ],
                             identity_columns=[
                                 IdentityColumn(column="customer_id", note="Buying account.")
@@ -645,8 +657,20 @@ class TestSynthesizeAndStoreTables:
                             grain_columns=["order_id"],
                             table_role="fact",
                             time_columns=[
-                                TimeColumn(column="order_date", aspect="order", note="Placed."),
-                                TimeColumn(column="ship_date", aspect="ship", note="Shipped."),
+                                TimeColumn(
+                                    column="order_date",
+                                    aspect="order",
+                                    role="event",
+                                    is_anchor=True,
+                                    note="Placed.",
+                                ),
+                                TimeColumn(
+                                    column="ship_date",
+                                    aspect="ship",
+                                    role="event",
+                                    is_anchor=False,
+                                    note="Shipped.",
+                                ),
                             ],
                             identity_columns=[
                                 IdentityColumn(column="customer_id", note="Buying account.")

--- a/packages/engine/tests/unit/analysis/semantic/test_synthesis_repair.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_synthesis_repair.py
@@ -31,6 +31,41 @@ _MALFORMED_REL = {k: v for k, v in _COMPLETE_REL.items() if k != "to_column"}
 _VALID_INPUT = {"tables": [], "relationships": [_COMPLETE_REL], "column_concepts": []}
 _MALFORMED_INPUT = {"tables": [], "relationships": [_MALFORMED_REL], "column_concepts": []}
 
+# DAT-780: a table with event dates but no anchor is a save-time contract
+# violation the TableEntityOutput validator raises — routed through the SAME
+# repair turn as a malformed relationship.
+_TABLE_NO_ANCHOR = {
+    "table_name": "orders",
+    "entity_type": "orders",
+    "description": "Customer orders.",
+    "is_fact_table": True,
+    "grain": ["order_id"],
+    "time_columns": [
+        {
+            "column": "order_date",
+            "aspect": "order",
+            "role": "event",
+            "is_anchor": False,
+            "note": "When placed.",
+        }
+    ],
+    "identity_columns": [],
+}
+_TABLE_WITH_ANCHOR = {
+    **_TABLE_NO_ANCHOR,
+    "time_columns": [{**_TABLE_NO_ANCHOR["time_columns"][0], "is_anchor": True}],
+}
+_ANCHORLESS_INPUT = {
+    "tables": [_TABLE_NO_ANCHOR],
+    "relationships": [],
+    "column_concepts": [],
+}
+_ANCHORED_INPUT = {
+    "tables": [_TABLE_WITH_ANCHOR],
+    "relationships": [],
+    "column_concepts": [],
+}
+
 
 def _response(tool_input: dict | None) -> MagicMock:
     response = MagicMock()
@@ -128,6 +163,38 @@ def test_missing_field_is_repaired_by_the_model(monkeypatch) -> None:
 
 def test_second_validation_failure_fails_loud(monkeypatch) -> None:
     provider = _provider(_response(_MALFORMED_INPUT), _response(_MALFORMED_INPUT))
+    agent = _agent_with(provider, monkeypatch)
+
+    result = agent.synthesize_tables(MagicMock(), ["t1"])
+
+    assert not result.success
+    assert "after a repair turn" in result.error
+    assert provider.converse.call_count == 2
+
+
+def test_missing_anchor_is_repaired_by_the_model(monkeypatch) -> None:
+    """DAT-780: a table with event dates but no is_anchor is a validation error the
+    repair turn catches — the model re-emits with the anchor committed, and
+    begin_session is never failed. Proves the anchor invariant rides the DAT-710 seam."""
+    provider = _provider(_response(_ANCHORLESS_INPUT), _response(_ANCHORED_INPUT))
+    agent = _agent_with(provider, monkeypatch)
+
+    result = agent.synthesize_tables(MagicMock(), ["t1"])
+
+    assert result.success
+    axes = result.value.entity_detections[0].time_columns
+    assert [tc.is_anchor for tc in axes] == [True]
+    assert provider.converse.call_count == 2
+
+    repair_request = provider.converse.call_args_list[1].args[0]
+    content = repair_request.messages[0].content
+    assert "Validation error" in content
+    assert "is_anchor" in content  # the invariant message rides along
+
+
+def test_persistent_missing_anchor_fails_loud(monkeypatch) -> None:
+    """A model that cannot satisfy the anchor invariant twice fails loud (DAT-780)."""
+    provider = _provider(_response(_ANCHORLESS_INPUT), _response(_ANCHORLESS_INPUT))
     agent = _agent_with(provider, monkeypatch)
 
     result = agent.synthesize_tables(MagicMock(), ["t1"])

--- a/packages/engine/tests/unit/graphs/test_context.py
+++ b/packages/engine/tests/unit/graphs/test_context.py
@@ -100,7 +100,15 @@ class TestTableContext:
             table_role="fact",
             table_description="Financial transactions table",
             grain_columns=["id"],
-            time_columns=[{"column": "created_at", "aspect": "created", "note": "Created."}],
+            time_columns=[
+                {
+                    "column": "created_at",
+                    "aspect": "created",
+                    "role": "event",
+                    "is_anchor": True,
+                    "note": "Created.",
+                }
+            ],
             columns=[col1, col2],
         )
         assert ctx.row_count == 1000
@@ -244,7 +252,13 @@ class TestFormatMetadataDocument:
             table_description="Records of all financial transactions",
             grain_columns=["transaction_id"],
             time_columns=[
-                {"column": "created_at", "aspect": "created", "note": "When the row was created."}
+                {
+                    "column": "created_at",
+                    "aspect": "created",
+                    "role": "event",
+                    "is_anchor": True,
+                    "note": "When the row was created.",
+                }
             ],
             identity_columns=[{"column": "customer_id", "note": "Recurring customer identity."}],
             columns=[

--- a/packages/engine/tests/unit/graphs/test_context.py
+++ b/packages/engine/tests/unit/graphs/test_context.py
@@ -298,6 +298,43 @@ class TestFormatMetadataDocument:
         assert "customer_id" in result
         assert "Recurring customer identity" in result
 
+    def test_attribute_role_time_column_is_not_rendered_as_a_lens(self) -> None:
+        """DAT-780: an attribute-role date is NOT presented as a time lens.
+
+        The answer agent picks a trend lens from these entries, so an attribute date
+        (due_date) must never appear as a 'Time column'/'by <aspect>' lens — it stays
+        a normal column in the table below."""
+        table = TableContext(
+            table_id="t1",
+            table_name="orders",
+            row_count=10,
+            column_count=2,
+            table_role="fact",
+            grain_columns=["order_id"],
+            time_columns=[
+                {
+                    "column": "order_date",
+                    "aspect": "order",
+                    "role": "event",
+                    "is_anchor": True,
+                    "note": "When placed.",
+                },
+                {
+                    "column": "due_date",
+                    "aspect": "due",
+                    "role": "attribute",
+                    "is_anchor": False,
+                    "note": "When payment is owed.",
+                },
+            ],
+        )
+        ctx = GraphExecutionContext(tables=[table], total_tables=1, total_columns=2)
+        result = format_metadata_document(ctx)
+        # The event axis renders as a lens; the attribute date does NOT.
+        assert "by order" in result
+        assert "by due" not in result
+        assert "When payment is owed." not in result
+
     def test_column_table_format(self) -> None:
         """Columns are formatted in a table with business metadata."""
         col = ColumnContext(

--- a/packages/engine/tests/unit/graphs/test_context_builder.py
+++ b/packages/engine/tests/unit/graphs/test_context_builder.py
@@ -172,7 +172,13 @@ class TestBuilderExtractsTableEntity:
                 description="Records of all financial transactions",
                 grain_columns=["invoice_id"],
                 time_columns=[
-                    {"column": "created_at", "aspect": "created", "note": "Row created."}
+                    {
+                        "column": "created_at",
+                        "aspect": "created",
+                        "role": "event",
+                        "is_anchor": True,
+                        "note": "Row created.",
+                    }
                 ],
                 identity_columns=[
                     {"column": "customer_id", "note": "Recurring customer identity."}

--- a/packages/engine/tests/unit/pipeline/test_slicing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_slicing_phase.py
@@ -34,9 +34,21 @@ from dataraum.storage.upsert import upsert
 from tests.conftest import baseline_run_id
 
 
-def _axes(column: str | None) -> list[dict[str, str]]:
-    """Plural ``time_columns`` JSON for a single named axis (DAT-565), or empty."""
-    return [{"column": column, "aspect": "event", "note": "seed axis."}] if column else []
+def _axes(column: str | None) -> list[dict[str, object]]:
+    """Plural ``time_columns`` JSON for a single named event axis (DAT-565/780), or empty."""
+    return (
+        [
+            {
+                "column": column,
+                "aspect": "event",
+                "role": "event",
+                "is_anchor": True,
+                "note": "seed axis.",
+            }
+        ]
+        if column
+        else []
+    )
 
 
 def _seed(

--- a/packages/engine/tests/unit/pipeline/test_slicing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_slicing_phase.py
@@ -55,8 +55,9 @@ def _seed(
     session: Session,
     *,
     dim_time_column: str | None = "date",
-    dim_axes: list[dict[str, str]] | None = None,
+    dim_axes: list[dict[str, Any]] | None = None,
     fact_time_column: str | None = None,
+    fact_axes: list[dict[str, Any]] | None = None,
     link_relationship: bool = True,
 ) -> dict[str, Any]:
     """Seed a fact table with an enriched view exposing FK-prefixed dim columns.
@@ -116,7 +117,7 @@ def _seed(
         table_id=fact.table_id,
         run_id=None,
         detected_entity_type="transaction",
-        time_columns=_axes(fact_time_column),
+        time_columns=fact_axes if fact_axes is not None else _axes(fact_time_column),
         detection_source="llm",
     )
     dim_entity = TableEntity(
@@ -245,8 +246,14 @@ class TestBuildContextDataTimeAxis:
         seeded = _seed(
             session,
             dim_axes=[
-                {"column": "other", "aspect": "x", "note": "n"},
-                {"column": "date", "aspect": "event", "note": "n"},
+                {"column": "other", "aspect": "x", "role": "event", "is_anchor": True, "note": "n"},
+                {
+                    "column": "date",
+                    "aspect": "event",
+                    "role": "event",
+                    "is_anchor": False,
+                    "note": "n",
+                },
             ],
         )
         fact: Table = seeded["fact"]
@@ -273,6 +280,33 @@ class TestBuildContextDataTimeAxis:
         by_name = _columns_by_name(data["tables"][0])
         assert by_name["invoice_id__date"]["is_dimension_time_column"] is False
         assert by_name["invoice_id__status"]["is_dimension_time_column"] is False
+
+    def test_attribute_role_dim_date_is_not_flagged(
+        self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection
+    ) -> None:
+        """DAT-780: a dim's ATTRIBUTE-role date (valid_until) whose suffix matches an
+        enriched column must NOT be flagged is_dimension_time_column — otherwise the
+        deterministic backstop would promote it to a false event axis on the fact."""
+        seeded = _seed(
+            session,
+            dim_axes=[
+                {
+                    "column": "date",
+                    "aspect": "due",
+                    "role": "attribute",
+                    "is_anchor": False,
+                    "note": "A date the row refers to, not an event.",
+                }
+            ],
+        )
+        fact: Table = seeded["fact"]
+
+        data = SlicingPhase()._build_context_data(
+            _ctx(session, duckdb_conn, [fact.table_id]), [fact]
+        )
+
+        by_name = _columns_by_name(data["tables"][0])
+        assert by_name["invoice_id__date"]["is_dimension_time_column"] is False
 
     def test_no_flag_without_relationship_provenance(
         self, session: Session, duckdb_conn: duckdb.DuckDBPyConnection
@@ -438,6 +472,50 @@ class TestRunTimeAxisFill:
         assert [tc["column"] for tc in seeded["fact_entity"].time_columns] == ["invoice_id__date"]
         assert any(e["event"] == "time_axis_filled" for e in logs)
         assert not any(e["event"] == "time_axis_unknown_column" for e in logs)
+
+    def test_attribute_only_fact_still_gets_backstop_axis_preserving_attribute(
+        self,
+        mock_load_config: MagicMock,
+        mock_create_provider: MagicMock,
+        mock_renderer_cls: MagicMock,
+        mock_agent_cls: MagicMock,
+        session: Session,
+        duckdb_conn: duckdb.DuckDBPyConnection,
+    ) -> None:
+        """DAT-780: a fact whose only date is attribute-role still gets the event-axis
+        backstop, and the attribute date is preserved (coverage, not an event axis).
+
+        Pre-DAT-780 the guard was bare truthiness; an attribute-only list would
+        suppress the backstop. The guard now tests role='event', and the fill
+        appends rather than clobbers.
+        """
+        mock_load_config.return_value = _mock_llm_config()
+        mock_agent_cls.return_value.analyze.return_value = _analysis_result(
+            {"invoices": "invoice_id__date"}
+        )
+        seeded = _seed(
+            session,
+            fact_axes=[
+                {
+                    "column": "due_date",
+                    "aspect": "due",
+                    "role": "attribute",
+                    "is_anchor": False,
+                    "note": "A date the row refers to.",
+                }
+            ],
+        )
+
+        with capture_logs() as logs:
+            result = SlicingPhase()._run(_ctx(session, duckdb_conn, [seeded["fact"].table_id]))
+
+        assert result.status == PhaseStatus.COMPLETED
+        axes = seeded["fact_entity"].time_columns
+        # The attribute date survives; the backstop appended the event axis + anchor.
+        assert [tc["column"] for tc in axes] == ["due_date", "invoice_id__date"]
+        assert [tc["role"] for tc in axes] == ["attribute", "event"]
+        assert [tc["is_anchor"] for tc in axes] == [False, True]
+        assert any(e["event"] == "time_axis_filled" for e in logs)
 
     def test_hallucinated_column_is_rejected(
         self,


### PR DESCRIPTION
## Task

[DAT-780](https://real-dataraum.atlassian.net/browse/DAT-780) — harden the `time_columns` contract (epic DAT-725 substrate hardening, Wave 3). Blocked-by DAT-778 (Done). Replaces the parked #486's positional-anchor approach — **#486 is not resurrected**.

Two gaps closed in one PR.

### Gap 1 — event/attribute was an unenforced example-list

`TimeColumn` gains a closed-vocabulary `role: 'event' | 'attribute'` the LLM commits per column (definition lives in the field description — the one home). Enforced at save (two-layer): strict Pydantic `Literal` + a `TableEntityOutput` validator routed through the existing DAT-710 repair turn (fall loud on repair failure). Attribute dates **stay** in `time_columns` with `role='attribute'` (one list, the role field is the typed home) — they keep getting coverage but can never be a trend axis. Record metadata (created_at) stays excluded entirely.

### Gap 2 — no anchor designation

`TimeColumn` gains `is_anchor: bool`; the validator enforces **exactly one anchor per table among `role='event'` columns** whenever an event date exists (zero / two / attribute-role anchor → repair turn, then fall loud). The measure's anchor is served at the **read seam** with **witness precedence** (DAT-778 lineage-witness event-side axis ▸ declared table anchor), documented in exactly one place. Witness data is **not** copied into `time_columns`.

## Consumers adapted (event-only / typed anchor)

| Consumer | Change |
|---|---|
| `analysis/lineage/processor.py` | rollup axes filter `role='event'` (an attribute date can't be a reconciliation axis) |
| `analysis/semantic/agent.py` `derive_table_role` | periodic-snapshot detection counts only event dates in the grain |
| `graphs/context.py` | answer-agent time-lens render is event-only |
| `pipeline/phases/slicing_phase.py` | event-axis backstops guard on `role='event'` (attribute-only fact still gets its axis, attribute dates preserved on fill); `is_dimension_time_column` matches only a dim's event dates |
| `storage/property_graph.py` `og_columns` | new `anchor_time_axis` property = `COALESCE(witness event-side axis, declared anchor)` — the single home of the witness-precedence rule, served via GRAPH_TABLE |
| cockpit `tools/query-context.ts` | answer agent (2nd SQL agent) renders event axes only, marks `[anchor]` |
| cockpit `tools/look-table.ts` | mirrors the two new fields (optional, tolerant) |
| DAT-778 prompt (`semantic_per_table.yaml`) | updated in lockstep with the stricter schema (DAT-781 lesson) |

## Witness-precedence seam decision

The ticket referenced a positional `og_measure_time_axis` view rendering `tc.ord = 1 AS is_anchor`. **That view does not exist on `main`** — it was only in the parked #486. Rather than build a new positional-shaped view, the anchor is served as a typed `anchor_time_axis` property on the **existing** `og_columns` measure vertex, mirroring the established witness-precedence `materialization` COALESCE pattern (witness posterior ▸ declared prior). Both reviewers independently endorsed this as the faithful realization of the spec's intent. The witness join is cleanly expressible per measure; the declared anchor is extracted from the `current_table_entities.time_columns` JSON via a lateral.

## For P5 re-cut (DAT-730)

The parked #486 took **array position 1** of `time_columns` as the anchor — an unenforced accident of LLM output order, wrong on any multi-date fact. P5 must now consume the **typed** anchor instead:

- **The anchor is `TimeColumn.is_anchor`** (exactly one `role='event'` column per table, enforced at save). Never read array position.
- **For a measure, read `column_node.anchor_time_axis` from the operating-model property graph** (GRAPH_TABLE over `og_columns`) — it already applies witness precedence (DAT-778 event-side axis where a lineage witness exists, else the declared anchor). This is the single home of the precedence rule; do not re-derive it.
- **Event vs attribute is now typed** — filter `role='event'` for trend axes; attribute dates (`role='attribute'`) are covered but never a trend axis.

## Testing

Save-time rejection (zero anchors with events / two anchors / attribute-role anchor) + the repair-turn path; event-only filtering at the lineage consumer; `og_columns.anchor_time_axis` via GRAPH_TABLE (witness precedence + declared fallback + **scrambled-order** proving nothing reads array position); slicing role-filtering + attribute preservation; context.py event-lens exclusion; cockpit projection + answer-agent rendering.

Gates (run in-lane — no end-of-turn hook): engine `ruff format`/`ruff check`/`mypy`/`vulture` clean, `pytest tests/unit -q -n auto` **2073 passed**, property_graph + additivity integration green; cockpit `check`/`typecheck`/`test` (**1673**)/`build` clean; `schema_graph.sql` re-dumped, no `schema.sql`/Drizzle-mirror drift.

## Reviewers

Senior-code-reviewer: **APPROVE** (no remaining findings). Spec-compliance-reviewer: **COMPLIANT**. Both re-verified the fix round (slicing role-blindness, cockpit answer-agent, handoff.md) and independently confirmed the `og_columns` seam choice.

## Other lanes in flight

DAT-783 (temporal profile_data wiring, #497) merged to `main` during this lane — no file overlap; rebased onto it cleanly, generated artifacts re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)