### PR TITLE
fix(temporal): DAT-810 — completeness_ratio is a real [0,1] ratio, not a clamped unit mismatch

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,48 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-810 — temporal completeness: both sides are grain buckets, the clamp is gone, and the fields can now be NULL (profile VALUES + nullability change)
+
+**Branch:** `fix/dat-810-grain-bucket-periods`. `analyze_basic_temporal` divided two
+different units and hid the result: `completeness_ratio = COUNT(DISTINCT raw_timestamp)
+/ expected_periods`, where the numerator was distinct raw **instants** and the
+denominator was **grain buckets**, then `min(ratio, 1.0)` clamped the overflow into a
+false "perfectly complete" 1.0.
+
+Both halves now come from one DuckDB pass over the same closed window —
+`COUNT(DISTINCT date_trunc(grain, col))` and `date_diff(grain, MIN(bucket), MAX(bucket))
++ 1` — so `actual <= expected` holds by construction and the clamp is deleted, not
+retained. `calculate_expected_periods` is gone: it carried a **second, independent** unit
+mismatch on the denominator, dividing elapsed seconds by config's *nominal* per-grain
+seconds (`phases/temporal.yaml:20` — `month = 2592000` = a flat 30 days). Jan 1 / Feb 1 /
+Mar 1 spans 59 days → `59/30 + 1 = 2` expected months against 3 real buckets → ratio 1.5.
+Config's nominal seconds now only *infer* the grain; they are never the denominator.
+
+**What changes for eval — three things:**
+
+1. **`actual_periods` changes meaning** — grain buckets, not distinct raw instants. Same
+   number whenever value resolution == detected grain (every DATE column, so the whole
+   finance corpus is unaffected); different for any TIMESTAMP column with sub-grain
+   resolution.
+2. **`completeness_ratio` values move** where the old ratio exceeded 1 and got clamped —
+   previously a false `1.0`, now the true present/expected fraction (e.g. 0.909).
+3. **All three fields are now nullable and NULL together** (`completeness_ratio`,
+   `expected_periods`, `actual_periods`) when the grain is the `irregular`/`unknown`
+   sentinel — no bucket exists, so completeness is not computable and falls loud rather
+   than resolving to a plausible 0.0/1.0. Gap fields stay populated (a gap is measured
+   against the median gap, not a grain). **No schema change** — the DB columns were
+   already nullable; `schema.sql` re-dumps byte-identical.
+
+**Calibration to re-verify:** a TIMESTAMP column with sub-grain resolution reports a true
+sub-1.0 ratio instead of a clamped 1.0; a clean daily/monthly column is unchanged; an
+irregular column yields NULL completeness rather than a number. Note the masking case can
+be **silent** — in the pinned fixture `gap_count` is 0 (the holes sit exactly *at* the
+2×median significance threshold), so completeness was the only signal carrying the
+absence. Any eval assertion that these fields are always numeric needs a nullable read.
+No backfill; recreate test DBs.
+
+---
+
 ## DAT-806 — driver `_candidate_dims` no longer orphans a dimension whose alias canonical is a slicing-excluded near-key (driver rankings populate)
 
 **Branch:** `feat/dat-806-candidate-dims-orphan`. `drivers/processor.py::_candidate_dims`

--- a/packages/engine/src/dataraum/analysis/cycles/context.py
+++ b/packages/engine/src/dataraum/analysis/cycles/context.py
@@ -633,11 +633,16 @@ def format_context_for_prompt(context: dict[str, Any]) -> str:
         lines.append("## TEMPORAL PATTERNS")
         for tp in temporal:
             stale_str = " [STALE]" if tp.get("is_stale") else ""
+            # completeness is None on an irregular/unknown grain — there is no bucket to
+            # count, so the ratio is not computable (DAT-810). Say so; a missing number
+            # must not read as a number, and `:.0%` on None raises.
+            comp = tp["completeness"]
+            comp_str = f"{comp:.0%}" if comp is not None else "not computable (no grain)"
             lines.append(
                 f"- {tp['table_name']}.{tp['column_name']}: "
                 f"{tp['granularity']}, "
                 f"{tp['date_range_start']} to {tp['date_range_end']}, "
-                f"completeness={tp['completeness']:.0%}{stale_str}"
+                f"completeness={comp_str}{stale_str}"
             )
         lines.append("")
 

--- a/packages/engine/src/dataraum/analysis/temporal/db_models.py
+++ b/packages/engine/src/dataraum/analysis/temporal/db_models.py
@@ -32,31 +32,21 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from dataraum.analysis.temporal.detection import DATE_TRUNC_GRAINS
 from dataraum.storage import Base
 
 if TYPE_CHECKING:
     from dataraum.storage import Column
 
