### PR TITLE
DAT-804: temporal granularity config-dup + finance vocab cleanup

### DIFF
--- a/packages/engine/src/dataraum/analysis/cycles/models.py
+++ b/packages/engine/src/dataraum/analysis/cycles/models.py
@@ -116,13 +116,13 @@ class BusinessCycleAnalysis(BaseModel):
 class CycleSummaryOutput(BaseModel):
     """Flat cycle summary — no nested objects."""
 
-    cycle_name: str = Field(description="Descriptive name, e.g., 'Accounts Receivable Cycle'")
+    cycle_name: str = Field(description="Descriptive name, e.g., 'Order Fulfillment Cycle'")
     cycle_type: str = Field(
         description=(
             "Type identifier in snake_case. Use a key from the KNOWN BUSINESS CYCLE TYPES "
             "vocabulary (provided in context) when the cycle matches a known type. "
             "For cycles not in the vocabulary, use a descriptive snake_case identifier "
-            "(e.g., bank_reconciliation, trial_balance_reporting, expense_reimbursement). "
+            "(e.g., order_fulfillment, incident_resolution, employee_onboarding). "
             "Do NOT use generic labels like 'custom' or 'other'."
         )
     )
@@ -160,7 +160,7 @@ class StageEntryOutput(BaseModel):
     """Flat stage — references a cycle by name."""
 
     cycle_name: str = Field(description="Name of the cycle this stage belongs to")
-    stage_name: str = Field(description="Name of this stage, e.g., 'Invoice Created'")
+    stage_name: str = Field(description="Name of this stage, e.g., 'Order Shipped'")
     stage_order: int = Field(description="Position in cycle (1, 2, 3...)")
     indicator_column: str | None = Field(
         default=None, description="Column that indicates this stage"

--- a/packages/engine/src/dataraum/analysis/semantic/models.py
+++ b/packages/engine/src/dataraum/analysis/semantic/models.py
@@ -53,7 +53,7 @@ class ColumnSemanticOutput(BaseModel):
         description=(
             "What real-world entity this column represents. Examples: "
             "'customer_id', 'product_name', 'order_date', 'transaction_amount', "
-            "'account_code', 'invoice_number'. Be specific to the domain."
+            "'location_code', 'ticket_number'. Be specific to the domain."
         )
     )
 
@@ -112,7 +112,7 @@ class ColumnSemanticOutput(BaseModel):
         le=1.0,
         description=(
             "Confidence (0.0–1.0) in temporal_behavior_claim. High (0.85–1.0) for "
-            "unambiguous domain language (balance, payment, revenue, closing_position). "
+            "unambiguous domain language (balance, payment, sale, headcount). "
             "Moderate (0.6–0.8) when the role implies it but the name is ambiguous. Low "
             "(0.2–0.4) for a weak signal. Set this low whenever you answer 'unsure'."
         ),
