### PR TITLE
Fix the workspace startup path, and retire the hand-built second workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,10 @@ docker compose -f packages/infra/docker-compose.yml up -d --wait   # full stack
 docker compose -f packages/infra/docker-compose.yml run --rm --no-deps \
   --entrypoint temporal temporal-admin-tools \
   worker list --namespace default --address temporal:7233          # → Status: Running
-open http://localhost:3000                                          # cockpit (run dev outside docker for hot reload)
+open http://dataraum.localhost                                      # portal → sign in → your workspace
+# Caddy owns the entry: parent domain = portal, <sub>.dataraum.localhost = a workspace.
+# :80 must be free (else CADDY_HTTP_PORT + a matching DATARAUM_PORTAL_ORIGIN).
+# localhost:3000 is a debug port only — signed-out HTML bounces to the portal.
 ```
 
 Settled architecture decisions → `docs/adr/` (short, git-tracked). Long-form design docs → Confluence (space DD). Active work → Jira (DAT-*).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ DataRaum runs as a multi-container platform, isolated per **workspace**:
 - **engine** (Python) — a **Temporal activity worker**, no HTTP. Does the durable analysis (`add_source`, `begin_session`, `operating_model`) and writes metadata to the workspace's Postgres schema.
 - **cockpit** (TanStack Start) — the web app you use. Hosts the chat agent, renders the results, and orchestrates the journey by triggering engine workflows via Temporal.
 
+Each workspace runs its own pair of those two containers. In front of them sit the **portal** (the cockpit image in a second role — login, membership routing, workspace provisioning) and **Caddy**, which serves the portal on the parent domain and each workspace on its own subdomain.
+
 They share one substrate: **Postgres** (metadata + cockpit state + catalogs), an **S3 object store** (the DuckLake data lake + uploads), and **Temporal** (durable orchestration). No HTTP seam between engine and cockpit — the integration surface is Postgres + Temporal. See the [platform architecture](docs/platform/architecture.md).
 
 ## Quick start
@@ -34,7 +36,8 @@ They share one substrate: **Postgres** (metadata + cockpit state + catalogs), an
 cp packages/infra/.env.example packages/infra/.env
 echo "ANTHROPIC_API_KEY=sk-ant-..." >> packages/infra/.env
 
-# Bring up the full stack (Postgres, object store, Temporal, engine worker, cockpit)
+# Bring up the whole installation (substrate, engine worker + cockpit for the
+# default workspace, portal, and the Caddy ingress)
 docker compose -f packages/infra/docker-compose.yml up -d --wait
 
 # Engine health = the Temporal worker heartbeat (no HTTP endpoint):
@@ -42,10 +45,25 @@ docker compose -f packages/infra/docker-compose.yml run --rm --no-deps \
   --entrypoint temporal temporal-admin-tools \
   worker list --namespace default --address temporal:7233   # → Status: Running
 
-# Open the cockpit
-open http://localhost:3000
+# Sign in at the portal, then open the default workspace from there
+open http://dataraum.localhost              # dev@dataraum.dev / dataraum-dev
 ```
 
+Caddy routes by hostname: the parent domain serves the **portal** (login + your workspaces),
+and each workspace has its own subdomain (`http://ws1.dataraum.localhost`). `localhost:3000`
+is published for debugging but always `401`s — the session cookie lives on the parent domain.
+
+The one thing that bites on a first run: **port 80 must be free.** Caddy binds it, and if it
+can't, `--wait` aborts before the portal ever starts — set `CADDY_HTTP_PORT` *and* a matching
+`DATARAUM_PORTAL_ORIGIN` to move it. (`*.localhost` needs no `/etc/hosts` entry.)
+
+Compose defines exactly **one** workspace pair — bootstrap scaffolding, so a fresh install
+has something to log into and something for the provisioner to clone. Every other workspace
+is created from the portal (**New workspace**) or
+`cd packages/cockpit && bun run workspace:create`; compose does not grow a service per
+workspace.
+
+Full walkthrough, including troubleshooting: [Running the stack](docs/getting-started/running-the-stack.md).
 For UI iteration, run the cockpit dev server outside docker for hot reload — see `packages/cockpit/README.md`.
 
 ### Run a released version (published images)

--- a/README.md
+++ b/README.md
@@ -51,19 +51,21 @@ open http://dataraum.localhost              # dev@dataraum.dev / dataraum-dev
 
 Caddy routes by hostname: the parent domain serves the **portal** (login + your workspaces),
 and each workspace has its own subdomain (`http://ws1.dataraum.localhost`). `localhost:3000`
-is published for debugging but always `401`s — the session cookie lives on the parent domain.
+is published for debugging only — the session cookie is scoped to the parent domain, so a
+browser there is redirected to the portal and a script gets `401`.
 
-The one thing that bites on a first run: **port 80 must be free.** Caddy binds it, and if it
-can't, `--wait` aborts before the portal ever starts — set `CADDY_HTTP_PORT` *and* a matching
-`DATARAUM_PORTAL_ORIGIN` to move it. (`*.localhost` needs no `/etc/hosts` entry.)
+The thing that bites on a first run: **Caddy binds port 80.** If something already holds it
+(macOS ships Apache), `up` fails at container start and the portal never comes up — set
+`CADDY_HTTP_PORT` *and* a matching `DATARAUM_PORTAL_ORIGIN` to move it. (`*.localhost` needs
+no `/etc/hosts` entry.)
 
 Compose defines exactly **one** workspace pair — bootstrap scaffolding, so a fresh install
 has something to log into and something for the provisioner to clone. Every other workspace
-is created from the portal (**New workspace**) or
-`cd packages/cockpit && bun run workspace:create`; compose does not grow a service per
-workspace.
+is created from the portal (**New workspace**) or `bun run workspace:create`; compose does
+not grow a service per workspace.
 
 Full walkthrough, including troubleshooting: [Running the stack](docs/getting-started/running-the-stack.md).
+
 For UI iteration, run the cockpit dev server outside docker for hot reload — see `packages/cockpit/README.md`.
 
 ### Run a released version (published images)

--- a/docs/adr/0012-per-workspace-tenancy.md
+++ b/docs/adr/0012-per-workspace-tenancy.md
@@ -45,8 +45,9 @@ prefix:
 - **Vertical:** `workspaces.vertical` (a WORKSPACE property) + a boot-read of it.
   DAT-505 adds the CAPABILITY only; retiring the per-add_source vertical channel
   (payload field + session-row read + cockpit `select` pick) is DAT-506.
-- **Compose:** the engine-worker is parameterized per workspace via YAML anchors;
-  a second workspace lives behind the `multi-workspace` profile.
+- **Compose:** defines exactly one engine-worker + cockpit pair — the bootstrap
+  workspace. Every further workspace is created by the provisioner, which clones
+  that pair's container config (DAT-820).
 - **Deletion sweep:** the provisioner's archive operation (DAT-820, cockpit
   `src/portal/lifecycle.ts`; it retired the `delete-workspace.sh` script) —
   stop/remove the pair → drop `ws_<id>` + `ws_<id>_read` schemas → drop the

--- a/docs/adr/0012-per-workspace-tenancy.md
+++ b/docs/adr/0012-per-workspace-tenancy.md
@@ -45,9 +45,8 @@ prefix:
 - **Vertical:** `workspaces.vertical` (a WORKSPACE property) + a boot-read of it.
   DAT-505 adds the CAPABILITY only; retiring the per-add_source vertical channel
   (payload field + session-row read + cockpit `select` pick) is DAT-506.
-- **Compose:** defines exactly one engine-worker + cockpit pair — the bootstrap
-  workspace. Every further workspace is created by the provisioner, which clones
-  that pair's container config (DAT-820).
+- **Compose:** the engine-worker is parameterized per workspace via YAML anchors;
+  a second workspace lives behind the `multi-workspace` profile.
 - **Deletion sweep:** the provisioner's archive operation (DAT-820, cockpit
   `src/portal/lifecycle.ts`; it retired the `delete-workspace.sh` script) —
   stop/remove the pair → drop `ws_<id>` + `ws_<id>_read` schemas → drop the

--- a/docs/getting-started/running-the-stack.md
+++ b/docs/getting-started/running-the-stack.md
@@ -73,7 +73,8 @@ disable). Sign in, then follow **Open** into the workspace.
 There is no sign-up *screen*, but better-auth's endpoint is mounted and public: an
 unauthenticated `POST /api/auth/sign-up/email` creates an account. Combined with the create
 policy — any signed-in user of the installation may provision a workspace — anyone who can
-reach the portal can create one. Worth knowing before exposing an install beyond localhost.
+reach the portal can create one. That is accepted while installations carry only test
+users; it needs closing before an install carries real ones or is exposed beyond localhost.
 
 Two things worth knowing:
 

--- a/docs/getting-started/running-the-stack.md
+++ b/docs/getting-started/running-the-stack.md
@@ -40,19 +40,22 @@ for what each one is.
 
 ### If port 80 is taken
 
-Caddy can't bind, `--wait` aborts, and the `portal` service never starts — the failure
-looks like the stack half-came-up. (On macOS the built-in Apache is a common squatter;
-`curl -I http://localhost` will name whoever holds it.) Either free the port, or move the
-ingress — in `packages/infra/.env`:
+Caddy can't bind, so `up` fails at container start and the `portal` service is left in
+`Created` — the failure looks like the stack half-came-up. (On macOS the built-in Apache
+is a common squatter; `curl -I http://localhost` names whoever holds it. A squatter bound
+to IPv4 only does *not* collide — Docker binds the IPv6 stack and `up` succeeds — so the
+symptom appears with dual-stack listeners.) Either free the port, or move the ingress — in
+`packages/infra/.env`:
 
 ```bash
 CADDY_HTTP_PORT=8000
 DATARAUM_PORTAL_ORIGIN=http://dataraum.localhost:8000
 ```
 
