### PR TITLE
feat(enrichment): DAT-801 — neutral extension rule (header eligible on equal footing) + grain-safe per-join rebuild

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -47,6 +47,52 @@ No backfill; recreate test DBs.
 
 ---
 
+## DAT-801 — enriched views extend a fact by ANY useful FK neighbour (incl. its header), so header/line facts gain an event-time axis (enriched-view shape + witness recall change)
+
+**Branch:** `feat/dat-801-neutral-extension-rule`. The enrichment selection asked the LLM
+for *"valuable analytical dimensions (geographic/category/reference)"* — a framing a
+**header** (the parent record a line belongs to, carrying the line's event date) fails by
+definition. So a fact whose event time lives on a joined header, not on itself, got an
+enriched view with **no time column**, its measures served a NULL trend anchor, and the
+aggregation-lineage witness could never form for it (recall 0 on that class).
+
+**What changed (this branch — two pieces):**
+- **Enrichment prompt + contract reframed neutrally** (`enrichment_analysis.yaml` v2,
+  `enrichment_models.py`): *"what related data usefully extends this fact?"*. A
+  classification table and the fact's header are the SAME mechanism — a column carried
+  across a confirmed grain-preserving key join — so the contract names a `related_table`
+  (not a `dimension`) with an open `relationship_role` (was a closed
+  geographic/category/reference/temporal enum that structurally excluded a header).
+- **Grain safety:** a fan-out join now drops **that join** and the view rebuilds with the
+  survivors, instead of dropping the whole view (the reframe makes fan-out picks more
+  likely; the old all-or-nothing drop would delete a central fact's view entirely).
+
+Nothing else changed: the anchor and witness are served by **existing** pipeline
+machinery (DAT-491/720 fills the exposed header axis into the fact's `time_columns`;
+the DAT-565 reconciliation + DAT-780 witness then run unmodified). A first-cut
+`period_resolver` change to read the axis's cadence was written and **removed** before
+merge — reviewers found it couldn't express a lineage-inherited axis and reconstructed
+the `{fk}__{col}` name (collision-prone). That work is a separate follow-up (see below).
+
+**What this changes for eval — verified on the finance corpus (live begin_session, real
+LLM):** a fact whose date lives one FK away now gets that date exposed in its enriched
+view (its enriched-view **column set grows** — more `{fk}__{col}` columns, including the
+header date). The aggregation-lineage **witness now fires** for that class (was recall 0;
+finance: the trial_balance ↔ journal_lines reconciliation forms), and those measures now
+serve a **non-NULL flow anchor** (`anchor_time_axis`, verified). Enriched-view shape is
+LLM-judged, so assert the **column set / witness presence** for the header/line class,
+not exact columns; the wide/denormalized fixture is eval's to shape (per lead — build
+generic, grade shape-invariance in eval). No schema change. No backfill; recreate test DBs.
+
+**NOT in this change (follow-up):** the header axis is exposed on the enriched view but
+that view's columns are absent from `og_columns`/`current_columns` (DAT-811), so a
+measure's `days_in_period` **cadence** for a header-derived axis is not yet resolvable —
+those flows fall loud to the flagged config default (degradation-safe, never a silent
+wrong value). Metric *values* that depend on a data-derived `days_in_period` for a
+header-dated flow are therefore unchanged by this branch.
+
+---
+
 ## DAT-806 — driver `_candidate_dims` no longer orphans a dimension whose alias canonical is a slicing-excluded near-key (driver rankings populate)
 
 **Branch:** `feat/dat-806-candidate-dims-orphan`. `drivers/processor.py::_candidate_dims`

--- a/packages/dataraum-config/llm/prompts/enrichment_analysis.yaml
+++ b/packages/dataraum-config/llm/prompts/enrichment_analysis.yaml
@@ -1,11 +1,19 @@
 # Enrichment Analysis Prompt
 #
-# Identifies valuable dimension joins to enrich main datasets.
-# Uses Pydantic tool for structured output with enrichment recommendations.
+# Identifies related tables whose columns usefully extend a fact table.
+# Uses a Pydantic tool for structured output.
+#
+# DAT-801: the selection question is NEUTRAL — "what related data usefully extends
+# this fact?" — not "which valuable analytical dimension?". A fact's grain-preserving
+# FK neighbours are all candidates on the same footing: a classification/lookup table
+# and the fact's own header (the parent record carrying its event date) are the SAME
+# mechanism — a column carried across a confirmed key join. The old phrasing asked only
+# for "valuable analytical dimensions (geographic/category/reference)", which a header
+# fails by definition, so the fact's own event date was silently dropped.
 
 name: enrichment_analysis
-version: "1.0.0"
-description: Identify valuable dimension joins to enrich main datasets
+version: "2.0.0"
+description: Identify related tables whose columns usefully extend the main datasets
 
 # Temperature (0.0 = deterministic, 1.0 = creative)
 temperature: 0.0
@@ -13,78 +21,77 @@ temperature: 0.0
 # System prompt - defines role and behavior
 system_prompt: |
   You are a senior data analyst specializing in dimensional modeling and data enrichment.
-  Your task is to identify which dimension tables can be joined to main datasets (fact tables)
-  to add valuable analytical dimensions.
+  Your task is to identify which related tables can be joined to a main dataset (fact table)
+  to bring in columns that usefully extend it for analysis.
 
   <role>
-  - Identify main datasets (fact tables) vs reference/lookup tables (dimensions)
-  - Recommend joins that add valuable dimensions (geographic, categories, etc.)
-  - Select specific columns from dimension tables that add analytical value
-  - Avoid joins that would only add redundant or low-value data
+  - Identify the main datasets (fact tables) to extend
+  - For each, recommend joins to RELATED tables whose columns usefully extend the fact
+  - A related table can be a classification/lookup, reference/master data, a geographic
+    table, OR the fact's own parent record — the header (entry, order, invoice) this row
+    belongs to. These are the SAME mechanism: a column carried across a confirmed
+    grain-preserving key join. Do not privilege one kind over another.
+  - Select the specific columns from each related table that add analytical value
+  - Avoid joins that only add redundant or low-value data
   </role>
+
+  <what_usefully_extends_a_fact>
+  A related table usefully extends a fact when its columns let you slice, filter, label,
+  or TREND the fact's measures. Common cases, none special:
+  - Classification / category: account type, product category, segment, status code
+  - Reference / master data: human-readable names, descriptions, labels
+  - Geographic: region, country, location hierarchy
+  - The parent record (header): the entry / order / invoice a line belongs to. Its columns
+    commonly include the fact's EVENT DATE — the date the line does not carry itself but
+    inherits from its header one key away. A fact that carries no date of its own is
+    exactly the case where its header is the most useful thing to join.
+  Do not exclude a related table because it is "not a dimension" — the test is usefulness,
+  not category. A header carrying the event date is useful; join it.
+  </what_usefully_extends_a_fact>
 
   <grain_preservation>
   CRITICAL: You must ONLY recommend joins that preserve the grain of the main table.
-  - Use only many-to-one or one-to-one relationships (fact -> dimension)
+  - Use only many-to-one or one-to-one relationships (fact -> related table)
   - NEVER recommend one-to-many joins as they would duplicate rows
-  - The enriched view should have the SAME row count as the original fact table
+  - The extended view should have the SAME row count as the original fact table
   - Relationships marked [GRAIN-SAFE] are safe to use
   - Relationships marked [AVOID] would duplicate rows - do NOT use these
   </grain_preservation>
 
-  <dimension_types>
-  Categorize each recommended dimension by type:
-  - geographic: Country, region, city, location hierarchies, addresses
-  - category: Product categories, customer segments, classification codes, types
-  - reference: Master data like customer names, product descriptions, location details
-  - temporal: Calendar attributes, reporting periods, time hierarchies
-  - other: Other valuable dimensions not in above categories
-  </dimension_types>
-
   <column_selection>
-  For each dimension join, recommend specific columns to include:
-  - HIGH value: Essential dimensions for slicing/filtering (category codes, regions, segments)
-  - MEDIUM value: Useful attributes (names, descriptions, labels)
-  - LOW value: Supplementary data (rarely used but potentially useful)
+  For each join, recommend specific columns to include:
+  - HIGH value: essential for slicing/filtering/trending (category codes, regions,
+    segments, the fact's event date)
+  - MEDIUM value: useful attributes (names, descriptions, labels)
+  - LOW value: supplementary data (rarely used but potentially useful)
 
   Do NOT include:
   - Primary key columns (already joined on)
   - Foreign key columns (redundant with fact table)
   - System/audit columns (created_at, updated_by, etc.)
-  - Columns with high cardinality that aren't useful for grouping
+  - High-cardinality columns that aren't useful for grouping OR trending (an event date
+    IS useful for trending — keep it)
   </column_selection>
 
   <when_to_skip>
-  Some tables should NOT be enriched:
-  - Dimension tables themselves (they are the enrichment source, not target)
+  Some tables should NOT be extended:
+  - Lookup/reference tables themselves (they are the source of an extension, not a target)
   - Junction/bridge tables (intermediate tables for many-to-many relationships)
-  - Tables with no confirmed dimension relationships
-  - Tables that are already maximally enriched
+  - Tables with no confirmed grain-preserving relationships
+  - Tables that are already maximally extended
 
-  If a table has no valuable enrichments, include it with skip_reason explaining why.
+  If a table has no valuable extensions, include it with skip_reason explaining why.
   </when_to_skip>
-
-  <enrichment_value>
-  Focus on enrichments that add analytical value:
-  - Geographic dimensions: Enable regional analysis, market segmentation
-  - Category dimensions: Enable product/service categorization, type analysis
-  - Reference dimensions: Add human-readable names and descriptions
-  - Temporal dimensions: Enable time-based analysis beyond raw dates
-
-  Avoid redundant enrichments:
-  - Don't recommend joins where columns already exist in fact table
-  - Don't recommend low-confidence relationships
-  - Don't recommend dimensions that add minimal analytical value
-  </enrichment_value>
 
   Use the analyze_enrichment tool to provide your recommendations.
 
 # User prompt - provides data and context
 user_prompt: |
   <task>
-  Analyze the following database schema and recommend dimension table joins
-  to enrich the main datasets. Focus on joins that add valuable analytical
-  dimensions (geographic, categorical, reference data).
+  Analyze the following database schema and recommend joins to related tables that
+  usefully extend the main datasets — columns to slice, filter, label, or trend the
+  fact's measures by. Consider EVERY confirmed grain-preserving relationship, including
+  a fact's own parent record (its header), not only classification/lookup tables.
 
   Only use CONFIRMED relationships (already validated by semantic analysis).
   Do NOT create views with aggregations - only LEFT JOINs that preserve grain.
@@ -102,18 +109,18 @@ user_prompt: |
 
   <confirmed_relationships>
   LLM-confirmed relationships from semantic analysis.
-  Only use relationships marked [GRAIN-SAFE] for enrichment.
+  Only use relationships marked [GRAIN-SAFE] for extension.
 
   {confirmed_relationships}
   </confirmed_relationships>
 
   <existing_enriched_views>
-  Views already created - avoid duplicating these enrichments:
+  Views already created - avoid duplicating these extensions:
   {existing_views}
   </existing_enriched_views>
 
   Analyze this schema using the analyze_enrichment tool.
-  Recommend valuable enrichments for each fact table.
+  Recommend valuable extensions for each fact table.
 
 # Input variable definitions
 inputs:

--- a/packages/engine/src/dataraum/analysis/views/__init__.py
+++ b/packages/engine/src/dataraum/analysis/views/__init__.py
@@ -12,12 +12,12 @@ from dataraum.analysis.views.builder import DimensionJoin, build_enriched_view_s
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.analysis.views.enrichment_agent import EnrichmentAgent
 from dataraum.analysis.views.enrichment_models import (
-    DimensionEnrichmentOutput,
     EnrichmentAnalysisOutput,
     EnrichmentAnalysisResult,
     EnrichmentColumnOutput,
     EnrichmentRecommendation,
     MainDatasetOutput,
+    RelatedTableJoinOutput,
 )
 
 __all__ = [
@@ -33,6 +33,6 @@ __all__ = [
     "EnrichmentAnalysisResult",
     "EnrichmentColumnOutput",
     "EnrichmentRecommendation",
-    "DimensionEnrichmentOutput",
+    "RelatedTableJoinOutput",
     "MainDatasetOutput",
 ]

--- a/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
+++ b/packages/engine/src/dataraum/analysis/views/enrichment_agent.py
@@ -289,13 +289,13 @@ class EnrichmentAgent(LLMFeature):
             # join of that table gets the same column set.
             unified_dim_columns: dict[str, set[str]] = {}
             for enrichment in dataset.recommended_enrichments:
-                dim_name = enrichment.dimension_table
+                dim_name = enrichment.related_table
                 for col in enrichment.enrichment_columns:
                     if col.enrichment_value in ("high", "medium"):
                         unified_dim_columns.setdefault(dim_name, set()).add(col.column_name)
 
             for enrichment in dataset.recommended_enrichments:
-                dim_table_name = enrichment.dimension_table
+                dim_table_name = enrichment.related_table
                 dim_table_info = table_map.get(dim_table_name, {})
                 dim_table_id = dim_table_info.get("table_id", "")
                 dim_duckdb_path = dim_table_info.get("duckdb_path", "")
@@ -322,7 +322,7 @@ class EnrichmentAgent(LLMFeature):
                     dim_table_name=dim_table_name,
                     dim_duckdb_path=dim_duckdb_path,
                     fact_fk_column=enrichment.join_fact_column,
-                    dim_pk_column=enrichment.join_dimension_column,
+                    dim_pk_column=enrichment.join_related_column,
                     include_columns=include_columns,
                     relationship_id="",  # Will be filled by caller if needed
                 )
@@ -337,7 +337,7 @@ class EnrichmentAgent(LLMFeature):
                     fact_table_id=fact_table_id,
                     fact_table_name=fact_table_name,
                     dimension_joins=[dimension_join],
-                    dimension_type=enrichment.dimension_type,
+                    relationship_role=enrichment.relationship_role,
                     confidence=enrichment.confidence,
                     reasoning=enrichment.reasoning,
                     enrichment_columns=enrichment_columns,

--- a/packages/engine/src/dataraum/analysis/views/enrichment_models.py
+++ b/packages/engine/src/dataraum/analysis/views/enrichment_models.py
@@ -2,6 +2,14 @@
 
 Contains tool output models for structured LLM output and internal
 result models for processing enrichment recommendations.
+
+DAT-801: the selection question is neutral — "what related data usefully extends
+this fact?" — not "which valuable analytical dimension?". A fact's grain-preserving
+FK neighbours are all candidates on the same footing: a classification/lookup table
+and the fact's own header (the parent record carrying its event date) are the SAME
+mechanism — a column carried across a confirmed key join — so the contract names a
+``related_table``, never a ``dimension``, and the relationship role is open text, not
+a closed dimension vocabulary that structurally excludes a header.
 """
 
 from __future__ import annotations
@@ -18,54 +26,61 @@ from dataraum.analysis.views.builder import DimensionJoin
 
 
 class EnrichmentColumnOutput(BaseModel):
-    """A column to include from a dimension table."""
+    """A column to include from a related table."""
 
-    column_name: str = Field(description="Column name from the dimension table")
+    column_name: str = Field(description="Column name from the related table")
     enrichment_value: Literal["high", "medium", "low"] = Field(
         description=(
-            "'high' = essential dimension (geographic, category codes); "
-            "'medium' = useful attribute (name, description); "
-            "'low' = supplementary data"
+            "How useful this column is on the extended fact: "
+            "'high' = essential for slicing/filtering/trending; "
+            "'medium' = useful attribute (a name, label, or the fact's event date); "
+            "'low' = supplementary"
         )
     )
     reasoning: str = Field(description="Why this column adds value to the main dataset")
 
 
-class DimensionEnrichmentOutput(BaseModel):
-    """A recommended dimension table join."""
+class RelatedTableJoinOutput(BaseModel):
+    """A recommended join to a related table that usefully extends the fact.
 
-    dimension_table: str = Field(description="Name of the dimension/lookup table to join")
-    join_fact_column: str = Field(description="Column in the main table used for joining")
-    join_dimension_column: str = Field(description="Column in the dimension table used for joining")
-    dimension_type: Literal["geographic", "category", "reference", "temporal", "other"] = Field(
+    The related table may be a classification/lookup, reference/master data, a
+    geographic table, OR the fact's own parent record (a header, carrying the event
+    date). All are the same mechanism — a column carried across a confirmed
+    grain-preserving key join — so none is privileged in this contract.
+    """
+
+    related_table: str = Field(description="Name of the related table to join")
+    join_fact_column: str = Field(description="Column in the main table used for joining (the FK)")
+    join_related_column: str = Field(
+        description="Column in the related table used for joining (its key)"
+    )
+    relationship_role: str = Field(
         description=(
-            "Type of dimension being added: "
-            "'geographic' = location/region data; "
-            "'category' = classification/grouping; "
-            "'reference' = lookup/master data; "
-            "'temporal' = calendar/time attributes; "
-            "'other' = other useful dimensions"
+            "What this related data is, in a few words — e.g. 'classification', "
+            "'reference/lookup', 'geographic', or 'parent record / header' (the entry, "
+            "order, or invoice this row belongs to, carrying its date). Free text; not a "
+            "fixed set — describe the relationship, do not force it into a category."
         )
     )
     enrichment_columns: list[EnrichmentColumnOutput] = Field(
-        description="Columns from the dimension table to include in the view"
+        description="Columns from the related table to include in the view"
     )
     confidence: float = Field(
         ge=0.0, le=1.0, description="Confidence that this join adds analytical value (0.0-1.0)"
     )
-    reasoning: str = Field(description="Why this dimension adds value to the main dataset")
+    reasoning: str = Field(description="Why this related table adds value to the main dataset")
 
 
 class MainDatasetOutput(BaseModel):
-    """A main dataset (fact table) with recommended enrichments."""
+    """A main dataset (fact table) with its recommended extensions."""
 
     table_name: str = Field(description="Name of the main/fact table")
     is_primary_fact: bool = Field(description="True if this is the primary transactional dataset")
-    recommended_enrichments: list[DimensionEnrichmentOutput] = Field(
-        default_factory=list, description="Recommended dimension joins to enrich this table"
+    recommended_enrichments: list[RelatedTableJoinOutput] = Field(
+        default_factory=list, description="Recommended related-table joins that extend this table"
     )
     skip_reason: str | None = Field(
-        default=None, description="If no enrichments recommended, explain why"
+        default=None, description="If no extensions recommended, explain why"
     )
 
 
@@ -77,8 +92,8 @@ class EnrichmentAnalysisOutput(BaseModel):
 
     main_datasets: list[MainDatasetOutput] = Field(
         description=(
-            "Main datasets (fact tables) with their recommended enrichments. "
-            "Include ALL fact tables, even those with no recommended enrichments."
+            "Main datasets (fact tables) with their recommended extensions. "
+            "Include ALL fact tables, even those with no recommended extensions."
         )
     )
     summary: str = Field(description="Brief summary of the overall enrichment strategy")
@@ -95,7 +110,7 @@ class EnrichmentRecommendation(BaseModel):
     fact_table_id: str
     fact_table_name: str
     dimension_joins: list[DimensionJoin]
-    dimension_type: str
+    relationship_role: str
     confidence: float
     reasoning: str
     enrichment_columns: list[str]  # Column names with enrichment values
@@ -112,7 +127,7 @@ class EnrichmentAnalysisResult(BaseModel):
 __all__ = [
     # Tool output models
     "EnrichmentColumnOutput",
-    "DimensionEnrichmentOutput",
+    "RelatedTableJoinOutput",
     "MainDatasetOutput",
     "EnrichmentAnalysisOutput",
     # Internal models

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -407,7 +407,7 @@ class EnrichedViewsPhase(BasePhase):
                     if rec.fact_table_id == fact_table.table_id:
                         evidence = {
                             "llm_reasoning": rec.reasoning,
-                            "dimension_type": rec.dimension_type,
+                            "relationship_role": rec.relationship_role,
                             "enrichment_columns": rec.enrichment_columns,
                             "model_name": llm_recommendations.model_name,
                         }

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -12,9 +12,13 @@ the judge's behalf which already-verified relationships it was allowed to see
 it anyway (DAT-699). Confidence and cardinality are served as evidence; the
 judge decides.
 
-Post-creation: verifies row count matches fact table. Drops view if grain
-violated — grain is the view's CONTRACT (a fan-out view silently corrupts
-every downstream number), so this stays deterministic.
+Post-creation: grain is the view's CONTRACT (a fan-out view silently corrupts
+every downstream number). Because the view is a one-hop STAR (every dimension
+LEFT JOINs the fact, never another dimension), each join's fan-out is
+independent — so a grain violation drops the OFFENDING join and rebuilds from
+the survivors (DAT-801), never the fact's whole view. A belt-and-braces
+whole-view COUNT then asserts the composed grain; if it ever fails, the
+star-independence assumption broke and the view is dropped.
 """
 
 from __future__ import annotations
@@ -286,6 +290,7 @@ class EnrichedViewsPhase(BasePhase):
 
         views_created = 0
         views_dropped = 0
+        joins_dropped = 0
 
         for fact_entity in fact_entities:
             fact_table = tables_by_id.get(fact_entity.table_id)
@@ -346,15 +351,6 @@ class EnrichedViewsPhase(BasePhase):
                             )
                         )
 
