### PR TITLE
DAT-815: Phase 2 — DuckLake catalog schema per workspace, one catalog DB per installation

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -124,9 +124,11 @@ jobs:
                   # workspace 1's parquet under s3://<bucket>/<ws>/lake, and DuckLake
                   # resolves DATA_PATH eagerly against the catalog — so the cockpit's
                   # READ_ONLY ATTACH must point at the SAME per-workspace prefix, not
-                  # the old shared s3://<bucket>/lake. Catalog DB stays the base name
-                  # (workspace 1 uses ${DUCKLAKE_CATALOG_DB}; the _<n> suffix is for
-                  # the multi-workspace profile only).
+                  # the old shared s3://<bucket>/lake. The catalog DB is the ONE
+                  # installation-wide database (DAT-815); the cockpit selects the
+                  # workspace's catalog via the ws_<id> METADATA_SCHEMA it derives
+                  # from DATARAUM_WORKSPACE_ID — the same schema the engine-worker
+                  # bootstrapped above.
                   DATARAUM_LAKE_PATH: s3://dataraum-lake/00000000-0000-0000-0000-000000000001/lake
                   DUCKLAKE_CATALOG_URL: postgresql://dataraum:dataraum@127.0.0.1:5432/dataraum_lake_catalog
                   ANTHROPIC_API_KEY: sk-ant-placeholder-replace-me

--- a/docs/adr/0012-per-workspace-tenancy.md
+++ b/docs/adr/0012-per-workspace-tenancy.md
@@ -1,8 +1,12 @@
 # ADR-0012 — Per-workspace tenancy: registry source-of-truth, one container/queue/catalog/prefix per workspace
 
-- **Status:** Accepted
+- **Status:** Accepted — lake clause amended 2026-07-19 by DAT-815 (epic DAT-813,
+  design doc Confluence DD/51740673): the per-workspace catalog DATABASE became a
+  per-workspace catalog SCHEMA (`METADATA_SCHEMA`) in ONE installation-wide
+  catalog database. Isolation properties unchanged (independent snapshot chains
+  per schema — spike DAT-814); provisioning/teardown became transactional SQL.
 - **Date:** 2026-06-15
-- **Ticket:** DAT-505 (epic DAT-501)
+- **Ticket:** DAT-505 (epic DAT-501); lake clause revised by DAT-815 (epic DAT-813)
 - **Design doc:** Confluence DD/34045953 §1
 
 ## Context
@@ -29,9 +33,13 @@ prefix:
   guards collapse to ONE boot-time assertion (env workspace ↔ queue name) in
   `bootstrap_workspace` — a payload for another workspace never reaches this
   worker, so the per-activity defence is redundant.
-- **Lake:** per-workspace DuckLake catalog DATABASE + `s3://<bucket>/<ws>/lake`
-  (never a shared catalog schema). The cockpit READ_ONLY-ATTACHes the active
-  workspace's catalog.
+- **Lake** (as amended by DAT-815): per-workspace DuckLake catalog SCHEMA —
+  `ws_<id>` inside the ONE installation-wide catalog database, selected via
+  `METADATA_SCHEMA` on the ATTACH and created by the ATTACH itself — plus
+  `s3://<bucket>/<ws>/lake`. The cockpit READ_ONLY-ATTACHes the active
+  workspace's catalog schema. (DAT-505 originally allocated a catalog DATABASE
+  per workspace; the DAT-814 spike verified schemas give the same isolation —
+  independent snapshot chains — with transactional provisioning.)
 - **Uploads:** staged under `s3://<bucket>/<ws>/uploads/<digest>/<file>`; the
   upload digest salt reads the registry workspace id.
 - **Vertical:** `workspaces.vertical` (a WORKSPACE property) + a boot-read of it.
@@ -40,14 +48,17 @@ prefix:
 - **Compose:** the engine-worker is parameterized per workspace via YAML anchors;
   a second workspace lives behind the `multi-workspace` profile.
 - **Deletion sweep:** `packages/infra/scripts/delete-workspace.sh` — stop
-  container → drop `ws_<id>` + `ws_<id>_read` schemas → drop catalog DB → delete
-  the `s3://<bucket>/<ws>/` prefix → cockpit_db rows (or `--soft` → `archived_at`).
+  container → drop `ws_<id>` + `ws_<id>_read` schemas → drop the `ws_<id>`
+  catalog schema in the shared catalog DB (DAT-815) → delete the
+  `s3://<bucket>/<ws>/` prefix → cockpit_db rows (or `--soft` → `archived_at`).
 
 ## Consequences
 
 - Two workspaces run side by side with zero cross-talk: distinct queues, schemas,
