### PR TITLE
DAT-774: instantiate og_derived_from edges — widen og_tables to enriched-view vertices

### DIFF
--- a/packages/engine/schema_graph.sql
+++ b/packages/engine/schema_graph.sql
@@ -19,7 +19,12 @@ CREATE VIEW __READ__.og_tables AS
 SELECT t.table_id::text AS table_id, t.table_name, t.layer,
        te.table_role, te.detected_entity_type
 FROM __READ__.current_tables t
-LEFT JOIN __READ__.current_table_entities te ON te.table_id = t.table_id;
+LEFT JOIN __READ__.current_table_entities te ON te.table_id = t.table_id
+UNION ALL
+SELECT ev.view_table_id::text AS table_id, ev.view_name AS table_name,
+       'enriched' AS layer, NULL AS table_role, NULL AS detected_entity_type
+FROM __READ__.current_enriched_views ev
+WHERE ev.view_table_id IS NOT NULL;
 
 CREATE VIEW __READ__.og_columns AS
 SELECT c.column_id::text AS column_id, c.table_id::text AS table_id, c.column_name,
@@ -76,7 +81,7 @@ SELECT (ev.view_id || '_fact')::text AS edge_key,
 FROM __READ__.current_enriched_views ev
 WHERE ev.view_table_id IS NOT NULL
 UNION ALL
-SELECT (ev.view_id || '_dim_' || dt.value)::text AS edge_key,
+SELECT DISTINCT (ev.view_id || '_dim_' || dt.value)::text AS edge_key,
        ev.view_table_id::text AS view_table_id,
        dt.value AS base_table_id, 'dimension' AS base_role
 FROM __READ__.current_enriched_views ev

--- a/packages/engine/src/dataraum/storage/property_graph.py
+++ b/packages/engine/src/dataraum/storage/property_graph.py
@@ -22,12 +22,19 @@ and ``Table``; the vocabulary ``Concept`` vertices are P3. Edges/props carried:
     column_node  (KEY column_id)  props: semantic_role (has_role),
                                           materialization (materializes_as),
                                           anchor_time_axis (witness axis ▸ declared anchor)
-    table_node   (KEY table_id)   props: table_role (fact/periodic_snapshot/dimension)
+    table_node   (KEY table_id)   props: layer (typed | enriched), table_role
+                                          (fact/periodic_snapshot/dimension)
     refs               table → table     [relationships]      FK topology (conformed dims excluded)
     has_dimension      table → column    [slice_definitions]  a fact's slice cols + dim identity
     derived_from       table → table     [enriched_views]     view → fact + dim bases
     concept_edge       concept → concept [concept_edges]      part_of/disjoint/reconciles (P4)
     conformed_dimension table → table    [slice_definitions]  two facts sharing a dimension (DAT-756)
