### PR TITLE
fix(drivers): DAT-806 _candidate_dims no longer orphans a dimension whose alias canonical is a slicing-excluded near-key

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,26 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-806 — driver `_candidate_dims` no longer orphans a dimension whose alias canonical is a slicing-excluded near-key (driver rankings populate)
+
+**Branch:** `feat/dat-806-candidate-dims-orphan`. `drivers/processor.py::_candidate_dims`
+collapsed a confirmed 1:1 alias group to its `canonical_label`, discarding the other
+members. But the canonical is sorted-first and can be a raw-FK near-key (`account_id`)
+the slicing gate correctly excludes from `SliceDefinition`s — so the surviving elected
+member (`account_id__name`) was discarded against an absent canonical, deleting the
+dimension. On the finance corpus this dropped `journal_lines`/`trial_balance` from 2
+candidates to 1 → `driver_too_few_candidates` → **all driver rankings empty** (surfaced
+by the DAT-805 smoke). Fix: collapse only when ≥2 members are ELECTED, keeping one
+representative (canonical if elected, else sorted-first elected) — never orphan.
+
+**What changes for eval:** driver rankings now populate for facts whose only dimension
+attaches via an alias whose canonical was filtered upstream — expect `ranked_dimensions`
+/ `interesting_slices` to be non-empty for `journal_lines` (debit/credit/net_amount) and
+`trial_balance` (balances) on the finance corpus, where they were `n_rows=0`, ranked=0
+before. No schema change.
+
+---
+
 ## DAT-762 — persisted bus matrix (cross-fact conform lane)
 
 **Branch:** `feat/dat-762-dimension-identity-lane`. The `dimension_hierarchies`

--- a/packages/engine/src/dataraum/analysis/drivers/processor.py
+++ b/packages/engine/src/dataraum/analysis/drivers/processor.py
@@ -115,12 +115,17 @@ def _enriched_view_name(session: Session, fact_table_id: str, run_id: str) -> st
 def _candidate_dims(session: Session, fact_table_id: str, run_id: str) -> list[str]:
     """This run's grain-safe slice dimensions, with CONFIRMED alias groups collapsed.
 
-    A DAT-537 1:1 alias group is a redundant axis — keep only its canonical member so
-    it doesn't compete as a separate candidate (the de-confounding the spike deferred).
-    Only CONFIRMED aliases collapse: a ``needs_confirmation`` alias is an UNCONFIRMED
-    redundancy (a coincidental bijection the DAT-762 identity judge declined, or an
-    undecidable role-check near-copy), and collapsing it would silently drop a real
-    axis the flag says we are not sure about — the safe default keeps both.
+    A DAT-537 1:1 alias group is a redundant axis. Confirmed groups are union-found
+    into equivalence classes (so a manual teach that overlaps an auto-detected group
+    collapses as ONE class, independent of row order), and each class keeps only ONE
+    of its ELECTED members so the rest don't compete as separate candidates (the
+    de-confounding the spike deferred). The representative is an elected canonical when
+    one exists, else the sorted-first elected member: the canonical may be a raw-FK
+    near-key the slicing gate excluded, so collapsing to it would orphan the whole
+    dimension (DAT-806). Only CONFIRMED aliases collapse: a ``needs_confirmation``
+    alias is an UNCONFIRMED redundancy (a coincidental bijection the DAT-762 identity
+    judge declined, or an undecidable role-check near-copy), and collapsing it would
+    silently drop a real axis the flag says we are not sure about — keep both.
     """
     defs = session.execute(
         select(SliceDefinition.column_name).where(
@@ -139,11 +144,56 @@ def _candidate_dims(session: Session, fact_table_id: str, run_id: str) -> list[s
             DimensionHierarchy.needs_confirmation.is_(False),
         )
     ).scalars()
+    # Union-find over every confirmed alias group's members: overlapping groups
+    # (a manual teach that partially covers an auto-detected group — ``overlay.py``
+    # sets no overlap guard, and ``_apply_teaches`` writes ``needs_confirmation=False``)
+    # must collapse as ONE equivalence class, independent of row order. Discarding
+    # per-group while reading the live ``candidates`` set would make the survivor set
+    # (hence the driver candidate set) depend on the ORDER-BY-less query order —
+    # varying across Temporal redeliveries. Same connected-component discipline the
+    # hierarchy assembly uses.
+    parent: dict[str, str] = {}
+    canonicals: set[str] = set()
+
+    def _root(x: str) -> str:
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]  # path-halving
+            x = parent[x]
+        return x
+
     for group in aliases:
