### PR TITLE
DAT-836: _adhoc header cites the right ticket

### DIFF
--- a/packages/dataraum-config/verticals/_adhoc/ontology.yaml
+++ b/packages/dataraum-config/verticals/_adhoc/ontology.yaml
@@ -1,4 +1,4 @@
-# _adhoc — the no-vertical placeholder (DAT-371; description corrected DAT-834)
+# _adhoc — the no-vertical placeholder (DAT-371; description corrected DAT-836)
 #
 # Used when no domain vertical has been selected. It stays empty, and an empty
 # `_adhoc` does NOT run: `semantic_per_column` fails loud with "No concepts for


### PR DESCRIPTION
One-line follow-up to #527. The header said `description corrected DAT-834`; DAT-834 is the unbounded cycle enumeration (#529), and the doc correction is DAT-836. The number was carried over from before the ticket was split.

A config file pointing at the wrong ticket is the same class of stale pointer the correction itself was about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)