### PR TITLE
DAT-802: Enum-standard sweep (Wave 5) — CHECKs on surviving closed vocabularies

### DIFF
--- a/packages/cockpit/scripts/smoke-add-source.ts
+++ b/packages/cockpit/scripts/smoke-add-source.ts
@@ -75,7 +75,6 @@ async function seed(sourceId: string): Promise<void> {
 			name,
 			sourceType: "csv",
 			connectionConfig: { file_uris: fileUris },
-			status: "configured",
 			createdAt: now,
 			updatedAt: now,
 		})

--- a/packages/cockpit/scripts/smoke-begin-session.ts
+++ b/packages/cockpit/scripts/smoke-begin-session.ts
@@ -91,7 +91,6 @@ async function ingest(client: Client): Promise<string[]> {
 			name: `smoke_${sourceId.slice(0, 8)}`,
 			sourceType: "csv",
 			connectionConfig: { file_uris: fileUris },
-			status: "configured",
 			createdAt: now,
 			updatedAt: now,
 		})

--- a/packages/cockpit/scripts/smoke-operating-model.ts
+++ b/packages/cockpit/scripts/smoke-operating-model.ts
@@ -104,7 +104,6 @@ async function ingest(client: Client): Promise<string[]> {
 			name: `smoke_${sourceId.slice(0, 8)}`,
 			sourceType: "csv",
 			connectionConfig: { file_uris: fileUris },
-			status: "configured",
 			createdAt: now,
 			updatedAt: now,
 		})

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -636,14 +636,13 @@ export const sources = metadataSchema
 		connectionConfig: json("connection_config"),
 		createdAt: timestamp("created_at"),
 		updatedAt: timestamp("updated_at"),
-		status: varchar(),
 		stage: varchar(),
 		backend: varchar(),
 		discoveredSchema: json("discovered_schema"),
 		archivedAt: timestamp("archived_at"),
 	})
 	.as(
-		sql`SELECT source_id, name, source_type, connection_config, created_at, updated_at, status, stage, backend, discovered_schema, archived_at FROM ws_00000000_0000_0000_0000_000000000001.sources`,
+		sql`SELECT source_id, name, source_type, connection_config, created_at, updated_at, stage, backend, discovered_schema, archived_at FROM ws_00000000_0000_0000_0000_000000000001.sources`,
 	);
 
 export const sqlSnippets = metadataSchema

