### PR TITLE
DAT-821: Phase 8 — Workspace UX: create workspace + switcher in the cockpit

### DIFF
--- a/packages/cockpit/src/lib/subdomain-label.test.ts
+++ b/packages/cockpit/src/lib/subdomain-label.test.ts
@@ -1,0 +1,44 @@
+// subdomain-label (DAT-821): the one shared derivation/validation for
+// workspace subdomain labels.
+
+import { describe, expect, it } from "vitest";
+import {
+	isValidSubdomainLabel,
+	subdomainLabelFrom,
+} from "#/lib/subdomain-label";
+
+describe("subdomainLabelFrom", () => {
+	it("lowercases and dashes a plain name", () => {
+		expect(subdomainLabelFrom("Sales Department")).toBe("sales-department");
+	});
+
+	it("strips diacritics and collapses symbol runs", () => {
+		expect(subdomainLabelFrom("Département — Finance & Co.")).toBe(
+			"departement-finance-co",
+		);
+	});
+
+	it("trims edge dashes and caps at 63 chars without a trailing dash", () => {
+		expect(subdomainLabelFrom("--ws--")).toBe("ws");
+		const long = `${"a".repeat(62)}-b`;
+		const label = subdomainLabelFrom(long);
+		expect(label.length).toBeLessThanOrEqual(63);
+		expect(label.endsWith("-")).toBe(false);
+	});
+
+	it("returns empty for an underivable name", () => {
+		expect(subdomainLabelFrom("!!!")).toBe("");
+	});
+});
+
+describe("isValidSubdomainLabel", () => {
+	it("accepts DNS labels and rejects the rest", () => {
+		expect(isValidSubdomainLabel("ws3")).toBe(true);
+		expect(isValidSubdomainLabel("dept-3")).toBe(true);
+		expect(isValidSubdomainLabel("")).toBe(false);
+		expect(isValidSubdomainLabel("-ws")).toBe(false);
+		expect(isValidSubdomainLabel("ws-")).toBe(false);
+		expect(isValidSubdomainLabel("Ws")).toBe(false);
+		expect(isValidSubdomainLabel("a".repeat(64))).toBe(false);
+	});
+});

--- a/packages/cockpit/src/lib/subdomain-label.ts
+++ b/packages/cockpit/src/lib/subdomain-label.ts
@@ -1,0 +1,31 @@
+// Workspace subdomain labels (DAT-821). Pure + isomorphic: the create form
+// derives a label from the workspace name as the user types, and the server
+// fn validates the submitted label with the same pattern — one definition,
+// mirroring lifecycle.ts's validateSubdomain (DNS label: lowercase
+// alphanumerics + inner dashes, ≤63 chars).
+
+export const SUBDOMAIN_LABEL_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+export const SUBDOMAIN_LABEL_MAX = 63;
+
+export function isValidSubdomainLabel(label: string): boolean {
+	return (
+		label.length <= SUBDOMAIN_LABEL_MAX && SUBDOMAIN_LABEL_PATTERN.test(label)
+	);
+}
+
+/**
+ * Derive a DNS label from a human workspace name: strip diacritics, lowercase,
+ * collapse every non-alphanumeric run into one dash, trim edge dashes, cap at
+ * 63. May return "" (e.g. an all-symbol name) — the form treats that as
+ * "no derivable label; type one".
+ */
+export function subdomainLabelFrom(name: string): string {
+	return name
+		.normalize("NFKD")
+		.replace(/\p{M}/gu, "")
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, SUBDOMAIN_LABEL_MAX)
+		.replace(/-+$/g, "");
+}

