### PR TITLE
fix(llm): key the envelope unwrap on the tool schema, not the tool name (DAT-795)

### DIFF
--- a/packages/engine/src/dataraum/llm/providers/anthropic.py
+++ b/packages/engine/src/dataraum/llm/providers/anthropic.py
@@ -505,26 +505,38 @@ class AnthropicProvider(LLMProvider):
                         }
                     )
                     coerced = original_input
+                    tool_schema = schemas_by_name.get(block.name)
                     # Envelope unwrap (Sonnet 5 under a forced tool_choice): the model
                     # intermittently wraps the WHOLE argument object under a single key
-                    # equal to the tool name — {"analyze_slicing": {<the real args>}}.
-                    # It is a valid tool call, but schema-validation at the call site
-                    # then finds no known top-level field and silently defaults every
-                    # field to empty (an empty ``recommendations`` list is
-                    # indistinguishable from "model declined"). This silently zeroed
-                    # slicing on a sampling-dependent fraction of runs → no slices →
-                    # dimension_hierarchies/aggregation_lineage/drivers all skipped, and
-                    # it hits EVERY forced-tool extractor (relationship judge,
-                    # reconciliation). Unwrap it here, once, for all of them.
-                    enveloped = coerced.get(block.name)
-                    if len(coerced) == 1 and isinstance(enveloped, dict):
-                        logger.warning(
-                            "tool_output_envelope_unwrapped",
-                            label=request.label,
-                            tool=block.name,
-                        )
-                        coerced = dict(enveloped)
-                    tool_schema = schemas_by_name.get(block.name)
+                    # — {"analyze_slicing": {<the real args>}}. It is a valid tool call,
+                    # but schema-validation at the call site then finds no known
+                    # top-level field and silently defaults every field to empty (an
+                    # empty ``recommendations`` list is indistinguishable from "model
+                    # declined"). This silently zeroed slicing on a sampling-dependent
+                    # fraction of runs → no slices → dimension_hierarchies/
+                    # aggregation_lineage/drivers all skipped, and it hits EVERY
+                    # forced-tool extractor (relationship judge, reconciliation).
+                    # Unwrap it here, once, for all of them.
+                    #
+                    # The wrapper key is NOT always the tool name: submit_analysis came
+                    # back as {"analysis": {...}} — a paraphrase — which zeroed
+                    # business_cycles (DAT-795's all-or-nothing cycle collapse). So key
+                    # on the SCHEMA, not the name: a lone top-level key that the tool
+                    # does not declare, carrying a dict, is an envelope by construction.
+                    # A single-property tool whose one declared key holds an object is
+                    # therefore left alone — that payload is legitimate, not wrapped.
+                    if len(coerced) == 1:
+                        (only_key,) = coerced
+                        enveloped = coerced[only_key]
+                        declared = (tool_schema or {}).get("properties") or {}
+                        if isinstance(enveloped, dict) and only_key not in declared:
+                            logger.warning(
+                                "tool_output_envelope_unwrapped",
+                                label=request.label,
+                                tool=block.name,
+                                envelope_key=only_key,
+                            )
+                            coerced = dict(enveloped)
                     if tool_schema is not None:
                         coerced = _coerce_stringified_args(
                             coerced, tool_schema, label=request.label

--- a/packages/engine/tests/unit/llm/test_anthropic_provider.py
+++ b/packages/engine/tests/unit/llm/test_anthropic_provider.py
@@ -505,6 +505,17 @@ class TestStringifiedArgCoercion:
         )
         assert coerced == {"tables": [{"table_name": "t"}], "note": "ok"}
 
+    def test_paraphrased_envelope_is_unwrapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The wrapper key is not always the tool name. `submit_analysis` came back
+        # as {"analysis": {...}} — a PARAPHRASE — and the tool-name-keyed unwrap
+        # declined, so business_cycles validated to zero cycles while its phase
+        # reported success (DAT-795's all-or-nothing cycle collapse). Any lone
+        # top-level key the tool does not declare is an envelope.
+        coerced = self._converse_with_tool_use(
+            monkeypatch, {"emission": {"tables": [{"table_name": "t"}], "note": "ok"}}
+        )
+        assert coerced == {"tables": [{"table_name": "t"}], "note": "ok"}
+
     def test_envelope_unwrap_then_coerces_inner(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Unwrap composes with stringified-arg coercion: an enveloped inner whose
         # container was itself stringified is still parsed.


### PR DESCRIPTION
## What

The forced-tool envelope-unwrap in `anthropic.py` only fired when the wrapper key equalled the **tool name** (`{"analyze_slicing": {...}}`). But the model paraphrases: the cycles agent's `submit_analysis` came back as `{"analysis": {...}}`, so the unwrap declined, the payload stayed wrapped, and `BusinessCycleAnalysisOutput` validation failed.

Downstream, `cycles/agent.py::_parse_output` swallows that ValidationError into `output = None` and falls back to `tool_input.get("cycles", [])` — the **same flat shape that just failed** — so it reads empty and the phase reports `completed` with **zero cycles persisted**. That is DAT-795's "cycle all-or-nothing collapse": flat shape → all cycles, enveloped → none. Observed on a clean-flat calibration run (dataraum-eval), where all four backbone cycles went missing while the phase went green.

## Fix

Key the unwrap on the **schema**, not the tool name: a lone top-level key the tool does not declare, carrying a dict, is an envelope by construction. This subsumes the tool-name case (a tool name is never one of its own properties) and generalises to any paraphrase. A single-property tool whose one declared key legitimately holds an object is left alone — `test_single_real_property_key_not_unwrapped` already pins that and still passes.

## Scope

- The masking fallback in `cycles/agent.py` is a **separate defect** and is NOT touched here; this fix stops the envelope from reaching it.
- Related: DAT-807 (structured-outputs spike) intends to retire the whole parse-coercion layer at the source; this is a targeted fix for the live cycle-collapse until then.

## Verification

New `test_paraphrased_envelope_is_unwrapped` **fails against the pre-fix provider and passes after**. 51/51 provider unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)