### PR TITLE
DAT-811: the served relation has a column set — enriched views are self-describing

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -5,6 +5,56 @@ change that affects a detector, pipeline phase, or a response shape eval consume
 
 ---
 
+## DAT-811 — the enriched view is self-describing: og_columns now returns its FULL column set, semantics resolved via a typed source link (catalog surface, no metric-value change)
+
+**Branch:** `feat/dat-811-served-column-set`. An enriched view is `SELECT f.* + joined
+dim columns`. Before this, only the dim columns got catalog `Column` rows, and even
+those were filtered out of the read surface (`current_columns` is `layer='typed'`), so
+`og_columns` over an enriched `table_id` returned **0 rows** — the view had a table
+vertex (DAT-774) but no columns the catalog could see. This is the substrate DAT-812
+(header-dated `days_in_period` cadence) needs.
+
+**What changed:**
+- **Two new `columns` fields** (additive; `schema.sql` + cockpit drizzle mirror
+  regenerated): `origin` — a CHECK-enforced enum `'fact' | 'dimension'`, NULL on base
+  (typed/raw) columns; `source_column_id` — a self-FK (`ON DELETE SET NULL`) to the
+  TYPED source column an enriched column projects.
+- **The enriched_views phase now registers EVERY served column** (the fact's own `f.*`
+  passthrough columns AND the joined dim columns) under the enriched table, built from
+  the view's `DESCRIBE`. Each carries `origin` + `source_column_id`, resolved FORWARD
+  from the join recipe (never `{fk}__{col}` name-parsing). f.* columns get `origin='fact'`
+  and are NOT re-profiled (their stats equal the source's on the grain-preserving view);
+  dim columns keep `origin='dimension'` and their fact-grain profile (unchanged).
+- **New read view `current_enriched_columns`** + an `og_columns` UNION branch: enriched
+  columns surface with their OWN `column_id` (the property-graph vertex KEY stays unique)
+  but resolve `semantic_role` / `materialization` / `anchor_time_axis` THROUGH
+  `source_column_id`. A MATCH over an enriched `table_id` now returns its full served set
+  with semantics attached.
+
+**What this means for eval:**
+- **No metric VALUE change.** `period_resolver` — the one production `og_columns`
+  reader — scopes `m.table_id`/`ax.table_id` to the TYPED fact id, so the new enriched
+  rows are invisible to it. The header-dated cadence fix that DOES move values is DAT-812
+  (blocked on this), not here.
+- **The dims-only detectors are behaviorally unchanged but their query changed.**
+  `dimension_coverage` (entropy detector), the slicing time-axis append, and the enriched
+  derived-columns pass now filter `origin='dimension'`, so they see exactly the added
+  dimensions and never the fact's own f.* columns. Re-verify `dimension_coverage` recall
+  did not regress (it should be identical — the fact columns were never registered before,
+  so the filtered set equals the old set).
+- **`og_columns` over an enriched table now returns rows** (was 0). Any eval/probe that
+  MATCHed an enriched table's columns and got nothing will now get the full set; anything
+  asserting a measure's semantics off the enriched view reads them resolved-via-source.
+- No backfill; recreate test DBs (the two new columns + CHECK).
+
+**NOT in this change (follow-up):** `additivity_resolver`'s `view_name → fact_table_id`
+name lookup is NOT retired here. Retiring the bounce means rewriting measure
+classification (`_temporal_by_column`) to read off the self-describing view via
+`source_column_id` — measure-classification work shared with `period_resolver`, folded
+into the DAT-812 "consume the substrate" line rather than ballooning this ticket.
+
+---
+
 ## DAT-810 — temporal completeness: both sides are grain buckets, the clamp is gone, and the fields can now be NULL (profile VALUES + nullability change)
 
 **Branch:** `fix/dat-810-grain-bucket-periods`. `analyze_basic_temporal` divided two

--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -30,6 +30,13 @@ vertex (DAT-774) but no columns the catalog could see. This is the substrate DAT
   but resolve `semantic_role` / `materialization` / `anchor_time_axis` THROUGH
   `source_column_id`. A MATCH over an enriched `table_id` now returns its full served set
   with semantics attached.
+- **Passthrough (no-dim) views are full catalog citizens too.** A fact with no confirmed
+  dim joins gets a passthrough enriched view (`SELECT * FROM fact`); it now registers its
+  `f.*` columns (`origin='fact'`) and sets `view_table_id`, so **`og_tables` emits an
+  enriched vertex for EVERY fact** (was: only dim-enriched facts) and `og_columns` returns
+  its columns. An eval that counts enriched tables/views, or asserts "a no-dim fact has no
+  enriched view", must update. `EnrichedView.dimension_columns` stays `[]` for a
+  passthrough, so the dims-only surfaces are unchanged.
 
 **What this means for eval:**
 - **No metric VALUE change.** `period_resolver` — the one production `og_columns`

--- a/packages/cockpit/src/db/metadata/schema.ts
+++ b/packages/cockpit/src/db/metadata/schema.ts
@@ -24,9 +24,11 @@ export const columns = metadataSchema
 		columnPosition: integer("column_position"),
 		rawType: varchar("raw_type"),
 		resolvedType: varchar("resolved_type"),
+		origin: varchar(),
+		sourceColumnId: varchar("source_column_id"),
 	})
 	.as(
-		sql`SELECT column_id, table_id, column_name, original_name, column_position, raw_type, resolved_type FROM ws_00000000_0000_0000_0000_000000000001.columns`,
+		sql`SELECT column_id, table_id, column_name, original_name, column_position, raw_type, resolved_type, origin, source_column_id FROM ws_00000000_0000_0000_0000_000000000001.columns`,
 	);
 
 export const conceptEdges = metadataSchema
@@ -165,9 +167,11 @@ export const currentColumns = metadataSchema
 		columnPosition: integer("column_position"),
 		rawType: varchar("raw_type"),
 		resolvedType: varchar("resolved_type"),
+		origin: varchar(),
+		sourceColumnId: varchar("source_column_id"),
 	})
 	.as(
-		sql`SELECT column_id, table_id, column_name, original_name, column_position, raw_type, resolved_type FROM ws_00000000_0000_0000_0000_000000000001.columns c WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.tables t JOIN ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h ON h.target::text = ('table:'::text || t.table_id::text) AND h.stage::text = 'generation'::text WHERE t.table_id::text = c.table_id::text AND t.layer::text = 'typed'::text))`,
+		sql`SELECT column_id, table_id, column_name, original_name, column_position, raw_type, resolved_type, origin, source_column_id FROM ws_00000000_0000_0000_0000_000000000001.columns c WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.tables t JOIN ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h ON h.target::text = ('table:'::text || t.table_id::text) AND h.stage::text = 'generation'::text WHERE t.table_id::text = c.table_id::text AND t.layer::text = 'typed'::text))`,
 	);
 
 export const currentDerivedColumns = metadataSchema
@@ -256,6 +260,22 @@ export const currentDriverRankings = metadataSchema
 	})
 	.as(
 		sql`SELECT ranking_id, run_id, measure_table_id, measure_column_id, measure_label, target_type, grain, entity, n_rows, ranked_dimensions, driver_paths, interesting_slices, secondary_dimensions, created_at FROM ws_00000000_0000_0000_0000_000000000001.driver_rankings r WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h WHERE h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = r.run_id::text))`,
+	);
+
+export const currentEnrichedColumns = metadataSchema
+	.view("current_enriched_columns", {
+		columnId: varchar("column_id"),
+		tableId: varchar("table_id"),
+		columnName: varchar("column_name"),
+		originalName: varchar("original_name"),
+		columnPosition: integer("column_position"),
+		rawType: varchar("raw_type"),
+		resolvedType: varchar("resolved_type"),
+		origin: varchar(),
+		sourceColumnId: varchar("source_column_id"),
+	})
+	.as(
+		sql`SELECT column_id, table_id, column_name, original_name, column_position, raw_type, resolved_type, origin, source_column_id FROM ws_00000000_0000_0000_0000_000000000001.columns c WHERE (EXISTS ( SELECT 1 FROM ws_00000000_0000_0000_0000_000000000001.enriched_views ev JOIN ws_00000000_0000_0000_0000_000000000001.metadata_snapshot_head h ON h.target::text = 'catalog'::text AND h.stage::text = 'catalog'::text AND h.run_id::text = ev.run_id::text WHERE ev.view_table_id::text = c.table_id::text))`,
 	);
 
 export const currentEnrichedViews = metadataSchema

--- a/packages/cockpit/src/tools/query-context.ts
+++ b/packages/cockpit/src/tools/query-context.ts
@@ -18,11 +18,12 @@
 // ingestion-internal.
 //
 // An enriched view's columns come from a LIVE `DESCRIBE` on the READ_ONLY lake
-// reader (mirroring the engine's `_describe_table`), NOT the column metadata: the
-// view is `SELECT f.*, <dim cols>` but the engine registers Column metadata for
-// the dim columns ONLY, so a metadata read would hide the fact's measures. DESCRIBE
-// returns the full set (names + types, no `[meaning:]` tags — the engine drops them
-// too); a lake-read failure falls back to the typed tables. The pure `formatSchema`
+// reader (mirroring the engine's `_describe_table`). Post-DAT-811 the engine registers
+// Column metadata for the FULL served set (fact `f.*` + dim columns, each linked to its
+// typed source), so a metadata read is now possible — reading it (and attaching
+// `[meaning:]` tags via `source_column_id`) is a deferred simplification (DAT-812,
+// "consume the substrate"). For now DESCRIBE returns names + types (no `[meaning:]`
+// tags); a lake-read failure falls back to the typed tables. The pure `formatSchema`
 // + `preferEnriched` are unit-tested; the Drizzle reads + the DESCRIBE are
 // smoke/integration-covered.
 

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -266,9 +266,12 @@ CREATE TABLE columns (
 	column_position INTEGER NOT NULL, 
 	raw_type VARCHAR, 
 	resolved_type VARCHAR, 
+	origin VARCHAR, 
+	source_column_id VARCHAR, 
 	CONSTRAINT pk_columns PRIMARY KEY (column_id), 
 	CONSTRAINT uq_table_column UNIQUE (table_id, column_name), 
-	CONSTRAINT fk_columns_table_id_tables FOREIGN KEY(table_id) REFERENCES tables (table_id) ON DELETE CASCADE
+	CONSTRAINT fk_columns_table_id_tables FOREIGN KEY(table_id) REFERENCES tables (table_id) ON DELETE CASCADE, 
+	CONSTRAINT fk_columns_source_column_id_columns FOREIGN KEY(source_column_id) REFERENCES columns (column_id) ON DELETE SET NULL
 );
 
 CREATE INDEX idx_columns_table ON columns (table_id);

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -275,6 +275,8 @@ CREATE TABLE columns (
 	CONSTRAINT fk_columns_source_column_id_columns FOREIGN KEY(source_column_id) REFERENCES columns (column_id) ON DELETE SET NULL
 );
 