-            dimension_joins: list[DimensionJoin] = [j for j, _ in joins_with_ids]
-
-            if not dimension_joins:
-                logger.info(
-                    "passthrough_enriched_view",
-                    fact_table=fact_table.table_name,
-                    reason="no qualifying dimension joins",
-                )
-
             # Name the view off the fact's narrow, workspace-unique duckdb_path
             # (``enriched_{table}`` — DAT-639). Table names are workspace-unique
             # (``uq_table_name_layer``), so two sources can't each own an
@@ -363,13 +359,45 @@ class EnrichedViewsPhase(BasePhase):
             view_name = f"enriched_{fact_table.duckdb_path}"
             view_fqn = _lake_fqn("enriched", view_name)
             fact_fqn = _lake_fqn("typed", fact_table.duckdb_path)
-            fqn_joins = [
-                replace(join, dim_duckdb_path=_lake_fqn("typed", dim.duckdb_path))
-                for join in dimension_joins
+
+            # Resolve each candidate join to its dimension FQN, carrying the stable
+            # column-pair so persistence tracks exactly what ships. A join whose dim
+            # table isn't in this session can't be resolved → dropped here (as before).
+            fqn_joins_with_ids = [
+                (replace(join, dim_duckdb_path=_lake_fqn("typed", dim.duckdb_path)), pair)
+                for join, pair in joins_with_ids
                 if (dim := tables_by_name.get(join.dim_table_name)) is not None and dim.duckdb_path
             ]
 
-            # Build view SQL
+            # DAT-801: a grain violation drops the OFFENDING join and rebuilds from
+            # the survivors — never the fact's whole view. The enriched view is a
+            # one-hop STAR (every dimension LEFT JOINs the fact, never another
+            # dimension — see ``build_enriched_view_sql``), so each join's fan-out is
+            # INDEPENDENT: a join whose isolated COUNT keeps the fact row count keeps
+            # it in the composed view, and composing grain-preservers preserves grain.
+            # Verifying each candidate ALONE is therefore sufficient for the whole
+            # view — no bisect. (DAT-801 reframed the prompt to join more neighbours,
+            # so a single fan-out pick used to cost a central fact its entire view.)
+            surviving = [
+                (join, pair)
+                for join, pair in fqn_joins_with_ids
+                if self._join_preserves_grain(ctx.duckdb_conn, fact_table, fact_fqn, join)
+            ]
+            joins_dropped += len(fqn_joins_with_ids) - len(surviving)
+
+            # Persistence + the view SQL now reflect the survivors only.
+            joins_with_ids = surviving
+            dimension_joins: list[DimensionJoin] = [join for join, _ in surviving]
+            fqn_joins = dimension_joins  # already FQN-resolved above
+
+            if not dimension_joins:
+                logger.info(
+                    "passthrough_enriched_view",
+                    fact_table=fact_table.table_name,
+                    reason="no qualifying dimension joins",
+                )
+
+            # Build view SQL from the grain-preserving survivors.
             view_sql, dim_columns = build_enriched_view_sql(view_fqn, fact_fqn, fqn_joins)
 
             # Create view in DuckDB
@@ -379,7 +407,10 @@ class EnrichedViewsPhase(BasePhase):
                 logger.warning("view_creation_failed", view_name=view_name, error=str(e))
                 continue
 
-            # Verify grain preservation
+            # Belt-and-braces (DAT-801): per-join filtering above already guarantees
+            # the grain, so this whole-view COUNT should never fail. If it does, the
+            # star-independence assumption broke — do NOT silently ship a fan-out view
+            # (grain is the view's CONTRACT). Log LOUD and drop the view.
             is_grain_verified = self._verify_grain(
                 ctx.duckdb_conn,
                 view_target=view_fqn,
@@ -387,11 +418,12 @@ class EnrichedViewsPhase(BasePhase):
             )
 
             if not is_grain_verified:
-                # Drop view — it would introduce duplicates
-                logger.warning(
-                    "grain_verification_failed",
+                logger.error(
+                    "grain_verification_failed_after_per_join_filter",
                     view_name=view_name,
+                    fact_table=fact_table.table_name,
                     expected_count=fact_table.row_count,
+                    surviving_joins=len(fqn_joins),
                 )
                 try:
                     ctx.duckdb_conn.execute(f"DROP VIEW IF EXISTS {view_fqn}")
@@ -536,6 +568,7 @@ class EnrichedViewsPhase(BasePhase):
             outputs={
                 "enriched_views": views_created,
                 "views_dropped": views_dropped,
+                "joins_dropped": joins_dropped,
                 "fact_tables": len(fact_entities),
             },
             records_processed=len(fact_entities),
@@ -928,6 +961,66 @@ class EnrichedViewsPhase(BasePhase):
             "confirmed_relationships": relationships_data,
             "existing_views": existing_views_data,
         }
+
+    @staticmethod
+    def _join_preserves_grain(
+        duckdb_conn: Any,
+        fact_table: Table,
+        fact_fqn: str,
+        join: DimensionJoin,
+    ) -> bool:
+        """Whether ONE dimension join, applied alone, preserves the fact grain (DAT-801).
+
+        The enriched view is a one-hop star (every dimension LEFT JOINs the fact,
+        never another dimension — ``build_enriched_view_sql``), so each join's
+        fan-out is independent: a join whose isolated ``COUNT(*)`` equals the fact
+        row count keeps the grain in the composed view too. This lets a grain
+        violation drop just the offending join and rebuild from the survivors,
+        instead of costing the fact its whole enriched view.
+
+        ``row_count is None`` → unmeasurable, keep the join (mirrors
+        ``_verify_grain``: can't verify → don't drop). A LEFT JOIN can only preserve
+        or inflate the fact's rows, so any COUNT above the expected count is a
+        fan-out (``one_to_many``). Both a fan-out and a probe that can't even execute
+        drop the join with a born-loud log naming the fact, the neighbour, and the
+        counts — a fan-out is a real topology fact, not debug noise.
+        """
+        expected = fact_table.row_count
+        if expected is None:
+            return True  # can't measure → don't drop (mirrors _verify_grain)
+
+        count_sql = (
+            f"SELECT COUNT(*) FROM {fact_fqn} AS f "
+            f"LEFT JOIN {join.dim_duckdb_path} AS d "
+            f'ON f."{join.fact_fk_column}" = d."{join.dim_pk_column}"'
+        )
+        try:
+            row = duckdb_conn.execute(count_sql).fetchone()
+        except Exception as e:
+            logger.warning(
+                "enrichment_join_probe_failed",
+                fact_table=fact_table.table_name,
+                dim_table=join.dim_table_name,
+                fact_fk_column=join.fact_fk_column,
+                dim_pk_column=join.dim_pk_column,
+                error=str(e),
+            )
+            return False
+
+        actual = row[0] if row else 0
+        if actual == expected:
+            return True
+
+        logger.warning(
+            "enrichment_join_fans_out",
+            fact_table=fact_table.table_name,
+            dim_table=join.dim_table_name,
+            fact_fk_column=join.fact_fk_column,
+            dim_pk_column=join.dim_pk_column,
+            expected_count=expected,
+            actual_count=actual,
+        )
+        return False
 
     @staticmethod
     def _verify_grain(

--- a/packages/engine/tests/integration/analysis/views/test_enriched_views.py
+++ b/packages/engine/tests/integration/analysis/views/test_enriched_views.py
@@ -265,7 +265,7 @@ class TestEnrichedViewsPhaseDuckLake:
                             relationship_id="rel-1",
                         )
                     ],