--- a/packages/cockpit/src/portal/create-gate.server.test.ts
+++ b/packages/cockpit/src/portal/create-gate.server.test.ts
@@ -11,6 +11,7 @@ const h = vi.hoisted(() => ({
 	portalMode: true,
 	session: null as { user: { id: string; email: string } } | null,
 	membershipRows: [] as { userId: string }[],
+	setStatus: vi.fn(),
 }));
 
 vi.mock("#/config.base", () => ({
@@ -25,9 +26,11 @@ vi.mock("#/auth/auth", () => ({
 	auth: { api: { getSession: async () => h.session } },
 }));
 // The gate reads the request headers for the session cookie — a bare Request
-// stands in for the server context.
+// stands in for the server context. setResponseStatus is spied: it is how a
+// rejection's HTTP status reaches the wire (server-fn-error.ts).
 vi.mock("@tanstack/react-start/server", () => ({
 	getRequest: () => new Request("http://dataraum.localhost/create"),
+	setResponseStatus: h.setStatus,
 }));
 // cockpit_db (bun:sql) — a thenable select chain that resolves the injected
 // membership rows.
@@ -53,33 +56,49 @@ import {
 } from "#/portal/create-gate.server";
 import { trackCreateRun } from "#/portal/create-tracker";
 
-async function rejectionStatus(promise: Promise<unknown>): Promise<number> {
+/** The gate must reject with a thrown ERROR (a thrown Response would RESOLVE
+ * the RPC client-side — server-fn-error.ts) whose message is the JSON
+ * envelope, alongside a setResponseStatus call carrying the HTTP status. */
+async function rejectionStatus(promise: Promise<unknown>): Promise<{
+	status: number | undefined;
+	code: string;
+}> {
 	try {
 		await promise;
 	} catch (err) {
-		if (err instanceof Response) {
-			return err.status;
+		if (err instanceof Error) {
+			return {
+				status: h.setStatus.mock.lastCall?.[0] as number | undefined,
+				code: (JSON.parse(err.message) as { error: string }).error,
+			};
 		}
 		throw err;
 	}
-	throw new Error("expected a thrown Response");
+	throw new Error("expected a rejection");
 }
 
 beforeEach(() => {
 	h.portalMode = true;
 	h.session = null;
 	h.membershipRows = [];
+	h.setStatus.mockClear();
 });
 
 describe("requirePortalSession", () => {
 	it("rejects a workspace cockpit with 403 — provisioning is portal-only", async () => {
 		h.portalMode = false;
 		h.session = { user: { id: "u1", email: "u1@x" } };
-		expect(await rejectionStatus(requirePortalSession())).toBe(403);
+		expect(await rejectionStatus(requirePortalSession())).toEqual({
+			status: 403,
+			code: "portal_only",
+		});
 	});
 
 	it("rejects a signed-out request with 401", async () => {
-		expect(await rejectionStatus(requirePortalSession())).toBe(401);
+		expect(await rejectionStatus(requirePortalSession())).toEqual({
+			status: 401,
+			code: "unauthenticated",
+		});
 	});
 
 	it("returns the session for a signed-in portal request", async () => {
@@ -107,6 +126,6 @@ describe("requireCreateVisibility", () => {
 		trackCreateRun("ws-other", "u1", new Promise(() => {}));
 		expect(
 			await rejectionStatus(requireCreateVisibility("ws-other", "u2")),
-		).toBe(403);
+		).toEqual({ status: 403, code: "not_a_member" });
 	});
 });

--- a/packages/cockpit/src/portal/create-gate.server.test.ts
+++ b/packages/cockpit/src/portal/create-gate.server.test.ts
@@ -1,0 +1,110 @@
+// The DAT-821 authz gate (create-gate.server.ts) on the portal lifecycle fns — the first
+// HTTP-reachable trigger of the provisioner, so the two gate helpers get
+// direct coverage: portal-role-only, session required, and progress
+// visibility = membership OR tracked starter. Handler orchestration (drizzle
+// reads, the fire-and-forget) is exercised by the lane smoke on the real
+// stack — mocking those chains would test the mock.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+	portalMode: true,
+	session: null as { user: { id: string; email: string } } | null,
+	membershipRows: [] as { userId: string }[],
+}));
+
+vi.mock("#/config.base", () => ({
+	baseConfig: {
+		get portalMode() {
+			return h.portalMode;
+		},
+		portalOrigin: "http://dataraum.localhost",
+	},
+}));
+vi.mock("#/auth/auth", () => ({
+	auth: { api: { getSession: async () => h.session } },
+}));
+// The gate reads the request headers for the session cookie — a bare Request
+// stands in for the server context.
+vi.mock("@tanstack/react-start/server", () => ({
+	getRequest: () => new Request("http://dataraum.localhost/create"),
+}));
+// cockpit_db (bun:sql) — a thenable select chain that resolves the injected
+// membership rows.
+vi.mock("#/db/cockpit/client", () => {
+	const chain = {
+		select: () => chain,
+		from: () => chain,
+		where: () => chain,
+		limit: () => Promise.resolve(h.membershipRows),
+	};
+	return { cockpitDb: chain };
+});
+// The real lifecycle assembly imports "bun" — never loaded in this test.
+vi.mock("#/portal/lifecycle-deps", () => ({
+	runLifecycle: async () => {
+		throw new Error("not under test");
+	},
+}));
+
+import {
+	requireCreateVisibility,
+	requirePortalSession,
+} from "#/portal/create-gate.server";
+import { trackCreateRun } from "#/portal/create-tracker";
+
+async function rejectionStatus(promise: Promise<unknown>): Promise<number> {
+	try {
+		await promise;
+	} catch (err) {
+		if (err instanceof Response) {
+			return err.status;
+		}
+		throw err;
+	}
+	throw new Error("expected a thrown Response");
+}
+
+beforeEach(() => {
+	h.portalMode = true;
+	h.session = null;
+	h.membershipRows = [];
+});
+
+describe("requirePortalSession", () => {
+	it("rejects a workspace cockpit with 403 — provisioning is portal-only", async () => {
+		h.portalMode = false;
+		h.session = { user: { id: "u1", email: "u1@x" } };
+		expect(await rejectionStatus(requirePortalSession())).toBe(403);
+	});
+
+	it("rejects a signed-out request with 401", async () => {
+		expect(await rejectionStatus(requirePortalSession())).toBe(401);
+	});
+
+	it("returns the session for a signed-in portal request", async () => {
+		h.session = { user: { id: "u1", email: "u1@x" } };
+		await expect(requirePortalSession()).resolves.toBe(h.session);
+	});
+});
+
+describe("requireCreateVisibility", () => {
+	it("passes a member", async () => {
+		h.membershipRows = [{ userId: "u1" }];
+		await expect(requireCreateVisibility("ws-a", "u1")).resolves.toBeUndefined();
+	});
+
+	it("passes the tracked starter before the membership row exists", async () => {
+		trackCreateRun("ws-pre-row", "u1", new Promise(() => {}));
+		await expect(
+			requireCreateVisibility("ws-pre-row", "u1"),
+		).resolves.toBeUndefined();
+	});
+
+	it("rejects everyone else with 403", async () => {
+		trackCreateRun("ws-other", "u1", new Promise(() => {}));
+		expect(await rejectionStatus(requireCreateVisibility("ws-other", "u2"))).toBe(
+			403,
+		);
+	});
+});

--- a/packages/cockpit/src/portal/create-gate.server.test.ts
+++ b/packages/cockpit/src/portal/create-gate.server.test.ts
@@ -91,7 +91,9 @@ describe("requirePortalSession", () => {
 describe("requireCreateVisibility", () => {
 	it("passes a member", async () => {
 		h.membershipRows = [{ userId: "u1" }];
-		await expect(requireCreateVisibility("ws-a", "u1")).resolves.toBeUndefined();
+		await expect(
+			requireCreateVisibility("ws-a", "u1"),
+		).resolves.toBeUndefined();
 	});
 
 	it("passes the tracked starter before the membership row exists", async () => {
@@ -103,8 +105,8 @@ describe("requireCreateVisibility", () => {
 
 	it("rejects everyone else with 403", async () => {
 		trackCreateRun("ws-other", "u1", new Promise(() => {}));
-		expect(await rejectionStatus(requireCreateVisibility("ws-other", "u2"))).toBe(
-			403,
-		);
+		expect(
+			await rejectionStatus(requireCreateVisibility("ws-other", "u2")),
+		).toBe(403);
 	});
 });

--- a/packages/cockpit/src/portal/create-gate.server.ts
+++ b/packages/cockpit/src/portal/create-gate.server.ts
@@ -19,19 +19,21 @@ import { baseConfig } from "#/config.base";
 import { cockpitDb } from "#/db/cockpit/client";
 import { memberships } from "#/db/cockpit/schema";
 import { createRunFor } from "#/portal/create-tracker";
+import { serverFnError } from "#/server/server-fn-error";
 
-/** Portal-role + session gate. Thrown Responses pass through the server-fn
- * handler verbatim (status-correct rejections for direct RPC callers; the
- * route's beforeLoad handles the human redirect). */
+/** Portal-role + session gate. Rejections go through `serverFnError` — a
+ * status-carrying thrown Error that actually REJECTS the client call (a
+ * thrown Response would resolve, see server-fn-error.ts); the route's
+ * beforeLoad handles the human redirect. */
 export async function requirePortalSession() {
 	if (!baseConfig.portalMode) {
 		// A workspace cockpit must never expose provisioning — its container
 		// deliberately lacks the admin env, and the surface belongs to the portal.
-		throw Response.json({ error: "portal_only" }, { status: 403 });
+		throw serverFnError(403, "portal_only");
 	}
 	const session = await auth.api.getSession({ headers: getRequest().headers });
 	if (!session) {
-		throw Response.json({ error: "unauthenticated" }, { status: 401 });
+		throw serverFnError(401, "unauthenticated");
 	}
 	return session;
 }
@@ -53,6 +55,6 @@ export async function requireCreateVisibility(
 		)
 		.limit(1);
 	if (!membership && createRunFor(workspaceId)?.userId !== userId) {
-		throw Response.json({ error: "not_a_member" }, { status: 403 });
+		throw serverFnError(403, "not_a_member");
 	}
 }

--- a/packages/cockpit/src/portal/create-gate.server.ts
+++ b/packages/cockpit/src/portal/create-gate.server.ts
@@ -1,0 +1,58 @@
+// The DAT-821 authz gate for the portal's lifecycle server fns. SERVER-ONLY
+// (the `.server.ts` split keeps these plain exports out of the isomorphic
+// route graph — the import-protection build check rejects non-serverFn
+// exports that reach `@tanstack/react-start/server`).
+//
+// v1 policy (decided on DAT-821): the portal role only, an authenticated
+// session required, and ANY signed-in user of the installation may create —
+// one installation = one tenant, every account arrived through this portal's
+// sign-up, and finer roles are explicitly post-v1 (`MembershipRole` is
+// `member`-only). The creator is the membership the new workspace gets; the
+// client can never attach other users.
+
+import "@tanstack/react-start/server-only";
+
+import { getRequest } from "@tanstack/react-start/server";
+import { and, eq } from "drizzle-orm";
+import { auth } from "#/auth/auth";
+import { baseConfig } from "#/config.base";
+import { cockpitDb } from "#/db/cockpit/client";
+import { memberships } from "#/db/cockpit/schema";
+import { createRunFor } from "#/portal/create-tracker";
+
+/** Portal-role + session gate. Thrown Responses pass through the server-fn
+ * handler verbatim (status-correct rejections for direct RPC callers; the
+ * route's beforeLoad handles the human redirect). */
+export async function requirePortalSession() {
+	if (!baseConfig.portalMode) {
+		// A workspace cockpit must never expose provisioning — its container
+		// deliberately lacks the admin env, and the surface belongs to the portal.
+		throw Response.json({ error: "portal_only" }, { status: 403 });
+	}
+	const session = await auth.api.getSession({ headers: getRequest().headers });
+	if (!session) {
+		throw Response.json({ error: "unauthenticated" }, { status: 401 });
+	}
+	return session;
+}
+
+/** Progress/retry visibility = membership (the creator's row lands with the
+ * registry write) OR having started the tracked run (the pre-row window). */
+export async function requireCreateVisibility(
+	workspaceId: string,
+	userId: string,
+): Promise<void> {
+	const [membership] = await cockpitDb
+		.select({ userId: memberships.userId })
+		.from(memberships)
+		.where(
+			and(
+				eq(memberships.userId, userId),
+				eq(memberships.workspaceId, workspaceId),
+			),
+		)
+		.limit(1);
+	if (!membership && createRunFor(workspaceId)?.userId !== userId) {
+		throw Response.json({ error: "not_a_member" }, { status: 403 });
+	}
+}

--- a/packages/cockpit/src/portal/create-tracker.test.ts
+++ b/packages/cockpit/src/portal/create-tracker.test.ts
@@ -1,0 +1,53 @@
+// create-tracker (DAT-821): terminal-state semantics of the in-process
+// create-run record — success deletes (the registry's `ready` says
+// everything), failure keeps the message, retry overwrites.
+
+import { describe, expect, it } from "vitest";
+import { createRunFor, trackCreateRun } from "#/portal/create-tracker";
+
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+describe("trackCreateRun", () => {
+	it("records a running op and deletes the entry on success", async () => {
+		let finish: (value: unknown) => void = () => {};
+		trackCreateRun(
+			"ws-ok",
+			"user-1",
+			new Promise((resolve) => {
+				finish = resolve;
+			}),
+		);
+		expect(createRunFor("ws-ok")).toEqual({ userId: "user-1", status: "running" });
+		finish(undefined);
+		await settle();
+		expect(createRunFor("ws-ok")).toBeNull();
+	});
+
+	it("keeps the failure message verbatim", async () => {
+		trackCreateRun(
+			"ws-fail",
+			"user-1",
+			Promise.reject(new Error("subdomain 'x' is already claimed")),
+		);
+		await settle();
+		expect(createRunFor("ws-fail")).toEqual({
+			userId: "user-1",
+			status: "failed",
+			error: "subdomain 'x' is already claimed",
+		});
+	});
+
+	it("a retry overwrites a failed record with the new run", async () => {
+		trackCreateRun("ws-retry", "user-1", Promise.reject(new Error("died")));
+		await settle();
+		trackCreateRun("ws-retry", "user-2", new Promise(() => {}));
+		expect(createRunFor("ws-retry")).toEqual({
+			userId: "user-2",
+			status: "running",
+		});
+	});
+
+	it("returns null for an untracked workspace", () => {
+		expect(createRunFor("ws-unknown")).toBeNull();
+	});
+});

--- a/packages/cockpit/src/portal/create-tracker.test.ts
+++ b/packages/cockpit/src/portal/create-tracker.test.ts
@@ -17,7 +17,10 @@ describe("trackCreateRun", () => {
 				finish = resolve;
 			}),
 		);
-		expect(createRunFor("ws-ok")).toEqual({ userId: "user-1", status: "running" });
+		expect(createRunFor("ws-ok")).toEqual({
+			userId: "user-1",
+			status: "running",
+		});
 		finish(undefined);
 		await settle();
 		expect(createRunFor("ws-ok")).toBeNull();

--- a/packages/cockpit/src/portal/create-tracker.test.ts
+++ b/packages/cockpit/src/portal/create-tracker.test.ts
@@ -53,4 +53,27 @@ describe("trackCreateRun", () => {
 	it("returns null for an untracked workspace", () => {
 		expect(createRunFor("ws-unknown")).toBeNull();
 	});
+
+	it("a stale run's settlement never clobbers the newer run's record", async () => {
+		// Double-submit race (TOCTOU past the "already running" guard's awaits):
+		// the LOSER hits the advisory lock and rejects near-instantly while the
+		// real run is live — its failure must not overwrite the live record,
+		// and its success must not delete it either.
+		let failLoser: (err: Error) => void = () => {};
+		trackCreateRun(
+			"ws-race",
+			"u1",
+			new Promise((_, reject) => {
+				failLoser = reject;
+			}),
+		);
+		// The newer (winning) run replaces the entry.
+		trackCreateRun("ws-race", "u1", new Promise(() => {}));
+		failLoser(new Error("a lifecycle operation is already in flight"));
+		await settle();
+		expect(createRunFor("ws-race")).toEqual({
+			userId: "u1",
+			status: "running",
+		});
+	});
 });

--- a/packages/cockpit/src/portal/create-tracker.ts
+++ b/packages/cockpit/src/portal/create-tracker.ts
@@ -1,0 +1,53 @@
+// In-process record of workspace-create runs (DAT-821). SERVER-ONLY, portal.
+//
+// The registry `state` column is the durable cursor (lifecycle.ts); this map
+// adds only what the registry deliberately does not persist: whether THIS
+// portal process still has the op in flight, who started it (the pre-row
+// authz window in create.functions.ts), and the failure message when it died
+// here. A portal restart empties the map — the progress UI then sees a bare
+// `creating` row and offers the same-id retry that createWorkspace's
+// convergence contract exists for. Success DELETES the entry: `ready` in the
+// registry says everything. Failed entries stay so the error survives poll
+// cycles; they are overwritten by the retry and bounded by the handful of
+// workspaces a human abandons mid-create.
+
+import "@tanstack/react-start/server-only";
+
+export interface CreateRun {
+	/** The session user who triggered this run — authorizes progress polls that
+	 * arrive before the registry row (and its membership) exists. */
+	userId: string;
+	status: "running" | "failed";
+	/** The lifecycle failure, verbatim — lifecycle errors are written for the
+	 * operator (subdomain claims, readiness timeouts with the resume hint). */
+	error?: string;
+}
+
+const runs = new Map<string, CreateRun>();
+
+/** Record a fired create op. Attaches the terminal handlers, so the
+ * fire-and-forget promise in the server fn never surfaces as an unhandled
+ * rejection. */
+export function trackCreateRun(
+	workspaceId: string,
+	userId: string,
+	op: Promise<unknown>,
+): void {
+	runs.set(workspaceId, { userId, status: "running" });
+	op.then(
+		() => {
+			runs.delete(workspaceId);
+		},
+		(err: unknown) => {
+			runs.set(workspaceId, {
+				userId,
+				status: "failed",
+				error: err instanceof Error ? err.message : String(err),
+			});
+		},
+	);
+}
+
+export function createRunFor(workspaceId: string): CreateRun | null {
+	return runs.get(workspaceId) ?? null;
+}

--- a/packages/cockpit/src/portal/create-tracker.ts
+++ b/packages/cockpit/src/portal/create-tracker.ts
@@ -27,23 +27,33 @@ const runs = new Map<string, CreateRun>();
 
 /** Record a fired create op. Attaches the terminal handlers, so the
  * fire-and-forget promise in the server fn never surfaces as an unhandled
- * rejection. */
+ * rejection. The entry's OBJECT IDENTITY is the generation token: two
+ * near-simultaneous starts for one id (double-submit racing past the
+ * "already running" guard's awaits) both call this, and only the LATEST
+ * entry's handlers may touch the map — the loser's near-instant
+ * advisory-lock rejection must not overwrite the live run's record with a
+ * misleading failure. */
 export function trackCreateRun(
 	workspaceId: string,
 	userId: string,
 	op: Promise<unknown>,
 ): void {
-	runs.set(workspaceId, { userId, status: "running" });
+	const entry: CreateRun = { userId, status: "running" };
+	runs.set(workspaceId, entry);
 	op.then(
 		() => {
-			runs.delete(workspaceId);
+			if (runs.get(workspaceId) === entry) {
+				runs.delete(workspaceId);
+			}
 		},
 		(err: unknown) => {
-			runs.set(workspaceId, {
-				userId,
-				status: "failed",
-				error: err instanceof Error ? err.message : String(err),
-			});
+			if (runs.get(workspaceId) === entry) {
+				runs.set(workspaceId, {
+					userId,
+					status: "failed",
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
 		},
 	);
 }

--- a/packages/cockpit/src/portal/provisioner-config.ts
+++ b/packages/cockpit/src/portal/provisioner-config.ts
@@ -26,6 +26,13 @@ const ProvisionerConfigSchema = z.object({
 	// `http://caddy:2019`.
 	caddyAdminUrl: z.string().min(1),
 
+	// The read-only config tree (DATARAUM_CONFIG_PATH — same env contract as
+	// the workspace config's `dataraumConfigPath`, re-declared here per the
+	// role-scoped-schema convention this file already uses for S3). The create
+	// flow (DAT-821) lists `verticals/*` off it, so the portal container mounts
+	// the same tree every other consumer does.
+	configPath: z.string().min(1),
+
 	// Object store — the archive sweep deletes the workspace's whole
 	// s3://<bucket>/<ws>/ prefix (lake + uploads). Same env contract as the
 	// workspace config's S3 block; endpoint is host:port without scheme.
@@ -59,6 +66,7 @@ export function provisionerConfig(): ProvisionerConfig {
 		adminDatabaseUrl: process.env.PROVISIONER_DATABASE_URL,
 		catalogDatabaseUrl: process.env.DUCKLAKE_CATALOG_URL,
 		caddyAdminUrl: process.env.CADDY_ADMIN_URL,
+		configPath: process.env.DATARAUM_CONFIG_PATH,
 		s3Endpoint: process.env.S3_ENDPOINT,
 		s3Bucket: process.env.S3_BUCKET,
 		s3Region: process.env.S3_REGION ?? "us-east-1",

--- a/packages/cockpit/src/portal/verticals.test.ts
+++ b/packages/cockpit/src/portal/verticals.test.ts
@@ -1,0 +1,80 @@
+// listBuiltinVerticals (DAT-821): the portal-safe fs scan — directories only,
+// `_`-prefix hidden, description from ontology.yaml (null when absent or
+// unparseable), name-sorted, loud when the config mount is missing.
+//
+// Real files in a tmp tree; ontology.yaml content is written as JSON (a YAML
+// subset) with Bun's YAML.parse stubbed to JSON.parse, so the test exercises
+// OUR scan rules without re-testing Bun's YAML under a node worker (where
+// `import("bun")` cannot resolve).
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockConfig } = vi.hoisted(() => ({
+	mockConfig: { configPath: "" },
+}));
+vi.mock("#/portal/provisioner-config", () => ({
+	provisionerConfig: () => mockConfig,
+}));
+vi.mock("bun", () => ({ YAML: { parse: JSON.parse } }));
+
+import { listBuiltinVerticals } from "#/portal/verticals";
+
+describe("listBuiltinVerticals", () => {
+	let root: string;
+
+	beforeEach(async () => {
+		root = await mkdtemp(join(tmpdir(), "dat821-verticals-"));
+		mockConfig.configPath = root;
+	});
+
+	afterEach(async () => {
+		await rm(root, { recursive: true, force: true });
+	});
+
+	async function seedVertical(name: string, ontology?: object): Promise<void> {
+		const dir = join(root, "verticals", name);
+		await mkdir(dir, { recursive: true });
+		if (ontology) {
+			await writeFile(join(dir, "ontology.yaml"), JSON.stringify(ontology));
+		}
+	}
+
+	it("lists directories name-sorted with ontology descriptions", async () => {
+		await seedVertical("retail", { description: "  Retail ops  " });
+		await seedVertical("finance", { description: "Corporate finance" });
+		expect(await listBuiltinVerticals()).toEqual([
+			{ name: "finance", description: "Corporate finance" },
+			{ name: "retail", description: "Retail ops" },
+		]);
+	});
+
+	it("hides underscore-prefixed internal seeds and non-directories", async () => {
+		await seedVertical("finance", { description: "Corporate finance" });
+		await seedVertical("_adhoc", { description: "internal" });
+		await writeFile(join(root, "verticals", "README.md"), "not a vertical");
+		expect(
+			(await listBuiltinVerticals()).map((vertical) => vertical.name),
+		).toEqual(["finance"]);
+	});
+
+	it("keeps a vertical whose ontology is missing or unparseable", async () => {
+		await seedVertical("bare");
+		await seedVertical("broken");
+		await writeFile(
+			join(root, "verticals", "broken", "ontology.yaml"),
+			"{not json",
+		);
+		expect(await listBuiltinVerticals()).toEqual([
+			{ name: "bare", description: null },
+			{ name: "broken", description: null },
+		]);
+	});
+
+	it("throws when the verticals tree is not readable (missing mount)", async () => {
+		mockConfig.configPath = join(root, "nowhere");
+		await expect(listBuiltinVerticals()).rejects.toThrow();
+	});
+});

--- a/packages/cockpit/src/portal/verticals.ts
+++ b/packages/cockpit/src/portal/verticals.ts
@@ -1,0 +1,67 @@
+// Builtin-vertical scan for the portal's create-workspace flow (DAT-821).
+//
+// PORTAL-SAFE by construction: the richer `tools/list-verticals.ts` is
+// workspace-role code (it reads the throwing workspace config and counts
+// typed concept rows in the metadata DB — surfaces a portal container
+// deliberately lacks). Creating a workspace only needs the BUILTIN choices —
+// the directories shipped in the bind-mounted config tree — so this is a pure
+// fs scan off `provisionerConfig().configPath`, sharing that module's rules:
+// a vertical's KEY is the directory name, and `_`-prefixed directories
+// (`_adhoc`, the induction substrate) are internal seeds, never offered.
+//
+// Framed verticals are deliberately absent: they are per-workspace overlay
+// declarations, meaningless as the frame ontology of a workspace that does
+// not exist yet.
+
+import "@tanstack/react-start/server-only";
+
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+// `#/` alias (not `./`) so the unit test's vi.mock intercepts — the vitest
+// mock registry matches the importer's specifier (vitest-mock-alias gotcha).
+import { provisionerConfig } from "#/portal/provisioner-config";
+
+/** One pickable vertical: the key `createWorkspace` receives, plus the
+ * one-line domain description from its ontology.yaml (null when the file is
+ * missing/unparseable — the directory still counts, mirroring
+ * list-verticals.ts). */
+export interface BuiltinVertical {
+	name: string;
+	description: string | null;
+}
+
+async function readDescription(path: string): Promise<string | null> {
+	try {
+		const text = await readFile(path, "utf8");
+		// Bun's YAML, imported lazily (list-verticals.ts convention): a static
+		// `import … from "bun"` would break the node-run test workers.
+		const { YAML } = await import("bun");
+		const onto = YAML.parse(text) as { description?: string } | null;
+		return onto?.description?.trim() || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Every builtin vertical under `<configPath>/verticals/`, name-sorted. Throws
+ * when the tree is not readable: unlike the workspace listing (where a missing
+ * mount degrades to framed-only), a create form with zero verticals is a dead
+ * end — the portal's config mount being absent is a deployment bug to surface,
+ * not to swallow.
+ */
+export async function listBuiltinVerticals(): Promise<BuiltinVertical[]> {
+	const root = join(provisionerConfig().configPath, "verticals");
+	const entries = await readdir(root, { withFileTypes: true, encoding: "utf8" });
+	const out: BuiltinVertical[] = [];
+	for (const entry of entries) {
+		if (!entry.isDirectory() || entry.name.startsWith("_")) {
+			continue;
+		}
+		out.push({
+			name: entry.name,
+			description: await readDescription(join(root, entry.name, "ontology.yaml")),
+		});
+	}
+	return out.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/packages/cockpit/src/portal/verticals.ts
+++ b/packages/cockpit/src/portal/verticals.ts
@@ -52,7 +52,10 @@ async function readDescription(path: string): Promise<string | null> {
  */
 export async function listBuiltinVerticals(): Promise<BuiltinVertical[]> {
 	const root = join(provisionerConfig().configPath, "verticals");
-	const entries = await readdir(root, { withFileTypes: true, encoding: "utf8" });
+	const entries = await readdir(root, {
+		withFileTypes: true,
+		encoding: "utf8",
+	});
 	const out: BuiltinVertical[] = [];
 	for (const entry of entries) {
 		if (!entry.isDirectory() || entry.name.startsWith("_")) {
@@ -60,7 +63,9 @@ export async function listBuiltinVerticals(): Promise<BuiltinVertical[]> {
 		}
 		out.push({
 			name: entry.name,
-			description: await readDescription(join(root, entry.name, "ontology.yaml")),
+			description: await readDescription(
+				join(root, entry.name, "ontology.yaml"),
+			),
 		});
 	}
 	return out.sort((a, b) => a.name.localeCompare(b.name));

--- a/packages/cockpit/src/routeTree.gen.ts
+++ b/packages/cockpit/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as CreateRouteImport } from './routes/create'
 import { Route as appRouteRouteImport } from './routes/(app)/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ApiWorkflowProgressRouteImport } from './routes/api/workflow-progress'
@@ -39,6 +40,11 @@ import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as appReportsReportIdRouteImport } from './routes/(app)/reports/$reportId'
 import { Route as appCockpitConversationIdRouteImport } from './routes/(app)/cockpit/$conversationId'
 
+const CreateRoute = CreateRouteImport.update({
+  id: '/create',
+  path: '/create',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const appRouteRoute = appRouteRouteImport.update({
   id: '/(app)',
   getParentRoute: () => rootRouteImport,
@@ -187,6 +193,7 @@ const appCockpitConversationIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/create': typeof CreateRoute
   '/cockpit': typeof appCockpitRouteRouteWithChildren
   '/governance': typeof appGovernanceRoute
   '/library': typeof appLibraryRoute
@@ -217,6 +224,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/create': typeof CreateRoute
   '/governance': typeof appGovernanceRoute
   '/library': typeof appLibraryRoute
   '/metadata': typeof appMetadataRoute
@@ -248,6 +256,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/(app)': typeof appRouteRouteWithChildren
+  '/create': typeof CreateRoute
   '/(app)/cockpit': typeof appCockpitRouteRouteWithChildren
   '/(app)/governance': typeof appGovernanceRoute
   '/(app)/library': typeof appLibraryRoute
@@ -280,6 +289,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/create'
     | '/cockpit'
     | '/governance'
     | '/library'
@@ -310,6 +320,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/create'
     | '/governance'
     | '/library'
     | '/metadata'
@@ -340,6 +351,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/(app)'
+    | '/create'
     | '/(app)/cockpit'
     | '/(app)/governance'
     | '/(app)/library'
@@ -372,6 +384,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   appRouteRoute: typeof appRouteRouteWithChildren
+  CreateRoute: typeof CreateRoute
   ApiAwaitingInputRoute: typeof ApiAwaitingInputRoute
   ApiChatRoute: typeof ApiChatRoute
   ApiChatStreamRoute: typeof ApiChatStreamRoute
@@ -392,6 +405,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/create': {
+      id: '/create'
+      path: '/create'
+      fullPath: '/create'
+      preLoaderRoute: typeof CreateRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/(app)': {
       id: '/(app)'
       path: ''
@@ -643,6 +663,7 @@ const appRouteRouteWithChildren = appRouteRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   appRouteRoute: appRouteRouteWithChildren,
+  CreateRoute: CreateRoute,
   ApiAwaitingInputRoute: ApiAwaitingInputRoute,
   ApiChatRoute: ApiChatRoute,
   ApiChatStreamRoute: ApiChatStreamRoute,

--- a/packages/cockpit/src/routes/create.functions.ts
+++ b/packages/cockpit/src/routes/create.functions.ts
@@ -1,0 +1,246 @@
+// Server functions for the portal's create-workspace flow (DAT-821) — the
+// FIRST HTTP-reachable trigger of the DAT-820 provisioner, so every handler
+// runs the authz gate itself (a route beforeLoad is UX, never the boundary —
+// server fns are reachable by direct POST). The gate and its v1 policy live
+// in #/portal/create-gate.server.ts: portal role only, session required, any
+// signed-in user may create, the creator is the membership the row gets.
+//
+// Create itself is fire-and-forget into the portal process: createWorkspace
+// is durable against the registry `state` cursor (lifecycle.ts), the advisory
+// lock serializes per-workspace ops, and the progress poll reads the registry
+// + the in-process tracker. Retry re-runs the SAME workspace id from the
+// registry row's own values — the convergence contract, not a new attempt.
+
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+import { and, eq, ne } from "drizzle-orm";
+import { z } from "zod";
+import { auth } from "#/auth/auth";
+import { workspaceUrlFor } from "#/auth/workspace-url";
+import { baseConfig } from "#/config.base";
+import { cockpitDb } from "#/db/cockpit/client";
+import type { WorkspaceState } from "#/db/cockpit/registry";
+import { workspaces } from "#/db/cockpit/schema";
+import {
+	SUBDOMAIN_LABEL_MAX,
+	SUBDOMAIN_LABEL_PATTERN,
+} from "#/lib/subdomain-label";
+import {
+	requireCreateVisibility,
+	requirePortalSession,
+} from "#/portal/create-gate.server";
+import { createRunFor, trackCreateRun } from "#/portal/create-tracker";
+import { createWorkspace } from "#/portal/lifecycle";
+import { runLifecycle } from "#/portal/lifecycle-deps";
+import { type BuiltinVertical, listBuiltinVerticals } from "#/portal/verticals";
+
+// ── Form context ────────────────────────────────────────────────────────────
+
+export type CreateContext =
+	// A per-workspace cockpit — the create flow lives on the portal.
+	| { mode: "workspace" }
+	// Portal, signed out — the `/` login screen is the answer.
+	| { mode: "signin" }
+	| {
+			mode: "form";
+			verticals: BuiltinVertical[];
+			/** For the live `<label>.<host>` URL preview (workspaceUrlFor). */
+			portalOrigin: string;
+	  };
+
+/** What the `/create` route needs: role/session (redirect decisions) and the
+ * pickable verticals off the bind-mounted config tree. */
+export const getCreateContext = createServerFn({ method: "GET" }).handler(
+	async (): Promise<CreateContext> => {
+		if (!baseConfig.portalMode) {
+			return { mode: "workspace" };
+		}
+		const session = await auth.api.getSession({
+			headers: getRequest().headers,
+		});
+		if (!session) {
+			return { mode: "signin" };
+		}
+		return {
+			mode: "form",
+			verticals: await listBuiltinVerticals(),
+			portalOrigin: baseConfig.portalOrigin,
+		};
+	},
+);
+
+// ── Start ───────────────────────────────────────────────────────────────────
+
+const StartCreateInput = z.object({
+	name: z.string().trim().min(1).max(120),
+	vertical: z.string().min(1),
+	subdomain: z
+		.string()
+		.max(SUBDOMAIN_LABEL_MAX)
+		.regex(SUBDOMAIN_LABEL_PATTERN, "not a valid DNS label"),
+});
+
+/**
+ * Kick off a workspace create and return its id immediately — the progress
+ * page polls `getCreateProgress`. The subdomain pre-check turns the common
+ * conflict into an inline 409 at submit; the partial unique index remains the
+ * real guard (a race just surfaces later as the run's failure).
+ */
+export const startWorkspaceCreate = createServerFn({ method: "POST" })
+	.inputValidator((input: z.infer<typeof StartCreateInput>) =>
+		StartCreateInput.parse(input),
+	)
+	.handler(async ({ data }) => {
+		const session = await requirePortalSession();
+
+		const verticals = await listBuiltinVerticals();
+		if (!verticals.some((vertical) => vertical.name === data.vertical)) {
+			// The engine resolves phase config by this key — an unknown vertical
+			// would mint a workspace that fails at first add_source.
+			throw Response.json({ error: "unknown_vertical" }, { status: 400 });
+		}
+
+		const [claimed] = await cockpitDb
+			.select({ id: workspaces.id })
+			.from(workspaces)
+			.where(
+				and(
+					eq(workspaces.subdomain, data.subdomain),
+					ne(workspaces.state, "archived"),
+				),
+			)
+			.limit(1);
+		if (claimed) {
+			throw Response.json(
+				{
+					error: "subdomain_taken",
+					message: `subdomain '${data.subdomain}' is already claimed by a live workspace — pick another label`,
+				},
+				{ status: 409 },
+			);
+		}
+
+		const workspaceId = crypto.randomUUID();
+		trackCreateRun(
+			workspaceId,
+			session.user.id,
+			runLifecycle((deps) =>
+				createWorkspace(
+					{
+						workspaceId,
+						name: data.name,
+						vertical: data.vertical,
+						subdomain: data.subdomain,
+						memberUserIds: [session.user.id],
+					},
+					deps,
+				),
+			),
+		);
+		return { workspaceId };
+	});
+
+// ── Retry ───────────────────────────────────────────────────────────────────
+
+const WorkspaceIdInput = z.object({ workspaceId: z.uuid() });
+
+/**
+ * Re-run a create that died (`state = 'creating'`, no run in flight) — the
+ * same-id convergence createWorkspace guarantees. Inputs come from the
+ * registry row itself (what the first attempt recorded), never re-submitted.
+ */
+export const retryWorkspaceCreate = createServerFn({ method: "POST" })
+	.inputValidator((input: z.infer<typeof WorkspaceIdInput>) =>
+		WorkspaceIdInput.parse(input),
+	)
+	.handler(async ({ data }) => {
+		const session = await requirePortalSession();
+		const workspaceId = data.workspaceId;
+		await requireCreateVisibility(workspaceId, session.user.id);
+
+		if (createRunFor(workspaceId)?.status === "running") {
+			// Idempotent re-submit: the run is already in flight here — starting
+			// another would only trip the advisory lock.
+			return { workspaceId };
+		}
+		const [row] = await cockpitDb
+			.select({
+				name: workspaces.name,
+				vertical: workspaces.vertical,
+				subdomain: workspaces.subdomain,
+				state: workspaces.state,
+			})
+			.from(workspaces)
+			.where(eq(workspaces.id, workspaceId))
+			.limit(1);
+		const subdomain = row?.subdomain;
+		if (!row || row.state !== "creating" || !subdomain) {
+			// Nothing to converge: the first attempt never wrote the row (e.g. a
+			// subdomain conflict) or the workspace has moved on.
+			throw Response.json({ error: "not_retryable" }, { status: 409 });
+		}
+		trackCreateRun(
+			workspaceId,
+			session.user.id,
+			runLifecycle((deps) =>
+				createWorkspace(
+					{
+						workspaceId,
+						name: row.name,
+						vertical: row.vertical,
+						subdomain,
+						memberUserIds: [session.user.id],
+					},
+					deps,
+				),
+			),
+		);
+		return { workspaceId };
+	});
+
+// ── Progress ────────────────────────────────────────────────────────────────
+
+export interface CreateProgress {
+	/** Registry state, or null while the run has not written the row yet. */
+	state: WorkspaceState | null;
+	name: string | null;
+	subdomain: string | null;
+	/** The workspace URL once `ready` (the redirect target). */
+	url: string | null;
+	/** A create op for this id is running in THIS portal process. False for a
+	 * bare `creating` row (crashed/restarted portal) — the retry case. */
+	inFlight: boolean;
+	/** The last failure in this process, verbatim from the lifecycle. */
+	error: string | null;
+}
+
+export const getCreateProgress = createServerFn({ method: "GET" })
+	.inputValidator((input: z.infer<typeof WorkspaceIdInput>) =>
+		WorkspaceIdInput.parse(input),
+	)
+	.handler(async ({ data }): Promise<CreateProgress> => {
+		const session = await requirePortalSession();
+		await requireCreateVisibility(data.workspaceId, session.user.id);
+
+		const run = createRunFor(data.workspaceId);
+		const [row] = await cockpitDb
+			.select({
+				name: workspaces.name,
+				subdomain: workspaces.subdomain,
+				state: workspaces.state,
+			})
+			.from(workspaces)
+			.where(eq(workspaces.id, data.workspaceId))
+			.limit(1);
+		return {
+			state: row ? (row.state as WorkspaceState) : null,
+			name: row?.name ?? null,
+			subdomain: row?.subdomain ?? null,
+			url:
+				row?.state === "ready" && row.subdomain
+					? workspaceUrlFor(row.subdomain, baseConfig.portalOrigin)
+					: null,
+			inFlight: run?.status === "running",
+			error: run?.status === "failed" ? (run.error ?? "create failed") : null,
+		};
+	});

--- a/packages/cockpit/src/routes/create.functions.ts
+++ b/packages/cockpit/src/routes/create.functions.ts
@@ -33,6 +33,7 @@ import { createRunFor, trackCreateRun } from "#/portal/create-tracker";
 import { createWorkspace } from "#/portal/lifecycle";
 import { runLifecycle } from "#/portal/lifecycle-deps";
 import { type BuiltinVertical, listBuiltinVerticals } from "#/portal/verticals";
+import { serverFnError } from "#/server/server-fn-error";
 
 // ── Form context ────────────────────────────────────────────────────────────
 
@@ -97,7 +98,7 @@ export const startWorkspaceCreate = createServerFn({ method: "POST" })
 		if (!verticals.some((vertical) => vertical.name === data.vertical)) {
 			// The engine resolves phase config by this key — an unknown vertical
 			// would mint a workspace that fails at first add_source.
-			throw Response.json({ error: "unknown_vertical" }, { status: 400 });
+			throw serverFnError(400, "unknown_vertical");
 		}
 
 		const [claimed] = await cockpitDb
@@ -111,12 +112,10 @@ export const startWorkspaceCreate = createServerFn({ method: "POST" })
 			)
 			.limit(1);
 		if (claimed) {
-			throw Response.json(
-				{
-					error: "subdomain_taken",
-					message: `subdomain '${data.subdomain}' is already claimed by a live workspace — pick another label`,
-				},
-				{ status: 409 },
+			throw serverFnError(
+				409,
+				"subdomain_taken",
+				`subdomain '${data.subdomain}' is already claimed by a live workspace — pick another label`,
 			);
 		}
 
@@ -177,7 +176,7 @@ export const retryWorkspaceCreate = createServerFn({ method: "POST" })
 		if (row?.state !== "creating" || !subdomain) {
 			// Nothing to converge: the first attempt never wrote the row (e.g. a
 			// subdomain conflict) or the workspace has moved on.
-			throw Response.json({ error: "not_retryable" }, { status: 409 });
+			throw serverFnError(409, "not_retryable");
 		}
 		trackCreateRun(
 			workspaceId,

--- a/packages/cockpit/src/routes/create.functions.ts
+++ b/packages/cockpit/src/routes/create.functions.ts
@@ -174,7 +174,7 @@ export const retryWorkspaceCreate = createServerFn({ method: "POST" })
 			.where(eq(workspaces.id, workspaceId))
 			.limit(1);
 		const subdomain = row?.subdomain;
-		if (!row || row.state !== "creating" || !subdomain) {
+		if (row?.state !== "creating" || !subdomain) {
 			// Nothing to converge: the first attempt never wrote the row (e.g. a
 			// subdomain conflict) or the workspace has moved on.
 			throw Response.json({ error: "not_retryable" }, { status: 409 });

--- a/packages/cockpit/src/routes/create.test.tsx
+++ b/packages/cockpit/src/routes/create.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+//
+// The create flow's CLIENT contract (DAT-821, senior-review finding): a
+// rejected server fn must surface — the form renders the parsed lifecycle
+// message in the error Alert, never a silent no-op navigation — and the
+// progress panel renders each terminal state (failed-with-retry,
+// restart-interrupted) off the polled shape. Server fns are mocked at the
+// module seam (switcher-test idiom); their rejection shape mirrors
+// serverFnError's JSON-envelope Error.
+
+import { MantineProvider } from "@mantine/core";
+import {
+	createMemoryHistory,
+	createRootRoute,
+	createRoute,
+	createRouter,
+	RouterProvider,
+} from "@tanstack/react-router";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+	start: vi.fn(),
+	retry: vi.fn(),
+	progress: vi.fn(),
+}));
+vi.mock("#/routes/create.functions", () => ({
+	getCreateContext: vi.fn(),
+	startWorkspaceCreate: h.start,
+	retryWorkspaceCreate: h.retry,
+	getCreateProgress: h.progress,
+}));
+
+import { CreateForm, CreateProgressPanel } from "#/routes/create";
+import type { CreateContext, CreateProgress } from "#/routes/create.functions";
+import { TestQueryProvider } from "#/ui/cockpit/test-query-provider";
+
+const FORM_CONTEXT: Extract<CreateContext, { mode: "form" }> = {
+	mode: "form",
+	verticals: [{ name: "finance", description: "Financial analysis" }],
+	portalOrigin: "http://dataraum.localhost:8000",
+};
+
+/** serverFnError's client-side face: a rethrown Error whose message is the
+ * JSON envelope. */
+function fnRejection(error: string, message?: string): Error {
+	return new Error(JSON.stringify(message ? { error, message } : { error }));
+}
+
+/** Mount `element` under a minimal memory router (the form uses useNavigate
+ * + Link, which need a live router). */
+function renderAtCreate(element: ReactNode) {
+	const rootRoute = createRootRoute();
+	const createRouteDef = createRoute({
+		getParentRoute: () => rootRoute,
+		path: "create",
+		component: () => <>{element}</>,
+		validateSearch: (search: Record<string, unknown>) => ({
+			ws: typeof search.ws === "string" ? search.ws : undefined,
+		}),
+	});
+	const router = createRouter({
+		routeTree: rootRoute.addChildren([createRouteDef]),
+		history: createMemoryHistory({ initialEntries: ["/create"] }),
+	});
+	render(
+		<TestQueryProvider>
+			<MantineProvider env="test">
+				{/* biome-ignore lint/suspicious/noExplicitAny: minimal ad-hoc tree, not the generated Register */}
+				<RouterProvider router={router as any} />
+			</MantineProvider>
+		</TestQueryProvider>,
+	);
+	return router;
+}
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe("CreateForm (DAT-821)", () => {
+	it("derives the subdomain from the name and submits it", async () => {
+		h.start.mockResolvedValue({ workspaceId: "ws-new" });
+		renderAtCreate(<CreateForm context={FORM_CONTEXT} />);
+		await screen.findByTestId("create-name");
+		fireEvent.change(screen.getByTestId("create-name"), {
+			target: { value: "Dept 3" },
+		});
+		expect(
+			(screen.getByTestId("create-subdomain") as HTMLInputElement).value,
+		).toBe("dept-3");
+		fireEvent.click(screen.getByTestId("create-submit"));
+		await waitFor(() =>
+			expect(h.start).toHaveBeenCalledWith({
+				data: { name: "Dept 3", vertical: "finance", subdomain: "dept-3" },
+			}),
+		);
+	});
+
+	it("renders a rejected start's lifecycle message in the error alert", async () => {
+		h.start.mockRejectedValue(
+			fnRejection(
+				"subdomain_taken",
+				"subdomain 'dept-3' is already claimed by a live workspace — pick another label",
+			),
+		);
+		renderAtCreate(<CreateForm context={FORM_CONTEXT} />);
+		await screen.findByTestId("create-name");
+		fireEvent.change(screen.getByTestId("create-name"), {
+			target: { value: "Dept 3" },
+		});
+		fireEvent.click(screen.getByTestId("create-submit"));
+		const alert = await screen.findByTestId("create-error");
+		expect(alert.textContent).toContain(
+			"subdomain 'dept-3' is already claimed",
+		);
+	});
+});
+
+describe("CreateProgressPanel (DAT-821)", () => {
+	const base: CreateProgress = {
+		state: "creating",
+		name: "Dept 3",
+		subdomain: "ws3",
+		url: null,
+		inFlight: false,
+		error: null,
+	};
+
+	it("renders a failed run's error verbatim with a Retry", async () => {
+		h.progress.mockResolvedValue({
+			...base,
+			error: "workspace did not come up within 300000ms",
+		});
+		renderAtCreate(<CreateProgressPanel workspaceId="ws-x" />);
+		const alert = await screen.findByTestId("create-error");
+		expect(alert.textContent).toContain("did not come up within");
+		expect(screen.getByTestId("create-retry")).toBeTruthy();
+	});
+
+	it("renders the restart-interrupted state with a Retry that re-runs the id", async () => {
+		h.progress.mockResolvedValue(base);
+		h.retry.mockResolvedValue({ workspaceId: "ws-x" });
+		renderAtCreate(<CreateProgressPanel workspaceId="ws-x" />);
+		expect(
+			(await screen.findByText(/Creation interrupted/)).textContent,
+		).toBeTruthy();
+		fireEvent.click(screen.getByTestId("create-retry"));
+		await waitFor(() =>
+			expect(h.retry).toHaveBeenCalledWith({ data: { workspaceId: "ws-x" } }),
+		);
+	});
+
+	it("shows the provisioning spinner while the run is in flight", async () => {
+		h.progress.mockResolvedValue({ ...base, inFlight: true });
+		renderAtCreate(<CreateProgressPanel workspaceId="ws-x" />);
+		expect(await screen.findByText(/Provisioning/)).toBeTruthy();
+		expect(screen.queryByTestId("create-retry")).toBeNull();
+	});
+});

--- a/packages/cockpit/src/routes/create.tsx
+++ b/packages/cockpit/src/routes/create.tsx
@@ -83,7 +83,8 @@ function CreatePage() {
 
 // ── Form ────────────────────────────────────────────────────────────────────
 
-function CreateForm({
+/** Exported for the unit test only — the route component is the caller. */
+export function CreateForm({
 	context,
 }: {
 	context: Extract<CreateContext, { mode: "form" }>;
@@ -212,10 +213,10 @@ function CreateForm({
 	);
 }
 
-/** The server fns reject with status-carrying JSON Responses; the RPC client
- * surfaces a non-ok response as `new Error(<body text>)` (start-client-core
- * serverFnFetcher), so the human `message` — or the `error` code — is parsed
- * back out of the error's message string. */
+/** The server fns reject via `serverFnError` — a thrown Error whose message
+ * is a JSON `{error, message?}` envelope (a thrown Response would RESOLVE
+ * client-side, see server/server-fn-error.ts) — so the human `message`, or
+ * the `error` code, is parsed back out of the rethrown error's message. */
 function rpcErrorMessage(error: unknown): string {
 	if (error instanceof Error && error.message) {
 		try {
@@ -238,19 +239,23 @@ function rpcErrorMessage(error: unknown): string {
 
 // ── Progress ────────────────────────────────────────────────────────────────
 
-function CreateProgressPanel({ workspaceId }: { workspaceId: string }) {
+/** Exported for the unit test only — the route component is the caller. */
+export function CreateProgressPanel({ workspaceId }: { workspaceId: string }) {
 	const queryClient = useQueryClient();
 	const progress = useQuery({
 		queryKey: ["create-progress", workspaceId],
 		queryFn: () => getCreateProgress({ data: { workspaceId } }),
-		// House polling idiom: interval callback, false once terminal (ready, or
-		// failed-and-idle — a retry restarts it via invalidate below).
+		// House polling idiom: interval callback, false once terminal. Terminal =
+		// ready (the effect below redirects) OR nothing in flight in this
+		// process (failed, or a restart-interrupted bare `creating` row) —
+		// idle states never make progress on their own, so polling them is
+		// noise. A retry restarts the cycle via the invalidate below.
 		refetchInterval: (query) => {
 			const data = query.state.data;
 			if (!data) {
 				return 2000;
 			}
-			return data.url || (!data.inFlight && data.error) ? false : 2000;
+			return data.url || !data.inFlight ? false : 2000;
 		},
 	});
 

--- a/packages/cockpit/src/routes/create.tsx
+++ b/packages/cockpit/src/routes/create.tsx
@@ -100,7 +100,8 @@ function CreateForm({
 
 	const subdomain = manualSubdomain ?? subdomainLabelFrom(name);
 	const subdomainValid = isValidSubdomainLabel(subdomain);
-	const submittable = name.trim().length > 0 && vertical !== "" && subdomainValid;
+	const submittable =
+		name.trim().length > 0 && vertical !== "" && subdomainValid;
 
 	const start = useMutation({
 		mutationFn: () =>
@@ -336,9 +337,9 @@ function CreateProgressPanel({ workspaceId }: { workspaceId: string }) {
 			) : state === "creating" && !inFlight ? (
 				<Stack gap="sm">
 					<Alert color="yellow" variant="light" title="Creation interrupted">
-						This workspace is still marked as creating, but no run is in
-						flight — the portal likely restarted mid-provision. Retrying
-						resumes where it stopped.
+						This workspace is still marked as creating, but no run is in flight
+						— the portal likely restarted mid-provision. Retrying resumes where
+						it stopped.
 					</Alert>
 					<Group justify="flex-end">
 						<Button

--- a/packages/cockpit/src/routes/create.tsx
+++ b/packages/cockpit/src/routes/create.tsx
@@ -1,0 +1,370 @@
+// `/create` — the portal's create-workspace flow (DAT-821): name + vertical
+// (+ a derived, editable subdomain) → provisioner → live progress until
+// `ready` → redirect to the new workspace's subdomain.
+//
+// PORTAL-ONLY: on a per-workspace cockpit (or signed out) the route bounces
+// to `/` — but that redirect is UX; the authz boundary is inside the server
+// fns (create.functions.ts). Same visual shell as the portal home: one
+// centered Paper card, house tokens, widths via Mantine props (the Tailwind
+// scale is remapped — see `/`).
+//
+// The two faces share the route via the `ws` search param: without it, the
+// form; with it, the progress panel polling the registry until the workspace
+// is ready (reload-safe — the id lives in the URL, and a dead run resumes
+// with the same-id retry the lifecycle's convergence contract guarantees).
+
+import {
+	Alert,
+	Anchor,
+	Button,
+	Group,
+	Loader,
+	Paper,
+	Radio,
+	Stack,
+	Text,
+	TextInput,
+	Title,
+} from "@mantine/core";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	createFileRoute,
+	Link,
+	redirect,
+	useNavigate,
+} from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { workspaceUrlFor } from "#/auth/workspace-url";
+import {
+	isValidSubdomainLabel,
+	subdomainLabelFrom,
+} from "#/lib/subdomain-label";
+import {
+	type CreateContext,
+	getCreateContext,
+	getCreateProgress,
+	retryWorkspaceCreate,
+	startWorkspaceCreate,
+} from "./create.functions";
+
+export const Route = createFileRoute("/create")({
+	validateSearch: (search: Record<string, unknown>) => ({
+		// The in-flight workspace id — present = progress panel, absent = form.
+		ws: typeof search.ws === "string" ? search.ws : undefined,
+	}),
+	beforeLoad: async () => {
+		const context = await getCreateContext();
+		if (context.mode !== "form") {
+			// Workspace cockpit → its `/` goes to the flat UI; portal signed-out →
+			// the login screen. Either way, `/` knows.
+			throw redirect({ to: "/", search: { denied: undefined } });
+		}
+		return { createContext: context };
+	},
+	loader: ({ context }) => context.createContext,
+	component: CreatePage,
+});
+
+function CreatePage() {
+	const context = Route.useLoaderData();
+	const { ws } = Route.useSearch();
+	return (
+		<div className="flex min-h-screen items-center justify-center bg-surface-muted p-lg">
+			<Paper w="100%" maw={440} withBorder shadow="sm" radius="md" p="xl">
+				{ws ? (
+					<CreateProgressPanel workspaceId={ws} />
+				) : (
+					<CreateForm context={context} />
+				)}
+			</Paper>
+		</div>
+	);
+}
+
+// ── Form ────────────────────────────────────────────────────────────────────
+
+function CreateForm({
+	context,
+}: {
+	context: Extract<CreateContext, { mode: "form" }>;
+}) {
+	const navigate = useNavigate();
+	const [name, setName] = useState("");
+	// The subdomain follows the name (subdomainLabelFrom) until the user takes
+	// it over by typing in its field — then it is theirs.
+	const [manualSubdomain, setManualSubdomain] = useState<string | null>(null);
+	const [vertical, setVertical] = useState(
+		// A single builtin (the common installation) needs no choice ceremony.
+		context.verticals.length === 1 ? (context.verticals[0]?.name ?? "") : "",
+	);
+
+	const subdomain = manualSubdomain ?? subdomainLabelFrom(name);
+	const subdomainValid = isValidSubdomainLabel(subdomain);
+	const submittable = name.trim().length > 0 && vertical !== "" && subdomainValid;
+
+	const start = useMutation({
+		mutationFn: () =>
+			startWorkspaceCreate({ data: { name, vertical, subdomain } }),
+		onSuccess: ({ workspaceId }) =>
+			navigate({ to: "/create", search: { ws: workspaceId } }),
+	});
+
+	return (
+		<form
+			onSubmit={(event) => {
+				event.preventDefault();
+				if (submittable) {
+					start.mutate();
+				}
+			}}
+		>
+			<Stack gap="lg">
+				<Stack gap={4}>
+					<Title order={2}>New workspace</Title>
+					<Text c="dimmed" size="sm">
+						A workspace gets its own engine, cockpit, and subdomain.
+					</Text>
+				</Stack>
+
+				<TextInput
+					label="Name"
+					required
+					data-testid="create-name"
+					value={name}
+					onChange={(event) => setName(event.currentTarget.value)}
+					placeholder="e.g. Controlling"
+				/>
+
+				<Radio.Group
+					label="Vertical"
+					description="The domain ontology the workspace's analysis grounds against."
+					required
+					value={vertical}
+					onChange={setVertical}
+				>
+					<Stack gap="xs" mt="xs">
+						{context.verticals.length === 0 ? (
+							<Alert color="red" variant="light" title="No verticals available">
+								The portal cannot read any vertical from its config tree — the
+								installation's config mount is missing or empty.
+							</Alert>
+						) : (
+							context.verticals.map((option) => (
+								<Radio
+									key={option.name}
+									value={option.name}
+									label={option.name}
+									description={option.description ?? undefined}
+									data-testid={`create-vertical-${option.name}`}
+								/>
+							))
+						)}
+					</Stack>
+				</Radio.Group>
+
+				<TextInput
+					label="Subdomain"
+					required
+					data-testid="create-subdomain"
+					value={subdomain}
+					onChange={(event) =>
+						setManualSubdomain(event.currentTarget.value.toLowerCase())
+					}
+					error={
+						subdomain && !subdomainValid
+							? "Lowercase letters, digits, and inner dashes only"
+							: undefined
+					}
+					description={
+						subdomainValid
+							? `Will live at ${workspaceUrlFor(subdomain, context.portalOrigin)}`
+							: "Derived from the name — edit to pick your own"
+					}
+				/>
+
+				{start.isError ? (
+					<Alert
+						color="red"
+						variant="light"
+						title="Could not start the workspace"
+						data-testid="create-error"
+					>
+						{rpcErrorMessage(start.error)}
+					</Alert>
+				) : null}
+
+				<Group justify="space-between">
+					<Anchor component={Link} to="/" size="sm" c="dimmed">
+						Back to workspaces
+					</Anchor>
+					<Button
+						type="submit"
+						data-testid="create-submit"
+						disabled={!submittable}
+						loading={start.isPending}
+					>
+						Create workspace
+					</Button>
+				</Group>
+			</Stack>
+		</form>
+	);
+}
+
+/** The server fns reject with status-carrying JSON Responses; the RPC client
+ * surfaces a non-ok response as `new Error(<body text>)` (start-client-core
+ * serverFnFetcher), so the human `message` — or the `error` code — is parsed
+ * back out of the error's message string. */
+function rpcErrorMessage(error: unknown): string {
+	if (error instanceof Error && error.message) {
+		try {
+			const body = JSON.parse(error.message) as {
+				message?: unknown;
+				error?: unknown;
+			};
+			if (typeof body.message === "string" && body.message) {
+				return body.message;
+			}
+			if (typeof body.error === "string" && body.error) {
+				return body.error;
+			}
+		} catch {
+			return error.message;
+		}
+	}
+	return "Something failed before provisioning started — try again.";
+}
+
+// ── Progress ────────────────────────────────────────────────────────────────
+
+function CreateProgressPanel({ workspaceId }: { workspaceId: string }) {
+	const queryClient = useQueryClient();
+	const progress = useQuery({
+		queryKey: ["create-progress", workspaceId],
+		queryFn: () => getCreateProgress({ data: { workspaceId } }),
+		// House polling idiom: interval callback, false once terminal (ready, or
+		// failed-and-idle — a retry restarts it via invalidate below).
+		refetchInterval: (query) => {
+			const data = query.state.data;
+			if (!data) {
+				return 2000;
+			}
+			return data.url || (!data.inFlight && data.error) ? false : 2000;
+		},
+	});
+
+	const retry = useMutation({
+		mutationFn: () => retryWorkspaceCreate({ data: { workspaceId } }),
+		onSuccess: () =>
+			queryClient.invalidateQueries({
+				queryKey: ["create-progress", workspaceId],
+			}),
+	});
+
+	const url = progress.data?.url ?? null;
+	// Effect justification: navigating the browser to the new subdomain is an
+	// external-system side effect (full document navigation off the portal
+	// origin — a router Link cannot express it).
+	useEffect(() => {
+		if (url) {
+			window.location.assign(url);
+		}
+	}, [url]);
+
+	if (!progress.data) {
+		return (
+			<Group gap="sm" data-testid="create-progress">
+				<Loader size="sm" />
+				<Text size="sm">Checking progress…</Text>
+			</Group>
+		);
+	}
+
+	const { state, name, subdomain, inFlight, error } = progress.data;
+
+	return (
+		<Stack gap="lg" data-testid="create-progress">
+			<Stack gap={4}>
+				<Title order={2}>{name ?? "New workspace"}</Title>
+				{subdomain ? (
+					<Text c="dimmed" size="sm">
+						{subdomain}
+					</Text>
+				) : null}
+			</Stack>
+
+			{url ? (
+				<Group gap="sm">
+					<Loader size="sm" />
+					<Text size="sm" data-testid="create-ready">
+						Ready — taking you there…
+					</Text>
+				</Group>
+			) : error && !inFlight ? (
+				<Stack gap="sm">
+					<Alert
+						color="red"
+						variant="light"
+						title="Provisioning failed"
+						data-testid="create-error"
+					>
+						{error}
+					</Alert>
+					<Group justify="space-between">
+						<Anchor
+							size="sm"
+							c="dimmed"
+							// renderRoot, not component={Link}: Mantine's polymorphic prop
+							// erases the router generics, so `search` would not typecheck.
+							renderRoot={(props) => (
+								<Link to="/create" search={{ ws: undefined }} {...props} />
+							)}
+						>
+							Back to the form
+						</Anchor>
+						{state === "creating" ? (
+							<Button
+								data-testid="create-retry"
+								onClick={() => retry.mutate()}
+								loading={retry.isPending}
+							>
+								Retry
+							</Button>
+						) : null}
+					</Group>
+				</Stack>
+			) : state === "creating" && !inFlight ? (
+				<Stack gap="sm">
+					<Alert color="yellow" variant="light" title="Creation interrupted">
+						This workspace is still marked as creating, but no run is in
+						flight — the portal likely restarted mid-provision. Retrying
+						resumes where it stopped.
+					</Alert>
+					<Group justify="flex-end">
+						<Button
+							data-testid="create-retry"
+							onClick={() => retry.mutate()}
+							loading={retry.isPending}
+						>
+							Retry
+						</Button>
+					</Group>
+				</Stack>
+			) : (
+				<Stack gap="sm">
+					<Group gap="sm">
+						<Loader size="sm" />
+						<Text size="sm">
+							Provisioning — engine and cockpit are starting. This takes a
+							minute or two.
+						</Text>
+					</Group>
+					<Text size="xs" c="dimmed">
+						Safe to leave open; this page follows the registry until the
+						workspace is ready.
+					</Text>
+				</Stack>
+			)}
+		</Stack>
+	);
+}

--- a/packages/cockpit/src/routes/index.functions.ts
+++ b/packages/cockpit/src/routes/index.functions.ts
@@ -6,19 +6,25 @@
 
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { auth } from "#/auth/auth";
 import { workspaceUrlFor } from "#/auth/workspace-url";
 import { baseConfig } from "#/config.base";
 import { cockpitDb } from "#/db/cockpit/client";
+import type { WorkspaceState } from "#/db/cockpit/registry";
 import { memberships, workspaces } from "#/db/cockpit/schema";
 
 /** One row of the portal's workspace list: a membership joined onto the
- * registry. `url` is null when the workspace has no subdomain yet (bare
- * host-dev seed — reachable only on its direct port, not through Caddy). */
+ * registry. `url` is null when the workspace is not enterable — mid-lifecycle
+ * (`creating`/`archiving`), or `ready` without a subdomain yet (bare host-dev
+ * seed — reachable only on its direct port, not through Caddy). */
 export interface PortalWorkspace {
 	id: string;
 	name: string;
+	/** Lifecycle state (DAT-821): `ready` is enterable; `creating`/`archiving`
+	 * render with their state instead of a link; `archived` never leaves the
+	 * server. */
+	state: Exclude<WorkspaceState, "archived">;
 	url: string | null;
 }
 
@@ -33,8 +39,9 @@ export type PortalHome =
 /**
  * The portal home state (DAT-819): role, session, and — signed in — the
  * user's workspaces. Lists memberships joined onto the registry, respecting
- * the provisioner lifecycle: only `state = 'ready'` workspaces are offered
- * (a creating/archiving/archived workspace is not a login target).
+ * the provisioner lifecycle end-to-end (DAT-821): `ready` workspaces link to
+ * their subdomain; `creating`/`archiving` are shown with their state but are
+ * not login targets; `archived` is hidden entirely.
  */
 export const getPortalHome = createServerFn({ method: "GET" }).handler(
 	async (): Promise<PortalHome> => {
@@ -51,6 +58,7 @@ export const getPortalHome = createServerFn({ method: "GET" }).handler(
 			.select({
 				id: workspaces.id,
 				name: workspaces.name,
+				state: workspaces.state,
 				subdomain: workspaces.subdomain,
 			})
 			.from(memberships)
@@ -58,7 +66,7 @@ export const getPortalHome = createServerFn({ method: "GET" }).handler(
 			.where(
 				and(
 					eq(memberships.userId, session.user.id),
-					eq(workspaces.state, "ready"),
+					ne(workspaces.state, "archived"),
 				),
 			);
 		return {
@@ -67,9 +75,11 @@ export const getPortalHome = createServerFn({ method: "GET" }).handler(
 			workspaces: rows.map((row) => ({
 				id: row.id,
 				name: row.name,
-				url: row.subdomain
-					? workspaceUrlFor(row.subdomain, baseConfig.portalOrigin)
-					: null,
+				state: row.state as Exclude<WorkspaceState, "archived">,
+				url:
+					row.state === "ready" && row.subdomain
+						? workspaceUrlFor(row.subdomain, baseConfig.portalOrigin)
+						: null,
 			})),
 		};
 	},

--- a/packages/cockpit/src/routes/index.tsx
+++ b/packages/cockpit/src/routes/index.tsx
@@ -11,6 +11,7 @@
 
 import {
 	Alert,
+	Badge,
 	Button,
 	Group,
 	Paper,
@@ -20,7 +21,12 @@ import {
 	TextInput,
 	Title,
 } from "@mantine/core";
-import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
+import {
+	createFileRoute,
+	Link,
+	redirect,
+	useRouter,
+} from "@tanstack/react-router";
 import { useState } from "react";
 import { authClient } from "#/auth/auth-client";
 import { getPortalHome, type PortalHome } from "./index.functions";
@@ -185,6 +191,16 @@ function WorkspaceList({
 								>
 									Open
 								</Button>
+							) : ws.state !== "ready" ? (
+								// Mid-lifecycle (DAT-821): visible with its state, not
+								// enterable — the provisioner flips it to `ready`.
+								<Badge
+									variant="light"
+									color={ws.state === "creating" ? "yellow" : "gray"}
+									className="shrink-0"
+								>
+									{ws.state}
+								</Badge>
 							) : (
 								<Text size="xs" c="dimmed" className="shrink-0">
 									no subdomain
@@ -194,6 +210,16 @@ function WorkspaceList({
 					</Paper>
 				))
 			)}
+			<Button
+				component={Link}
+				to="/create"
+				variant="light"
+				fullWidth
+				mt="xs"
+				data-testid="portal-new-workspace"
+			>
+				New workspace
+			</Button>
 			<Group justify="space-between" mt="xs">
 				<Text size="xs" c="dimmed">
 					{home.email}

--- a/packages/cockpit/src/server/server-fn-error.ts
+++ b/packages/cockpit/src/server/server-fn-error.ts
@@ -1,0 +1,27 @@
+// Status-carrying server-fn rejection (DAT-821). SERVER-ONLY.
+//
+// A `Response` thrown from a createServerFn handler does NOT reject the
+// client call on the installed TanStack Start: the server tags it
+// `x-tss-raw` and the client fetcher returns it as the RESOLVED value before
+// its `!response.ok` check (start-client-core serverFnFetcher) — so every
+// error branch would silently succeed (senior-review finding on DAT-821,
+// verified empirically). A thrown ERROR takes the serialization path and
+// rethrows client-side, so that is the contract: `setResponseStatus` keeps
+// the wire-visible status for direct RPC callers, and the Error message is a
+// JSON envelope (`{error, message?}`) the UI parses back out
+// (routes/create.tsx `rpcErrorMessage`).
+
+import "@tanstack/react-start/server-only";
+
+import { setResponseStatus } from "@tanstack/react-start/server";
+
+/** Build (don't throw — callers `throw serverFnError(...)` so control flow
+ * stays visible at the call site) a status-carrying rejection. */
+export function serverFnError(
+	status: number,
+	error: string,
+	message?: string,
+): Error {
+	setResponseStatus(status);
+	return new Error(JSON.stringify(message ? { error, message } : { error }));
+}

--- a/packages/cockpit/src/server/switcher-workspaces.ts
+++ b/packages/cockpit/src/server/switcher-workspaces.ts
@@ -22,6 +22,7 @@ import { baseConfig } from "#/config.base";
 import { cockpitDb } from "#/db/cockpit/client";
 import { bootWorkspaceId, type WorkspaceState } from "#/db/cockpit/registry";
 import { memberships, workspaces } from "#/db/cockpit/schema";
+import { serverFnError } from "#/server/server-fn-error";
 
 export interface SwitcherWorkspace {
 	id: string;
@@ -45,7 +46,7 @@ export interface SwitcherData {
 export const getSwitcherWorkspaces = createServerFn({ method: "GET" }).handler(
 	async (): Promise<SwitcherData> => {
 		if (baseConfig.portalMode) {
-			throw Response.json({ error: "workspace_only" }, { status: 403 });
+			throw serverFnError(403, "workspace_only");
 		}
 		const session = await auth.api.getSession({
 			headers: getRequest().headers,
@@ -53,7 +54,7 @@ export const getSwitcherWorkspaces = createServerFn({ method: "GET" }).handler(
 		if (!session) {
 			// The membership gate fronts every request; reaching this without a
 			// session means the caller bypassed HTML navigation — same status.
-			throw Response.json({ error: "unauthenticated" }, { status: 401 });
+			throw serverFnError(401, "unauthenticated");
 		}
 
 		const currentId = bootWorkspaceId();

--- a/packages/cockpit/src/server/switcher-workspaces.ts
+++ b/packages/cockpit/src/server/switcher-workspaces.ts
@@ -1,0 +1,98 @@
+// The workspace switcher's data (DAT-821). SERVER FN, workspace role.
+//
+// A per-workspace cockpit never resolves "which workspace" per request — the
+// switcher does not either: it lists the SESSION USER's memberships from the
+// shared cockpit_db (joined onto the registry, the multi-workspace source of
+// truth) and marks this cockpit's boot workspace as current. Switching IS
+// navigation: every other `ready` workspace is an absolute URL to its
+// subdomain (DD/51740673); `creating`/`archiving` rows surface with their
+// state but no URL; `archived` never leaves the server.
+//
+// Authz: the global membership gate (start.ts) already vetted this request —
+// session + membership of the boot workspace — so the session read here is
+// scoping (whose memberships), not the boundary. The portal-mode rejection is
+// a fence: the portal serves the same server bundle but has no boot identity.
+
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+import { and, eq, ne } from "drizzle-orm";
+import { auth } from "#/auth/auth";
+import { workspaceUrlFor } from "#/auth/workspace-url";
+import { baseConfig } from "#/config.base";
+import { cockpitDb } from "#/db/cockpit/client";
+import { bootWorkspaceId, type WorkspaceState } from "#/db/cockpit/registry";
+import { memberships, workspaces } from "#/db/cockpit/schema";
+
+export interface SwitcherWorkspace {
+	id: string;
+	name: string;
+	state: Exclude<WorkspaceState, "archived">;
+	/** Absolute subdomain URL — set only for `ready` workspaces with a routed
+	 * subdomain (null on the current one too: it needs no link). */
+	url: string | null;
+	current: boolean;
+}
+
+export interface SwitcherData {
+	/** The boot workspace's display name — the switcher target's label. */
+	currentName: string;
+	/** The user's non-archived workspaces, name-sorted. */
+	workspaces: SwitcherWorkspace[];
+	/** The portal's create flow — the switcher's "New workspace" entry. */
+	createUrl: string;
+}
+
+export const getSwitcherWorkspaces = createServerFn({ method: "GET" }).handler(
+	async (): Promise<SwitcherData> => {
+		if (baseConfig.portalMode) {
+			throw Response.json({ error: "workspace_only" }, { status: 403 });
+		}
+		const session = await auth.api.getSession({
+			headers: getRequest().headers,
+		});
+		if (!session) {
+			// The membership gate fronts every request; reaching this without a
+			// session means the caller bypassed HTML navigation — same status.
+			throw Response.json({ error: "unauthenticated" }, { status: 401 });
+		}
+
+		const currentId = bootWorkspaceId();
+		const rows = await cockpitDb
+			.select({
+				id: workspaces.id,
+				name: workspaces.name,
+				state: workspaces.state,
+				subdomain: workspaces.subdomain,
+			})
+			.from(memberships)
+			.innerJoin(workspaces, eq(memberships.workspaceId, workspaces.id))
+			.where(
+				and(
+					eq(memberships.userId, session.user.id),
+					ne(workspaces.state, "archived"),
+				),
+			);
+
+		const list: SwitcherWorkspace[] = rows
+			.map((row) => ({
+				id: row.id,
+				name: row.name,
+				state: row.state as Exclude<WorkspaceState, "archived">,
+				url:
+					row.id !== currentId && row.state === "ready" && row.subdomain
+						? workspaceUrlFor(row.subdomain, baseConfig.portalOrigin)
+						: null,
+				current: row.id === currentId,
+			}))
+			.sort((a, b) => a.name.localeCompare(b.name));
+
+		return {
+			// The gate guarantees membership of the boot workspace, so it is in
+			// the list; the id is the born-loud fallback for a broken registry.
+			currentName:
+				list.find((workspace) => workspace.current)?.name ?? currentId,
+			workspaces: list,
+			createUrl: `${baseConfig.portalOrigin}/create`,
+		};
+	},
+);

--- a/packages/cockpit/src/ui/app-shell.test.tsx
+++ b/packages/cockpit/src/ui/app-shell.test.tsx
@@ -13,7 +13,25 @@ import {
 	RouterProvider,
 } from "@tanstack/react-router";
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The switcher (DAT-821) fetches the session user's memberships via a server
+// fn — an RPC with no server under jsdom, so the shell test injects the data.
+vi.mock("#/server/switcher-workspaces", () => ({
+	getSwitcherWorkspaces: async () => ({
+		currentName: "Dept One",
+		workspaces: [
+			{
+				id: "ws-1",
+				name: "Dept One",
+				state: "ready",
+				url: null,
+				current: true,
+			},
+		],
+		createUrl: "http://dataraum.localhost/create",
+	}),
+}));
 
 import { CockpitShell } from "#/ui/app-shell";
 import { TestQueryProvider } from "#/ui/cockpit/test-query-provider";
@@ -81,10 +99,13 @@ describe("CockpitShell (DAT-380)", () => {
 
 		// The active section's content renders inside the shell <Outlet/>.
 		expect(await screen.findByTestId("section-content")).toBeTruthy();
-		// The top bar shows the brand wordmark, never a raw workspace id.
-		expect(screen.getByTestId("workspace-switcher").textContent).toContain(
-			"DataRaum",
-		);
+		// The top bar's switcher target shows the workspace NAME (DAT-821) —
+		// never a raw workspace id.
+		expect(
+			(await screen.findByText("Dept One")).closest(
+				"[data-testid='workspace-switcher']",
+			),
+		).toBeTruthy();
 	});
 
 	it("links every rail item at its flat section path", async () => {

--- a/packages/cockpit/src/ui/app-shell.tsx
+++ b/packages/cockpit/src/ui/app-shell.tsx
@@ -1,7 +1,7 @@
 // OUTER SHELL (DAT-380, C0).
 //
 // Thin chrome around the active section: a slim left rail of the six section
-// icons + a thin top bar (workspace-switcher placeholder + a ⌘K hint). Uses
+// icons + a thin top bar (the workspace switcher, DAT-821 + a ⌘K hint). Uses
 // Mantine AppShell. Every dimension / color reads from src/ui/theme.ts — no
 // hardcoded px/hex here.
 
@@ -12,7 +12,6 @@ import {
 	Stack,
 	Text,
 	Tooltip,
-	UnstyledButton,
 } from "@mantine/core";
 import { useDisclosure, useHotkeys } from "@mantine/hooks";
 import { Link } from "@tanstack/react-router";
@@ -21,6 +20,7 @@ import { CommandPalette } from "#/ui/command-palette";
 import { RunRailBadge } from "#/ui/runs/run-rail-badge";
 import { type Section, sections } from "#/ui/sections";
 import { tokens } from "#/ui/theme";
+import { WorkspaceSwitcher } from "#/ui/workspace-switcher";
 
 /** One rail icon. Every section is a fixed flat path (DAT-822) — one cockpit
  * per workspace, so no link carries params. */
@@ -66,17 +66,11 @@ export function CockpitShell({ children }: { children: ReactNode }) {
 				padding="md"
 			>
 				<AppShell.Header>
-					{/* Wordmark left; the ⌘K command-palette trigger top-right. The
-					    chat-type nav now lives in the composer drop-up (cockpit-only), so
-					    the header is plain global chrome again. */}
+					{/* The workspace switcher left (DAT-821); the ⌘K command-palette
+					    trigger top-right. The chat-type nav lives in the composer
+					    drop-up (cockpit-only), so the header is global chrome only. */}
 					<Group h="100%" px="md" justify="space-between" wrap="nowrap">
-						<UnstyledButton data-testid="workspace-switcher">
-							{/* Brand wordmark — never the raw workspace UUID. A real workspace
-							    name lands with the workspaces registry (DAT-339 slice 1). */}
-							<Text size="sm" fw={600} c="text">
-								DataRaum
-							</Text>
-						</UnstyledButton>
+						<WorkspaceSwitcher />
 						<Tooltip label="Command palette" position="bottom" withArrow>
 							<ActionIcon
 								variant="default"

--- a/packages/cockpit/src/ui/runs/run-rail-badge.tsx
+++ b/packages/cockpit/src/ui/runs/run-rail-badge.tsx
@@ -33,9 +33,9 @@ export function RunRailBadge({ children }: { children: ReactNode }) {
 	// run during SSR — where a relative fetch has no host. Gate to the client; the
 	// badge renders inactive on the server, then polls once hydrated (the project's
 	// `typeof window` SSR-guard idiom).
-	// TODO(DAT-357): when multi-workspace switching lands, scope these keys (and the
-	// endpoints) by workspace id — today the endpoints resolve the single active
-	// workspace server-side, so the bare keys are correct.
+	// Bare keys are correct under multi-workspace (DAT-821): the cockpit is
+	// per-workspace (DD/51740673) — switching navigates to another subdomain's
+	// own app instance, so one process never sees two workspaces' counts.
 	const enabled = typeof window !== "undefined";
 	const { data: runningData } = useQuery({
 		queryKey: ["workspace-running-runs"],

--- a/packages/cockpit/src/ui/workspace-switcher.test.tsx
+++ b/packages/cockpit/src/ui/workspace-switcher.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+//
+// WorkspaceSwitcher (DAT-821): the target names the current workspace; the
+// menu marks it, links ready workspaces to their subdomains, disables
+// mid-lifecycle ones in place with their state, and leads to the portal's
+// create flow. (Archived workspaces never arrive — the server fn filters.)
+
+import { MantineProvider } from "@mantine/core";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SwitcherData } from "#/server/switcher-workspaces";
+
+const h = vi.hoisted(() => ({
+	data: null as SwitcherData | null,
+}));
+vi.mock("#/server/switcher-workspaces", () => ({
+	getSwitcherWorkspaces: async () => {
+		if (!h.data) {
+			throw new Error("no fixture");
+		}
+		return h.data;
+	},
+}));
+
+import { TestQueryProvider } from "#/ui/cockpit/test-query-provider";
+import { WorkspaceSwitcher } from "#/ui/workspace-switcher";
+
+const FIXTURE: SwitcherData = {
+	currentName: "Controlling",
+	workspaces: [
+		{
+			id: "ws-b",
+			name: "Billing",
+			state: "ready",
+			url: "http://ws-b.dataraum.localhost",
+			current: false,
+		},
+		{
+			id: "ws-a",
+			name: "Controlling",
+			state: "ready",
+			url: null,
+			current: true,
+		},
+		{
+			id: "ws-c",
+			name: "Dept 3",
+			state: "creating",
+			url: null,
+			current: false,
+		},
+	],
+	createUrl: "http://dataraum.localhost/create",
+};
+
+function renderSwitcher(data: SwitcherData | null = FIXTURE) {
+	h.data = data;
+	render(
+		<TestQueryProvider>
+			<MantineProvider env="test">
+				<WorkspaceSwitcher />
+			</MantineProvider>
+		</TestQueryProvider>,
+	);
+}
+
+const openMenu = () =>
+	fireEvent.click(screen.getByTestId("workspace-switcher"));
+
+afterEach(() => cleanup());
+
+describe("WorkspaceSwitcher (DAT-821)", () => {
+	it("names the current workspace in the target", async () => {
+		renderSwitcher();
+		expect(await screen.findByText("Controlling")).toBeTruthy();
+	});
+
+	it("falls back to the wordmark while the memberships are not loaded", () => {
+		renderSwitcher(null);
+		expect(screen.getByTestId("workspace-switcher").textContent).toContain(
+			"DataRaum",
+		);
+	});
+
+	it("links a ready workspace to its subdomain — switching is navigation", async () => {
+		renderSwitcher();
+		await screen.findByText("Controlling");
+		openMenu();
+		expect(screen.getByTestId("switcher-item-ws-b").getAttribute("href")).toBe(
+			"http://ws-b.dataraum.localhost",
+		);
+	});
+
+	it("marks the current workspace and gives it no link", async () => {
+		renderSwitcher();
+		await screen.findByText("Controlling");
+		openMenu();
+		const current = screen.getByTestId("switcher-item-ws-a");
+		expect(current.getAttribute("href")).toBeNull();
+		expect(current.querySelector("svg")).toBeTruthy();
+	});
+
+	it("disables a creating workspace in place with its state", async () => {
+		renderSwitcher();
+		await screen.findByText("Controlling");
+		openMenu();
+		const creating = screen.getByTestId("switcher-item-ws-c");
+		expect(creating.getAttribute("href")).toBeNull();
+		expect(creating.hasAttribute("data-disabled")).toBe(true);
+		expect(creating.textContent).toContain("creating");
+	});
+
+	it("offers the portal's create flow", async () => {
+		renderSwitcher();
+		await screen.findByText("Controlling");
+		openMenu();
+		expect(
+			screen.getByTestId("switcher-new-workspace").getAttribute("href"),
+		).toBe("http://dataraum.localhost/create");
+	});
+});

--- a/packages/cockpit/src/ui/workspace-switcher.tsx
+++ b/packages/cockpit/src/ui/workspace-switcher.tsx
@@ -11,9 +11,12 @@
 //     arrives from the server;
 //   - "New workspace" leads to the portal's create flow.
 //
-// Until the memberships query resolves (SSR included — the RPC needs a
-// browser origin, the RunRailBadge `typeof window` idiom), the target renders
-// the brand wordmark, menu-less: the shell never shows a raw workspace UUID.
+// Until the memberships query resolves, the target renders the brand
+// wordmark, menu-less: the shell never shows a raw workspace UUID. The query
+// is client-gated (`typeof window`, the RunRailBadge idiom) because the shell
+// is always-rendered chrome: during SSR the queryFn would fire outside the
+// document request's server context, so the server renders the fallback and
+// the client polls once hydrated.
 
 import { Badge, Group, Menu, Text, UnstyledButton } from "@mantine/core";
 import { useQuery } from "@tanstack/react-query";

--- a/packages/cockpit/src/ui/workspace-switcher.tsx
+++ b/packages/cockpit/src/ui/workspace-switcher.tsx
@@ -1,0 +1,129 @@
+// The workspace switcher (DAT-821) — the top-bar control that replaced the
+// static wordmark placeholder. Quiet chrome in the chat-switcher's idiom: a
+// flat target showing WHERE YOU ARE (the boot workspace's name), dropping
+// into the user's workspaces from `memberships`:
+//
+//   - the current workspace is checked (and a no-op — you are here);
+//   - every other `ready` workspace is a plain <a> to its subdomain —
+//     switching IS navigation, there is no client-side workspace state;
+//   - `creating`/`archiving` are disabled IN PLACE with a state badge (the
+//     menu shows lifecycle truth rather than hiding it); `archived` never
+//     arrives from the server;
+//   - "New workspace" leads to the portal's create flow.
+//
+// Until the memberships query resolves (SSR included — the RPC needs a
+// browser origin, the RunRailBadge `typeof window` idiom), the target renders
+// the brand wordmark, menu-less: the shell never shows a raw workspace UUID.
+
+import { Badge, Group, Menu, Text, UnstyledButton } from "@mantine/core";
+import { useQuery } from "@tanstack/react-query";
+import { Check, ChevronDown, Plus } from "lucide-react";
+import { getSwitcherWorkspaces } from "#/server/switcher-workspaces";
+import { tokens } from "#/ui/theme";
+
+const targetStyle = {
+	display: "inline-flex",
+	alignItems: "center",
+	gap: 6,
+	padding: `2px ${tokens.spacing.xs}`,
+	borderRadius: tokens.radii.sm,
+	color: tokens.colors.text,
+} as const;
+
+export function WorkspaceSwitcher() {
+	const { data } = useQuery({
+		queryKey: ["switcher-workspaces"],
+		queryFn: () => getSwitcherWorkspaces(),
+		// Memberships/lifecycle move on human timescales; refresh when the menu's
+		// tab regains focus (query default) rather than polling.
+		staleTime: 30_000,
+		enabled: typeof window !== "undefined",
+	});
+
+	if (!data) {
+		return (
+			<UnstyledButton data-testid="workspace-switcher" style={targetStyle}>
+				<Text size="sm" fw={600} c="text">
+					DataRaum
+				</Text>
+			</UnstyledButton>
+		);
+	}
+
+	return (
+		<Menu position="bottom-start" withArrow shadow="md" width={260}>
+			<Menu.Target>
+				<UnstyledButton
+					data-testid="workspace-switcher"
+					aria-label="Switch workspace"
+					style={targetStyle}
+				>
+					<Text size="sm" fw={600} truncate maw={220}>
+						{data.currentName}
+					</Text>
+					<ChevronDown size={14} aria-hidden color={tokens.colors.textMuted} />
+				</UnstyledButton>
+			</Menu.Target>
+			<Menu.Dropdown>
+				<Menu.Label>Workspaces</Menu.Label>
+				{data.workspaces.map((workspace) =>
+					workspace.url ? (
+						// Ready, elsewhere: switching is a full navigation to the
+						// workspace's subdomain (its own cockpit instance).
+						<Menu.Item
+							key={workspace.id}
+							component="a"
+							href={workspace.url}
+							data-testid={`switcher-item-${workspace.id}`}
+						>
+							<Text size="sm" truncate>
+								{workspace.name}
+							</Text>
+						</Menu.Item>
+					) : (
+						<Menu.Item
+							key={workspace.id}
+							disabled={!workspace.current}
+							data-testid={`switcher-item-${workspace.id}`}
+							leftSection={
+								workspace.current ? <Check size={14} aria-hidden /> : undefined
+							}
+							rightSection={
+								workspace.state !== "ready" ? (
+									<Badge
+										variant="light"
+										size="xs"
+										color={workspace.state === "creating" ? "yellow" : "gray"}
+									>
+										{workspace.state}
+									</Badge>
+								) : workspace.current ? undefined : (
+									// Ready but unroutable: the bare host-dev seed has no
+									// subdomain — reachable only on its direct port.
+									<Text size="xs" c="dimmed">
+										no subdomain
+									</Text>
+								)
+							}
+						>
+							<Group gap={6} wrap="nowrap">
+								<Text size="sm" fw={workspace.current ? 600 : 400} truncate>
+									{workspace.name}
+								</Text>
+							</Group>
+						</Menu.Item>
+					),
+				)}
+				<Menu.Divider />
+				<Menu.Item
+					component="a"
+					href={data.createUrl}
+					leftSection={<Plus size={14} aria-hidden />}
+					data-testid="switcher-new-workspace"
+				>
+					New workspace
+				</Menu.Item>
+			</Menu.Dropdown>
+		</Menu>
+	);
+}

--- a/packages/infra/docker-compose.yml
+++ b/packages/infra/docker-compose.yml
@@ -572,6 +572,7 @@ services:
       PROVISIONER_DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       DUCKLAKE_CATALOG_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${DUCKLAKE_CATALOG_DB}
       CADDY_ADMIN_URL: http://caddy:2019
+      DATARAUM_CONFIG_PATH: /opt/dataraum/config
       S3_ENDPOINT: ${S3_ENDPOINT}
       S3_REGION: ${S3_REGION:-us-east-1}
       S3_USE_SSL: ${S3_USE_SSL:-false}
@@ -584,6 +585,9 @@ services:
     volumes:
       # The Docker Engine API — the compose provisioning driver (DAT-820).
       - /var/run/docker.sock:/var/run/docker.sock
+      # Read-only config tree — the create flow (DAT-821) lists the builtin
+      # verticals off it (src/portal/verticals.ts); same mount as engine/cockpit.
+      - ${HOST_CONFIG_DIR:-../dataraum-config}:/opt/dataraum/config:ro
     healthcheck:
       test: ["CMD", "wget", "-qO-", "--spider", "http://localhost:3000/api/health"]
       interval: 10s


### PR DESCRIPTION
## Task

DAT-821 — https://real-dataraum.atlassian.net/browse/DAT-821 (Phase 8 of DAT-813, design [DD/51740673](https://real-dataraum.atlassian.net/wiki/spaces/DD/pages/51740673))

## What shipped

**Switcher** (`src/ui/workspace-switcher.tsx` + `src/server/switcher-workspaces.ts`): the app-shell wordmark placeholder becomes the real switcher — the session user's memberships joined onto the registry, current workspace named in the target and checked in the menu, every other `ready` workspace an absolute link to its subdomain (switching IS navigation — per-workspace cockpit), `creating`/`archiving` disabled in place with a state badge, `archived` filtered server-side, "New workspace" leading to the portal.

**Create flow** (portal `/create` + `create.functions.ts` + `portal/create-tracker.ts`): name + vertical + subdomain (derived from the name, editable, live URL preview) → fire-and-forget `createWorkspace` (DAT-820 lifecycle, consumed untouched) → progress panel polling the registry `state` until `ready` → redirect to the new subdomain. Failure shows the lifecycle error verbatim with a same-id **Retry** (the convergence contract); a portal restart degrades to the same retry ("Creation interrupted"). Subdomain conflicts 409 inline at submit; the partial unique index stays the real guard.

**Authz gate (deferred here from DAT-820)** — the lifecycle server fns are the provisioner's first HTTP-reachable trigger. Gate inside every handler (`portal/create-gate.server.ts`): portal role only + authenticated session required. v1 policy: any signed-in user may create (one installation = one tenant; finer roles are explicitly post-v1), the creator is the membership the row gets, the client cannot attach other users. Progress/retry visibility = membership OR tracked starter.

**Vertical source**: the portal container gains the read-only `dataraum-config` mount (same as engine/cockpit) + `DATARAUM_CONFIG_PATH`; `portal/verticals.ts` scans `verticals/*` (underscore-prefixed internal seeds hidden). No hardcoded vertical lists.

**Portal home** widened to the same state semantics: non-archived memberships listed, `creating`/`archiving` badged instead of linked.

## Refine decisions

- **Create-flow home = portal**: it alone carries the provisioner env (admin DB URLs, Docker socket, Caddy admin) — workspace cockpits deliberately don't.
- **Vertical source = the bind-mounted config tree**, re-declared in the provisioner's role-scoped schema (the existing S3-block convention) rather than moving `dataraumConfigPath` across 11 workspace-role files.
- **Authz v1 = any authenticated user creates; creator gets membership** (see above). Docker-socket posture unchanged per the DAT-820 lead decision.

## Lane smoke (fresh `down -v`, multi-workspace profile, real browser via Playwright)

Full journey on the compose stack (Caddy on `:8000` — host `:80` was taken; `CADDY_HTTP_PORT` escape hatch):

1. Portal login (`dev@dataraum.dev`) → workspace list (ws1, ws2 + **New workspace**).
2. ws1 switcher: current checked, ws2 linked, New workspace → portal `/create`.
3. Create "Dept 3" / vertical `finance` (auto-selected single builtin, ontology description read off the mount) / subdomain `ws3` → progress panel → **auto-redirect onto `ws3.dataraum.localhost:8000`**, switcher target reads "Dept 3" (creator membership admitted through the gate).
4. States: invalid subdomain inline error; `creating` badge in switcher (disabled) + portal; "Creation interrupted" + Retry panel; signed-out `/create` → login (denial). Narrow-viewport (400px) form clean.
5. Switching ws3→ws1→ws3 and back again post-pipeline — both directions via the menu.
6. **Real-LLM leg (lead-authorized)**: add_source with ALL 8 finance tables on `engine-<ws3>` — Temporal `addsource-<ws3>` **COMPLETED**, 8/8 raw→typed, real `claude-sonnet-5` call (42.7k input tokens, `column_annotation`), ws3 Runs page shows the completed run; ws3 read schema carries all 8 tables with real row counts. **ws1 unaffected** (0 tables, "No runs yet").
7. Archive via `bun run workspace:archive` → registry `archived`, pair + schemas + routes swept, workspace gone from switcher/portal. Stack left in the standard two-workspace state.

**Error-path matrix (senior-review follow-up, live on the rebuilt stack):** unauthenticated raw RPC to the compiled `/_serverFn` endpoint → **401** `unauthenticated`; signed-in unknown vertical → **400** `unknown_vertical`; claimed subdomain via the UI → **409** rendered inline in the form's error Alert; no stray registry rows from any rejection. (This exercised the senior reviewer's critical finding: thrown `Response`s RESOLVE client-side on the installed TanStack Start — all rejections now go through `serverFnError`, a `setResponseStatus` + thrown JSON-envelope Error.)

A second full create/archive cycle ("Dept 4"/`ws4`) ran on the fixed build for the screenshot set. Key screenshots (in `.playwright-mcp/dat821/` on the dev host): `03-switcher-open-ws1`, `05-create-form-invalid`, `07-create-progress`, `08-ws4-landed`, `09-switcher-open-ws4`, `10-switcher-nonready`, `11-portal-list-creating`, `12-create-interrupted-retry`, `13-create-denied-signedout`, `16-switcher-after-archive`, `17-create-subdomain-conflict`. (The ws3 pipeline-leg UI evidence — Runs page "Add source / completed" — was captured pre-archive; the Temporal `COMPLETED` result and per-table row counts are quoted above, and the `runs` row persists in cockpit_db.)

## Gates

- biome check clean · `tsc --noEmit` clean · full unit suite **1777 tests green** · prod build green (route tree regenerated).
- Engine untouched; no cockpit_db migration (state + resource record landed in DAT-817/820).

## Reviewers

- **spec-compliance-reviewer: COMPLIANT** — all ACs + lane constraints verified, no findings.
- **senior-code-reviewer: APPROVE** (re-verdict on the final delta: "Nothing outstanding. Clear to merge."). First pass was NEEDS WORK — 2 critical + 2 should-fix + 1 nit, all folded in `a6fa6b4c2`: (1) thrown `Response` resolves instead of rejecting on the installed TanStack Start (`x-tss-raw` short-circuit) → all 7 rejection sites now `serverFnError` (setResponseStatus + thrown JSON-envelope Error); (2) create-tracker TOCTOU → entry-identity generation guard; (3) progress poll now terminal when idle; (4) create-flow client tests added; (5) switcher SSR-gate comment corrected. The reviewer verified the fixes **independently** — fresh dev server + Playwright re-repro of the critical (unauthenticated calls now reject as real Errors with the JSON envelope while the wire keeps the true 401/403), race test exercised, gates re-run (1777 tests, tsc, biome). This lane additionally re-verified the fix on the rebuilt compose stack: unauthenticated raw RPC → 401 envelope, unknown vertical → 400, claimed subdomain → 409 rendered inline (screenshot 17), no stray registry rows.

## Other lanes in flight

None — `gh pr list` is empty; this is the epic's final phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