-  catalog DBs, and S3 prefixes. "Create a workspace" in dev = a registry insert +
-  a compose service that derives the four routing knobs from its workspace id.
+  catalog schemas, and S3 prefixes. "Create a workspace" in dev = a registry
+  insert + a compose service that derives the three routing knobs (workspace id,
+  queue, lake prefix) from its workspace id — the catalog URL is installation-wide
+  common env since DAT-815.
 - The engine's workspace-isolation surface is one boot assertion, not 8 scattered
   guards. A misconfigured container (queue ↔ workspace mismatch) fails loud at
   boot, before it advertises itself as polling.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -83,10 +83,11 @@ per service.
 
 A [workspace](../platform/architecture.md#the-per-workspace-model) is the unit of
 isolation — its own engine container, Temporal queue (`engine-<id>`), Postgres schema
-(`ws_<id>`), DuckLake catalog DB, and `s3://bucket/<id>/` prefix. The
+(`ws_<id>`), DuckLake catalog schema (`ws_<id>` in the installation-wide catalog DB),
+and `s3://bucket/<id>/` prefix. The
 `x-engine-worker-base` anchor in `docker-compose.yml` is the per-workspace template:
 adding a workspace is a registry row plus one more engine service that merges the anchor
-and overrides the four routing knobs (workspace id, queue, catalog DB, lake prefix). The
+and overrides the three routing knobs (workspace id, queue, lake prefix). The
 cockpit is a **single** app that routes each request to the right workspace by the
 registry.
 

--- a/docs/platform/architecture.md
+++ b/docs/platform/architecture.md
@@ -70,7 +70,7 @@ flowchart LR
 | `ws_<id>` schema | engine (SQLAlchemy) | per-workspace metadata: tables, columns, semantics, relationships, readiness, lifecycle artifacts |
 | `ws_<id>_read` schema | engine | the promoted read views the cockpit is allowed to see |
 | `cockpit_db` | cockpit (Drizzle) | the cockpit's own state: workspace registry, chat history, UI state |
-| `<catalog>` database(s) | engine | one DuckLake catalog database per workspace |
+| `<catalog>` database | engine | the ONE installation-wide DuckLake catalog database; each workspace's catalog is its own `ws_<id>` schema inside it (`METADATA_SCHEMA` on ATTACH) |
 | `temporal` / `temporal_visibility` | Temporal | durable workflow state |
 
 **Object store (S3)** — the data lake lives here, not on a local disk. The engine writes
@@ -137,7 +137,7 @@ flowchart TB
         C["1 engine container"]
         Q["1 Temporal task queue<br/>engine-&lt;id&gt;"]
         SCH["1 Postgres schema<br/>ws_&lt;id&gt;"]
-        CAT["1 DuckLake catalog DB"]
+        CAT["1 DuckLake catalog schema<br/>in the shared catalog DB"]
         LAKE["1 S3 prefix<br/>s3://bucket/&lt;id&gt;/"]
     end
 ```

--- a/packages/cockpit/.env.example
+++ b/packages/cockpit/.env.example
@@ -26,12 +26,15 @@ DATARAUM_CONFIG_PATH=../dataraum-config
 
 # DuckLake DATA_PATH — the s3:// URI the engine writes parquet to and the
 # cockpit reads READ_ONLY. Must match the engine's DUCKLAKE_DATA_PATH exactly
-# (DAT-388). The bucket path is the same from host or in-container.
-DATARAUM_LAKE_PATH=s3://dataraum-lake/lake
+# (DAT-388) — per-workspace prefix s3://<bucket>/<ws>/lake since DAT-505. The
+# bucket path is the same from host or in-container.
+DATARAUM_LAKE_PATH=s3://dataraum-lake/00000000-0000-0000-0000-000000000001/lake
 
-# DuckLake catalog (Postgres) — the cockpit ATTACHes it READ_ONLY to read
-# committed lake snapshots (run_sql, schema-sniff). Must point at the engine's
-# DuckLake catalog DB. Required by src/config.ts (no default).
+# DuckLake catalog (Postgres) — the ONE installation-wide catalog database
+# (DAT-815). The cockpit ATTACHes it READ_ONLY to read committed lake
+# snapshots (run_sql, schema-sniff); the workspace's catalog within it is the
+# ws_<id> METADATA_SCHEMA derived from DATARAUM_WORKSPACE_ID — no
+# per-workspace DB name in this URL. Required by src/config.ts (no default).
 DUCKLAKE_CATALOG_URL=postgres://dataraum:dataraum@localhost:5432/dataraum_lake_catalog
 
 # --- Object store (DAT-388; required) ---

--- a/packages/cockpit/src/duckdb/lake.ts
+++ b/packages/cockpit/src/duckdb/lake.ts
@@ -11,12 +11,12 @@
 // Postgres catalog and writes immutable parquet snapshots to DATA_PATH. A
 // reader on a SEPARATE process/instance (this cockpit) ATTACHing the same
 // catalog observes the latest COMMITTED snapshot — it does not share the
-// engine's in-memory write buffer. Two consequences, both acceptable for the
-// read verbs: (1) writes the engine has buffered but not CHECKPOINTed are not
-// yet visible here; the engine checkpoints at activity boundaries, so the
-// cockpit reads stage-complete state, which is exactly what the chat agent
-// reasons over. (2) Opening READ_ONLY means the cockpit never contends for the
-// catalog's write path. See the DAT-367 PR body for the full caveat.
+// engine's in-memory write buffer. Visibility is per committed snapshot, NOT
+// per CHECKPOINT (verified in the DAT-814 spike): small committed INSERTs land
+// as inlined data in the catalog itself and are readable here before the
+// engine flushes them to parquet, so the cockpit reads everything the engine
+// has committed. Uncommitted writes stay invisible, and opening READ_ONLY
+// means the cockpit never contends for the catalog's write path.
 //
 // Lifecycle: ONE lazily-opened, bootstrapped instance per process; a FRESH
 // connection PER request. A DuckDB connection runs statements serially — it is
@@ -35,7 +35,11 @@ import { type DuckDBConnection, DuckDBInstance } from "@duckdb/node-api";
 
 import { config } from "../config";
 import { applyS3Secret } from "./s3-secret";
-import { buildDucklakeAttachSql, escapeSqlLiteral } from "./sql-escape";
+import {
+	buildDucklakeAttachSql,
+	ducklakeMetadataSchemaFor,
+	escapeSqlLiteral,
+} from "./sql-escape";
 
 // Alias the DuckLake catalog is ATTACHed under. Matches the engine's
 // `LAKE_CATALOG_ALIAS` so fully-qualified names (`lake.typed.orders`) resolve
@@ -54,10 +58,15 @@ let instancePromise: Promise<DuckDBInstance> | null = null;
  * {@link getLakeConnection}/{@link withLakeConnection}, never re-attach.
  */
 async function attachLakeReadOnly(conn: DuckDBConnection): Promise<void> {
+	// One catalog DB per installation (DAT-815): the workspace's catalog is the
+	// ws_<id> METADATA_SCHEMA inside it, derived from the cockpit's boot
+	// identity — the same schema the engine's writer ATTACH names for this
+	// workspace, so reader and writer see one catalog.
 	const attachSql = buildDucklakeAttachSql(
 		LAKE_ALIAS,
 		config.ducklakeCatalogUrl,
 		config.dataraumLakePath,
+		ducklakeMetadataSchemaFor(config.dataraumWorkspaceId),
 	);
 
 	// The container image pre-bakes ducklake at DUCKDB_EXTENSION_DIRECTORY and

--- a/packages/cockpit/src/duckdb/sql-escape.test.ts
+++ b/packages/cockpit/src/duckdb/sql-escape.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	buildDucklakeAttachSql,
+	ducklakeMetadataSchemaFor,
 	escapeSqlLiteral,
 	pgUrlToLibpq,
 } from "./sql-escape";
@@ -62,6 +63,21 @@ describe("escapeSqlLiteral (DAT-386 — DuckDB doubles quotes, backslash is lite
 	});
 });
 
+describe("ducklakeMetadataSchemaFor (DAT-815)", () => {
+	it("derives ws_<id> with dashes as underscores, mirroring the engine", () => {
+		// Must agree with the engine's `schema_name_for` (server/workspace.py):
+		// the engine's writer ATTACH names this exact schema, and a divergent
+		// derivation would point the cockpit reader at a different catalog.
+		expect(
+			ducklakeMetadataSchemaFor("00000000-0000-0000-0000-000000000001"),
+		).toBe("ws_00000000_0000_0000_0000_000000000001");
+	});
+
+	it("keeps a dash-free id verbatim under the ws_ prefix", () => {
+		expect(ducklakeMetadataSchemaFor("test")).toBe("ws_test");
+	});
+});
+
 describe("buildDucklakeAttachSql (DAT-367 escaping fix)", () => {
 	it("builds a well-formed ATTACH for clean credentials", () => {
 		expect(
@@ -69,11 +85,13 @@ describe("buildDucklakeAttachSql (DAT-367 escaping fix)", () => {
 				"lake",
 				"postgresql://dataraum:dataraum@postgres:5432/lake_catalog",
 				"s3://dataraum-lake/lake",
+				"ws_00000000_0000_0000_0000_000000000001",
 			),
 		).toBe(
 			"ATTACH 'ducklake:postgres:dbname=lake_catalog host=postgres port=5432 " +
 				"user=dataraum password=dataraum' AS lake " +
-				"(DATA_PATH 's3://dataraum-lake/lake', READ_ONLY)",
+				"(DATA_PATH 's3://dataraum-lake/lake', " +
+				"METADATA_SCHEMA 'ws_00000000_0000_0000_0000_000000000001', READ_ONLY)",
 		);
 	});
 
@@ -86,12 +104,15 @@ describe("buildDucklakeAttachSql (DAT-367 escaping fix)", () => {
 			"lake",
 			"postgresql://u:pa%20ss@h:5432/db",
 			"/data",
+			"ws_test",
 		);
 		expect(sql).toContain("password=''pa ss''");
 		// The outer literal stays balanced: exactly one unescaped opening quote
-		// after ATTACH and the only unescaped quotes wrap the two literals.
+		// after ATTACH and the only unescaped quotes wrap the literals.
 		expect(sql.startsWith("ATTACH 'ducklake:postgres:")).toBe(true);
-		expect(sql).toContain("' AS lake (DATA_PATH '/data', READ_ONLY)");
+		expect(sql).toContain(
+			"' AS lake (DATA_PATH '/data', METADATA_SCHEMA 'ws_test', READ_ONLY)",
+		);
 	});
 
 	it("escapes a quote in the data path by doubling it; backslash stays literal", () => {
@@ -99,7 +120,22 @@ describe("buildDucklakeAttachSql (DAT-367 escaping fix)", () => {
 			"lake",
 			"postgresql://u:p@h:5432/db",
 			"/da'ta\\x",
+			"ws_test",
 		);
-		expect(sql).toContain("(DATA_PATH '/da''ta\\x', READ_ONLY)");
+		expect(sql).toContain(
+			"(DATA_PATH '/da''ta\\x', METADATA_SCHEMA 'ws_test', READ_ONLY)",
+		);
+	});
+
+	it("escapes a quote in the metadata schema by doubling it", () => {
+		// The schema comes from a derivation over the workspace id, but the
+		// builder must not rely on that: it is the escaping seam.
+		const sql = buildDucklakeAttachSql(
+			"lake",
+			"postgresql://u:p@h:5432/db",
+			"/data",
+			"ws'x",
+		);
+		expect(sql).toContain("METADATA_SCHEMA 'ws''x'");
 	});
 });

--- a/packages/cockpit/src/duckdb/sql-escape.ts
+++ b/packages/cockpit/src/duckdb/sql-escape.ts
@@ -52,26 +52,43 @@ export function escapeSqlLiteral(value: string): string {
 }
 
 /**
+ * The workspace's Postgres schema inside the installation-wide DuckLake
+ * catalog database (DAT-815) — `ws_<id>` with dashes as underscores, the same
+ * derivation as the engine's `schema_name_for` (server/workspace.py), which
+ * derives the METADATA_SCHEMA the engine's writer ATTACH names. The cockpit's
+ * READ_ONLY ATTACH must name the SAME schema or it reads a different (empty)
+ * catalog than the one the engine writes.
+ */
+export function ducklakeMetadataSchemaFor(workspaceId: string): string {
+	return `ws_${workspaceId.replaceAll("-", "_")}`;
+}
+
+/**
  * Build the DuckLake `ATTACH` statement for a Postgres catalog.
  *
- * BOTH single-quoted literals — the `ducklake:postgres:<libpq>` connection
- * string and the data path — are escaped. This matters for the connection
- * string: `pgUrlToLibpq` emits inner single quotes for any value containing
- * whitespace/quotes (e.g. `password='pa ss'`), and those must be doubled (`''`)
- * so they don't terminate the outer SQL literal. DuckDB collapses each `''`
- * back to one `'` before handing the string to its postgres connector, so the
- * libpq quoting survives intact. (Escaping only the data path and interpolating
- * the libpq string raw was a real bug: a space or quote in the catalog
- * credentials produced malformed/injectable ATTACH SQL.)
+ * The catalog database is ONE per installation; `metadataSchema` selects the
+ * workspace's catalog schema within it (DAT-815, `ducklakeMetadataSchemaFor`).
+ *
+ * ALL single-quoted literals — the `ducklake:postgres:<libpq>` connection
+ * string, the data path, and the metadata schema — are escaped. This matters
+ * for the connection string: `pgUrlToLibpq` emits inner single quotes for any
+ * value containing whitespace/quotes (e.g. `password='pa ss'`), and those must
+ * be doubled (`''`) so they don't terminate the outer SQL literal. DuckDB
+ * collapses each `''` back to one `'` before handing the string to its
+ * postgres connector, so the libpq quoting survives intact. (Escaping only the
+ * data path and interpolating the libpq string raw was a real bug: a space or
+ * quote in the catalog credentials produced malformed/injectable ATTACH SQL.)
  */
 export function buildDucklakeAttachSql(
 	alias: string,
 	catalogUrl: string,
 	lakePath: string,
+	metadataSchema: string,
 ): string {
 	const connStr = escapeSqlLiteral(
 		`ducklake:postgres:${pgUrlToLibpq(catalogUrl)}`,
 	);
 	const dataPath = escapeSqlLiteral(lakePath);
-	return `ATTACH '${connStr}' AS ${alias} (DATA_PATH '${dataPath}', READ_ONLY)`;
+	const schema = escapeSqlLiteral(metadataSchema);
+	return `ATTACH '${connStr}' AS ${alias} (DATA_PATH '${dataPath}', METADATA_SCHEMA '${schema}', READ_ONLY)`;
 }

--- a/packages/engine/docker/postgres-init/init-databases.sh
+++ b/packages/engine/docker/postgres-init/init-databases.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-# Postgres first-boot init: create the per-workspace DuckLake catalog databases
-# + the cockpit_db database alongside the primary platform database. The primary
-# db (`$POSTGRES_DB`) is created by the official postgres image; this script adds
-# the catalog DBs and `$COCKPIT_DB`.
+# Postgres first-boot init: create the installation-wide DuckLake catalog
+# database + the cockpit_db database alongside the primary platform database.
+# The primary db (`$POSTGRES_DB`) is created by the official postgres image;
+# this script adds `$DUCKLAKE_CATALOG_DB` and `$COCKPIT_DB`.
 #
-# Per-workspace catalogs (DAT-505): each workspace's engine worker ATTACHes its
-# OWN DuckLake catalog DB — never a shared one. Workspace 1 uses
-# `$DUCKLAKE_CATALOG_DB`; the dev `multi-workspace` compose profile's workspace 2
-# uses `${DUCKLAKE_CATALOG_DB}_2`. Both are created here so the worker's ATTACH
-# finds its catalog whether or not the second workspace is brought up (creating
-# an unused DB is harmless; an ATTACH to a missing one fails loud at boot). A new
-# dev workspace = add its `_<n>` catalog to the list below + a compose service.
+# ONE catalog database per installation (DAT-815): every workspace's DuckLake
+# catalog lives in `$DUCKLAKE_CATALOG_DB` as its own Postgres schema, selected
+# via METADATA_SCHEMA on the ATTACH (`ws_<id>`, derived from the workspace id
+# at boot). The ATTACH creates the schema itself (spike DAT-814), so nothing is
+# allocated per workspace here — a new workspace needs no Postgres first-boot
+# step at all. Teardown drops the workspace's schema
+# (packages/infra/scripts/delete-workspace.sh), never this database.
 set -euo pipefail
 
 : "${DUCKLAKE_CATALOG_DB:?DUCKLAKE_CATALOG_DB must be set on the postgres service}"
@@ -18,6 +18,5 @@ set -euo pipefail
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
     CREATE DATABASE "$DUCKLAKE_CATALOG_DB";
-    CREATE DATABASE "${DUCKLAKE_CATALOG_DB}_2";
     CREATE DATABASE "$COCKPIT_DB";
 EOSQL

--- a/packages/engine/src/dataraum/core/settings.py
+++ b/packages/engine/src/dataraum/core/settings.py
@@ -47,6 +47,11 @@ class Settings(BaseSettings):
     # ``postgresql+psycopg://``; DuckDB's postgres extension wants the bare
     # ``postgresql://`` libpq form) and a parsed DSN type would re-serialize them.
     database_url: str
+    # ONE installation-wide DuckLake catalog database (DAT-815): every
+    # workspace's catalog lives in it as its own Postgres schema, selected via
+    # METADATA_SCHEMA at ATTACH time (ws_<id>, derived from
+    # ``dataraum_workspace_id`` in the worker bootstrap — never a per-workspace
+    # env var, and no per-workspace DB name in this URL).
     ducklake_catalog_url: str
     # ``str``, NOT ``Path``: this is a DuckLake DATA_PATH, an ``s3://bucket/prefix``
     # URI in production (DAT-388). ``Path`` collapses ``s3://`` to ``s3:/`` and

--- a/packages/engine/src/dataraum/server/storage.py
+++ b/packages/engine/src/dataraum/server/storage.py
@@ -1,7 +1,11 @@
 """DuckLake bootstrap and shared in-memory anchor for the worker process.
 
 DuckLake stores data as parquet files on an object store (DATA_PATH is an
-``s3://`` URI — DAT-388) with metadata in a Postgres catalog database. DuckDB
+``s3://`` URI — DAT-388) with metadata in a Postgres catalog database. The
+catalog database is ONE per installation (DAT-815): each workspace's catalog
+lives in it as its own Postgres schema, selected via ``METADATA_SCHEMA`` on
+the ATTACH. Snapshot chains are independent per schema, so workspaces share
+the database without sharing any catalog state (spike DAT-814). DuckDB
 clients access DuckLake by ATTACHing the catalog as an external database; the
 connection must first register the S3 secret + ``httpfs`` (see
 :func:`apply_s3_secret`) so DuckLake can resolve the ``s3://`` DATA_PATH.
@@ -228,7 +232,7 @@ def apply_s3_secret(conn: duckdb.DuckDBPyConnection, *, disable_local_fs: bool =
         conn.execute("SET disabled_filesystems='LocalFileSystem'")
 
 
-def bootstrap_lake(catalog_url: str, data_path: str) -> None:
+def bootstrap_lake(catalog_url: str, data_path: str, metadata_schema: str) -> None:
     """Open the process-wide DuckLake anchor.
 
     Idempotent: subsequent calls with the anchor already open are a no-op.
@@ -237,11 +241,18 @@ def bootstrap_lake(catalog_url: str, data_path: str) -> None:
     inaccessible, or the ATTACH fails.
 
     Args:
-        catalog_url: Postgres connection URL for the DuckLake catalog
-            (``postgresql://...``).
+        catalog_url: Postgres connection URL for the installation-wide DuckLake
+            catalog database (``postgresql://...``). ONE database per
+            installation (DAT-815); the workspace split happens via
+            ``metadata_schema``, not per-workspace DB names.
         data_path: ``s3://`` URI where DuckLake writes parquet files. The bucket
             must exist; the object-store secret is registered via
             :func:`apply_s3_secret` here, before the ATTACH.
+        metadata_schema: Postgres schema inside the catalog database that holds
+            THIS workspace's ``ducklake_*`` metadata tables (``ws_<id>``,
+            derived from the boot workspace id — ``schema_name_for``). The
+            ATTACH creates the schema itself on first use; no separate
+            ``CREATE SCHEMA`` step exists anywhere (spike DAT-814).
 
     Raises:
         RuntimeError: If bootstrap fails. The original DuckDB exception is
@@ -275,9 +286,10 @@ def bootstrap_lake(catalog_url: str, data_path: str) -> None:
 
         libpq = _pg_url_to_libpq(catalog_url)
         safe_data_path = _escape_sql_literal(data_path)
+        safe_metadata_schema = _escape_sql_literal(metadata_schema)
         attach_sql = (
             f"ATTACH 'ducklake:postgres:{libpq}' AS {LAKE_CATALOG_ALIAS} "
-            f"(DATA_PATH '{safe_data_path}')"
+            f"(DATA_PATH '{safe_data_path}', METADATA_SCHEMA '{safe_metadata_schema}')"
         )
         settings = get_settings()
         pool_max = settings.ducklake_pg_pool_max
@@ -329,7 +341,8 @@ def bootstrap_lake(catalog_url: str, data_path: str) -> None:
             # test double recording call args — defers the close indefinitely).
             conn.close()
             raise RuntimeError(
-                f"DuckLake bootstrap failed (catalog_url={catalog_url}, data_path={data_path}): {e}"
+                f"DuckLake bootstrap failed (catalog_url={catalog_url}, "
+                f"data_path={data_path}, metadata_schema={metadata_schema}): {e}"
             ) from e
 
         _anchor = conn
@@ -337,6 +350,7 @@ def bootstrap_lake(catalog_url: str, data_path: str) -> None:
             "ducklake_bootstrapped",
             catalog_url=catalog_url,
             data_path=data_path,
+            metadata_schema=metadata_schema,
             pg_pool_max=pool_max,
         )
 

--- a/packages/engine/src/dataraum/worker/bootstrap.py
+++ b/packages/engine/src/dataraum/worker/bootstrap.py
@@ -23,7 +23,7 @@ from dataraum.server.overlay_resolver import (
     uninstall_overlay_resolver,
 )
 from dataraum.server.storage import bootstrap_lake, teardown_lake
-from dataraum.server.workspace import bootstrap_workspace
+from dataraum.server.workspace import bootstrap_workspace, schema_name_for
 
 logger = get_logger(__name__)
 
@@ -41,7 +41,17 @@ def bootstrap_worker_substrate() -> ConnectionManager:
     initializes its ``ws_<id>`` schema.
     """
     settings = get_settings()
-    bootstrap_lake(settings.ducklake_catalog_url, settings.ducklake_data_path)
+    # The catalog DB is installation-wide (DAT-815); this workspace's catalog
+    # lives in it as METADATA_SCHEMA ws_<id> — the SAME ws_<id> derivation as
+    # the primary-DB metadata schema, in a DIFFERENT database. schema_name_for
+    # is pure and validates the id, so deriving it here (before
+    # bootstrap_workspace sets the module pointer) is safe and fails loud on a
+    # malformed workspace id before the ATTACH.
+    bootstrap_lake(
+        settings.ducklake_catalog_url,
+        settings.ducklake_data_path,
+        metadata_schema=schema_name_for(settings.dataraum_workspace_id),
+    )
 
     # bootstrap_lake set the process-wide DuckLake anchor. If anything after it
     # fails, release the anchor (and any partially-opened manager) so a

--- a/packages/engine/tests/conftest.py
+++ b/packages/engine/tests/conftest.py
@@ -271,7 +271,21 @@ def _stub_s3_secret() -> Generator[None]:
 
 
 @pytest.fixture(scope="session")
-def lake_anchor(lake_catalog_url: str, lake_data_path: str):
+def lake_metadata_schema() -> str:
+    """The per-workspace catalog schema every test ATTACH uses (DAT-815).
+
+    Same ``ws_<id>`` derivation as production (the worker bootstrap derives it
+    from the boot workspace id), applied to the suite's fixed test workspace —
+    so the whole suite exercises the METADATA_SCHEMA path, never the implicit
+    ``public`` layout.
+    """
+    from dataraum.server.workspace import schema_name_for
+
+    return schema_name_for(os.environ["DATARAUM_WORKSPACE_ID"])
+
+
+@pytest.fixture(scope="session")
+def lake_anchor(lake_catalog_url: str, lake_data_path: str, lake_metadata_schema: str):
     """Bootstrap the DuckLake anchor once for the whole pytest invocation.
 
     Pairs the session-scoped lake catalog DB with a session-scoped tmp DATA_PATH.
@@ -279,13 +293,13 @@ def lake_anchor(lake_catalog_url: str, lake_data_path: str):
     """
     from dataraum.server.storage import bootstrap_lake, teardown_lake
 
-    bootstrap_lake(lake_catalog_url, lake_data_path)
+    bootstrap_lake(lake_catalog_url, lake_data_path, metadata_schema=lake_metadata_schema)
     yield
     teardown_lake()
 
 
 @pytest.fixture
-def no_anchor(lake_anchor, lake_catalog_url: str, lake_data_path: str):
+def no_anchor(lake_anchor, lake_catalog_url: str, lake_data_path: str, lake_metadata_schema: str):
     """Tear down the session anchor for one test; restore it after.
 
     Use this for "before bootstrap" tests so other session-scoped consumers of
@@ -296,7 +310,7 @@ def no_anchor(lake_anchor, lake_catalog_url: str, lake_data_path: str):
 
     teardown_lake()
     yield
-    bootstrap_lake(lake_catalog_url, lake_data_path)
+    bootstrap_lake(lake_catalog_url, lake_data_path, metadata_schema=lake_metadata_schema)
 
 
 def clean_lake_layers() -> None:

--- a/packages/engine/tests/unit/server/test_storage.py
+++ b/packages/engine/tests/unit/server/test_storage.py
@@ -207,10 +207,12 @@ class TestBootstrap:
         ).fetchall()
         assert rows == [(LAKE_CATALOG_ALIAS,)]
 