-# The closed vocabulary of ``detected_granularity``: the config granularity set
-# (config/phases/temporal.yaml ``granularity.definitions``) plus the two sentinels
-# ``infer_granularity`` emits — ``irregular`` (no definition matched) and ``unknown``
-# (no median gap). Sorted for a deterministic CHECK string in the offline DDL dump.
-_GRANULARITY_VALUES: tuple[str, ...] = tuple(
-    sorted(
-        (
-            "second",
-            "minute",
-            "hour",
-            "day",
-            "week",
-            "month",
-            "quarter",
-            "year",
-            "irregular",
-            "unknown",
-        )
-    )
-)
+# The closed vocabulary of ``detected_granularity``: the real grains (DATE_TRUNC_GRAINS
+# — the config granularity set, whose one home is the detection module that mints these
+# labels) plus the two sentinels ``infer_granularity`` emits when there is no grain at
+# all: ``irregular`` (no definition matched) and ``unknown`` (no median gap). Deriving
+# the union rather than re-typing the labels keeps the grain/sentinel split structural:
+# a value in here but NOT in DATE_TRUNC_GRAINS is exactly a value with no bucket, hence
+# with no completeness ratio (DAT-810).
+# Sorted for a deterministic CHECK string in the offline DDL dump.
+_GRANULARITY_VALUES: tuple[str, ...] = tuple(sorted(DATE_TRUNC_GRAINS | {"irregular", "unknown"}))
 
 
 class TemporalColumnProfile(Base):

--- a/packages/engine/src/dataraum/analysis/temporal/db_models.py
+++ b/packages/engine/src/dataraum/analysis/temporal/db_models.py
@@ -32,7 +32,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from dataraum.analysis.temporal.detection import DATE_TRUNC_GRAINS
+from dataraum.analysis.temporal.models import DATE_TRUNC_GRAINS
 from dataraum.storage import Base
 
 if TYPE_CHECKING:

--- a/packages/engine/src/dataraum/analysis/temporal/detection.py
+++ b/packages/engine/src/dataraum/analysis/temporal/detection.py
@@ -25,6 +25,21 @@ from dataraum.core.models.base import Result
 
 logger = get_logger(__name__)
 