-        for member in group.members:
-            name = member.get("column_name")
-            if name and name != group.canonical_label:
-                candidates.discard(name)
+        members = [
+            name for m in group.members if isinstance(name := m.get("column_name"), str) and name
+        ]
+        if not members:
+            continue
+        canonicals.add(group.canonical_label)
+        for m in members[1:]:
+            parent[_root(members[0])] = _root(m)
+
+    classes: dict[str, list[str]] = {}
+    for col in parent:
+        classes.setdefault(_root(col), []).append(col)
+
+    for members in classes.values():
+        # Keep ONE representative among the class's ELECTED members (1:1 aliases
+        # partition identically, so the choice is immaterial for ranking). With 0-or-1
+        # elected there is nothing redundant to drop — critically, when the canonical
+        # is an un-elected raw-FK near-key the slicing gate excluded, the surviving
+        # member is the class's ONLY representative and must NOT be orphaned (DAT-806).
+        elected = sorted(m for m in members if m in candidates)
+        if len(elected) < 2:
+            continue
+        # Prefer an elected canonical — a manual teach's canonical is the user's chosen
+        # label, NOT sorted-first (``_apply_teaches`` sets it to ``ordered[0]``), so
+        # respect it over blind alphabetical order; else the sorted-first elected
+        # member. Deterministic → rerun-stable.
+        elected_canon = [m for m in elected if m in canonicals]
+        keeper = elected_canon[0] if elected_canon else elected[0]
+        for m in elected:
+            if m != keeper:
+                candidates.discard(m)
     return sorted(candidates)
 
 

--- a/packages/engine/tests/unit/analysis/drivers/test_processor.py
+++ b/packages/engine/tests/unit/analysis/drivers/test_processor.py
@@ -171,6 +171,104 @@ class TestDiscoverDrivers:
         dims = _candidate_dims(real_session, tid, RUN)
         assert a in dims and b in dims  # unconfirmed redundancy → both axes kept
 