-    def test_bootstrap_is_idempotent(self, lake_anchor, lake_catalog_url, tmp_path):
+    def test_bootstrap_is_idempotent(
+        self, lake_anchor, lake_catalog_url, lake_metadata_schema, tmp_path
+    ):
         # Second call must not reopen, raise, or replace the anchor.
         first = get_anchor()
-        bootstrap_lake(lake_catalog_url, str(tmp_path))
+        bootstrap_lake(lake_catalog_url, str(tmp_path), metadata_schema=lake_metadata_schema)
         second = get_anchor()
         assert first is second
 
@@ -219,7 +221,29 @@ class TestBootstrap:
             bootstrap_lake(
                 "postgresql://nobody:nothing@127.0.0.1:1/no_such_db",
                 str(tmp_path),
+                metadata_schema="ws_test",
             )
+
+    def test_metadata_lands_in_named_schema(
+        self, lake_anchor, lake_catalog_url, lake_metadata_schema
+    ):
+        """DAT-815: the catalog's ``ducklake_*`` tables live in the per-workspace
+        METADATA_SCHEMA named on the ATTACH — created by the ATTACH itself, no
+        separate CREATE SCHEMA step — and ``public`` stays empty, which is what
+        lets ONE catalog database host every workspace's catalog side by side.
+        """
+        import psycopg
+
+        with psycopg.connect(lake_catalog_url, autocommit=True) as conn:
+            metadata_schemas = conn.execute(
+                "SELECT DISTINCT table_schema FROM information_schema.tables "
+                "WHERE table_name LIKE 'ducklake_%'"
+            ).fetchall()
+            public_tables = conn.execute(
+                "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public'"
+            ).fetchone()
+        assert metadata_schemas == [(lake_metadata_schema,)]
+        assert public_tables == (0,)
 
     def test_get_anchor_raises_before_bootstrap(self, no_anchor):
         with pytest.raises(RuntimeError, match="not bootstrapped"):