+# The granularity labels that are valid DuckDB ``date_trunc`` period parts — exactly
+# the ``granularity.definitions`` names in config/phases/temporal.yaml, which is where
+# :func:`infer_granularity` mints them. ONE home for the label→``date_trunc``-part
+# mapping (label and part are spelled identically, so the set IS the mapping);
+# ``graphs.period_resolver`` reads it from here rather than keeping a second copy.
+#
+# The two sentinels ``irregular`` / ``unknown`` are deliberately absent: they are
+# infer_granularity's "no definition matched" / "no median gap" fallbacks, not
+# granularities. A column with no cadence has no bucket to count, so consumers fall
+# loud instead of bucketing by a meaningless grain (or injecting an invalid part into
+# a query).
+DATE_TRUNC_GRAINS: frozenset[str] = frozenset(
+    {"second", "minute", "hour", "day", "week", "month", "quarter", "year"}
+)
+
 
 def infer_granularity(
     median_gap_seconds: float | None,
@@ -77,45 +92,56 @@ def infer_granularity(
     return ("irregular", irregular_confidence)
 
 
-def calculate_expected_periods(
-    min_ts: datetime,
-    max_ts: datetime,
+def count_grain_periods(
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    table_name: str,
+    column_name: str,
     granularity: str,
-    *,
-    config: dict[str, Any],
-) -> int:
-    """Calculate expected number of periods for a time range.
+) -> tuple[int, int] | None:
+    """Count the present and the expected ``granularity`` buckets of a time column.
 
-    Args:
-        min_ts: Start of time range
-        max_ts: End of time range
-        granularity: Detected granularity
-        config: Temporal config dict (from config/phases/temporal.yaml) — the
-            same ``granularity.definitions`` source ``infer_granularity`` reads,
-            so the two functions share one home for per-granularity seconds
-            instead of each hardcoding its own copy.
+    Both halves of the completeness ratio, in ONE unit and from one pass:
+
+    - **actual** — how many grain buckets carry an observation.
+    - **expected** — how many grain buckets the ``[min, max]`` window contains, counted
+      on the CALENDAR (``date_diff`` between the truncated endpoints, inclusive), not
+      by dividing elapsed seconds by a nominal period length.
+
+    The calendar is the whole point. Config's per-granularity seconds are *nominal*
+    (a month is "2592000s" = 30 days), so seconds-division silently undercounts real
+    calendar buckets: Jan 1 / Feb 1 / Mar 1 spans 59 days, and 59/30 + 1 = 2 "months"
+    for 3 actual month buckets — a 1.5 ratio out of a denominator that never had the
+    same unit as the numerator. Those nominal seconds are for *inferring* the grain
+    (:func:`infer_granularity`), which is all they are accurate enough for; they must
+    never be the denominator (DAT-810).
+
+    So ``actual <= expected`` now holds by construction: every distinct bucket in the
+    data lies inside the closed window the expected count enumerates.
 
     Returns:
-        Expected number of periods
+        ``(actual, expected)``, or ``None`` when ``granularity`` is not a ``date_trunc``
+        part (the ``irregular``/``unknown`` sentinels) — no bucket exists to count, so
+        it falls loud rather than returning a plausible 0.
     """
-    delta = max_ts - min_ts
-    total_seconds = delta.total_seconds()
+    if granularity not in DATE_TRUNC_GRAINS:
+        return None
 
-    # Per-granularity expected seconds, sourced from config — same definitions
-    # list infer_granularity uses to classify a granularity in the first place.
-    granularity_seconds: dict[str, float] = {
-        name: expected_seconds
-        for name, expected_seconds, _tolerance in config["granularity"]["definitions"]
-    }
-    # "irregular"/"unknown" are infer_granularity's sentinels for "no definition
-    # matched" / "no median gap" — they're not granularities, so config has no
-    # entry for them; keep the 1-second fallback that makes their expected-period
-    # count track total elapsed seconds.
-    granularity_seconds.setdefault("irregular", 1)
-    granularity_seconds.setdefault("unknown", 1)
+    # `granularity` is a member of the closed DATE_TRUNC_GRAINS set (checked above),
+    # never caller input; table/column are internal catalog identifiers.
+    bucket = f"date_trunc('{granularity}', \"{column_name}\"::TIMESTAMP)"
+    row = duckdb_conn.execute(
+        f"""
+        SELECT
+            COUNT(DISTINCT {bucket}),
+            date_diff('{granularity}', MIN({bucket}), MAX({bucket})) + 1
+        FROM {table_name}
+        WHERE "{column_name}" IS NOT NULL
+    """  # noqa: S608
+    ).fetchone()
 
-    seconds = granularity_seconds.get(granularity, 86400)
-    return int(total_seconds / seconds) + 1
+    if not row or row[0] is None or row[1] is None:
+        return None
+    return int(row[0]), int(row[1])
 
 
 def analyze_basic_temporal(
@@ -148,6 +174,8 @@ def analyze_basic_temporal(
         stale_mult = config["staleness"]["stale_multiplier"]
         # Get min/max timestamps and count. Cast to TIMESTAMP so a DATE column
         # also yields a datetime (the model + DB column are DateTime-typed).
+        # `distinct_count` here is raw distinct INSTANTS — reported as-is, and
+        # deliberately NOT the completeness numerator (see below).
         result = duckdb_conn.execute(
             f"""
             SELECT
@@ -195,14 +223,27 @@ def analyze_basic_temporal(
 
         median_gap, min_gap, max_gap = gap_result if gap_result else (None, None, None)
 
-        # Infer granularity from median gap
+        # Infer granularity from median gap. This is why the bucket count below needs
+        # its own round-trip: the grain is not declared, it is inferred from the gaps,
+        # so it isn't known until the query above has run and cannot be folded into it.
         granularity, confidence = infer_granularity(median_gap, min_gap, max_gap, config=config)
 
-        # Calculate expected periods based on granularity
-        expected_periods = calculate_expected_periods(min_ts, max_ts, granularity, config=config)
+        # Both sides of the ratio in ONE unit: calendar grain buckets. `distinct_count`
+        # above is raw INSTANTS — a different unit, and dividing it by a period count is
+        # what let the ratio exceed 1 (a TIMESTAMP column with sub-grain resolution has
+        # more instants than buckets) and get clamped to a false "perfectly complete" 1.0.
+        periods = count_grain_periods(duckdb_conn, table_name, column_name, granularity)
+        actual_periods, expected_periods = periods if periods else (None, None)
 
-        # Calculate completeness
-        completeness_ratio = distinct_count / expected_periods if expected_periods > 0 else 1.0
+        # No clamp (DAT-810): actual and expected are both calendar bucket counts over
+        # the same closed window, so actual <= expected holds by construction and a >1
+        # ratio is unreachable. A clamp here could only hide the next unit mismatch —
+        # exactly what it did before — so it is gone rather than kept "for safety".
+        completeness_ratio = (
+            actual_periods / expected_periods
+            if actual_periods is not None and expected_periods
+            else None
+        )
 
         # Detect significant gaps
         sig_gap_mult = gap_cfg["significant_gap_multiplier"]
@@ -260,13 +301,12 @@ def analyze_basic_temporal(
         span_days = (max_ts - min_ts).total_seconds() / (24 * 3600)
 
         # Build completeness analysis
-        completeness_ratio_clamped = min(completeness_ratio, 1.0)
         largest_gap_days = max((g.gap_length_days for g in gaps), default=None) if gaps else None
 
         completeness = TemporalCompletenessAnalysis(
-            completeness_ratio=completeness_ratio_clamped,
+            completeness_ratio=completeness_ratio,
             expected_periods=expected_periods,
-            actual_periods=distinct_count,
+            actual_periods=actual_periods,
             gap_count=len(gaps),
             largest_gap_days=largest_gap_days,
             gaps=gaps,
@@ -306,7 +346,8 @@ def analyze_basic_temporal(
 
 
 __all__ = [
+    "DATE_TRUNC_GRAINS",
     "infer_granularity",
-    "calculate_expected_periods",
+    "count_grain_periods",
     "analyze_basic_temporal",
 ]

--- a/packages/engine/src/dataraum/analysis/temporal/detection.py
+++ b/packages/engine/src/dataraum/analysis/temporal/detection.py
@@ -17,6 +17,7 @@ from typing import Any
 import duckdb
 
 from dataraum.analysis.temporal.models import (
+    DATE_TRUNC_GRAINS,
     TemporalCompletenessAnalysis,
     TemporalGapInfo,
 )
@@ -24,21 +25,6 @@ from dataraum.core.logging import get_logger
 from dataraum.core.models.base import Result
 
 logger = get_logger(__name__)
-
-# The granularity labels that are valid DuckDB ``date_trunc`` period parts — exactly
-# the ``granularity.definitions`` names in config/phases/temporal.yaml, which is where
-# :func:`infer_granularity` mints them. ONE home for the label→``date_trunc``-part
-# mapping (label and part are spelled identically, so the set IS the mapping);
-# ``graphs.period_resolver`` reads it from here rather than keeping a second copy.
-#
-# The two sentinels ``irregular`` / ``unknown`` are deliberately absent: they are
-# infer_granularity's "no definition matched" / "no median gap" fallbacks, not
-# granularities. A column with no cadence has no bucket to count, so consumers fall
-# loud instead of bucketing by a meaningless grain (or injecting an invalid part into
-# a query).
-DATE_TRUNC_GRAINS: frozenset[str] = frozenset(
-    {"second", "minute", "hour", "day", "week", "month", "quarter", "year"}
-)
 
 
 def infer_granularity(
@@ -241,7 +227,7 @@ def analyze_basic_temporal(
         # exactly what it did before — so it is gone rather than kept "for safety".
         completeness_ratio = (
             actual_periods / expected_periods
-            if actual_periods is not None and expected_periods
+            if actual_periods is not None and expected_periods is not None
             else None
         )
 
@@ -346,7 +332,6 @@ def analyze_basic_temporal(
 
 
 __all__ = [
-    "DATE_TRUNC_GRAINS",
     "infer_granularity",
     "count_grain_periods",
     "analyze_basic_temporal",

--- a/packages/engine/src/dataraum/analysis/temporal/models.py
+++ b/packages/engine/src/dataraum/analysis/temporal/models.py
@@ -19,6 +19,31 @@ from pydantic import BaseModel, Field
 
 from dataraum.core.models.base import ColumnRef
 
+# The granularity labels that are valid DuckDB ``date_trunc`` period parts — exactly
+# the ``granularity.definitions`` names in config/phases/temporal.yaml, which is where
+# :func:`~dataraum.analysis.temporal.detection.infer_granularity` mints them. ONE home
+# for the label→``date_trunc``-part mapping (label and part are spelled identically, so
+# the set IS the mapping); ``detection``, ``db_models`` and ``graphs.period_resolver``
+# all read it from here rather than keeping their own copies.
+#
+# It lives in this module, not in ``detection``, so the models/DDL layer can reach it
+# without importing ``duckdb`` — ``db_models`` needs it at class-body-eval time to build
+# the ``detected_granularity`` CHECK vocabulary.
+#
+# Sync with config is enforced by a contract test (``test_basic_temporal.py``), not by
+# reading the YAML here: ``db_models`` needs this at import time, and a config edit that
+# silently disabled completeness for a real grain is exactly the failure that test
+# catches loudly.
+#
+# The two sentinels ``irregular`` / ``unknown`` are deliberately absent: they are
+# infer_granularity's "no definition matched" / "no median gap" fallbacks, not
+# granularities. A column with no cadence has no bucket to count, so consumers fall
+# loud instead of bucketing by a meaningless grain (or injecting an invalid part into
+# a query).
+DATE_TRUNC_GRAINS: frozenset[str] = frozenset(
+    {"second", "minute", "hour", "day", "week", "month", "quarter", "year"}
+)
+
 # =============================================================================
 # Basic Temporal Detection Models
 # =============================================================================

--- a/packages/engine/src/dataraum/analysis/temporal/models.py
+++ b/packages/engine/src/dataraum/analysis/temporal/models.py
@@ -43,13 +43,20 @@ class TemporalCompletenessAnalysis(BaseModel):
     """Temporal completeness analysis.
 
     Computed from the DISTINCT timestamps (robust to duplicate-per-day fact rows),
-    so ``actual_periods`` is the distinct-period count and the gaps are genuine
-    absences between consecutive present periods.
+    so the gaps are genuine absences between consecutive present periods.
+
+    ``actual_periods`` and ``expected_periods`` are both counts of **detected-grain
+    buckets** over the same ``[min, max]`` window, so ``completeness_ratio`` is
+    ``actual / expected`` in one unit and lands in [0, 1] by construction — no clamp
+    (DAT-810). The three are ``None`` together when the grain is ``irregular``/
+    ``unknown``: those have no bucket, so completeness over them is not computable and
+    falls loud rather than resolving to a plausible 1.0/0.0. The gap fields stay
+    populated — a gap is measured against the median gap, not against a grain.
     """
 
-    completeness_ratio: float  # 0-1
-    expected_periods: int
-    actual_periods: int
+    completeness_ratio: float | None  # 0-1, or None when the grain has no bucket
+    expected_periods: int | None
+    actual_periods: int | None
     gap_count: int
     largest_gap_days: float | None = None
     gaps: list[TemporalGapInfo] = Field(default_factory=list)

--- a/packages/engine/src/dataraum/graphs/period_resolver.py
+++ b/packages/engine/src/dataraum/graphs/period_resolver.py
@@ -67,7 +67,7 @@ from typing import TYPE_CHECKING, Any
 import duckdb
 from sqlalchemy import bindparam, text
 
-from dataraum.analysis.temporal.detection import DATE_TRUNC_GRAINS
+from dataraum.analysis.temporal.models import DATE_TRUNC_GRAINS
 from dataraum.core.logging import get_logger
 from dataraum.graphs.additivity import parse_aggregate_calls
 from dataraum.graphs.additivity_resolver import fact_table_id, grounded_select

--- a/packages/engine/src/dataraum/graphs/period_resolver.py
+++ b/packages/engine/src/dataraum/graphs/period_resolver.py
@@ -67,6 +67,7 @@ from typing import TYPE_CHECKING, Any
 import duckdb
 from sqlalchemy import bindparam, text
 
+from dataraum.analysis.temporal.detection import DATE_TRUNC_GRAINS
 from dataraum.core.logging import get_logger
 from dataraum.graphs.additivity import parse_aggregate_calls
 from dataraum.graphs.additivity_resolver import fact_table_id, grounded_select
@@ -89,16 +90,6 @@ _PARAMETER = "days_in_period"
 # COALESCE of the aggregation-lineage witness posterior over the concept prior); the
 # non-``flow`` measures (stocks, point-in-time levels) are excluded.
 _FLOW = "flow"
-
-# The detected-granularity labels that are valid DuckDB ``date_trunc`` period parts —
-# exactly the config granularity definitions (config/phases/temporal.yaml). The two
-# sentinels ``irregular`` / ``unknown`` (temporal detection's no-cadence fallbacks)
-# are deliberately excluded: a column with no clean cadence has no period to count or
-# fencepost-correct against, so the resolver falls loud rather than bucket by a
-# meaningless grain (or inject an invalid identifier into the window query).
-_DATE_TRUNC_GRAINS: frozenset[str] = frozenset(
-    {"second", "minute", "hour", "day", "week", "month", "quarter", "year"}
-)
 
 
 @dataclass(frozen=True)
@@ -333,7 +324,7 @@ def _observe_window(
     filtered window is empty (no rows match the predicate), or it collapses to a
     single period (no gap to fencepost-correct against).
     """
-    if grain not in _DATE_TRUNC_GRAINS:
+    if grain not in DATE_TRUNC_GRAINS:
         return f"anchor axis {axis!r} cadence {grain!r} has no clean period to correct against"
     sql = (
         f'SELECT MIN("{axis}"), MAX("{axis}"), '  # noqa: S608 - identifiers are internal catalog names

--- a/packages/engine/tests/unit/analysis/cycles/test_context.py
+++ b/packages/engine/tests/unit/analysis/cycles/test_context.py
@@ -186,6 +186,58 @@ def test_format_context_for_prompt_renders_grain_column_names() -> None:
     assert "grain: columns" not in rendered
 
 
+def test_format_context_for_prompt_renders_uncomputable_completeness() -> None:
+    """DAT-810 regression: a temporal profile whose grain is irregular/unknown carries
+    ``completeness=None`` — no bucket exists, so the ratio is not computable and the
+    three fields fall loud together. Rendering it with ``:.0%`` raised ``TypeError:
+    unsupported format string passed to NoneType.__format__``, crashing the whole
+    business-cycles phase (``format_context_for_prompt`` is called unguarded from
+    ``cycles/agent.py`` → ``business_cycles_phase.py``). The absence must render as
+    absence, never as a number."""
+    context = {
+        "tables": [{"table_name": "events", "row_count": 10, "columns": []}],
+        "temporal_profiles": [
+            {
+                "table_name": "events",
+                "column_name": "occurred_at",
+                "granularity": "irregular",
+                "date_range_start": "2025-01-01",
+                "date_range_end": "2026-02-11",
+                "completeness": None,
+                "is_stale": False,
+            }
+        ],
+    }
+
+    rendered = format_context_for_prompt(context)
+
+    assert "completeness=not computable (no grain)" in rendered
+    assert "completeness=0%" not in rendered
+    assert "completeness=100%" not in rendered
+
+
+def test_format_context_for_prompt_renders_known_completeness_as_percent() -> None:
+    """The computable case is unchanged — a real grain still renders its ratio."""
+    context = {
+        "tables": [{"table_name": "events", "row_count": 10, "columns": []}],
+        "temporal_profiles": [
+            {
+                "table_name": "events",
+                "column_name": "occurred_at",
+                "granularity": "day",
+                "date_range_start": "2025-01-01",
+                "date_range_end": "2025-01-31",
+                "completeness": 0.909,
+                "is_stale": True,
+            }
+        ],
+    }
+
+    rendered = format_context_for_prompt(context)
+
+    assert "completeness=91% [STALE]" in rendered
+
+
 @pytest.fixture
 def ledger_with_derivations(session):
     """A ledger table with a debit/credit/net triple + derivation rows.

--- a/packages/engine/tests/unit/analysis/temporal/test_basic_temporal.py
+++ b/packages/engine/tests/unit/analysis/temporal/test_basic_temporal.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 import duckdb
+import pytest
 
-from dataraum.analysis.temporal.detection import analyze_basic_temporal
+from dataraum.analysis.temporal.detection import DATE_TRUNC_GRAINS, analyze_basic_temporal
 
 # Real thresholds mirrored from config/phases/temporal.yaml (self-contained — no
 # config bind-mount needed at unit-test time).
@@ -93,6 +94,196 @@ def test_duplicate_heavy_fact_column_still_reads_daily() -> None:
 
     assert v["granularity"] == "day"
     assert v["completeness"].actual_periods == 60  # distinct days, not row count
+
+
+def test_resolution_equals_grain_is_unchanged_and_exact() -> None:
+    """The common case: one instant per bucket, at the grain. Ratio is exact.
+
+    When the column's resolution already IS the detected grain, bucket-counting and
+    instant-counting agree, so DAT-810 must not move this number. 60 consecutive days,
+    no holes: 60 buckets over a 59-day span → expected 60, ratio exactly 1.0 — a
+    genuine 1.0 that is *computed*, not clamped into place.
+    """
+    conn = duckdb.connect()
+    base = datetime(2024, 1, 1)
+    _table(conn, [base + timedelta(days=i) for i in range(60)])
+
+    c = analyze_basic_temporal(conn, "t", "ts", config=_CONFIG).unwrap()["completeness"]
+
+    assert (c.actual_periods, c.expected_periods) == (60, 60)
+    assert c.completeness_ratio == 1.0
+
+
+def test_subgrain_timestamps_do_not_inflate_completeness_past_one() -> None:
+    """Sub-grain instants must not overrun the bucket denominator (DAT-810).
+
+    The shape that triggers the defect: a TIMESTAMP column at day cadence where a
+    MINORITY of days carry a second intra-day instant. The minority matters — grain is
+    inferred from the *median* gap, so intra-day duplicates have to stay below half the
+    gaps or the median drops off 86400 and the column reads 'irregular' instead of
+    'day'. (This is also why the finance corpus cannot trigger it: every date column
+    there is a plain DATE, so there are no sub-day instants at all.)
+
+    Layout: a 22-day window, days 10 and 16 absent (20 days present), and 5 of the
+    present days carrying an extra 17:00 instant beside the 09:00 one.
+      - 25 distinct instants, 20 distinct day buckets, span 21d → expected 22 buckets.
+      - Gaps sort to 5×28800, 5×57600, 12×86400, 2×172800 → median 86400 → 'day'.
+      - OLD: 25 raw instants / 22 buckets = 1.136 → min(…, 1.0) → a reported 1.0.
+      - NEW: 20 buckets / 22 buckets = 0.909.
+    The clamp did not merely round a wrong number — it certified a column that is
+    missing 2 of its 22 days as *perfectly complete*, and gap_count is 0 here (both
+    holes are 172800s, exactly at the 2×median threshold, not above it), so
+    completeness is the only signal that could have carried the absence.
+    """
+    conn = duckdb.connect()
+    base = datetime(2024, 1, 1, 9, 0)
+    missing = {10, 16}
+    dup = {2, 4, 6, 12, 14}
+    dates: list[datetime] = []
+    for i in range(1, 23):
+        if i in missing:
+            continue
+        day = base + timedelta(days=i - 1)
+        dates.append(day)
+        if i in dup:
+            dates.append(day + timedelta(hours=8))
+    _table(conn, dates)
+
+    v = analyze_basic_temporal(conn, "t", "ts", config=_CONFIG).unwrap()
+    c = v["completeness"]
+
+    assert v["granularity"] == "day"  # the median gap must still land on 'day'
+    assert v["distinct_count"] == 25  # raw instants — the old, wrong numerator
+    assert c.actual_periods == 20  # day buckets — the correct numerator
+    assert c.expected_periods == 22
+    assert c.completeness_ratio is not None
+    assert c.completeness_ratio == pytest.approx(20 / 22)
+    assert c.completeness_ratio < 1.0  # the false "complete" verdict is gone
+    assert c.gap_count == 0  # nothing else would have flagged the 2 missing days
+
+
+def test_month_denominator_counts_calendar_months_not_nominal_seconds() -> None:
+    """The denominator is calendar buckets, not elapsed/nominal seconds (DAT-810).
+
+    Config's per-granularity seconds are nominal — a month is 2592000s (30 days) — which
+    is fine for *inferring* the grain but wrong for counting it. Jan 1 / Feb 1 / Mar 1
+    2023 spans 59 days (Feb has 28), so the old seconds-division denominator gave
+    59/30 + 1 = 2 "expected months" against 3 real month buckets → ratio 1.5. Counting
+    the denominator on the calendar (``date_diff`` between truncated endpoints) gives 3,
+    and the series is exactly complete: 3/3.
+
+    This is the same unit-mismatch defect as the raw-instants numerator, on the other
+    side of the ratio — and it is why the clamp could be deleted rather than moved.
+    """
+    conn = duckdb.connect()
+    _table(conn, [datetime(2023, m, 1) for m in (1, 2, 3)])
+
+    v = analyze_basic_temporal(conn, "t", "ts", config=_CONFIG).unwrap()
+    c = v["completeness"]
+
+    assert v["granularity"] == "month"
+    assert (c.actual_periods, c.expected_periods) == (3, 3)
+    assert c.completeness_ratio == 1.0
+
+
+def _at_cadence(grain: str) -> tuple[list[datetime], timedelta]:
+    """20 instants at ``grain`` cadence, plus the sub-grain offset to perturb them with.
+
+    The offset always lands inside its own bucket, so it adds an instant without adding
+    a bucket — the sub-grain shape that overran the old raw-instant numerator.
+    """
+    monday = datetime(2024, 1, 1)  # 2024-01-01 is a Monday, so week buckets align
+    per_grain: dict[str, tuple[list[datetime], timedelta]] = {
+        "second": ([monday + timedelta(seconds=i) for i in range(20)], timedelta(milliseconds=500)),
+        "minute": ([monday + timedelta(minutes=i) for i in range(20)], timedelta(seconds=30)),
+        "hour": ([monday + timedelta(hours=i) for i in range(20)], timedelta(minutes=30)),
+        "day": ([monday + timedelta(days=i) for i in range(20)], timedelta(hours=9)),
+        "week": ([monday + timedelta(weeks=i) for i in range(20)], timedelta(days=3)),
+        # Calendar-awkward on purpose: 20 consecutive months (two Februaries, 28/30/31-day
+        # months), 20 quarters, and 20 years spanning five leap years.
+        "month": ([datetime(2023 + m // 12, m % 12 + 1, 1) for m in range(20)], timedelta(days=10)),
+        "quarter": (
+            [datetime(2020 + q // 4, (q % 4) * 3 + 1, 1) for q in range(20)],
+            timedelta(days=20),
+        ),
+        "year": ([datetime(2005 + i, 1, 1) for i in range(20)], timedelta(days=100)),
+    }
+    return per_grain[grain]
+
+
+def test_completeness_ratio_never_exceeds_one_across_grains() -> None:
+    """The invariant the deleted clamp used to fake, now true by construction.
+
+    Sweeps every ``date_trunc`` grain with sub-grain noise (an extra instant inside a
+    bucket) over calendar-awkward spans (short/long months, quarter and year boundaries,
+    leap years) — the shapes that made both seconds-vs-buckets mismatches fire.
+    ``actual`` counts buckets holding data; ``expected`` counts the buckets of the closed
+    window that contains them; so ``actual <= expected`` always, with no clamp in the code.
+
+    The noise is deliberately a MINORITY (3 perturbed of 20): each one splits a
+    grain-sized gap into two sub-grain gaps, so past ``K < (B-1)/3`` the median gap drops
+    off the grain and the column reads 'irregular' instead — which is the honest verdict,
+    but not the case under test here.
+    """
+    cases: list[tuple[str, list[datetime]]] = []
+    for grain in sorted(DATE_TRUNC_GRAINS):
+        base, offset = _at_cadence(grain)
+        cases.append((grain, base + [base[i] + offset for i in (2, 7, 13)]))
+
+    for grain, dates in cases:
+        conn = duckdb.connect()
+        _table(conn, dates)
+        v = analyze_basic_temporal(conn, "t", "ts", config=_CONFIG).unwrap()
+        c = v["completeness"]
+
+        assert v["granularity"] == grain, f"{grain}: inferred {v['granularity']!r}"
+        assert c.actual_periods is not None and c.expected_periods is not None
+        assert c.actual_periods <= c.expected_periods, (
+            f"{grain}: {c.actual_periods}>{c.expected_periods}"
+        )
+        assert c.completeness_ratio is not None
+        assert 0.0 < c.completeness_ratio <= 1.0, f"{grain}: ratio {c.completeness_ratio}"
+
+
+def test_irregular_grain_has_no_completeness_ratio() -> None:
+    """An 'irregular' column falls loud: no bucket → no ratio (DAT-810).
+
+    Gaps that match no granularity definition leave the grain as the 'irregular'
+    sentinel, which has no ``date_trunc`` part and no config seconds — so there is
+    neither a numerator nor a denominator. Completeness must be absent, not a
+    plausible default. The old code gave the sentinel a 1-second fallback, making
+    ``expected`` the elapsed seconds (a ~1.8M-period denominator) and the ratio a
+    meaningless ~0.0.
+
+    Gaps stay populated: they are measured against the median gap, not against a grain.
+    """
+    conn = duckdb.connect()
+    base = datetime(2024, 1, 1)
+    # Gaps of ~5 days: between 'day' (86400±3600) and 'week' (604800±86400) — no match.
+    _table(conn, [base + timedelta(days=5 * i) for i in range(10)])
+
+    v = analyze_basic_temporal(conn, "t", "ts", config=_CONFIG).unwrap()
+    c = v["completeness"]
+
+    assert v["granularity"] == "irregular"
+    assert c.completeness_ratio is None
+    assert c.actual_periods is None
+    assert c.expected_periods is None
+    assert c.gap_count == 0  # a regular 5-day cadence has no gap vs its own median
+
+
+def test_unknown_grain_has_no_completeness_ratio() -> None:
+    """A single distinct instant falls loud too: no median gap → no grain → no ratio."""
+    conn = duckdb.connect()
+    _table(conn, [datetime(2024, 6, 30) for _ in range(50)])
+
+    v = analyze_basic_temporal(conn, "t", "ts", config=_CONFIG).unwrap()
+    c = v["completeness"]
+
+    assert v["granularity"] == "unknown"
+    assert c.completeness_ratio is None
+    assert c.actual_periods is None
+    assert c.expected_periods is None
 
 
 def test_old_data_is_stale_recent_data_is_not() -> None:

--- a/packages/engine/tests/unit/analysis/temporal/test_basic_temporal.py
+++ b/packages/engine/tests/unit/analysis/temporal/test_basic_temporal.py
@@ -13,7 +13,8 @@ from datetime import UTC, datetime, timedelta
 import duckdb
 import pytest
 
-from dataraum.analysis.temporal.detection import DATE_TRUNC_GRAINS, analyze_basic_temporal
+from dataraum.analysis.temporal.detection import analyze_basic_temporal
+from dataraum.analysis.temporal.models import DATE_TRUNC_GRAINS
 
 # Real thresholds mirrored from config/phases/temporal.yaml (self-contained — no
 # config bind-mount needed at unit-test time).
@@ -313,3 +314,33 @@ def test_single_distinct_timestamp_is_not_stale() -> None:
 
     assert v["median_gap_seconds"] is None
     assert v["is_stale"] is False
+
+
+def test_date_trunc_grains_match_the_real_config_definitions() -> None:
+    """DAT-810 contract: ``DATE_TRUNC_GRAINS`` is a hand-typed frozenset, but its whole
+    premise is that it equals ``granularity.definitions`` in the REAL
+    config/phases/temporal.yaml — the labels ``infer_granularity`` actually mints.
+
+    Nothing structural enforces that (config is YAML; ``db_models`` needs the constant at
+    class-body-eval time, so it cannot load config there). Without this test, adding or
+    renaming a grain in the YAML makes ``count_grain_periods`` silently return ``None``
+    for that grain — completeness quietly vanishes for real data, with no error. That is
+    precisely the "absence resolves to a plausible default" failure this ticket removed,
+    so the drift must fail LOUDLY in CI instead.
+
+    Also pins the inverse: the two sentinels are NOT grains and must never appear in the
+    config definitions.
+    """
+    from dataraum.core.config import load_phase_config
+
+    config = load_phase_config("temporal")
+    config_grains = {d[0] for d in config["granularity"]["definitions"]}
+
+    assert config_grains == set(DATE_TRUNC_GRAINS), (
+        "config/phases/temporal.yaml granularity.definitions has drifted from "
+        "DATE_TRUNC_GRAINS (analysis/temporal/models.py). Config-only labels silently "
+        "lose completeness; constant-only labels are dead. Reconcile both."
+    )
+    assert not ({"irregular", "unknown"} & config_grains), (
+        "irregular/unknown are infer_granularity's no-grain sentinels, not granularities"
+    )


### PR DESCRIPTION
Closes DAT-810.

## The defect

`analyze_basic_temporal` divided two different units and then hid the result:

- numerator — `COUNT(DISTINCT "col")`, distinct **raw instants**
- denominator — `expected_periods`, **grain buckets**
- `min(ratio, 1.0)` clamped the overflow into a perfect **1.0**

Nonsense converted into a green verdict rather than falling loud.

## Two mismatches, not one

The ticket's spec assumed only the numerator was wrong. It wasn't. `calculate_expected_periods` divided elapsed seconds by config's *nominal* per-grain seconds (`phases/temporal.yaml:20` — `month = 2592000`, a flat 30 days). Jan 1 / Feb 1 / Mar 1 spans 59 days → `59/30 + 1 = 2` expected months against 3 real buckets → ratio **1.5**. Fixing the numerator alone would have shipped a >1 ratio with the clamp removed and nothing catching it.

Both counts now come from one DuckDB pass over the same closed window — `COUNT(DISTINCT date_trunc(grain, col))` and `date_diff(grain, MIN(bucket), MAX(bucket)) + 1` — so `actual <= expected` holds **by construction**. `calculate_expected_periods` is deleted; config's nominal seconds now only *infer* the grain, which is all they're accurate enough for. The clamp is gone, not retained "for safety".

## Correcting the ticket's severity claim

The original filing claimed `journal_entries.date` (401 distinct values / 14 months) resolved to monthly grain giving `401/14 = 28.6`. **That cannot happen** — the grain is inferred from the median gap, so that column resolves *daily* (ratio ≈ 0.99). The finance corpus has no sub-day timestamps at all, so this bug cannot fire on it. The real trigger is a TIMESTAMP column with sub-grain resolution where intra-bucket duplicates stay a *minority* of gaps. The ticket has been corrected.

It is worse in one respect than "a few percent", though: in the pinned fixture `gap_count` is **0** (both holes sit exactly *at* the 2×median significance threshold), so completeness was the only signal that could have carried the absence — and it certified the column perfectly complete.

## Fall loud

`irregular`/`unknown` grains have no bucket, so `completeness_ratio` / `expected_periods` / `actual_periods` are now `None` **together** rather than resolving to a plausible 0.0/1.0. The DB columns were already nullable — **no schema change**, `schema.sql` re-dumps byte-identical.

## Review findings, fixed

- **Critical (senior review):** the nullable value reached one unguarded formatter — `cycles/context.py` rendered it with `:.0%`, which raises `TypeError` on `None`, and the call chain (`cycles/agent.py:109` → `business_cycles_phase.py:169`) has no try/except. Any workspace with an irregular-grain temporal column would have hard-crashed the business-cycles phase. That path had **zero** test coverage, which is why CI was green. Now renders `not computable (no grain)`, with a regression test that raises the exact `TypeError` against the unfixed formatter.
- `DATE_TRUNC_GRAINS` moved to `models.py` (keeps `duckdb` out of the models/DDL import graph) and a contract test now asserts it against the real YAML both ways — a config edit that silently disabled completeness for a real grain would otherwise be invisible.
- `.claude/handoff.md` entry added: `actual_periods` changes meaning and three fields go nullable.

## Verification

2153 unit + affected integration green · ruff format/check, mypy, vulture clean · `schema.sql` re-dumped, no drift · both reviewers run, all findings closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)