+CREATE INDEX idx_columns_source_column_id ON columns (source_column_id);
+
 CREATE INDEX idx_columns_table ON columns (table_id);
 
 CREATE TABLE dimension_hierarchies (

--- a/packages/engine/schema.sql
+++ b/packages/engine/schema.sql
@@ -270,6 +270,7 @@ CREATE TABLE columns (
 	source_column_id VARCHAR, 
 	CONSTRAINT pk_columns PRIMARY KEY (column_id), 
 	CONSTRAINT uq_table_column UNIQUE (table_id, column_name), 
+	CONSTRAINT ck_columns_origin CHECK (origin IS NULL OR origin IN ('fact', 'dimension')), 
 	CONSTRAINT fk_columns_table_id_tables FOREIGN KEY(table_id) REFERENCES tables (table_id) ON DELETE CASCADE, 
 	CONSTRAINT fk_columns_source_column_id_columns FOREIGN KEY(source_column_id) REFERENCES columns (column_id) ON DELETE SET NULL
 );

--- a/packages/engine/schema_graph.sql
+++ b/packages/engine/schema_graph.sql
@@ -46,6 +46,28 @@ LEFT JOIN LATERAL (
     FROM json_array_elements(COALESCE(te.time_columns, '[]'::json)) AS elem
     WHERE elem->>'role' = 'event' AND (elem->>'is_anchor')::boolean IS TRUE
     LIMIT 1
+  ) declared_anchor ON TRUE
+UNION ALL
+SELECT ec.column_id::text AS column_id, ec.table_id::text AS table_id, ec.column_name,
+       sa.semantic_role,
+       COALESCE(
+         CASE mal.pattern WHEN 'per_period' THEN 'flow' WHEN 'cumulative' THEN 'stock' END,
+         CASE cc.temporal_behavior WHEN 'additive' THEN 'flow'
+                                   WHEN 'point_in_time' THEN 'stock' END
+       ) AS materialization,
+       COALESCE(mal.event_time_axis_column, declared_anchor.column_name) AS anchor_time_axis
+FROM __READ__.current_enriched_columns ec
+LEFT JOIN __READ__.current_semantic_annotations sa ON sa.column_id = ec.source_column_id
+LEFT JOIN __READ__.current_column_concepts cc ON cc.column_id = ec.source_column_id
+LEFT JOIN __READ__.current_measure_aggregation_lineage mal
+       ON mal.measure_column_id = ec.source_column_id
+LEFT JOIN __READ__.current_columns src ON src.column_id = ec.source_column_id
+LEFT JOIN __READ__.current_table_entities te ON te.table_id = src.table_id
+LEFT JOIN LATERAL (
+    SELECT elem->>'column' AS column_name
+    FROM json_array_elements(COALESCE(te.time_columns, '[]'::json)) AS elem
+    WHERE elem->>'role' = 'event' AND (elem->>'is_anchor')::boolean IS TRUE
+    LIMIT 1
   ) declared_anchor ON TRUE;
 
 CREATE VIEW __READ__.og_concepts AS

--- a/packages/engine/schema_read.sql
+++ b/packages/engine/schema_read.sql
@@ -416,3 +416,15 @@ WHERE EXISTS (
   WHERE t.table_id = c.table_id
     AND t.layer = 'typed'
 );
+
+DROP VIEW IF EXISTS __READ__.current_enriched_columns;
+CREATE VIEW __READ__.current_enriched_columns AS
+SELECT c.* FROM __WS__.columns c
+WHERE EXISTS (
+  SELECT 1 FROM __WS__.enriched_views ev
+  JOIN __WS__.metadata_snapshot_head h
+    ON h.target = 'catalog'
+   AND h.stage = 'catalog'
+   AND h.run_id = ev.run_id
+  WHERE ev.view_table_id = c.table_id
+);

--- a/packages/engine/src/dataraum/analysis/correlation/within_table/derived_columns.py
+++ b/packages/engine/src/dataraum/analysis/correlation/within_table/derived_columns.py
@@ -348,11 +348,17 @@ def detect_enriched_derived_columns(
         if not fact_columns:
             return Result.ok([])
 
-        # 2. Get dimension columns from Column records (registered during enriched_views phase)
+        # 2. Get the JOINED dimension columns from Column records (registered during the
+        # enriched_views phase). The enriched view now also registers the fact's own f.*
+        # passthrough columns (DAT-811) — already counted in ``fact_columns`` below — so
+        # ``origin='dimension'`` selects only the added ones and avoids double-counting.
         dim_columns: list[Column] = []
 
         if enriched_view.view_table_id:
-            dim_stmt = select(Column).where(Column.table_id == enriched_view.view_table_id)
+            dim_stmt = select(Column).where(
+                Column.table_id == enriched_view.view_table_id,
+                Column.origin == "dimension",
+            )
             dim_columns = list(session.execute(dim_stmt).scalars().all())
 
         # 3. Load statistical profiles for fact + dimension columns (degenerate filtering)

--- a/packages/engine/src/dataraum/analysis/correlation/within_table/derived_columns.py
+++ b/packages/engine/src/dataraum/analysis/correlation/within_table/derived_columns.py
@@ -21,6 +21,7 @@ from dataraum.analysis.correlation.db_models import (
 )
 from dataraum.analysis.correlation.models import DerivedColumn
 from dataraum.analysis.statistics.db_models import StatisticalProfile
+from dataraum.analysis.views.served_columns import enriched_dimension_columns
 from dataraum.core.logging import get_logger
 from dataraum.core.models.base import Result
 from dataraum.storage import Column, Table
@@ -348,18 +349,14 @@ def detect_enriched_derived_columns(
         if not fact_columns:
             return Result.ok([])
 
-        # 2. Get the JOINED dimension columns from Column records (registered during the
-        # enriched_views phase). The enriched view now also registers the fact's own f.*
-        # passthrough columns (DAT-811) — already counted in ``fact_columns`` below — so
-        # ``origin='dimension'`` selects only the added ones and avoids double-counting.
+        # 2. Get the JOINED dimension columns (registered during the enriched_views phase).
+        # The enriched view also registers the fact's own f.* passthrough columns (DAT-811),
+        # already counted in ``fact_columns`` below — the helper filters them out so they
+        # are not double-counted.
         dim_columns: list[Column] = []
 
         if enriched_view.view_table_id:
-            dim_stmt = select(Column).where(
-                Column.table_id == enriched_view.view_table_id,
-                Column.origin == "dimension",
-            )
-            dim_columns = list(session.execute(dim_stmt).scalars().all())
+            dim_columns = enriched_dimension_columns(session, enriched_view.view_table_id)
 
         # 3. Load statistical profiles for fact + dimension columns (degenerate filtering)
         all_col_ids = [c.column_id for c in fact_columns] + [c.column_id for c in dim_columns]

--- a/packages/engine/src/dataraum/analysis/views/__init__.py
+++ b/packages/engine/src/dataraum/analysis/views/__init__.py
@@ -4,11 +4,16 @@ Creates grain-preserving DuckDB views that join fact tables with their
 confirmed dimension tables. These views materialize the semantic understanding
 of relationships for downstream consumption (slicing, correlations, etc.).
 
-Uses LLM-powered enrichment analysis to identify which dimension joins add
-valuable analytical dimensions (geographic, category, reference data).
+Uses LLM-powered enrichment analysis to identify which related tables usefully
+extend a fact — a classification, a reference/lookup, or the fact's own header —
+on equal footing (DAT-801), never a fixed dimension vocabulary.
 """
 
-from dataraum.analysis.views.builder import DimensionJoin, build_enriched_view_sql
+from dataraum.analysis.views.builder import (
+    DimensionJoin,
+    EnrichedDimColumn,
+    build_enriched_view_sql,
+)
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.analysis.views.enrichment_agent import EnrichmentAgent
 from dataraum.analysis.views.enrichment_models import (
@@ -23,6 +28,7 @@ from dataraum.analysis.views.enrichment_models import (
 __all__ = [
     # Builder
     "DimensionJoin",
+    "EnrichedDimColumn",
     "build_enriched_view_sql",
     # DB models
     "EnrichedView",

--- a/packages/engine/src/dataraum/analysis/views/builder.py
+++ b/packages/engine/src/dataraum/analysis/views/builder.py
@@ -22,11 +22,28 @@ class DimensionJoin:
     relationship_id: str = ""
 
 
+@dataclass(frozen=True)
+class EnrichedDimColumn:
+    """A dimension column exposed on an enriched view, with its typed source.
+
+    ``name`` is the physical view column (``{fk}__{col}``, numeric-suffix disambiguated
+    by :func:`build_enriched_view_sql`). The source is named *relationally* — by
+    ``(dim_table_name, source_column_name)`` — so the enriched_views phase resolves the
+    typed ``source_column_id`` (DAT-811) from the catalog WITHOUT ever reverse-parsing
+    ``name``. The builder is the single authority on both the SQL and these refs, so the
+    physical name here is byte-identical to the view's column.
+    """
+
+    name: str
+    dim_table_name: str
+    source_column_name: str
+
+
 def build_enriched_view_sql(
     view_fqn: str,
     fact_fqn: str,
     dimension_joins: list[DimensionJoin],
-) -> tuple[str, list[str]]:
+) -> tuple[str, list[EnrichedDimColumn]]:
     """Build the ``CREATE OR REPLACE VIEW`` SQL for an enriched view.
 
     Every table identity is a fully-qualified DuckDB name
@@ -49,7 +66,9 @@ def build_enriched_view_sql(
             dimension's FQN.
 
     Returns:
-        Tuple of ``(create_view_sql, dimension_column_names)``.
+        Tuple of ``(create_view_sql, dim_columns)`` where ``dim_columns`` is the list of
+        :class:`EnrichedDimColumn` refs (physical view name + its typed source), in view
+        order. Empty when the view is a bare ``SELECT *`` passthrough (no joins).
     """
     if not dimension_joins:
         # No joins — view is just the fact table.
@@ -58,7 +77,7 @@ def build_enriched_view_sql(
 
     # Build SELECT clause
     select_parts = ["f.*"]
-    dimension_column_names: list[str] = []
+    dim_columns: list[EnrichedDimColumn] = []
 
     # Track used aliases to avoid duplicates
     used_aliases: dict[str, int] = {}
@@ -96,7 +115,13 @@ def build_enriched_view_sql(
         for col in join.include_columns:
             qualified_name = get_unique_column_name(f"{col_prefix}__{col}")
             select_parts.append(f'"{alias}"."{col}" AS "{qualified_name}"')
-            dimension_column_names.append(qualified_name)
+            dim_columns.append(
+                EnrichedDimColumn(
+                    name=qualified_name,
+                    dim_table_name=join.dim_table_name,
+                    source_column_name=col,
+                )
+            )
 
     select_clause = ",\n    ".join(select_parts)
 
@@ -117,7 +142,7 @@ def build_enriched_view_sql(
         f"{joins_sql}"
     )
 
-    return sql, dimension_column_names
+    return sql, dim_columns
 
 
 def _table_alias(table_name: str) -> str:

--- a/packages/engine/src/dataraum/analysis/views/builder.py
+++ b/packages/engine/src/dataraum/analysis/views/builder.py
@@ -43,6 +43,7 @@ def build_enriched_view_sql(
     view_fqn: str,
     fact_fqn: str,
     dimension_joins: list[DimensionJoin],
+    fact_column_names: tuple[str, ...] = (),
 ) -> tuple[str, list[EnrichedDimColumn]]:
     """Build the ``CREATE OR REPLACE VIEW`` SQL for an enriched view.
 
@@ -64,6 +65,12 @@ def build_enriched_view_sql(
         fact_fqn: Fully-qualified fact-table source.
         dimension_joins: Joins to include; each ``dim_duckdb_path`` is the
             dimension's FQN.
+        fact_column_names: The fact's OWN column names (carried through by ``f.*``). A
+            generated ``{fk}__{col}`` name that would collide with one of these is
+            disambiguated too, so the view never emits two identically-named columns —
+            an ambiguous column reference in the view AND a ``uq_table_column`` violation
+            when DAT-811 registers every served column. Empty = skip fact-name dedup
+            (callers that only assert on SQL shape).
 
     Returns:
         Tuple of ``(create_view_sql, dim_columns)`` where ``dim_columns`` is the list of
@@ -96,10 +103,12 @@ def build_enriched_view_sql(
     join_aliases = [get_unique_alias(join.dim_table_name) for join in dimension_joins]
 
     # Output column names must be unique by construction — the ``{fact_fk}__{col}``
-    # prefix does NOT guarantee it (two joins can share a fact column), and a
-    # duplicate would violate the enriched-layer ``uq_table_column`` on registration.
-    # Disambiguate with a numeric suffix, mirroring ``get_unique_alias``.
-    used_column_names: dict[str, int] = {}
+    # prefix does NOT guarantee it (two joins can share a fact column, OR a fact's own
+    # column can already be named like a generated dim name), and a duplicate would make
+    # the view column ambiguous AND violate the enriched-layer ``uq_table_column`` on
+    # registration. Seed the used set with the fact's OWN columns (``f.*``) so a colliding
+    # dim name is suffixed against them too, then disambiguate dim-vs-dim as we go.
+    used_column_names: dict[str, int] = dict.fromkeys(fact_column_names, 1)
 
     def get_unique_column_name(base: str) -> str:
         if base not in used_column_names:

--- a/packages/engine/src/dataraum/analysis/views/served_columns.py
+++ b/packages/engine/src/dataraum/analysis/views/served_columns.py
@@ -1,0 +1,35 @@
+"""Read helpers over an enriched view's served columns (DAT-811).
+
+An enriched view registers EVERY served column under its ``view_table_id`` — the
+fact's own ``f.*`` passthrough columns (``origin='fact'``) AND the joined dimension
+columns (``origin='dimension'``). Consumers that want only the added dimensions filter
+on ``origin`` in ONE place here, so the filter cannot be silently dropped in one
+consumer and kept in another.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from dataraum.storage import Column
+
+
+def enriched_dimension_columns(session: Session, view_table_id: str) -> list[Column]:
+    """The JOINED dimension columns of an enriched view (``origin='dimension'``).
+
+    Excludes the fact's own ``f.*`` passthrough columns (``origin='fact'``), which are
+    already carried by the fact table itself — a consumer counting the *added*
+    dimensions must not double-count them.
+    """
+    return list(
+        session.execute(
+            select(Column).where(
+                Column.table_id == view_table_id,
+                Column.origin == "dimension",
+            )
+        ).scalars()
+    )
+
+
+__all__ = ["enriched_dimension_columns"]

--- a/packages/engine/src/dataraum/entropy/detectors/semantic/dimension_coverage.py
+++ b/packages/engine/src/dataraum/entropy/detectors/semantic/dimension_coverage.py
@@ -133,16 +133,11 @@ class DimensionCoverageDetector(EntropyDetector):
             return {}
 
         from dataraum.analysis.statistics.db_models import StatisticalProfile
-        from dataraum.storage import Column
+        from dataraum.analysis.views.served_columns import enriched_dimension_columns
 
-        # Get the JOINED dimension columns of the enriched view — coverage measures the
-        # added dimensions, not the fact's own f.* passthrough columns the view now also
-        # registers (DAT-811); ``origin='dimension'`` selects them.
-        col_stmt = select(Column).where(
-            Column.table_id == view.view_table_id,
-            Column.origin == "dimension",
-        )
-        columns = context.session.execute(col_stmt).scalars().all()
+        # Coverage measures the JOINED dimensions, not the fact's own f.* passthrough
+        # columns the enriched view also registers (DAT-811).
+        columns = enriched_dimension_columns(context.session, view.view_table_id)
         if not columns:
             return {}
 

--- a/packages/engine/src/dataraum/entropy/detectors/semantic/dimension_coverage.py
+++ b/packages/engine/src/dataraum/entropy/detectors/semantic/dimension_coverage.py
@@ -135,8 +135,13 @@ class DimensionCoverageDetector(EntropyDetector):
         from dataraum.analysis.statistics.db_models import StatisticalProfile
         from dataraum.storage import Column
 
-        # Get Column records for the enriched view table
-        col_stmt = select(Column).where(Column.table_id == view.view_table_id)
+        # Get the JOINED dimension columns of the enriched view — coverage measures the
+        # added dimensions, not the fact's own f.* passthrough columns the view now also
+        # registers (DAT-811); ``origin='dimension'`` selects them.
+        col_stmt = select(Column).where(
+            Column.table_id == view.view_table_id,
+            Column.origin == "dimension",
+        )
         columns = context.session.execute(col_stmt).scalars().all()
         if not columns:
             return {}

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -463,9 +463,10 @@ class EnrichedViewsPhase(BasePhase):
                         }
                         break
 
-            # Register and profile dimension columns (latest-only substrate:
-            # reconciled by view_name, prior columns/profiles replaced).
-            view_table = self._register_and_profile_dim_columns(
+            # Register every served column (f.* + dims) under the enriched table so the
+            # catalog describes the view completely (DAT-811); latest-only substrate,
+            # reconciled by view_name with dim profiles preserved across re-runs.
+            view_table = self._register_and_profile_served_columns(
                 ctx,
                 fact_table,
                 view_name,
@@ -622,7 +623,7 @@ class EnrichedViewsPhase(BasePhase):
                 return cand
         return None
 
-    def _register_and_profile_dim_columns(
+    def _register_and_profile_served_columns(
         self,
         ctx: PhaseContext,
         fact_table: Table,
@@ -631,32 +632,42 @@ class EnrichedViewsPhase(BasePhase):
         dim_columns: list[str],
         source_by_name: dict[str, str | None],
     ) -> Table | None:
-        """Register enriched-layer Table + Column records for dimension columns and profile them.
+        """Register enriched-layer Table + Column records for EVERY served column of the view.
 
-        Latest-only substrate (DAT-415): the enriched ``Table`` is reconciled on
-        its ``(source, view_name, "enriched")`` unique key — reused across runs,
-        with its prior ``Column``s replaced. Since the FK children of ``columns``
-        no longer ``ON DELETE CASCADE`` (DAT-506), the prior run's
-        ``StatisticalProfile``s (and every other child) are deleted explicitly via
-        ``delete_column_dependents`` before the columns go. The view *definition*
-        is what is run-versioned (``EnrichedView`` + recipe DDL); the lake
-        substrate stays latest-only and is re-materialized from the versioned
-        recipe on a reset.
+        DAT-811: an enriched view is ``SELECT f.* + joined dim columns``. Every one of its
+        columns becomes a real ``Column`` row under the enriched table, so the catalog
+        (``og_columns``) describes the view COMPLETELY without walking back to origin
+        tables. Each row carries its typed ``source_column_id`` and an ``origin``:
+
+        * ``'fact'`` — the fact's own column, carried through by ``f.*``. On the
+          grain-preserving view its stats are identical to the source's by construction,
+          so it is NOT re-profiled; read views reach its profile/semantics through
+          ``source_column_id``. It gets its OWN ``column_id`` — the property-graph vertex
+          KEY must stay unique, so a typed id must never appear twice.
+        * ``'dimension'`` — a joined dim column. Profiled at enriched (fact) grain, whose
+          null/coverage differs from the dim table's own; ``source_column_id`` still links
+          the typed dim column for its semantics.
+
+        Latest-only substrate (DAT-415): the enriched ``Table`` is reconciled on its
+        ``(source, view_name, "enriched")`` unique key — reused across runs, its prior
+        ``Column``s reconciled by name (keep column_id + profile where the name survives,
+        drop what left the shape, mint the genuinely-new). Since the FK children of
+        ``columns`` no longer ``ON DELETE CASCADE`` (DAT-506), a dropped column's children
+        are cleared explicitly via ``delete_column_dependents`` before the ``delete``.
 
         Args:
             ctx: Phase context.
             fact_table: The fact table this view is based on.
             view_name: Bare name of the enriched DuckDB view (stored as duckdb_path).
             view_fqn: Fully-qualified view name, used to query the view (DESCRIBE / profile).
-            dim_columns: List of dimension column names in the view.
-            source_by_name: Physical dim-column name → its TYPED source ``column_id``
-                (DAT-811), resolved forward from the join recipe. ``None`` for a column
-                whose source could not be resolved (defensive; should not occur for a
-                surviving join). Persisted as ``Column.source_column_id`` so read views
-                resolve the column's semantics through its typed source.
+            dim_columns: The joined dimension column names (the ``origin='dimension'`` set).
+            source_by_name: Dim-column name → its TYPED source ``column_id`` (DAT-811),
+                resolved forward from the join recipe — never parsed from the name.
 
         Returns:
-            The enriched-layer Table record, or None if no dimension columns.
+            The enriched-layer Table record, or None if the view has no dimension joins (a
+            bare passthrough has no vertex; its columns are the fact's own, read directly
+            off the typed table).
         """
         if not dim_columns:
             return None
@@ -668,7 +679,6 @@ class EnrichedViewsPhase(BasePhase):
                 Table.layer == "enriched",
             )
         ).scalar_one_or_none()
-        existing: dict[str, Column] = {}
         if view_table is None:
             view_table = Table(
                 table_id=str(uuid4()),
@@ -681,47 +691,62 @@ class EnrichedViewsPhase(BasePhase):
             ctx.session.add(view_table)
             ctx.session.flush()
         else:
-            # Reconcile, don't replace (DAT-516): keep each dimension column (with its
-            # ``column_id`` AND its ``StatisticalProfile``) whose name survives in the new
-            # set, drop only columns whose join left the shape, add only genuinely-new ones.
-            # This preserves ``column_id`` across re-runs, so a consumer holding one (and the
-            # profiles those columns carry) is not silently invalidated by an unchanged shape.
-            # Dropped columns' FK children are cleared first (``columns`` no longer
-            # ``ON DELETE CASCADE`` — DAT-506) so the ``delete(Column)`` can't FK-violate.
             view_table.duckdb_path = view_name
             view_table.row_count = fact_table.row_count
-            existing = {
-                c.column_name: c
-                for c in ctx.session.execute(
-                    select(Column).where(Column.table_id == view_table.table_id)
-                ).scalars()
-            }
-            wanted = set(dim_columns)
-            removed = [c for name, c in existing.items() if name not in wanted]
-            if removed:
-                delete_column_dependents(ctx, [c.column_id for c in removed])
-                ctx.session.execute(
-                    delete(Column).where(Column.column_id.in_([c.column_id for c in removed]))
-                )
-                ctx.session.flush()
-                for c in removed:
-                    existing.pop(c.column_name)
 
-        # Get DuckDB types for dimension columns
+        # The physical served columns in view order — the ground truth for names + types.
+        # ``f.*`` fact columns come first (in fact order), then the joined dim columns.
         duckdb_cols = ctx.duckdb_conn.execute(f"DESCRIBE {view_fqn}").fetchall()
+        served_names = [row[0] for row in duckdb_cols]
         type_by_name = {row[0]: row[1] for row in duckdb_cols}
 
-        # Keep + reposition existing columns; mint only genuinely-new ones (DAT-516).
-        # Every registered column is a joined dimension column (``origin='dimension'``,
-        # DAT-811) carrying its typed ``source_column_id``; both are refreshed on a kept
-        # column too, since a re-run may resolve a source the prior run left unlinked.
+        # Classify each served column + resolve its typed source (DAT-811). A dim column
+        # links its dim source (forward from the recipe); a fact passthrough links the
+        # same-named typed fact column.
+        dim_set = set(dim_columns)
+        fact_source_by_name = {
+            c.column_name: c.column_id
+            for c in ctx.session.execute(
+                select(Column).where(Column.table_id == fact_table.table_id)
+            ).scalars()
+        }
+
+        def origin_and_source(name: str) -> tuple[str, str | None]:
+            if name in dim_set:
+                return "dimension", source_by_name.get(name)
+            return "fact", fact_source_by_name.get(name)
+
+        # Reconcile by name (DAT-516): keep each surviving column's column_id (and profile),
+        # drop those whose shape left, mint the genuinely-new. Preserving column_id keeps a
+        # consumer holding one — and the profiles a dim column carries — valid across re-runs.
+        existing = {
+            c.column_name: c
+            for c in ctx.session.execute(
+                select(Column).where(Column.table_id == view_table.table_id)
+            ).scalars()
+        }
+        removed = [c for name, c in existing.items() if name not in set(served_names)]
+        if removed:
+            delete_column_dependents(ctx, [c.column_id for c in removed])
+            ctx.session.execute(
+                delete(Column).where(Column.column_id.in_([c.column_id for c in removed]))
+            )
+            ctx.session.flush()
+            for c in removed:
+                existing.pop(c.column_name)
+
+        # Keep + reposition existing columns; mint only genuinely-new ones. ``origin`` and
+        # ``source_column_id`` are refreshed on kept columns too — a re-run may newly resolve
+        # a source the prior run left unlinked.
         new_columns: list[Column] = []
-        for pos, col_name in enumerate(dim_columns):
+        new_dim_columns: list[Column] = []
+        for pos, col_name in enumerate(served_names):
+            origin, source_id = origin_and_source(col_name)
             kept = existing.get(col_name)
             if kept is not None:
                 kept.column_position = pos  # keep column_id + its profile; refresh order only
-                kept.origin = "dimension"
-                kept.source_column_id = source_by_name.get(col_name)
+                kept.origin = origin
+                kept.source_column_id = source_id
                 continue
             col_type = type_by_name.get(col_name, "VARCHAR")
             col = Column(
@@ -731,21 +756,24 @@ class EnrichedViewsPhase(BasePhase):
                 column_position=pos,
                 raw_type=col_type,
                 resolved_type=col_type,
-                origin="dimension",
-                source_column_id=source_by_name.get(col_name),
+                origin=origin,
+                source_column_id=source_id,
             )
             ctx.session.add(col)
             new_columns.append(col)
+            if origin == "dimension":
+                new_dim_columns.append(col)
         ctx.session.flush()
 
-        # Profile ONLY the new columns. A kept column's join is unchanged, so its data —
-        # and thus its existing profile — is stable; re-profiling would just churn it.
-        # Per-column profiling failures are absorbed inside ``_profile_column_stats_parallel``
-        # (returns None → skipped); a genuine DB / IntegrityError on the column-set
-        # reconcile above is NOT swallowed — it propagates and fails the activity loud.
+        # Profile ONLY new DIMENSION columns. A fact passthrough's stats equal its source's
+        # on the grain-preserving view — nothing to profile; read views reach them through
+        # ``source_column_id``. A kept dim column's join is unchanged, so its profile is
+        # stable. Per-column failures are absorbed in ``_profile_column_stats_parallel``
+        # (None → skipped); a DB error on the reconcile above is NOT swallowed — it fails
+        # the activity loud.
         profiled_at = datetime.now(UTC)
         profiled_count = 0
-        for col in new_columns:
+        for col in new_dim_columns:
             # Bare name, NOT view_fqn: the profiler interpolates the path as
             # ONE quoted identifier, so a pre-quoted catalog.schema."name"
             # FQN parses as a zero-length identifier and every dim-column
@@ -784,9 +812,10 @@ class EnrichedViewsPhase(BasePhase):
                 profiled_count += 1
 
         logger.info(
-            "dim_columns_profiled",
+            "served_columns_registered",
             view_name=view_name,
-            columns=len(dim_columns),
+            served_columns=len(served_names),
+            dimension_columns=len(dim_columns),
             new_columns=len(new_columns),
             profiles=profiled_count,
         )

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -42,7 +42,11 @@ from dataraum.analysis.statistics.db_models import StatisticalProfile
 from dataraum.analysis.statistics.profiler import _profile_column_stats_parallel
 from dataraum.analysis.typing.db_models import MaterializationRecipe
 from dataraum.analysis.typing.recipe import store_recipe
-from dataraum.analysis.views.builder import DimensionJoin, build_enriched_view_sql
+from dataraum.analysis.views.builder import (
+    DimensionJoin,
+    EnrichedDimColumn,
+    build_enriched_view_sql,
+)
 from dataraum.analysis.views.db_models import EnrichedView
 from dataraum.analysis.views.enrichment_agent import EnrichmentAgent
 from dataraum.analysis.views.enrichment_models import EnrichmentAnalysisResult
@@ -398,7 +402,21 @@ class EnrichedViewsPhase(BasePhase):
                 )
 
             # Build view SQL from the grain-preserving survivors.
-            view_sql, dim_columns = build_enriched_view_sql(view_fqn, fact_fqn, fqn_joins)
+            view_sql, dim_col_refs = build_enriched_view_sql(view_fqn, fact_fqn, fqn_joins)
+            dim_columns = [c.name for c in dim_col_refs]
+
+            # DAT-811: resolve each dim column's TYPED source column_id relationally —
+            # (dim table, source column name) → column_id, forward from the recipe. The
+            # builder is the sole authority on the physical ``{fk}__{col}`` name, so this
+            # never reverse-parses it (which would collide when two joins share a prefix).
+            source_by_name: dict[str, str | None] = {}
+            for ref in dim_col_refs:
+                dim_table = tables_by_name.get(ref.dim_table_name)
+                source_by_name[ref.name] = (
+                    col_id_by_name.get((dim_table.table_id, ref.source_column_name))
+                    if dim_table
+                    else None
+                )
 
             # Create view in DuckDB
             try:
@@ -453,6 +471,7 @@ class EnrichedViewsPhase(BasePhase):
                 view_name,
                 view_fqn,
                 dim_columns,
+                source_by_name,
             )
 
             # Version the view DDL on the DAT-414 recipe substrate (emit → store →
@@ -610,6 +629,7 @@ class EnrichedViewsPhase(BasePhase):
         view_name: str,
         view_fqn: str,
         dim_columns: list[str],
+        source_by_name: dict[str, str | None],
     ) -> Table | None:
         """Register enriched-layer Table + Column records for dimension columns and profile them.
 
@@ -629,6 +649,11 @@ class EnrichedViewsPhase(BasePhase):
             view_name: Bare name of the enriched DuckDB view (stored as duckdb_path).
             view_fqn: Fully-qualified view name, used to query the view (DESCRIBE / profile).
             dim_columns: List of dimension column names in the view.
+            source_by_name: Physical dim-column name → its TYPED source ``column_id``
+                (DAT-811), resolved forward from the join recipe. ``None`` for a column
+                whose source could not be resolved (defensive; should not occur for a
+                surviving join). Persisted as ``Column.source_column_id`` so read views
+                resolve the column's semantics through its typed source.
 
         Returns:
             The enriched-layer Table record, or None if no dimension columns.
@@ -687,11 +712,16 @@ class EnrichedViewsPhase(BasePhase):
         type_by_name = {row[0]: row[1] for row in duckdb_cols}
 
         # Keep + reposition existing columns; mint only genuinely-new ones (DAT-516).
+        # Every registered column is a joined dimension column (``origin='dimension'``,
+        # DAT-811) carrying its typed ``source_column_id``; both are refreshed on a kept
+        # column too, since a re-run may resolve a source the prior run left unlinked.
         new_columns: list[Column] = []
         for pos, col_name in enumerate(dim_columns):
             kept = existing.get(col_name)
             if kept is not None:
                 kept.column_position = pos  # keep column_id + its profile; refresh order only
+                kept.origin = "dimension"
+                kept.source_column_id = source_by_name.get(col_name)
                 continue
             col_type = type_by_name.get(col_name, "VARCHAR")
             col = Column(
@@ -701,6 +731,8 @@ class EnrichedViewsPhase(BasePhase):
                 column_position=pos,
                 raw_type=col_type,
                 resolved_type=col_type,
+                origin="dimension",
+                source_column_id=source_by_name.get(col_name),
             )
             ctx.session.add(col)
             new_columns.append(col)

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -673,11 +673,18 @@ class EnrichedViewsPhase(BasePhase):
                 resolved forward from the join recipe — never parsed from the name.
 
         Returns:
-            The enriched-layer Table record, or None if the view has no dimension joins (a
-            bare passthrough has no vertex; its columns are the fact's own, read directly
-            off the typed table).
+            The enriched-layer Table record, or None if the view has no dimension joins.
+
+        Scope boundary (DAT-811): a passthrough view (no dim joins) is ``SELECT *`` over the
+        fact — it adds no column the typed fact doesn't already carry, and the typed fact is
+        fully in ``og_columns``. So it deliberately gets NO enriched vertex/columns; a no-dim
+        fact's served relation IS the typed fact — both ``agent.py::_build_schema_info`` (via
+        a DuckDB DESCRIBE, catalog-independent today) and ``additivity_resolver.fact_table_id``
+        resolve it that way. Graph-native (P9 / DAT-734) grounding of no-dim facts must
+        resolve them to the typed vertex, or DAT-734 decides to register passthrough columns.
         """
         if not dim_columns:
+            logger.info("passthrough_view_no_catalog_rows", view_name=view_name)
             return None
 
         view_table = ctx.session.execute(

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -44,7 +44,6 @@ from dataraum.analysis.typing.db_models import MaterializationRecipe
 from dataraum.analysis.typing.recipe import store_recipe
 from dataraum.analysis.views.builder import (
     DimensionJoin,
-    EnrichedDimColumn,
     build_enriched_view_sql,
 )
 from dataraum.analysis.views.db_models import EnrichedView
@@ -405,9 +404,7 @@ class EnrichedViewsPhase(BasePhase):
             # names seed the builder's dedup so a generated {fk}__{col} name that collides
             # with an f.* column is disambiguated (else the view emits two same-named
             # columns and DAT-811's per-column registration hits uq_table_column).
-            fact_col_names = tuple(
-                name for (tid, name) in col_id_by_name if tid == fact_id
-            )
+            fact_col_names = tuple(name for (tid, name) in col_id_by_name if tid == fact_id)
             view_sql, dim_col_refs = build_enriched_view_sql(
                 view_fqn, fact_fqn, fqn_joins, fact_col_names
             )

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -401,8 +401,16 @@ class EnrichedViewsPhase(BasePhase):
                     reason="no qualifying dimension joins",
                 )
 
-            # Build view SQL from the grain-preserving survivors.
-            view_sql, dim_col_refs = build_enriched_view_sql(view_fqn, fact_fqn, fqn_joins)
+            # Build view SQL from the grain-preserving survivors. The fact's own column
+            # names seed the builder's dedup so a generated {fk}__{col} name that collides
+            # with an f.* column is disambiguated (else the view emits two same-named
+            # columns and DAT-811's per-column registration hits uq_table_column).
+            fact_col_names = tuple(
+                name for (tid, name) in col_id_by_name if tid == fact_id
+            )
+            view_sql, dim_col_refs = build_enriched_view_sql(
+                view_fqn, fact_fqn, fqn_joins, fact_col_names
+            )
             dim_columns = [c.name for c in dim_col_refs]
 
             # DAT-811: resolve each dim column's TYPED source column_id relationally —

--- a/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/enriched_views_phase.py
@@ -672,21 +672,16 @@ class EnrichedViewsPhase(BasePhase):
             source_by_name: Dim-column name → its TYPED source ``column_id`` (DAT-811),
                 resolved forward from the join recipe — never parsed from the name.
 
+        A passthrough view (no dim joins) is transparently a full catalog citizen too: it
+        is ``SELECT *`` over the fact, so every served column is an ``origin='fact'``
+        passthrough (no dim columns) — ``og_tables`` still emits its vertex and
+        ``og_columns`` still returns its columns, so a consumer never has to special-case
+        "no enriched view → walk back to the typed table".
+
         Returns:
-            The enriched-layer Table record, or None if the view has no dimension joins.
-
-        Scope boundary (DAT-811): a passthrough view (no dim joins) is ``SELECT *`` over the
-        fact — it adds no column the typed fact doesn't already carry, and the typed fact is
-        fully in ``og_columns``. So it deliberately gets NO enriched vertex/columns; a no-dim
-        fact's served relation IS the typed fact — both ``agent.py::_build_schema_info`` (via
-        a DuckDB DESCRIBE, catalog-independent today) and ``additivity_resolver.fact_table_id``
-        resolve it that way. Graph-native (P9 / DAT-734) grounding of no-dim facts must
-        resolve them to the typed vertex, or DAT-734 decides to register passthrough columns.
+            The enriched-layer Table record (None only if the view has no columns at all,
+            which a real fact never hits).
         """
-        if not dim_columns:
-            logger.info("passthrough_view_no_catalog_rows", view_name=view_name)
-            return None
-
         view_table = ctx.session.execute(
             select(Table).where(
                 Table.source_id == fact_table.source_id,

--- a/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
@@ -704,8 +704,13 @@ class SlicingPhase(BasePhase):
             # Stats come from StatisticalProfile — no ad-hoc DuckDB queries needed.
             table_ev = ev_by_fact.get(table.table_id)
             if table_ev and table_ev.view_table_id and table_ev.dimension_columns:
-                # Load Column records for dimension columns
-                dim_col_stmt = select(Column).where(Column.table_id == table_ev.view_table_id)
+                # Load the JOINED dimension columns only — the enriched view now also
+                # registers the fact's own f.* passthrough columns (DAT-811), which are
+                # already on this fact; ``origin='dimension'`` selects the added ones.
+                dim_col_stmt = select(Column).where(
+                    Column.table_id == table_ev.view_table_id,
+                    Column.origin == "dimension",
+                )
                 dim_cols = list(ctx.session.execute(dim_col_stmt).scalars().all())
                 dim_col_ids = [c.column_id for c in dim_cols]
 

--- a/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
+++ b/packages/engine/src/dataraum/pipeline/phases/slicing_phase.py
@@ -19,6 +19,7 @@ from dataraum.analysis.slicing.models import (
     SliceRecommendation,
     SlicingAnalysisResult,
 )
+from dataraum.analysis.views.served_columns import enriched_dimension_columns
 from dataraum.core.logging import get_logger
 from dataraum.llm import PromptRenderer, create_provider, load_llm_config
 from dataraum.pipeline.base import PhaseContext, PhaseResult
@@ -704,14 +705,9 @@ class SlicingPhase(BasePhase):
             # Stats come from StatisticalProfile — no ad-hoc DuckDB queries needed.
             table_ev = ev_by_fact.get(table.table_id)
             if table_ev and table_ev.view_table_id and table_ev.dimension_columns:
-                # Load the JOINED dimension columns only — the enriched view now also
-                # registers the fact's own f.* passthrough columns (DAT-811), which are
-                # already on this fact; ``origin='dimension'`` selects the added ones.
-                dim_col_stmt = select(Column).where(
-                    Column.table_id == table_ev.view_table_id,
-                    Column.origin == "dimension",
-                )
-                dim_cols = list(ctx.session.execute(dim_col_stmt).scalars().all())
+                # Only the JOINED dimension columns — the enriched view also registers the
+                # fact's own f.* passthrough columns (DAT-811), already on this fact.
+                dim_cols = enriched_dimension_columns(ctx.session, table_ev.view_table_id)
                 dim_col_ids = [c.column_id for c in dim_cols]
 
                 # Load their StatisticalProfiles

--- a/packages/engine/src/dataraum/storage/models.py
+++ b/packages/engine/src/dataraum/storage/models.py
@@ -169,6 +169,28 @@ class Column(Base):
         String
     )  # Final decided type after type resolution
 
+    # DAT-811 — served-column identity for ENRICHED-view columns. An enriched view is
+    # ``SELECT f.* + joined dim columns``; every one of its columns is a real Column row
+    # so the catalog (``og_columns``) describes the view completely, WITHOUT walking back
+    # to origin tables. Both fields are NULL on base (typed/raw) columns, where the
+    # distinction is moot — they carry meaning only under an ``layer='enriched'`` table.
+    #   ``origin``           — how the column reached the view: ``'fact'`` (the fact's own
+    #                          column, carried through by ``f.*``) or ``'dimension'`` (added
+    #                          by a grain-preserving dim join). The discriminator the
+    #                          dims-only consumers filter on (``origin == 'dimension'``).
+    #   ``source_column_id`` — the TYPED source column this one projects. Read views resolve
+    #                          semantics (concept, role, anchor axis, granularity) THROUGH
+    #                          this link, so an enriched column inherits its source's meaning
+    #                          while keeping its OWN ``column_id`` (the property-graph vertex
+    #                          KEY must stay unique — a typed id must not appear twice). Set
+    #                          at the enriched_views phase from the join recipe — NEVER parsed
+    #                          from the ``{fk}__{col}`` name. SET NULL if the source is torn
+    #                          down; the enriched view is re-derived each run regardless.
+    origin: Mapped[str | None] = mapped_column(String)
+    source_column_id: Mapped[str | None] = mapped_column(
+        ForeignKey("columns.column_id", ondelete="SET NULL")
+    )
+
     # Relationships
     table: Mapped[Table] = relationship(back_populates="columns")
 

--- a/packages/engine/src/dataraum/storage/models.py
+++ b/packages/engine/src/dataraum/storage/models.py
@@ -255,4 +255,8 @@ class Column(Base):
 
 # Indexes for common queries
 Index("idx_columns_table", Column.table_id)
+# DAT-811 — the self-FK is ON DELETE SET NULL, so every typed-column delete (teardown,
+# reconcile, re-typing) must find the enriched columns referencing it; index the FK so
+# that is not a seq scan over `columns` per bulk delete.
+Index("idx_columns_source_column_id", Column.source_column_id)
 Index("idx_tables_source", Table.source_id)

--- a/packages/engine/src/dataraum/storage/models.py
+++ b/packages/engine/src/dataraum/storage/models.py
@@ -153,7 +153,13 @@ class Column(Base):
     """
 
     __tablename__ = "columns"
-    __table_args__ = (UniqueConstraint("table_id", "column_name", name="uq_table_column"),)
+    __table_args__ = (
+        UniqueConstraint("table_id", "column_name", name="uq_table_column"),
+        # DAT-811 — origin is a closed enum: NULL on base (typed/raw) columns, and 'fact'
+        # or 'dimension' on an enriched view's served columns. CHECK-enforced like
+        # Table.layer so an unknown value fails loud at write.
+        CheckConstraint("origin IS NULL OR origin IN ('fact', 'dimension')", name="origin"),
+    )
 
     column_id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
     table_id: Mapped[str] = mapped_column(

--- a/packages/engine/src/dataraum/storage/property_graph.py
+++ b/packages/engine/src/dataraum/storage/property_graph.py
@@ -172,6 +172,17 @@ def _element_view_sql(name: str) -> str:
         #      lateral; the save-time contract guarantees at most one such row.
         # NULL when neither exists. The COALESCE order IS the precedence, exactly like
         # materialization prefers the witness posterior over the concept prior.
+        #
+        # DAT-811 — the vertex set is the UNION of two branches:
+        #   TYPED    (current_columns): a column resolves its own semantics by its own
+        #     column_id, and the declared anchor comes from its own table's entity.
+        #   ENRICHED (current_enriched_columns): a served column of an enriched view. It
+        #     keeps its OWN column_id (the KEY must stay unique — a typed id must never
+        #     appear on two vertices), but resolves EVERY semantic (role, materialization,
+        #     anchor) THROUGH ``source_column_id`` — its typed source. So the enriched view
+        #     is self-describing: a MATCH over its table_id returns its full column set with
+        #     semantics attached, no walk back to origin tables. ``te`` joins the SOURCE
+        #     column's table so an f.* measure inherits the fact's declared anchor.
         return (
             f"CREATE VIEW {READ_TOKEN}.og_columns AS\n"
             f"SELECT c.column_id::text AS column_id, c.table_id::text AS table_id, c.column_name,\n"
@@ -188,6 +199,29 @@ def _element_view_sql(name: str) -> str:
             f"LEFT JOIN {READ_TOKEN}.current_measure_aggregation_lineage mal\n"
             f"       ON mal.measure_column_id = c.column_id\n"
             f"LEFT JOIN {READ_TOKEN}.current_table_entities te ON te.table_id = c.table_id\n"
+            f"LEFT JOIN LATERAL (\n"
+            f"    SELECT elem->>'column' AS column_name\n"
+            f"    FROM json_array_elements(COALESCE(te.time_columns, '[]'::json)) AS elem\n"
+            f"    WHERE elem->>'role' = 'event' AND (elem->>'is_anchor')::boolean IS TRUE\n"
+            f"    LIMIT 1\n"
+            f"  ) declared_anchor ON TRUE\n"
+            f"UNION ALL\n"
+            f"SELECT ec.column_id::text AS column_id, ec.table_id::text AS table_id,"
+            f" ec.column_name,\n"
+            f"       sa.semantic_role,\n"
+            f"       COALESCE(\n"
+            f"         CASE mal.pattern WHEN 'per_period' THEN 'flow' WHEN 'cumulative' THEN 'stock' END,\n"
+            f"         CASE cc.temporal_behavior WHEN 'additive' THEN 'flow'\n"
+            f"                                   WHEN 'point_in_time' THEN 'stock' END\n"
+            f"       ) AS materialization,\n"
+            f"       COALESCE(mal.event_time_axis_column, declared_anchor.column_name) AS anchor_time_axis\n"
+            f"FROM {READ_TOKEN}.current_enriched_columns ec\n"
+            f"LEFT JOIN {READ_TOKEN}.current_semantic_annotations sa ON sa.column_id = ec.source_column_id\n"
+            f"LEFT JOIN {READ_TOKEN}.current_column_concepts cc ON cc.column_id = ec.source_column_id\n"
+            f"LEFT JOIN {READ_TOKEN}.current_measure_aggregation_lineage mal\n"
+            f"       ON mal.measure_column_id = ec.source_column_id\n"
+            f"LEFT JOIN {READ_TOKEN}.current_columns src ON src.column_id = ec.source_column_id\n"
+            f"LEFT JOIN {READ_TOKEN}.current_table_entities te ON te.table_id = src.table_id\n"
             f"LEFT JOIN LATERAL (\n"
             f"    SELECT elem->>'column' AS column_name\n"
             f"    FROM json_array_elements(COALESCE(te.time_columns, '[]'::json)) AS elem\n"

--- a/packages/engine/src/dataraum/storage/read_views.py
+++ b/packages/engine/src/dataraum/storage/read_views.py
@@ -368,6 +368,33 @@ def _current_entity_view_statements() -> list[tuple[str, str]]:
                 f");"
             ),
         ),
+        # DAT-811 — the served columns of the CURRENT enriched views. Enriched columns are
+        # latest-only substrate (no generations, unlike typed): the ``enriched`` Table is
+        # reconciled in place each run, so the current set is every column whose table is a
+        # current enriched view. Scoped by the SAME (catalog, 'catalog') head that
+        # ``current_enriched_views`` uses (``enriched_views`` is _CATALOG_GRAIN), so a
+        # column surfaces iff its view's ``og_tables`` vertex does — but read off the BASE
+        # ``enriched_views`` (NOT the ``current_enriched_views`` read view), because the
+        # read schema is re-materialized DROP-then-CREATE in list order: a view depending on
+        # another read view would fail to drop. ``current_columns`` hard-filters
+        # ``layer='typed'`` and excludes these; this is the parallel surface ``og_columns``
+        # unions in so the catalog describes an enriched view completely.
+        # ``source_column_id`` rides along as the typed identity semantics resolve through.
+        (
+            "current_enriched_columns",
+            (
+                f"CREATE VIEW {READ_TOKEN}.current_enriched_columns AS\n"
+                f"SELECT c.* FROM {WS_TOKEN}.columns c\n"
+                f"WHERE EXISTS (\n"
+                f"  SELECT 1 FROM {WS_TOKEN}.enriched_views ev\n"
+                f"  JOIN {WS_TOKEN}.metadata_snapshot_head h\n"
+                f"    ON h.target = 'catalog'\n"
+                f"   AND h.stage = 'catalog'\n"
+                f"   AND h.run_id = ev.run_id\n"
+                f"  WHERE ev.view_table_id = c.table_id\n"
+                f");"
+            ),
+        ),
     ]
 
 