--- a/packages/infra/.env.example
+++ b/packages/infra/.env.example
@@ -7,7 +7,11 @@
 # `up`, which ignores it. See docker-compose.release.yml.
 # DATARAUM_VERSION=0.2.2
 
-# Postgres (platform + DuckLake catalog + cockpit_db)
+# Postgres (platform + DuckLake catalog + cockpit_db).
+# DUCKLAKE_CATALOG_DB is the ONE installation-wide DuckLake catalog database
+# (DAT-815): every workspace's catalog lives in it as its own ws_<id>
+# METADATA_SCHEMA, created by the worker's ATTACH — nothing is allocated per
+# workspace at Postgres first-boot.
 POSTGRES_USER=dataraum
 POSTGRES_PASSWORD=dataraum
 POSTGRES_DB=dataraum
@@ -20,20 +24,23 @@ COCKPIT_DB=cockpit_db
 # value for drizzle-kit pull + the metadata client.
 # Defaulted in docker-compose.yml; override here to use a different workspace.
 #
-# DAT-505: a workspace = one engine container + one task queue + one catalog DB
-# + one s3://<ws>/ prefix. The engine-worker container DERIVES, per workspace:
+# DAT-505: a workspace = one engine container + one task queue + one catalog
+# schema in the shared catalog DB (DAT-815) + one s3://<ws>/ prefix. The
+# engine-worker container DERIVES, per workspace:
 #   - TEMPORAL_TASK_QUEUE = engine-<DATARAUM_WORKSPACE_ID>  (asserted at boot)
 #   - DUCKLAKE_DATA_PATH  = s3://${S3_BUCKET}/<DATARAUM_WORKSPACE_ID>/lake