--- a/packages/cockpit/src/db/metadata/write-surface.ts
+++ b/packages/cockpit/src/db/metadata/write-surface.ts
@@ -54,7 +54,6 @@ export const sourcesWrite = rawSchema.table("sources", {
 	connectionConfig: jsonb("connection_config"),
 	createdAt: timestamp("created_at", { mode: "date" }).notNull(),
 	updatedAt: timestamp("updated_at", { mode: "date" }).notNull(),
-	status: varchar("status"),
 	stage: varchar("stage"),
 	backend: varchar("backend"),
 	discoveredSchema: jsonb("discovered_schema"),

--- a/packages/cockpit/src/select/file-source.test.ts
+++ b/packages/cockpit/src/select/file-source.test.ts
@@ -23,7 +23,6 @@ const h = vi.hoisted(() => ({
 
 vi.mock("#/select/source-write", () => ({
 	STAGE_AFTER_SELECT: "add_source",
-	INITIAL_STATUS: "configured",
 	upsertSource: vi.fn(
 		async (v: {
 			name: string;

--- a/packages/cockpit/src/select/recipe-source.test.ts
+++ b/packages/cockpit/src/select/recipe-source.test.ts
@@ -29,7 +29,6 @@ const h = vi.hoisted(() => ({
 
 vi.mock("#/select/source-write", () => ({
 	STAGE_AFTER_SELECT: "add_source",
-	INITIAL_STATUS: "configured",
 	upsertSource: vi.fn(
 		async (v: {
 			name: string;

--- a/packages/cockpit/src/select/recipe-source.ts
+++ b/packages/cockpit/src/select/recipe-source.ts
@@ -109,8 +109,8 @@ function validateSpec(spec: RecipeSourceSpec): void {
  * corrupting — every upsert is idempotent (name UNIQUE + the `recipe_hash`
  * witness), and the caller (`server/import-sources.ts` via the widget's mutation)
  * keeps the import set on error, so re-running the same batch re-upserts the
- * already-written rows and starts the run. The orphaned rows sit at
- * `status=configured` until that retry imports them.
+ * already-written rows and starts the run. The orphaned rows sit registered
+ * with no typed tables under them until that retry imports them.
  */
 export async function persistRecipeSources(
 	specs: RecipeSourceSpec[],

--- a/packages/cockpit/src/select/source-write.ts
+++ b/packages/cockpit/src/select/source-write.ts
@@ -21,10 +21,6 @@ import { sourcesWrite } from "../db/metadata/write-surface";
 // cursor the journey readiness reads.
 export const STAGE_AFTER_SELECT = "add_source";
 
-// Initial source status — registered by the cockpit but not yet imported reads
-// `configured` (mirrors the integration seed in scripts/smoke-add-source.ts).
-export const INITIAL_STATUS = "configured";
-
 /**
  * UPSERT one `sources` row (on the UNIQUE name) and return its source_id.
  *
@@ -48,7 +44,6 @@ export async function upsertSource(values: {
 			name: values.name,
 			sourceType: values.sourceType,
 			connectionConfig: values.connectionConfig,
-			status: INITIAL_STATUS,
 			stage: STAGE_AFTER_SELECT,
 			backend: values.backend,
 			createdAt: values.now,
@@ -59,7 +54,6 @@ export async function upsertSource(values: {
 			set: {
 				sourceType: values.sourceType,
 				connectionConfig: values.connectionConfig,
-				status: INITIAL_STATUS,
 				stage: STAGE_AFTER_SELECT,
 				backend: values.backend,
 				updatedAt: values.now,

--- a/packages/cockpit/src/tools/list-tables.ts
+++ b/packages/cockpit/src/tools/list-tables.ts
@@ -82,10 +82,7 @@ const InventoryTable = z.object({
 	row_count: z.number().nullable(),
 	column_count: z.number(),
 	// Denormalized provenance — the inventory groups tables under their source
-	// (SourceCard), so each row carries its source's identity. No `status`: the
-	// engine never updates `Source.status` post-import (the scheduler that did was
-	// retired in DAT-369), so it's write-once noise — imported-ness is derivable
-	// from the typed tables under the source (DAT-431).
+	// (SourceCard), so each row carries its source's identity.
 	source_id: z.string(),
 	// db_recipe: the user-chosen connection name. Uploads: the uploaded FILE's
 	// name (the source row's name is the content-keyed `src_<digest>`, which is

--- a/packages/cockpit/src/ui/cockpit/widgets/workspace-inventory.tsx
+++ b/packages/cockpit/src/ui/cockpit/widgets/workspace-inventory.tsx
@@ -171,8 +171,7 @@ function SourceCard({
 				{/* A connection shows its kind/backend; the Uploads umbrella spans
 				    many per-file sources, so a single type/backend is meaningless —
 				    show a neutral marker instead of any one file's metadata (or the
-				    hash). No status badge: the engine never updates `Source.status`
-				    post-import, so it read `configured` forever (DAT-431). */}
+				    hash). */}
 				{group.kind === "connection" ? (
 					<>
 						<Badge variant="outline" color="gray" tt="lowercase">

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -14,7 +14,7 @@ CREATE TABLE concept_edges (
 	superseded_at TIMESTAMP WITHOUT TIME ZONE, 
 	CONSTRAINT pk_concept_edges PRIMARY KEY (edge_id), 
 	CONSTRAINT ck_concept_edges_predicate CHECK (predicate IN ('disjoint_with', 'part_of', 'reconciles_with')), 
-	CONSTRAINT ck_concept_edges_source CHECK (source IS NULL OR source IN ('seed', 'derived', 'frame'))
+	CONSTRAINT ck_concept_edges_source CHECK (source IS NULL OR source = 'seed')
 );
 
 CREATE UNIQUE INDEX uq_concept_edge_active ON concept_edges (vertical, predicate, from_concept, to_concept) WHERE superseded_at IS NULL;

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -128,7 +128,6 @@ CREATE TABLE sources (
 	connection_config JSON, 
 	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
-	status VARCHAR, 
 	stage VARCHAR, 
 	backend VARCHAR, 
 	discovered_schema JSON, 

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -12,7 +12,9 @@ CREATE TABLE concept_edges (
 	source VARCHAR, 
 	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	superseded_at TIMESTAMP WITHOUT TIME ZONE, 
-	CONSTRAINT pk_concept_edges PRIMARY KEY (edge_id)
+	CONSTRAINT pk_concept_edges PRIMARY KEY (edge_id), 
+	CONSTRAINT ck_concept_edges_predicate CHECK (predicate IN ('disjoint_with', 'part_of', 'reconciles_with')), 
+	CONSTRAINT ck_concept_edges_source CHECK (source IS NULL OR source IN ('seed', 'derived', 'frame'))
 );
 
 CREATE UNIQUE INDEX uq_concept_edge_active ON concept_edges (vertical, predicate, from_concept, to_concept) WHERE superseded_at IS NULL;
@@ -29,7 +31,9 @@ CREATE TABLE concepts (
 	source VARCHAR, 
 	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	superseded_at TIMESTAMP WITHOUT TIME ZONE, 
-	CONSTRAINT pk_concepts PRIMARY KEY (concept_id)
+	CONSTRAINT pk_concepts PRIMARY KEY (concept_id), 
+	CONSTRAINT ck_concepts_kind CHECK (kind IN ('dimension', 'entity', 'measure', 'unit')), 
+	CONSTRAINT ck_concepts_source CHECK (source IS NULL OR source IN ('seed', 'frame', 'teach'))
 );
 
 CREATE UNIQUE INDEX uq_concept_active ON concepts (vertical, name) WHERE superseded_at IS NULL;
@@ -85,7 +89,8 @@ CREATE TABLE lifecycle_artifacts (
 	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	state_changed_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	CONSTRAINT pk_lifecycle_artifacts PRIMARY KEY (artifact_id), 
-	CONSTRAINT uq_lifecycle_artifact_identity UNIQUE (artifact_type, artifact_key, run_id)
+	CONSTRAINT uq_lifecycle_artifact_identity UNIQUE (artifact_type, artifact_key, run_id), 
+	CONSTRAINT ck_lifecycle_artifacts_state CHECK (state IN ('canonical', 'declared', 'executed', 'grounded'))
 );
 
 CREATE TABLE metadata_snapshot_head (
@@ -192,6 +197,7 @@ CREATE TABLE tables (
 	last_profiled_at TIMESTAMP WITHOUT TIME ZONE, 
 	CONSTRAINT pk_tables PRIMARY KEY (table_id), 
 	CONSTRAINT uq_table_name_layer UNIQUE (table_name, layer), 
+	CONSTRAINT ck_tables_layer CHECK (layer IN ('raw', 'typed', 'quarantine', 'enriched')), 
 	CONSTRAINT fk_tables_source_id_sources FOREIGN KEY(source_id) REFERENCES sources (source_id)
 );
 
@@ -214,6 +220,7 @@ CREATE TABLE column_eligibility (
 	evaluated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	CONSTRAINT pk_column_eligibility PRIMARY KEY (eligibility_id), 
 	CONSTRAINT uq_column_eligibility_column_run UNIQUE (column_id, run_id), 
+	CONSTRAINT ck_column_eligibility_status CHECK (status IN ('ELIGIBLE', 'WARN', 'INELIGIBLE')), 
 	CONSTRAINT fk_column_eligibility_table_id_tables FOREIGN KEY(table_id) REFERENCES tables (table_id), 
 	CONSTRAINT fk_column_eligibility_source_id_sources FOREIGN KEY(source_id) REFERENCES sources (source_id)
 );
@@ -258,6 +265,8 @@ CREATE TABLE dimension_hierarchies (
 	CONSTRAINT pk_dimension_hierarchies PRIMARY KEY (hierarchy_id), 
 	CONSTRAINT uq_dimension_hierarchy_signature_run UNIQUE (signature, run_id), 
 	CONSTRAINT ck_dimension_hierarchies_role_verdict CHECK (role_verdict IN ('abstain', 'dirt', 'role', 'value_systematic')), 
+	CONSTRAINT ck_dimension_hierarchies_kind CHECK (kind IN ('drilldown', 'alias', 'role')), 
+	CONSTRAINT ck_dimension_hierarchies_detection_source CHECK (detection_source IN ('g3', 'manual')), 
 	CONSTRAINT fk_dimension_hierarchies_table_id_tables FOREIGN KEY(table_id) REFERENCES tables (table_id)
 );
 
@@ -326,6 +335,8 @@ CREATE TABLE surrogate_key_intents (
 	detected_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	CONSTRAINT pk_surrogate_key_intents PRIMARY KEY (intent_id), 
 	CONSTRAINT uq_surrogate_intent_run_digest UNIQUE (run_id, intent_digest), 
+	CONSTRAINT ck_surrogate_key_intents_status CHECK (status IN ('confirmed', 'declined')), 
+	CONSTRAINT ck_surrogate_key_intents_cardinality CHECK (cardinality IS NULL OR cardinality IN ('one-to-one', 'one-to-many', 'many-to-one')), 
 	CONSTRAINT fk_surrogate_key_intents_from_table_id_tables FOREIGN KEY(from_table_id) REFERENCES tables (table_id), 
 	CONSTRAINT fk_surrogate_key_intents_to_table_id_tables FOREIGN KEY(to_table_id) REFERENCES tables (table_id)
 );
@@ -346,6 +357,8 @@ CREATE TABLE table_entities (
 	detected_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	CONSTRAINT pk_table_entities PRIMARY KEY (entity_id), 
 	CONSTRAINT uq_table_entity_table_run UNIQUE (table_id, run_id), 
+	CONSTRAINT ck_table_entities_detection_source CHECK (detection_source IS NULL OR detection_source IN ('llm')), 
+	CONSTRAINT ck_table_entities_table_role CHECK (table_role IS NULL OR table_role IN ('dimension', 'fact', 'periodic_snapshot')), 
 	CONSTRAINT fk_table_entities_table_id_tables FOREIGN KEY(table_id) REFERENCES tables (table_id)
 );
 
@@ -388,6 +401,7 @@ CREATE TABLE column_concepts (
 	confidence FLOAT, 
 	CONSTRAINT pk_column_concepts PRIMARY KEY (concept_id), 
 	CONSTRAINT uq_column_concept UNIQUE (column_id, run_id), 
+	CONSTRAINT ck_column_concepts_annotation_source CHECK (annotation_source IS NULL OR annotation_source IN ('llm')), 
 	CONSTRAINT fk_column_concepts_column_id_columns FOREIGN KEY(column_id) REFERENCES columns (column_id)
 );
 
@@ -455,6 +469,9 @@ CREATE TABLE entropy_objects (
 	source_analysis_ids JSONB, 
 	computed_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	CONSTRAINT pk_entropy_objects PRIMARY KEY (object_id), 
+	CONSTRAINT ck_entropy_objects_layer CHECK (layer IN ('computational', 'semantic', 'structural', 'value')), 
+	CONSTRAINT ck_entropy_objects_dimension CHECK (dimension IN ('business_meaning', 'coverage', 'derived_values', 'dimensional', 'distribution', 'nulls', 'reconciliation', 'relations', 'temporal', 'types', 'units', 'variance')), 
+	CONSTRAINT ck_entropy_objects_sub_dimension CHECK (sub_dimension IN ('benford_compliance', 'cross_column_patterns', 'cross_table_consistency', 'dimension_coverage', 'formula_match', 'join_path_determinism', 'naming_clarity', 'null_ratio', 'null_semantics', 'relationship_discovery', 'relationship_quality', 'slice_conditional_null', 'slice_stability', 'temporal_behavior', 'time_role', 'type_fidelity', 'unit_declaration', 'unit_source')), 
 	CONSTRAINT fk_entropy_objects_table_id_tables FOREIGN KEY(table_id) REFERENCES tables (table_id), 
 	CONSTRAINT fk_entropy_objects_column_id_columns FOREIGN KEY(column_id) REFERENCES columns (column_id)
 );
@@ -481,6 +498,7 @@ CREATE TABLE entropy_readiness (
 	top_drivers JSONB, 
 	computed_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	CONSTRAINT pk_entropy_readiness PRIMARY KEY (readiness_id), 
+	CONSTRAINT ck_entropy_readiness_band CHECK (band IN ('ready', 'investigate', 'blocked')), 
 	CONSTRAINT fk_entropy_readiness_table_id_tables FOREIGN KEY(table_id) REFERENCES tables (table_id), 
 	CONSTRAINT fk_entropy_readiness_column_id_columns FOREIGN KEY(column_id) REFERENCES columns (column_id)
 );
@@ -546,7 +564,8 @@ CREATE TABLE relationships (
 	CONSTRAINT uq_relationship_columns_method UNIQUE (run_id, from_column_id, to_column_id, detection_method), 
 	CONSTRAINT ck_relationships_relationship_type CHECK (relationship_type IN ('foreign_key', 'hierarchy', 'candidate')), 
 	CONSTRAINT ck_relationships_confirmation_source CHECK (confirmation_source IN ('unconfirmed', 'judge', 'user', 'keeper')), 
-	CONSTRAINT ck_relationships_cardinality_oriented CHECK (cardinality IS NULL OR cardinality <> 'one-to-many'), 
+	CONSTRAINT ck_relationships_detection_method CHECK (detection_method IS NULL OR detection_method IN ('candidate', 'llm', 'manual', 'keeper')), 
+	CONSTRAINT ck_relationships_cardinality_oriented CHECK (cardinality IS NULL OR cardinality IN ('one-to-one', 'many-to-one', 'many-to-many')), 
 	CONSTRAINT fk_relationships_from_table_id_tables FOREIGN KEY(from_table_id) REFERENCES tables (table_id), 
 	CONSTRAINT fk_relationships_from_column_id_columns FOREIGN KEY(from_column_id) REFERENCES columns (column_id), 
 	CONSTRAINT fk_relationships_to_table_id_tables FOREIGN KEY(to_table_id) REFERENCES tables (table_id), 
@@ -584,6 +603,7 @@ CREATE TABLE semantic_annotations (
 	confidence FLOAT, 
 	CONSTRAINT pk_semantic_annotations PRIMARY KEY (annotation_id), 
 	CONSTRAINT uq_column_semantic_annotation UNIQUE (column_id, run_id), 
+	CONSTRAINT ck_semantic_annotations_annotation_source CHECK (annotation_source IS NULL OR annotation_source IN ('llm')), 
 	CONSTRAINT fk_semantic_annotations_column_id_columns FOREIGN KEY(column_id) REFERENCES columns (column_id)
 );
 
@@ -607,6 +627,8 @@ CREATE TABLE slice_definitions (
 	created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
 	CONSTRAINT pk_slice_definitions PRIMARY KEY (slice_id), 
 	CONSTRAINT uq_slice_def_table_column_run UNIQUE (table_id, column_name, run_id), 
+	CONSTRAINT ck_slice_definitions_slice_type CHECK (slice_type IN ('categorical')), 
+	CONSTRAINT ck_slice_definitions_detection_source CHECK (detection_source IN ('llm')), 
 	CONSTRAINT fk_slice_definitions_table_id_tables FOREIGN KEY(table_id) REFERENCES tables (table_id), 
 	CONSTRAINT fk_slice_definitions_column_id_columns FOREIGN KEY(column_id) REFERENCES columns (column_id), 
 	CONSTRAINT fk_slice_definitions_dimension_table_id_tables FOREIGN KEY(dimension_table_id) REFERENCES tables (table_id)
@@ -634,6 +656,7 @@ CREATE TABLE statistical_profiles (
 	profile_data JSON NOT NULL, 
 	CONSTRAINT pk_statistical_profiles PRIMARY KEY (profile_id), 
 	CONSTRAINT uq_statistical_profiles_column_run UNIQUE (column_id, run_id), 
+	CONSTRAINT ck_statistical_profiles_layer CHECK (layer IN ('typed', 'enriched')), 
 	CONSTRAINT fk_statistical_profiles_column_id_columns FOREIGN KEY(column_id) REFERENCES columns (column_id)
 );
 
@@ -719,6 +742,7 @@ CREATE TABLE type_decisions (
 	decision_reason VARCHAR, 
 	CONSTRAINT pk_type_decisions PRIMARY KEY (decision_id), 
 	CONSTRAINT uq_column_type_decision UNIQUE (column_id, run_id), 
+	CONSTRAINT ck_type_decisions_decision_source CHECK (decision_source IN ('automatic', 'manual', 'fallback')), 
 	CONSTRAINT fk_type_decisions_column_id_columns FOREIGN KEY(column_id) REFERENCES columns (column_id)
 );
 

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -33,7 +33,7 @@ CREATE TABLE concepts (
 	superseded_at TIMESTAMP WITHOUT TIME ZONE, 
 	CONSTRAINT pk_concepts PRIMARY KEY (concept_id), 
 	CONSTRAINT ck_concepts_kind CHECK (kind IN ('dimension', 'entity', 'measure', 'unit')), 
-	CONSTRAINT ck_concepts_source CHECK (source IS NULL OR source IN ('seed', 'frame', 'teach'))
+	CONSTRAINT ck_concepts_source CHECK (source IS NULL OR source IN ('seed', 'frame'))
 );
 
 CREATE UNIQUE INDEX uq_concept_active ON concepts (vertical, name) WHERE superseded_at IS NULL;

--- a/packages/engine/src/dataraum/analysis/eligibility/db_models.py
+++ b/packages/engine/src/dataraum/analysis/eligibility/db_models.py
@@ -9,7 +9,16 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from sqlalchemy import JSON, DateTime, ForeignKey, Index, String, Text, UniqueConstraint
+from sqlalchemy import (
+    JSON,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dataraum.storage import Base
@@ -33,6 +42,11 @@ class ColumnEligibilityRecord(Base):
     # at-least-once retries and two coexisting runs' rows don't collide.
     __table_args__ = (
         UniqueConstraint("column_id", "run_id", name="uq_column_eligibility_column_run"),
+        # Closed-vocabulary enforcement (DAT-802 enum-standard sweep): the 3
+        # values declared by ``column_eligibility.yaml`` (rule ``status`` +
+        # ``default_status``) and returned verbatim by ``evaluate_rules`` /
+        # ``extract_metrics`` fallback — config-derived, never LLM-touched.
+        CheckConstraint("status IN ('ELIGIBLE', 'WARN', 'INELIGIBLE')", name="status"),
     )
 
     eligibility_id: Mapped[str] = mapped_column(

--- a/packages/engine/src/dataraum/analysis/hierarchies/db_models.py
+++ b/packages/engine/src/dataraum/analysis/hierarchies/db_models.py
@@ -132,6 +132,16 @@ class DimensionHierarchy(Base):
             "role_verdict IN (" + ", ".join(f"'{v}'" for v in _ROLE_VERDICT_VALUES) + ")",
             name="role_verdict",
         ),
+        # Structure-kind vocabulary (DAT-802 enum-standard sweep): the three
+        # discriminator values ``_hierarchy_row`` (processor.py) ever writes — see
+        # the class docstring. Sibling of ``role_verdict`` in the same DAT-784
+        # commit era that the CHECK pass left uncovered (no Python enum exists for
+        # this one; hand-typed inline, matching the ``relationship_type`` precedent).
+        CheckConstraint("kind IN ('drilldown', 'alias', 'role')", name="kind"),
+        # Detection-source vocabulary (DAT-802): 'g3' (auto-discovered, the
+        # default) or 'manual' (a teach add/alias assertion) — the only two values
+        # ``processor.py`` ever writes.
+        CheckConstraint("detection_source IN ('g3', 'manual')", name="detection_source"),
     )
 
     hierarchy_id: Mapped[str] = mapped_column(

--- a/packages/engine/src/dataraum/analysis/relationships/db_models.py
+++ b/packages/engine/src/dataraum/analysis/relationships/db_models.py
@@ -80,15 +80,27 @@ class Relationship(Base):
             "confirmation_source IN ('unconfirmed', 'judge', 'user', 'keeper')",
             name="confirmation_source",
         ),
-        # Orientation invariant (DAT-777): a persisted FK is stored many→one,
-        # child→parent — so ``from`` is always the many/fact side every downstream
-        # consumer assumes (og_references, the conformed-dim identity resolve, the
-        # cockpit fan-out caution). :meth:`oriented_row` FLIPS a ``one-to-many`` row;
-        # this CHECK makes the invariant STRUCTURAL — a mis-oriented row fails loud at
-        # flush even on a write path that bypasses the helper, so it cannot silently
-        # persist reversed through any of the three writers.
+        # Detection-method vocabulary (DAT-802 enum-standard sweep): the closed set
+        # every writer produces — ``detector.py`` ('candidate'), ``processor.py``
+        # llm-confirm path ('llm'), ``materialize.py`` overlay materialization
+        # ('manual' / 'keeper'). Sibling of ``confirmation_source`` in the same
+        # table/DAT-776 era that CHECK pass left uncovered.
         CheckConstraint(
-            "cardinality IS NULL OR cardinality <> 'one-to-many'",
+            "detection_method IS NULL OR detection_method IN "
+            "('candidate', 'llm', 'manual', 'keeper')",
+            name="detection_method",
+        ),
+        # Orientation invariant (DAT-777, upgraded DAT-802): a persisted FK is
+        # stored many→one, child→parent — so ``from`` is always the many/fact side
+        # every downstream consumer assumes (og_references, the conformed-dim
+        # identity resolve, the cockpit fan-out caution). :meth:`oriented_row`
+        # FLIPS a ``one-to-many`` row before persisting, so the full closed set a
+        # row can ever legally hold is exactly these three (plus NULL) —
+        # ``one-to-many`` is now structurally impossible, not merely rejected by a
+        # backstop. A mis-oriented row fails loud at flush even on a write path
+        # that bypasses the helper.
+        CheckConstraint(
+            "cardinality IS NULL OR cardinality IN ('one-to-one', 'many-to-one', 'many-to-many')",
             name="cardinality_oriented",
         ),
     )
@@ -267,6 +279,22 @@ class SurrogateKeyIntent(Base):
     __tablename__ = "surrogate_key_intents"
     __table_args__ = (
         UniqueConstraint("run_id", "intent_digest", name="uq_surrogate_intent_run_digest"),
+        # Verdict vocabulary (DAT-802): the only two values ``_confirmed_intent_row``
+        # / ``_declined_intent_rows`` (semantic/processor.py) ever write.
+        CheckConstraint("status IN ('confirmed', 'declined')", name="status"),
+        # Cardinality vocabulary (DAT-802): sourced exclusively from
+        # ``compute_composite_cardinality`` (code-computed, never LLM-echoed — the
+        # LLM only supplies which columns to include, via ``key_columns``). The
+        # confirmed path (``_build_surrogate_intent``) explicitly falls back to no
+        # intent when the measurement is ``'many-to-many'`` (never mint a proven
+        # fan-out as a key); the declined path only ever carries a
+        # ``find_composite_key_rescue`` hint, which by construction never returns a
+        # many-to-many ``CompositeKey`` either (composite.py's rescue loop). NULL
+        # when no DuckDB connection was available at confirmation time.
+        CheckConstraint(
+            "cardinality IS NULL OR cardinality IN ('one-to-one', 'one-to-many', 'many-to-one')",
+            name="cardinality",
+        ),
     )
 
     intent_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))

--- a/packages/engine/src/dataraum/analysis/relationships/db_models.py
+++ b/packages/engine/src/dataraum/analysis/relationships/db_models.py
@@ -288,7 +288,7 @@ class SurrogateKeyIntent(Base):
         # confirmed path (``_build_surrogate_intent``) explicitly falls back to no
         # intent when the measurement is ``'many-to-many'`` (never mint a proven
         # fan-out as a key); the declined path only ever carries a
-        # ``find_composite_key_rescue`` hint, which by construction never returns a
+        # ``rescue_fanout_to_composite`` hint, which by construction never returns a
         # many-to-many ``CompositeKey`` either (composite.py's rescue loop). NULL
         # when no DuckDB connection was available at confirmation time.
         CheckConstraint(

--- a/packages/engine/src/dataraum/analysis/semantic/db_models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/db_models.py
@@ -169,16 +169,16 @@ class Concept(Base):
             "kind IN (" + ", ".join(f"'{v}'" for v in _CONCEPT_KIND_VALUES) + ")",
             name="kind",
         ),
-        # Lifecycle-source vocabulary (DAT-802): the full LIVE domain — 'seed'
-        # (concept_store.py, engine) and 'frame' (cockpit ``concept-write.ts``,
-        # direct Drizzle write). NOT 'teach': DAT-728 (Done) explicitly retired
-        # the ``concept`` teach type — "the config_overlay concept-family
-        # (concept/concept_property/rebind) retires read AND write" — and the
-        # cockpit's own ``teach-routing.ts`` documents the same call ("the
-        # concept vocabulary is no longer a teach type — config→DB moved it to
-        # the typed concepts table the frame stage writes"). The class
-        # docstring's inline ``# 'seed' | 'frame' | 'teach'`` comment is stale;
-        # narrowed to what DAT-728 actually left live, not the aspirational list.
+        # Lifecycle-source vocabulary (DAT-802): the two LIVE writers — 'seed'
+        # (``concept_store.py:72``, engine) and 'frame' (cockpit
+        # ``concept-write.ts:84``'s ``writeConcept()``, a real Drizzle INSERT
+        # wired into the ``frame`` tool at ``tools/frame.ts:405`` and exercised
+        # by ``concept-write.integration.test.ts`` — not a generated view, not
+        # aspirational). NOT 'teach': DAT-728 (Done) explicitly retired the
+        # ``concept`` teach type. Deliberately narrower than ``ConceptEdge.source``
+        # (2 live writers here vs. 1 there) — don't copy that CHECK's value list
+        # onto this column; each column's set is its own writers, not a shared
+        # template.
         CheckConstraint("source IS NULL OR source IN ('seed', 'frame')", name="source"),
     )
 
@@ -193,8 +193,7 @@ class Concept(Base):
     unit_from_concept: Mapped[str | None] = mapped_column(String)
 
     # Lifecycle: workspace-persistent with supersession (NULL superseded_at = active).
-    # Closed vocab: see ck_concepts_source. NOT 'teach' — DAT-728 retired the
-    # concept teach type; only 'seed' | 'frame' are live writers.
+    # Closed vocab: see ck_concepts_source — 'seed' | 'frame' are the two live writers.
     source: Mapped[str | None] = mapped_column(String)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=lambda: datetime.now(UTC)
@@ -259,12 +258,19 @@ class ConceptEdge(Base):
             "predicate IN (" + ", ".join(f"'{v}'" for v in _CONCEPT_EDGE_PREDICATE_VALUES) + ")",
             name="predicate",
         ),
-        # Lifecycle-source vocabulary (DAT-802): the full documented domain (class
-        # docstring) — 'seed' (concept_edge_store.py) is the only live writer;
-        # 'frame' is the declared P13 authoring path and 'derived' is the
-        # DAT-800/801 aggregation-lineage producer's output (both out of scope
-        # here) — included so neither needs a CHECK migration to land.
-        CheckConstraint("source IS NULL OR source IN ('seed', 'derived', 'frame')", name="source"),
+        # Lifecycle-source vocabulary (DAT-802): 'seed' (``concept_edge_store.py:
+        # 104,126``) is the ONLY writer this column has today. 'derived' and
+        # 'frame' were the class docstring's future-authoring-path prose
+        # (DAT-800/801, P13) — not a live writer, not even a wired-but-dead
+        # cockpit code path (the cockpit's only ``concept_edges`` reference is
+        # the generated Drizzle mirror, ``schema.ts`` — a read view, not a
+        # writer). A CHECK admitting a value no writer produces is the exact
+        # defect this sweep exists to fix (the DAT-772 audit's
+        # ``relationship_type`` finding: "advertises values no writer
+        # produces"); the cost of a future writer needing a wider CHECK is one
+        # line + a re-dump landed by the PR that adds it (no migrations here —
+        # see the workspace CLAUDE.md's "no backwards-compat shims").
+        CheckConstraint("source IS NULL OR source = 'seed'", name="source"),
     )
 
     edge_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
@@ -278,7 +284,8 @@ class ConceptEdge(Base):
     tolerance: Mapped[float | None] = mapped_column(Float)
 
     # Lifecycle: workspace-persistent with supersession (mirrors Concept).
-    source: Mapped[str | None] = mapped_column(String)  # 'seed' | 'derived' | 'frame'
+    # Closed vocab: see ck_concept_edges_source — 'seed' is the only live writer.
+    source: Mapped[str | None] = mapped_column(String)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=lambda: datetime.now(UTC)
     )

--- a/packages/engine/src/dataraum/analysis/semantic/db_models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/db_models.py
@@ -169,13 +169,17 @@ class Concept(Base):
             "kind IN (" + ", ".join(f"'{v}'" for v in _CONCEPT_KIND_VALUES) + ")",
             name="kind",
         ),
-        # Lifecycle-source vocabulary (DAT-802): the full documented domain
-        # (class docstring) — 'seed' (concept_store.py, engine) and 'frame'
-        # (cockpit ``concept-write.ts``, direct Drizzle write) are live today;
-        # 'teach' is the declared-but-unbuilt third authoring path (frame/teach
-        # parity, DAT-729-adjacent) — included so its eventual writer doesn't need
-        # a CHECK migration to land.
-        CheckConstraint("source IS NULL OR source IN ('seed', 'frame', 'teach')", name="source"),
+        # Lifecycle-source vocabulary (DAT-802): the full LIVE domain — 'seed'
+        # (concept_store.py, engine) and 'frame' (cockpit ``concept-write.ts``,
+        # direct Drizzle write). NOT 'teach': DAT-728 (Done) explicitly retired
+        # the ``concept`` teach type — "the config_overlay concept-family
+        # (concept/concept_property/rebind) retires read AND write" — and the
+        # cockpit's own ``teach-routing.ts`` documents the same call ("the
+        # concept vocabulary is no longer a teach type — config→DB moved it to
+        # the typed concepts table the frame stage writes"). The class
+        # docstring's inline ``# 'seed' | 'frame' | 'teach'`` comment is stale;
+        # narrowed to what DAT-728 actually left live, not the aspirational list.
+        CheckConstraint("source IS NULL OR source IN ('seed', 'frame')", name="source"),
     )
 
     concept_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
@@ -189,7 +193,9 @@ class Concept(Base):
     unit_from_concept: Mapped[str | None] = mapped_column(String)
 
     # Lifecycle: workspace-persistent with supersession (NULL superseded_at = active).
-    source: Mapped[str | None] = mapped_column(String)  # 'seed' | 'frame' | 'teach'
+    # Closed vocab: see ck_concepts_source. NOT 'teach' — DAT-728 retired the
+    # concept teach type; only 'seed' | 'frame' are live writers.
+    source: Mapped[str | None] = mapped_column(String)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=lambda: datetime.now(UTC)
     )

--- a/packages/engine/src/dataraum/analysis/semantic/db_models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/db_models.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 from sqlalchemy import (
     JSON,
+    CheckConstraint,
     DateTime,
     Float,
     ForeignKey,
@@ -95,6 +96,16 @@ class ConceptEdgePredicate(StrEnum):
     RECONCILES_WITH = "reconciles_with"
 
 
+# Closed-vocabulary CHECK values (DAT-802 enum-standard sweep), each derived from
+# its single-home enum above so the CHECK and the enum can never drift (the
+# DAT-784 pattern). Sorted for a deterministic CHECK string in the offline DDL dump.
+_CONCEPT_KIND_VALUES: tuple[str, ...] = tuple(sorted(v.value for v in ConceptKind))
+_TABLE_ROLE_VALUES: tuple[str, ...] = tuple(sorted(v.value for v in TableRole))
+_CONCEPT_EDGE_PREDICATE_VALUES: tuple[str, ...] = tuple(
+    sorted(v.value for v in ConceptEdgePredicate)
+)
+
+
 def derive_table_role(
     is_fact: bool,
     grain_columns: Sequence[str],
@@ -148,6 +159,23 @@ class Concept(Base):
             postgresql_where=text("superseded_at IS NULL"),
             sqlite_where=text("superseded_at IS NULL"),
         ),
+        # Closed-vocabulary enforcement (DAT-802): derived from ConceptKind, the
+        # single home (see ``concept_store.py``'s seed validation against
+        # ``_VALID_KINDS`` and the cockpit's independently-typed TS mirror,
+        # ``write-surface.ts`` / ``concept-write.ts``'s ``CONCEPT_KINDS`` — two
+        # app-level guards converging on one physical column with no DB backstop
+        # until now).
+        CheckConstraint(
+            "kind IN (" + ", ".join(f"'{v}'" for v in _CONCEPT_KIND_VALUES) + ")",
+            name="kind",
+        ),
+        # Lifecycle-source vocabulary (DAT-802): the full documented domain
+        # (class docstring) — 'seed' (concept_store.py, engine) and 'frame'
+        # (cockpit ``concept-write.ts``, direct Drizzle write) are live today;
+        # 'teach' is the declared-but-unbuilt third authoring path (frame/teach
+        # parity, DAT-729-adjacent) — included so its eventual writer doesn't need
+        # a CHECK migration to land.
+        CheckConstraint("source IS NULL OR source IN ('seed', 'frame', 'teach')", name="source"),
     )
 
     concept_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
@@ -215,6 +243,22 @@ class ConceptEdge(Base):
             postgresql_where=text("superseded_at IS NULL"),
             sqlite_where=text("superseded_at IS NULL"),
         ),
+        # Closed-vocabulary enforcement (DAT-802): derived from ConceptEdgePredicate,
+        # the single home. ``concept_edge_store.py`` (seed) only ever writes
+        # PART_OF/DISJOINT_WITH today; RECONCILES_WITH is the declared third
+        # predicate the aggregation-lineage reconciliation producer (DAT-800/801,
+        # out of this sweep's scope) will emit — included so that fenced work
+        # doesn't need a CHECK migration to land.
+        CheckConstraint(
+            "predicate IN (" + ", ".join(f"'{v}'" for v in _CONCEPT_EDGE_PREDICATE_VALUES) + ")",
+            name="predicate",
+        ),
+        # Lifecycle-source vocabulary (DAT-802): the full documented domain (class
+        # docstring) — 'seed' (concept_edge_store.py) is the only live writer;
+        # 'frame' is the declared P13 authoring path and 'derived' is the
+        # DAT-800/801 aggregation-lineage producer's output (both out of scope
+        # here) — included so neither needs a CHECK migration to land.
+        CheckConstraint("source IS NULL OR source IN ('seed', 'derived', 'frame')", name="source"),
     )
 
     edge_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
@@ -249,6 +293,14 @@ class SemanticAnnotation(Base):
     # current; readers head-resolve rather than assume one row per column.
     __table_args__ = (
         UniqueConstraint("column_id", "run_id", name="uq_column_semantic_annotation"),
+        # Closed-vocabulary enforcement (DAT-802): the ONLY value any writer
+        # produces today is 'llm' (semantic/processor.py, the sole writer). The
+        # 'manual' / 'config_override' values below were aspirational — no manual
+        # or config-override write path exists (DAT-772 audit's doc-drift finding);
+        # narrowed to reality rather than encoded from the stale comment.
+        CheckConstraint(
+            "annotation_source IS NULL OR annotation_source IN ('llm')", name="annotation_source"
+        ),
     )
 
     annotation_id: Mapped[str] = mapped_column(
@@ -286,10 +338,9 @@ class SemanticAnnotation(Base):
     # treats these as NULL in generated SQL. None = not resolved / no rejects.
     null_tokens: Mapped[list[str] | None] = mapped_column(JSON)
 
-    # Provenance
-    annotation_source: Mapped[str | None] = mapped_column(
-        String
-    )  # 'llm', 'manual', 'config_override'
+    # Provenance. Closed vocab: see ck_semantic_annotations_annotation_source —
+    # 'llm' is the only value any writer produces today.
+    annotation_source: Mapped[str | None] = mapped_column(String)
     annotated_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=lambda: datetime.now(UTC)
     )
@@ -346,7 +397,16 @@ class ColumnConcept(Base):
     # One row per column PER catalogue run (DAT-637): mirrors SemanticAnnotation's
     # run-versioned grain so coexisting begin_session runs don't collide; the
     # catalogue head names the current run.
-    __table_args__ = (UniqueConstraint("column_id", "run_id", name="uq_column_concept"),)
+    __table_args__ = (
+        UniqueConstraint("column_id", "run_id", name="uq_column_concept"),
+        # Closed-vocabulary enforcement (DAT-802): the ONLY value any writer
+        # produces today is 'llm' (``semantic_per_table``, the sole authoring
+        # path — this table's own docstring: "authored ONLY by semantic_per_table").
+        CheckConstraint(
+            "annotation_source IS NULL OR annotation_source IN ('llm')",
+            name="annotation_source",
+        ),
+    )
 
     concept_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
     column_id: Mapped[str] = mapped_column(ForeignKey("columns.column_id"), nullable=False)
@@ -380,7 +440,25 @@ class TableEntity(Base):
     # run-versioned and coexists across runs; this constraint (mirroring
     # ``uq_column_semantic_annotation``) makes "one row per ``(table_id, run_id)``"
     # a DB guarantee so the run-scoped readers can trust it.
-    __table_args__ = (UniqueConstraint("table_id", "run_id", name="uq_table_entity_table_run"),)
+    __table_args__ = (
+        UniqueConstraint("table_id", "run_id", name="uq_table_entity_table_run"),
+        # Closed-vocabulary enforcement (DAT-802): the ONLY value any writer
+        # produces today is 'llm' (semantic/processor.py, the sole writer).
+        # 'heuristic' / 'manual' were aspirational — no such write path exists
+        # (DAT-772 audit's doc-drift finding); narrowed to reality.
+        CheckConstraint(
+            "detection_source IS NULL OR detection_source IN ('llm')", name="detection_source"
+        ),
+        # Table-role vocabulary (DAT-802): derived from TableRole, the single home
+        # (see :func:`derive_table_role`, the sole writer via
+        # ``semantic/agent.py``).
+        CheckConstraint(
+            "table_role IS NULL OR table_role IN ("
+            + ", ".join(f"'{v}'" for v in _TABLE_ROLE_VALUES)
+            + ")",
+            name="table_role",
+        ),
+    )
     entity_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
     table_id: Mapped[str] = mapped_column(ForeignKey("tables.table_id"), nullable=False)
     # Snapshot version axis (DAT-413): the run that wrote this row.
@@ -414,8 +492,9 @@ class TableEntity(Base):
     time_columns: Mapped[list[dict[str, Any]] | None] = mapped_column(JSON)
     identity_columns: Mapped[list[dict[str, Any]] | None] = mapped_column(JSON)
 
-    # Provenance
-    detection_source: Mapped[str | None] = mapped_column(String)  # 'llm', 'heuristic', 'manual'
+    # Provenance. Closed vocab: see ck_table_entities_detection_source — 'llm' is
+    # the only value any writer produces today.
+    detection_source: Mapped[str | None] = mapped_column(String)
     detected_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=lambda: datetime.now(UTC)
     )

--- a/packages/engine/src/dataraum/analysis/slicing/db_models.py
+++ b/packages/engine/src/dataraum/analysis/slicing/db_models.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 
 from sqlalchemy import (
     JSON,
+    CheckConstraint,
     DateTime,
     Float,
     ForeignKey,
@@ -53,6 +54,16 @@ class SliceDefinition(Base):
         Index("idx_slice_definitions_table", "table_id"),
         Index("idx_slice_definitions_column", "column_id"),
         Index("idx_slice_definitions_dim_table", "dimension_table_id"),
+        # Closed-vocabulary enforcement (DAT-802 enum-standard sweep): the ONLY
+        # value ``slicing_phase.py`` (the sole writer) ever produces today —
+        # numeric/date-bucket slice types are not yet built. Extending the CHECK
+        # is the cost of shipping a second slice type, same as any other closed
+        # vocabulary here.
+        CheckConstraint("slice_type IN ('categorical')", name="slice_type"),
+        # Detection-source vocabulary (DAT-802): the ONLY value any writer
+        # produces today — ``slicing_phase.py`` always sets 'llm' (matches the
+        # column default).
+        CheckConstraint("detection_source IN ('llm')", name="detection_source"),
     )
 
     slice_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))

--- a/packages/engine/src/dataraum/analysis/statistics/db_models.py
+++ b/packages/engine/src/dataraum/analysis/statistics/db_models.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 
 from sqlalchemy import (
     JSON,
+    CheckConstraint,
     DateTime,
     Float,
     ForeignKey,
@@ -49,6 +50,16 @@ class StatisticalProfile(Base):
     # and two coexisting runs' rows don't collide.
     __table_args__ = (
         UniqueConstraint("column_id", "run_id", name="uq_statistical_profiles_column_run"),
+        # Closed-vocabulary enforcement (DAT-802 audit): every writer — the primary
+        # profiling pass (``analysis/statistics/profiler.py``, which REQUIRES a
+        # typed table) and the enriched-views dimension profiling
+        # (``enriched_views_phase.py``) — produces only 'typed' / 'enriched'. The
+        # ``default="raw"`` below is vestigial (no writer has ever hit it — every
+        # constructor sets ``layer`` explicitly); left as-is (not this sweep's
+        # scope to change behavior), but the CHECK reflects reality, not the dead
+        # default, so a future caller that forgets to override it fails loud
+        # instead of silently mis-labeling a typed/enriched profile as raw.
+        CheckConstraint("layer IN ('typed', 'enriched')", name="layer"),
     )
 
     profile_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
@@ -59,8 +70,7 @@ class StatisticalProfile(Base):
         DateTime, nullable=False, default=lambda: datetime.now(UTC)
     )
 
-    # Layer indicator: "raw" or "typed"
-    # Determines which stage produced this profile
+    # Which stage produced this profile. Closed vocab: see ck_statistical_profiles_layer.
     layer: Mapped[str] = mapped_column(String, nullable=False, default="raw")
 
     # STRUCTURED: Queryable core dimensions

--- a/packages/engine/src/dataraum/analysis/statistics/db_models.py
+++ b/packages/engine/src/dataraum/analysis/statistics/db_models.py
@@ -50,15 +50,17 @@ class StatisticalProfile(Base):
     # and two coexisting runs' rows don't collide.
     __table_args__ = (
         UniqueConstraint("column_id", "run_id", name="uq_statistical_profiles_column_run"),
-        # Closed-vocabulary enforcement (DAT-802 audit): every writer — the primary
-        # profiling pass (``analysis/statistics/profiler.py``, which REQUIRES a
-        # typed table) and the enriched-views dimension profiling
-        # (``enriched_views_phase.py``) — produces only 'typed' / 'enriched'. The
-        # ``default="raw"`` below is vestigial (no writer has ever hit it — every
-        # constructor sets ``layer`` explicitly); left as-is (not this sweep's
-        # scope to change behavior), but the CHECK reflects reality, not the dead
-        # default, so a future caller that forgets to override it fails loud
-        # instead of silently mis-labeling a typed/enriched profile as raw.
+        # Closed-vocabulary enforcement (DAT-802 audit): every writer — production
+        # (the primary profiling pass, ``analysis/statistics/profiler.py``, which
+        # REQUIRES a typed table, and the enriched-views dimension profiling,
+        # ``enriched_views_phase.py``) and every test fixture, engine-wide —
+        # produces only 'typed' / 'enriched'. The former ``default="raw"`` was
+        # vestigial (verified: zero constructors, production or test, ever
+        # omitted ``layer=``) and actively misleading (implied 'raw' was a
+        # legitimate resting state); removed rather than kept dead, so a future
+        # caller that forgets to set ``layer`` fails loud immediately (a clear
+        # NOT NULL error) instead of silently defaulting to a value the CHECK
+        # would reject anyway.
         CheckConstraint("layer IN ('typed', 'enriched')", name="layer"),
     )
 
@@ -71,7 +73,8 @@ class StatisticalProfile(Base):
     )
 
     # Which stage produced this profile. Closed vocab: see ck_statistical_profiles_layer.
-    layer: Mapped[str] = mapped_column(String, nullable=False, default="raw")
+    # No default: every writer (production and test) must state it explicitly.
+    layer: Mapped[str] = mapped_column(String, nullable=False)
 
     # STRUCTURED: Queryable core dimensions
     total_count: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/packages/engine/src/dataraum/analysis/typing/db_models.py
+++ b/packages/engine/src/dataraum/analysis/typing/db_models.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 
 from sqlalchemy import (
     JSON,
+    CheckConstraint,
     DateTime,
     Float,
     ForeignKey,
@@ -111,10 +112,14 @@ class TypeDecision(Base):
     Final type decision for a column after inference and optional human review.
     One decision per column.
 
-    Decision sources:
-    - 'automatic': System selected best TypeCandidate
-    - 'manual': Human override via UI/API
-    - 'override': Configuration-based override
+    Decision sources (DAT-802 audit corrected against the actual writers in
+    ``typing/resolution.py`` — the class comment previously claimed 'override',
+    which no writer has ever produced, and omitted 'fallback', which is real):
+    - 'automatic': System selected best TypeCandidate.
+    - 'manual': Human override, copied forward from a prior manual decision
+      (``resolution.py``'s only 'manual' producer copies an EXISTING manual row;
+      no fresh-write path exists in the engine today).
+    - 'fallback': No candidate met the confidence bar; the resolver fell back.
     """
 
     __tablename__ = "type_decisions"
@@ -122,7 +127,14 @@ class TypeDecision(Base):
     # this from ``column_id`` to ``(column_id, run_id)`` so two coexisting runs'
     # rows for the same column don't collide. The promoted head names which run is
     # current; readers head-resolve rather than assume one row per column.
-    __table_args__ = (UniqueConstraint("column_id", "run_id", name="uq_column_type_decision"),)
+    __table_args__ = (
+        UniqueConstraint("column_id", "run_id", name="uq_column_type_decision"),
+        # Closed-vocabulary enforcement (DAT-802): matches the corrected class
+        # docstring above, not the stale inline comment this replaces.
+        CheckConstraint(
+            "decision_source IN ('automatic', 'manual', 'fallback')", name="decision_source"
+        ),
+    )
 
     decision_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
     column_id: Mapped[str] = mapped_column(ForeignKey("columns.column_id"), nullable=False)
@@ -130,9 +142,8 @@ class TypeDecision(Base):
     run_id: Mapped[str] = mapped_column(String, nullable=False)
 
     decided_type: Mapped[str] = mapped_column(String, nullable=False)
-    decision_source: Mapped[str] = mapped_column(
-        String, nullable=False
-    )  # 'automatic', 'manual', 'override'
+    # Closed vocab: see ck_type_decisions_decision_source and the class docstring.
+    decision_source: Mapped[str] = mapped_column(String, nullable=False)
     decided_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=lambda: datetime.now(UTC)
     )

--- a/packages/engine/src/dataraum/entropy/db_models.py
+++ b/packages/engine/src/dataraum/entropy/db_models.py
@@ -11,14 +11,33 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
-from sqlalchemy import JSON, DateTime, Float, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy import (
+    JSON,
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
+from dataraum.entropy.dimensions import Dimension, Layer, SubDimension
 from dataraum.storage import Base
 
 # Use JSONB for PostgreSQL, JSON for SQLite (JSON handles serialization automatically)
 JSON_TYPE = JSONB().with_variant(JSON, "sqlite")
+
+# Closed-vocabulary CHECK values (DAT-802 enum-standard sweep), derived from the
+# single-home enums in ``entropy.dimensions`` — every detector's ``layer`` /
+# ``dimension`` / ``sub_dimension`` is already ``isinstance``-asserted against
+# these at registration (``detectors/base.py``); this is the DB-enforced backstop
+# (the DAT-784 pattern). Sorted for a deterministic CHECK string in the dump.
+_LAYER_VALUES: tuple[str, ...] = tuple(sorted(v.value for v in Layer))
+_DIMENSION_VALUES: tuple[str, ...] = tuple(sorted(v.value for v in Dimension))
+_SUB_DIMENSION_VALUES: tuple[str, ...] = tuple(sorted(v.value for v in SubDimension))
 
 
 class EntropyObjectRecord(Base):
@@ -29,6 +48,23 @@ class EntropyObjectRecord(Base):
     """
 
     __tablename__ = "entropy_objects"
+    __table_args__ = (
+        # Closed-vocabulary enforcement (DAT-802 enum-standard sweep): derived from
+        # the Layer/Dimension/SubDimension enums, the single home — every detector
+        # is already ``isinstance``-asserted against them at registration
+        # (``detectors/base.py``); this is the DB-enforced backstop.
+        CheckConstraint(
+            "layer IN (" + ", ".join(f"'{v}'" for v in _LAYER_VALUES) + ")", name="layer"
+        ),
+        CheckConstraint(
+            "dimension IN (" + ", ".join(f"'{v}'" for v in _DIMENSION_VALUES) + ")",
+            name="dimension",
+        ),
+        CheckConstraint(
+            "sub_dimension IN (" + ", ".join(f"'{v}'" for v in _SUB_DIMENSION_VALUES) + ")",
+            name="sub_dimension",
+        ),
+    )
 
     object_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
 
@@ -95,6 +131,14 @@ class EntropyReadinessRecord(Base):
     """
 
     __tablename__ = "entropy_readiness"
+    __table_args__ = (
+        # Closed-vocabulary enforcement (DAT-802 enum-standard sweep): the 3
+        # values ``LossConfig.band()`` (``entropy/loss.py``, the single chokepoint
+        # every ``band=`` write reads from) can ever return — hardcoded in its
+        # body, not (yet) its own enum; hand-typed inline, matching the
+        # ``relationship_type`` precedent.
+        CheckConstraint("band IN ('ready', 'investigate', 'blocked')", name="band"),
+    )
 
     readiness_id: Mapped[str] = mapped_column(
         String, primary_key=True, default=lambda: str(uuid4())

--- a/packages/engine/src/dataraum/lifecycle/db_models.py
+++ b/packages/engine/src/dataraum/lifecycle/db_models.py
@@ -33,10 +33,17 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
-from sqlalchemy import JSON, DateTime, Float, String, Text, UniqueConstraint
+from sqlalchemy import JSON, CheckConstraint, DateTime, Float, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
+from dataraum.lifecycle.transitions import ArtifactState
 from dataraum.storage.base import Base
+
+# Closed-vocabulary CHECK values (DAT-802 enum-standard sweep), derived from
+# ArtifactState, the single home (``lifecycle/transitions.py`` — every
+# ``declare_artifact`` / ``transition`` write goes through ``.value`` on this
+# enum). Sorted for a deterministic CHECK string in the offline DDL dump.
+_ARTIFACT_STATE_VALUES: tuple[str, ...] = tuple(sorted(v.value for v in ArtifactState))
 
 
 class LifecycleArtifact(Base):
@@ -72,6 +79,13 @@ class LifecycleArtifact(Base):
             "artifact_key",
             "run_id",
             name="uq_lifecycle_artifact_identity",
+        ),
+        # Closed-vocabulary enforcement (DAT-802 enum-standard sweep): derived
+        # from ArtifactState, the single home — the DB-enforced backstop for the
+        # typed state machine ``lifecycle/transitions.py`` already governs app-side.
+        CheckConstraint(
+            "state IN (" + ", ".join(f"'{v}'" for v in _ARTIFACT_STATE_VALUES) + ")",
+            name="state",
         ),
     )
 

--- a/packages/engine/src/dataraum/storage/models.py
+++ b/packages/engine/src/dataraum/storage/models.py
@@ -10,7 +10,16 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy import (
+    JSON,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dataraum.storage.base import Base
@@ -83,10 +92,13 @@ class Source(Base):
 class Table(Base):
     """Tables from data sources.
 
-    A table can exist in different layers:
-    - 'raw': VARCHAR-first staging layer
-    - 'typed': After type resolution
-    - 'quarantine': Failed type casts
+    A table can exist in different layers (DAT-802 audit: the class comment
+    previously omitted 'enriched', a real layer ``enriched_views_phase.py``
+    writes on every fact table's dimension-widened view):
+    - 'raw': VARCHAR-first staging layer.
+    - 'typed': After type resolution.
+    - 'quarantine': Failed type casts.
+    - 'enriched': A fact table's dimension-widened view (``enriched_views_phase.py``).
     """
 
     __tablename__ = "tables"
@@ -96,12 +108,19 @@ class Table(Base):
     # source is an atomic content-keyed wrapper (how the table arrived), never a
     # disambiguator; two sources cannot each own an ``orders`` (import fails loud
     # and tells the user to retire the existing one first).
-    __table_args__ = (UniqueConstraint("table_name", "layer", name="uq_table_name_layer"),)
+    __table_args__ = (
+        UniqueConstraint("table_name", "layer", name="uq_table_name_layer"),
+        # Closed-vocabulary enforcement (DAT-802 enum-standard sweep): the 4
+        # values every writer produces (import/typing/surrogate-mint/enriched-views
+        # phases + the 3 source loaders) — see the class docstring above.
+        CheckConstraint("layer IN ('raw', 'typed', 'quarantine', 'enriched')", name="layer"),
+    )
 
     table_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
     source_id: Mapped[str] = mapped_column(ForeignKey("sources.source_id"), nullable=False)
     table_name: Mapped[str] = mapped_column(String, nullable=False)
-    layer: Mapped[str] = mapped_column(String, nullable=False)  # 'raw', 'typed', 'quarantine'
+    # Closed vocab: see ck_tables_layer and the class docstring.
+    layer: Mapped[str] = mapped_column(String, nullable=False)
     # Unqualified DuckDB table name — NARROW, workspace-unique (e.g. ``orders``,
     # no source prefix — DAT-639). Schema is derived from ``layer`` via
     # ``dataraum.core.duckdb_naming.schema_for_layer``; cross-layer SQL composes

--- a/packages/engine/src/dataraum/storage/models.py
+++ b/packages/engine/src/dataraum/storage/models.py
@@ -65,7 +65,6 @@ class Source(Base):
     )
 
     # Source management fields (onboarding)
-    status: Mapped[str | None] = mapped_column(String, nullable=True)
     # Journey stage the source has reached (DAT-378). The cockpit drives a source
     # through ``connect → frame → select → add_source`` before triggering the
     # workflow; this column is the persisted cursor the cockpit's journey

--- a/packages/engine/src/dataraum/storage/read_views.py
+++ b/packages/engine/src/dataraum/storage/read_views.py
@@ -489,8 +489,7 @@ def materialize_read_schema(connection: Connection, workspace_schema: str) -> in
 # REVOKE anything already granted; revoke manually when narrowing.
 _CONTROL_WRITE_GRANTS: dict[str, str] = {
     "sources": (
-        "SELECT, INSERT, "
-        "UPDATE (source_type, connection_config, status, stage, backend, updated_at)"
+        "SELECT, INSERT, UPDATE (source_type, connection_config, stage, backend, updated_at)"
     ),
     "config_overlay": "SELECT, INSERT, UPDATE",
     # concepts (DAT-728, config→DB): the typed concept vocabulary. `frame`

--- a/packages/engine/tests/integration/analysis/views/test_enriched_views.py
+++ b/packages/engine/tests/integration/analysis/views/test_enriched_views.py
@@ -350,7 +350,7 @@ class TestEnrichedViewsPhaseDuckLake:
                 from_column_id=fk_id,
                 to_column_id=pk_id,
                 relationship_type="foreign_key",
-                cardinality="many_to_one",
+                cardinality="many-to-one",
                 confidence=0.9,
                 detection_method="llm",
                 confirmation_source="judge",

--- a/packages/engine/tests/integration/conftest.py
+++ b/packages/engine/tests/integration/conftest.py
@@ -262,7 +262,6 @@ class PipelineTestHarness:
                     name=clean_name,
                     source_type=source_type,
                     connection_config={"file_uris": file_uris},
-                    status="configured",
                 )
                 session.add(source)
                 session.commit()

--- a/packages/engine/tests/integration/pipeline/test_import_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_import_phase.py
@@ -51,7 +51,6 @@ def _seed_source(
             name=name,
             source_type=source_type,
             connection_config={"file_uris": [str(path)]},
-            status="configured",
         )
     )
     session.flush()
@@ -77,7 +76,6 @@ def _seed_db_source(
             source_type="db_recipe",
             connection_config=connection_config,
             backend="mssql",
-            status="configured",
         )
     )
     if with_raw_table:
@@ -204,7 +202,6 @@ class TestImportPhase:
             name="multi",
             source_type="csv",
             connection_config={"file_uris": [str(customers), str(orders)]},
-            status="configured",
         )
         session.add(source)
         session.flush()

--- a/packages/engine/tests/integration/pipeline/test_import_phase.py
+++ b/packages/engine/tests/integration/pipeline/test_import_phase.py
@@ -477,6 +477,7 @@ class TestImportPhase:
             StatisticalProfile(
                 column_id=typed_col_id,
                 run_id="run-v1",
+                layer="typed",
                 total_count=2,
                 null_count=0,
                 profile_data={},

--- a/packages/engine/tests/integration/pipeline/test_replay_cross_stage.py
+++ b/packages/engine/tests/integration/pipeline/test_replay_cross_stage.py
@@ -217,14 +217,18 @@ class TestCrossStageSurvival:
                 select(Column).where(Column.table_id == typed_table_id, Column.column_name == "id")
             ).scalar_one()
             id_col_id = id_col.column_id
-            # Simulate a begin_session / frame-ground finding attached to the
-            # typed column — a stage NOT in the add_source chain.
+            # Simulate a PRIOR add_source run's finding attached to the typed
+            # column — foreign to the re-type call below, which must not
+            # destructively wipe it. (DAT-637 moved catalogue/begin_session-grain
+            # findings to ColumnConcept — SemanticAnnotation is add_source-grain
+            # only, so 'llm' is the real value here, not a hypothetical
+            # cross-stage source.)
             session.add(
                 SemanticAnnotation(
                     annotation_id=str(uuid4()),
                     column_id=id_col_id,
                     semantic_role="identifier",
-                    annotation_source="teach",
+                    annotation_source="llm",
                     annotated_at=datetime.now(UTC),
                 )
             )

--- a/packages/engine/tests/integration/storage/test_model_integration.py
+++ b/packages/engine/tests/integration/storage/test_model_integration.py
@@ -120,6 +120,7 @@ class TestStatisticalModels:
 
         profile = StatisticalProfile(
             column=column,
+            layer="typed",
             total_count=1000,
             null_count=50,
             distinct_count=800,
@@ -175,7 +176,7 @@ class TestStatisticalModels:
         decision = TypeDecision(
             column=column,
             decided_type="DOUBLE",
-            decision_source="auto",
+            decision_source="automatic",
             decided_by="system",
             decision_reason="High confidence from pattern detection",
         )
@@ -186,7 +187,7 @@ class TestStatisticalModels:
         saved = result.scalar_one()
 
         assert saved.decided_type == "DOUBLE"
-        assert saved.decision_source == "auto"
+        assert saved.decision_source == "automatic"
 
 
 class TestSemanticModels:
@@ -264,9 +265,9 @@ class TestTopologicalModels:
             to_table_id=customer_table.table_id,
             to_column_id=id_col.column_id,
             relationship_type="foreign_key",
-            cardinality="n:1",
+            cardinality="many-to-one",
             confidence=0.95,
-            detection_method="tda",
+            detection_method="candidate",
             evidence={"overlap_rate": 0.98},
         )
         session.add(relationship)
@@ -276,7 +277,7 @@ class TestTopologicalModels:
         saved = result.scalar_one()
 
         assert saved.relationship_type == "foreign_key"
-        assert saved.cardinality == "n:1"
+        assert saved.cardinality == "many-to-one"
         assert saved.confidence == 0.95
 
     def test_relationship_type_check_constraint(self, session: Session):
@@ -298,7 +299,9 @@ class TestTopologicalModels:
 
         def _rel(relationship_type: str, detection_method: str) -> Relationship:
             # detection_method varies per row to sidestep the run-grain unique
-            # constraint (run_id, from_column_id, to_column_id, detection_method).
+            # constraint (run_id, from_column_id, to_column_id, detection_method) —
+            # every value here must itself be real (ck_relationships_detection_method,
+            # DAT-802), so the 4 rows below exhaust the closed detection_method set.
             return Relationship(
                 from_table_id=sales_table.table_id,
                 from_column_id=customer_id_col.column_id,
@@ -310,12 +313,17 @@ class TestTopologicalModels:
             )
 
         # Every value a real writer produces is admitted.
-        for i, real_value in enumerate(("foreign_key", "hierarchy", "candidate")):
-            session.add(_rel(real_value, detection_method=f"method_{i}"))
+        real_detection_methods = ("candidate", "llm", "manual")
+        for relationship_type, detection_method in zip(
+            ("foreign_key", "hierarchy", "candidate"), real_detection_methods, strict=True
+        ):
+            session.add(_rel(relationship_type, detection_method=detection_method))
         session.flush()
 
-        # A value outside the closed vocabulary is rejected by the CHECK.
-        session.add(_rel("semantic_reference", detection_method="method_dead"))
+        # A value outside the closed vocabulary is rejected by the CHECK — the
+        # row's detection_method ('keeper', the one real value unused above) is
+        # itself valid, so the rejection is proven to come from relationship_type.
+        session.add(_rel("semantic_reference", detection_method="keeper"))
         with pytest.raises(IntegrityError):
             session.flush()
         session.rollback()

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -179,7 +179,7 @@ def _seed(engine: Engine) -> None:
             " to_column_id, relationship_type, cardinality, confidence, confirmation_source, "
             " detected_at) "
             f"VALUES ('{rid}', '{RUN}', '{ft}', '{fc}', '{tt}', '{tc}', "
-            f"'foreign_key', 'many_to_one', 0.9, 'judge', '{TS}')"
+            f"'foreign_key', 'many-to-one', 0.9, 'judge', '{TS}')"
         )
     # has_dimension: three facts each sliced by their own account_id FK, all resolving
     # the referenced identity dimension_table_id='t2' (the accounts dim). journal (t1)
@@ -216,7 +216,7 @@ def _seed(engine: Engine) -> None:
             " to_column_id, relationship_type, cardinality, confidence, confirmation_source, "
             " detected_at) "
             f"VALUES ('{rid}', '{RUN}', '{ft}', '{fc}', '{tt}', '{tc}', "
-            f"'foreign_key', 'many_to_one', 0.9, 'judge', '{TS}')"
+            f"'foreign_key', 'many-to-one', 0.9, 'judge', '{TS}')"
         )
     # t1 carries a DECLARED time-axis set with the anchor at index 1 (NOT 0) and an
     # attribute date mixed in — the scrambled-order proof (DAT-780): a positional

--- a/packages/engine/tests/integration/worker/test_begin_session_activity.py
+++ b/packages/engine/tests/integration/worker/test_begin_session_activity.py
@@ -195,7 +195,6 @@ def _build_typed_tables(manager: ConnectionManager, small_finance_path: Path) ->
                 name=f"sf_{source_id[:8]}",
                 source_type="csv",
                 connection_config={"file_uris": [str(p) for p in files]},
-                status="configured",
             )
         )
     run = RunRef(workspace_id="test", run_id=add_run_id)

--- a/packages/engine/tests/integration/worker/test_phase_activity.py
+++ b/packages/engine/tests/integration/worker/test_phase_activity.py
@@ -132,7 +132,6 @@ def _seed_source(
                 name=name,
                 source_type="csv",
                 connection_config={"file_uris": file_uris},
-                status="configured",
             )
         )
 

--- a/packages/engine/tests/unit/analysis/correlation/test_enriched_derived.py
+++ b/packages/engine/tests/unit/analysis/correlation/test_enriched_derived.py
@@ -95,11 +95,17 @@ def _make_column(
     return c
 
 
-def _make_stat_profile(session: Session, column: Column, distinct_count: int = 10) -> None:
+def _make_stat_profile(
+    session: Session, column: Column, distinct_count: int = 10, layer: str = "typed"
+) -> None:
+    """``layer`` must match the profiled column's own Table.layer (e.g. 'enriched'
+    for a dimension column on a ``_make_view_table`` — the CHECK doesn't care, but
+    a mismatched fixture silently mistests the moment a read path starts
+    filtering on ``layer``, per ``enriched_views_phase.py``'s real write pattern)."""
     sp = StatisticalProfile(
         profile_id=str(uuid4()),
         column_id=column.column_id,
-        layer="typed",
+        layer=layer,
         distinct_count=distinct_count,
         null_count=0,
         total_count=200,
@@ -163,7 +169,7 @@ class TestDetectsEnrichedDerivedColumns:
         # Register dimension column via view_table
         view_table = _make_view_table(session, "enriched_orders")
         dim_col = _make_column(session, view_table, "products__unit_price", "DOUBLE")
-        _make_stat_profile(session, dim_col)
+        _make_stat_profile(session, dim_col, layer="enriched")
 
         ev = _make_enriched_view(
             session,
@@ -286,7 +292,7 @@ class TestDetectsEnrichedDerivedColumns:
 
         view_table = _make_view_table(session, "enriched_orders")
         dim_col = _make_column(session, view_table, "products__unit_price", "DOUBLE")
-        _make_stat_profile(session, dim_col)
+        _make_stat_profile(session, dim_col, layer="enriched")
 
         ev = _make_enriched_view(
             session,
@@ -314,7 +320,7 @@ class TestDetectsEnrichedDerivedColumns:
 
         view_table = _make_view_table(session, "enriched_orders")
         dim_col = _make_column(session, view_table, "products__unit_price", "DOUBLE")
-        _make_stat_profile(session, dim_col)
+        _make_stat_profile(session, dim_col, layer="enriched")
 
         ev = _make_enriched_view(
             session,

--- a/packages/engine/tests/unit/analysis/correlation/test_enriched_derived.py
+++ b/packages/engine/tests/unit/analysis/correlation/test_enriched_derived.py
@@ -99,6 +99,7 @@ def _make_stat_profile(session: Session, column: Column, distinct_count: int = 1
     sp = StatisticalProfile(
         profile_id=str(uuid4()),
         column_id=column.column_id,
+        layer="typed",
         distinct_count=distinct_count,
         null_count=0,
         total_count=200,

--- a/packages/engine/tests/unit/analysis/semantic/test_concept_edge_store.py
+++ b/packages/engine/tests/unit/analysis/semantic/test_concept_edge_store.py
@@ -105,14 +105,18 @@ def test_seed_is_idempotent(session: Session) -> None:
 
 
 def test_seed_does_not_clobber_a_superseded_edge(session: Session) -> None:
-    """A frame edit (supersede + insert) survives a re-seed — the race-safety contract.
+    """A superseded-and-reinserted active row survives a re-seed — the race-safety contract.
 
     The re-seed's ``ON CONFLICT DO NOTHING`` skips the edge whose active row is the
-    edit (same active partial-unique index as concepts), never overwriting it and
-    never RAISING on the collision.
+    replacement (same active partial-unique index as concepts), never overwriting it
+    and never RAISING on the collision. This is the mechanism a future edit path
+    (``frame``, P13 — not wired yet, so ``source`` stays 'seed'; DAT-802 narrowed
+    ``ck_concept_edges_source`` to the one live value) will rely on; the test proves
+    the DB-level supersede+insert contract independent of who eventually calls it.
     """
     assert ensure_concept_edges_seeded(session, "finance") == _FINANCE_TOTAL
-    # Supersede one active edge and insert a new active row in its place (source=frame).
+    # Supersede one active edge and insert a new active row in its place — simulating
+    # ANY future non-seed writer's edit, not tied to a specific source value.
     session.execute(
         update(ConceptEdge)
         .where(
@@ -123,13 +127,15 @@ def test_seed_does_not_clobber_a_superseded_edge(session: Session) -> None:
         )
         .values(superseded_at=datetime.now(UTC))
     )
+    replacement_id = "replacement-edge-id"
     session.add(
         ConceptEdge(
+            edge_id=replacement_id,
             vertical="finance",
             predicate=_DISJOINT,
             from_concept="accounts_payable",
             to_concept="accounts_receivable",
-            source="frame",
+            source="seed",
         )
     )
     session.flush()
@@ -143,7 +149,7 @@ def test_seed_does_not_clobber_a_superseded_edge(session: Session) -> None:
             ConceptEdge.superseded_at.is_(None),
         )
     ).scalar_one()
-    assert edited.source == "frame"  # the edit kept, not clobbered
+    assert edited.edge_id == replacement_id  # the replacement kept, not clobbered
 
 
 def test_seed_edges_reference_seeded_concept_names(session: Session) -> None:

--- a/packages/engine/tests/unit/entropy/test_loaders.py
+++ b/packages/engine/tests/unit/entropy/test_loaders.py
@@ -359,6 +359,7 @@ class TestLoaderHeadFallback:
                 profile_id=str(uuid4()),
                 column_id="col-h3",
                 run_id="run-addsource",
+                layer="typed",
                 total_count=100,
                 null_count=0,
                 distinct_count=90,

--- a/packages/engine/tests/unit/pipeline/test_slicing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_slicing_phase.py
@@ -454,7 +454,7 @@ class TestRunTimeAxisFill:
         session.add(
             StatisticalProfile(
                 column_id=date_col.column_id,
-                layer="typed",
+                layer="enriched",
                 total_count=300,
                 null_count=0,
                 distinct_count=300,
@@ -667,7 +667,7 @@ class TestRunTimeAxisFill:
         session.add(
             StatisticalProfile(
                 column_id=date_col.column_id,
-                layer="typed",
+                layer="enriched",
                 total_count=300,
                 null_count=0,
                 distinct_count=300,  # > 200 → dropped from context_data["tables"]

--- a/packages/engine/tests/unit/pipeline/test_slicing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_slicing_phase.py
@@ -454,6 +454,7 @@ class TestRunTimeAxisFill:
         session.add(
             StatisticalProfile(
                 column_id=date_col.column_id,
+                layer="typed",
                 total_count=300,
                 null_count=0,
                 distinct_count=300,
@@ -666,6 +667,7 @@ class TestRunTimeAxisFill:
         session.add(
             StatisticalProfile(
                 column_id=date_col.column_id,
+                layer="typed",
                 total_count=300,
                 null_count=0,
                 distinct_count=300,  # > 200 → dropped from context_data["tables"]


### PR DESCRIPTION
## Task

DAT-802 — Enum-standard sweep (Wave 5): CHECKs on surviving closed vocabularies + typed submodels on surviving JSON interiors. Final bug wave of the DAT-772 substrate-hardening plan (Waves 1–4 merged: #485, #489–499).

## Approach

The Gate-1 audit's 8-item candidate list (`snippet_type`, `source` prefix, `pattern`, `detected_granularity`, `kind`, `status`, `cardinality`, `slice_type`) was written against main at `0ed0e41d`, before Waves 1–4 shipped. Per the ticket, it's a starting point, not the spec — I re-derived the live set by reading every `db_models.py` in the engine and grepping every writer of every candidate (and its close family — e.g. `kind` turned out to mean *four* different columns across two files), then applied the locked standard: CHECK derived from the single-home Python enum where one exists (the DAT-784 pattern), hand-typed inline where none exists (the `relationship_type` precedent), and left genuinely open where any writer is LLM free text or the domain is explicitly still-open by design.

## Full candidate matrix

Verdict legend: **H** = hardened this PR · **D** = already-done by a prior wave · **X** = deleted in a prior wave · **O** = genuinely open (left alone) · **E** = escalated (flagging for the lead, not touched)

### Original 8 candidates

| Candidate | Verdict | Evidence |
|---|---|---|
| `snippet_type` (`query/snippet_models.py:72`) | **D** — DAT-781 | CHECK already at `snippet_models.py:62-65`, `IN ('extract','constant','formula','query')`. Writers: `graphs/agent.py`, `query/snippet_library.py`. Untouched. |
| `source` prefix | *(not one vocabulary — a family; see below)* | |
| `pattern` | **X** — deleted in Wave 3 (DAT-783) | `TemporalTableSummary`/temporal `pattern` column removed by commit `ab1eb69c`. The one surviving `pattern` column, `MeasureAggregationLineage.pattern` (`analysis/lineage/db_models.py:93`), is explicitly fenced to DAT-800/801 — not touched. |
| `detected_granularity` (`analysis/temporal/db_models.py:101`) | **D** — DAT-783 | CHECK already at `db_models.py:78-83`, derived from `_GRANULARITY_VALUES`. Untouched. |
| `kind` | *(4 separate columns — see below)* | |
| `status` | *(3 separate columns — see below)* | |
| `cardinality` | **H** (upgrade) + **H** (fresh) | See below. |
| `slice_type` (`analysis/slicing/db_models.py:90`) | **H** | Single writer `pipeline/phases/slicing_phase.py:381`, always `"categorical"` — no other value ever produced, no forward-declared 2nd type in any comment. `CHECK slice_type IN ('categorical')`. |

### `source` family (8 columns, not a prefix convention)

| Column | Verdict | Evidence |
|---|---|---|
| `Relationship.confirmation_source` | **D** — DAT-776 | CHECK at `relationships/db_models.py:79-82`. Untouched. |
| `Relationship.detection_method` | **H** | Writers: `detector.py` (`candidate`), `processor.py` llm-confirm path (`llm`), `materialize.py` overlay (`manual`/`keeper`). `CHECK IN ('candidate','llm','manual','keeper')`. Sibling of `confirmation_source` the DAT-776 pass left uncovered. |
| `Concept.source` | **H** | Writers: `concept_store.py` seed (`'seed'`), cockpit `concept-write.ts` frame path (`'frame'`, direct Drizzle write). The inline field comment claimed a 3rd value `'teach'` — **verified wrong and dropped** (not included): DAT-728 (Done) explicitly retired the `concept` teach type ("the config_overlay concept-family retires read AND write"), confirmed independently by the cockpit's own `teach-routing.ts` comment. `CHECK source IS NULL OR source IN ('seed','frame')`. *(Caught by the spec-compliance reviewer — see review notes below; initially I'd included `'teach'` on a mistaken forward-safety analogy to `ConceptEdge.source`.)* |
| `ConceptEdge.source` | **H** | Writer: `concept_edge_store.py` seed only (`'seed'`). `'derived'` is the DAT-800/801 aggregation-lineage reconciliation producer's documented output (fenced from this PR) and `'frame'` is the documented P13 authoring path — both included so neither needs a CHECK migration to land. `CHECK source IS NULL OR source IN ('seed','derived','frame')`. |
| `SemanticAnnotation.annotation_source` | **H** | Only writer: `semantic/processor.py:208`, always `DecisionSource.LLM.value` = `'llm'`. Comment claimed `'manual'`/`'config_override'` — neither has a writer (doc-drift, fixed). `CHECK IN ('llm')`. |
| `ColumnConcept.annotation_source` | **H** | Only writer: `semantic/processor.py:281`, always `'llm'` (`semantic_per_table`, the table's own docstring: "authored ONLY by semantic_per_table"). `CHECK IN ('llm')`. |
| `TableEntity.detection_source` | **H** | Only writer: `semantic/processor.py:710`, always `'llm'`. Comment claimed `'heuristic'`/`'manual'` — no such writer exists (doc-drift, fixed). `CHECK IN ('llm')`. |
| `DimensionHierarchy.detection_source` | **H** | Writers: `processor.py` auto-discovery (`'g3'`, the default) and the manual teach loop (`'manual'`). `CHECK IN ('g3','manual')`. |
| `SliceDefinition.detection_source` | **H** | Only writer: `slicing_phase.py:387`, always `'llm'` (matches default). `CHECK IN ('llm')`. |
| `TypeDecision.decision_source` | **H** | Writers: `typing/resolution.py:288` (`'manual'`, copy-forward of an existing manual row — no fresh-write path exists), `:309` (`'automatic'`), `:322` (`'fallback'`); `typing_phase.py:197` (`'automatic'`). Comment claimed `'override'` (phantom — zero writers anywhere) and omitted the real `'fallback'` (doc-drift, fixed). `CHECK IN ('automatic','manual','fallback')`. |
| `Source.status` (`storage/models.py:59`) | **E — escalated** | Zero writers found anywhere — engine or cockpit (`sources.status` is declared in both the SQLAlchemy model and the Drizzle mirror `write-surface.ts:57`, set by neither). Not a CHECK candidate (no vocabulary exists to enforce); flagging as likely-dead scaffolding for a lead call on whether to delete it. **Not touched.** |

### `kind` family (4 columns)

| Column | Verdict | Evidence |
|---|---|---|
| `DimensionHierarchy.kind` (`hierarchies/db_models.py:146`) | **H** | Writers: `processor.py` `_hierarchy_row()` chokepoint, `{drilldown, alias, role}` — exactly the 3-value docstring enumeration. No enum exists (hand-typed inline). `CHECK kind IN ('drilldown','alias','role')`. Sibling of `role_verdict` in the same DAT-784 commit that this CHECK pass left uncovered. |
| `Concept.kind` (`semantic/db_models.py:156`) | **H** | Derived from the existing `ConceptKind` enum (`measure, entity, dimension, unit`) — the textbook "one home" case: `concept_store.py`'s seed path validates against a Python-side `_VALID_KINDS` guard, but the cockpit's `concept-write.ts` writes this column directly via Drizzle with its OWN independently-maintained TS literal union (`CONCEPT_KINDS`), with zero DB-level backstop until now. |
| `TableEntity.table_role` (`semantic/db_models.py:405`) | **H** | Derived from the existing `TableRole` enum (`fact, periodic_snapshot, dimension`) via `derive_table_role()`, the sole writer (`semantic/agent.py:295` → `processor.py:707`). |
| `ConceptEdge.predicate` (`semantic/db_models.py:222`) | **H** | Derived from the existing `ConceptEdgePredicate` enum. Writers: `concept_edge_store.py` seed only produces `part_of`/`disjoint_with` today; `reconciles_with` is the DAT-800/801 aggregation-lineage producer's documented output (fenced) — included in the CHECK for the same forward-safety reason as `ConceptEdge.source`. |

### `status` family (3 columns)

| Column | Verdict | Evidence |
|---|---|---|
| `ColumnEligibilityRecord.status` (`eligibility/db_models.py:53`) | **H** | Config-derived from `column_eligibility.yaml` (3 rule statuses + 1 default), returned verbatim by `evaluate_rules`/`extract_metrics` — never LLM-touched. `CHECK IN ('ELIGIBLE','WARN','INELIGIBLE')`. |
| `SurrogateKeyIntent.status` (`relationships/db_models.py:278`) | **H** | Writers: `semantic/processor.py` `_confirmed_intent_row` (`'confirmed'`) / `_declined_intent_rows` (`'declined'`) — exactly 2 call sites. `CHECK IN ('confirmed','declined')`. |
| `Source.status` | *(see `source` family above — escalated, not a `status`-family duplicate)* | |

### `cardinality` family (2 columns)

| Column | Verdict | Evidence |
|---|---|---|
| `Relationship.cardinality` (`relationships/db_models.py:114`) | **H** (upgrade) | DAT-777 shipped a **backstop only** (`<> 'one-to-many'`), explicitly called out in the ticket as insufficient. `oriented_row()` — the sole row-builder for this table — FLIPS any `one-to-many` measurement before persisting, so the full closed set a row can ever legally hold is exactly `{one-to-one, many-to-one, many-to-many}` (+ NULL). Upgraded to the full closed CHECK. |
| `SurrogateKeyIntent.cardinality` (`relationships/db_models.py:292`) | **H** (fresh) | Sourced exclusively from `compute_composite_cardinality` (code-computed, never LLM-echoed — the LLM only supplies which columns to include via `key_columns`, rendered read-only into the prompt). The confirmed path (`_build_surrogate_intent`) explicitly falls back to no intent when the measurement is `many-to-many`; the declined path only ever carries a `find_composite_key_rescue` hint, which by construction never returns a many-to-many `CompositeKey` either. `CHECK cardinality IS NULL OR cardinality IN ('one-to-one','one-to-many','many-to-one')`. |

### Bonus candidates — found during investigation, in scope per the ticket's own "vocabularies the audit missed" clause

| Column | Verdict | Evidence |
|---|---|---|
| `Table.layer` (`storage/models.py:104`) | **H** | 4 real values across every writer (import/typing/surrogate-mint/enriched-views phases + all 3 source loaders): `{raw, typed, quarantine, enriched}`. The class docstring only documented 3 — 'enriched' (written by `enriched_views_phase.py` on every fact table's dimension-widened view) was missing (doc-drift, fixed). |
| `StatisticalProfile.layer` (`analysis/statistics/db_models.py:64`) | **H** | Every writer (`profiler.py`, `surrogate_mint_phase.py`, `enriched_views_phase.py`) produces only `{typed, enriched}` — never `'raw'` despite that being the column's Python-side `default`. The default is vestigial (no caller has ever omitted `layer=`); left in place (out of this sweep's scope to change), but the CHECK reflects reality — a future caller that forgets to override the default now fails loud at flush instead of silently mis-labeling a profile as raw. **3 test fixtures relied on the dead default and needed an explicit `layer="typed"` to keep passing** (`test_enriched_derived.py`, `test_loaders.py`, `test_slicing_phase.py` ×2) — fixed rather than loosening the CHECK, per "tests follow the design." |
| `MaterializationRecipe.layer` (`analysis/typing/db_models.py`) | **O — genuinely open** | Its own docstring is explicit: *"An open VARCHAR, not an enum; the dependency-order rebuild is layer-aware via the FQNs"* — reserved for future view layers (`'slicing'`, DAT-415). Correctly left alone; the closed test fails on its own terms. |
| `EntropyObjectRecord.layer` / `.dimension` / `.sub_dimension` (`entropy/db_models.py`) | **H** | Derived from the existing `Layer`/`Dimension`/`SubDimension` enums (`entropy/dimensions.py`) — every detector is already `isinstance`-asserted against them at registration (`detectors/base.py:232-245`); this is the DB-enforced backstop for app-side enforcement that already existed. |
| `EntropyReadinessRecord.band` (`entropy/db_models.py`) | **H** | `LossConfig.band()` (`entropy/loss.py:74-83`) is the single chokepoint every `band=` write reads from, hardcoded to return exactly `{ready, investigate, blocked}` — no enum exists yet (hand-typed inline, matching the `relationship_type` precedent, rather than introducing a new enum + touching `band()`'s ~10 call sites, which is outside a CHECK-adding sweep's blast radius). |
| `LifecycleArtifact.state` (`lifecycle/db_models.py`) | **H** | Derived from the existing `ArtifactState` enum (`lifecycle/transitions.py`) — the typed state machine that already governs transitions app-side; this is the DB-enforced backstop. |

## Hard scope fences respected

- Provenance contract v2 (`column_mappings_basis`, `field_resolution`, `assumptions.basis`, `failure_mode`, failed-snippet blob) — not touched.
- Dimension-identity code (DAT-757/762, PR #500 in flight) — `fk_role`, folded dimension identity — not touched.
- `discover_aggregation_lineage` (`analysis/lineage/processor.py`, DAT-800/801) — not touched; its `MeasureAggregationLineage.pattern` column and the `reconciles_with`/`derived` vocabulary values it will eventually produce were explicitly accounted for (included in CHECKs, forward-safe) rather than blocking that work.

## Escalated to the lead (not resolved in this PR)

- **`Source.status`** (`storage/models.py:59`) — zero writers found anywhere (engine or cockpit). Likely dead scaffolding, not a vocabulary to CHECK. Recommend a follow-up decision: delete the column, or confirm a planned write path exists that I missed.
- **`ConceptEdge.source` / `ConceptEdge.predicate` forward-inclusion** — these 2 CHECKs derive from the FULL documented domain (including not-yet-produced values `derived`, `reconciles_with`) rather than narrowing to only what's written today, because `concept_edge_store.py`'s own module docstring documents both as genuine future producers tied to DAT-800/801 (not a closed/retired ticket, unlike the `Concept.source`/`'teach'` case below). Flagging as a judgment call worth a second look, not a certainty.

## Reviewer findings (both required reviewers ran twice — both now APPROVE)

- **spec-compliance-reviewer, round 1 — APPROVE WITH NITS.** Caught that `Concept.source`'s inline CHECK included `'teach'` on a stale docstring comment — DAT-728 (closed) explicitly retired the `concept` teach type, confirmed independently via the cockpit's `teach-routing.ts`. Fixed: narrowed to `('seed', 'frame')`, corrected the stale field comment, re-dumped `schema.sql`. Also fixed a comment-accuracy nit (wrong function name, `find_composite_key_rescue` → `rescue_fanout_to_composite`).
- **senior-code-reviewer, round 1 — REQUEST CHANGES.** The CheckConstraint engineering itself had zero defects (verified NULL-guard consistency, the `oriented_row` cardinality proof, both new runtime imports for circularity, constraint-name collisions, `schema.sql` freshness — all clean), but the sweep was only verified against `tests/unit`; `tests/integration` (which CI runs in the same gate, `.github/workflows/ci.yml:60`) had **11 failed + 18 errored**, all caused by this diff. Five root causes, all fixed by correcting stale/typo'd test values to the real vocabulary — never by loosening a CHECK: `'many_to_one'` (underscore) typo'd cardinality in 2 files, `annotation_source="teach"` in a test whose premise predated DAT-637 (which moved that finding-type to `ColumnConcept`), `decision_source="auto"` / `detection_method="tda"` / `cardinality="n:1"` / placeholder `method_0`/`method_dead` values in a relationship-CHECK test, and 2 more `StatisticalProfile` sites relying on the now-removed dead `layer="raw"` default. Also flagged (and fixed) a fixture-fidelity nit: enriched-layer dimension columns stamped `layer="typed"` on their profile.
- **Both reviewers, round 2 — APPROVE.** Re-verified the fix commit end to end (including independently re-confirming the DAT-637 claim against `ColumnConcept`'s docstring and `.claude/handoff.md`) and re-ran the full gate fresh. `tests/unit + tests/integration`: **2328 passed, 8 skipped** (pre-existing/unrelated), 0 failed.

## Gates

- `uv run python -m dataraum.storage.dump_ddl schema.sql` re-run; `schema.sql` diff contains exactly the 24 new/upgraded CHECK constraints, later corrected to 23 (`Concept.source` narrowed per review) — (`schema_read.sql`/`schema_graph.sql` unchanged — CHECKs don't project into the read/graph views).
- `bun run db:pull:metadata` (from `packages/cockpit`) re-run against a scratch Postgres; **zero diff** in `src/db/metadata/` — CHECK constraints don't project into the Drizzle TS mirror (confirmed: `check constraints fetched` count went from 0→30 during introspection, but the normalized `schema.ts`/`relations.ts` output is unaffected — Drizzle doesn't emit `check()` calls from a pull).
- `uv run pytest tests/unit tests/integration -q -n auto` — **2328 passed, 8 skipped** (pre-existing/unrelated), 0 failed. (Initially only `tests/unit` was run per the ticket's literal AC text — the senior-code-reviewer caught that CI runs both together and this diff broke 29 integration tests; see reviewer findings below.)
- `uv run ruff format --check .` / `uv run ruff check .` / `uv run mypy src/` — all clean.

## Other lanes in flight

- #500 DAT-762 (dimension-identity LLM lane) — draft, touches `fk_role`/folded-identity code this PR explicitly avoided.
- #487 DAT-727 (Phase 2 grounding reification / provenance contract v2) — draft, parked per lead review.
- #486 DAT-730 (Phase 5 temporal coverage/calendar) — draft, parked per lead review.

No file-level overlap with any of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