@@ -198,8 +198,8 @@ class TimeColumn(BaseModel):
         description=(
             "The kind of date this column holds — a CLOSED vocabulary the LLM "
             "commits per column (DAT-780). 'event' = WHEN the row's own event "
-            "occurred (order_date, ship_date, payment_date, a periodic-statement "
-            "period date) — a genuine time axis analysis may segment or roll up by. "
+            "occurred (order_date, ship_date, delivery_date, a recurring "
+            "reporting-period date) — a genuine time axis analysis may segment or roll up by. "
             "'attribute' = a date the row merely REFERS to, not when the row's "
             "event happened (due_date, valid_until, effective_from) — it gets "
             "coverage like any column but must never be used as a trend/event axis. "
@@ -242,7 +242,7 @@ class TableEntityOutput(BaseModel):
     entity_type: str = Field(
         description=(
             "What real-world entity this table represents. Examples: 'customers', "
-            "'orders', 'products', 'transactions', 'invoices', 'payments'"
+            "'orders', 'products', 'transactions', 'shipments', 'appointments'"
         )
     )
 
@@ -269,7 +269,7 @@ class TableEntityOutput(BaseModel):
         description=(
             "EVERY date column of the table, each tagged with a typed ``role`` "
             "(DAT-780). Emit event dates — when a row's own event occurred "
-            "(order_date, ship_date, delivery_date, a periodic-statement period "
+            "(order_date, ship_date, delivery_date, a recurring reporting-period "
             "date) — with role='event'; a denormalized table commonly has several, "
             "emit all. Emit attribute dates — a date the row merely refers to "
             "(due_date, valid_until, effective_from) — with role='attribute' so "

--- a/packages/engine/src/dataraum/analysis/temporal/detection.py
+++ b/packages/engine/src/dataraum/analysis/temporal/detection.py
@@ -81,6 +81,8 @@ def calculate_expected_periods(
     min_ts: datetime,
     max_ts: datetime,
     granularity: str,
+    *,
+    config: dict[str, Any],
 ) -> int:
     """Calculate expected number of periods for a time range.
 
@@ -88,6 +90,10 @@ def calculate_expected_periods(
         min_ts: Start of time range
         max_ts: End of time range
         granularity: Detected granularity
+        config: Temporal config dict (from config/phases/temporal.yaml) — the
+            same ``granularity.definitions`` source ``infer_granularity`` reads,
+            so the two functions share one home for per-granularity seconds
+            instead of each hardcoding its own copy.
 
     Returns:
         Expected number of periods
@@ -95,22 +101,18 @@ def calculate_expected_periods(
     delta = max_ts - min_ts
     total_seconds = delta.total_seconds()
 
-    granularity_seconds = {
-        "second": 1,
-        "minute": 60,
-        "hour": 3600,
-        "day": 86400,
-        "week": 604800,
-        "weekly": 604800,
-        "month": 2592000,
-        "monthly": 2592000,
-        "quarter": 7776000,
-        "quarterly": 7776000,
-        "year": 31536000,
-        "yearly": 31536000,
-        "irregular": 1,
-        "unknown": 1,
+    # Per-granularity expected seconds, sourced from config — same definitions
+    # list infer_granularity uses to classify a granularity in the first place.
+    granularity_seconds: dict[str, float] = {
+        name: expected_seconds
+        for name, expected_seconds, _tolerance in config["granularity"]["definitions"]
     }
+    # "irregular"/"unknown" are infer_granularity's sentinels for "no definition
+    # matched" / "no median gap" — they're not granularities, so config has no
+    # entry for them; keep the 1-second fallback that makes their expected-period
+    # count track total elapsed seconds.
+    granularity_seconds.setdefault("irregular", 1)
+    granularity_seconds.setdefault("unknown", 1)
 
     seconds = granularity_seconds.get(granularity, 86400)
     return int(total_seconds / seconds) + 1
@@ -197,7 +199,7 @@ def analyze_basic_temporal(
         granularity, confidence = infer_granularity(median_gap, min_gap, max_gap, config=config)
 
         # Calculate expected periods based on granularity
-        expected_periods = calculate_expected_periods(min_ts, max_ts, granularity)
+        expected_periods = calculate_expected_periods(min_ts, max_ts, granularity, config=config)
 
         # Calculate completeness
         completeness_ratio = distinct_count / expected_periods if expected_periods > 0 else 1.0

--- a/packages/engine/src/dataraum/graphs/context.py
+++ b/packages/engine/src/dataraum/graphs/context.py
@@ -1715,7 +1715,7 @@ def _build_column_notes(col: ColumnContext) -> str:
     if col.semantic_role == "measure" and col.numeric_min is not None:
         rng = f"Range: {col.numeric_min:g}..{col.numeric_max:g}."
         if col.numeric_min < 0:
-            rng += " Signed (has negatives) — SUM nets debits/credits."
+            rng += " Signed (has negatives) — SUM nets positive and negative values."
         notes.append(rng)
 
     if col.is_derived and col.derived_formula:

--- a/packages/engine/src/dataraum/graphs/models.py
+++ b/packages/engine/src/dataraum/graphs/models.py
@@ -388,7 +388,7 @@ class ExtractGroundingOutput(BaseModel):
     grounding: str = Field(
         description="FIRST, commit to the evidence: which column grounds the concept, and "
         "the EXACT served values you selected from its Value set (or the complete "
-        "discriminator you filter on) — e.g. \"revenue via account_type = 'revenue' "
+        "discriminator you filter on) — e.g. \"volume via category = 'primary' "
         '(complete 5-value set)". Name the value-set entries verbatim; if you cannot, '
         "the concept is not grounded — fall loud instead of writing SQL around it."
     )
@@ -408,11 +408,11 @@ class ExtractGroundingOutput(BaseModel):
     select_expr: str = Field(
         description="The scalar value expression over the relation's columns using the "
         "step's aggregation, WITHOUT an alias (the system renders it AS value) — e.g. "
-        '"SUM(credit) - SUM(debit)". In the fall-loud case: "NULL".',
+        '"SUM(gross) - SUM(fees)". In the fall-loud case: "NULL".',
     )
     description: str = Field(
         description="One short line: what this extract computes and how it is filtered, "
-        "e.g. 'Total revenue: SUM(amount) where account_type IN (Revenue)'."
+        "e.g. 'Total volume: SUM(amount) where category IN (Primary)'."
     )
     assumptions: list[GraphAssumptionOutput] = Field(
         default_factory=list,


### PR DESCRIPTION
## Task

DAT-804 — https://real-dataraum.atlassian.net/browse/DAT-804

Two low-risk fixes from the 2026-07-16 short-wire audit (triggered by the DAT-785 `income_statement` revert). Both approved by Philipp as quick fixes, bundled into one lane.

## Fix 1 — temporal granularity: read from config, don't re-hardcode

`analysis/temporal/detection.py` `calculate_expected_periods` hardcoded a `granularity_seconds` dict. Its sibling `infer_granularity` (same file) already reads the same per-granularity seconds from `config["granularity"]["definitions"]` (`packages/dataraum-config/phases/temporal.yaml`). `calculate_expected_periods` now reads from that same config source — no new config key invented.

Confirmed behavior-preserving: the deleted hardcoded numbers exactly matched the config values (second=1, minute=60, hour=3600, day=86400, week=604800, month=2592000, quarter=7776000, year=31536000). The dropped alias entries (`weekly`/`monthly`/`quarterly`/`yearly`) were dead — `infer_granularity`'s closed vocabulary (cross-checked against `db_models.py`'s `_GRANULARITY_VALUES` CHECK constraint) never emits plural forms, only `second/minute/hour/day/week/month/quarter/year` plus the `irregular`/`unknown` sentinels, which keep their 1-second fallback via `.setdefault` since they have no config entry.

## Fix 2 — finish DAT-769's de-financing of LLM-facing example strings

Replaced finance-specific illustrative examples in engine-core `Field(description=...)` strings with vertical-neutral ones, matching the style established in `c655d40b` (DAT-769):

- `graphs/models.py:391,411,415` — `revenue via account_type = 'revenue'` → `volume via category = 'primary'`; `SUM(credit) - SUM(debit)` → `SUM(gross) - SUM(fees)`; `Total revenue: ... account_type IN (Revenue)` → `Total volume: ... category IN (Primary)`
- `analysis/cycles/models.py:119,125,163` — `Accounts Receivable Cycle` → `Order Fulfillment Cycle`; `bank_reconciliation, trial_balance_reporting, expense_reimbursement` → `order_fulfillment, incident_resolution, employee_onboarding`; `Invoice Created` → `Order Shipped`
- `analysis/semantic/models.py:56,115,201,245,272` — `account_code`/`invoice_number` → `location_code`/`ticket_number`; `balance, payment, revenue, closing_position` → `balance, payment, sale, headcount`; `payment_date`/`a periodic-statement period date` → `delivery_date`/`a recurring reporting-period date`; `invoices, payments` → `shipments, appointments`
- `graphs/context.py:1718` — a spec-reviewer catch: `_build_column_notes()`'s `"SUM nets debits/credits"` flows into the LLM-facing metadata document, not a comment/docstring → `"SUM nets positive and negative values"`

Grepped the whole engine `src` for other finance literals reachable from `Field(description=...)` or prompt-facing strings; everything else found (`query/snippet_library.py`'s `Usage:` block, various `#` comments, docstrings) is explicitly out of scope per the ticket and correctly left untouched.

## Hard fences respected

`slicing_phase.py`, `cycles/health.py`, `cycle-badges.tsx`, `period_resolver.py` — none touched. `TimeColumn`/materialization/lineage **behavior** (validators, field types, the DAT-780 event/attribute role logic) untouched — only illustrative-example vocabulary inside `Field(description=...)` strings, at the exact lines the ticket named.

## Gates

```
uv run ruff format --check .    # 547 files already formatted
uv run ruff check .             # All checks passed
uv run mypy src                 # Success: no issues found in 266 source files
uv run vulture src               # pre-existing core/logging.py noise only, confirmed via git stash against origin/main baseline — nothing new
uv run pytest tests/unit tests/integration -q -n auto
# 2328 passed, 8 skipped
```

## Reviewers

- **spec-compliance-reviewer**: APPROVE WITH NITS — confirmed Fix 1 behavior-preserving and same-config-source, confirmed Fix 2 scope was text-only and hard fences untouched; caught one missed sibling (`graphs/context.py:1718`), folded in before this PR opened.
- **senior-code-reviewer**: APPROVE — verified the dead-alias removal against the DB CHECK constraint, verified the `setdefault` sentinel handling, verified the single call site, verified no test hardcodes the old finance strings. Nits are `#` comments in non-LLM-facing internal parse classes (`cycles/models.py`, `graphs/models.py`) — explicitly excluded from this ticket's scope ("do NOT touch ... comments").

## Other lanes in flight

- #486 `feat/dat-730-temporal-coverage-calendar` (DAT-730, draft) — different files (temporal coverage/calendar), no overlap with `analysis/temporal/detection.py` beyond the same package.
- #487 `feat/dat-727-grounding-reification` (DAT-727, draft) — grounding reification, no overlap.
- #500 `feat/dat-762-dimension-identity-lane` (DAT-762) — dimension identity, no overlap.

This lane's four touched files (`analysis/temporal/detection.py`, `graphs/models.py`, `analysis/cycles/models.py`, `analysis/semantic/models.py`, `graphs/context.py`) don't appear in any of the above lanes' descriptions.

Do NOT merge — merge order is Philipp's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)