-#   - DUCKLAKE_CATALOG_URL → ${DUCKLAKE_CATALOG_DB} (workspace 1) / _2 (workspace 2)
+#   - DuckLake METADATA_SCHEMA = ws_<id> inside ${DUCKLAKE_CATALOG_DB} (derived
+#     at bootstrap — DUCKLAKE_CATALOG_URL is installation-wide common env)
 # The cockpit drivers route workflows to engine-<id> read from the cockpit_db
 # registry row — NOT a shared TEMPORAL_TASK_QUEUE (that var is gone for routing).
 DATARAUM_WORKSPACE_ID=00000000-0000-0000-0000-000000000001
 
-# Second workspace for the AC1 two-workspace side-by-side smoke (DAT-505). Only
+# Second workspace for the two-workspace side-by-side smoke (DAT-505/815). Only
 # used by the `multi-workspace` compose profile's engine-worker-2:
 #   docker compose --profile multi-workspace up -d
-# Its queue (engine-<id>), ws_<id> schema, catalog DB (${DUCKLAKE_CATALOG_DB}_2),
-# and s3://<ws2>/lake prefix are all isolated from workspace 1.
+# Its queue (engine-<id>), ws_<id> schema, ws_<id> catalog schema (in the SAME
+# ${DUCKLAKE_CATALOG_DB}), and s3://<ws2>/lake prefix are all isolated from
+# workspace 1.
 DATARAUM_WORKSPACE_ID_2=00000000-0000-0000-0000-000000000002
 
 # File sources are addressed by an s3:// URI on the object store (DAT-389) — no