+
+One vertex label spans both layers (DAT-774): typed source tables AND enriched-view
+tables are ``table_node``, discriminated by the ``layer`` property (the DD types "Table
+… incl. enriched views" as one label). Before DAT-774 ``og_tables`` was typed-only, so
+every ``derived_from`` edge — whose source is always an enriched-view table — dangled at
+its source endpoint and none ever instantiated in a MATCH. See ``og_tables`` below.
 
 ``rolls_up_to`` (dimension_hierarchies' JSON members) lands in P5 where its
 consumer does. The ``concept_edge`` edge (DAT-729) carries the vocabulary relations
@@ -100,16 +107,43 @@ def _element_view_sql(name: str) -> str:
     comparison; the cast is free (the values are already textual ids).
     """
     if name == "og_tables":
-        # Table vertex: the analyzed-representative table + its role
-        # (table_role: fact / periodic_snapshot / dimension). current_table_entities
-        # is (table_id, run) unique post-head, so the LEFT JOIN stays 1:1 and
-        # table_id is a valid KEY.
+        # Table vertex: BOTH typed source tables AND enriched-view tables (DAT-774).
+        # The DD's type system declares "Table (physical relation, incl. enriched
+        # views)" as ONE vertex label, so both layers bind to table_node with ``layer``
+        # ('typed' | 'enriched') the discriminating property — a consumer meaning
+        # "source tables only" filters ``WHERE layer = 'typed'``; a SECOND vertex label
+        # would contradict the declared typing (the DAT-774 tiebreaker).
+        #
+        # Typed branch: the analyzed-representative typed table + its role (table_role:
+        # fact / periodic_snapshot / dimension). current_table_entities is (table_id,
+        # run) unique post-head, so the LEFT JOIN stays 1:1 and table_id is a valid KEY.
+        #
+        # Enriched branch (the DAT-774 fix): the enriched-view tables. Sourced from
+        # current_enriched_views — NOT current_tables, which is hard-filtered
+        # ``layer='typed'`` (read_views.py, DAT-655), so enriched tables never surfaced
+        # and EVERY og_derived_from edge dangled at its source endpoint: no derived_from
+        # edge had ever instantiated. Head-resolution stays intact under the two-head
+        # model — a typed vertex is current under its (table:{id}, generation) head; an
+        # enriched vertex is current under the begin_session (catalog) enriched_views
+        # head, the SAME head og_derived_from reads — so every derived_from SOURCE
+        # endpoint now resolves BY CONSTRUCTION (both views read current_enriched_views).
+        # ``view_name`` IS the enriched Table's table_name (enriched_views_phase sets
+        # both to ``enriched_{fact}``); layer is the constant 'enriched'; table_role /
+        # detected_entity_type are NULL (an enriched view is a derived relation, never a
+        # detected entity). ``WHERE view_table_id IS NOT NULL`` drops an un-materialized
+        # view (no vertex), mirroring the edge's own guard. table_id is uuid4-unique
+        # across both branches, so the union KEY stays valid.
         return (
             f"CREATE VIEW {READ_TOKEN}.og_tables AS\n"
             f"SELECT t.table_id::text AS table_id, t.table_name, t.layer,\n"
             f"       te.table_role, te.detected_entity_type\n"
             f"FROM {READ_TOKEN}.current_tables t\n"
-            f"LEFT JOIN {READ_TOKEN}.current_table_entities te ON te.table_id = t.table_id;"
+            f"LEFT JOIN {READ_TOKEN}.current_table_entities te ON te.table_id = t.table_id\n"
+            f"UNION ALL\n"
+            f"SELECT ev.view_table_id::text AS table_id, ev.view_name AS table_name,\n"
+            f"       'enriched' AS layer, NULL AS table_role, NULL AS detected_entity_type\n"
+            f"FROM {READ_TOKEN}.current_enriched_views ev\n"
+            f"WHERE ev.view_table_id IS NOT NULL;"
         )
     if name == "og_columns":
         # Column vertex: the physical column with its semantic role (has_role),
@@ -247,6 +281,12 @@ def _element_view_sql(name: str) -> str:
         # unnested). edge_key = view_id + role[+dim] keeps it unique across the union
         # — '_'-delimited, NOT ':' (a ':' before a letter is a bind param to text()).
         # view_table_id is nullable (a non-materialized view has no vertex) → skip.
+        # The dimension branch is SELECT DISTINCT (DAT-774): dimension_table_ids is a
+        # JSON array, and a DUPLICATE id in it would unnest to two rows sharing one
+        # edge_key (view_id || '_dim_' || id) — a non-unique PGQ edge KEY. DISTINCT over
+        # the projected columns dedups on (view_id, id), so the key is genuinely unique
+        # regardless of the JSON's contents. (The writer already set-dedups the ids, but
+        # the KEY invariant must hold on the view, not on a producer's good behaviour.)
         return (
             f"CREATE VIEW {READ_TOKEN}.og_derived_from AS\n"
             f"SELECT (ev.view_id || '_fact')::text AS edge_key,\n"
@@ -255,7 +295,7 @@ def _element_view_sql(name: str) -> str:
             f"FROM {READ_TOKEN}.current_enriched_views ev\n"
             f"WHERE ev.view_table_id IS NOT NULL\n"
             f"UNION ALL\n"
-            f"SELECT (ev.view_id || '_dim_' || dt.value)::text AS edge_key,\n"
+            f"SELECT DISTINCT (ev.view_id || '_dim_' || dt.value)::text AS edge_key,\n"
             f"       ev.view_table_id::text AS view_table_id,\n"
             f"       dt.value AS base_table_id, 'dimension' AS base_role\n"
             f"FROM {READ_TOKEN}.current_enriched_views ev\n"

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -9,7 +9,10 @@ engine:
   GRAPH succeed);
 * a PGQ ``MATCH`` returns correct rows — every measure column → its stock/flow
   materialization, seeded with the REAL pipeline vocabularies;
-* ``derived_from`` edges are enumerable (enriched view → fact + dim bases);
+* ``derived_from`` edges are enumerable from a REALISTIC enriched-VIEW table
+  (layer='enriched', head-scoped via enriched_views — the DAT-774 fix that made
+  ``og_tables`` admit enriched vertices) → its fact + dim bases; the edge_key is deduped
+  against a duplicate dimension id, and an un-materialized (NULL) view yields nothing;
 * the ``cockpit_reader`` role can query the graph (a property graph needs its own
   GRANT — table grants don't reach GRAPH_TABLE);
 * the two-mechanism query model is de-risked on a chain that OUTRUNS the depth cap
@@ -53,15 +56,28 @@ READER_PW = "graph-reader-test-pw"
 # back edge t6→t4 (the cycle t4→t5→t6→t4). This lets the de-risk tests distinguish
 # "hit the depth cap" (t6 exists but is unreachable from t1 within 4 hops) from
 # "ran out of edges", and fire the cycle guard (from t4, t4 never re-enters).
-# t_enr is the enriched-view table over (t1 fact, t2 dim).
-_TABLES = [
+# t7/t8 are two extra facts carrying ONLY enriched views (no refs / slices / entity, so
+# the refs/conformed counts are untouched) — for the DAT-774 derived_from cases: t7
+# backs the duplicate-dim dedup view, t8 the un-materialized (NULL view_table_id) view.
+_TYPED_TABLES = [
     ("t1", "journal"),
     ("t2", "accounts"),
     ("t3", "account_group"),
     ("t4", "statement"),
     ("t5", "division"),
     ("t6", "root"),
-    ("t_enr", "journal_enriched"),
+    ("t7", "ledger"),
+    ("t8", "paylog"),
+]
+# Enriched-VIEW tables (DAT-774): layer='enriched' and — like the real pipeline — NO
+# generation head. An enriched view is minted in begin_session, never promoted under a
+# (table:{id}, generation) head; its currency flows from the (catalog) enriched_views
+# head, resolved through current_enriched_views. og_tables surfaces these as table
+# vertices via that same view, or every derived_from edge dangles at its source — the
+# exact bug DAT-774 fixes.
+_ENRICHED_TABLES = [
+    ("t_enr", "enriched_journal"),  # v_1 — realistic: journal fact + accounts dim
+    ("t_enr2", "enriched_ledger"),  # v_2 — duplicate dim id, dedup proof
 ]
 _COLUMNS = [
     ("c_amt", "t1", "amount", 1),
@@ -97,7 +113,7 @@ def _seed(engine: Engine) -> None:
     so the ``current_*`` views (and the graph's element views) resolve them.
     """
     stmts: list[str] = []
-    for tid, name in _TABLES:
+    for tid, name in _TYPED_TABLES:
         stmts.append(
             f"INSERT INTO tables (table_id, source_id, table_name, layer, created_at) "
             f"VALUES ('{tid}', '{SRC}', '{name}', 'typed', '{TS}')"
@@ -105,6 +121,14 @@ def _seed(engine: Engine) -> None:
         stmts.append(
             f"INSERT INTO metadata_snapshot_head (head_id, target, stage, run_id, promoted_at) "
             f"VALUES ('h_{tid}', 'table:{tid}', 'generation', '{RUN}', '{TS}')"
+        )
+    # Enriched-view tables: layer='enriched', and NO generation head (the pipeline
+    # promotes none for them). They're referenced by the enriched_views rows below (FK)
+    # and surfaced as vertices only through current_enriched_views (DAT-774).
+    for tid, name in _ENRICHED_TABLES:
+        stmts.append(
+            f"INSERT INTO tables (table_id, source_id, table_name, layer, created_at) "
+            f"VALUES ('{tid}', '{SRC}', '{name}', 'enriched', '{TS}')"
         )
     stmts.append(
         f"INSERT INTO metadata_snapshot_head (head_id, target, stage, run_id, promoted_at) "
@@ -223,14 +247,28 @@ def _seed(engine: Engine) -> None:
                 "(entity_id, table_id, run_id, detected_entity_type, table_role, detected_at) "
                 f"VALUES ('{eid}', '{tid}', '{RUN}', 'entity', '{role}', '{TS}')"
             )
-    # derived_from: journal_enriched view over the journal fact + the accounts dim.
-    stmts.append(
-        "INSERT INTO enriched_views "
-        "(view_id, fact_table_id, view_table_id, view_name, run_id, "
-        " dimension_table_ids, is_grain_verified, created_at) "
-        f"VALUES ('v_1', 't1', 't_enr', 'journal_enriched', '{RUN}', "
-        f"'[\"t2\"]'::json, true, '{TS}')"
-    )
+    # derived_from (DAT-774): three enriched-view rows exercising the fixed edge.
+    #  v_1 REALISTIC — enriched_journal over the journal fact (t1) + accounts dim (t2).
+    #     Its source vertex (t_enr, layer='enriched') resolves via current_enriched_views,
+    #     so BOTH the view→fact and view→dim edges MATCH.
+    #  v_2 DEDUP — enriched_ledger whose dimension_table_ids carries a DUPLICATE id
+    #     (["t2","t2"]); the og_derived_from SELECT DISTINCT collapses it to one view→dim
+    #     edge (a non-deduped view would emit two rows sharing one edge_key — a non-unique
+    #     PGQ KEY).
+    #  v_3 ABSENCE — paylog's view was never materialized (view_table_id NULL); the WHERE
+    #     view_table_id IS NOT NULL guard drops it: no vertex, no edge.
+    for vid, fact, view_tid, vname, dims in [
+        ("v_1", "t1", "'t_enr'", "enriched_journal", '["t2"]'),
+        ("v_2", "t7", "'t_enr2'", "enriched_ledger", '["t2", "t2"]'),
+        ("v_3", "t8", "NULL", "enriched_paylog", '["t2"]'),
+    ]:
+        stmts.append(
+            "INSERT INTO enriched_views "
+            "(view_id, fact_table_id, view_table_id, view_name, run_id, "
+            " dimension_table_ids, is_grain_verified, created_at) "
+            f"VALUES ('{vid}', '{fact}', {view_tid}, '{vname}', '{RUN}', "
+            f"'{dims}'::json, true, '{TS}')"
+        )
     # Concept vertices + a disjoint_with concept edge (DAT-729): the vocabulary graph.
     # Concepts/edges are workspace-persistent (NOT run-versioned) — plain active rows,
     # no head to promote. The og_concept_edges view resolves the edge's (vertical, name)
@@ -371,15 +409,66 @@ def test_references_edges_match_the_fk_topology(graph_engine: Engine) -> None:
 
 
 def test_derived_from_edges_enumerable(graph_engine: Engine) -> None:
-    """derived_from: the enriched view resolves to its fact + dimension bases."""
+    """derived_from (DAT-774): the enriched-VIEW table (layer='enriched') resolves as a
+    table vertex, so both the view→fact and view→dimension edges MATCH.
+
+    Before the fix ``og_tables`` was typed-only (it sat on ``current_tables``, filtered
+    ``layer='typed'``), the ``derived_from`` SOURCE endpoint dangled, and NO such edge
+    ever instantiated in a MATCH. Scoped to the realistic v_1 view (enriched_journal);
+    the projected source ``layer`` proves the enriched vertex — not a typed one — anchors
+    the edge.
+    """
+    sql = (
+        f"SELECT vlayer, base, role FROM GRAPH_TABLE ({_graph_ref()} "
+        "MATCH (v IS table_node WHERE v.table_name = 'enriched_journal')"
+        "-[e IS derived_from]->(base IS table_node) "
+        "COLUMNS (v.layer AS vlayer, base.table_name AS base, e.base_role AS role))"
+    )
+    with graph_engine.connect() as conn:
+        rows = {(r.vlayer, r.base, r.role) for r in conn.execute(text(sql))}
+    assert rows == {
+        ("enriched", "journal", "fact"),
+        ("enriched", "accounts", "dimension"),
+    }
+
+
+def test_derived_from_edge_key_unique_under_duplicate_dim(graph_engine: Engine) -> None:
+    """DAT-774 secondary defect: a DUPLICATE id in dimension_table_ids must not emit two
+    edges sharing one edge_key (a non-unique PGQ KEY).
+
+    v_2 (enriched_ledger) carries dimension_table_ids=["t2","t2"]; the og_derived_from
+    dimension branch SELECT DISTINCTs it, so exactly ONE view→dim edge exists alongside
+    the one view→fact edge. Collected as a LIST (not a set): a leaked duplicate would
+    surface as a repeated ('accounts','dimension') row.
+    """
     sql = (
         f"SELECT base, role FROM GRAPH_TABLE ({_graph_ref()} "
-        "MATCH (v IS table_node)-[e IS derived_from]->(base IS table_node) "
+        "MATCH (v IS table_node WHERE v.table_name = 'enriched_ledger')"
+        "-[e IS derived_from]->(base IS table_node) "
         "COLUMNS (base.table_name AS base, e.base_role AS role))"
     )
     with graph_engine.connect() as conn:
-        rows = {(r.base, r.role) for r in conn.execute(text(sql))}
-    assert rows == {("journal", "fact"), ("accounts", "dimension")}
+        rows = sorted((r.base, r.role) for r in conn.execute(text(sql)))
+    assert rows == [("accounts", "dimension"), ("ledger", "fact")]
+
+
+def test_derived_from_unmaterialized_view_has_no_edge(graph_engine: Engine) -> None:
+    """DAT-774: an enriched_views row whose view was never materialized (view_table_id
+    NULL — v_3 over paylog) contributes NO vertex and NO edge.
+
+    The ``WHERE view_table_id IS NOT NULL`` guard drops exactly the rows guaranteed to
+    dangle, so every derived_from edge's source is one of the two materialized views and
+    'enriched_paylog' is never a source vertex.
+    """
+    sql = (
+        f"SELECT vname FROM GRAPH_TABLE ({_graph_ref()} "
+        "MATCH (v IS table_node)-[e IS derived_from]->(base IS table_node) "
+        "COLUMNS (v.table_name AS vname))"
+    )
+    with graph_engine.connect() as conn:
+        sources = {r.vname for r in conn.execute(text(sql))}
+    assert sources == {"enriched_journal", "enriched_ledger"}
+    assert "enriched_paylog" not in sources
 
 
 def test_has_dimension_edge(graph_engine: Engine) -> None:


### PR DESCRIPTION
## Task

[DAT-774](https://real-dataraum.atlassian.net/browse/DAT-774) — `og_derived_from` edges never instantiate (enriched-layer source vs typed-only `og_tables`). Bug from the DAT-772 substrate audit (lane A5, epic DAT-725).

## The bug

`og_derived_from` binds `SOURCE KEY (view_table_id) REFERENCES og_tables`, but `view_table_id` is always an **enriched**-layer table, while `og_tables` sat on `current_tables`, hard-filtered `WHERE layer='typed'` (`read_views.py`, DAT-655). SQL/PGQ instantiates an edge only when **both** endpoints resolve → **no `derived_from` edge had ever appeared in a MATCH.** The `WHERE view_table_id IS NOT NULL` guard was selecting exactly the rows guaranteed to dangle.

Secondary defect: `edge_key = view_id || '_dim_' || dt.value` was non-unique if `dimension_table_ids` JSON carried a duplicate id.

## The fix (Option B — lead-decided, Jira comment 2026-07-15)

Widen `og_tables` to also admit **enriched-view tables** as `table_node` vertices, discriminated by the existing `layer` property (`'typed' | 'enriched'`). The DD's type system declares "Table (physical relation, incl. enriched views)" as **one** vertex label; a second label would contradict the declared typing. Consumers meaning "source tables only" filter `WHERE layer = 'typed'`.

**Widening seam: the `og_tables` element view, NOT `current_tables`.** I grepped `current_tables`' consumers first: in the engine it has exactly one (`og_tables`); in the cockpit it is read heavily via the Drizzle `currentTables` mirror (`operating-model-load.ts`, `query-context.ts`), all relying on its "analyzed typed-layer representative" contract — widening `current_tables` would leak enriched views into every cockpit table listing. So the enriched branch is a `UNION ALL` sourced from `current_enriched_views` — the **same begin_session (catalog) `enriched_views` head** `og_derived_from` reads — so every `derived_from` source endpoint now resolves **by construction**, and the two-head model (generation vs catalog) stays intact.

Secondary fix: the `og_derived_from` dimension branch is now `SELECT DISTINCT`, so a duplicate id in `dimension_table_ids` can't emit two rows sharing one `edge_key` (a non-unique PGQ edge KEY). Defense at the view layer, not reliant on the writer's Python-side set-dedup.

## Consumers checked (constraint 2)

- **`current_tables`** — engine: only `og_tables`; cockpit: Drizzle `currentTables` readers depend on typed-only semantics → **did NOT widen it**, widened `og_tables` instead.
- **`og_references` / `og_has_dimension` / `og_conformed_dimension`** — source `current_relationships` / `current_slice_definitions`, which only ever hold typed-table ids → cannot spuriously match an enriched vertex. No change needed.
- **GRAPH_TABLE / `table_node` consumers** — none in the engine outside `property_graph.py` (this is P1 substrate; the GraphAgent consumer is DAT-734, still To Do). No recursive-CTE closure over `derived_from` exists yet.
- **Cockpit graph reader** (`operating-model-graph.ts`) — does **not** query the Postgres property graph; re-derives lineage from metadata. Unaffected.

## Acceptance criteria

- [x] `og_derived_from` edges instantiate in a live `GRAPH_TABLE` MATCH (both view→fact and view→dimension) from a realistic enriched-view seed.
- [x] `og_tables` admits enriched-view vertices with `layer` as the discriminating property; typed-only semantics of `current_tables` preserved.
- [x] `edge_key` is genuinely unique under a duplicate `dimension_table_ids` id (`SELECT DISTINCT`).
- [x] Regression test seeds a realistic enriched-view row (`layer='enriched'`, no generation head) + duplicate-dim + NULL-view absence cases.
- [x] PG19 PGQ discipline preserved (keys `::text`, views-as-elements, `GRANT ON PROPERTY GRAPH`, teardown ordering).
- [x] `schema_graph.sql` re-dumped; `schema.sql` / Drizzle mirror untouched (no relational-model change).

## Regression test (its absence shipped this dead)

`tests/integration/storage/test_property_graph.py` (real Postgres 19, materialized graph). The prior seed cheated by labelling the view table `layer='typed'` with a generation head — masking the bug. Now it seeds a **realistic** enriched-view row (`layer='enriched'`, no generation head; currency via the `enriched_views` catalog head) and asserts both edges MATCH, plus a duplicate-dim dedup proof and a NULL-view absence case. **Verified the test has teeth:** with the source fix reverted, all three `derived_from` tests return empty (the edges dangle exactly as described).

## Verification

```
ruff format/check ....... clean
mypy (property_graph.py)  clean
vulture ................. clean
pytest tests/unit ....... 2073 passed
pytest tests/integration/storage ... 33 passed (property_graph: 18, incl. 3 new/updated DAT-774 tests)
schema drift ............ clean (re-dumped, no diff to schema.sql / schema_read.sql)
```

Both reviewers (senior-code-reviewer + spec-compliance-reviewer) ran against the diff and approved: **no blockers/majors; ship as-is.** Two low/cosmetic nits (docstring alignment, test view-name convention) fixed before push.

## Downstream

**DAT-774 blocks [DAT-734](https://real-dataraum.atlassian.net/browse/DAT-734)** (Phase 9 — Graph context replaces flat at the GraphAgent; the P9 payoff). With `derived_from` edges now live, the GraphAgent can traverse enriched-view lineage.

## Other lanes in flight

No other DAT-772 wave-4 lane has an open PR. Unrelated older PRs open: #486 (DAT-730), #487 (DAT-727). This change is isolated to the engine property-graph read surface — no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)