+    def test_unelected_canonical_keeps_surviving_member(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """DAT-806: when the alias canonical is a raw-FK near-key the slicing gate
+        excluded (never a SliceDefinition), the surviving ELECTED member is the
+        dimension's only representative — it must NOT be discarded against the absent
+        canonical, which would orphan the axis and starve the driver-tree
+        (``too_few_candidates``)."""
+        tid = _seed(real_session, duck)
+        member = next(d for d in ALL_DIMS if d != "D_e25")  # an elected slice
+        real_session.add(
+            DimensionHierarchy(
+                run_id=RUN,
+                table_id=tid,
+                kind="alias",
+                members=[
+                    {
+                        "column_name": "account_id",
+                        "column_id": "",
+                        "distinct_count": 900,
+                        "level": 0,
+                    },
+                    {"column_name": member, "column_id": "", "distinct_count": 900, "level": 1},
+                ],
+                canonical_label="account_id",  # a near-key FK — excluded from slices
+                signature=f"alias:{tid}:account_id|{member}",
+                g3=0.0,
+            )
+        )
+        real_session.flush()
+        dims = _candidate_dims(real_session, tid, RUN)
+        assert member in dims  # surviving elected member kept, not orphaned
+        assert "account_id" not in dims  # the un-elected canonical never was a candidate
+
+    def test_multi_member_class_collapses_to_one_when_canonical_unelected(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """DAT-806: a ≥2-elected alias class whose canonical (a near-key FK) is NOT a
+        slice collapses to exactly ONE elected representative — not zero (orphan), not
+        two (double-count). Exercises the discard branch the single-member case skips."""
+        tid = _seed(real_session, duck)
+        a, b = [d for d in ALL_DIMS if d != "D_e25"][:2]  # two elected slices
+        real_session.add(
+            DimensionHierarchy(
+                run_id=RUN,
+                table_id=tid,
+                kind="alias",
+                members=[
+                    {
+                        "column_name": "account_id",
+                        "column_id": "",
+                        "distinct_count": 900,
+                        "level": 0,
+                    },
+                    {"column_name": a, "column_id": "", "distinct_count": 900, "level": 1},
+                    {"column_name": b, "column_id": "", "distinct_count": 900, "level": 2},
+                ],
+                canonical_label="account_id",  # un-elected near-key FK
+                signature=f"alias:{tid}:account_id|{a}|{b}",
+                g3=0.0,
+            )
+        )
+        real_session.flush()
+        dims = _candidate_dims(real_session, tid, RUN)
+        assert len([d for d in (a, b) if d in dims]) == 1  # exactly one survives
+        assert "account_id" not in dims
+
+    def test_overlapping_confirmed_groups_collapse_order_independently(
+        self, real_session: Session, duck: duckdb.DuckDBPyConnection
+    ) -> None:
+        """DAT-806 (review): two confirmed alias groups sharing a member (a manual
+        teach overlapping an auto group — ``needs_confirmation=False``, no overlap
+        guard) form ONE equivalence class → exactly one survivor, independent of the
+        ORDER-BY-less query's row order. The per-group collapse yields two survivors."""
+        tid = _seed(real_session, duck)
+        a, b, c = [d for d in ALL_DIMS if d != "D_e25"][:3]  # three elected slices
+        for members, canon, sig in (
+            ([a, b], a, f"alias:{tid}:{a}|{b}"),  # G1: a ≡ b
+            ([b, c], c, f"alias:{tid}:{b}|{c}"),  # G2: b ≡ c → a~b~c is one class
+        ):
+            real_session.add(
+                DimensionHierarchy(
+                    run_id=RUN,
+                    table_id=tid,
+                    kind="alias",
+                    members=[
+                        {"column_name": m, "column_id": "", "distinct_count": 3, "level": i}
+                        for i, m in enumerate(members)
+                    ],
+                    canonical_label=canon,
+                    signature=sig,
+                    g3=0.0,
+                )
+            )
+        real_session.flush()
+        dims = _candidate_dims(real_session, tid, RUN)
+        assert len([d for d in (a, b, c) if d in dims]) == 1  # one class → one rep
+
     def test_end_to_end_ranks_drivers(
         self, real_session: Session, duck: duckdb.DuckDBPyConnection
     ) -> None:


### PR DESCRIPTION
## Problem (surfaced by the DAT-805 downstream smoke)

On the finance corpus, **all 9 driver rankings came back empty**. Root cause is `drivers/processor.py::_candidate_dims`, not the slicing gate.

`_candidate_dims` collapses a confirmed 1:1 alias group to its `canonical_label` and discards the other members. But the canonical is **sorted-first** and can be a raw-FK **near-key** (`account_id`) that the slicing gate correctly excludes from `SliceDefinition`s. So the surviving *elected* member (`account_id__name`) was discarded against an **absent canonical**, deleting the whole dimension. `journal_lines`/`trial_balance` dropped from 2 candidates → 1 → `driver_too_few_candidates` → the function bails with `n_rows=0` before any scan.

## Fix

Collapse only when **≥2 members are ELECTED** slice candidates, keeping one representative — the canonical if it is itself elected, else the sorted-first elected member (1:1 aliases partition identically, so the choice is immaterial for ranking). Never orphan a dimension because its canonical was filtered upstream.

## The bus_matrix was evaluated and rejected as the selection source

`BusMatrixEntry` (DAT-762) is **(fact × dimension) grain** with all attributes inlined (`attributes=[account_type, name]`) — too coarse for `_candidate_dims`, which needs *attribute-grain* candidates (account_type and account_name are distinct driver grains, not one dimension). For 1:1 aliases the representative choice is immaterial anyway.

## Verified

76 driver unit tests green (+1 new: `test_unelected_canonical_keeps_surviving_member`); ruff/mypy clean. Runtime verification (driver rankings actually populate) is the pending combined smoke of #508 + #500 + this.

Relates DAT-805 (surfaced it), DAT-762 (bus_matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)