### PR TITLE
DAT-817: Phase 4 — control plane in cockpit_db: users, memberships, registry states + workspace-scoped queries

### DIFF
--- a/packages/cockpit/drizzle/cockpit/20260719100238_noisy_paper_doll/migration.sql
+++ b/packages/cockpit/drizzle/cockpit/20260719100238_noisy_paper_doll/migration.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "memberships" (
+	"user_id" varchar,
+	"workspace_id" varchar,
+	"role" varchar DEFAULT 'member' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "memberships_pkey" PRIMARY KEY("user_id","workspace_id")
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" varchar PRIMARY KEY,
+	"display_name" varchar NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DROP TABLE "actors";--> statement-breakpoint
+ALTER TABLE "workspaces" ADD COLUMN "state" varchar DEFAULT 'ready' NOT NULL;--> statement-breakpoint
+ALTER TABLE "workspaces" ADD COLUMN "subdomain" varchar;--> statement-breakpoint
+ALTER TABLE "workspaces" ADD COLUMN "reader_role" varchar;--> statement-breakpoint
+ALTER TABLE "workspaces" ADD COLUMN "writer_role" varchar;--> statement-breakpoint
+ALTER TABLE "workspaces" ADD COLUMN "catalog_schema" varchar;--> statement-breakpoint
+ALTER TABLE "workspaces" DROP COLUMN "archived_at";--> statement-breakpoint
+ALTER TABLE "memberships" ADD CONSTRAINT "memberships_user_id_users_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id");--> statement-breakpoint
+ALTER TABLE "memberships" ADD CONSTRAINT "memberships_workspace_id_workspaces_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id");

--- a/packages/cockpit/drizzle/cockpit/20260719100238_noisy_paper_doll/snapshot.json
+++ b/packages/cockpit/drizzle/cockpit/20260719100238_noisy_paper_doll/snapshot.json
@@ -1,0 +1,1198 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "e31d1648-c5b5-4ff2-ae47-164d66599967",
+  "prevIds": [
+    "22d728d4-5727-4d44-a5f9-0de7546799b2"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "conversation_messages",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "conversations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "memberships",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "reports",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "runs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "ui_state",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "workspaces",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seq",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "model_only",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_active_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "message_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "summary",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "summary_fingerprint",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "sql",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "chart_config",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "confidence",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stage",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workflow_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "run_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'running'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "awaiting_note",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "conversation_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "pinned_call_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "engine_schema",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'_adhoc'",
+      "generated": null,
+      "identity": null,
+      "name": "vertical",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'ready'",
+      "generated": null,
+      "identity": null,
+      "name": "state",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "subdomain",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reader_role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "writer_role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "catalog_schema",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workspaces"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "conversation_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "seq",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "conversation_messages_conversation_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "conversations_workspace_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "reports_workspace_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workflow_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "run_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "runs_workflow_run_uq",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "runs_workspace_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "conversation_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "runs_conversation_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "conversation_messages_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "conversation_messages"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "workspace_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "workspaces",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "conversations_workspace_id_workspaces_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "conversations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "memberships_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "workspace_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "workspaces",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "memberships_workspace_id_workspaces_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "workspace_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "workspaces",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "reports_workspace_id_workspaces_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "reports_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "parent_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "reports",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "reports_parent_id_reports_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "workspace_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "workspaces",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "runs_workspace_id_workspaces_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "runs_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "conversation_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "conversations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "ui_state_conversation_id_conversations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "ui_state"
+    },
+    {
+      "columns": [
+        "user_id",
+        "workspace_id"
+      ],
+      "nameExplicit": false,
+      "name": "memberships_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "conversation_messages_pkey",
+      "schema": "public",
+      "table": "conversation_messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "conversations_pkey",
+      "schema": "public",
+      "table": "conversations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "reports_pkey",
+      "schema": "public",
+      "table": "reports",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "runs_pkey",
+      "schema": "public",
+      "table": "runs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "conversation_id"
+      ],
+      "nameExplicit": false,
+      "name": "ui_state_pkey",
+      "schema": "public",
+      "table": "ui_state",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "workspaces_pkey",
+      "schema": "public",
+      "table": "workspaces",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/cockpit/scripts/smoke-begin-session.ts
+++ b/packages/cockpit/scripts/smoke-begin-session.ts
@@ -28,7 +28,7 @@ import { z } from "zod";
 import { cockpitDb } from "#/db/cockpit/client";
 import { engineTaskQueueFor } from "#/db/cockpit/registry";
 import { recordRun } from "#/db/cockpit/runs";
-import { actors, workspaces } from "#/db/cockpit/schema";
+import { users, workspaces } from "#/db/cockpit/schema";
 import { metadataDb } from "#/db/metadata/client";
 import { sourcesWrite } from "#/db/metadata/write-surface";
 import { lookRelationships } from "#/tools/look-relationships";