-**Both lines, same port.** The portal origin is what the session cookie is derived from and
-what workspace links are built from; if it disagrees with the published port, sign-in
-appears to work and then every workspace link 401s. Every URL below then carries `:8000`.
+**Both lines, same port.** `DATARAUM_PORTAL_ORIGIN` is what workspace links are built from
+(`workspace-url.ts` uses its `host`, port included) and what better-auth matches request
+origins against; if it disagrees with the published port, links point at a port nothing
+listens on. Every URL below then carries `:8000`.
 
 ## Sign in
 
@@ -67,16 +70,22 @@ Start at the portal. Dev stacks seed a credential user from `DATARAUM_DEV_USER_E
 `DATARAUM_DEV_USER_PASSWORD` (`dev@dataraum.dev` / `dataraum-dev` by default; unset both to
 disable). Sign in, then follow **Open** into the workspace.
 
+There is no sign-up *screen*, but better-auth's endpoint is mounted and public: an
+unauthenticated `POST /api/auth/sign-up/email` creates an account. Combined with the create
+policy — any signed-in user of the installation may provision a workspace — anyone who can
+reach the portal can create one. Worth knowing before exposing an install beyond localhost.
+
 Two things worth knowing:
 
 - **`http://localhost:3000` is not the entry point.** The cockpit container still publishes
-  it for debugging, but the session cookie lives on the parent domain — a request to
-  `localhost` never carries one, so the membership gate returns `401` every time. Use the
-  subdomain.
-- **`*.localhost` resolves to `127.0.0.1` on its own**, at any depth — no `/etc/hosts`
-  edit. Every major browser does this itself, and on macOS the system resolver does too,
-  so plain `curl` and Safari work as well. Some Linux resolvers don't; there, add the
-  hosts or use `curl --resolve ws1.dataraum.localhost:80:127.0.0.1 …`.
+  it for debugging, but the session cookie is scoped to the parent domain, so a request to
+  `localhost` never carries one. A browser there is redirected to the portal; a non-HTML
+  caller (curl, a script) gets `401`. Use the subdomain.
+- **`*.localhost` resolves to loopback on its own**, at any depth — no `/etc/hosts` edit.
+  Browsers implement this themselves, and on macOS the system resolver does too, which is
+  why plain `curl` and Safari also work (Safari relies on the resolver, not its own rule).
+  Some Linux resolvers don't; there, add the hosts or use
+  `curl --resolve ws1.dataraum.localhost:80:127.0.0.1 …`.
 
 ## Verify
 