--- a/packages/infra/docker-compose.yml
+++ b/packages/infra/docker-compose.yml
@@ -32,12 +32,12 @@
 # bring their own network policy.
 
 # ── Per-workspace engine-worker template (DAT-505) ─────────────────────────
-# A workspace = one engine container + one task queue + one catalog DB + one
-# s3://<ws>/ prefix. These anchors hold everything COMMON to every workspace's
-# worker; each per-workspace service (engine-worker, engine-worker-2, …) merges
-# them and overrides only the four routing knobs (workspace id, queue, catalog
-# DB, lake prefix). Adding a workspace in dev = a registry insert + one more
-# service that merges these anchors.
+# A workspace = one engine container + one task queue + one catalog schema in
+# the shared catalog DB (DAT-815) + one s3://<ws>/ prefix. These anchors hold
+# everything COMMON to every workspace's worker; each per-workspace service
+# (engine-worker, engine-worker-2, …) merges them and overrides only the three
+# routing knobs (workspace id, queue, lake prefix). Adding a workspace in dev =
+# a registry insert + one more service that merges these anchors.
 x-engine-worker-base: &engine-worker-base
   build:
     context: ../engine
@@ -59,10 +59,15 @@ x-engine-worker-base: &engine-worker-base
     - ${HOST_CONFIG_DIR:-../dataraum-config}:/opt/dataraum/config:ro
 
 # Env COMMON to every workspace's worker — the per-workspace service appends the
-# four routing overrides (workspace id, TEMPORAL_TASK_QUEUE, DUCKLAKE_CATALOG_URL,
-# DUCKLAKE_DATA_PATH). S3 creds are plain env (single source is .env).
+# three routing overrides (workspace id, TEMPORAL_TASK_QUEUE, DUCKLAKE_DATA_PATH).
+# S3 creds are plain env (single source is .env).
 x-engine-worker-env: &engine-worker-env
   DATABASE_URL: postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+  # ONE installation-wide DuckLake catalog DB (DAT-815), shared by every
+  # workspace's worker: the per-workspace split is the ws_<id> METADATA_SCHEMA
+  # the worker derives from its DATARAUM_WORKSPACE_ID at bootstrap — the URL
+  # carries no per-workspace DB name, so it is common env, not a routing knob.
+  DUCKLAKE_CATALOG_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${DUCKLAKE_CATALOG_DB}
   S3_ENDPOINT: ${S3_ENDPOINT}
   S3_REGION: ${S3_REGION:-us-east-1}
   S3_USE_SSL: ${S3_USE_SSL:-false}
@@ -106,11 +111,11 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
-      # Per-workspace DuckLake catalog databases (DAT-505): each workspace's
-      # worker ATTACHes its OWN catalog DB — never a shared one. init-databases.sh
-      # creates the base name + a `_<n>` per additional dev workspace. Workspace 1
-      # uses ${DUCKLAKE_CATALOG_DB}; the multi-workspace profile's workspace 2 uses
-      # ${DUCKLAKE_CATALOG_DB}_2.
+      # The ONE installation-wide DuckLake catalog database (DAT-815), created
+      # at postgres first-boot by init-databases.sh. Every workspace's catalog
+      # lives in it as its own ws_<id> METADATA_SCHEMA, created by the
+      # worker's ATTACH itself — no per-workspace DB (or schema) allocation
+      # anywhere in first-boot.
       DUCKLAKE_CATALOG_DB: ${DUCKLAKE_CATALOG_DB}
       # COCKPIT_DB is created at postgres first-boot by init-databases.sh
       # alongside the catalog DBs. Holds the cockpit's own state
@@ -305,12 +310,13 @@ services:
   # Engine Temporal activity worker (DAT-344, parameterized per workspace by
   # DAT-505). The engine is a pure activity worker — no HTTP port. ONE container
   # per workspace: it bootstraps that workspace's ConnectionManager + DuckLake
-  # anchor (materializing ws_<id> + its OWN catalog DB on its OWN s3://<ws>/lake
-  # prefix) and polls EXACTLY its own queue `engine-<workspace_id>`. The shared
-  # base (anchor below) carries everything common; each per-workspace service
-  # overrides the four routing knobs: workspace id, queue, catalog DB, lake
-  # prefix. "Create a workspace" in dev = a registry insert + adding such a
-  # service. Health = the worker heartbeat (`temporal worker list`), not a probe.
+  # anchor (materializing ws_<id> + its ws_<id> catalog schema in the shared
+  # catalog DB — DAT-815 — on its OWN s3://<ws>/lake prefix) and polls EXACTLY
+  # its own queue `engine-<workspace_id>`. The shared base (anchor below)
+  # carries everything common; each per-workspace service overrides the three
+  # routing knobs: workspace id, queue, lake prefix. "Create a workspace" in
+  # dev = a registry insert + adding such a service. Health = the worker
+  # heartbeat (`temporal worker list`), not a probe.
   engine-worker:
     <<: *engine-worker-base
     environment:
@@ -320,19 +326,17 @@ services:
       # this matches DATARAUM_WORKSPACE_ID at boot (server/workspace.py), and the
       # cockpit drivers route here from the registry row.
       TEMPORAL_TASK_QUEUE: engine-${DATARAUM_WORKSPACE_ID:-00000000-0000-0000-0000-000000000001}
-      # Per-workspace DuckLake catalog DB + S3 lake prefix (DAT-505) — never a
-      # shared catalog. Catalog DB is created at postgres first-boot by
-      # init-databases.sh; the lake parquet lives under this workspace's own
-      # s3://<bucket>/<ws>/lake prefix.
-      DUCKLAKE_CATALOG_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${DUCKLAKE_CATALOG_DB}
+      # Per-workspace S3 lake prefix (DAT-505): the lake parquet lives under
+      # this workspace's own s3://<bucket>/<ws>/lake prefix. (The catalog is
+      # the shared DUCKLAKE_CATALOG_URL in the common env — DAT-815.)
       DUCKLAKE_DATA_PATH: s3://${S3_BUCKET}/${DATARAUM_WORKSPACE_ID:-00000000-0000-0000-0000-000000000001}/lake
 
   # Second workspace worker (DAT-505) — behind the `multi-workspace` profile so a
-  # default `up` stays single-workspace. Bring it up for the AC1 two-workspace
+  # default `up` stays single-workspace. Bring it up for the two-workspace
   # side-by-side smoke (`--profile multi-workspace`): a SECOND container, a second