@@ -67,7 +67,7 @@ async function ingest(client: Client): Promise<string[]> {
 	// The workspace registry carries the vertical (DAT-506): seed it = finance so
 	// the begin_session driver (and any other driver) sources the right ontology.
 	await cockpitDb
-		.insert(actors)
+		.insert(users)
 		.values({ id: "default", displayName: "Default user" })
 		.onConflictDoNothing();
 	await cockpitDb

--- a/packages/cockpit/scripts/smoke-dat-461.ts
+++ b/packages/cockpit/scripts/smoke-dat-461.ts
@@ -21,9 +21,9 @@
 import assert from "node:assert/strict";
 import { and, eq } from "drizzle-orm";
 import { cockpitDb } from "#/db/cockpit/client";
-import { DEFAULT_ACTOR_ID, resolveActiveWorkspace } from "#/db/cockpit/registry";
+import { DEFAULT_USER_ID, resolveActiveWorkspace } from "#/db/cockpit/registry";
 import { markRunStatus, recordRun } from "#/db/cockpit/runs";
-import { actors, runs, workspaces } from "#/db/cockpit/schema";
+import { memberships, runs, users, workspaces } from "#/db/cockpit/schema";
 
 // DAT-562/DAT-595: a run is recorded keyed by (workflowId, REAL runId) — the run row
 // carries the Temporal execution id directly (recorded post-start), no placeholder.
@@ -47,12 +47,25 @@ async function main(): Promise<void> {
 		`ws_${wsId.replaceAll("-", "_")}`,
 		"engine schema derived",
 	);
-	const [actor] = await cockpitDb
-		.select({ id: actors.id })
-		.from(actors)
-		.where(eq(actors.id, DEFAULT_ACTOR_ID))
+	const [user] = await cockpitDb
+		.select({ id: users.id })
+		.from(users)
+		.where(eq(users.id, DEFAULT_USER_ID))
 		.limit(1);
-	assert.equal(actor?.id, DEFAULT_ACTOR_ID, "default actor seeded");
+	assert.equal(user?.id, DEFAULT_USER_ID, "default user seeded");
+	// DAT-817: the seed also grants the default user membership in the boot
+	// workspace — what the portal (Phase 6) lists at login.
+	const [membership] = await cockpitDb
+		.select({ role: memberships.role })
+		.from(memberships)
+		.where(
+			and(
+				eq(memberships.userId, DEFAULT_USER_ID),
+				eq(memberships.workspaceId, wsId),
+			),
+		)
+		.limit(1);
+	assert.equal(membership?.role, "member", "default membership seeded");
 
 	// 2. recordRun: writes one `runs` row (DAT-562) keyed by (workflowId, real runId);
 	//    re-recording the same run is a UNIQUE no-op. The kind lives on the run row.
@@ -98,7 +111,7 @@ async function main(): Promise<void> {
 	assert.equal(r?.status, "completed", "run marked completed");
 
 	// Cleanup — delete the test runs (by their workflow ids). Leave the shared
-	// registry rows (workspace, default actor) intact.
+	// registry rows (workspace, default user, membership) intact.
 	await cockpitDb.delete(runs).where(eq(runs.workflowId, WF_1));
 	await cockpitDb.delete(runs).where(eq(runs.workflowId, WF_2));
 

--- a/packages/cockpit/scripts/smoke-operating-model.ts
+++ b/packages/cockpit/scripts/smoke-operating-model.ts
@@ -30,7 +30,7 @@ import { z } from "zod";
 
 import { cockpitDb } from "#/db/cockpit/client";
 import { recordRun } from "#/db/cockpit/runs";
-import { actors, workspaces } from "#/db/cockpit/schema";
+import { users, workspaces } from "#/db/cockpit/schema";
 import { metadataDb } from "#/db/metadata/client";
 import {
 	currentLifecycleArtifacts,
@@ -78,7 +78,7 @@ async function ingest(client: Client): Promise<string[]> {
 	// The workspace registry carries the vertical (DAT-506): seed it = finance so
 	// the begin_session / operating_model drivers source the right ontology.
 	await cockpitDb
-		.insert(actors)
+		.insert(users)
 		.values({ id: "default", displayName: "Default user" })
 		.onConflictDoNothing();
 	await cockpitDb

--- a/packages/cockpit/src/db/cockpit/conversations.test.ts
+++ b/packages/cockpit/src/db/cockpit/conversations.test.ts
@@ -1,18 +1,33 @@
-// Unit tests for server-owned conversation persistence (DAT-462). Mocks the
-// cockpit_db client at the `#/` boundary (no DB). Covers the real logic the
-// functions own: resolve-or-create branching, seq continuation from max,
-// model-only defaulting + the display/transcript filter contract (the leak guard
-// for the refs flip), idempotent-by-id append, and the empty no-op. The real SQL
-// is covered by the Bun lane smoke.
+// Unit tests for server-owned conversation persistence (DAT-462; boot-workspace
+// scope DAT-817). Mocks the cockpit_db client at the `#/` boundary (no DB).
+// Covers the real logic the functions own: resolve-or-create branching, seq
+// continuation from max, model-only defaulting + the display/transcript filter
+// contract (the leak guard for the refs flip), idempotent-by-id append, the
+// empty no-op — and the DAT-817 scope: every query carries the boot-workspace
+// fence (structurally asserted here; the row-level proof is the
+// workspace-isolation integration test).
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => ({
 	inserts: [] as Array<{ table: string; rows: unknown }>,
 	conflicts: [] as unknown[],
-	updates: [] as Array<{ table: string; set: Record<string, unknown> }>,
+	updates: [] as Array<{
+		table: string;
+		set: Record<string, unknown>;
+		where: unknown[];
+	}>,
 	whereArgs: [] as unknown[][],
+	joins: [] as unknown[][],
 	selectResult: [] as Array<Record<string, unknown>>,
+	// When non-empty, each select() consumes the next result from this queue
+	// (lets one call under test see different results per select — e.g. the
+	// appendMessages ownership gate vs its max(seq) read).
+	selectQueue: [] as Array<Array<Record<string, unknown>>>,
+}));
+
+vi.mock("#/config", () => ({
+	config: { dataraumWorkspaceId: "ws-1" },
 }));
 
 vi.mock("#/db/cockpit/schema", () => ({
@@ -32,6 +47,9 @@ vi.mock("#/db/cockpit/schema", () => ({
 		seq: "seq",
 		modelOnly: "model_only",
 	},
+	users: { _t: "users", id: "id" },
+	workspaces: { _t: "workspaces", id: "id", vertical: "vertical" },
+	memberships: { _t: "memberships" },
 }));
 vi.mock("drizzle-orm", () => ({
 	eq: (...a: unknown[]) => ["eq", ...a],
@@ -46,9 +64,16 @@ function chainable() {
 	// A real Promise (so it's awaitable at every terminal — .limit / .orderBy /
 	// bare .where) with the query-builder methods attached. Using a native
 	// thenable avoids a hand-rolled `then` property.
+	const result = h.selectQueue.length
+		? (h.selectQueue.shift() as Array<Record<string, unknown>>)
+		: h.selectResult;
 	// biome-ignore lint/suspicious/noExplicitAny: minimal drizzle query-builder stub
-	const p: any = Promise.resolve(h.selectResult);
+	const p: any = Promise.resolve(result);
 	p.from = () => p;
+	p.innerJoin = (...a: unknown[]) => {
+		h.joins.push(a);
+		return p;
+	};
 	p.where = (...a: unknown[]) => {
 		h.whereArgs.push(a);
 		return p;
@@ -73,8 +98,8 @@ vi.mock("#/db/cockpit/client", () => ({
 		select: () => chainable(),
 		update: (table: { _t: string }) => ({
 			set: (s: Record<string, unknown>) => ({
-				where: async () => {
-					h.updates.push({ table: table._t, set: s });
+				where: async (...a: unknown[]) => {
+					h.updates.push({ table: table._t, set: s, where: a });
 				},
 			}),
 		}),
@@ -100,7 +125,9 @@ beforeEach(() => {
 	h.conflicts = [];
 	h.updates = [];
 	h.whereArgs = [];
+	h.joins = [];
 	h.selectResult = [];
+	h.selectQueue = [];
 });
 afterEach(() => vi.restoreAllMocks());
 
@@ -114,6 +141,13 @@ describe("createConversation", () => {
 			workspaceId: "ws-1",
 			kind: "stage",
 		});
+	});
+
+	it("refuses a non-boot workspace born-loud (DAT-817)", async () => {
+		await expect(createConversation("ws-other", "stage")).rejects.toThrow(
+			/cross-workspace query refused/,
+		);
+		expect(h.inserts).toEqual([]);
 	});
 });
 
@@ -129,6 +163,12 @@ describe("listConversations", () => {
 		// Scoped to the workspace and ordered by recency (lastActiveAt).
 		expect(JSON.stringify(h.whereArgs)).toContain("workspace_id");
 	});
+
+	it("refuses a non-boot workspace born-loud (DAT-817)", async () => {
+		await expect(listConversations("ws-other")).rejects.toThrow(
+			/cross-workspace query refused/,
+		);
+	});
 });
 
 describe("getConversation", () => {
@@ -142,6 +182,8 @@ describe("getConversation", () => {
 			kind: "connect",
 			title: "t1",
 		});
+		// Boot-workspace fenced (DAT-817): a foreign conversation reads as null.
+		expect(JSON.stringify(h.whereArgs)).toContain("workspace_id");
 
 		h.selectResult = [];
 		expect(await getConversation("missing")).toBeNull();
@@ -153,12 +195,17 @@ describe("setConversationTitle", () => {
 		await setConversationTitle("c1", "Add the orders CSV");
 		const upd = h.updates.find((u) => u.table === "conversations");
 		expect(upd?.set).toEqual({ title: "Add the orders CSV" });
+		// Boot-workspace fenced alongside the IS NULL guard (DAT-817).
+		expect(JSON.stringify(upd?.where)).toContain("workspace_id");
 	});
 });
 
 describe("appendMessages", () => {
 	it("continues seq from max, denormalizes role, defaults model_only, bumps updatedAt", async () => {
-		h.selectResult = [{ maxSeq: 2 }];
+		h.selectQueue = [
+			[{ id: "conv-1" }], // the DAT-817 ownership gate — conversation is boot-owned
+			[{ maxSeq: 2 }],
+		];
 		await appendMessages("conv-1", [
 			{ message: msg("m3", "user") },
 			{ message: msg("m4", "assistant"), modelOnly: true },
@@ -176,12 +223,14 @@ describe("appendMessages", () => {
 		expect(rows[1]).toMatchObject({ id: "m4", seq: 4, modelOnly: true });
 		// idempotent by message id
 		expect(h.conflicts[0]).toMatchObject({ target: "id" });
-		// updatedAt bumped on the conversation
-		expect(h.updates.find((u) => u.table === "conversations")).toBeTruthy();
+		// updatedAt bumped on the conversation, workspace-fenced (DAT-817)
+		const upd = h.updates.find((u) => u.table === "conversations");
+		expect(upd).toBeTruthy();
+		expect(JSON.stringify(upd?.where)).toContain("workspace_id");
 	});
 
 	it("treats an empty/absent max as seq 0", async () => {
-		h.selectResult = [{ maxSeq: null }];
+		h.selectQueue = [[{ id: "conv-1" }], [{ maxSeq: null }]];
 		await appendMessages("conv-1", [{ message: msg("first") }]);
 		const rows = (
 			h.inserts.find((i) => i.table === "conversation_messages")?.rows as Array<
@@ -196,6 +245,15 @@ describe("appendMessages", () => {
 		expect(h.inserts).toEqual([]);
 		expect(h.updates).toEqual([]);
 	});
+
+	it("throws without writing when the conversation isn't the boot workspace's (DAT-817)", async () => {
+		h.selectQueue = [[]]; // ownership gate finds no boot-owned row
+		await expect(
+			appendMessages("foreign-conv", [{ message: msg("m1") }]),
+		).rejects.toThrow(/not in the boot workspace/);
+		expect(h.inserts).toEqual([]);
+		expect(h.updates).toEqual([]);
+	});
 });
 
 describe("display/transcript filter contract (the refs-leak guard)", () => {
@@ -203,15 +261,23 @@ describe("display/transcript filter contract (the refs-leak guard)", () => {
 		h.selectResult = [{ message: msg("a") }, { message: msg("b") }];
 
 		h.whereArgs = [];
+		h.joins = [];
 		const display = await loadDisplayMessages("conv-1");
 		expect(display.map((m) => m.id)).toEqual(["a", "b"]);
 		// display's WHERE references the model_only column (excludes refs rows)
 		expect(JSON.stringify(h.whereArgs)).toContain("model_only");
+		// and is workspace-fenced through the owning conversation (DAT-817)
+		expect(JSON.stringify(h.whereArgs)).toContain("workspace_id");
+		expect(h.joins).toHaveLength(1);
 
 		h.whereArgs = [];
+		h.joins = [];
 		const full = await loadModelTranscript("conv-1");
 		expect(full.map((m) => m.id)).toEqual(["a", "b"]);
 		// the full transcript must NOT filter model_only — refs rows feed the model
 		expect(JSON.stringify(h.whereArgs)).not.toContain("model_only");
+		// but IS workspace-fenced the same way (DAT-817)
+		expect(JSON.stringify(h.whereArgs)).toContain("workspace_id");
+		expect(h.joins).toHaveLength(1);
 	});
 });

--- a/packages/cockpit/src/db/cockpit/conversations.ts
+++ b/packages/cockpit/src/db/cockpit/conversations.ts
@@ -19,7 +19,35 @@ import type { UIMessage } from "@tanstack/ai-react";
 import { and, desc, eq, isNull, max } from "drizzle-orm";
 import { foldModelOnlyRefs } from "#/lib/model-messages";
 import { cockpitDb } from "./client";
+import { assertBootWorkspace, bootWorkspaceId } from "./registry";
 import { conversationMessages, conversations } from "./schema";
+
+/**
+ * Prove `conversationId` belongs to the boot workspace (DAT-817) — the scope
+ * gate for the conversation-child writes (`conversation_messages` rows carry no
+ * workspace_id of their own; they scope through their conversation). Throws on
+ * a foreign or unknown id — same born-loud degradation path a stale threadId
+ * always took (the chat route catches and serves the turn unpersisted).
+ */
+async function assertConversationInBootWorkspace(
+	conversationId: string,
+): Promise<void> {
+	const [row] = await cockpitDb
+		.select({ id: conversations.id })
+		.from(conversations)
+		.where(
+			and(
+				eq(conversations.id, conversationId),
+				eq(conversations.workspaceId, bootWorkspaceId()),
+			),
+		)
+		.limit(1);
+	if (!row) {
+		throw new Error(
+			`[cockpit] conversation ${conversationId} is not in the boot workspace`,
+		);
+	}
+}
 
 /** A message to persist, with whether it is model-only (the refs channel). */
 export interface MessageEntry {
@@ -63,6 +91,7 @@ export async function listConversations(
 	workspaceId: string,
 	limit: number = HISTORY_LIMIT,
 ): Promise<Array<ConversationSummary>> {
+	assertBootWorkspace(workspaceId);
 	const rows = await cockpitDb
 		.select({
 			id: conversations.id,
@@ -88,14 +117,17 @@ export async function createConversation(
 	workspaceId: string,
 	kind: ConversationKind,
 ): Promise<string> {
+	assertBootWorkspace(workspaceId);
 	const id = randomUUID();
 	await cockpitDb.insert(conversations).values({ id, workspaceId, kind });
 	return id;
 }
 
 /** Hydrate a conversation by id (the chat route loader) — kind + title +
- * owning workspace. Null if the id is unknown (a stale deep link → the route
- * 404s rather than mounting an orphan chat). */
+ * owning workspace. Null if the id is unknown OR belongs to another workspace
+ * (DAT-817 — cockpit_db is shared across per-workspace cockpits, so a foreign
+ * deep link must 404 exactly like a stale one, never mount another
+ * workspace's chat). */
 export async function getConversation(
 	conversationId: string,
 ): Promise<ConversationRow | null> {
@@ -107,7 +139,12 @@ export async function getConversation(
 			title: conversations.title,
 		})
 		.from(conversations)
-		.where(eq(conversations.id, conversationId))
+		.where(
+			and(
+				eq(conversations.id, conversationId),
+				eq(conversations.workspaceId, bootWorkspaceId()),
+			),
+		)
 		.limit(1);
 	if (!row) return null;
 	return { ...row, kind: row.kind as ConversationKind };
@@ -129,7 +166,11 @@ export async function setConversationTitle(
 			.update(conversations)
 			.set({ title })
 			.where(
-				and(eq(conversations.id, conversationId), isNull(conversations.title)),
+				and(
+					eq(conversations.id, conversationId),
+					eq(conversations.workspaceId, bootWorkspaceId()),
+					isNull(conversations.title),
+				),
 			);
 	} catch (err) {
 		console.warn(
@@ -139,16 +180,23 @@ export async function setConversationTitle(
 }
 
 /** The display transcript (modelOnly rows excluded), in order — reload hydration
- * + the canvas source. */
+ * + the canvas source. Scoped through the owning conversation's workspace
+ * (DAT-817): a foreign conversation id yields an empty transcript, exactly like
+ * an unknown one. */
 export async function loadDisplayMessages(
 	conversationId: string,
 ): Promise<Array<UIMessage>> {
 	const rows = await cockpitDb
 		.select({ message: conversationMessages.message })
 		.from(conversationMessages)
+		.innerJoin(
+			conversations,
+			eq(conversationMessages.conversationId, conversations.id),
+		)
 		.where(
 			and(
 				eq(conversationMessages.conversationId, conversationId),
+				eq(conversations.workspaceId, bootWorkspaceId()),
 				eq(conversationMessages.modelOnly, false),
 			),
 		)
@@ -158,7 +206,8 @@ export async function loadDisplayMessages(
 
 /** The full transcript with model-only refs rows FOLDED into their user turns,
  * in order — the `buildModelMessages` input. No model_only filter (refs feed the
- * model); the fold keeps them from becoming consecutive same-role messages. */
+ * model); the fold keeps them from becoming consecutive same-role messages.
+ * Workspace-scoped through the owning conversation (DAT-817). */
 export async function loadModelTranscript(
 	conversationId: string,
 ): Promise<Array<UIMessage>> {
@@ -168,7 +217,16 @@ export async function loadModelTranscript(
 			modelOnly: conversationMessages.modelOnly,
 		})
 		.from(conversationMessages)
-		.where(eq(conversationMessages.conversationId, conversationId))
+		.innerJoin(
+			conversations,
+			eq(conversationMessages.conversationId, conversations.id),
+		)
+		.where(
+			and(
+				eq(conversationMessages.conversationId, conversationId),
+				eq(conversations.workspaceId, bootWorkspaceId()),
+			),
+		)
 		.orderBy(conversationMessages.seq);
 	return foldModelOnlyRefs(rows);
 }
@@ -190,6 +248,9 @@ export async function appendMessages(
 	entries: ReadonlyArray<MessageEntry>,
 ): Promise<void> {
 	if (entries.length === 0) return;
+	// Scope gate (DAT-817): appending to a foreign workspace's conversation must
+	// throw, not write — the FK alone can't tell foreign from boot-owned.
+	await assertConversationInBootWorkspace(conversationId);
 	const [{ maxSeq } = { maxSeq: null }] = await cockpitDb
 		.select({ maxSeq: max(conversationMessages.seq) })
 		.from(conversationMessages)
@@ -211,5 +272,10 @@ export async function appendMessages(
 	await cockpitDb
 		.update(conversations)
 		.set({ updatedAt: now, lastActiveAt: now })
-		.where(eq(conversations.id, conversationId));
+		.where(
+			and(
+				eq(conversations.id, conversationId),
+				eq(conversations.workspaceId, bootWorkspaceId()),
+			),
+		);
 }

--- a/packages/cockpit/src/db/cockpit/registry.test.ts
+++ b/packages/cockpit/src/db/cockpit/registry.test.ts
@@ -1,9 +1,13 @@
-// Unit tests for the workspace registry resolver (DAT-461). Mocks the cockpit_db
-// client at the `#/` boundary (no DB) + the schema table objects (sentinels so
-// the insert mock can tell which table it targeted). Asserts the warm path
-// (workspace row exists → returned, no seed) and the cold path (no row → seed
-// the default actor + workspace, then return). The real SQL is covered by the
-// Bun lane smoke (scripts/smoke-dat-461.ts).
+// Unit tests for the workspace registry resolver (DAT-461, control plane
+// DAT-817). Mocks the cockpit_db client at the `#/` boundary (no DB) + the
+// schema table objects (sentinels so the insert mock can tell which table it
+// targeted). Asserts the once-per-boot seed (default user + workspace +
+// membership, all idempotent), the born-loud missing-row path, the seed retry
+// after a transient failure, and the boot-scope guard. The real SQL is covered
+// by the workspace-isolation integration test.
+//
+// The seed memo is MODULE state (once per process), so each test imports a
+// FRESH registry via `vi.resetModules()` + dynamic import.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -14,7 +18,7 @@ const h = vi.hoisted(() => ({
 	config: {
 		dataraumWorkspaceId: "00000000-0000-0000-0000-000000000001",
 	} as Record<string, unknown>,
-	// Rows the workspace SELECT returns (empty = cold path → seed).
+	// Rows the workspace SELECT returns.
 	workspaceRows: [] as Array<{ id: string; vertical: string }>,
 	// Every onConflictDoNothing insert, tagged by table.
 	inserts: [] as Array<{ table: string; row: Record<string, unknown> }>,
@@ -24,6 +28,8 @@ const h = vi.hoisted(() => ({
 		row: Record<string, unknown>;
 		set: Record<string, unknown>;
 	}>,
+	// When true, the NEXT seed insert rejects once (the transient-failure test).
+	failNextInsert: false,
 }));
 
 vi.mock("#/config", () => ({
@@ -33,8 +39,9 @@ vi.mock("#/config", () => ({
 }));
 
 vi.mock("#/db/cockpit/schema", () => ({
-	actors: { _t: "actors", id: "id" },
+	users: { _t: "users", id: "id" },
 	workspaces: { _t: "workspaces", id: "id", vertical: "vertical" },
+	memberships: { _t: "memberships", userId: "user_id", workspaceId: "workspace_id" },
 }));
 
 vi.mock("drizzle-orm", () => ({ eq: (...a: unknown[]) => a }));
@@ -45,6 +52,10 @@ vi.mock("#/db/cockpit/client", () => ({
 		insert: (table: { _t: string }) => ({
 			values: (row: Record<string, unknown>) => ({
 				onConflictDoNothing: async () => {
+					if (h.failNextInsert) {
+						h.failNextInsert = false;
+						throw new Error("transient db blip");
+					}
 					h.inserts.push({ table: table._t, row });
 				},
 				onConflictDoUpdate: async (cfg: { set: Record<string, unknown> }) => {
@@ -58,56 +69,92 @@ vi.mock("#/db/cockpit/client", () => ({
 	},
 }));
 
-import {
-	DEFAULT_ACTOR_ID,
-	engineTaskQueueFor,
-	resolveActiveWorkspace,
-	resolveActiveWorkspaceRow,
-	setActiveWorkspaceVertical,
-} from "./registry";
+/** A fresh registry module — resets the once-per-process seed memo. */
+async function freshRegistry() {
+	vi.resetModules();
+	return import("./registry");
+}
 
 beforeEach(() => {
 	h.config = { dataraumWorkspaceId: WS };
-	h.workspaceRows = [];
+	h.workspaceRows = [{ id: WS, vertical: "_adhoc" }];
 	h.inserts = [];
 	h.upserts = [];
+	h.failNextInsert = false;
 	limitMock.mockClear();
 });
 
 describe("engineTaskQueueFor (DAT-505)", () => {
-	it("derives the per-workspace queue engine-<id>, id verbatim", () => {
+	it("derives the per-workspace queue engine-<id>, id verbatim", async () => {
+		const { engineTaskQueueFor } = await freshRegistry();
 		expect(engineTaskQueueFor(WS)).toBe(`engine-${WS}`);
 	});
 });
 
-describe("resolveActiveWorkspace (DAT-461)", () => {
-	it("returns the existing workspace WITHOUT seeding (warm path)", async () => {
-		h.workspaceRows = [{ id: WS, vertical: "_adhoc" }];
-		const id = await resolveActiveWorkspace();
-		expect(id).toBe(WS);
-		expect(h.inserts).toEqual([]); // no seed when the row already exists
+describe("boot scope (DAT-817)", () => {
+	it("bootWorkspaceId returns the boot identity from config", async () => {
+		const { bootWorkspaceId } = await freshRegistry();
+		expect(bootWorkspaceId()).toBe(WS);
 	});
 
-	it("seeds the default actor + workspace then returns it (cold path)", async () => {
-		h.workspaceRows = []; // nothing yet
+	it("assertBootWorkspace passes the boot id and throws on any other", async () => {
+		const { assertBootWorkspace } = await freshRegistry();
+		expect(() => assertBootWorkspace(WS)).not.toThrow();
+		expect(() => assertBootWorkspace("other-workspace")).toThrow(
+			/cross-workspace query refused/,
+		);
+	});
+});
+
+describe("resolveActiveWorkspace seed (DAT-461 / DAT-817)", () => {
+	it("seeds default user + workspace (state ready) + membership once, then resolves", async () => {
+		const { resolveActiveWorkspace, DEFAULT_USER_ID } = await freshRegistry();
 		const id = await resolveActiveWorkspace();
 		expect(id).toBe(WS);
 
-		const actor = h.inserts.find((i) => i.table === "actors");
-		expect(actor?.row.id).toBe(DEFAULT_ACTOR_ID);
+		const user = h.inserts.find((i) => i.table === "users");
+		expect(user?.row.id).toBe(DEFAULT_USER_ID);
 
 		const ws = h.inserts.find((i) => i.table === "workspaces");
 		expect(ws?.row.id).toBe(WS);
 		// engine schema derives from the id (underscores, not dashes) — matches the
 		// metadata write-surface.
 		expect(ws?.row.engineSchema).toBe(`ws_${WS.replaceAll("-", "_")}`);
-		// Cold-start seeds the no-vertical placeholder (DAT-505).
+		// Seeds the no-vertical placeholder (DAT-505) + the live lifecycle state
+		// (DAT-817 — a self-seeded boot workspace is by definition live).
 		expect(ws?.row.vertical).toBe("_adhoc");
+		expect(ws?.row.state).toBe("ready");
+
+		const membership = h.inserts.find((i) => i.table === "memberships");
+		expect(membership?.row).toMatchObject({
+			userId: DEFAULT_USER_ID,
+			workspaceId: WS,
+			role: "member",
+		});
+	});
+
+	it("runs the seed ONCE per process — the second resolve only reads", async () => {
+		const { resolveActiveWorkspace } = await freshRegistry();
+		await resolveActiveWorkspace();
+		const afterFirst = h.inserts.length;
+		expect(afterFirst).toBe(3); // users + workspaces + memberships
+		await resolveActiveWorkspace();
+		expect(h.inserts.length).toBe(afterFirst); // memoized — no re-seed
+	});
+
+	it("retries the seed on the next resolve after a transient failure", async () => {
+		const { resolveActiveWorkspace } = await freshRegistry();
+		h.failNextInsert = true;
+		await expect(resolveActiveWorkspace()).rejects.toThrow("transient db blip");
+		// The memo reset on failure — the next resolve seeds successfully.
+		await resolveActiveWorkspace();
+		expect(h.inserts.length).toBe(3);
 	});
 });
 
 describe("resolveActiveWorkspaceRow (DAT-505)", () => {
-	it("returns the row's id, per-workspace queue, and vertical (warm path)", async () => {
+	it("returns the row's id, per-workspace queue, and vertical", async () => {
+		const { resolveActiveWorkspaceRow } = await freshRegistry();
 		h.workspaceRows = [{ id: WS, vertical: "finance" }];
 		const row = await resolveActiveWorkspaceRow();
 		expect(row).toEqual({
@@ -115,22 +162,22 @@ describe("resolveActiveWorkspaceRow (DAT-505)", () => {
 			taskQueue: `engine-${WS}`,
 			vertical: "finance",
 		});
-		expect(h.inserts).toEqual([]);
 	});
 
-	it("seeds then returns the placeholder vertical + queue (cold path)", async () => {
+	it("throws born-loud when the row is missing even after the seed", async () => {
+		const { resolveActiveWorkspaceRow } = await freshRegistry();
+		// The idempotent seed ran but the select still returns nothing — a broken
+		// database, not a cold start; silent defaults would mask it.
 		h.workspaceRows = [];
-		const row = await resolveActiveWorkspaceRow();
-		expect(row).toEqual({
-			id: WS,
-			taskQueue: `engine-${WS}`,
-			vertical: "_adhoc",
-		});
+		await expect(resolveActiveWorkspaceRow()).rejects.toThrow(
+			/missing from the registry after seeding/,
+		);
 	});
 });
 
 describe("setActiveWorkspaceVertical (DAT-523)", () => {
 	it("upserts the active workspace's framed vertical (seed-or-update)", async () => {
+		const { setActiveWorkspaceVertical } = await freshRegistry();
 		await setActiveWorkspaceVertical("finance");
 		const up = h.upserts.find((u) => u.table === "workspaces");
 		// Upsert seeds the row if missing, with the real vertical not _adhoc...

--- a/packages/cockpit/src/db/cockpit/registry.test.ts
+++ b/packages/cockpit/src/db/cockpit/registry.test.ts
@@ -41,7 +41,11 @@ vi.mock("#/config", () => ({
 vi.mock("#/db/cockpit/schema", () => ({
 	users: { _t: "users", id: "id" },
 	workspaces: { _t: "workspaces", id: "id", vertical: "vertical" },
-	memberships: { _t: "memberships", userId: "user_id", workspaceId: "workspace_id" },
+	memberships: {
+		_t: "memberships",
+		userId: "user_id",
+		workspaceId: "workspace_id",
+	},
 }));
 
 vi.mock("drizzle-orm", () => ({ eq: (...a: unknown[]) => a }));

--- a/packages/cockpit/src/db/cockpit/registry.ts
+++ b/packages/cockpit/src/db/cockpit/registry.ts
@@ -1,35 +1,69 @@
-// Workspace registry resolver (DAT-461) — the source of truth for "which
-// workspace", replacing scattered `config.dataraumWorkspaceId` env reads.
+// Workspace registry resolver (DAT-461, control plane DAT-817) — the source of
+// truth for "which workspace", replacing scattered `config.dataraumWorkspaceId`
+// env reads.
 //
-// Phase 1 is single-active-workspace: the registry holds ONE row, seeded from
-// `DATARAUM_WORKSPACE_ID`, and `resolveActiveWorkspace()` returns it. The value
-// is still the env-designated workspace — what changes is that the cockpit_db
-// `workspaces` table is now the system of record (its row backs the FK on
-// `runs.workspaceId`, and reads go through here). Per-request workspace
-// SELECTION (a switcher) is Phase 3 (DAT-357); tools have no per-request context
-// channel today (TanStack AI `.server((input)=>…)` passes only input), so a
-// single resolver is the correct seam now.
+// The cockpit is PER-WORKSPACE (DD/51740673): each container boots with a single
+// workspace identity and never resolves the workspace per request. cockpit_db,
+// however, is ONE shared database across all cockpit containers of the
+// installation — so isolation is by scoped queries: every accessor in this
+// directory scopes reads/writes by `bootWorkspaceId()` (the sweep is DAT-817).
 //
 // Seeding is LAZY here rather than a boot step: the compose `cockpit-migrate`
 // init service applies the SCHEMA only, and host dev (cockpit run outside docker)
 // has no init step at all — so the registry self-populates on first resolve,
-// idempotently, working identically everywhere.
+// idempotently, working identically everywhere. The seed runs ONCE per process
+// (memoized) so the default user + membership also appear on an installation
+// whose workspace row predates them — the old cold-path-only seed would skip a
+// warm registry forever.
 
 import { eq } from "drizzle-orm";
 import { config } from "../../config";
 import { cockpitDb } from "./client";
-import { actors, workspaces } from "./schema";
+import { memberships, users, workspaces } from "./schema";
 
-// The single coarse actor (DAT-460): no auth, no multi-user yet. Seeded so the
-// attribution seam exists for when auth lands (DAT-357); run `createdBy` was carried
-// by the retired `sessions` table (DAT-562) and had no reader, so nothing stamps this
-// today. Real actors/auth are Phase 3 (DAT-357).
-export const DEFAULT_ACTOR_ID = "default";
+// The single coarse user (was the DAT-460 `actors` placeholder): no auth, no
+// multi-user yet. Seeded so the portal's login/membership routing (Phase 6,
+// DD/51740673) has a real identity row to start from.
+export const DEFAULT_USER_ID = "default";
 
 // The no-vertical placeholder a cold-start workspace is seeded with (DAT-505) —
 // mirrors the engine's `_adhoc` and the schema column default. Vertical is a
 // WORKSPACE property; the per-add_source channel retires in DAT-506.
 const DEFAULT_VERTICAL = "_adhoc";
+
+/** The provisioner lifecycle of a workspace (DAT-817, DD/51740673). The retired
+ * `archived_at` timestamp folds into `archiving`/`archived`. */
+export type WorkspaceState = "creating" | "ready" | "archiving" | "archived";
+
+/** A user's role in a workspace (DAT-817). `member` is the only role in v1;
+ * finer roles are a portal-phase (DAT-819) concern. */
+export type MembershipRole = "member";
+
+/**
+ * The workspace id this cockpit process SERVES — the boot identity
+ * (`DATARAUM_WORKSPACE_ID`), one per container (DD/51740673). THE scoping value
+ * of the control plane: every cockpit_db accessor filters its reads and fences
+ * its writes on this id (DAT-817), which is what keeps one shared cockpit_db
+ * isolated between per-workspace cockpits without per-request resolution.
+ */
+export function bootWorkspaceId(): string {
+	return config.dataraumWorkspaceId;
+}
+
+/**
+ * Born-loud guard for accessors that take a `workspaceId` parameter (DAT-817):
+ * in a per-workspace cockpit the only legal value is the boot workspace, so a
+ * mismatch is a programming error (or a mis-routed Temporal activity) — throw,
+ * never silently query another workspace's rows.
+ */
+export function assertBootWorkspace(workspaceId: string): void {
+	const boot = bootWorkspaceId();
+	if (workspaceId !== boot) {
+		throw new Error(
+			`[cockpit] cross-workspace query refused: ${workspaceId} is not the boot workspace ${boot}`,
+		);
+	}
+}
 
 /** The engine's `ws_<id>` Postgres schema for a workspace id — mirrors the
  * metadata write-surface's derivation (underscores, not dashes). */
@@ -58,13 +92,13 @@ export interface ActiveWorkspace {
 	vertical: string;
 }
 
-/** Idempotently seed the default actor + the env-designated workspace row.
- * Runs only on the cold path (first resolve after a fresh boot). */
-async function ensureRegistry(workspaceId: string): Promise<void> {
+/** Idempotently seed the default user, the env-designated workspace row (live:
+ * `state = 'ready'`), and the user's membership in it (DAT-817). */
+async function seedRegistry(workspaceId: string): Promise<void> {
 	await cockpitDb
-		.insert(actors)
-		.values({ id: DEFAULT_ACTOR_ID, displayName: "Default user" })
-		.onConflictDoNothing({ target: actors.id });
+		.insert(users)
+		.values({ id: DEFAULT_USER_ID, displayName: "Default user" })
+		.onConflictDoNothing({ target: users.id });
 	await cockpitDb
 		.insert(workspaces)
 		.values({
@@ -72,43 +106,66 @@ async function ensureRegistry(workspaceId: string): Promise<void> {
 			name: `Workspace ${workspaceId}`,
 			engineSchema: engineSchemaFor(workspaceId),
 			vertical: DEFAULT_VERTICAL,
+			state: "ready" satisfies WorkspaceState,
 		})
 		.onConflictDoNothing({ target: workspaces.id });
+	await cockpitDb
+		.insert(memberships)
+		.values({
+			userId: DEFAULT_USER_ID,
+			workspaceId,
+			role: "member" satisfies MembershipRole,
+		})
+		.onConflictDoNothing({
+			target: [memberships.userId, memberships.workspaceId],
+		});
+}
+
+// Once per process: the inserts are idempotent, so memoizing is purely a cost
+// cap (three no-op upserts per boot, not per resolve). Reset on failure so a
+// transient DB blip retries on the next resolve instead of wedging the seam.
+let seeded: Promise<void> | null = null;
+function ensureRegistrySeeded(workspaceId: string): Promise<void> {
+	seeded ??= seedRegistry(workspaceId).catch((err: unknown) => {
+		seeded = null;
+		throw err;
+	});
+	return seeded;
 }
 
 /**
- * The active workspace ROW, read from the registry (seeding it on the cold path).
- * The single seam the drivers use to route a workflow: it carries the per-workspace
- * task queue (`engine-<id>`) and the frame `vertical` alongside the id, so nothing
- * re-derives routing from the bare env var. Proven to exist as a `workspaces` row,
- * so `runs.workspaceId` FKs resolve.
+ * The active workspace ROW, read from the registry (seeding user + workspace +
+ * membership once per boot). The single seam the drivers use to route a
+ * workflow: it carries the per-workspace task queue (`engine-<id>`) and the
+ * frame `vertical` alongside the id, so nothing re-derives routing from the
+ * bare env var. Proven to exist as a `workspaces` row, so `runs.workspaceId`
+ * FKs resolve. Born-loud if the row is missing AFTER the idempotent seed —
+ * that's a broken database, not a cold start.
  */
 export async function resolveActiveWorkspaceRow(): Promise<ActiveWorkspace> {
-	const workspaceId = config.dataraumWorkspaceId;
+	const workspaceId = bootWorkspaceId();
+	await ensureRegistrySeeded(workspaceId);
 	const [row] = await cockpitDb
 		.select({ id: workspaces.id, vertical: workspaces.vertical })
 		.from(workspaces)
 		.where(eq(workspaces.id, workspaceId))
 		.limit(1);
-	if (row) {
-		return {
-			id: row.id,
-			taskQueue: engineTaskQueueFor(row.id),
-			vertical: row.vertical,
-		};
+	if (!row) {
+		throw new Error(
+			`[cockpit] workspace ${workspaceId} missing from the registry after seeding`,
+		);
 	}
-	await ensureRegistry(workspaceId);
 	return {
-		id: workspaceId,
-		taskQueue: engineTaskQueueFor(workspaceId),
-		vertical: DEFAULT_VERTICAL,
+		id: row.id,
+		taskQueue: engineTaskQueueFor(row.id),
+		vertical: row.vertical,
 	};
 }
 
 /**
  * The active workspace id, read from the registry (seeding it on the cold path).
- * Returns the `DATARAUM_WORKSPACE_ID` value in Phase 1 — but proven to exist as
- * a `workspaces` row, so `runs.workspaceId` FKs resolve. Thin wrapper over
+ * Returns the `DATARAUM_WORKSPACE_ID` value — but proven to exist as a
+ * `workspaces` row, so `runs.workspaceId` FKs resolve. Thin wrapper over
  * `resolveActiveWorkspaceRow` for call sites that need only the id.
  */
 export async function resolveActiveWorkspace(): Promise<string> {
@@ -125,11 +182,12 @@ export async function resolveActiveWorkspace(): Promise<string> {
  * vertical would silently leave the workspace `_adhoc` and fail add_source later
  * with a misleading "run frame first". Never called with `_adhoc` (frame guards
  * the no-vertical default so it can't overwrite a previously-framed workspace).
+ * Boot-scoped by construction: the target row is always the boot workspace.
  */
 export async function setActiveWorkspaceVertical(
 	vertical: string,
 ): Promise<void> {
-	const workspaceId = config.dataraumWorkspaceId;
+	const workspaceId = bootWorkspaceId();
 	await cockpitDb
 		.insert(workspaces)
 		.values({
@@ -137,6 +195,7 @@ export async function setActiveWorkspaceVertical(
 			name: `Workspace ${workspaceId}`,
 			engineSchema: engineSchemaFor(workspaceId),
 			vertical,
+			state: "ready" satisfies WorkspaceState,
 		})
 		.onConflictDoUpdate({ target: workspaces.id, set: { vertical } });
 }

--- a/packages/cockpit/src/db/cockpit/reports.test.ts
+++ b/packages/cockpit/src/db/cockpit/reports.test.ts
@@ -1,9 +1,10 @@
-// Unit tests for server-owned report persistence (DAT-624). Mocks the cockpit_db
-// client at the `#/` boundary (no DB). Covers the real logic the functions own:
-// mint with nullable-provenance defaulting, the live-only gallery filter
-// (deleted_at IS NULL) scoped + ordered by recency, getReport's missing/deleted →
-// null contract, and the rename/soft-delete guards. The real SQL is covered by the
-// Bun lane smoke.
+// Unit tests for server-owned report persistence (DAT-624; boot-workspace scope
+// DAT-817). Mocks the cockpit_db client at the `#/` boundary (no DB). Covers the
+// real logic the functions own: mint with nullable-provenance defaulting, the
+// live-only gallery filter (deleted_at IS NULL) scoped + ordered by recency,
+// getReport's missing/deleted → null contract, the rename/soft-delete guards,
+// and the DAT-817 boot-workspace fence on every by-id path. The real SQL is
+// covered by the workspace-isolation integration test.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -14,7 +15,14 @@ const h = vi.hoisted(() => ({
 	selectResult: [] as Array<Record<string, unknown>>,
 }));
 
+vi.mock("#/config", () => ({
+	config: { dataraumWorkspaceId: "ws-1" },
+}));
+
 vi.mock("#/db/cockpit/schema", () => ({
+	users: { _t: "users", id: "id" },
+	workspaces: { _t: "workspaces", id: "id", vertical: "vertical" },
+	memberships: { _t: "memberships" },
 	reports: {
 		_t: "reports",
 		id: "id",
@@ -159,6 +167,19 @@ describe("createReport", () => {
 			parentId: null,
 		});
 	});
+
+	it("refuses a non-boot workspace born-loud (DAT-817)", async () => {
+		await expect(
+			createReport({
+				workspaceId: "ws-other",
+				title: "t",
+				summary: "s",
+				sql: "SELECT 1",
+				confidence,
+			}),
+		).rejects.toThrow(/cross-workspace query refused/);
+		expect(h.inserts).toEqual([]);
+	});
 });
 
 describe("listReports", () => {
@@ -180,8 +201,10 @@ describe("getReport", () => {
 	it("hydrates a live report, or null for a missing/soft-deleted id", async () => {
 		h.selectResult = [{ id: "r1", title: "a", confidence }];
 		expect(await getReport("r1")).toMatchObject({ id: "r1", title: "a" });
-		// The query excludes soft-deleted rows.
+		// The query excludes soft-deleted rows AND is boot-workspace fenced
+		// (DAT-817): a foreign report id behaves exactly like an unknown one.
 		expect(JSON.stringify(h.whereArgs)).toContain("deleted_at");
+		expect(JSON.stringify(h.whereArgs)).toContain("workspace_id");
 
 		h.selectResult = [];
 		expect(await getReport("missing")).toBeNull();
@@ -189,11 +212,12 @@ describe("getReport", () => {
 });
 
 describe("renameReport", () => {
-	it("updates only the title, scoped to live rows", async () => {
+	it("updates only the title, scoped to live rows in the boot workspace", async () => {
 		await renameReport("r1", "New title");
 		const upd = h.updates.find((u) => u.table === "reports");
 		expect(upd?.set).toEqual({ title: "New title" });
 		expect(JSON.stringify(h.whereArgs)).toContain("deleted_at");
+		expect(JSON.stringify(h.whereArgs)).toContain("workspace_id");
 	});
 });
 
@@ -206,6 +230,7 @@ describe("updateReportSummary", () => {
 			summaryFingerprint: "fp-new",
 		});
 		expect(JSON.stringify(h.whereArgs)).toContain("deleted_at");
+		expect(JSON.stringify(h.whereArgs)).toContain("workspace_id");
 	});
 });
 
@@ -216,14 +241,16 @@ describe("setReportFingerprint", () => {
 		expect(upd?.set).toEqual({ summaryFingerprint: "fp-backfill" });
 		expect(upd?.set.summary).toBeUndefined();
 		expect(JSON.stringify(h.whereArgs)).toContain("deleted_at");
+		expect(JSON.stringify(h.whereArgs)).toContain("workspace_id");
 	});
 });
 
 describe("softDeleteReport", () => {
-	it("sets deletedAt (guarded by deleted_at IS NULL → idempotent)", async () => {
+	it("sets deletedAt (guarded by deleted_at IS NULL → idempotent), workspace-fenced", async () => {
 		await softDeleteReport("r1");
 		const upd = h.updates.find((u) => u.table === "reports");
 		expect(upd?.set.deletedAt).toBeInstanceOf(Date);
 		expect(JSON.stringify(h.whereArgs)).toContain("deleted_at");
+		expect(JSON.stringify(h.whereArgs)).toContain("workspace_id");
 	});
 });

--- a/packages/cockpit/src/db/cockpit/reports.ts
+++ b/packages/cockpit/src/db/cockpit/reports.ts
@@ -15,7 +15,13 @@ import { and, desc, eq, isNull } from "drizzle-orm";
 import type { ChartConfig } from "#/charts/chart-config";
 import type { AnswerConfidence } from "#/ui/cockpit/canvas-state";
 import { cockpitDb } from "./client";
+import { assertBootWorkspace, bootWorkspaceId } from "./registry";
 import { reports } from "./schema";
+
+// Workspace scope (DAT-817): cockpit_db is shared across per-workspace cockpit
+// containers, so every by-id read/mutation here is additionally fenced on
+// `reports.workspaceId = bootWorkspaceId()` — a foreign report id behaves
+// exactly like an unknown one (null / no-op), never a cross-workspace touch.
 
 /** How many reports the gallery lists. Bounded (cockpit "bound every data surface")
  * — newest-first; pagination is a follow-up when a workspace outgrows this. */
@@ -63,6 +69,7 @@ export interface ReportRow {
  * open. Provenance is best-effort — `workspaceId` is the only owner.
  */
 export async function createReport(input: CreateReportInput): Promise<string> {
+	assertBootWorkspace(input.workspaceId);
 	const id = randomUUID();
 	await cockpitDb.insert(reports).values({
 		id,
@@ -88,6 +95,7 @@ export async function listReports(
 	workspaceId: string,
 	limit: number = REPORTS_LIMIT,
 ): Promise<Array<ReportRow>> {
+	assertBootWorkspace(workspaceId);
 	return cockpitDb
 		.select({
 			id: reports.id,
@@ -126,7 +134,13 @@ export async function getReport(reportId: string): Promise<ReportRow | null> {
 			createdAt: reports.createdAt,
 		})
 		.from(reports)
-		.where(and(eq(reports.id, reportId), isNull(reports.deletedAt)))
+		.where(
+			and(
+				eq(reports.id, reportId),
+				eq(reports.workspaceId, bootWorkspaceId()),
+				isNull(reports.deletedAt),
+			),
+		)
 		.limit(1);
 	return row ?? null;
 }
@@ -142,7 +156,13 @@ export async function renameReport(
 	await cockpitDb
 		.update(reports)
 		.set({ title })
-		.where(and(eq(reports.id, reportId), isNull(reports.deletedAt)));
+		.where(
+			and(
+				eq(reports.id, reportId),
+				eq(reports.workspaceId, bootWorkspaceId()),
+				isNull(reports.deletedAt),
+			),
+		);
 }
 
 /**
@@ -159,7 +179,13 @@ export async function updateReportSummary(
 	await cockpitDb
 		.update(reports)
 		.set({ summary, summaryFingerprint })
-		.where(and(eq(reports.id, reportId), isNull(reports.deletedAt)));
+		.where(
+			and(
+				eq(reports.id, reportId),
+				eq(reports.workspaceId, bootWorkspaceId()),
+				isNull(reports.deletedAt),
+			),
+		);
 }
 
 /**
@@ -175,7 +201,13 @@ export async function setReportFingerprint(
 	await cockpitDb
 		.update(reports)
 		.set({ summaryFingerprint })
-		.where(and(eq(reports.id, reportId), isNull(reports.deletedAt)));
+		.where(
+			and(
+				eq(reports.id, reportId),
+				eq(reports.workspaceId, bootWorkspaceId()),
+				isNull(reports.deletedAt),
+			),
+		);
 }
 
 /**
@@ -187,5 +219,11 @@ export async function softDeleteReport(reportId: string): Promise<void> {
 	await cockpitDb
 		.update(reports)
 		.set({ deletedAt: new Date() })
-		.where(and(eq(reports.id, reportId), isNull(reports.deletedAt)));
+		.where(
+			and(
+				eq(reports.id, reportId),
+				eq(reports.workspaceId, bootWorkspaceId()),
+				isNull(reports.deletedAt),
+			),
+		);
 }

--- a/packages/cockpit/src/db/cockpit/runs.test.ts
+++ b/packages/cockpit/src/db/cockpit/runs.test.ts
@@ -1,20 +1,32 @@
-// Unit tests for control-plane run recording (DAT-461, DAT-506, DAT-562, DAT-595).
+// Unit tests for control-plane run recording (DAT-461, DAT-506, DAT-562, DAT-595;
+// boot-workspace scope DAT-817).
 // Mocks the cockpit_db client at the `#/` boundary (no DB). Asserts recordRun inserts
 // the run row directly (workspace-grouped, conflict target = workflow+run) keyed by the
 // REAL Temporal execution id (DAT-595 — recorded post-start, so each run of the reused
 // `addsource-<ws>` id is a distinct row, no placeholder/attachRunId swap); that a db
-// error THROWS; and that markRunStatus issues the terminal update (best-effort). The
-// real SQL + idempotency/append are covered by the Bun lane smoke.
+// error THROWS; that markRunStatus issues the terminal update (best-effort); and
+// the DAT-817 boot-workspace fences (the activity-contract writers scope
+// INTERNALLY — their signatures are an engine-mirrored wire shape). The real SQL
+// is covered by the workspace-isolation integration test.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => ({
 	inserts: [] as Array<{ table: string; row: Record<string, unknown> }>,
 	conflicts: [] as unknown[],
-	updates: [] as Array<{ table: string; set: Record<string, unknown> }>,
+	updates: [] as Array<{
+		table: string;
+		set: Record<string, unknown>;
+		where: unknown[];
+	}>,
+	whereArgs: [] as unknown[][],
 	// Rows the latest-run lookup (markRunAwaitingInput) returns.
 	latestRows: [{ id: "run-row-latest" }] as Array<{ id: string }>,
 	throwOnInsert: false,
+}));
+
+vi.mock("#/config", () => ({
+	config: { dataraumWorkspaceId: "ws-1" },
 }));
 
 vi.mock("#/db/cockpit/schema", () => ({
@@ -29,10 +41,13 @@ vi.mock("#/db/cockpit/schema", () => ({
 		awaitingNote: "awaiting_note",
 		startedAt: "started_at",
 	},
+	users: { _t: "users", id: "id" },
+	workspaces: { _t: "workspaces", id: "id", vertical: "vertical" },
+	memberships: { _t: "memberships" },
 }));
 vi.mock("drizzle-orm", () => ({
-	eq: (...a: unknown[]) => a,
-	and: (...a: unknown[]) => a,
+	eq: (...a: unknown[]) => ["eq", ...a],
+	and: (...a: unknown[]) => ["and", ...a],
 	desc: (x: unknown) => x,
 }));
 
@@ -52,16 +67,19 @@ vi.mock("#/db/cockpit/client", () => ({
 		}),
 		select: () => ({
 			from: () => ({
-				where: () => ({
-					limit: limitMock,
-					orderBy: () => ({ limit: limitMock }),
-				}),
+				where: (...a: unknown[]) => {
+					h.whereArgs.push(a);
+					return {
+						limit: limitMock,
+						orderBy: () => ({ limit: limitMock }),
+					};
+				},
 			}),
 		}),
 		update: (table: { _t: string }) => ({
 			set: (s: Record<string, unknown>) => ({
-				where: async () => {
-					h.updates.push({ table: table._t, set: s });
+				where: async (...a: unknown[]) => {
+					h.updates.push({ table: table._t, set: s, where: a });
 				},
 			}),
 		}),
@@ -84,6 +102,7 @@ beforeEach(() => {
 	h.inserts = [];
 	h.conflicts = [];
 	h.updates = [];
+	h.whereArgs = [];
 	h.latestRows = [{ id: "run-row-latest" }];
 	h.throwOnInsert = false;
 	limitMock.mockClear();
@@ -137,14 +156,24 @@ describe("recordRun (DAT-461, DAT-506, DAT-562)", () => {
 		h.throwOnInsert = true;
 		await expect(recordRun(BASE)).rejects.toThrow(/db down/);
 	});
+
+	it("refuses a non-boot workspace born-loud — a mis-routed activity (DAT-817)", async () => {
+		await expect(
+			recordRun({ ...BASE, workspaceId: "ws-other" }),
+		).rejects.toThrow(/cross-workspace query refused/);
+		expect(h.inserts).toEqual([]);
+	});
 });
 
 describe("markRunStatus (DAT-461)", () => {
-	it("issues a terminal status update for the run", async () => {
+	it("issues a terminal status update for the run, boot-workspace fenced", async () => {
 		await markRunStatus("wf-1", "run-1", "completed");
 		expect(h.updates).toHaveLength(1);
 		expect(h.updates[0].table).toBe("runs");
 		expect(h.updates[0].set).toEqual({ status: "completed" });
+		// DAT-817: the activity has no workspace parameter (wire contract) — the
+		// fence rides in the WHERE, so a foreign (workflowId, runId) is a no-op.
+		expect(JSON.stringify(h.updates[0].where)).toContain("workspace_id");
 	});
 
 	it("is best-effort: swallows a db error", async () => {
@@ -171,6 +200,9 @@ describe("markRunAwaitingInput (DAT-551)", () => {
 			status: "awaiting_input",
 			awaitingNote: "payments.method needs a concept",
 		});
+		// DAT-817: the latest-run lookup is boot-workspace fenced (wire contract
+		// carries no workspace), so a foreign workflow id parks nothing.
+		expect(JSON.stringify(h.whereArgs)).toContain("workspace_id");
 	});
 
 	it("no-ops when the workflow has no recorded run (nothing to park)", async () => {

--- a/packages/cockpit/src/db/cockpit/runs.ts
+++ b/packages/cockpit/src/db/cockpit/runs.ts
@@ -26,7 +26,14 @@ import { and, count, desc, eq, gt, notExists } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { currentConversationId } from "#/lib/run-context";
 import { cockpitDb } from "./client";
+import { assertBootWorkspace, bootWorkspaceId } from "./registry";
 import { runs } from "./schema";
+
+// Workspace scope (DAT-817): cockpit_db is shared across per-workspace cockpit
+// containers, so every read/write here is fenced to the boot workspace. The
+// activity-contract writers (recordRun / markRunStatus / markRunAwaitingInput —
+// engine-mirrored IO, worker/contracts.py) scope INTERNALLY: their signatures
+// are a cross-package wire shape and must not grow a scope parameter.
 
 /** How a run originated (was the retired `sessions.kind`). */
 export type RunKind = "onboarding" | "begin_session" | "replay";
@@ -68,6 +75,10 @@ export interface RecordRunInput {
  * old workflowId-placeholder scheme allowed; DAT-595).
  */
 export async function recordRun(input: RecordRunInput): Promise<void> {
+	// Born-loud (DAT-817): a recordRun for another workspace means a mis-routed
+	// activity (the engine schedules these on the workspace's own cockpit queue)
+	// — fail the activity, never write a foreign workspace's run row.
+	assertBootWorkspace(input.workspaceId);
 	await cockpitDb
 		.insert(runs)
 		.values({
@@ -119,7 +130,13 @@ export async function markRunStatus(
 		await cockpitDb
 			.update(runs)
 			.set({ status })
-			.where(and(eq(runs.workflowId, workflowId), eq(runs.runId, runId)));
+			.where(
+				and(
+					eq(runs.workspaceId, bootWorkspaceId()),
+					eq(runs.workflowId, workflowId),
+					eq(runs.runId, runId),
+				),
+			);
 	} catch (err) {
 		console.warn(
 			`[cockpit] markRunStatus failed for run ${runId} (${workflowId}): ${err}`,
@@ -144,7 +161,12 @@ export async function markRunAwaitingInput(
 		const [latest] = await cockpitDb
 			.select({ id: runs.id })
 			.from(runs)
-			.where(eq(runs.workflowId, workflowId))
+			.where(
+				and(
+					eq(runs.workspaceId, bootWorkspaceId()),
+					eq(runs.workflowId, workflowId),
+				),
+			)
 			.orderBy(desc(runs.startedAt))
 			.limit(1);
 		if (!latest) return;
@@ -188,7 +210,11 @@ export async function listNonTerminalRuns(
 		})
 		.from(runs)
 		.where(
-			and(eq(runs.conversationId, conversationId), eq(runs.status, "running")),
+			and(
+				eq(runs.workspaceId, bootWorkspaceId()),
+				eq(runs.conversationId, conversationId),
+				eq(runs.status, "running"),
+			),
 		)
 		.orderBy(desc(runs.startedAt))
 		.limit(limit);
@@ -211,6 +237,7 @@ export async function listNonTerminalRunsByWorkspace(
 	workspaceId: string,
 	limit: number,
 ): Promise<Array<ActiveRun>> {
+	assertBootWorkspace(workspaceId);
 	return cockpitDb
 		.select({
 			workflowId: runs.workflowId,
@@ -237,7 +264,11 @@ export async function listRunningStages(
 		.selectDistinct({ stage: runs.stage })
 		.from(runs)
 		.where(
-			and(eq(runs.conversationId, conversationId), eq(runs.status, "running")),
+			and(
+				eq(runs.workspaceId, bootWorkspaceId()),
+				eq(runs.conversationId, conversationId),
+				eq(runs.status, "running"),
+			),
 		);
 	return rows.map((r) => r.stage as RunStage);
 }
@@ -276,7 +307,11 @@ export async function listWatchableRuns(
 		})
 		.from(runs)
 		.where(
-			and(eq(runs.conversationId, conversationId), eq(runs.status, "running")),
+			and(
+				eq(runs.workspaceId, bootWorkspaceId()),
+				eq(runs.conversationId, conversationId),
+				eq(runs.status, "running"),
+			),
 		)
 		.orderBy(desc(runs.startedAt))
 		.limit(limit);
@@ -301,6 +336,7 @@ export async function hasRunningRun(
 	workspaceId: string,
 	stage: RunStage,
 ): Promise<boolean> {
+	assertBootWorkspace(workspaceId);
 	const [row] = await cockpitDb
 		.select({ id: runs.id })
 		.from(runs)
@@ -341,6 +377,7 @@ export async function listRunsByWorkspace(
 	workspaceId: string,
 	limit: number,
 ): Promise<Array<WorkspaceRun>> {
+	assertBootWorkspace(workspaceId);
 	const rows = await cockpitDb
 		.select({
 			workflowId: runs.workflowId,
@@ -368,6 +405,7 @@ export async function listRunsByWorkspace(
  * stream). Cheap aggregate, workspace-scoped.
  */
 export async function countRunningRuns(workspaceId: string): Promise<number> {
+	assertBootWorkspace(workspaceId);
 	const [row] = await cockpitDb
 		.select({ n: count() })
 		.from(runs)
@@ -408,6 +446,10 @@ function openAwaitingItem(workspaceId: string) {
 				.from(newer)
 				.where(
 					and(
+						// Workspace-fenced like the outer predicate (DAT-817). Workflow ids
+						// embed the workspace so cross-workspace collisions can't happen
+						// today — this keeps the invariant local + provable, not inferred.
+						eq(newer.workspaceId, workspaceId),
 						eq(newer.workflowId, runs.workflowId),
 						gt(newer.startedAt, runs.startedAt),
 					),
@@ -427,6 +469,7 @@ export async function listAwaitingInput(
 	workspaceId: string,
 	limit: number,
 ): Promise<Array<AwaitingInputItem>> {
+	assertBootWorkspace(workspaceId);
 	const rows = await cockpitDb
 		.select({
 			workflowId: runs.workflowId,
@@ -447,6 +490,7 @@ export async function listAwaitingInput(
  * `openAwaitingItem` predicate as the list, so badge and panel never disagree.
  */
 export async function countAwaitingInput(workspaceId: string): Promise<number> {
+	assertBootWorkspace(workspaceId);
 	const [row] = await cockpitDb
 		.select({ n: count() })
 		.from(runs)

--- a/packages/cockpit/src/db/cockpit/schema.ts
+++ b/packages/cockpit/src/db/cockpit/schema.ts
@@ -27,6 +27,7 @@ import {
 	integer,
 	jsonb,
 	pgTable,
+	primaryKey,
 	text,
 	timestamp,
 	uniqueIndex,
@@ -36,13 +37,14 @@ import type { ChartConfig } from "#/charts/chart-config";
 import type { AnswerConfidence } from "#/ui/cockpit/canvas-state";
 
 /**
- * Who triggered control-plane work. A coarse identity seam (DAT-460): a single
- * seeded `default` row for now — NO auth, NO multi-user. Real actors/auth are
- * Phase 3 (DAT-357). The registry seeds the `default` row; run attribution
- * (`createdBy`) was carried by the retired `sessions` table (DAT-562) and had no
- * reader, so it is reintroduced on `runs` only when auth lands.
+ * A control-plane user (DAT-817) — the identity the portal logs in and routes by
+ * (DD/51740673). Replaces the DAT-460 `actors` placeholder (same seam, real
+ * name): a single seeded `default` row until the portal's login lands (Phase 6),
+ * which also decides the auth model (credential store vs OIDC) and adds its
+ * columns then — this table deliberately carries no credential/identity claim
+ * columns yet.
  */
-export const actors = pgTable("actors", {
+export const users = pgTable("users", {
 	id: varchar("id").primaryKey(),
 	displayName: varchar("display_name").notNull(),
 	createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
@@ -53,14 +55,21 @@ export const actors = pgTable("actors", {
  * the bare `DATARAUM_WORKSPACE_ID` env read. Seeded from that env var on first
  * resolve (registry.ts). `id` is the workspace key (the same value the engine is
  * bootstrapped with, e.g. `00000000-…-001`); `engineSchema` is the derived
- * `ws_<id>` Postgres schema the metadata client reads. Phase 1 is single-active-
- * workspace; the switcher + lifecycle are Phase 3 (DAT-357 — hence `archivedAt`).
+ * `ws_<id>` Postgres schema the metadata client reads.
+ *
+ * Multi-workspace control plane (DAT-817, DD/51740673): cockpit_db stays ONE
+ * shared database across all per-workspace cockpit containers, so this registry
+ * holds every workspace of the installation. `state` is the provisioner
+ * lifecycle (`creating → ready → archiving → archived` — the retired
+ * `archived_at` folds into it; a self-seeded boot workspace is live, hence the
+ * `ready` default). The resource record — `subdomain` (Caddy route, Phase 6),
+ * `readerRole` / `writerRole` (the per-workspace Postgres roles that resolve +
+ * fence the `ws_<id>` schemas), `catalogSchema` (the DuckLake catalog schema) —
+ * is minted by the provisioner (Phase 7), so all four stay NULL on an
+ * env-seeded workspace until then.
  *
  * `vertical` is the workspace's frame ontology (DAT-505): vertical is a WORKSPACE
- * property, not a per-add_source pick. The capability lands here (the column + the
- * boot-read via `resolveActiveWorkspaceRow`); the per-add_source vertical channel
- * (select.ts / the workflow payload) is retired in DAT-506 (Phase 5), which deletes
- * the session row that carries it today. Defaults to `_adhoc` (the no-vertical
+ * property, not a per-add_source pick. Defaults to `_adhoc` (the no-vertical
  * placeholder) so a freshly-seeded workspace is always valid.
  */
 export const workspaces = pgTable("workspaces", {
@@ -68,9 +77,41 @@ export const workspaces = pgTable("workspaces", {
 	name: varchar("name").notNull(),
 	engineSchema: varchar("engine_schema").notNull(),
 	vertical: varchar("vertical").notNull().default("_adhoc"),
+	// Provisioner lifecycle (DAT-817): creating | ready | archiving | archived.
+	// Typed as WorkspaceState (registry.ts) — varchar + TS union per the
+	// schema-wide convention (kind/status/stage columns), not a pgEnum.
+	state: varchar("state").notNull().default("ready"),
+	// Per-workspace resource record (DAT-817) — filled by the provisioner
+	// (Phase 7); NULL on an env-seeded workspace.
+	subdomain: varchar("subdomain"),
+	readerRole: varchar("reader_role"),
+	writerRole: varchar("writer_role"),
+	catalogSchema: varchar("catalog_schema"),
 	createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
-	archivedAt: timestamp("archived_at", { mode: "date" }),
 });
+
+/**
+ * A user's membership in a workspace (DAT-817) — what the portal lists at login
+ * to route the user to their workspaces' subdomains (Phase 6, DD/51740673).
+ * One row per (user, workspace); `role` is a varchar + TS union
+ * (`MembershipRole`, registry.ts) with `member` the only role in v1 — finer
+ * roles are a portal-phase concern. The registry seeds the default user's
+ * membership in the boot workspace alongside the workspace row itself.
+ */
+export const memberships = pgTable(
+	"memberships",
+	{
+		userId: varchar("user_id")
+			.notNull()
+			.references(() => users.id),
+		workspaceId: varchar("workspace_id")
+			.notNull()
+			.references(() => workspaces.id),
+		role: varchar("role").notNull().default("member"),
+		createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.userId, t.workspaceId] })],
+);
 
 /**
  * One Temporal run in a workspace — the reload-recovery substrate (DAT-462 reads

--- a/packages/cockpit/src/db/cockpit/ui-state.test.ts
+++ b/packages/cockpit/src/db/cockpit/ui-state.test.ts
@@ -1,19 +1,38 @@
-// Unit tests for per-conversation UI-state persistence (DAT-462). Mocks the
-// cockpit_db boundary. Covers loadUiState's null-vs-row branch and saveUiState's
-// upsert + best-effort swallow. Real SQL is the Bun lane smoke's job.
+// Unit tests for per-conversation UI-state persistence (DAT-462; boot-workspace
+// scope DAT-817). Mocks the cockpit_db boundary. Covers loadUiState's
+// null-vs-row branch, saveUiState's upsert + best-effort swallow, and the
+// DAT-817 fence: both paths scope through the owning conversation's workspace.
+// The row-level proof is the workspace-isolation integration test.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => ({
 	upserts: [] as Array<{ values: Record<string, unknown>; set?: unknown }>,
+	whereArgs: [] as unknown[][],
+	joins: [] as unknown[][],
 	selectResult: [] as Array<Record<string, unknown>>,
 	throwOnInsert: false,
 }));
 
+vi.mock("#/config", () => ({
+	config: { dataraumWorkspaceId: "ws-1" },
+}));
+
 vi.mock("#/db/cockpit/schema", () => ({
 	uiState: { _t: "ui_state", conversationId: "conversation_id" },
+	conversations: {
+		_t: "conversations",
+		id: "id",
+		workspaceId: "workspace_id",
+	},
+	users: { _t: "users", id: "id" },
+	workspaces: { _t: "workspaces", id: "id", vertical: "vertical" },
+	memberships: { _t: "memberships" },
 }));
-vi.mock("drizzle-orm", () => ({ eq: (...a: unknown[]) => a }));
+vi.mock("drizzle-orm", () => ({
+	eq: (...a: unknown[]) => ["eq", ...a],
+	and: (...a: unknown[]) => ["and", ...a],
+}));
 
 vi.mock("#/db/cockpit/client", () => ({
 	cockpitDb: {
@@ -27,9 +46,21 @@ vi.mock("#/db/cockpit/client", () => ({
 				};
 			},
 		}),
-		select: () => ({
-			from: () => ({ where: () => ({ limit: async () => h.selectResult }) }),
-		}),
+		select: () => {
+			const chain = {
+				from: () => chain,
+				innerJoin: (...a: unknown[]) => {
+					h.joins.push(a);
+					return chain;
+				},
+				where: (...a: unknown[]) => {
+					h.whereArgs.push(a);
+					return chain;
+				},
+				limit: async () => h.selectResult,
+			};
+			return chain;
+		},
 	},
 }));
 
@@ -37,6 +68,8 @@ import { loadUiState, saveUiState } from "./ui-state";
 
 beforeEach(() => {
 	h.upserts = [];
+	h.whereArgs = [];
+	h.joins = [];
 	h.selectResult = [];
 	h.throwOnInsert = false;
 });
@@ -48,9 +81,13 @@ describe("loadUiState", () => {
 		expect(await loadUiState("conv-1")).toBeNull();
 	});
 
-	it("returns the pinned call id when a row exists", async () => {
+	it("returns the pinned call id when a row exists, workspace-fenced", async () => {
 		h.selectResult = [{ pinnedCallId: "call-9" }];
 		expect(await loadUiState("conv-1")).toEqual({ pinnedCallId: "call-9" });
+		// DAT-817: scoped through the owning conversation's workspace — a foreign
+		// conversation id reads as "no stored state".
+		expect(h.joins).toHaveLength(1);
+		expect(JSON.stringify(h.whereArgs)).toContain("workspace_id");
 	});
 
 	it("normalizes a null pin to null", async () => {
@@ -60,7 +97,8 @@ describe("loadUiState", () => {
 });
 
 describe("saveUiState", () => {
-	it("upserts on the conversation id", async () => {
+	it("upserts on the conversation id once ownership is proven", async () => {
+		h.selectResult = [{ id: "conv-1" }]; // the DAT-817 ownership gate
 		await saveUiState("conv-1", { pinnedCallId: "call-3" });
 		expect(h.upserts).toHaveLength(1);
 		expect(h.upserts[0].values).toMatchObject({
@@ -68,10 +106,20 @@ describe("saveUiState", () => {
 			pinnedCallId: "call-3",
 		});
 		expect(h.upserts[0].set).toMatchObject({ pinnedCallId: "call-3" });
+		expect(JSON.stringify(h.whereArgs)).toContain("workspace_id");
+	});
+
+	it("drops the write (logged) for a conversation outside the boot workspace (DAT-817)", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		h.selectResult = []; // ownership gate finds no boot-owned conversation
+		await saveUiState("foreign-conv", { pinnedCallId: "call-3" });
+		expect(h.upserts).toEqual([]);
+		expect(warn).toHaveBeenCalledTimes(1);
 	});
 
 	it("is best-effort: swallows + logs a db error", async () => {
 		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		h.selectResult = [{ id: "conv-1" }];
 		h.throwOnInsert = true;
 		await expect(
 			saveUiState("conv-1", { pinnedCallId: null }),

--- a/packages/cockpit/src/db/cockpit/ui-state.ts
+++ b/packages/cockpit/src/db/cockpit/ui-state.ts
@@ -4,35 +4,66 @@
 // `saveUiState` is best-effort (fired on a UI interaction — a failed pin write
 // must never surface an error to the user); `loadUiState` throws and the loader
 // degrades to "no restored state" (live canvas) on failure.
+//
+// Workspace scope (DAT-817): `ui_state` rows carry no workspace_id — they scope
+// through their owning conversation, so both paths gate on the conversation
+// belonging to the boot workspace (cockpit_db is shared across per-workspace
+// cockpits). A foreign conversation reads as "no stored state" and its pin
+// write is dropped (logged), matching the module's degradation contract.
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { cockpitDb } from "./client";
-import { uiState } from "./schema";
+import { bootWorkspaceId } from "./registry";
+import { conversations, uiState } from "./schema";
 
 export interface UiState {
 	/** The pinned tool-call id the canvas is "viewing history" on, or null for live. */
 	pinnedCallId: string | null;
 }
 
-/** Load the restorable UI state for a conversation, or null if none stored. */
+/** Load the restorable UI state for a conversation, or null if none stored
+ * (or the conversation isn't the boot workspace's — DAT-817). */
 export async function loadUiState(
 	conversationId: string,
 ): Promise<UiState | null> {
 	const [row] = await cockpitDb
 		.select({ pinnedCallId: uiState.pinnedCallId })
 		.from(uiState)
-		.where(eq(uiState.conversationId, conversationId))
+		.innerJoin(conversations, eq(uiState.conversationId, conversations.id))
+		.where(
+			and(
+				eq(uiState.conversationId, conversationId),
+				eq(conversations.workspaceId, bootWorkspaceId()),
+			),
+		)
 		.limit(1);
 	if (!row) return null;
 	return { pinnedCallId: row.pinnedCallId ?? null };
 }
 
-/** Upsert the UI state for a conversation. Best-effort: swallows + logs. */
+/** Upsert the UI state for a conversation. Best-effort: swallows + logs; a
+ * foreign workspace's conversation id is dropped the same way (DAT-817). */
 export async function saveUiState(
 	conversationId: string,
 	state: UiState,
 ): Promise<void> {
 	try {
+		const [owned] = await cockpitDb
+			.select({ id: conversations.id })
+			.from(conversations)
+			.where(
+				and(
+					eq(conversations.id, conversationId),
+					eq(conversations.workspaceId, bootWorkspaceId()),
+				),
+			)
+			.limit(1);
+		if (!owned) {
+			console.warn(
+				`[cockpit] saveUiState dropped for ${conversationId}: not in the boot workspace`,
+			);
+			return;
+		}
 		await cockpitDb
 			.insert(uiState)
 			.values({ conversationId, pinnedCallId: state.pinnedCallId })

--- a/packages/cockpit/src/db/cockpit/workspace-isolation.integration.test.ts
+++ b/packages/cockpit/src/db/cockpit/workspace-isolation.integration.test.ts
@@ -1,0 +1,388 @@
+// Real-Postgres integration test for the DAT-817 boot-workspace scope — the
+// row-level proof behind the unit tests' structural WHERE assertions.
+//
+// cockpit_db is ONE shared database across per-workspace cockpit containers
+// (DD/51740673); isolation is scoped queries only. This test seeds a FOREIGN
+// workspace (B) with a full set of rows — conversation, messages, ui_state,
+// runs, report — alongside the boot workspace (A), then proves PER TABLE that
+// B's rows never surface through any accessor of A's cockpit and that A's
+// bare-id writes cannot touch them (foreign id ⇒ null / empty / no-op / throw).
+// Counts are asserted RELATIVELY (before vs after seeding B) because the dev
+// database is shared state — smokes may have left workspace-A rows behind.
+//
+// Requires the compose Postgres with cockpit_db migrated
+// (`bun run db:migrate:cockpit`). Self-skips when COCKPIT_DATABASE_URL is unset
+// so unit CI without the stack stays green.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const STACK_AVAILABLE = !!process.env.COCKPIT_DATABASE_URL;
+
+// Stub the cockpit env so config.ts loads for the DB-bound imports.
+const REQUIRED_DEFAULTS: Record<string, string> = {
+	COCKPIT_DATABASE_URL: process.env.COCKPIT_DATABASE_URL ?? "",
+	METADATA_DATABASE_URL:
+		process.env.METADATA_DATABASE_URL ??
+		"postgresql://dataraum:dataraum@127.0.0.1:5432/dataraum",
+	DATARAUM_WORKSPACE_ID:
+		process.env.DATARAUM_WORKSPACE_ID ?? "00000000-0000-0000-0000-000000000001",
+	DATARAUM_CONFIG_PATH: process.env.DATARAUM_CONFIG_PATH ?? "/tmp",
+	S3_BUCKET: process.env.S3_BUCKET ?? "dataraum-lake",
+	DATARAUM_LAKE_PATH:
+		process.env.DATARAUM_LAKE_PATH ?? "s3://dataraum-lake/lake",
+	DUCKLAKE_CATALOG_URL:
+		process.env.DUCKLAKE_CATALOG_URL ??
+		"postgresql://dataraum:dataraum@127.0.0.1:5432/lake_catalog",
+	ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? "sk-ant-test-placeholder",
+	S3_ENDPOINT: process.env.S3_ENDPOINT ?? "127.0.0.1:8333",
+	S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID ?? "dataraum",
+	S3_SECRET_ACCESS_KEY:
+		process.env.S3_SECRET_ACCESS_KEY ?? "dataraum-s3-secret",
+};
+for (const [k, v] of Object.entries(REQUIRED_DEFAULTS)) {
+	if (!process.env[k]) process.env[k] = v;
+}
+
+const WS_A = process.env.DATARAUM_WORKSPACE_ID as string;
+
+// Unique ids so parallel/repeat runs don't collide on the shared database.
+const u = Date.now().toString(36);
+const WS_B = `iso_b_ws_${u}`;
+const CONV_A = `iso_conv_a_${u}`;
+const CONV_B = `iso_conv_b_${u}`;
+const MSG_B = `iso_msg_b_${u}`;
+const WF_B = `iso_wf_b_${u}`;
+const RUN_B_RUNNING = `iso_run_b1_${u}`;
+const RUN_B_AWAITING = `iso_run_b2_${u}`;
+const WF_B_AWAITING = `iso_wf_b_await_${u}`;
+const REPORT_B = `iso_report_b_${u}`;
+
+const confidence = {
+	band: "ready",
+	groundedRatio: 1,
+	reuse: { exactReuse: 0, adapted: 0, fresh: 1 },
+	assumptions: [],
+	conceptsUsed: [],
+};
+
+describe.skipIf(!STACK_AVAILABLE)(
+	"boot-workspace isolation over shared cockpit_db (DAT-817)",
+	() => {
+		/* biome-ignore-start lint/suspicious/noExplicitAny: dynamic-imported module shapes */
+		let db: any;
+		let schema: any;
+		let registry: any;
+		let conversationsMod: any;
+		let runsMod: any;
+		let reportsMod: any;
+		let uiStateMod: any;
+		let drizzle: any;
+		/* biome-ignore-end lint/suspicious/noExplicitAny: dynamic-imported module shapes */
+
+		beforeAll(async () => {
+			db = (await import("./client")).cockpitDb;
+			schema = await import("./schema");
+			registry = await import("./registry");
+			conversationsMod = await import("./conversations");
+			runsMod = await import("./runs");
+			reportsMod = await import("./reports");
+			uiStateMod = await import("./ui-state");
+			drizzle = await import("drizzle-orm");
+
+			// Boot resolve: seeds workspace A + default user + membership.
+			await registry.resolveActiveWorkspace();
+
+			// The FOREIGN workspace and its rows — written directly (the accessors
+			// under test would rightly refuse them).
+			await db.insert(schema.workspaces).values({
+				id: WS_B,
+				name: "Workspace B (isolation probe)",
+				engineSchema: `ws_${WS_B}`,
+				state: "ready",
+			});
+			// title deliberately NULL: setConversationTitle's own `title IS NULL`
+			// first-write guard must not be what blocks the cross-workspace write —
+			// only the DAT-817 fence can be.
+			await db.insert(schema.conversations).values({
+				id: CONV_B,
+				workspaceId: WS_B,
+				kind: "analyse",
+			});
+			await db.insert(schema.conversationMessages).values({
+				id: MSG_B,
+				conversationId: CONV_B,
+				seq: 0,
+				role: "user",
+				message: { id: MSG_B, role: "user", parts: [] },
+			});
+			await db
+				.insert(schema.uiState)
+				.values({ conversationId: CONV_B, pinnedCallId: "b-pin" });
+			await db.insert(schema.runs).values([
+				{
+					id: RUN_B_RUNNING,
+					workspaceId: WS_B,
+					kind: "begin_session",
+					stage: "begin_session",
+					workflowId: WF_B,
+					runId: RUN_B_RUNNING,
+					conversationId: CONV_B,
+					status: "running",
+				},
+				{
+					id: RUN_B_AWAITING,
+					workspaceId: WS_B,
+					kind: "onboarding",
+					stage: "add_source",
+					workflowId: WF_B_AWAITING,
+					runId: RUN_B_AWAITING,
+					status: "awaiting_input",
+					awaitingNote: "B needs a human",
+				},
+			]);
+			await db.insert(schema.reports).values({
+				id: REPORT_B,
+				workspaceId: WS_B,
+				title: "B report",
+				summary: "B summary",
+				sql: "SELECT 1",
+				confidence,
+			});
+
+			// One boot-owned conversation for the positive paths (inserted directly
+			// under a deterministic id so cleanup can target it).
+			await db
+				.insert(schema.conversations)
+				.values({ id: CONV_A, workspaceId: WS_A, kind: "analyse" });
+		});
+
+		afterAll(async () => {
+			if (!db) return;
+			// FK-safe order; best-effort — a failed cleanup only leaves uniquely-named
+			// probe rows behind.
+			const { eq, inArray } = drizzle;
+			await db
+				.delete(schema.uiState)
+				.where(inArray(schema.uiState.conversationId, [CONV_A, CONV_B]));
+			await db
+				.delete(schema.conversationMessages)
+				.where(
+					inArray(schema.conversationMessages.conversationId, [CONV_A, CONV_B]),
+				);
+			await db
+				.delete(schema.runs)
+				.where(inArray(schema.runs.id, [RUN_B_RUNNING, RUN_B_AWAITING]));
+			await db.delete(schema.reports).where(eq(schema.reports.id, REPORT_B));
+			await db
+				.delete(schema.conversations)
+				.where(inArray(schema.conversations.id, [CONV_A, CONV_B]));
+			await db
+				.delete(schema.memberships)
+				.where(eq(schema.memberships.workspaceId, WS_B));
+			await db.delete(schema.workspaces).where(eq(schema.workspaces.id, WS_B));
+		});
+
+		it("registry: resolves the boot workspace and seeds the default user + membership", async () => {
+			const { eq, and } = drizzle;
+			expect(await registry.resolveActiveWorkspace()).toBe(WS_A);
+			const [user] = await db
+				.select({ id: schema.users.id })
+				.from(schema.users)
+				.where(eq(schema.users.id, registry.DEFAULT_USER_ID))
+				.limit(1);
+			expect(user?.id).toBe(registry.DEFAULT_USER_ID);
+			const [membership] = await db
+				.select({ role: schema.memberships.role })
+				.from(schema.memberships)
+				.where(
+					and(
+						eq(schema.memberships.userId, registry.DEFAULT_USER_ID),
+						eq(schema.memberships.workspaceId, WS_A),
+					),
+				)
+				.limit(1);
+			expect(membership?.role).toBe("member");
+			// The seeded boot workspace is live.
+			const [ws] = await db
+				.select({ state: schema.workspaces.state })
+				.from(schema.workspaces)
+				.where(eq(schema.workspaces.id, WS_A))
+				.limit(1);
+			expect(ws?.state).toBe("ready");
+		});
+
+		it("conversations: B's rows never list, hydrate, or accept writes in A's cockpit", async () => {
+			const { eq } = drizzle;
+			const listed = await conversationsMod.listConversations(WS_A, 1000);
+			expect(listed.map((c: { id: string }) => c.id)).toContain(CONV_A);
+			expect(listed.map((c: { id: string }) => c.id)).not.toContain(CONV_B);
+
+			expect(await conversationsMod.getConversation(CONV_B)).toBeNull();
+			expect(await conversationsMod.getConversation(CONV_A)).toMatchObject({
+				id: CONV_A,
+				workspaceId: WS_A,
+			});
+
+			await expect(
+				conversationsMod.createConversation(WS_B, "analyse"),
+			).rejects.toThrow(/cross-workspace query refused/);
+
+			// setConversationTitle against B's UNTITLED row: its `title IS NULL`
+			// first-write guard would let this through — only the DAT-817 workspace
+			// fence stops it.
+			await conversationsMod.setConversationTitle(CONV_B, "hijacked");
+			const [bRow] = await db
+				.select({ title: schema.conversations.title })
+				.from(schema.conversations)
+				.where(eq(schema.conversations.id, CONV_B))
+				.limit(1);
+			expect(bRow?.title).toBeNull();
+		});
+
+		it("conversation_messages: B's transcript is invisible and unappendable from A", async () => {
+			const { eq } = drizzle;
+			expect(await conversationsMod.loadDisplayMessages(CONV_B)).toEqual([]);
+			expect(await conversationsMod.loadModelTranscript(CONV_B)).toEqual([]);
+
+			await expect(
+				conversationsMod.appendMessages(CONV_B, [
+					{
+						message: { id: `iso_inj_${u}`, role: "user", parts: [] },
+					},
+				]),
+			).rejects.toThrow(/not in the boot workspace/);
+			const bMessages = await db
+				.select({ id: schema.conversationMessages.id })
+				.from(schema.conversationMessages)
+				.where(eq(schema.conversationMessages.conversationId, CONV_B));
+			expect(bMessages).toHaveLength(1); // only B's own seeded message
+
+			// Positive path: the boot-owned conversation accepts the append.
+			await conversationsMod.appendMessages(CONV_A, [
+				{ message: { id: `iso_msg_a_${u}`, role: "user", parts: [] } },
+			]);
+			const aTranscript = await conversationsMod.loadModelTranscript(CONV_A);
+			expect(aTranscript.map((m: { id: string }) => m.id)).toContain(
+				`iso_msg_a_${u}`,
+			);
+		});
+
+		it("ui_state: B's pin neither loads nor accepts writes from A", async () => {
+			const { eq } = drizzle;
+			expect(await uiStateMod.loadUiState(CONV_B)).toBeNull();
+
+			await uiStateMod.saveUiState(CONV_B, { pinnedCallId: "a-hijack" });
+			const [bPin] = await db
+				.select({ pinnedCallId: schema.uiState.pinnedCallId })
+				.from(schema.uiState)
+				.where(eq(schema.uiState.conversationId, CONV_B))
+				.limit(1);
+			expect(bPin?.pinnedCallId).toBe("b-pin");
+
+			// Positive path on the boot-owned conversation.
+			await uiStateMod.saveUiState(CONV_A, { pinnedCallId: "a-pin" });
+			expect(await uiStateMod.loadUiState(CONV_A)).toEqual({
+				pinnedCallId: "a-pin",
+			});
+		});
+
+		it("runs: B's runs never surface in A's monitor/watchers and A's writers can't touch them", async () => {
+			const { eq } = drizzle;
+			const monitor = await runsMod.listRunsByWorkspace(WS_A, 1000);
+			expect(
+				monitor.map((r: { workflowId: string }) => r.workflowId),
+			).not.toContain(WF_B);
+
+			await expect(runsMod.listRunsByWorkspace(WS_B, 10)).rejects.toThrow(
+				/cross-workspace query refused/,
+			);
+			await expect(
+				runsMod.hasRunningRun(WS_B, "begin_session"),
+			).rejects.toThrow(/cross-workspace query refused/);
+
+			// Conversation-keyed reads: B's conversation id yields nothing through
+			// A's fence even though B's run rows reference it.
+			expect(await runsMod.listNonTerminalRuns(CONV_B, 10)).toEqual([]);
+			expect(await runsMod.listRunningStages(CONV_B)).toEqual([]);
+			expect(await runsMod.listWatchableRuns(CONV_B, 10)).toEqual([]);
+
+			// The awaiting-input inbox: B's parked run is not A's worklist.
+			const awaiting = await runsMod.listAwaitingInput(WS_A, 1000);
+			expect(
+				awaiting.map((r: { workflowId: string }) => r.workflowId),
+			).not.toContain(WF_B_AWAITING);
+
+			// Activity-contract writers (no workspace parameter — the fence rides
+			// inside): a foreign (workflowId, runId) is a no-op...
+			await runsMod.markRunStatus(WF_B, RUN_B_RUNNING, "completed");
+			const [bRun] = await db
+				.select({ status: schema.runs.status })
+				.from(schema.runs)
+				.where(eq(schema.runs.id, RUN_B_RUNNING))
+				.limit(1);
+			expect(bRun?.status).toBe("running");
+			// ...and a foreign workflow id parks nothing.
+			await runsMod.markRunAwaitingInput(WF_B, "hijack note");
+			const [bRun2] = await db
+				.select({
+					status: schema.runs.status,
+					awaitingNote: schema.runs.awaitingNote,
+				})
+				.from(schema.runs)
+				.where(eq(schema.runs.id, RUN_B_RUNNING))
+				.limit(1);
+			expect(bRun2?.status).toBe("running");
+			expect(bRun2?.awaitingNote).toBeNull();
+
+			// recordRun for a foreign workspace is a mis-routed activity — born-loud.
+			await expect(
+				runsMod.recordRun({
+					workspaceId: WS_B,
+					kind: "begin_session",
+					stage: "begin_session",
+					workflowId: WF_B,
+					runId: `iso_new_${u}`,
+				}),
+			).rejects.toThrow(/cross-workspace query refused/);
+		});
+
+		it("reports: B's report never lists, hydrates, or accepts writes in A's gallery", async () => {
+			const { eq } = drizzle;
+			const gallery = await reportsMod.listReports(WS_A, 1000);
+			expect(gallery.map((r: { id: string }) => r.id)).not.toContain(REPORT_B);
+
+			expect(await reportsMod.getReport(REPORT_B)).toBeNull();
+
+			await reportsMod.renameReport(REPORT_B, "hijacked");
+			await reportsMod.updateReportSummary(REPORT_B, "hijacked", "fp-x");
+			await reportsMod.setReportFingerprint(REPORT_B, "fp-y");
+			await reportsMod.softDeleteReport(REPORT_B);
+			const [bReport] = await db
+				.select({
+					title: schema.reports.title,
+					summary: schema.reports.summary,
+					summaryFingerprint: schema.reports.summaryFingerprint,
+					deletedAt: schema.reports.deletedAt,
+				})
+				.from(schema.reports)
+				.where(eq(schema.reports.id, REPORT_B))
+				.limit(1);
+			expect(bReport).toEqual({
+				title: "B report",
+				summary: "B summary",
+				summaryFingerprint: null,
+				deletedAt: null,
+			});
+
+			await expect(
+				reportsMod.createReport({
+					workspaceId: WS_B,
+					title: "t",
+					summary: "s",
+					sql: "SELECT 1",
+					confidence,
+				}),
+			).rejects.toThrow(/cross-workspace query refused/);
+		});
+	},
+);


### PR DESCRIPTION
## Task

DAT-817 — https://real-dataraum.atlassian.net/browse/DAT-817 (epic DAT-813, design [DD/51740673](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/51740673))

Two commits, one PR (the ticket's 4a/4b split): **4a** control-plane tables + migration, **4b** the boot-workspace query-scoping sweep.

## What changed

- **`users`** replaces the DAT-460 `actors` placeholder (same seam, real name — the identity the Phase 6 portal logs in and routes by). No credential columns yet: the portal phase decides the auth model (open question in the design doc). Migration drops `actors`; the seeded `default` row is recreated by the lazy seed under the same id.
- **`memberships`** = (user, workspace, role), composite PK; role is varchar + TS union (`"member"` only in v1) per the schema-wide convention (kind/status/stage are varchar everywhere — no pgEnum anywhere in this schema).
- **`workspaces`** gains `state` (`creating/ready/archiving/archived`, default `ready`; the reader-less `archived_at` folds into it and is dropped) + the per-workspace resource record: `subdomain`, `reader_role`, `writer_role`, `catalog_schema` — all nullable until the provisioner (Phase 7) mints them.
- **Registry seed** is once-per-process and idempotent: default user + boot workspace (`state='ready'`) + membership. (The old cold-path-only seed would never have added the new rows to a warm registry.) Missing row after seeding is now born-loud.
- **Scoping seam**: `bootWorkspaceId()` / `assertBootWorkspace()` in `registry.ts`; every accessor in `src/db/cockpit/*` enforces the boot fence internally (see sweep below).

`workspace_id` NOT NULL FK: holds on `runs`/`conversations`/`reports` (pre-existing) + new `memberships`. `conversation_messages`/`ui_state` are conversation-scoped children by design (the design doc's own enumeration) — they scope transitively through their owning conversation, enforced by joins/ownership gates and proven per-table below.

## Enumerated query-site sweep (complete, not sampled)

`cockpitDb` is touched **only** inside `src/db/cockpit/` (grep-verified with positive control; the only external references are `vi.mock` stubs in tests). Every accessor function, with its scoping mechanism:

| # | Function | Table(s) | Scoping |
|---|---|---|---|
| 1 | `registry.resolveActiveWorkspaceRow` | workspaces (+seed: users, workspaces, memberships) | reads/writes only `bootWorkspaceId()` rows by construction |
| 2 | `registry.resolveActiveWorkspace` | — | wrapper of #1 |
| 3 | `registry.setActiveWorkspaceVertical` | workspaces | upserts the boot row only (id = boot) |
| 4 | `conversations.listConversations(workspaceId)` | conversations | `assertBootWorkspace` + `WHERE workspace_id` |
| 5 | `conversations.createConversation(workspaceId)` | conversations | `assertBootWorkspace` (born-loud) |
| 6 | `conversations.getConversation(id)` | conversations | `WHERE id AND workspace_id = boot` → foreign id = null/404 |
| 7 | `conversations.setConversationTitle(id)` | conversations | fenced UPDATE (`workspace_id = boot`) |
| 8 | `conversations.loadDisplayMessages(id)` | conversation_messages ⋈ conversations | INNER JOIN + `conversations.workspace_id = boot` |
| 9 | `conversations.loadModelTranscript(id)` | conversation_messages ⋈ conversations | INNER JOIN + boot fence |
| 10 | `conversations.appendMessages(id)` | conversation_messages, conversations | ownership gate (throws on foreign id, nothing written) + fenced recency bump |
| 11 | `runs.recordRun(input)` | runs | `assertBootWorkspace(input.workspaceId)` — **activity wire contract unchanged**, fence internal |
| 12 | `runs.markRunStatus(wfId, runId)` | runs | fenced UPDATE (`workspace_id = boot`) — activity contract unchanged |
| 13 | `runs.markRunAwaitingInput(wfId)` | runs | fenced latest-run SELECT — activity contract unchanged |
| 14 | `runs.listNonTerminalRuns(convId)` | runs | `workspace_id = boot` added |
| 15 | `runs.listNonTerminalRunsByWorkspace(wsId)` | runs | `assertBootWorkspace` |
| 16 | `runs.listRunningStages(convId)` | runs | `workspace_id = boot` added |
| 17 | `runs.listWatchableRuns(convId)` | runs | `workspace_id = boot` added |
| 18 | `runs.hasRunningRun(wsId)` | runs | `assertBootWorkspace` |
| 19 | `runs.listRunsByWorkspace(wsId)` | runs | `assertBootWorkspace` |
| 20 | `runs.countRunningRuns(wsId)` | runs | `assertBootWorkspace` |
| 21 | `runs.listAwaitingInput(wsId)` | runs (+ newer-run alias subquery) | `assertBootWorkspace`; subquery now workspace-fenced too |
| 22 | `runs.countAwaitingInput(wsId)` | runs | same shared predicate as #21 |
| 23 | `reports.createReport(input)` | reports | `assertBootWorkspace` |
| 24 | `reports.listReports(wsId)` | reports | `assertBootWorkspace` + `WHERE workspace_id` |
| 25 | `reports.getReport(id)` | reports | `WHERE id AND workspace_id = boot AND live` |
| 26 | `reports.renameReport(id)` | reports | fenced UPDATE |
| 27 | `reports.updateReportSummary(id)` | reports | fenced UPDATE |
| 28 | `reports.setReportFingerprint(id)` | reports | fenced UPDATE |
| 29 | `reports.softDeleteReport(id)` | reports | fenced UPDATE |
| 30 | `uiState.loadUiState(convId)` | ui_state ⋈ conversations | INNER JOIN + boot fence |
| 31 | `uiState.saveUiState(convId)` | ui_state, conversations | ownership gate — foreign id dropped (logged), best-effort contract kept |

Caller inventory (all flow the boot workspace or a fenced bare id): route fns (`(app)/route`, `index`, `cockpit/{route,index,$conversationId}`, `governance`, `workflows`, `reports/{index,$reportId}`), API routes (`chat`, `chat-stream`→completion-watcher, `awaiting-input`, `running-runs`, `workflow-progress`, `reports/mint`, `upload`), `temporal/{orchestration-trigger,trigger-add-source,reconcile}`, `lib/{agent-turn,completion-watcher}`, `prompts/workspace-context`, `db/metadata/briefing/build`, `server/active-vertical`, tools (`begin-session`, `list-sources`, `operating-model`, `query`, `replay`, `frame`, `use-vertical`), `worker/activities` (re-exports #11–13 — names + IO byte-identical, engine `worker/contracts.py` untouched).

Foreign-id semantics: reads → null/empty (same as unknown id, routes 404); best-effort writes → no-op; load-bearing writes (`appendMessages`, `createConversation`, `recordRun`) → born-loud throw.

## Acceptance criteria

- [x] `users` + `memberships` tables (Drizzle migration), seeded default user; memberships = (user, workspace, role — `member`)
- [x] `workspaces` registry: `state` column (archived_at folded in) + resource record (subdomain, reader/writer role names, catalog schema)
- [x] `workspace_id` NOT NULL FK on every workspace-scoped table (runs/conversations/reports/memberships; children scope through conversations)
- [x] Every cockpit_db read/write scoped by the boot workspace id — enumerated sweep above; per-table isolation test (`workspace-isolation.integration.test.ts`) proves workspace B's rows never surface in A's cockpit (conversations, conversation_messages, ui_state, runs, reports, registry)
- [x] Full cockpit suite green; single-workspace behavior unchanged (every fence is a tautology for boot-owned rows)

## Lane smoke

```
bunx tsc --noEmit                          → clean
bun run check (biome)                      → clean (487 files)
bun run test                               → 177 files / 1683 tests passed
db:migrate:cockpit on compose Postgres     → applied (20260719100238_noisy_paper_doll)
workspace-isolation.integration.test.ts    → 6/6 passed (real Postgres)
scripts/smoke-dat-461.ts                   → ✓ passed (now asserts user + membership seed)
```

No real-LLM path in this lane's surface — no live smoke needed.

## Notes for merge order

- **Collision with DAT-816 (metadata schema resolution):** that lane's branch also touches cockpit_db — it drops `workspaces.engine_schema` and adds its own `drizzle/cockpit` migration (observed live on the shared dev DB mid-smoke). Whichever lane merges second must rebase and **re-generate** its cockpit migration against the winner (standing rule: generated files are re-dumped, never hand-merged). The `workspaces`-table diffs are otherwise disjoint (they remove a column; this PR adds columns/tables).
- `$wsId` URL param stays decorative (explicit precedent in `governance.functions.ts`; Phase 6 subdomain routing replaces it).
- Reviewers: senior-code-reviewer **APPROVE** (2 nits, both folded in), spec-compliance-reviewer **APPROVE** (AC-by-AC).

## Other lanes in flight

```
517  DAT-815: Phase 2 — DuckLake catalog schema per workspace, one catalog DB per installation  feat/dat-815-ducklake-catalog-schema
516  DAT-818: Phase 5 — per-workspace cockpit-<ws> callback queue (cross-package)               feat/dat-818-cockpit-ws-queue
(DAT-816 lane in flight, PR not yet open at time of writing)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)