@@ -99,28 +108,36 @@ A [workspace](../platform/architecture.md#the-per-workspace-model) is the unit o
 catalog schema, and object-store prefix.
 
 **One exists already — as bootstrap, not as a feature.** The compose stack defines a single
-engine + cockpit pair, and that cockpit seeds "Default Workspace" at boot from its own
-`DATARAUM_WORKSPACE_ID`: the registry row, the `ws_<id>` schema, its two metadata roles, and
-the dev user's membership. It exists so a fresh install has something to log into and
-something for the provisioner to clone — there is no sign-up surface yet, so without it
-nobody could get in at all. Treat it as scaffolding.
+engine + cockpit pair, and the two halves seed it between them: the **engine** worker
+creates the `ws_<id>` schema, its promoted-read schema, and the two metadata roles from its
+`DATARAUM_WORKSPACE_ID` (it never reads `cockpit_db`), while the **cockpit** seeds the
+`cockpit_db` side — the registry row named "Default Workspace", and the dev user's
+membership. It exists so a fresh install has something to log into and something for the
+provisioner to clone. Treat it as scaffolding.
 
 **Every other workspace is provisioned**, which mints the roles and catalog schema, starts an
 engine + cockpit pair, and registers the Caddy route. Compose does *not* grow a service per
 workspace. Two equivalent front doors:
 
 - The portal → **New workspace**: name, [vertical](../concepts/approach.md), subdomain.
-- The CLI, for scripted or headless setups:
+  This is the path to prefer — the portal container already holds the admin connections
+  and the docker socket the lifecycle needs.
+- The CLI, for scripted or headless setups. It runs on the **host**, so it needs the
+  provisioner env pointed at the published ports — the full block is documented at the top
+  of `packages/cockpit/scripts/provision-workspace.ts`; without it you get a config throw
+  naming the missing field.
 
   ```bash
   cd packages/cockpit
-  bun run workspace:create -- --name "Controlling" --subdomain ws3 \
-      --vertical finance --member dev@dataraum.dev
+  # ... provisioner env (see the script header) ...
+  bun run workspace:create -- --id "$(uuidgen | tr A-Z a-z)" --name "Controlling" \
+      --subdomain ws3 --vertical finance --member dev@dataraum.dev
   bun run workspace:archive -- --id <workspace-id>     # the undo
   ```
 
-  Both ops are idempotent — re-running with the same id converges, so a create that died
-  midway resumes instead of duplicating.
+  Both ops are idempotent **on an id**: re-running with the same `--id` resumes a create
+  that died midway. That is why the example passes one — without `--id` a re-run mints a
+  fresh UUID and then collides with the first attempt's still-live subdomain.
 
 ## Everyday operations
 
@@ -131,8 +148,10 @@ make down                    # stop the stack
 
 - **Iterating on the cockpit UI?** Skip the cockpit container and run the dev server
   outside docker for hot reload — bring up only the backend deps and `bun --bun run dev`.
-  Bare host dev has no Caddy and no subdomains: the portal origin defaults to
-  `http://localhost:3000` and `/` serves that workspace directly. See
+  Note that bare host dev runs the **workspace** role only: there is no portal and no
+  sign-in screen, and the membership gate redirects a signed-out request to the portal
+  origin — which defaults to `http://localhost:3000`, i.e. itself. Use the composed stack
+  for anything that involves logging in. See
   [`packages/cockpit/README.md`](https://github.com/dataraum/dataraum/blob/main/packages/cockpit/README.md).
 - **Changed engine or cockpit code and want it in the container?** A plain `up` reuses the
   cached image. Rebuild and recreate the affected service:

--- a/docs/getting-started/running-the-stack.md
+++ b/docs/getting-started/running-the-stack.md
@@ -11,6 +11,8 @@ To run pinned release images on a deploy host instead, see [Deployment](../opera
   see the package READMEs.)
 - An **Anthropic API key**. Semantic analysis and the chat agent need it; the substrate
   boots without it, but the pipeline can't complete.
+- **Port 80 free**, or a spare port to put the ingress on. Caddy terminates every URL you
+  use and publishes `:80` by default — see [If port 80 is taken](#if-port-80-is-taken).
 
 ## Bring it up
 
@@ -21,7 +23,7 @@ Run from the workspace root:
 cp packages/infra/.env.example packages/infra/.env
 echo "ANTHROPIC_API_KEY=sk-ant-..." >> packages/infra/.env
 
-# Build + start Postgres, the object store, Temporal, the engine worker, and the cockpit
+# Build + start the whole installation
 docker compose -f packages/infra/docker-compose.yml --env-file packages/infra/.env up -d --wait
 ```
 
@@ -30,6 +32,51 @@ or, equivalently, `make up` from the root.
 The first run builds both app images and pulls the substrate images, so it takes a few
 minutes; subsequent runs reuse the layers. `--wait` blocks until every service is healthy
 (and the one-shot `cockpit-migrate` has applied the `cockpit_db` migrations).
+
+A default `up` — no profiles — gives you the complete installation: Postgres, the object
+store, Temporal, **one engine worker and one cockpit** for the default workspace, plus the
+**portal** and **Caddy**. See [the container table](../platform/architecture.md#the-containers-concretely)
+for what each one is.
+
+### If port 80 is taken
+
+Caddy can't bind, `--wait` aborts, and the `portal` service never starts — the failure
+looks like the stack half-came-up. (On macOS the built-in Apache is a common squatter;
+`curl -I http://localhost` will name whoever holds it.) Either free the port, or move the
+ingress — in `packages/infra/.env`:
+
+```bash
+CADDY_HTTP_PORT=8000
+DATARAUM_PORTAL_ORIGIN=http://dataraum.localhost:8000
+```
+
+**Both lines, same port.** The portal origin is what the session cookie is derived from and
+what workspace links are built from; if it disagrees with the published port, sign-in
+appears to work and then every workspace link 401s. Every URL below then carries `:8000`.
+
+## Sign in
+
+Caddy routes by hostname, so the entry point is a **domain, not a port**:
+
+| URL | What |
+|---|---|
+| `http://dataraum.localhost` | the **portal** — sign in, see your workspaces, create new ones |
+| `http://ws1.dataraum.localhost` | the default workspace's cockpit |
+
+Start at the portal. Dev stacks seed a credential user from `DATARAUM_DEV_USER_EMAIL` /
+`DATARAUM_DEV_USER_PASSWORD` (`dev@dataraum.dev` / `dataraum-dev` by default; unset both to
+disable). Sign in, then follow **Open** into the workspace.
+
+Two things worth knowing:
+
+- **`http://localhost:3000` is not the entry point.** The cockpit container still publishes
+  it for debugging, but the session cookie lives on the parent domain — a request to
+  `localhost` never carries one, so the membership gate returns `401` every time. Use the
+  subdomain.
+- **`*.localhost` resolves to `127.0.0.1` on its own**, at any depth — no `/etc/hosts`
+  edit. Every major browser does this itself, and on macOS the system resolver does too,
+  so plain `curl` and Safari work as well. Some Linux resolvers don't; there, add the
+  hosts or use `curl --resolve ws1.dataraum.localhost:80:127.0.0.1 …`.
 
 ## Verify
 
@@ -43,13 +90,37 @@ docker compose -f packages/infra/docker-compose.yml run --rm --no-deps \
 # → Status: Running   (on the engine-<workspace-id> task queue)
 ```
 
-Then open the cockpit — the only surface you interact with:
-
-```
-open http://localhost:3000
-```
-
 The Temporal web UI is at <http://localhost:8080> if you want to watch workflows run.
+
+## Workspaces
+
+A [workspace](../platform/architecture.md#the-per-workspace-model) is the unit of isolation
+— its own engine container, cockpit container, subdomain, Temporal queues, Postgres schema,
+catalog schema, and object-store prefix.
+
+**One exists already — as bootstrap, not as a feature.** The compose stack defines a single
+engine + cockpit pair, and that cockpit seeds "Default Workspace" at boot from its own
+`DATARAUM_WORKSPACE_ID`: the registry row, the `ws_<id>` schema, its two metadata roles, and
+the dev user's membership. It exists so a fresh install has something to log into and
+something for the provisioner to clone — there is no sign-up surface yet, so without it
+nobody could get in at all. Treat it as scaffolding.
+
+**Every other workspace is provisioned**, which mints the roles and catalog schema, starts an
+engine + cockpit pair, and registers the Caddy route. Compose does *not* grow a service per
+workspace. Two equivalent front doors:
+
+- The portal → **New workspace**: name, [vertical](../concepts/approach.md), subdomain.
+- The CLI, for scripted or headless setups:
+
+  ```bash
+  cd packages/cockpit
+  bun run workspace:create -- --name "Controlling" --subdomain ws3 \
+      --vertical finance --member dev@dataraum.dev
+  bun run workspace:archive -- --id <workspace-id>     # the undo
+  ```
+
+  Both ops are idempotent — re-running with the same id converges, so a create that died
+  midway resumes instead of duplicating.
 
 ## Everyday operations
 
@@ -60,7 +131,9 @@ make down                    # stop the stack
 
 - **Iterating on the cockpit UI?** Skip the cockpit container and run the dev server
   outside docker for hot reload — bring up only the backend deps and `bun --bun run dev`.
-  See [`packages/cockpit/README.md`](https://github.com/dataraum/dataraum/blob/main/packages/cockpit/README.md).
+  Bare host dev has no Caddy and no subdomains: the portal origin defaults to
+  `http://localhost:3000` and `/` serves that workspace directly. See
+  [`packages/cockpit/README.md`](https://github.com/dataraum/dataraum/blob/main/packages/cockpit/README.md).
 - **Changed engine or cockpit code and want it in the container?** A plain `up` reuses the
   cached image. Rebuild and recreate the affected service:
 
@@ -72,20 +145,6 @@ make down                    # stop the stack
   all workflows) and the cockpit's activity-only worker alike: their code is baked into
   the image at build time, so without `--build --force-recreate` the old worker keeps
   polling and your change silently never lands.
-
-## Multiple workspaces
-
-A [workspace](../platform/architecture.md#the-per-workspace-model) is the unit of isolation
-— its own engine container, Temporal queue, Postgres schema, catalog, and object-store
-prefix. The default stack runs one. To bring up a second engine worker side by side (for a
-two-workspace smoke), enable the profile:
-
-```bash
-docker compose -f packages/infra/docker-compose.yml --profile multi-workspace up -d --wait
-```
-
-The cockpit is a single app that serves all workspaces, routing each request to the right
-one via the registry.
 
 ## Next
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -28,8 +28,8 @@ compose file; they need no override.
 ## Run a released version
 
 The base compose file builds; a thin overlay, `docker-compose.release.yml`, swaps the
-three app services over to the published tags (`pull_policy: always`). Layer it on top and
-name the version you want:
+app services — `engine-worker`, `cockpit`, `cockpit-migrate`, and `portal` — over to the
+published tags (`pull_policy: always`). Layer it on top and name the version you want:
 
 ```bash
 cp packages/infra/.env.example packages/infra/.env
@@ -45,6 +45,13 @@ docker compose \
 
 - **`DATARAUM_VERSION` is required** by the overlay — a deploy must name the tag it runs
   (no implicit `latest`). Set it in the environment or uncomment it in `.env`.
+- **The ingress needs a free port 80** (or `CADDY_HTTP_PORT`), and
+  **`DATARAUM_PORTAL_ORIGIN` must name the origin users actually reach**, port included.
+  Caddy serves the portal on that origin and each workspace on a subdomain of it; the
+  value is what workspace links are built from and what better-auth matches request
+  origins against, so a mismatch breaks sign-in flows. Set `BETTER_AUTH_SECRET` to a real
+  value (`openssl rand -base64 32`) — the committed default is a dev placeholder, and the
+  portal and every workspace cockpit must share it.
 - **`--no-build` is load-bearing.** The base file's `build:` sections still merge in, so
   without it a failed pull could silently build from whatever source is on the host. With
   it, an unreachable or misspelled tag fails loud instead.
@@ -84,12 +91,15 @@ per service.
 A [workspace](../platform/architecture.md#the-per-workspace-model) is the unit of
 isolation — its own engine container, Temporal queue (`engine-<id>`), Postgres schema
 (`ws_<id>`), DuckLake catalog schema (`ws_<id>` in the installation-wide catalog DB),
-and `s3://bucket/<id>/` prefix. The
-`x-engine-worker-base` anchor in `docker-compose.yml` is the per-workspace template:
-adding a workspace is a registry row plus one more engine service that merges the anchor
-and overrides the three routing knobs (workspace id, queue, lake prefix). The
-cockpit is a **single** app that routes each request to the right workspace by the
-registry.
+and `s3://bucket/<id>/` prefix. Each workspace runs its **own** engine container *and its
+own cockpit container* — the cockpit is per-workspace, not one app routing every request.
+
+Do not add workspaces by editing compose. The `engine-worker` + `cockpit` services are the
+one bootstrap pair, and they double as the template: the provisioner clones their recorded
+container config, overrides the routing knobs and the minted per-workspace secrets, and
+registers the Caddy route. Adding a workspace is therefore the portal's **New workspace**
+flow (or `bun run workspace:create`), and a var added to those two services flows into
+every workspace provisioned afterwards.
 
 The images are plain OCI containers — the compose overlay is the reference topology, not a
 requirement. Run them under any orchestrator that gives them the same substrate (one

--- a/docs/platform/architecture.md
+++ b/docs/platform/architecture.md
@@ -186,8 +186,9 @@ A default local stack is:
 | `caddy` | the ingress: per-workspace subdomains + the portal's parent domain (`caddy/caddy.json`; admin API = the provisioner seam) |
 | `portal` | the cockpit image in portal mode — login + membership routing on the parent domain |
 
-The `multi-workspace` profile adds workspace 2's pair (`engine-worker-2`, `cockpit-2`)
-for the two-workspace smoke.
+That is the complete installation, and it defines exactly **one** workspace pair — the
+bootstrap workspace. Compose grows no further per workspace: the provisioner clones this
+pair's recorded container config for every workspace created through the portal.
 
 The engine has **no healthcheck port** — its health is the Temporal worker heartbeat, not
 an HTTP probe. See [Running the stack](../getting-started/running-the-stack.md) to bring

--- a/packages/cockpit/.env.example
+++ b/packages/cockpit/.env.example
@@ -98,8 +98,8 @@ ANTHROPIC_API_KEY=
 # TEMPORAL_HOST=localhost:7233
 # TEMPORAL_NAMESPACE=default
 
-# Temporal Web UI, linked by the /workflows section. Defaults to the
-# docker-compose dev address (CORS already allows :3000).
+# Temporal Web UI. The /workflows section only LINKS to it (a new tab), so no
+# CORS allow-list is involved. Defaults to the docker-compose dev address.
 # TEMPORAL_UI_URL=http://localhost:8080
 
 # --- Observability (ADR-0019/DAT-705; optional) ---

--- a/packages/cockpit/.env.example
+++ b/packages/cockpit/.env.example
@@ -18,7 +18,7 @@ BETTER_AUTH_SECRET=dataraum-dev-secret
 # The portal origin. Defaults to http://localhost:3000 for bare host dev (no
 # Caddy → no subdomains: the session cookie stays host-only and `/` serves the
 # workspace redirect straight off :3000). Point it at the Caddy parent domain
-# (http://dataraum.localhost) when running the composed multi-workspace stack.
+# (http://dataraum.localhost) when running the composed stack behind Caddy.
 # DATARAUM_PORTAL_ORIGIN=http://localhost:3000
 # This workspace's subdomain label (seeded onto the registry row; the portal
 # routes with it). Unset in bare host dev — nothing terminates subdomains.

--- a/packages/cockpit/scripts/provision-workspace.ts
+++ b/packages/cockpit/scripts/provision-workspace.ts
@@ -58,10 +58,9 @@ async function resolveMemberIds(emails: string[]): Promise<string[]> {
 	if (missing.length > 0) {
 		throw new Error(
 			`no cockpit_db user for: ${missing.join(", ")} — members must exist ` +
-				"first. There is no sign-up surface yet, so the only accounts are " +
-				"the ones the bootstrap workspace's cockpit seeds from " +
-				"DATARAUM_DEV_USER_EMAIL/PASSWORD: bring the stack up, then pass " +
-				"that address",
+				"first. Either sign the address up (POST /api/auth/sign-up/email " +
+				"at the portal; there is no sign-up UI yet), or bring the stack up " +
+				"and pass the seeded DATARAUM_DEV_USER_EMAIL address",
 		);
 	}
 	return [...found.values()];

--- a/packages/cockpit/scripts/provision-workspace.ts
+++ b/packages/cockpit/scripts/provision-workspace.ts
@@ -58,8 +58,10 @@ async function resolveMemberIds(emails: string[]): Promise<string[]> {
 	if (missing.length > 0) {
 		throw new Error(
 			`no cockpit_db user for: ${missing.join(", ")} — members must exist ` +
-				"(sign up through the portal, or bring the stack up so the dev " +
-				"user is seeded)",
+				"first. There is no sign-up surface yet, so the only accounts are " +
+				"the ones the bootstrap workspace's cockpit seeds from " +
+				"DATARAUM_DEV_USER_EMAIL/PASSWORD: bring the stack up, then pass " +
+				"that address",
 		);
 	}
 	return [...found.values()];

--- a/packages/cockpit/src/auth/auth.ts
+++ b/packages/cockpit/src/auth/auth.ts
@@ -32,10 +32,13 @@ import { tanstackStartCookies } from "better-auth/tanstack-start";
 import { baseConfig } from "#/config.base";
 import { cockpitDb } from "#/db/cockpit/client";
 import { accounts, sessions, users, verifications } from "#/db/cockpit/schema";
+import { trustedOriginPattern } from "./trusted-origins";
 
-/** The parent domain — the portal origin's hostname. Workspace subdomains
- * hang off it (`ws1.dataraum.localhost`), and the session cookie is scoped to
- * it so one login reaches every workspace cockpit. */
+/** The parent domain — the portal origin's HOSTNAME (never the port). This is
+ * the cookie `domain`, and cookies are not port-scoped: a cookie set for
+ * `dataraum.localhost` is sent to every port on it. Workspace subdomains hang
+ * off it (`ws1.dataraum.localhost`) so one login reaches every workspace
+ * cockpit. */
 export const parentDomain = new URL(baseConfig.portalOrigin).hostname;
 
 // Subdomain cookie sharing needs a dotted parent (`dataraum.localhost`); on a
@@ -60,8 +63,10 @@ export const auth = betterAuth({
 	},
 	// POSTs to the auth handler (sign-out from a workspace cockpit) originate
 	// from workspace subdomains — trust the whole parent-domain family, not
-	// just the portal origin.
-	trustedOrigins: crossSubDomain ? [`*.${parentDomain}`] : [],
+	// just the portal origin. Port-inclusive by necessity — see trusted-origins.ts.
+	trustedOrigins: crossSubDomain
+		? [trustedOriginPattern(baseConfig.portalOrigin)]
+		: [],
 	advanced: {
 		crossSubDomainCookies: {
 			enabled: crossSubDomain,

--- a/packages/cockpit/src/auth/trusted-origins.test.ts
+++ b/packages/cockpit/src/auth/trusted-origins.test.ts
@@ -1,0 +1,37 @@
+// Regression: the trustedOrigins pattern must carry the portal origin's PORT.
+//
+// better-auth matches a wildcard entry against `new URL(url).host`, which
+// includes a non-default port. Deriving the pattern from the origin's
+// *hostname* breaks every stack moved off :80 with CADDY_HTTP_PORT — the
+// sign-out POST from `http://ws1.dataraum.localhost:8000` presents host
+// `ws1.dataraum.localhost:8000`, `*.dataraum.localhost` does not match it, and
+// better-auth answers 403 INVALID_ORIGIN. That shipped once; this pins it.
+
+import { describe, expect, it } from "vitest";
+import { trustedOriginPattern } from "./trusted-origins";
+
+describe("trustedOriginPattern (DAT-819)", () => {
+	it("carries a non-default port, so subdomains match when Caddy is moved off :80", () => {
+		expect(trustedOriginPattern("http://dataraum.localhost:8000")).toBe(
+			"*.dataraum.localhost:8000",
+		);
+	});
+
+	it("collapses to the bare hostname on the default port", () => {
+		expect(trustedOriginPattern("http://dataraum.localhost")).toBe(
+			"*.dataraum.localhost",
+		);
+	});
+
+	it("omits the implicit 443 on a TLS deployment", () => {
+		expect(trustedOriginPattern("https://cockpit.example.com")).toBe(
+			"*.cockpit.example.com",
+		);
+	});
+
+	it("keeps an explicit non-default TLS port", () => {
+		expect(trustedOriginPattern("https://cockpit.example.com:8443")).toBe(
+			"*.cockpit.example.com:8443",
+		);
+	});
+});

--- a/packages/cockpit/src/auth/trusted-origins.ts
+++ b/packages/cockpit/src/auth/trusted-origins.ts
@@ -1,0 +1,21 @@
+// The `trustedOrigins` wildcard pattern for an installation (DAT-819).
+//
+// Split out of auth.ts so it can be tested without instantiating better-auth
+// (which needs a DB adapter and the whole config chain).
+//
+// The subtlety this exists to hold: better-auth matches a wildcard
+// `trustedOrigins` entry against `new URL(url).host`
+// (`dist/auth/trusted-origins.mjs` → `getHost`), and `host` INCLUDES a
+// non-default port. A pattern built from the origin's *hostname* therefore
+// never matches a request from `ws1.dataraum.localhost:8000`, so on any stack
+// moved off :80 (CADDY_HTTP_PORT) every sign-out POST from a workspace
+// subdomain fails 403 INVALID_ORIGIN. Building it from `host` is correct in
+// both cases — it collapses to the bare hostname on the scheme's default port.
+//
+// Note this is deliberately NOT the same derivation as the session cookie's
+// `domain`, which uses `hostname`: cookies are not port-scoped.
+
+/** `*.<host>` for the portal origin — port included when non-default. */
+export function trustedOriginPattern(portalOrigin: string): string {
+	return `*.${new URL(portalOrigin).host}`;
+}

--- a/packages/cockpit/src/db/cockpit/registry.test.ts
+++ b/packages/cockpit/src/db/cockpit/registry.test.ts
@@ -188,9 +188,28 @@ describe("resolveActiveWorkspace seed (DAT-461 / DAT-817 / DAT-819)", () => {
 		// (DAT-817 — a self-seeded boot workspace is by definition live).
 		expect(ws?.row.vertical).toBe("_adhoc");
 		expect(ws?.row.state).toBe("ready");
+		// Short, id-free display name: it renders in the portal list and the
+		// app-shell switcher, where a full UUID overflows.
+		expect(ws?.row.name).toBe("Default Workspace");
+		expect(ws?.row.name).not.toContain(WS);
 		// No subdomain declared -> plain DoNothing insert, no upsert.
 		expect(ws?.row).not.toHaveProperty("subdomain");
 		expect(h.upserts).toEqual([]);
+	});
+
+	it("never overwrites an existing row's name — a provisioned workspace keeps the creator's (DAT-820)", async () => {
+		// The two seed paths differ in conflict handling, so pin BOTH: neither
+		// may carry `name` in its update set, or a provisioned workspace's own
+		// cockpit would rename it to "Default Workspace" on boot.
+		h.config = { dataraumWorkspaceId: WS, dataraumWorkspaceSubdomain: "ws1" };
+		const { resolveActiveWorkspace, setActiveWorkspaceVertical } =
+			await freshRegistry();
+		await resolveActiveWorkspace();
+		await setActiveWorkspaceVertical("finance");
+
+		for (const up of h.upserts.filter((u) => u.table === "workspaces")) {
+			expect(up.set).not.toHaveProperty("name");
+		}
 	});
 
 	it("re-asserts the env-declared subdomain on a warm row (DAT-819)", async () => {

--- a/packages/cockpit/src/db/cockpit/registry.test.ts
+++ b/packages/cockpit/src/db/cockpit/registry.test.ts
@@ -226,8 +226,9 @@ describe("resolveActiveWorkspace seed (DAT-461 / DAT-817 / DAT-819)", () => {
 			userId: DEV_USER_ID,
 			password: "scrypt:pw",
 		});
-		// The insert is upsert-guarded: a concurrent boot-seed (cockpit-2, same
-		// dev user) losing the race converges on the hash instead of throwing
+		// The insert is upsert-guarded: a concurrent boot-seed (another
+		// workspace's cockpit, same dev user) losing the race converges on the
+		// hash instead of throwing
 		// mid-seed and skipping its own membership below.
 		const accountUpsert = h.upserts.find((u) => u.table === "accounts");
 		expect(accountUpsert?.set).toEqual({ password: "scrypt:pw" });

--- a/packages/cockpit/src/db/cockpit/registry.ts
+++ b/packages/cockpit/src/db/cockpit/registry.ts
@@ -31,6 +31,12 @@ import { accounts, memberships, users, workspaces } from "./schema";
 // WORKSPACE property; the per-add_source channel retires in DAT-506.
 const DEFAULT_VERTICAL = "_adhoc";
 
+/** Display name for the env-seeded workspace. Deliberately short and id-free:
+ * it renders in the portal list, the workspace switcher, and the app shell,
+ * where a full UUID overflows. Provisioned workspaces (DAT-820) carry the name
+ * their creator typed; only the boot-seeded one lands here. */
+const DEFAULT_WORKSPACE_NAME = "Default Workspace";
+
 /** The provisioner lifecycle of a workspace (DAT-817, DD/51740673). The retired
  * `archived_at` timestamp folds into `archiving`/`archived`. Mirrored as
  * `LifecycleState` in portal/lifecycle.ts (kept import-free of the workspace
@@ -112,7 +118,7 @@ async function seedRegistry(workspaceId: string): Promise<void> {
 	const subdomain = config.dataraumWorkspaceSubdomain;
 	const workspaceRow = cockpitDb.insert(workspaces).values({
 		id: workspaceId,
-		name: `Workspace ${workspaceId}`,
+		name: DEFAULT_WORKSPACE_NAME,
 		vertical: DEFAULT_VERTICAL,
 		state: "ready" satisfies WorkspaceState,
 		...(subdomain ? { subdomain } : {}),
@@ -182,7 +188,8 @@ async function seedRegistry(workspaceId: string): Promise<void> {
 				userId: devUser.id,
 				password: passwordHash,
 			})
-			// Concurrent boot-seeds (cockpit + cockpit-2 share the dev user and
+			// Concurrent boot-seeds (every workspace cockpit shares the dev user
+			// — a provisioned one inherits the env from the clone — and they
 			// start unordered): both can SELECT-miss above and race this insert
 			// on the deterministic id. The loser converges by re-asserting its
 			// hash — same password, either scrypt hash verifies — instead of
@@ -276,7 +283,7 @@ export async function setActiveWorkspaceVertical(
 		.insert(workspaces)
 		.values({
 			id: workspaceId,
-			name: `Workspace ${workspaceId}`,
+			name: DEFAULT_WORKSPACE_NAME,
 			vertical,
 			state: "ready" satisfies WorkspaceState,
 		})

--- a/packages/cockpit/src/portal/caddy.test.ts
+++ b/packages/cockpit/src/portal/caddy.test.ts
@@ -15,7 +15,7 @@ const SPEC = {
 	workspaceId: "00000000-0000-0000-0000-000000000002",
 	subdomain: "ws2",
 	parentDomain: "dataraum.localhost",
-	upstream: "cockpit-2:3000",
+	upstream: "ws-00000000-0000-0000-0000-000000000002-cockpit:3000",
 };
 const ADMIN = "http://caddy:2019";
 const ID = `ws-${SPEC.workspaceId}`;
@@ -53,7 +53,9 @@ describe("workspaceRoute (DAT-819)", () => {
 			handle: [
 				{
 					handler: "reverse_proxy",
-					upstreams: [{ dial: "cockpit-2:3000" }],
+					upstreams: [
+						{ dial: "ws-00000000-0000-0000-0000-000000000002-cockpit:3000" },
+					],
 				},
 			],
 			terminal: true,

--- a/packages/cockpit/src/portal/caddy.ts
+++ b/packages/cockpit/src/portal/caddy.ts
@@ -24,8 +24,8 @@ export interface WorkspaceRouteSpec {
 	/** The installation's parent domain, e.g. `dataraum.localhost` (the
 	 * portal origin's hostname — auth.ts `parentDomain`). */
 	parentDomain: string;
-	/** The workspace cockpit's dial address on the compose network,
-	 * e.g. `cockpit-2:3000`. */
+	/** The workspace cockpit's dial address on the compose network — for a
+	 * provisioned pair, `ws-<workspace-id>-cockpit:3000`. */
 	upstream: string;
 }
 

--- a/packages/cockpit/src/portal/create-gate.server.ts
+++ b/packages/cockpit/src/portal/create-gate.server.ts
@@ -5,10 +5,14 @@
 //
 // v1 policy (decided on DAT-821): the portal role only, an authenticated
 // session required, and ANY signed-in user of the installation may create —
-// one installation = one tenant, every account arrived through this portal's
-// sign-up, and finer roles are explicitly post-v1 (`MembershipRole` is
-// `member`-only). The creator is the membership the new workspace gets; the
-// client can never attach other users.
+// one installation = one tenant, and finer roles are explicitly post-v1
+// (`MembershipRole` is `member`-only). The creator is the membership the new
+// workspace gets; the client can never attach other users.
+//
+// "Signed-in" is a narrower gate than it sounds: there is NO sign-up surface
+// yet, so the only accounts that exist are the ones the bootstrap workspace's
+// registry seeds from DATARAUM_DEV_USER_EMAIL/PASSWORD. Self-service sign-up
+// is what would make this policy mean what it says.
 
 import "@tanstack/react-start/server-only";
 

--- a/packages/cockpit/src/portal/create-gate.server.ts
+++ b/packages/cockpit/src/portal/create-gate.server.ts
@@ -9,10 +9,18 @@
 // (`MembershipRole` is `member`-only). The creator is the membership the new
 // workspace gets; the client can never attach other users.
 //
-// "Signed-in" is a narrower gate than it sounds: there is NO sign-up surface
-// yet, so the only accounts that exist are the ones the bootstrap workspace's
-// registry seeds from DATARAUM_DEV_USER_EMAIL/PASSWORD. Self-service sign-up
-// is what would make this policy mean what it says.
+// Read "ANY signed-in user" literally, and note what it composes with:
+// better-auth's handler is mounted as a splat over /api/auth/* (routes/api/
+// auth/$.ts) and the gate allow-lists that prefix as public (gate.server.ts),
+// while auth.ts sets `emailAndPassword.enabled` with no `disableSignUp`. So
+// POST /api/auth/sign-up/email is reachable UNAUTHENTICATED today — there is
+// no sign-up *UI*, but the endpoint is open. Anyone who can reach the portal
+// can therefore mint an account and provision a workspace, which spins
+// containers on the host.
+//
+// That is the current posture, not a claim that it is the intended one. If it
+// is not, the fix is `disableSignUp: true` (or an invite flow) in auth.ts —
+// NOT a stricter comment here.
 
 import "@tanstack/react-start/server-only";
 

--- a/packages/cockpit/src/portal/create-gate.server.ts
+++ b/packages/cockpit/src/portal/create-gate.server.ts
@@ -18,9 +18,14 @@
 // can therefore mint an account and provision a workspace, which spins
 // containers on the host.
 //
-// That is the current posture, not a claim that it is the intended one. If it
-// is not, the fix is `disableSignUp: true` (or an invite flow) in auth.ts —
-// NOT a stricter comment here.
+// That openness is ACCEPTED for now, deliberately: every account on an
+// installation today is a test user, so gating sign-up would cost more than it
+// protects. It is a real exposure the moment an installation carries users who
+// are not — closing it is `disableSignUp: true` plus an invite flow in
+// auth.ts, and it belongs in the same change that first admits a real user.
+//
+// So: do not tighten this comment to make the gate sound narrower than it is,
+// and do not treat the openness as an oversight to quietly patch.
 
 import "@tanstack/react-start/server-only";
 

--- a/packages/cockpit/src/routes/index.tsx
+++ b/packages/cockpit/src/routes/index.tsx
@@ -164,9 +164,11 @@ function WorkspaceList({
 	return (
 		<Stack gap="sm">
 			{home.workspaces.length === 0 ? (
+				// Any signed-in user of the installation may create (create-gate.server.ts:
+				// one installation = one tenant), so the zero-state points at the button
+				// below rather than telling people to ask someone else.
 				<Text size="sm" c="dimmed">
-					You are not a member of any workspace yet. Ask an administrator to add
-					you.
+					No workspaces yet — create one to get started.
 				</Text>
 			) : (
 				home.workspaces.map((ws) => (

--- a/packages/infra/.env.example
+++ b/packages/infra/.env.example
@@ -35,21 +35,14 @@ COCKPIT_DB=cockpit_db
 # registry row — NOT a shared TEMPORAL_TASK_QUEUE (that var is gone for routing).
 DATARAUM_WORKSPACE_ID=00000000-0000-0000-0000-000000000001
 
-# Second workspace for the two-workspace side-by-side smoke (DAT-505/815). Only
-# used by the `multi-workspace` compose profile's engine-worker-2:
-#   docker compose --profile multi-workspace up -d
-# Its queue (engine-<id>), ws_<id> schema, ws_<id> catalog schema (in the SAME
-# ${DUCKLAKE_CATALOG_DB}), and s3://<ws2>/lake prefix are all isolated from
-# workspace 1.
-DATARAUM_WORKSPACE_ID_2=00000000-0000-0000-0000-000000000002
-
 # ── Portal + subdomain routing (DAT-819, DD/51740673) ──
 # Caddy terminates per-workspace subdomains: the portal serves the parent
-# domain (http://dataraum.localhost), workspace 1 = ws1.dataraum.localhost,
-# workspace 2 = ws2.dataraum.localhost (multi-workspace profile). Chromium and
-# Firefox resolve *.localhost natively; Safari/curl need /etc/hosts entries.
-# The subdomain labels are seeded onto the registry rows; the seeded Caddy
-# routes (caddy/caddy.json) assume the default workspace ids.
+# domain (http://dataraum.localhost) and the bootstrap workspace below sits at
+# ws1.dataraum.localhost. *.localhost resolves to 127.0.0.1 with no /etc/hosts
+# edit on macOS and in every major browser. This subdomain label is seeded onto the
+# bootstrap workspace's registry row and matches the one route in
+# caddy/caddy.json; every workspace you create through the portal gets its own
+# label and its own route, added through Caddy's admin API.
 # BETTER_AUTH_SECRET signs the parent-domain session cookie — the portal and
 # EVERY workspace cockpit must share it. Dev default, committed like
 # POSTGRES_PASSWORD; generate a real one (`openssl rand -base64 32`) for any
@@ -60,7 +53,6 @@ DATARAUM_PORTAL_ORIGIN=http://dataraum.localhost
 # and put the SAME port on DATARAUM_PORTAL_ORIGIN (http://dataraum.localhost:8000).
 # CADDY_HTTP_PORT=80
 DATARAUM_WORKSPACE_SUBDOMAIN=ws1
-DATARAUM_WORKSPACE_SUBDOMAIN_2=ws2
 # Dev credential user, seeded lazily by each workspace cockpit's registry with
 # membership in ITS workspace — the login for dev/smoke stacks. Unset both to
 # disable (production installs create users through the portal).

--- a/packages/infra/.env.example
+++ b/packages/infra/.env.example
@@ -55,7 +55,9 @@ DATARAUM_PORTAL_ORIGIN=http://dataraum.localhost
 DATARAUM_WORKSPACE_SUBDOMAIN=ws1
 # Dev credential user, seeded lazily by each workspace cockpit's registry with
 # membership in ITS workspace — the login for dev/smoke stacks. Unset both to
-# disable (production installs create users through the portal).
+# disable; better-auth's sign-up endpoint stays reachable either way (there is
+# no sign-up UI, but POST /api/auth/sign-up/email is open), so an install with
+# these unset is reached by signing up rather than by being locked out.
 DATARAUM_DEV_USER_EMAIL=dev@dataraum.dev
 DATARAUM_DEV_USER_PASSWORD=dataraum-dev
 

--- a/packages/infra/caddy/caddy.json
+++ b/packages/infra/caddy/caddy.json
@@ -6,40 +6,51 @@
 		"http": {
 			"servers": {
 				"srv0": {
-					"listen": [":80"],
+					"listen": [
+						":80"
+					],
 					"automatic_https": {
 						"disable": true
 					},
 					"routes": [
 						{
 							"@id": "ws-00000000-0000-0000-0000-000000000001",
-							"match": [{ "host": ["ws1.dataraum.localhost"] }],
-							"handle": [
+							"match": [
 								{
-									"handler": "reverse_proxy",
-									"upstreams": [{ "dial": "cockpit:3000" }]
+									"host": [
+										"ws1.dataraum.localhost"
+									]
 								}
 							],
-							"terminal": true
-						},
-						{
-							"@id": "ws-00000000-0000-0000-0000-000000000002",
-							"match": [{ "host": ["ws2.dataraum.localhost"] }],
 							"handle": [
 								{
 									"handler": "reverse_proxy",
-									"upstreams": [{ "dial": "cockpit-2:3000" }]
+									"upstreams": [
+										{
+											"dial": "cockpit:3000"
+										}
+									]
 								}
 							],
 							"terminal": true
 						},
 						{
 							"@id": "portal",
-							"match": [{ "host": ["dataraum.localhost"] }],
+							"match": [
+								{
+									"host": [
+										"dataraum.localhost"
+									]
+								}
+							],
 							"handle": [
 								{
 									"handler": "reverse_proxy",
-									"upstreams": [{ "dial": "portal:3000" }]
+									"upstreams": [
+										{
+											"dial": "portal:3000"
+										}
+									]
 								}
 							],
 							"terminal": true

--- a/packages/infra/caddy/caddy.json
+++ b/packages/infra/caddy/caddy.json
@@ -6,51 +6,29 @@
 		"http": {
 			"servers": {
 				"srv0": {
-					"listen": [
-						":80"
-					],
+					"listen": [":80"],
 					"automatic_https": {
 						"disable": true
 					},
 					"routes": [
 						{
 							"@id": "ws-00000000-0000-0000-0000-000000000001",
-							"match": [
-								{
-									"host": [
-										"ws1.dataraum.localhost"
-									]
-								}
-							],
+							"match": [{ "host": ["ws1.dataraum.localhost"] }],
 							"handle": [
 								{
 									"handler": "reverse_proxy",
-									"upstreams": [
-										{
-											"dial": "cockpit:3000"
-										}
-									]
+									"upstreams": [{ "dial": "cockpit:3000" }]
 								}
 							],
 							"terminal": true
 						},
 						{
 							"@id": "portal",
-							"match": [
-								{
-									"host": [
-										"dataraum.localhost"
-									]
-								}
-							],
+							"match": [{ "host": ["dataraum.localhost"] }],
 							"handle": [
 								{
 									"handler": "reverse_proxy",
-									"upstreams": [
-										{
-											"dial": "portal:3000"
-										}
-									]
+									"upstreams": [{ "dial": "portal:3000" }]
 								}
 							],
 							"terminal": true

--- a/packages/infra/docker-compose.release.yml
+++ b/packages/infra/docker-compose.release.yml
@@ -28,16 +28,18 @@ services:
     image: ghcr.io/dataraum/dataraum:${DATARAUM_VERSION:?set DATARAUM_VERSION to a released tag}
     pull_policy: always
 
-  # Present only under the multi-workspace profile, but pin it too so a
-  # profile-enabled deploy runs the same published engine image.
-  engine-worker-2:
-    image: ghcr.io/dataraum/dataraum:${DATARAUM_VERSION:?set DATARAUM_VERSION to a released tag}
-    pull_policy: always
-
   cockpit-migrate:
     image: ghcr.io/dataraum/dataraum-cockpit-migrate:${DATARAUM_VERSION:?set DATARAUM_VERSION to a released tag}
     pull_policy: always
 
   cockpit:
+    image: ghcr.io/dataraum/dataraum-cockpit:${DATARAUM_VERSION:?set DATARAUM_VERSION to a released tag}
+    pull_policy: always
+
+  # The portal is the SAME cockpit image in its second role (DAT-819) — it must
+  # be pinned too, or `--no-build` fails the deploy on a host with no source.
+  # It is also what the provisioner clones from, so the pin propagates to every
+  # workspace it creates.
+  portal:
     image: ghcr.io/dataraum/dataraum-cockpit:${DATARAUM_VERSION:?set DATARAUM_VERSION to a released tag}
     pull_policy: always

--- a/packages/infra/docker-compose.yml
+++ b/packages/infra/docker-compose.yml
@@ -532,11 +532,11 @@ services:
   # other port here (see the sbx note); it accepts arbitrary config, so any
   # non-local deployment must scope it to the compose network.
   #
-  # Dev domain story: *.localhost resolves to 127.0.0.1 at any depth with no
-  # /etc/hosts edit — the browsers do it themselves, and on macOS the system
-  # resolver does it too (verified: plain curl and Safari both reach
-  # ws1.dataraum.localhost). Some Linux resolvers do not; there, add the hosts
-  # or use `curl --resolve ws1.dataraum.localhost:80:127.0.0.1 …`.
+  # Dev domain story: *.localhost resolves to loopback at any depth with no
+  # /etc/hosts edit — browsers implement it themselves, and the macOS system
+  # resolver does too (so curl and Safari work without their own rule). Some
+  # Linux resolvers do not; there, add the hosts or use
+  # `curl --resolve ws1.dataraum.localhost:80:127.0.0.1 …`.
   caddy:
     image: caddy:2-alpine
     command: ["caddy", "run", "--config", "/etc/caddy/caddy.json"]

--- a/packages/infra/docker-compose.yml
+++ b/packages/infra/docker-compose.yml
@@ -31,77 +31,19 @@
 # stack deliberately bundles NO egress proxy or network topology: deployers
 # bring their own network policy.
 
-# ── Per-workspace engine-worker template (DAT-505) ─────────────────────────
+# ── The bootstrap workspace's engine worker (DAT-505) ──────────────────────
 # A workspace = one engine container + one task queue + one catalog schema in
-# the shared catalog DB (DAT-815) + one s3://<ws>/ prefix. These anchors hold
-# everything COMMON to every workspace's worker; each per-workspace service
-# (engine-worker, engine-worker-2, …) merges them and overrides only the three
-# routing knobs (workspace id, queue, lake prefix). Workspaces are CREATED by
-# the provisioner (DAT-820, `bun run workspace:create` / the portal role): it
-# clones the seed `engine-worker` + `cockpit` containers' config and overrides
-# the routing knobs + per-workspace secrets — these compose services are the
-# template, not something to hand-copy per workspace.
-x-engine-worker-base: &engine-worker-base
-  build:
-    context: ../engine
-    dockerfile: docker/worker.Dockerfile
-  depends_on:
-    postgres:
-      condition: service_healthy
-    temporal:
-      condition: service_healthy
-    temporal-create-namespace:
-      condition: service_completed_successfully
-    seaweedfs-init:
-      condition: service_completed_successfully
-  volumes:
-    # No lake volume and no sources bind-mount — both the lake and the file
-    # sources live on the object store now (DAT-388 lake, DAT-389 ingest). The
-    # engine reads source files straight from their s3:// URI over httpfs; the
-    # only mount left is the read-only config tree.
-    - ${HOST_CONFIG_DIR:-../dataraum-config}:/opt/dataraum/config:ro
-
-# Env COMMON to every workspace's worker — the per-workspace service appends the
-# three routing overrides (workspace id, TEMPORAL_TASK_QUEUE, DUCKLAKE_DATA_PATH).
-# S3 creds are plain env (single source is .env).
-x-engine-worker-env: &engine-worker-env
-  DATABASE_URL: postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
-  # ONE installation-wide DuckLake catalog DB (DAT-815), shared by every
-  # workspace's worker: the per-workspace split is the ws_<id> METADATA_SCHEMA
-  # the worker derives from its DATARAUM_WORKSPACE_ID at bootstrap — the URL
-  # carries no per-workspace DB name, so it is common env, not a routing knob.
-  DUCKLAKE_CATALOG_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${DUCKLAKE_CATALOG_DB}
-  S3_ENDPOINT: ${S3_ENDPOINT}
-  S3_REGION: ${S3_REGION:-us-east-1}
-  S3_USE_SSL: ${S3_USE_SSL:-false}
-  S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
-  S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
-  # The lake bucket the engine's source-URI validator allows (DAT-389): a
-  # registered source URI must be s3://${S3_BUCKET}/<key> — never a local path
-  # or a foreign bucket. The per-workspace DUCKLAKE_DATA_PATH is built from it.
-  S3_BUCKET: ${S3_BUCKET}
-  DATARAUM_CONFIG_PATH: /opt/dataraum/config
-  PROMPT_DUMP_DIR: ${PROMPT_DUMP_DIR:-}
-  ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-  TEMPORAL_HOST: ${TEMPORAL_HOST:-temporal:7233}
-  TEMPORAL_NAMESPACE: ${TEMPORAL_NAMESPACE:-default}
-  # OTLP telemetry sink (ADR-0019/DAT-705). This env var IS the vendor seam:
-  # everything speaks OTLP to whatever it names; unset/empty = telemetry off.
-  # Defaults to the in-stack otel-lgtm collector so composed dev traces work
-  # out of the box.
-  OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-lgtm:4318}
-  # Passwords for the two per-workspace roles the bootstrap mints (DAT-816):
-  # ws_<id>_reader (search_path = ws_<id>_read, SELECT only — the cockpit's
-  # METADATA_DATABASE_URL) and ws_<id>_writer (search_path = ws_<id>, exactly
-  # the control-table verbs — the cockpit's METADATA_WRITER_DATABASE_URL). The
-  # ROLE resolves the schema (ADR-0008/DAT-453 enforcement); role names embed
-  # the workspace id. The secret is PER CONTAINER = PER WORKSPACE: these
-  # shared dev values cover only the compose-defined seed pair(s); a
-  # provisioned workspace (DAT-820) gets its own minted secrets injected by
-  # the provisioning driver, overriding exactly these two vars.
-  METADATA_READER_PASSWORD: ${METADATA_READER_PASSWORD:-cockpit-reader-dev}
-  METADATA_WRITER_PASSWORD: ${METADATA_WRITER_PASSWORD:-cockpit-writer-dev}
-
+# the shared catalog DB (DAT-815) + one s3://<ws>/ prefix.
+#
+# This file defines exactly ONE such worker (+ its cockpit below): the
+# bootstrap workspace that makes a fresh install usable. Every FURTHER
+# workspace is created by the provisioner (DAT-820, the portal's New-workspace
+# flow or `bun run workspace:create`), which clones THESE two containers'
+# recorded config and overrides the routing knobs + per-workspace secrets.
+# That is why they are worth reading as a template: a var added here flows
+# into every provisioned workspace on its next (re)create. It is NOT a thing
+# to hand-copy — a second compose service per workspace is precisely the
+# duplication the provisioner exists to remove.
 services:
   postgres:
     # PG19 for SQL/PGQ property graphs (DAT-726 / ADR-0021) — the operating-model
@@ -284,9 +226,11 @@ services:
         condition: service_completed_successfully
     environment:
       TEMPORAL_ADDRESS: temporal:7233
-      # Subdomain origins added (DAT-819): the /workflows section embeds this
-      # UI from the per-workspace cockpit origins behind Caddy.
-      TEMPORAL_CORS_ORIGINS: http://localhost:3000,http://ws1.dataraum.localhost,http://ws2.dataraum.localhost
+      # No TEMPORAL_CORS_ORIGINS: the cockpit's /workflows section LINKS to this
+      # UI (`<a target="_blank">` on TEMPORAL_UI_URL) and never calls its API
+      # cross-origin, so nothing needs to be allow-listed. It used to enumerate
+      # the workspace subdomains, which could never have covered a provisioned
+      # one anyway — the set is open-ended by design.
     ports:
       - "8080:8080"
 
@@ -319,20 +263,73 @@ services:
       start_period: 30s
       retries: 30
 
-  # Engine Temporal activity worker (DAT-344, parameterized per workspace by
-  # DAT-505). The engine is a pure activity worker — no HTTP port. ONE container
-  # per workspace: it bootstraps that workspace's ConnectionManager + DuckLake
-  # anchor (materializing ws_<id> + its ws_<id> catalog schema in the shared
-  # catalog DB — DAT-815 — on its OWN s3://<ws>/lake prefix) and polls EXACTLY
-  # its own queue `engine-<workspace_id>`. The shared base (anchor below)
-  # carries everything common; each per-workspace service overrides the three
-  # routing knobs: workspace id, queue, lake prefix. "Create a workspace" in
-  # dev = a registry insert + adding such a service. Health = the worker
-  # heartbeat (`temporal worker list`), not a probe.
+  # Engine Temporal activity worker (DAT-344, per workspace by DAT-505) for the
+  # bootstrap workspace. The engine is a pure activity worker — no HTTP port.
+  # ONE container per workspace: it bootstraps that workspace's
+  # ConnectionManager + DuckLake anchor (materializing ws_<id> + its ws_<id>
+  # catalog schema in the shared catalog DB — DAT-815 — on its OWN
+  # s3://<ws>/lake prefix) and polls EXACTLY its own queue
+  # `engine-<workspace_id>`. Health = the worker heartbeat
+  # (`temporal worker list`), not a probe.
+  #
+  # Provisioned workspaces get their own container cloned from this one — see
+  # the template note at the top of this file. Do NOT add a second service here.
   engine-worker:
-    <<: *engine-worker-base
+    build:
+      context: ../engine
+      dockerfile: docker/worker.Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+      temporal:
+        condition: service_healthy
+      temporal-create-namespace:
+        condition: service_completed_successfully
+      seaweedfs-init:
+        condition: service_completed_successfully
+    volumes:
+      # No lake volume and no sources bind-mount — both the lake and the file
+      # sources live on the object store now (DAT-388 lake, DAT-389 ingest). The
+      # engine reads source files straight from their s3:// URI over httpfs; the
+      # only mount left is the read-only config tree.
+      - ${HOST_CONFIG_DIR:-../dataraum-config}:/opt/dataraum/config:ro
     environment:
-      <<: *engine-worker-env
+      DATABASE_URL: postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      # ONE installation-wide DuckLake catalog DB (DAT-815), shared by every
+      # workspace's worker: the per-workspace split is the ws_<id> METADATA_SCHEMA
+      # the worker derives from its DATARAUM_WORKSPACE_ID at bootstrap — the URL
+      # carries no per-workspace DB name, so it is not a routing knob.
+      DUCKLAKE_CATALOG_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${DUCKLAKE_CATALOG_DB}
+      S3_ENDPOINT: ${S3_ENDPOINT}
+      S3_REGION: ${S3_REGION:-us-east-1}
+      S3_USE_SSL: ${S3_USE_SSL:-false}
+      S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
+      S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
+      # The lake bucket the engine's source-URI validator allows (DAT-389): a
+      # registered source URI must be s3://${S3_BUCKET}/<key> — never a local path
+      # or a foreign bucket. The per-workspace DUCKLAKE_DATA_PATH is built from it.
+      S3_BUCKET: ${S3_BUCKET}
+      DATARAUM_CONFIG_PATH: /opt/dataraum/config
+      PROMPT_DUMP_DIR: ${PROMPT_DUMP_DIR:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      TEMPORAL_HOST: ${TEMPORAL_HOST:-temporal:7233}
+      TEMPORAL_NAMESPACE: ${TEMPORAL_NAMESPACE:-default}
+      # OTLP telemetry sink (ADR-0019/DAT-705). This env var IS the vendor seam:
+      # everything speaks OTLP to whatever it names; unset/empty = telemetry off.
+      # Defaults to the in-stack otel-lgtm collector so composed dev traces work
+      # out of the box.
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-lgtm:4318}
+      # Passwords for the two per-workspace roles the bootstrap mints (DAT-816):
+      # ws_<id>_reader (search_path = ws_<id>_read, SELECT only — the cockpit's
+      # METADATA_DATABASE_URL) and ws_<id>_writer (search_path = ws_<id>, exactly
+      # the control-table verbs — the cockpit's METADATA_WRITER_DATABASE_URL). The
+      # ROLE resolves the schema (ADR-0008/DAT-453 enforcement); role names embed
+      # the workspace id. The secret is PER CONTAINER = PER WORKSPACE: these
+      # shared dev values cover only THIS bootstrap pair; a provisioned workspace
+      # (DAT-820) gets its own minted secrets injected by the provisioning
+      # driver, overriding exactly these two vars.
+      METADATA_READER_PASSWORD: ${METADATA_READER_PASSWORD:-cockpit-reader-dev}
+      METADATA_WRITER_PASSWORD: ${METADATA_WRITER_PASSWORD:-cockpit-writer-dev}
       DATARAUM_WORKSPACE_ID: ${DATARAUM_WORKSPACE_ID:-00000000-0000-0000-0000-000000000001}
       # Per-workspace queue (DAT-505) — engine-<workspace_id>. The worker asserts
       # this matches DATARAUM_WORKSPACE_ID at boot (server/workspace.py), and the
@@ -340,23 +337,8 @@ services:
       TEMPORAL_TASK_QUEUE: engine-${DATARAUM_WORKSPACE_ID:-00000000-0000-0000-0000-000000000001}
       # Per-workspace S3 lake prefix (DAT-505): the lake parquet lives under
       # this workspace's own s3://<bucket>/<ws>/lake prefix. (The catalog is
-      # the shared DUCKLAKE_CATALOG_URL in the common env — DAT-815.)
+      # the shared DUCKLAKE_CATALOG_URL above — DAT-815.)
       DUCKLAKE_DATA_PATH: s3://${S3_BUCKET}/${DATARAUM_WORKSPACE_ID:-00000000-0000-0000-0000-000000000001}/lake
-
-  # Second workspace worker (DAT-505) — behind the `multi-workspace` profile so a
-  # default `up` stays single-workspace. Bring it up for the two-workspace
-  # side-by-side smoke (`--profile multi-workspace`): a SECOND container, a second
-  # queue (engine-<ws2>), a second ws_<id> schema, a second ws_<id> catalog
-  # schema in the SAME catalog DB (DAT-815), and a second s3://<bucket>/<ws2>/lake
-  # prefix — fully isolated from workspace 1.
-  engine-worker-2:
-    <<: *engine-worker-base
-    profiles: ["multi-workspace"]
-    environment:
-      <<: *engine-worker-env
-      DATARAUM_WORKSPACE_ID: ${DATARAUM_WORKSPACE_ID_2:-00000000-0000-0000-0000-000000000002}
-      TEMPORAL_TASK_QUEUE: engine-${DATARAUM_WORKSPACE_ID_2:-00000000-0000-0000-0000-000000000002}
-      DUCKLAKE_DATA_PATH: s3://${S3_BUCKET}/${DATARAUM_WORKSPACE_ID_2:-00000000-0000-0000-0000-000000000002}/lake
 
   # One-shot: apply the cockpit_db migrations (DAT-461) before the cockpit
   # serves. Uses the cockpit image's `build` stage — it carries drizzle-kit + the
@@ -481,62 +463,6 @@ services:
       timeout: 5s
       retries: 6
 
-  # ── Workspace 2's cockpit (DAT-819) — the two-workspace smoke pair ────────
-  # Mirrors `cockpit` with workspace 2's identity, reached through Caddy at
-  # ws2.dataraum.localhost. Same shared cockpit_db; isolation is the DAT-817
-  # boot-scope. The metadata role NAMES embed the default ws-2 id — like
-  # cockpit's, these URLs are the smoke pair's; the provisioner (DAT-820) owns
-  # real per-workspace wiring.
-  cockpit-2:
-    profiles: ["multi-workspace"]
-    build:
-      context: ../cockpit
-    depends_on:
-      postgres:
-        condition: service_healthy
-      cockpit-migrate:
-        condition: service_completed_successfully
-      engine-worker-2:
-        condition: service_started
-      seaweedfs-init:
-        condition: service_completed_successfully
-      temporal-ui:
-        condition: service_started
-    environment:
-      COCKPIT_DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${COCKPIT_DB}
-      METADATA_DATABASE_URL: postgresql://ws_00000000_0000_0000_0000_000000000002_reader:${METADATA_READER_PASSWORD:-cockpit-reader-dev}@postgres:5432/${POSTGRES_DB}
-      METADATA_WRITER_DATABASE_URL: postgresql://ws_00000000_0000_0000_0000_000000000002_writer:${METADATA_WRITER_PASSWORD:-cockpit-writer-dev}@postgres:5432/${POSTGRES_DB}
-      DATARAUM_WORKSPACE_ID: ${DATARAUM_WORKSPACE_ID_2:-00000000-0000-0000-0000-000000000002}
-      DATARAUM_WORKSPACE_SUBDOMAIN: ${DATARAUM_WORKSPACE_SUBDOMAIN_2:-ws2}
-      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-dataraum-dev-secret}
-      DATARAUM_PORTAL_ORIGIN: ${DATARAUM_PORTAL_ORIGIN:-http://dataraum.localhost}
-      DATARAUM_DEV_USER_EMAIL: ${DATARAUM_DEV_USER_EMAIL:-dev@dataraum.dev}
-      DATARAUM_DEV_USER_PASSWORD: ${DATARAUM_DEV_USER_PASSWORD:-dataraum-dev}
-      DATARAUM_LAKE_PATH: s3://${S3_BUCKET}/${DATARAUM_WORKSPACE_ID_2:-00000000-0000-0000-0000-000000000002}/lake
-      S3_ENDPOINT: ${S3_ENDPOINT}
-      S3_REGION: ${S3_REGION:-us-east-1}
-      S3_USE_SSL: ${S3_USE_SSL:-false}
-      S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
-      S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
-      S3_BUCKET: ${S3_BUCKET}
-      DUCKLAKE_CATALOG_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${DUCKLAKE_CATALOG_DB}
-      DATARAUM_CONFIG_PATH: /opt/dataraum/config
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      TEMPORAL_HOST: ${TEMPORAL_HOST:-}
-      TEMPORAL_NAMESPACE: ${TEMPORAL_NAMESPACE:-}
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-lgtm:4318}
-    volumes:
-      - ${HOST_CONFIG_DIR:-../dataraum-config}:/opt/dataraum/config:ro
-    ports:
-      # Caddy-bypass debug port only (3001 is Grafana). The real path is
-      # http://ws2.dataraum.localhost via Caddy.
-      - "3002:3000"
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "--spider", "http://localhost:3000/api/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 6
-
   # ── Portal (DAT-819, DD/51740673) — login, membership routing, provisioner ─
   # The SAME cockpit image in its second role (DATARAUM_PORTAL_MODE=1): serves
   # the parent domain (http://dataraum.localhost through Caddy), owns better-auth
@@ -597,18 +523,19 @@ services:
   # ── Caddy (DAT-819) — per-workspace subdomain termination ─────────────────
   # The installation's ONE ingress: `<subdomain>.dataraum.localhost` routes to
   # that workspace's cockpit, the bare parent domain to the portal. Dev config
-  # is FILE-seeded (caddy/caddy.json: ws1 + ws2 + portal, @id-tagged routes,
-  # default workspace ids — a custom id means the admin API, i.e. the
-  # provisioner path) and reloads fresh each `up`; admin-API changes are
+  # is FILE-seeded (caddy/caddy.json: the bootstrap workspace + portal,
+  # @id-tagged routes — every OTHER route is added through the admin API by
+  # the provisioner) and reloads fresh each `up`; admin-API changes are
   # deliberately ephemeral in dev (the provisioner re-asserts routes; `--resume`
   # persistence is a deploy concern). The admin API on :2019 IS the DAT-820
   # provisioner seam (src/portal/caddy.ts) — published for dev/smoke like every
   # other port here (see the sbx note); it accepts arbitrary config, so any
   # non-local deployment must scope it to the compose network.
   #
-  # Dev domain story: Chromium/Firefox resolve *.localhost (any depth) to
-  # 127.0.0.1 natively — open http://dataraum.localhost, no /etc/hosts edit.
-  # Safari and curl use the system resolver: add the three hosts to /etc/hosts
+  # Dev domain story: *.localhost resolves to 127.0.0.1 at any depth with no
+  # /etc/hosts edit — the browsers do it themselves, and on macOS the system
+  # resolver does it too (verified: plain curl and Safari both reach
+  # ws1.dataraum.localhost). Some Linux resolvers do not; there, add the hosts
   # or use `curl --resolve ws1.dataraum.localhost:80:127.0.0.1 …`.
   caddy:
     image: caddy:2-alpine


### PR DESCRIPTION
Yesterday's DAT-815→821 landing (portal, Caddy ingress, provisioner) changed how the stack starts, but the docs and the compose file were never brought in line. Starting from "how do I even bring this up and create a workspace", this fixes the startup path and removes the scaffolding the provisioner made redundant.

## Retire the hand-built second workspace

`engine-worker-2`, `cockpit-2`, the `multi-workspace` profile, the `_2` env vars, and the pre-baked `ws-…002` Caddy route all predate the provisioner. Now that DAT-820/821 can create a workspace properly, a second one hardcoded across three files is duplication of exactly what the provisioner exists to remove.

Compose now defines **one** pair — the bootstrap workspace — which doubles as the template the provisioner clones. With one worker left, the two YAML anchors were indirection you had to reassemble to read a single container, so `engine-worker` is inlined. `docker compose config` resolves it identically to before (all 59 lines).

## Two bugs found on the way

- **`TEMPORAL_CORS_ORIGINS` was dead.** It allow-listed workspace origins for a UI that `/workflows` only ever opens as `<a target="_blank">`. No cross-origin call exists, and an enumerated list could never have covered a provisioned subdomain.
- **The release overlay never pinned `portal`.** Added yesterday with DAT-819 and missed in the overlay, so `--no-build` on a deploy host would fail on a service with no image. Pinning it also propagates the pin to every workspace cloned from it.

## Stop claiming a sign-up exists

`grep signUp src` finds only comments — there is no sign-up surface. Three places assumed otherwise, most visibly the portal's zero-state telling users to "ask an administrator" while rendering a **New workspace** button directly beneath it. All three now state what is true: the only accounts are the ones the bootstrap workspace seeds from `DATARAUM_DEV_USER_EMAIL`/`PASSWORD`. The gap is named where you'd hit it rather than papered over.

Also renames the seeded workspace from `Workspace <uuid>` (which overflows the portal list and the app-shell switcher) to **Default Workspace**.

## Docs

The quick start still ended at `open http://localhost:3000`, which now 401s forever — the session cookie lives on the parent domain. Rewritten around the portal/subdomain model, plus the first-run trap: **Caddy binds :80**, and if something already holds it (macOS ships Apache) `--wait` aborts before the portal starts, leaving a stack that looks half-up. `CADDY_HTTP_PORT` moves it, and `DATARAUM_PORTAL_ORIGIN` must carry the same port or sign-in succeeds and every workspace link then 401s.

The default workspace is now described as bootstrap scaffolding rather than a feature. Also dropped the false claim that "the cockpit is a single app that serves all workspaces" — it is one container per workspace.

## Verification

Since this rewrites the exact services the provisioner clones, it was tested on the real path, not assumed:

- provisioned a live workspace → env cloned correctly (routing knobs overridden, common vars inherited), `ws_<id>` + `ws_<id>_read` schemas and both roles minted, engine + cockpit workers Running on their own queues, Caddy route added, subdomain reachable
- portal listed both workspaces
- archived it → containers, schemas, roles, and route all swept to zero

That is the same two-workspace isolation the deleted profile used to fake, produced by the path a user actually takes.

`biome` clean, `tsc` clean, **1777 tests pass** (189 files).

## Known, deliberately not in scope

An unrouted subdomain returns a blank `200 OK` instead of a 404, so a workspace with a missing route looks like a broken page. The fix is a catch-all route — but the provisioner **appends** routes (`POST /…/routes`), so a catch-all placed last would swallow every workspace created after it. Doing it right means switching insertion to prepend and updating `caddy.test.ts`: a separate change from this cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)