-  # queue (engine-<ws2>), a second ws_<id> schema, a second catalog DB
-  # (${DUCKLAKE_CATALOG_DB}_2, created by init-databases.sh), and a second
-  # s3://<bucket>/<ws2>/lake prefix — fully isolated from workspace 1.
+  # queue (engine-<ws2>), a second ws_<id> schema, a second ws_<id> catalog
+  # schema in the SAME catalog DB (DAT-815), and a second s3://<bucket>/<ws2>/lake
+  # prefix — fully isolated from workspace 1.
   engine-worker-2:
     <<: *engine-worker-base
     profiles: ["multi-workspace"]
@@ -340,7 +344,6 @@ services:
       <<: *engine-worker-env
       DATARAUM_WORKSPACE_ID: ${DATARAUM_WORKSPACE_ID_2:-00000000-0000-0000-0000-000000000002}
       TEMPORAL_TASK_QUEUE: engine-${DATARAUM_WORKSPACE_ID_2:-00000000-0000-0000-0000-000000000002}
-      DUCKLAKE_CATALOG_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${DUCKLAKE_CATALOG_DB}_2
       DUCKLAKE_DATA_PATH: s3://${S3_BUCKET}/${DATARAUM_WORKSPACE_ID_2:-00000000-0000-0000-0000-000000000002}/lake
 
   # One-shot: apply the cockpit_db migrations (DAT-461) before the cockpit
@@ -413,11 +416,13 @@ services:
       # The cockpit needs it explicitly to address PutObject (it can't infer the
       # bucket from the lake path, which carries the lake/ suffix).
       S3_BUCKET: ${S3_BUCKET}
-      # DuckLake catalog (DAT-367/505) — the cockpit ATTACHes the same per-workspace
-      # DuckLake catalog engine-worker 1 owns, READ_ONLY, for the interactive read
-      # verbs (run_sql). Same value as that worker's DUCKLAKE_CATALOG_URL (bare
-      # postgresql:// libpq form — DuckDB's postgres extension wants it, not the
-      # +psycopg SQLAlchemy scheme) and the same DATARAUM_LAKE_PATH above.
+      # DuckLake catalog (DAT-367/815) — the ONE installation-wide catalog DB.
+      # The cockpit ATTACHes it READ_ONLY for the interactive read verbs
+      # (run_sql), selecting the active workspace's catalog via the ws_<id>
+      # METADATA_SCHEMA it derives from DATARAUM_WORKSPACE_ID — the same schema
+      # that workspace's engine-worker writes. Bare postgresql:// libpq form
+      # (DuckDB's postgres extension wants it, not the +psycopg SQLAlchemy
+      # scheme); pairs with the DATARAUM_LAKE_PATH above.
       DUCKLAKE_CATALOG_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${DUCKLAKE_CATALOG_DB}
       # Config (DAT-361) — read-only access to vertical YAMLs for future UX
       # hints ("which concept did the agent bind to?"). No consumers yet; the

--- a/packages/infra/scripts/delete-workspace.sh
+++ b/packages/infra/scripts/delete-workspace.sh
@@ -84,11 +84,13 @@ psql_primary -c "DROP SCHEMA IF EXISTS \"${SCHEMA}_read\" CASCADE;"
 #    (DAT-815). No pg_terminate_backend sweep here: the catalog database is
 #    shared by EVERY workspace, so terminating its backends would kill sibling
 #    workspaces' live catalog pools. The stopped worker (step 1) holds no locks
-#    on this schema; idle reader connections don't either (locks release at
-#    transaction end), so the DROP proceeds without a terminate.
+#    on this schema; a still-running cockpit for THIS workspace normally doesn't
+#    either (its reader pool idles outside transactions), but a straggling
+#    in-flight read could — so a lock_timeout makes the DROP fail loud after 30s
+#    (stop the workspace's cockpit, re-run) instead of hanging on the lock.
 echo "==> [3/5] drop DuckLake catalog schema ${SCHEMA} in ${CATALOG_DB}"
 psql -v ON_ERROR_STOP=1 -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$CATALOG_DB" \
-  -c "DROP SCHEMA IF EXISTS \"${SCHEMA}\" CASCADE;"
+  -c "SET lock_timeout = '30s'; DROP SCHEMA IF EXISTS \"${SCHEMA}\" CASCADE;"
 
 # 4. Delete the workspace's S3 prefix (lake + uploads) via weed shell. The
 #    fs.rm -r removes everything under the workspace's <ws>/ prefix in the bucket.

--- a/packages/infra/scripts/delete-workspace.sh
+++ b/packages/infra/scripts/delete-workspace.sh
@@ -8,23 +8,24 @@
 #   1. STOP the workspace's engine container  (no more writes to its ws_<id> /
 #      catalog / s3 prefix while we drop them).
 #   2. DROP the engine Postgres schemas        ws_<id> + ws_<id>_read.
-#   3. DROP the per-workspace DuckLake catalog database.
+#   3. DROP the workspace's DuckLake catalog SCHEMA (ws_<id>) from the
+#      installation-wide catalog database (DAT-815 — the database is shared by
+#      every workspace and is never dropped here).
 #   4. DELETE the workspace's S3 prefix         s3://<bucket>/<ws>/  (lake + uploads).
 #   5. DELETE the cockpit_db control-plane rows  (session_runs → sessions →
 #      conversations/ui_state → the workspace row) OR, for a soft delete, stamp
 #      workspaces.archived_at and stop (steps 2–4 + the registry row stay).
 #
 # Clean cut, dev posture: no migration tooling, no graceful drain — a dev
-# workspace is re-provisioned, not migrated. Destructive: it DROPs schemas and a
-# database and DELETEs an S3 prefix. Run it deliberately.
+# workspace is re-provisioned, not migrated. Destructive: it DROPs schemas and
+# DELETEs an S3 prefix. Run it deliberately.
 #
 # Usage:
-#   packages/infra/scripts/delete-workspace.sh <workspace_id> [--soft] [--catalog-db <name>]
+#   packages/infra/scripts/delete-workspace.sh <workspace_id> [--soft]
 #
 # Env (defaults match docker-compose.yml / .env.example):
 #   POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB
-#   DUCKLAKE_CATALOG_DB   base catalog DB name (workspace 1 = this; workspace N
-#                         = <base>_<n> — pass --catalog-db to override)
+#   DUCKLAKE_CATALOG_DB   the ONE installation-wide catalog database (DAT-815)
 #   COCKPIT_DB            cockpit control-plane database
 #   S3_BUCKET             the lake bucket
 #   PGHOST / PGPORT       Postgres host/port (default localhost:5432)
@@ -35,7 +36,7 @@
 set -euo pipefail
 
 if [ $# -lt 1 ]; then
-  echo "usage: $0 <workspace_id> [--soft] [--catalog-db <name>]" >&2
+  echo "usage: $0 <workspace_id> [--soft]" >&2
   exit 2
 fi
 
@@ -46,7 +47,6 @@ CATALOG_DB="${DUCKLAKE_CATALOG_DB:-dataraum_lake_catalog}"
 while [ $# -gt 0 ]; do
   case "$1" in
     --soft) SOFT=1; shift ;;
-    --catalog-db) CATALOG_DB="$2"; shift 2 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -61,10 +61,12 @@ S3_BUCKET="${S3_BUCKET:-dataraum-lake}"
 SEAWEEDFS_MASTER="${SEAWEEDFS_MASTER:-seaweedfs:9333}"
 SEAWEEDFS_FILER="${SEAWEEDFS_FILER:-seaweedfs:8888}"
 