-                    dimension_type="reference",
+                    relationship_role="reference/lookup",
                     confidence=0.9,
                     reasoning="customers names/regions enrich orders",
                     enrichment_columns=["name", "country"],
@@ -501,7 +501,7 @@ class TestEnrichedViewsPhaseDuckLake:
                             relationship_id="rel-1",
                         )
                     ],
-                    dimension_type="reference",
+                    relationship_role="reference/lookup",
                     confidence=0.9,
                     reasoning="contradictory re-judgment",
                     enrichment_columns=["name"],

--- a/packages/engine/tests/integration/analysis/views/test_enriched_views.py
+++ b/packages/engine/tests/integration/analysis/views/test_enriched_views.py
@@ -787,6 +787,252 @@ class TestEnrichedViewsPhaseDuckLake:
         assert dim_cols() == ["customer_id__country", "customer_id__name"]
         assert calls["n"] == 2, "a genuinely re-confirmed relationship is re-judged, not inherited"
 
+    @staticmethod
+    def _seed_fanout(session, duckdb_conn):
+        """Seed a fact with TWO proposed joins: one grain-preserving, one fan-out.
+
+        The good dim (``customers``) has a UNIQUE key → its LEFT JOIN keeps the
+        3-row grain. The fan-out dim (``customer_tags``) has DUPLICATE keys on the
+        join column → its LEFT JOIN inflates the fact (DAT-801). Both joins ride the
+        same fact FK (``customer_id``), so the drop is driven by the MEASURED
+        fan-out, not the cardinality label. Returns
+        ``(fact_id, good_dim_id, fanout_dim_id, canned)``.
+        """
+        from uuid import uuid4
+
+        from dataraum.analysis.views.builder import DimensionJoin
+        from dataraum.analysis.views.enrichment_models import (
+            EnrichmentAnalysisResult,
+            EnrichmentRecommendation,
+        )
+        from dataraum.storage import Column, Source, Table
+
+        duckdb_conn.execute(
+            'CREATE OR REPLACE TABLE lake.typed."csv__orders" AS '
+            "SELECT * FROM (VALUES (1, 10, 100.0), (2, 20, 200.0), (3, 10, 150.0)) "
+            "AS t(order_id, customer_id, amount)"
+        )
+        duckdb_conn.execute(
+            'CREATE OR REPLACE TABLE lake.typed."csv__customers" AS '
+            "SELECT * FROM (VALUES (10, 'Alice', 'US'), (20, 'Bob', 'UK')) "
+            "AS t(id, name, country)"
+        )
+        # Duplicate keys on cust_key → a one-to-many LEFT JOIN that fans the fact out.
+        duckdb_conn.execute(
+            'CREATE OR REPLACE TABLE lake.typed."csv__customer_tags" AS '
+            "SELECT * FROM (VALUES (10, 'vip'), (10, 'gold'), (20, 'new')) "
+            "AS t(cust_key, tag)"
+        )
+
+        source = Source(source_id=str(uuid4()), name="csv", source_type="csv")
+        session.add(source)
+        session.flush()
+
+        fact = Table(
+            table_id=str(uuid4()),
+            source_id=source.source_id,
+            table_name="orders",
+            layer="typed",
+            duckdb_path="csv__orders",
+            row_count=3,
+        )
+        good = Table(
+            table_id=str(uuid4()),
+            source_id=source.source_id,
+            table_name="customers",
+            layer="typed",
+            duckdb_path="csv__customers",
+            row_count=2,
+        )
+        fanout = Table(
+            table_id=str(uuid4()),
+            source_id=source.source_id,
+            table_name="customer_tags",
+            layer="typed",
+            duckdb_path="csv__customer_tags",
+            row_count=3,
+        )
+        session.add_all([fact, good, fanout])
+        session.flush()
+
+        for tbl, names in (
+            (fact, ("order_id", "customer_id", "amount")),
+            (good, ("id", "name", "country")),
+            (fanout, ("cust_key", "tag")),
+        ):
+            for pos, name in enumerate(names):
+                session.add(
+                    Column(
+                        column_id=str(uuid4()),
+                        table_id=tbl.table_id,
+                        column_name=name,
+                        column_position=pos,
+                        raw_type="VARCHAR",
+                        resolved_type="VARCHAR",
+                    )
+                )
+        session.flush()
+
+        canned = EnrichmentAnalysisResult(
+            recommendations=[
+                EnrichmentRecommendation(
+                    fact_table_id=fact.table_id,
+                    fact_table_name="orders",
+                    dimension_joins=[
+                        DimensionJoin(
+                            dim_table_name="customers",
+                            dim_duckdb_path="(rewritten by the phase)",
+                            fact_fk_column="customer_id",
+                            dim_pk_column="id",
+                            include_columns=["name", "country"],
+                            relationship_id="rel-good",
+                        ),
+                        DimensionJoin(
+                            dim_table_name="customer_tags",
+                            dim_duckdb_path="(rewritten by the phase)",
+                            fact_fk_column="customer_id",
+                            dim_pk_column="cust_key",
+                            include_columns=["tag"],
+                            relationship_id="rel-fanout",
+                        ),
+                    ],
+                    relationship_role="reference/lookup",
+                    confidence=0.9,
+                    reasoning="customers + tags both proposed",
+                    enrichment_columns=["name", "country", "tag"],
+                )
+            ],
+            summary="stub",
+            model_name="stub-model",
+        )
+        return fact.table_id, good.table_id, fanout.table_id, canned
+
+    def test_fanout_join_dropped_view_ships_with_survivors(
+        self, session, duckdb_conn, monkeypatch, capsys
+    ):
+        """A fan-out join drops the OFFENDING join and rebuilds; the view still ships (DAT-801).
+
+        Two joins are proposed for the fact: a grain-preserving one (``customers``,
+        unique key) and a fan-out one (``customer_tags``, duplicate keys). The view
+        must SHIP with the good join's columns, EXCLUDE the fan-out join's columns,
+        preserve the fact grain, and the drop must be logged born-loud. Under the
+        old all-or-nothing behavior the whole view was dropped instead.
+        """
+        from sqlalchemy import select
+
+        from dataraum.analysis.views.db_models import EnrichedView
+        from dataraum.pipeline.base import PhaseContext, PhaseStatus
+
+        fact_id, good_id, fanout_id, canned = self._seed_fanout(session, duckdb_conn)
+        monkeypatch.setattr(
+            EnrichedViewsPhase, "_get_llm_recommendations", lambda self, **kw: canned
+        )
+
+        self._seed_fact_entity(session, table_id=fact_id, run_id="run-1")
+        self._seed_relationship(
+            session,
+            from_table_id=fact_id,
+            from_col="customer_id",
+            to_table_id=good_id,
+            to_col="id",
+            run_id="run-1",
+        )
+        self._seed_relationship(
+            session,
+            from_table_id=fact_id,
+            from_col="customer_id",
+            to_table_id=fanout_id,
+            to_col="cust_key",
+            run_id="run-1",
+        )
+
+        ctx = PhaseContext(
+            session=session,
+            duckdb_conn=duckdb_conn,
+            table_ids=[fact_id, good_id, fanout_id],
+            run_id="run-1",
+        )
+        result = EnrichedViewsPhase().run(ctx)
+        assert result.status == PhaseStatus.COMPLETED, result.error
+
+        # The view SHIPS (not dropped) with exactly the good join's columns dropped
+        # to the survivors, and one join was dropped for fanning out.
+        assert result.outputs["enriched_views"] == 1
+        assert result.outputs["views_dropped"] == 0
+        assert result.outputs["joins_dropped"] == 1
+
+        view = session.execute(
+            select(EnrichedView).where(EnrichedView.fact_table_id == fact_id)
+        ).scalar_one()
+        assert view.is_grain_verified is True
+        assert sorted(view.dimension_columns or []) == [
+            "customer_id__country",
+            "customer_id__name",
+        ], "the good join's columns ship; the fan-out join's column is excluded"
+
+        # Physical view: grain preserved (3 fact rows), the good columns resolve,
+        # and the fan-out column is absent from the schema.
+        rows = duckdb_conn.execute(
+            'SELECT order_id, "customer_id__name", "customer_id__country" '
+            'FROM lake.typed."enriched_csv__orders" ORDER BY order_id'
+        ).fetchall()
+        assert rows == [(1, "Alice", "US"), (2, "Bob", "UK"), (3, "Alice", "US")]
+        view_columns = {
+            r[0]
+            for r in duckdb_conn.execute('DESCRIBE lake.typed."enriched_csv__orders"').fetchall()
+        }
+        assert "customer_id__tag" not in view_columns, "the fan-out column never ships"
+
+        # Born-loud: the drop names the fact, the neighbour, and expected-vs-actual.
+        err = capsys.readouterr().err
+        assert "enrichment_join_fans_out" in err
+        assert "customer_tags" in err
+
+    def test_all_good_joins_still_ship(self, session, duckdb_conn, monkeypatch):
+        """The all-grain-preserving case is unchanged: every proposed join ships.
+
+        Guards against the per-join filter over-dropping — with no fan-out, nothing
+        is dropped and the view carries both dimension columns.
+        """
+        from sqlalchemy import select
+
+        from dataraum.analysis.views.db_models import EnrichedView
+        from dataraum.pipeline.base import PhaseContext, PhaseStatus
+
+        fact_id, dim_id, canned = self._seed(session, duckdb_conn)
+        monkeypatch.setattr(
+            EnrichedViewsPhase, "_get_llm_recommendations", lambda self, **kw: canned
+        )
+        self._seed_fact_entity(session, table_id=fact_id, run_id="run-1")
+        self._seed_relationship(
+            session,
+            from_table_id=fact_id,
+            from_col="customer_id",
+            to_table_id=dim_id,
+            to_col="id",
+            run_id="run-1",
+        )
+
+        ctx = PhaseContext(
+            session=session,
+            duckdb_conn=duckdb_conn,
+            table_ids=[fact_id, dim_id],
+            run_id="run-1",
+        )
+        result = EnrichedViewsPhase().run(ctx)
+        assert result.status == PhaseStatus.COMPLETED, result.error
+        assert result.outputs["enriched_views"] == 1
+        assert result.outputs["joins_dropped"] == 0
+
+        view = session.execute(
+            select(EnrichedView).where(EnrichedView.fact_table_id == fact_id)
+        ).scalar_one()
+        assert view.is_grain_verified is True
+        assert sorted(view.dimension_columns or []) == [
+            "customer_id__country",
+            "customer_id__name",
+        ]
+
 
 class TestVersionedGrainConstraints:
     """The latest-only / run-grain invariants are DB-enforced, not app-level only.


### PR DESCRIPTION
Part of **DAT-801**. Ships the two verified, review-clean pieces; the days_in_period cadence read is carved into a follow-up (see below).

## The problem

The enrichment selection asked the LLM for *"valuable analytical dimensions (geographic/category/reference)"* — a framing a **header** (the parent record a line belongs to, carrying the line's event date) fails by definition. So a fact whose event time lives on a joined header, not on itself, got an enriched view with **no time column**; its measures served a NULL trend anchor and the aggregation-lineage witness never formed for it (recall 0 on that class).

## What this ships

**1. Neutral extension rule (prompt + contract).** `enrichment_analysis.yaml` v2 + `enrichment_models.py`: *"what related data usefully extends this fact?"*. A classification table and the fact's header are the SAME mechanism — a column carried across a confirmed grain-preserving key join — so the contract names a `related_table` (not a `dimension`) with an open-text `relationship_role` (was a closed geographic/category/reference/temporal enum that structurally excluded a header). Join builder, grain-preservation, and confidence model untouched.

**Verified live** (real-LLM `begin_session` on the finance corpus): the reframed agent recommends the header itself — `date:high`, relationship_role `"parent record / header (carries the entry date)"`. The prior v1 prompt (same model) recommended only the classification dim. The reframe is what changed the decision.

**2. Grain-safe per-join rebuild** (`enriched_views_phase.py`). The reframe joins more neighbours, so a single fan-out pick would cost a fact its whole enriched view (the old all-or-nothing drop). Each candidate join is now grain-checked in isolation — sound because the view is a one-hop STAR, so each join's fan-out is independent — and only survivors build the view; persistence reflects exactly what ships. The whole-view check stays as a belt-and-braces assertion. Every dropped join is born-loud. (Also fixes a latent bug: an unresolvable-dim join was dropped from the SQL but left in persistence.)

## What downstream gets, without new code

Once the header is exposed, **existing** pipeline machinery does the rest: DAT-491/720's slice-agent backstop fills the exposed header axis into the fact's `time_columns`, and the DAT-565 reconciliation + DAT-780 witness then run unmodified. Result, verified on the finance corpus: the witness **fires** for the header/line class (was recall 0), and those measures serve a **non-NULL flow anchor**. No lineage/og_columns change was needed.

## What is NOT here (follow-up, blocked by DAT-811)

A measure's `days_in_period` **cadence** for a header-derived axis is not yet resolvable: the axis is exposed on the enriched view, but that view's columns are absent from `og_columns`/`current_columns` (**DAT-811**), so period_resolver can't read the axis's granularity. Those flows fall loud to the flagged config default (degradation-safe — never a silent wrong value). A first-cut period_resolver change was written and **removed after review** — it couldn't express a lineage-inherited axis (an axis a fact inherits from a *different* fact via reconciliation) and reconstructed the `{fk}__{col}` name, which collides. The correct shape (stored source-column identity via DAT-811's column set, resolved cross-fact) is the follow-up.

## Reviews

Both reviewers ran (senior + spec-compliance). They passed the two shipped pieces as clean and test-pinned, and flagged the period_resolver piece — which is why it was pulled. Findings verified against live SQL before acting.

## Tests

2144 unit + enriched-view integration green; the grain-safe rebuild is pinned by a fan-out fixture (`test_fanout_join_dropped_view_ships_with_survivors`) + an all-good-joins guard. ruff/mypy clean. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)