--- a/packages/engine/tests/integration/analysis/views/test_enriched_views.py
+++ b/packages/engine/tests/integration/analysis/views/test_enriched_views.py
@@ -454,33 +454,60 @@ class TestEnrichedViewsPhaseDuckLake:
 
         assert calls["n"] == 1, "run 1 judged the one undecided relationship"
 
-        # DAT-811: every registered enriched column is a dimension column carrying its
-        # TYPED source column_id — resolved forward from the join recipe, NEVER parsed
-        # from the {fk}__{col} name. This is the identity read views resolve semantics
-        # (concept, role, anchor axis, granularity) through.
+        # DAT-811: the enriched view registers EVERY served column — the fact's own f.*
+        # passthrough columns AND the joined dim columns — each carrying its TYPED source
+        # column_id (resolved forward from the recipe, NEVER parsed from the {fk}__{col}
+        # name). That source id is the identity read views resolve semantics through.
         from dataraum.storage import Column as _Column
 
-        src_id_of = {
-            name: session.execute(
+        def _src_id(table_id: str, name: str) -> str:
+            return session.execute(
                 select(_Column.column_id).where(
-                    _Column.table_id == dim_id, _Column.column_name == name
+                    _Column.table_id == table_id, _Column.column_name == name
                 )
             ).scalar_one()
-            for name in ("name", "country")
-        }
+
         enriched_cols = (
             session.execute(select(_Column).where(_Column.table_id == views[0].view_table_id))
             .scalars()
             .all()
         )
-        assert {c.column_name for c in enriched_cols} == {
+        by_name = {c.column_name: c for c in enriched_cols}
+        # No served column is left unclassified.
+        assert all(c.origin in ("fact", "dimension") for c in enriched_cols)
+
+        # The fact's own columns are carried through (origin='fact'), each linked to its
+        # typed fact source. They are NOT re-profiled — read views reach stats via the link.
+        assert {n for n, c in by_name.items() if c.origin == "fact"} == {
+            "order_id",
+            "customer_id",
+            "amount",
+        }
+        for n in ("order_id", "customer_id", "amount"):
+            assert by_name[n].source_column_id == _src_id(fact_id, n)
+
+        # The joined dim columns (origin='dimension') link their typed dim source — this is
+        # exactly the set the dims-only consumers now select via ``origin == 'dimension'``.
+        assert {n for n, c in by_name.items() if c.origin == "dimension"} == {
             "customer_id__name",
             "customer_id__country",
         }
-        assert all(c.origin == "dimension" for c in enriched_cols)
-        assert {c.column_name: c.source_column_id for c in enriched_cols} == {
-            "customer_id__name": src_id_of["name"],
-            "customer_id__country": src_id_of["country"],
+        assert by_name["customer_id__name"].source_column_id == _src_id(dim_id, "name")
+        assert by_name["customer_id__country"].source_column_id == _src_id(dim_id, "country")
+
+        dims_only = (
+            session.execute(
+                select(_Column).where(
+                    _Column.table_id == views[0].view_table_id,
+                    _Column.origin == "dimension",
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert {c.column_name for c in dims_only} == {
+            "customer_id__name",
+            "customer_id__country",
         }
 
         # --- Run 1 retry: same run_id is idempotent (no duplicate rows) ----

--- a/packages/engine/tests/integration/analysis/views/test_enriched_views.py
+++ b/packages/engine/tests/integration/analysis/views/test_enriched_views.py
@@ -771,9 +771,7 @@ class TestEnrichedViewsPhaseDuckLake:
         ).scalar_one()
         assert v1.view_table_id is not None, "passthrough view is materialized in the catalog"
         pv_cols = list(
-            session.execute(
-                select(Column).where(Column.table_id == v1.view_table_id)
-            ).scalars()
+            session.execute(select(Column).where(Column.table_id == v1.view_table_id)).scalars()
         )
         assert {c.column_name for c in pv_cols} == {"order_id", "customer_id", "amount"}
         assert all(c.origin == "fact" for c in pv_cols)

--- a/packages/engine/tests/integration/analysis/views/test_enriched_views.py
+++ b/packages/engine/tests/integration/analysis/views/test_enriched_views.py
@@ -63,7 +63,7 @@ class TestEnrichedViewsIntegration:
         ]
 
         view = '"enriched_orders"'
-        sql, dim_cols = build_enriched_view_sql(view, "typed_orders", joins)
+        sql, _ = build_enriched_view_sql(view, "typed_orders", joins)
 
         duckdb_conn.execute(sql)
 
@@ -453,6 +453,35 @@ class TestEnrichedViewsPhaseDuckLake:
         assert len(enriched_tables) == 1
 
         assert calls["n"] == 1, "run 1 judged the one undecided relationship"
+
+        # DAT-811: every registered enriched column is a dimension column carrying its
+        # TYPED source column_id — resolved forward from the join recipe, NEVER parsed
+        # from the {fk}__{col} name. This is the identity read views resolve semantics
+        # (concept, role, anchor axis, granularity) through.
+        from dataraum.storage import Column as _Column
+
+        src_id_of = {
+            name: session.execute(
+                select(_Column.column_id).where(
+                    _Column.table_id == dim_id, _Column.column_name == name
+                )
+            ).scalar_one()
+            for name in ("name", "country")
+        }
+        enriched_cols = (
+            session.execute(select(_Column).where(_Column.table_id == views[0].view_table_id))
+            .scalars()
+            .all()
+        )
+        assert {c.column_name for c in enriched_cols} == {
+            "customer_id__name",
+            "customer_id__country",
+        }
+        assert all(c.origin == "dimension" for c in enriched_cols)
+        assert {c.column_name: c.source_column_id for c in enriched_cols} == {
+            "customer_id__name": src_id_of["name"],
+            "customer_id__country": src_id_of["country"],
+        }
 
         # --- Run 1 retry: same run_id is idempotent (no duplicate rows) ----
         run("run-1")

--- a/packages/engine/tests/integration/analysis/views/test_enriched_views.py
+++ b/packages/engine/tests/integration/analysis/views/test_enriched_views.py
@@ -786,6 +786,29 @@ class TestEnrichedViewsPhaseDuckLake:
         # Run 2: a newly-confirmed relationship is judged in → its columns are ADDED.
         run("run-2", with_rel=True)
         assert dim_cols() == ["customer_id__country", "customer_id__name"], "grow on new confirm"
+        # Capture the dim columns' ids + confirm they were profiled, so the reject below
+        # can prove the underlying rows (not just the dimension_columns JSON) are deleted.
+        from dataraum.analysis.statistics.db_models import StatisticalProfile
+
+        v2 = session.execute(
+            select(EnrichedView).where(EnrichedView.fact_table_id == fact_id)
+        ).scalar_one()
+        dim2_ids = [
+            c.column_id
+            for c in session.execute(
+                select(Column).where(
+                    Column.table_id == v2.view_table_id, Column.origin == "dimension"
+                )
+            ).scalars()
+        ]
+        assert len(dim2_ids) == 2
+        assert (
+            session.execute(
+                select(StatisticalProfile).where(StatisticalProfile.column_id.in_(dim2_ids))
+            )
+            .scalars()
+            .all()
+        ), "dim columns were profiled"
 
         # Run 3: the user rejects the relationship → its columns DROP (shrink), even though
         # the relationship is still structurally confirmed and already in `considered`.
@@ -807,6 +830,31 @@ class TestEnrichedViewsPhaseDuckLake:
         session.flush()
         run("run-3", with_rel=True)
         assert dim_cols() == [], "shrink on explicit reject"
+        # The shrink DELETES the stale dim Column + StatisticalProfile rows (not just the
+        # dimension_columns JSON summary) — the view is now a passthrough carrying only the
+        # fact's own f.* columns. (Senior review: this cleanup path was unreachable before
+        # DAT-811 made passthrough registration run, so it was newly load-bearing.)
+        assert (
+            session.execute(select(Column).where(Column.column_id.in_(dim2_ids))).scalars().all()
+            == []
+        ), "dim Column rows deleted on shrink"
+        assert (
+            session.execute(
+                select(StatisticalProfile).where(StatisticalProfile.column_id.in_(dim2_ids))
+            )
+            .scalars()
+            .all()
+            == []
+        ), "dim StatisticalProfiles deleted on shrink"
+        v3 = session.execute(
+            select(EnrichedView).where(EnrichedView.fact_table_id == fact_id)
+        ).scalar_one()
+        assert {
+            c.origin
+            for c in session.execute(
+                select(Column).where(Column.table_id == v3.view_table_id)
+            ).scalars()
+        } == {"fact"}, "view is now a passthrough citizen (fact columns only)"
 
     def test_dropped_then_reconfirmed_relationship_is_rejudged(
         self, session, duckdb_conn, monkeypatch

--- a/packages/engine/tests/integration/analysis/views/test_enriched_views.py
+++ b/packages/engine/tests/integration/analysis/views/test_enriched_views.py
@@ -762,6 +762,28 @@ class TestEnrichedViewsPhaseDuckLake:
         # Run 1: no relationship yet → passthrough view, zero dimension columns.
         run("run-1", with_rel=False)
         assert dim_cols() == []
+        # DAT-811: a passthrough view is STILL a full catalog citizen — it registers its
+        # f.* columns (origin='fact', linked to their typed source) and sets view_table_id,
+        # so og_tables/og_columns describe it too. No consumer special-cases "no enriched
+        # view → walk back to the typed table".
+        v1 = session.execute(
+            select(EnrichedView).where(EnrichedView.fact_table_id == fact_id)
+        ).scalar_one()
+        assert v1.view_table_id is not None, "passthrough view is materialized in the catalog"
+        pv_cols = list(
+            session.execute(
+                select(Column).where(Column.table_id == v1.view_table_id)
+            ).scalars()
+        )
+        assert {c.column_name for c in pv_cols} == {"order_id", "customer_id", "amount"}
+        assert all(c.origin == "fact" for c in pv_cols)
+        for c in pv_cols:
+            src = session.execute(
+                select(Column.column_id).where(
+                    Column.table_id == fact_id, Column.column_name == c.column_name
+                )
+            ).scalar_one()
+            assert c.source_column_id == src
 
         # Run 2: a newly-confirmed relationship is judged in → its columns are ADDED.
         run("run-2", with_rel=True)

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -86,6 +86,8 @@ _COLUMNS = [
     ("c_amt2", "t1", "amount_declared", 3),
     ("c_k1", "t1", "account_id", 2),
     ("c_k2", "t2", "account_id", 1),
+    ("c_at", "t2", "account_type", 2),  # accounts dim attribute — a DAT-811 dim-column source
+
     ("c_k3", "t3", "group_id", 1),
     ("c_k3b", "t3", "account_id", 2),  # t3's own account_id — a cross-LEVEL accounts slice
     ("c_k4", "t4", "statement_id", 1),
@@ -138,6 +140,22 @@ def _seed(engine: Engine) -> None:
         stmts.append(
             f"INSERT INTO columns (column_id, table_id, column_name, column_position) "
             f"VALUES ('{cid}', '{tid}', '{name}', {pos})"
+        )
+    # DAT-811: served columns of the enriched view t_enr (enriched_journal, v_1). Each is a
+    # real column vertex under the enriched table with its OWN column_id, carrying ``origin``
+    # and the typed ``source_column_id`` og_columns resolves semantics through:
+    #   ec_amt — f.* passthrough of the fact measure c_amt (origin='fact'): inherits
+    #            semantic_role='measure' + materialization='flow' from its source.
+    #   ec_at  — joined dim column account_id__account_type (origin='dimension') sourced
+    #            from the accounts attribute c_at (unannotated → NULL semantics).
+    for cid, name, pos, origin, src in [
+        ("ec_amt", "amount", 0, "fact", "c_amt"),
+        ("ec_at", "account_id__account_type", 1, "dimension", "c_at"),
+    ]:
+        stmts.append(
+            "INSERT INTO columns "
+            "(column_id, table_id, column_name, column_position, origin, source_column_id) "
+            f"VALUES ('{cid}', 't_enr', '{name}', {pos}, '{origin}', '{src}')"
         )
     # has_role: amount / amount_declared are measures, account_id a key.
     for cid, role in [("c_amt", "measure"), ("c_amt2", "measure"), ("c_k1", "key")]:
@@ -360,7 +378,9 @@ def test_measure_anchor_time_axis_prefers_the_witness(graph_engine: Engine) -> N
     COALESCE order (mirrors materialization's witness-over-claim precedence)."""
     sql = (
         f"SELECT anchor FROM GRAPH_TABLE ({_graph_ref()} "
-        "MATCH (c IS column_node WHERE c.column_name = 'amount') "
+        # Scope to the typed fact vertex: DAT-811 adds an enriched 'amount' vertex on
+        # t_enr (same name, own id) that inherits the same witness axis via its source.
+        "MATCH (c IS column_node WHERE c.column_name = 'amount' AND c.table_id = 't1') "
         "COLUMNS (c.anchor_time_axis AS anchor))"
     )
     with graph_engine.connect() as conn:
@@ -387,6 +407,34 @@ def test_measure_anchor_time_axis_falls_back_to_declared_anchor(graph_engine: En
     with graph_engine.connect() as conn:
         rows = conn.execute(text(sql)).all()
     assert rows == [("txn_date",)]
+
+
+def test_enriched_view_columns_carry_source_resolved_semantics(graph_engine: Engine) -> None:
+    """DAT-811 AC: an enriched view's served columns are column vertices UNDER the enriched
+    table, each keeping its OWN column_id (the KEY stays unique — a typed id never appears
+    twice) but resolving EVERY semantic THROUGH its typed ``source_column_id``. A MATCH over
+    the enriched table_id returns its full served set with semantics attached — the view is
+    self-describing, no walk back to origin tables (the ``og_derived_from`` lesson: a
+    structurally-dead surface is invisible without a MATCH-returns-rows test).
+    """
+    sql = (
+        f"SELECT column_id, column_name, role, mat FROM GRAPH_TABLE ({_graph_ref()} "
+        "MATCH (c IS column_node WHERE c.table_id = 't_enr') "
+        "COLUMNS (c.column_id AS column_id, c.column_name AS column_name, "
+        "c.semantic_role AS role, c.materialization AS mat))"
+    )
+    with graph_engine.connect() as conn:
+        rows = {
+            (r.column_id, r.column_name, r.role, r.mat) for r in conn.execute(text(sql))
+        }
+    assert rows == {
+        # f.* passthrough measure: its OWN id (ec_amt, NOT the typed c_amt), semantics
+        # resolved through source c_amt → measure + flow. This is what a MATCH-driven
+        # GraphAgent (P9) and the cadence resolver (DAT-812) will read off the view.
+        ("ec_amt", "amount", "measure", "flow"),
+        # joined dim column: surfaces with its own id; source c_at is unannotated → NULL.
+        ("ec_at", "account_id__account_type", None, None),
+    }
 
 
 def test_references_edges_match_the_fk_topology(graph_engine: Engine) -> None:

--- a/packages/engine/tests/integration/storage/test_property_graph.py
+++ b/packages/engine/tests/integration/storage/test_property_graph.py
@@ -87,7 +87,6 @@ _COLUMNS = [
     ("c_k1", "t1", "account_id", 2),
     ("c_k2", "t2", "account_id", 1),
     ("c_at", "t2", "account_type", 2),  # accounts dim attribute — a DAT-811 dim-column source
-
     ("c_k3", "t3", "group_id", 1),
     ("c_k3b", "t3", "account_id", 2),  # t3's own account_id — a cross-LEVEL accounts slice
     ("c_k4", "t4", "statement_id", 1),
@@ -424,9 +423,7 @@ def test_enriched_view_columns_carry_source_resolved_semantics(graph_engine: Eng
         "c.semantic_role AS role, c.materialization AS mat))"
     )
     with graph_engine.connect() as conn:
-        rows = {
-            (r.column_id, r.column_name, r.role, r.mat) for r in conn.execute(text(sql))
-        }
+        rows = {(r.column_id, r.column_name, r.role, r.mat) for r in conn.execute(text(sql))}
     assert rows == {
         # f.* passthrough measure: its OWN id (ec_amt, NOT the typed c_amt), semantics
         # resolved through source c_amt → measure + flow. This is what a MATCH-driven

--- a/packages/engine/tests/unit/analysis/correlation/test_enriched_derived.py
+++ b/packages/engine/tests/unit/analysis/correlation/test_enriched_derived.py
@@ -80,7 +80,11 @@ def _make_table(session: Session, name: str, source_id: str = "src1") -> Table:
 
 
 def _make_column(
-    session: Session, table: Table, name: str, resolved_type: str = "DOUBLE"
+    session: Session,
+    table: Table,
+    name: str,
+    resolved_type: str = "DOUBLE",
+    origin: str | None = None,
 ) -> Column:
     c = Column(
         column_id=str(uuid4()),
@@ -89,6 +93,7 @@ def _make_column(
         column_position=0,
         raw_type="VARCHAR",
         resolved_type=resolved_type,
+        origin=origin,
     )
     session.add(c)
     session.flush()
@@ -168,7 +173,9 @@ class TestDetectsEnrichedDerivedColumns:
 
         # Register dimension column via view_table
         view_table = _make_view_table(session, "enriched_orders")
-        dim_col = _make_column(session, view_table, "products__unit_price", "DOUBLE")
+        dim_col = _make_column(
+            session, view_table, "products__unit_price", "DOUBLE", origin="dimension"
+        )
         _make_stat_profile(session, dim_col, layer="enriched")
 
         ev = _make_enriched_view(
@@ -266,7 +273,7 @@ class TestDetectsEnrichedDerivedColumns:
 
         # Register VARCHAR dimension column via view_table
         view_table = _make_view_table(session, "enriched_varchar")
-        _make_column(session, view_table, "dim__name", "VARCHAR")
+        _make_column(session, view_table, "dim__name", "VARCHAR", origin="dimension")
 
         ev = _make_enriched_view(
             session,
@@ -291,7 +298,9 @@ class TestDetectsEnrichedDerivedColumns:
         _make_stat_profile(session, col_total)
 
         view_table = _make_view_table(session, "enriched_orders")
-        dim_col = _make_column(session, view_table, "products__unit_price", "DOUBLE")
+        dim_col = _make_column(
+            session, view_table, "products__unit_price", "DOUBLE", origin="dimension"
+        )
         _make_stat_profile(session, dim_col, layer="enriched")
 
         ev = _make_enriched_view(
@@ -319,7 +328,9 @@ class TestDetectsEnrichedDerivedColumns:
         _make_stat_profile(session, col_total)
 
         view_table = _make_view_table(session, "enriched_orders")
-        dim_col = _make_column(session, view_table, "products__unit_price", "DOUBLE")
+        dim_col = _make_column(
+            session, view_table, "products__unit_price", "DOUBLE", origin="dimension"
+        )
         _make_stat_profile(session, dim_col, layer="enriched")
 
         ev = _make_enriched_view(

--- a/packages/engine/tests/unit/analysis/hierarchies/conftest.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/conftest.py
@@ -43,9 +43,7 @@ class StubIdentityJudge:
         self._fail = fail
         self.calls: list[list[dict]] = []
 
-    def alias_identity(
-        self, *, candidates: list[dict]
-    ) -> Result[list[AliasIdentityVerdict]]:
+    def alias_identity(self, *, candidates: list[dict]) -> Result[list[AliasIdentityVerdict]]:
         self.calls.append(candidates)
         if self._fail:
             return Result.fail("stub judge unavailable")
@@ -60,6 +58,7 @@ class StubIdentityJudge:
 def approving_judge() -> StubIdentityJudge:
     """Fresh stub that approves every relabeling bijection (default discovery judge)."""
     return StubIdentityJudge()
+
 
 VIEW = "sales_enriched"
 

--- a/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
+++ b/packages/engine/tests/unit/analysis/hierarchies/test_processor.py
@@ -263,8 +263,8 @@ class TestDiscoverDimensionHierarchies:
         position."""
         tid = seed_sales(real_session, duck)
         discover_dimension_hierarchies(
-        real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
-    )
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
+        )
         row = _rows(real_session, tid, "drilldown")[0]
         for member in row.members:
             assert set(member) == {"column_name", "column_id", "distinct_count", "level"}
@@ -278,8 +278,8 @@ class TestDiscoverDimensionHierarchies:
     ) -> None:
         tid = seed_sales(real_session, duck)
         discover_dimension_hierarchies(
-        real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
-    )
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
+        )
         aliases = {tuple(_members(r)): r for r in _rows(real_session, tid, "alias")}
         assert ("zip", "zip_code") in aliases
         assert ("state", "state_name") in aliases
@@ -292,8 +292,8 @@ class TestDiscoverDimensionHierarchies:
     ) -> None:
         tid = seed_sales(real_session, duck)
         discover_dimension_hierarchies(
-        real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
-    )
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
+        )
         all_members = {
             m
             for r in _rows(real_session, tid, "drilldown") + _rows(real_session, tid, "alias")
@@ -310,8 +310,8 @@ class TestDiscoverDimensionHierarchies:
         # Below MIN_SUPPORT_ROWS (100): the chain is found but flagged, not asserted.
         tid = seed_sales(real_session, duck, rows_per_zip=2)  # 12 rows
         discover_dimension_hierarchies(
-        real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
-    )
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
+        )
         drills = _rows(real_session, tid, "drilldown")
         assert drills and all(r.needs_confirmation for r in drills)
 
@@ -367,8 +367,8 @@ class TestStackV4:
             real_session, duck, "skewed", {"det": det, "vacuous": vacuous, "flag": flag}
         )
         discover_dimension_hierarchies(
-        real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
-    )
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
+        )
         chains = [_members(r) for r in _rows(real_session, tid, "drilldown")]
         # Stored coarse → fine: ``flag`` (2 distinct, coarsest) determines nothing
         # finer than ``det`` (50 distinct) — det → flag reversed for storage.
@@ -386,8 +386,8 @@ class TestStackV4:
         ]
         tid = seed_view(real_session, duck, "dirty_geo", {"city": city, "state": state})
         discover_dimension_hierarchies(
-        real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
-    )
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
+        )
         drills = _rows(real_session, tid, "drilldown")
         # Coarse → fine: state (coarser) before city (finer).
         assert [_members(r) for r in drills] == [["state", "city"]]
@@ -418,8 +418,8 @@ class TestStackV4:
             {"soldto": soldto, "billto": billto, "channel": channel},
         )
         discover_dimension_hierarchies(
-        real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
-    )
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
+        )
         roles = _rows(real_session, tid, "role")
         assert [_members(r) for r in roles] == [["billto", "soldto"]]
         assert roles[0].needs_confirmation is False
@@ -448,8 +448,8 @@ class TestStackV4:
         state = [None if i % 10 == 0 else f"s{(i % 40) // 5}" for i in range(n)]
         tid = seed_view(real_session, duck, "null_geo", {"city": city, "state": state})
         discover_dimension_hierarchies(
-        real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
-    )
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
+        )
         drills = _rows(real_session, tid, "drilldown")
         assert [_members(r) for r in drills] == [["state", "city"]]  # coarse → fine
 
@@ -466,8 +466,8 @@ class TestStackV4:
         state = [f"s{(i % 20) // 5}" if (i // 20) % 5 == 0 else None for i in range(n)]
         tid = seed_view(real_session, duck, "sparse_geo", {"city": city, "state": state})
         discover_dimension_hierarchies(
-        real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
-    )
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
+        )
         drills = _rows(real_session, tid, "drilldown")
         assert [_members(r) for r in drills] == [["state", "city"]]  # coarse → fine
         assert drills[0].needs_confirmation is True
@@ -488,8 +488,8 @@ class TestStackV4:
             real_session, duck, "customers", {"fn": fn, "active": list(fn), "city": city}
         )
         discover_dimension_hierarchies(
-        real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
-    )
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
+        )
         aliases = [_members(r) for r in _rows(real_session, tid, "alias")]
         assert ["active", "fn"] in aliases
 
@@ -518,8 +518,8 @@ class TestStackV4:
         )
         real_session.flush()
         discover_dimension_hierarchies(
-        real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
-    )
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
+        )
         all_members = {
             m
             for kind in ("drilldown", "alias", "role")
@@ -545,8 +545,8 @@ class TestStackV4:
             register={"state"},
         )
         discover_dimension_hierarchies(
-        real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
-    )
+            real_session, duckdb_conn=duck, table_ids=[tid], run_id=RUN, judge=approving_judge()
+        )
         aliases = _rows(real_session, tid, "alias")
         assert [_members(r) for r in aliases] == [["mystery", "state"]]
         by_name = {m["column_name"]: m["column_id"] for m in aliases[0].members}

--- a/packages/engine/tests/unit/analysis/views/test_builder.py
+++ b/packages/engine/tests/unit/analysis/views/test_builder.py
@@ -50,7 +50,13 @@ class TestBuildEnrichedViewSql:
         assert 'AS "customer_id__country"' in sql
         assert 'LEFT JOIN lake.typed."csv__customers"' in sql
         assert 'ON f."customer_id"' in sql
-        assert dim_cols == ["customer_id__name", "customer_id__country"]
+        assert [c.name for c in dim_cols] == ["customer_id__name", "customer_id__country"]
+        # Each ref names its typed source relationally (dim table + source column) —
+        # what the phase resolves to source_column_id, never parsed from the name.
+        assert [(c.dim_table_name, c.source_column_name) for c in dim_cols] == [
+            ("customers", "name"),
+            ("customers", "country"),
+        ]
 
     def test_multiple_dimension_joins(self):
         """View with multiple dimension joins."""
@@ -79,10 +85,11 @@ class TestBuildEnrichedViewSql:
             dimension_joins=joins,
         )
 
+        names = [c.name for c in dim_cols]
         assert sql.count("LEFT JOIN") == 2
-        assert "customer_id__name" in dim_cols
-        assert "product_id__product_name" in dim_cols
-        assert "product_id__category" in dim_cols
+        assert "customer_id__name" in names
+        assert "product_id__product_name" in names
+        assert "product_id__category" in names
         assert len(dim_cols) == 3
 
     def test_colliding_column_names_are_made_unique(self):
@@ -109,8 +116,16 @@ class TestBuildEnrichedViewSql:
             fact_fqn='lake.typed."csv__txn"',
             dimension_joins=joins,
         )
-        assert len(dim_cols) == len(set(dim_cols))  # no duplicates
-        assert dim_cols == ["org__city", "org__city_2"]
+        names = [c.name for c in dim_cols]
+        assert len(names) == len(set(names))  # no duplicates
+        assert names == ["org__city", "org__city_2"]
+        # The collision the physical name cannot resolve (both are ``org__city``): the
+        # forward refs map each disambiguated name to its DISTINCT source table, so the
+        # phase links them correctly without reverse-parsing (the DAT-811/812 defect).
+        assert [(c.name, c.dim_table_name, c.source_column_name) for c in dim_cols] == [
+            ("org__city", "customers", "city"),
+            ("org__city_2", "vendors", "city"),
+        ]
 
     def test_same_dim_table_joined_twice_produces_unique_column_names(self):
         """Same dimension table joined via two different FK columns gets distinct column names."""
@@ -140,11 +155,12 @@ class TestBuildEnrichedViewSql:
         )
 
         # All four columns must be distinct — no duplicates
-        assert len(dim_cols) == len(set(dim_cols)), f"Duplicate column names: {dim_cols}"
-        assert "kontonummer_des_gegenkontos__beschriftung" in dim_cols
-        assert "kontonummer_des_gegenkontos__zusfkt" in dim_cols
-        assert "kontonummer_des_kontos__beschriftung" in dim_cols
-        assert "kontonummer_des_kontos__zusfkt" in dim_cols
+        names = [c.name for c in dim_cols]
+        assert len(names) == len(set(names)), f"Duplicate column names: {names}"
+        assert "kontonummer_des_gegenkontos__beschriftung" in names
+        assert "kontonummer_des_gegenkontos__zusfkt" in names
+        assert "kontonummer_des_kontos__beschriftung" in names
+        assert "kontonummer_des_kontos__zusfkt" in names
         # SQL aliases for the two joins must also be distinct
         assert sql.count("LEFT JOIN") == 2
 

--- a/packages/engine/tests/unit/analysis/views/test_builder.py
+++ b/packages/engine/tests/unit/analysis/views/test_builder.py
@@ -127,6 +127,32 @@ class TestBuildEnrichedViewSql:
             ("org__city_2", "vendors", "city"),
         ]
 
+    def test_dim_name_colliding_with_a_fact_column_is_disambiguated(self):
+        """A fact column ALREADY named like a generated {fk}__{col} dim name must not
+        collide with the f.* passthrough (DAT-811). Seeding the dedup with the fact's own
+        columns pushes the dim column to a suffixed name, so the view never emits two
+        identically-named columns (ambiguous ref + uq_table_column on registration)."""
+        joins = [
+            DimensionJoin(
+                dim_table_name="customers",
+                dim_duckdb_path='lake.typed."csv__customers"',
+                fact_fk_column="customer_id",
+                dim_pk_column="id",
+                include_columns=["name"],
+            )
+        ]
+        sql, dim_cols = build_enriched_view_sql(
+            view_fqn='lake.typed."enriched_csv__orders"',
+            fact_fqn='lake.typed."csv__orders"',
+            dimension_joins=joins,
+            # The fact ALREADY carries a column literally named "customer_id__name".
+            fact_column_names=("order_id", "customer_id", "customer_id__name"),
+        )
+        # The dim column is suffixed; the f.* passthrough keeps the bare name.
+        assert [c.name for c in dim_cols] == ["customer_id__name_2"]
+        assert dim_cols[0].source_column_name == "name"
+        assert 'AS "customer_id__name_2"' in sql
+
     def test_same_dim_table_joined_twice_produces_unique_column_names(self):
         """Same dimension table joined via two different FK columns gets distinct column names."""
         joins = [

--- a/packages/engine/tests/unit/analysis/views/test_served_columns.py
+++ b/packages/engine/tests/unit/analysis/views/test_served_columns.py
@@ -1,0 +1,57 @@
+"""Tests for the enriched-view served-column read helpers (DAT-811)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from dataraum.analysis.views.served_columns import enriched_dimension_columns
+from dataraum.storage import Column, Source, Table
+
+
+def test_enriched_dimension_columns_excludes_fact_passthrough(session):
+    """Only ``origin='dimension'`` columns surface.
+
+    An enriched view registers the fact's own ``f.*`` passthrough columns
+    (``origin='fact'``) under the SAME ``view_table_id`` (DAT-811). The helper is the
+    single home of the ``origin='dimension'`` filter that all three dims-only consumers
+    (slicing, enriched derived columns, dimension_coverage) call — so a coexisting
+    fact-origin sibling here proves the filter discriminates for all of them at once
+    (dropping it would surface the fact column and this test would fail).
+    """
+    src = Source(source_id=str(uuid4()), name="csv", source_type="csv")
+    session.add(src)
+    session.flush()
+    view_table = Table(
+        table_id=str(uuid4()),
+        source_id=src.source_id,
+        table_name="enriched_orders",
+        layer="enriched",
+        duckdb_path="enriched_orders",
+        row_count=3,
+    )
+    session.add(view_table)
+    session.flush()
+    session.add_all(
+        [
+            Column(
+                column_id=str(uuid4()),
+                table_id=view_table.table_id,
+                column_name="customer_id__country",
+                column_position=0,
+                origin="dimension",
+            ),
+            # A fact-origin passthrough sibling under the same view_table_id.
+            Column(
+                column_id=str(uuid4()),
+                table_id=view_table.table_id,
+                column_name="amount",
+                column_position=1,
+                origin="fact",
+            ),
+        ]
+    )
+    session.flush()
+
+    got = enriched_dimension_columns(session, view_table.table_id)
+
+    assert [c.column_name for c in got] == ["customer_id__country"]

--- a/packages/engine/tests/unit/entropy/test_dimension_coverage.py
+++ b/packages/engine/tests/unit/entropy/test_dimension_coverage.py
@@ -173,6 +173,72 @@ class TestLoadData:
         assert "enriched_view" not in ctx.analysis_results
 
 
+class TestLoadNullRatesFiltersOrigin:
+    def test_fact_origin_columns_are_excluded(self, session):
+        """DAT-811: the enriched view now also registers the fact's own f.* columns
+        (origin='fact'); coverage measures only the JOINED dimensions. ``_load_null_rates``
+        returns the dim column and NEVER the fact-origin sibling under the SAME
+        view_table_id — a real-session proof the ``origin='dimension'`` filter discriminates
+        (a regression dropping it would surface the fact column here)."""
+        from uuid import uuid4
+
+        from dataraum.analysis.statistics.db_models import StatisticalProfile
+        from dataraum.storage import Column, Source, Table
+
+        src = Source(source_id=str(uuid4()), name="csv", source_type="csv")
+        session.add(src)
+        session.flush()
+        view_table = Table(
+            table_id=str(uuid4()),
+            source_id=src.source_id,
+            table_name="enriched_orders",
+            layer="enriched",
+            duckdb_path="enriched_orders",
+            row_count=10,
+        )
+        session.add(view_table)
+        session.flush()
+
+        dim = Column(
+            column_id=str(uuid4()),
+            table_id=view_table.table_id,
+            column_name="customers__country",
+            column_position=0,
+            origin="dimension",
+        )
+        fact = Column(
+            column_id=str(uuid4()),
+            table_id=view_table.table_id,
+            column_name="amount",
+            column_position=1,
+            origin="fact",
+        )
+        session.add_all([dim, fact])
+        session.flush()
+        for col, nr in ((dim, 0.2), (fact, 0.9)):
+            session.add(
+                StatisticalProfile(
+                    profile_id=str(uuid4()),
+                    column_id=col.column_id,
+                    run_id="run-1",
+                    layer="enriched",
+                    total_count=10,
+                    null_count=int(nr * 10),
+                    null_ratio=nr,
+                    profile_data={},
+                )
+            )
+        session.flush()
+
+        view = MagicMock()
+        view.view_table_id = view_table.table_id
+        ctx = DetectorContext(view_name="enriched_orders", session=session)
+
+        rates = DimensionCoverageDetector._load_null_rates(ctx, view)
+
+        assert rates == {"customers__country": 0.2}  # the fact-origin 'amount' is excluded
+
+
 class TestQueryFallback:
     def test_no_duckdb_conn_returns_1(self, detector: DimensionCoverageDetector):
         """Without duckdb_conn, null rate defaults to 1.0 (worst case)."""

--- a/packages/engine/tests/unit/pipeline/test_slicing_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_slicing_phase.py
@@ -158,12 +158,14 @@ def _seed(
                 column_name="invoice_id__date",
                 column_position=0,
                 resolved_type="DATE",
+                origin="dimension",
             ),
             Column(
                 table_id=view_table.table_id,
                 column_name="invoice_id__status",
                 column_position=1,
                 resolved_type="VARCHAR",
+                origin="dimension",
             ),
         ]
     )

--- a/packages/engine/tests/unit/pipeline/test_surrogate_mint_phase.py
+++ b/packages/engine/tests/unit/pipeline/test_surrogate_mint_phase.py
@@ -692,7 +692,7 @@ def test_semantic_to_mint_to_enriched_join_holds_grain(session, lake) -> None:
         'LEFT JOIN lake.typed."coa" d ON f."account" = d."account_name"'
     ).fetchone()
     assert fanout is not None and fanout[0] == 10  # what the naive join would do
-    assert dim_cols == ["_sk__account__business_id__account_type"]
+    assert [c.name for c in dim_cols] == ["_sk__account__business_id__account_type"]
     # The enriched view serves the correct discriminator, grain-safe.
     typed = lake.execute(
         'SELECT DISTINCT "_sk__account__business_id__account_type" '


### PR DESCRIPTION
## What & why

DAT-811. An enriched view is `SELECT f.* + joined dim columns`. Before this, only the dim columns got catalog `Column` rows, and even those were filtered out of the read surface (`current_columns` is `layer='typed'`), so **`og_columns` over an enriched `table_id` returned 0 rows** — the view had a table vertex (DAT-774) but no columns the catalog could see. This is the substrate DAT-812 (header-dated `days_in_period` cadence) is blocked on.

Now every enriched view is **self-describing**: each served column is a real `Column` row carrying a relational `source_column_id` to its typed source, and `og_columns` returns the full set with semantics resolved through that link — no walk back to origin tables.

## The model

- **Two new `columns` fields** (additive): `origin` — a CHECK-enforced enum `'fact' | 'dimension'` (NULL on base columns); `source_column_id` — a self-FK (`ON DELETE SET NULL`, indexed) to the typed source column an enriched column projects.
- **The enriched_views phase registers every served column** — the fact's own `f.*` passthrough columns (`origin='fact'`) and the joined dim columns (`origin='dimension'`) — resolved **forward from the join recipe**, never by parsing the `{fk}__{col}` name (which collides). Enriched columns keep their **own** `column_id` (the property-graph vertex KEY stays unique); f.* columns are not re-profiled (their stats equal the source's on the grain-preserving view).
- **`og_columns` UNIONs a new `current_enriched_columns` read view**: enriched columns resolve `semantic_role` / `materialization` / `anchor_time_axis` through `source_column_id`.
- **Passthrough (no-dim) views are full catalog citizens too** — a `SELECT *` view registers its `f.*` columns and sets `view_table_id`, so `og_tables` emits an enriched vertex for every fact and no consumer special-cases "no enriched view".
- The three dims-only consumers (`slicing`, `derived_columns`, `dimension_coverage`) filter `origin='dimension'` and are behaviorally unchanged.

## Scope boundary

No metric-value change. `period_resolver` — the one production `og_columns` reader — scopes to the typed fact id, so the new enriched rows are invisible to it. Consuming this substrate (period_resolver cadence + additivity_resolver retire) is **DAT-812**.

## Verification

- Full unit suite (**2156**) + full integration suite (**275**) green; mypy clean; schema/read/graph DDL + cockpit drizzle mirror regenerated in lockstep.
- Both reviewers (senior + spec-compliance) run; findings fixed (source-FK index, builder column-name uniqueness, real-session exclusion test).
- **Live smoke on the real finance corpus** (begin_session, real LLM): `og_columns` returns 5–14 columns per enriched view (was 0); 64/64 enriched columns linked to a typed source; passthrough `enriched_journal_entries` fully registered; `journal_lines` measures resolve **flow** + anchor `entry_id__date` (the header date), and that axis resolves to `journal_entries.date` at cadence `day` — the DAT-812 substrate, confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)