-# Engine schema name mirrors server/workspace.py::schema_name_for (dashes → _).
+# Schema name mirrors server/workspace.py::schema_name_for (dashes → _). The
+# SAME ws_<id> name identifies the workspace in the primary DB (engine
+# metadata) and in the catalog DB (DuckLake METADATA_SCHEMA, DAT-815).
 SCHEMA="ws_${WS_ID//-/_}"
 
-echo "==> Deleting workspace ${WS_ID} (schema ${SCHEMA}, catalog ${CATALOG_DB})"
+echo "==> Deleting workspace ${WS_ID} (schema ${SCHEMA}, catalog db ${CATALOG_DB})"
 
 # 1. Stop the workspace's engine container (best-effort; it may not be named
 #    deterministically in every deployment — in dev it is engine-worker[-N]).
@@ -78,11 +80,15 @@ echo "==> [2/5] drop schemas ${SCHEMA}, ${SCHEMA}_read"
 psql_primary -c "DROP SCHEMA IF EXISTS \"${SCHEMA}\" CASCADE;"
 psql_primary -c "DROP SCHEMA IF EXISTS \"${SCHEMA}_read\" CASCADE;"
 
-# 3. Drop the per-workspace DuckLake catalog database. Terminate any lingering
-#    connections first (a stopped worker should hold none, but be safe).
-echo "==> [3/5] drop DuckLake catalog database ${CATALOG_DB}"
-psql_primary -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${CATALOG_DB}' AND pid <> pg_backend_pid();" >/dev/null || true
-psql_primary -c "DROP DATABASE IF EXISTS \"${CATALOG_DB}\";"
+# 3. Drop the workspace's DuckLake catalog schema from the shared catalog DB
+#    (DAT-815). No pg_terminate_backend sweep here: the catalog database is
+#    shared by EVERY workspace, so terminating its backends would kill sibling
+#    workspaces' live catalog pools. The stopped worker (step 1) holds no locks
+#    on this schema; idle reader connections don't either (locks release at
+#    transaction end), so the DROP proceeds without a terminate.
+echo "==> [3/5] drop DuckLake catalog schema ${SCHEMA} in ${CATALOG_DB}"
+psql -v ON_ERROR_STOP=1 -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$CATALOG_DB" \
+  -c "DROP SCHEMA IF EXISTS \"${SCHEMA}\" CASCADE;"
 
 # 4. Delete the workspace's S3 prefix (lake + uploads) via weed shell. The
 #    fs.rm -r removes everything under the workspace's <ws>/ prefix in the bucket.


### PR DESCRIPTION
## Task

[DAT-815](https://real-dataraum.atlassian.net/browse/DAT-815) — epic DAT-813 · design [DD/51740673](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/51740673) · unblocked by the DAT-814 spike (GO)

## Contract consumed

None named on the ticket. Conventions consumed: the `ws_<id>` derivation (`server/workspace.py::schema_name_for`, mirrored cockpit-side as `ducklakeMetadataSchemaFor` in `src/duckdb/sql-escape.ts`) and the DAT-814 spike facts (ATTACH creates the schema; independent snapshot chains; READ_ONLY+METADATA_SCHEMA reads committed snapshots).

## Acceptance criteria

- [x] Engine `bootstrap_lake` ATTACHes with `METADATA_SCHEMA` derived from the boot workspace id; settings carry one installation-wide catalog URL (per-workspace DB names retired)
- [x] Cockpit lake attach uses the same parameter from its boot identity (`ducklakeMetadataSchemaFor(config.dataraumWorkspaceId)`)
- [x] `init-databases.sh` no longer allocates per-workspace catalog DBs (`${DUCKLAKE_CATALOG_DB}_2` gone)
- [x] `delete-workspace.sh` drops the catalog schema (`DROP SCHEMA … CASCADE`, 30s `lock_timeout`) instead of the DB; the `pg_terminate_backend` sweep is removed (the DB is shared — it would kill sibling workspaces' catalog pools)
- [x] compose `multi-workspace` profile: both workspaces against one catalog DB (`DUCKLAKE_CATALOG_URL` moved to the common worker env anchor); full unit suite green
- [x] Spike said GO → no-go clause n/a

## Lane smoke

```
# isolated compose project (dat815-smoke, shifted ports), built from this branch,
# --profile multi-workspace: postgres, seaweedfs(+init), temporal(+ns), engine-worker, engine-worker-2
temporal worker list  → engine-…0001 Running, engine-…0002 Running (one catalog DB)
catalog DB            → exactly ws_…0001 + ws_…0002 (28 ducklake_* tables each), public EMPTY, no *_2 database
reader (cockpit mirror, in-container): READ_ONLY+METADATA_SCHEMA attach of ws1 sees
  raw/typed/quarantine + a committed-but-uncheckpointed marker (inlined data, per spike);
  same attach of ws2 → CatalogException on the ws1 table (isolation)
step-3 semantics      → DROP SCHEMA ws_…0002 CASCADE drops 28 tables; ws1 catalog intact + still readable
```

Gates on the rebased tree: engine `tests/unit` 2158 passed + `tests/integration` 277 passed (full runs, not testmon); ruff/mypy/vulture clean; cockpit vitest suite + biome + tsc clean. Reviewers: senior-code-reviewer APPROVE, spec-compliance-reviewer APPROVE (findings folded in: `lock_timeout`, ADR-0012 lake-clause amendment, architecture/deployment docs).

## Notes for the lead

- **Existing dev stacks must re-seed** (`down -v`): an old catalog has its metadata in `public`; the schema'd ATTACH starts a fresh `ws_<id>` catalog and the old lake state is invisible. Clean cut, no migration path.
- **No live add_source was run** — the ACs are bootstrap-level and needed no LLM. CI `compose-smoke` exercises the engine-writes/cockpit-reads seam on the schema'd catalog; a full pipeline live smoke stays with you per lane rules.
- **Pre-existing boot race surfaced by the smoke** (not this diff): two workers booting concurrently can collide in `ensure_reader_role`'s non-atomic `CREATE ROLE cockpit_reader` (unique violation, container restart recovers). Worth a small ticket; touches DAT-816's surface, so I left it.
- **Follow-up candidate:** the cockpit now has three copies of the `ws_<id>` derivation (`registry.ts::engineSchemaFor`, `write-surface.ts::rawSchemaName`, new `ducklakeMetadataSchemaFor`) — consolidation was fenced off (DAT-816/817 own those files).

## Other lanes in flight

- #516 DAT-818: Phase 5 — per-workspace cockpit-<ws> callback queue (cross-package)
- DAT-816 / DAT-817 lanes not yet at PR at push time. Compose diff here is confined to DUCKLAKE_* keys + adjacent comments to minimize conflicts; merge-order note: any lane rebasing over this must keep `DUCKLAKE_CATALOG_URL` in the common `x-engine-worker-env` anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)